### PR TITLE
Fix message ordering when sending multiple messages rapidly

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -651,7 +651,8 @@ export default function ControlClient() {
 
   // Desktop stream state
   const [showDesktopStream, setShowDesktopStream] = useState(false);
-  const [desktopDisplayId] = useState(":99");
+  const [desktopDisplayId, setDesktopDisplayId] = useState(":101");
+  const [showDisplaySelector, setShowDisplaySelector] = useState(false);
 
   // Check if the mission we're viewing is actually running (not just any mission)
   const viewingMissionIsRunning = useMemo(() => {
@@ -1758,25 +1759,66 @@ export default function ControlClient() {
             </button>
           )}
 
-          {/* Desktop stream toggle */}
-          <button
-            onClick={() => setShowDesktopStream(!showDesktopStream)}
-            className={cn(
-              "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
-              showDesktopStream
-                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-                : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
-            )}
-            title={showDesktopStream ? "Hide desktop stream" : "Show desktop stream"}
-          >
-            <Monitor className="h-4 w-4" />
-            <span className="hidden sm:inline">Desktop</span>
-            {showDesktopStream ? (
-              <PanelRightClose className="h-4 w-4" />
-            ) : (
-              <PanelRight className="h-4 w-4" />
-            )}
-          </button>
+          {/* Desktop stream toggle with display selector */}
+          <div className="relative flex items-center">
+            <button
+              onClick={() => setShowDesktopStream(!showDesktopStream)}
+              className={cn(
+                "flex items-center gap-2 rounded-l-lg border px-3 py-2 text-sm transition-colors",
+                showDesktopStream
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                  : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
+              )}
+              title={showDesktopStream ? "Hide desktop stream" : "Show desktop stream"}
+            >
+              <Monitor className="h-4 w-4" />
+              <span className="hidden sm:inline">Desktop</span>
+              {showDesktopStream ? (
+                <PanelRightClose className="h-4 w-4" />
+              ) : (
+                <PanelRight className="h-4 w-4" />
+              )}
+            </button>
+            <div className="relative">
+              <button
+                onClick={() => setShowDisplaySelector(!showDisplaySelector)}
+                className={cn(
+                  "flex items-center gap-1 rounded-r-lg border-y border-r px-2 py-2 text-sm transition-colors",
+                  showDesktopStream
+                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                    : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
+                )}
+                title="Select display"
+              >
+                <span className="text-xs font-mono">{desktopDisplayId}</span>
+                <ChevronDown className="h-3 w-3" />
+              </button>
+              {showDisplaySelector && (
+                <div className="absolute right-0 top-full mt-1 z-50 min-w-[120px] rounded-lg border border-white/[0.06] bg-[#121214] shadow-xl">
+                  {[":99", ":100", ":101", ":102"].map((display) => (
+                    <button
+                      key={display}
+                      onClick={() => {
+                        setDesktopDisplayId(display);
+                        setShowDisplaySelector(false);
+                      }}
+                      className={cn(
+                        "flex w-full items-center px-3 py-2 text-sm font-mono transition-colors hover:bg-white/[0.04]",
+                        desktopDisplayId === display
+                          ? "text-emerald-400"
+                          : "text-white/70"
+                      )}
+                    >
+                      {display}
+                      {desktopDisplayId === display && (
+                        <CheckCircle className="ml-auto h-3.5 w-3.5" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
 
           {/* Status panel */}
           <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1287,11 +1287,13 @@ export default function ControlClient() {
           // Skip if already added with this ID
           if (prev.some((item) => item.id === msgId)) return prev;
 
-          // Check if there's a pending temp message (SSE arrived before API response)
-          // Match by position: find FIRST temp message, since SSE events arrive in server order
-          // which matches the order messages were sent
+          // Check if there's a pending temp message with matching content (SSE arrived before API response)
+          // We verify content to avoid mismatching with messages from other sessions/devices
           const tempIndex = prev.findIndex(
-            (item) => item.kind === "user" && item.id.startsWith("temp-")
+            (item) =>
+              item.kind === "user" &&
+              item.id.startsWith("temp-") &&
+              item.content === msgContent
           );
 
           if (tempIndex !== -1) {
@@ -1301,7 +1303,7 @@ export default function ControlClient() {
             return updated;
           }
 
-          // No temp message found, add new (message came from another client/session)
+          // No matching temp message found, add new (message came from another client/session)
           return [
             ...prev,
             {

--- a/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
@@ -793,7 +793,7 @@ struct ControlView: View {
         messages.append(tempMessage)
         shouldScrollToBottom = true
 
-        Task {
+        Task { @MainActor in
             do {
                 let (messageId, _) = try await api.sendMessage(content: content)
 


### PR DESCRIPTION
## Summary
- Fixed bug where rapid message sends could display in wrong order
- Messages are now added optimistically BEFORE the API call with a temp ID
- Ensures messages always appear in send order, not response order
- Handles edge case where SSE arrives before API response

## Test plan
- [ ] Send multiple messages rapidly in web dashboard
- [ ] Verify messages appear in correct order
- [ ] Test same scenario in iOS app
- [ ] Verify error case properly removes optimistic message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures user messages render in send order and are deduplicated when SSE responses race API returns.
> 
> - Web (`control-client.tsx`): Add optimistic user message with `temp-*` IDs before API call, replace with server ID on success, remove on error; SSE `user_message` now matches by content to replace temp IDs and avoid duplicates; minor refactor to use `msgContent`. 
> - iOS (`ControlView.swift`): Mirror the optimistic send flow with temp IDs, replace on success preserving timestamp; SSE handler replaces matching temp entries by content, otherwise appends.
> - Web UI: Desktop stream control now includes a display selector dropdown and `desktopDisplayId` state (default `":101"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f622903d87e404e2406f45911ea9d707e86baae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->