### PR TITLE
docs: rebrand to cloud orchestrator, document dual runtime support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open_agent"
 version = "0.2.0"
 edition = "2021"
-description = "Managed control plane for OpenCode-based agents"
+description = "Cloud orchestrator for AI coding agents (Claude Code & OpenCode)"
 authors = ["Open Agent Contributors"]
 
 [dependencies]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -481,7 +481,7 @@ Create `/etc/systemd/system/open_agent.service`:
 
 ```ini
 [Unit]
-Description=OpenAgent (managed control plane)
+Description=OpenAgent (cloud orchestrator)
 After=network-online.target
 Wants=network-online.target
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Open Agent</h1>
 
 <p align="center">
-  <strong>Self-hosted control plane for AI autonomous agents</strong><br/>
-  Isolated Linux workspaces and git-backed Library configuration
+  <strong>Self-hosted cloud orchestrator for AI coding agents</strong><br/>
+  Isolated Linux workspaces with Claude Code & OpenCode runtimes
 </p>
 
 <p align="center">
@@ -43,6 +43,7 @@ What if you could:
 
 ## Features
 
+- **Dual Runtime Support**: Run Claude Code or OpenCode agents in the same infrastructure
 - **Mission Control**: Start, stop, and monitor agents remotely with real-time streaming
 - **Isolated Workspaces**: Containerized Linux environments (systemd-nspawn) with per-mission directories
 - **Git-backed Library**: Skills, tools, rules, agents, and MCPs versioned in a single repo
@@ -53,9 +54,12 @@ What if you could:
 
 ## Ecosystem
 
-Open Agent is a control plane for [**OpenCode**](https://github.com/anomalyco/opencode) and Claude Code. It executes harnesses inside each workspace so native bash and file effects are scoped correctly, while Open Agent handles orchestration, workspace isolation, and configuration management.
+Open Agent orchestrates multiple AI coding agent runtimes:
 
-Works great with [**oh-my-opencode**](https://github.com/code-yeongyu/oh-my-opencode) for enhanced agent capabilities and prebuilt skill packs.
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**: Anthropic's official coding agent with native skills support (`.claude/skills/`)
+- **[OpenCode](https://github.com/anomalyco/opencode)**: Open-source alternative via [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
+
+Each runtime executes inside isolated workspaces, so bash commands and file operations are scoped correctly. Open Agent handles orchestration, workspace isolation, and Library-based configuration management.
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -47,7 +47,8 @@ in the correct workspace without a host-proxy tool.
 - Runs **per workspace** using the Claude CLI.
 - Configuration is written to each workspace:
   - `.claude/settings.local.json` (MCP servers + permissions)
-  - `CLAUDE.md` (generated from Library skills)
+  - `.claude/skills/<name>/SKILL.md` (native skills with YAML frontmatter)
+  - `CLAUDE.md` (general workspace context)
 - Built-in `Bash` is **enabled** in the permissions allowlist.
 
 ## Tool policy
@@ -82,7 +83,8 @@ Files written per mission workspace:
 - `opencode.json` and `.opencode/opencode.json`
 - `.opencode/oh-my-opencode.json` (for OpenCode agents)
 - `.claude/settings.local.json` (for Claude Code)
-- `CLAUDE.md` (skill-based context)
+- `.claude/skills/<name>/SKILL.md` (native Claude Code skills)
+- `CLAUDE.md` (general workspace context)
 
 ## Observability
 

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -18,11 +18,11 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL("https://openagent.thomas.md"),
   title: {
-    default: "Open Agent | Managed Control Plane for AI Agents",
+    default: "Open Agent | Cloud Orchestrator for AI Coding Agents",
     template: "%s | Open Agent",
   },
   description:
-    "Open-source managed control plane for OpenCode-based agents. Mission orchestration, workspace management, and library sync.",
+    "Self-hosted cloud orchestrator for AI coding agents (Claude Code & OpenCode). Mission orchestration, workspace management, and library sync.",
   applicationName: "Open Agent",
   generator: "Next.js",
   keywords: [
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Open Agent",
     description:
-      "Open-source managed control plane for OpenCode-based agents. Mission orchestration, workspace management, and library sync.",
+      "Self-hosted cloud orchestrator for AI coding agents (Claude Code & OpenCode). Mission orchestration, workspace management, and library sync.",
     creator: "@music_music_yo",
     images: ["/og-image.png"],
   },
@@ -57,13 +57,13 @@ export const metadata: Metadata = {
     siteName: "Open Agent",
     title: "Open Agent",
     description:
-      "Open-source managed control plane for OpenCode-based agents. Mission orchestration, workspace management, and library sync.",
+      "Self-hosted cloud orchestrator for AI coding agents (Claude Code & OpenCode). Mission orchestration, workspace management, and library sync.",
     images: [
       {
         url: "/og-image.png",
         width: 1200,
         height: 630,
-        alt: "Open Agent - Managed Control Plane for AI Agents",
+        alt: "Open Agent - Cloud Orchestrator for AI Coding Agents",
       },
     ],
   },

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Open Agent
-description: Self-hosted control plane for autonomous AI agents
+description: Self-hosted cloud orchestrator for AI coding agents
 ---
 
 import { Callout } from 'nextra/components'
@@ -25,11 +25,11 @@ Open Agent fixes all three.
 
 ## What It Actually Does
 
-Open Agent is a control plane that runs on your server. You connect to it from a web dashboard, iOS app, or CLI. You tell an agent what to do. It works until it's done, whether that takes 10 minutes or 10 hours.
+Open Agent is a cloud orchestrator that runs on your server. You connect to it from a web dashboard, iOS app, or CLI. You tell an agent what to do. It works until it's done, whether that takes 10 minutes or 10 hours.
 
 Your code stays on your machine. You define how the agent behaves through a git repo of skills, commands, and rules. Each project gets its own isolated container.
 
-Under the hood, it runs [OpenCode](https://opencode.ai) for the actual agent work. Open Agent handles everything around it: starting tasks, streaming progress, managing environments, syncing configuration.
+Under the hood, it runs [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [OpenCode](https://opencode.ai) for the actual agent work. Open Agent handles everything around it: starting tasks, streaming progress, managing environments, syncing configuration.
 
 ## When To Use This
 
@@ -51,7 +51,7 @@ Container workspaces isolate everything. Your Node project doesn't see your Pyth
 ┌─────────────────────────────────────────────────────────┐
 │                     Your Devices                         │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────┐  │
-│  │ Web Dashboard│  │  iOS App   │  │ Claude Code CLI │  │
+│  │ Web Dashboard│  │  iOS App   │  │       CLI       │  │
 │  └──────┬──────┘  └──────┬──────┘  └────────┬────────┘  │
 └─────────┼────────────────┼──────────────────┼───────────┘
           │                │                  │
@@ -68,7 +68,7 @@ Container workspaces isolate everything. Your Node project doesn't see your Pyth
 │  └──────────────────────┬──────────────────────────┘    │
 │                         │                                │
 │  ┌──────────────────────▼──────────────────────────┐    │
-│  │              OpenCode                            │    │
+│  │          Claude Code / OpenCode                  │    │
 │  │  • Runs the actual agent logic                   │    │
 │  │  • Executes tools, writes code                   │    │
 │  │  • Talks to Claude/GPT/local models              │    │
@@ -76,7 +76,7 @@ Container workspaces isolate everything. Your Node project doesn't see your Pyth
 └─────────────────────────────────────────────────────────┘
 ```
 
