### PR TITLE
Fix race condition causing duplicate user messages in iOS

### DIFF
--- a/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
@@ -777,10 +777,12 @@ struct ControlView: View {
             do {
                 let (messageId, _) = try await api.sendMessage(content: content)
 
-                // Optimistically add user message to UI immediately
-                let userMessage = ChatMessage(id: messageId, type: .user, content: content)
-                messages.append(userMessage)
-                shouldScrollToBottom = true
+                // Add user message to UI if not already added by SSE (race condition guard)
+                if !messages.contains(where: { $0.id == messageId }) {
+                    let userMessage = ChatMessage(id: messageId, type: .user, content: content)
+                    messages.append(userMessage)
+                    shouldScrollToBottom = true
+                }
 
                 // If we don't have a current mission, the backend may have just created one
                 // Refresh to get the new mission context


### PR DESCRIPTION
## Summary
Add duplicate check in sendMessage() before appending user message to prevent race condition where SSE user_message event arrives before API call returns.

## Test plan
- [x] Verify no duplicate messages appear when sending messages rapidly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate user messages caused by an SSE/API race.
> 
> - Update `ControlView.swift` `sendMessage()` to append the user message only when `messages` does not already contain the `messageId` returned by `api.sendMessage()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24401edf525d4cb89fe4a1457c244cf17e7ec3d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->