### PR TITLE
iOS: Improve mission UI, add auto-reconnect, and refine input field

### DIFF
--- a/ios_dashboard/OpenAgentDashboard/Models/ChatMessage.swift
+++ b/ios_dashboard/OpenAgentDashboard/Models/ChatMessage.swift
@@ -90,7 +90,7 @@ enum ControlRunState: String, Codable {
     case idle
     case running
     case waitingForTool = "waiting_for_tool"
-    
+
     var statusType: StatusType {
         switch self {
         case .idle: return .idle
@@ -98,12 +98,41 @@ enum ControlRunState: String, Codable {
         case .waitingForTool: return .pending
         }
     }
-    
+
     var label: String {
         switch self {
         case .idle: return "Idle"
         case .running: return "Running"
         case .waitingForTool: return "Waiting"
+        }
+    }
+}
+
+// MARK: - Connection State
+
+enum ConnectionState {
+    case connected
+    case reconnecting(attempt: Int)
+    case disconnected
+
+    var isConnected: Bool {
+        if case .connected = self { return true }
+        return false
+    }
+
+    var label: String {
+        switch self {
+        case .connected: return ""
+        case .reconnecting(let attempt): return attempt > 1 ? "Reconnecting (\(attempt))..." : "Reconnecting..."
+        case .disconnected: return "Disconnected"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .connected: return "wifi"
+        case .reconnecting: return "wifi.exclamationmark"
+        case .disconnected: return "wifi.slash"
         }
     }
 }

--- a/ios_dashboard/OpenAgentDashboard/Models/Mission.swift
+++ b/ios_dashboard/OpenAgentDashboard/Models/Mission.swift
@@ -192,8 +192,13 @@ struct RunningMissionInfo: Codable, Identifiable {
     }
     
     var displayModel: String {
-        guard let model = modelOverride else { return "Default" }
+        guard let model = modelOverride else { return missionId.prefix(8).uppercased() }
         return model.split(separator: "/").last.map(String.init) ?? model
+    }
+
+    /// Short identifier for the mission (first 8 chars of ID)
+    var shortId: String {
+        String(missionId.prefix(8)).uppercased()
     }
 }
 

--- a/ios_dashboard/OpenAgentDashboard/Views/Components/RunningMissionsBar.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Components/RunningMissionsBar.swift
@@ -79,8 +79,8 @@ struct RunningMissionsBar: View {
                     .fill(Theme.success)
                     .frame(width: 6, height: 6)
                 
-                // Model name
-                Text(mission.displayModel ?? "Default")
+                // Model name or mission ID
+                Text(mission.displayModel ?? String(mission.id.prefix(8)).uppercased())
                     .font(.caption.weight(.medium))
                     .foregroundStyle(Theme.textPrimary)
                     .lineLimit(1)


### PR DESCRIPTION
## Summary

Fixed three major iOS dashboard issues:

1. **Mission identification**: Missions now show first 8 chars of ID instead of "Default" when no model override is set
2. **Connection resilience**: Added automatic reconnection with exponential backoff (1s→30s) and status indicator in toolbar
3. **Input field UX**: Redesigned to ChatGPT style with clean outline, no background fill, and integrated send button

## Implementation Details

- Added `ConnectionState` enum to track SSE stream health
- Filter connection errors from error messages, show only in status bar
- Fix status event filtering for parallel missions
- Reset run state when creating or switching missions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Connection resilience**: Introduces `ConnectionState` and exponential backoff reconnect in `ControlView` for SSE (`startStreaming`), with toolbar status (icon/label) and filtered connection errors kept out of chat.
> - **Mission identification**: `Mission.displayModel` and `RunningMissionsBar` now fall back to the mission’s short ID (first 8 chars) when no `model_override` is present; added `shortId`.
> - **Input UX**: Reworks input to a ChatGPT-style bordered field with an integrated send/stop button and subtle state-dependent styling.
> - **Parallel missions correctness**: Tightens status/event routing in `handleStreamEvent` to only update the viewed mission; `switchToMission` preloads `runState`/`queueLength` from `runningMissions` and resets `progress`.
> - **State resets**: On new mission creation/switch, clears run state, queue, and progress; cleans up connection state on disappear.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a960e6381fd89b51805584df1637fc867630d91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->