-Open Agent doesn't do AI. It manages the infrastructure around AI. OpenCode does the thinking. Open Agent makes sure it has somewhere to run, something to work on, and a way for you to watch.
+Open Agent doesn't do AI. It manages the infrastructure around AI. The runtime (Claude Code or OpenCode) does the thinking. Open Agent makes sure it has somewhere to run, something to work on, and a way for you to watch.
 
 **Note**: The setup guide installs the **backend** on your server. For the dashboard, you have options:
 - **Vercel**: Host the Next.js dashboard for free

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -2,7 +2,7 @@
 # For AI Agents and LLMs
 # https://openagent.thomas.md
 
-> Open Agent is a self-hosted control plane for autonomous AI agents.
+> Open Agent is a self-hosted cloud orchestrator for AI coding agents (Claude Code & OpenCode).
 > Isolated Linux workspaces, git-backed configuration, remote mission control.
 
 ## How to Access Documentation
@@ -51,7 +51,7 @@ Your Devices (Dashboard, iOS, CLI)
 │  └──────────┬──────────┘  │
 │             ▼             │
 │  ┌─────────────────────┐  │
-│  │     OpenCode        │  │  ← Model inference, tool execution
+│  │ Claude Code/OpenCode│  │  ← Model inference, tool execution
 │  └─────────────────────┘  │
 └───────────────────────────┘
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Open Agent Panel
 //!
-//! Managed control plane for OpenCode-based agents.
+//! Cloud orchestrator for AI coding agents (Claude Code & OpenCode).
 //!
 //! This library provides:
 //! - HTTP APIs for missions, workspaces, MCP tooling, and library sync


### PR DESCRIPTION
## Summary
- Changes "control plane" terminology to "cloud orchestrator" throughout the codebase
- Documents Claude Code & OpenCode as dual runtime support
- Updates README Ecosystem section to reflect both runtimes
- Adds documentation for native Claude Code skills format (.claude/skills/)
- Updates architecture diagrams to show both runtimes

## Files Changed
- README.md, CLAUDE.md, agents.md - Core documentation
- Cargo.toml, src/lib.rs - Package description
- INSTALL.md - Service description
- docs-site/* - Website documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Rebrand + dual runtime docs**
> 
> - Replaces "control plane" with "cloud orchestrator" across docs, site metadata, and service descriptions
> - Documents dual runtime support (Claude Code & OpenCode) with updated architecture diagrams and execution flow
> - Adds native Claude Code skills documentation (`.claude/skills/<name>/SKILL.md`) and clarifies per-workspace config sync
> - Updates README Ecosystem/Features, docs-site index/metadata/llms.txt, and project guide (`.claude/CLAUDE.md`, `agents.md`)
> - Refreshes timeout philosophy and entry points to be runtime-agnostic
> - Updates package description in `Cargo.toml` and crate docs in `src/lib.rs`
> 
> **Scope/Risk**
> - Documentation and metadata only; no functional code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5700d4bd6fffa536fab07e5dc2bf0b67a4530064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->