### PR TITLE
Add display selector to iOS dashboard

### DIFF
--- a/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
@@ -38,7 +38,8 @@ struct ControlView: View {
 
     // Desktop stream state
     @State private var showDesktopStream = false
-    @State private var desktopDisplayId = ":99"
+    @State private var desktopDisplayId = ":101"
+    private let availableDisplays = [":99", ":100", ":101", ":102"]
 
     @FocusState private var isInputFocused: Bool
     
@@ -153,11 +154,23 @@ struct ControlView: View {
                         Label("New Mission", systemImage: "plus")
                     }
 
-                    // Desktop stream option in menu too
-                    Button {
-                        showDesktopStream = true
+                    // Desktop stream option with display selector
+                    Menu {
+                        ForEach(availableDisplays, id: \.self) { display in
+                            Button {
+                                desktopDisplayId = display
+                                showDesktopStream = true
+                            } label: {
+                                HStack {
+                                    Text(display)
+                                    if display == desktopDisplayId {
+                                        Image(systemName: "checkmark")
+                                    }
+                                }
+                            }
+                        }
                     } label: {
-                        Label("View Desktop", systemImage: "display")
+                        Label("View Desktop (\(desktopDisplayId))", systemImage: "display")
                     }
 
                     if let mission = viewingMission {

--- a/ios_dashboard/OpenAgentDashboard/Views/Desktop/DesktopStreamView.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Desktop/DesktopStreamView.swift
@@ -243,5 +243,5 @@ struct DesktopStreamView: View {
 // MARK: - Preview
 
 #Preview {
-    DesktopStreamView(displayId: ":99")
+    DesktopStreamView(displayId: ":101")
 }


### PR DESCRIPTION
## Summary
- Change default display from `:99` to `:101` (matching web dashboard)
- Add submenu in toolbar menu to select display (`:99`, `:100`, `:101`, `:102`)
- Shows current display selection in menu label: "View Desktop (:101)"

## Test plan
- [x] Build iOS app
- [ ] Verify display selector appears in toolbar menu
- [ ] Verify selecting a display opens stream with correct display
- [ ] Verify checkmark shows next to selected display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a desktop display selector to the iOS dashboard and updates the default display.
> 
> - Default desktop `displayId` changed from `:99` to `:101` (also in `DesktopStreamView` preview)
> - Introduces `availableDisplays` and a submenu in `ControlView` toolbar to choose `:99`, `:100`, `:101`, or `:102`
> - Selecting a display opens the stream and shows a checkmark for the current selection
> - Menu label now displays the chosen display: `View Desktop (:101)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d056976953d5641cf64cf67b6ed86e5dc6b0b75d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->