### PR TITLE
Fix agent working indicator position and iOS message filtering

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1967,28 +1967,6 @@ export default function ControlClient() {
             </div>
           ) : (
             <div className="mx-auto max-w-3xl space-y-6">
-              {/* Show streaming indicator when running but no active thinking/phase */}
-              {runState === "running" &&
-                items.length > 0 &&
-                !items.some(
-                  (it) =>
-                    (it.kind === "thinking" && !it.done) || it.kind === "phase"
-                ) && (
-                  <div className="flex justify-start gap-3 animate-fade-in">
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
-                      <Bot className="h-4 w-4 text-indigo-400 animate-pulse" />
-                    </div>
-                    <div className="rounded-2xl rounded-bl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Loader className="h-4 w-4 text-indigo-400 animate-spin" />
-                        <span className="text-sm text-white/60">
-                          Agent is working...
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
               {items.map((item) => {
                 if (item.kind === "user") {
                   return (
@@ -2233,7 +2211,29 @@ export default function ControlClient() {
                   </div>
                 );
               })}
-              
+
+              {/* Show streaming indicator when running but no active thinking/phase */}
+              {runState === "running" &&
+                items.length > 0 &&
+                !items.some(
+                  (it) =>
+                    (it.kind === "thinking" && !it.done) || it.kind === "phase"
+                ) && (
+                  <div className="flex justify-start gap-3 animate-fade-in">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
+                      <Bot className="h-4 w-4 text-indigo-400 animate-pulse" />
+                    </div>
+                    <div className="rounded-2xl rounded-bl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <Loader className="h-4 w-4 text-indigo-400 animate-spin" />
+                        <span className="text-sm text-white/60">
+                          Agent is working...
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
               {/* Continue banner for blocked missions */}
               {activeMission?.status === "blocked" && items.length > 0 && (
                 <div className="flex justify-center py-4">


### PR DESCRIPTION
## Summary
- Move "Agent is working..." indicator to appear after messages (not before) in both web dashboard and iOS app
- Fix iOS mission_id filtering bug that blocked user_message events when viewingMissionId was nil
- Add optimistic user message display in iOS for immediate feedback
- Add duplicate prevention for user_message SSE events

## Test plan
- [x] Verify web dashboard shows user message before "Agent is working..." indicator
- [x] Verify iOS app shows user messages correctly when sending new messages
- [x] Build and run iOS app in simulator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts chat UX and iOS event handling for correctness and responsiveness.
> 
> - Web: Renders the `"Agent is working..."` streaming indicator after existing `items` instead of before
> - iOS: Moves working indicator below `messages` when running with no active streaming item
> - iOS: Fixes `mission_id` filtering to accept events when `viewingMissionId` is nil (and handle main vs. parallel missions correctly)
> - iOS: Adds optimistic user message insertion on `sendMessage` and avoids duplicate `user_message` SSE events
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e50486d01553292783ef3a40f7b031100315720. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->