### PR TITLE
Fix iOS build: use isUser property instead of enum comparison

### DIFF
--- a/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
@@ -1094,7 +1094,7 @@ struct ControlView: View {
                 // Check if there's a pending temp message with matching content (SSE arrived before API response)
                 // We verify content to avoid mismatching with messages from other sessions/devices
                 if let tempIndex = messages.firstIndex(where: {
-                    $0.type == .user && $0.id.hasPrefix("temp-") && $0.content == content
+                    $0.isUser && $0.id.hasPrefix("temp-") && $0.content == content
                 }) {
                     // Replace temp ID with server ID, preserving original timestamp
                     let originalTimestamp = messages[tempIndex].timestamp


### PR DESCRIPTION
## Summary
- Fix Xcode Cloud build failure caused by comparing `ChatMessageType` enum with `==`
- Swift cannot directly compare enums with associated values using `==`
- Use the existing `isUser` computed property which uses pattern matching

## Test plan
- [x] Verify Xcode Cloud build passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix Swift enum comparison causing iOS build failure**
> 
> - In `ControlView.swift` (`handleStreamEvent` for `user_message`), replace `messages.firstIndex(where: { $0.type == .user ... })` with `... { $0.isUser ... }` to avoid direct enum equality on a type that may carry associated values and ensure proper temp-to-server ID reconciliation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c85993e22a53e00ca4ac45613d3093de4278f3c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->