### PR TITLE
feat(ios): enhance tool call display with args, results, and duration tracking

### DIFF
--- a/ios_dashboard/ISSUES.md
+++ b/ios_dashboard/ISSUES.md
@@ -1,0 +1,97 @@
+# iOS Dashboard Issues - Comparison with Web Dashboard
+
+## Fixed Issues
+
+### 1. Tool Call Display - Missing Arguments and Results ✅ FIXED
+**Was:** iOS only shows tool name with a spinner when active, then removes it when done
+**Now:** Shows tool name, arguments preview, duration timer, expandable arguments/results, error detection
+
+**Changes:**
+- Added `ToolCallData` struct in `ChatMessage.swift` to store tool call data
+- Updated `ToolCallBubble` component to show args preview, duration, state indicators
+- Expandable view shows full JSON arguments and results
+
+### 2. Tool Calls Are Removed Instead of Preserved ✅ FIXED
+**Was:** `messages.removeAll { $0.isToolCall && $0.isActiveToolCall }` - removes previous tool when new one starts
+**Now:** Marks previous tool as completed, keeps all tools in history
+
+**Changes:**
+- Updated `tool_call` handler to mark previous active tools as completed instead of removing
+- Updated `assistant_message` handler to preserve completed tool calls
+
+### 3. Missing Tool Results Display ✅ FIXED
+**Was:** `tool_result` event only extracts desktop display ID, ignores actual result content
+**Now:** Stores and displays tool results with error detection
+
+**Changes:**
+- Updated `tool_result` handler to find matching tool call and update its result
+- Added error detection based on result content
+- Shows result in expandable section with error highlighting
+
+### 4. No Tool Duration Tracking ✅ FIXED
+**Was:** No elapsed time shown for tools
+**Now:** Shows "Xs..." with live timer while running, then final duration when done
+
+**Changes:**
+- Added `startTime` and `endTime` to `ToolCallData`
+- Added timer in `ToolCallBubble` that updates every second
+- Shows formatted duration in collapsed and expanded views
+
+### 5. Missing `mission_status_changed` Event Handler ✅ FIXED
+**Was:** Not handled
+**Now:** Updates mission status, marks pending tools as cancelled when mission ends
+
+**Changes:**
+- Added `mission_status_changed` case to `handleStreamEvent`
+- Marks all active tools as cancelled when mission ends
+- Updates viewing/current mission status
+- Triggers refresh of running missions
+
+### 6. No Stall Detection ✅ ALREADY EXISTED
+**Was:** Previously implemented in `RunningMissionsBar`
+**Now:** Shows warning after 60+ seconds of no activity with amber/red indicators
+
+### 7. Missing Tool Arguments in Event Data ✅ FIXED
+**Was:** Tool args parsed but only used for ToolUI parsing
+**Now:** Stored in `ToolCallData` and displayed in UI
+
+### 12. Running Missions Bar Missing Queue Info ✅ FIXED
+**Was:** Shows state indicator only
+**Now:** Also shows queue length indicator (e.g., "2Q")
+
+**Changes:**
+- Added queue length display to `runningMissionChip` in `RunningMissionsBar.swift`
+
+### 15. No Error State Distinction in Tools ✅ FIXED
+**Was:** No visual distinction for errors
+**Now:** Red highlighting for error results, amber for cancelled, green for success
+
+**Changes:**
+- Added `ToolCallState` enum with running/success/error/cancelled states
+- Color-coded borders, icons, and text based on state
+
+## Remaining Issues (Lower Priority)
+
+### 8. History View Missing Tool Information
+When loading mission history, tool calls aren't extracted from events.
+Could add parsing of tool_call/tool_result from stored history.
+
+### 9. No Tool Grouping/Collapsing
+Dashboard groups consecutive tools with "Show X previous tools" toggle.
+Could add grouping logic for cleaner conversation view.
+
+### 10. Missing Image Extraction from Tool Results
+Dashboard extracts image paths from screenshot tool results.
+`ToolCallData.imagePaths` is implemented but preview not yet displayed.
+
+### 11. No JSON Syntax Highlighting
+Dashboard uses syntax highlighter for JSON args/results.
+Currently showing plain monospaced text.
+
+### 13. No Copy Functionality for Tool Data
+Dashboard allows copying tool args/results.
+Could add long-press to copy.
+
+### 14. Missing Model Info in Status Bar During Execution
+Dashboard shows current model being used during execution.
+Status bar shows "Running" but not which model.

--- a/ios_dashboard/OpenAgentDashboard/Models/ChatMessage.swift
+++ b/ios_dashboard/OpenAgentDashboard/Models/ChatMessage.swift
@@ -71,6 +71,130 @@ enum SharedFileKind: String, Codable {
     }
 }
 
+// MARK: - Tool Call State
+
+/// State of a tool call (tracks lifecycle from start to completion)
+enum ToolCallState {
+    case running
+    case success
+    case error
+    case cancelled
+
+    var isComplete: Bool {
+        switch self {
+        case .running: return false
+        case .success, .error, .cancelled: return true
+        }
+    }
+}
+
+// MARK: - Tool Call Data
+
+/// Data associated with a tool call, including arguments, result, and timing
+struct ToolCallData {
+    let toolCallId: String
+    let name: String
+    let args: [String: Any]
+    let startTime: Date
+    var endTime: Date?
+    var result: Any?
+    var state: ToolCallState
+
+    /// Format args as JSON string for display
+    var argsString: String {
+        formatAsJSON(args)
+    }
+
+    /// Format result as JSON string for display
+    var resultString: String? {
+        guard let result = result else { return nil }
+        if let dict = result as? [String: Any] {
+            return formatAsJSON(dict)
+        } else if let str = result as? String {
+            return str
+        } else {
+            return String(describing: result)
+        }
+    }
+
+    /// Check if result indicates an error
+    var isErrorResult: Bool {
+        guard let result = result else { return false }
+
+        // Check dictionary error indicators
+        if let dict = result as? [String: Any] {
+            if dict["error"] != nil { return true }
+            if dict["is_error"] as? Bool == true { return true }
+            if dict["success"] as? Bool == false { return true }
+        }
+
+        // Check string error patterns
+        if let str = resultString?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            if str.hasPrefix("error:") || str.hasPrefix("error -") ||
+               str.hasPrefix("failed:") || str.hasPrefix("exception:") {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /// Duration in seconds (ongoing or final)
+    var duration: TimeInterval {
+        let end = endTime ?? Date()
+        return end.timeIntervalSince(startTime)
+    }
+
+    /// Formatted duration string
+    var durationFormatted: String {
+        let seconds = Int(duration)
+        if seconds <= 0 { return "<1s" }
+        if seconds < 60 { return "\(seconds)s" }
+        let mins = seconds / 60
+        let secs = seconds % 60
+        return secs > 0 ? "\(mins)m \(secs)s" : "\(mins)m"
+    }
+
+    /// Preview of arguments (truncated)
+    var argsPreview: String {
+        let keys = args.keys.prefix(2).joined(separator: ", ")
+        let preview = keys.isEmpty ? "" : keys
+        return preview.count > 50 ? String(preview.prefix(47)) + "..." : preview
+    }
+
+    /// Extract image paths from result (for screenshot tools)
+    var imagePaths: [String] {
+        guard let str = resultString else { return [] }
+        // Match common image file patterns
+        let pattern = #"/[\w/.-]+\.(png|jpg|jpeg|gif|webp|bmp|svg)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return []
+        }
+        let range = NSRange(str.startIndex..., in: str)
+        let matches = regex.matches(in: str, options: [], range: range)
+        return matches.compactMap { match in
+            guard let range = Range(match.range, in: str) else { return nil }
+            return String(str[range])
+        }
+    }
+
+    /// Check if this tool produces images (screenshots, captures, etc.)
+    var isImageProducingTool: Bool {
+        let lower = name.lowercased()
+        return lower.contains("screenshot") || lower.contains("capture") ||
+               lower.contains("desktop_screenshot") || lower.contains("browser_take_screenshot")
+    }
+
+    private func formatAsJSON(_ dict: [String: Any]) -> String {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys])
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            return "{}"
+        }
+    }
+}
+
 // MARK: - Chat Message Type
 
 enum ChatMessageType {
@@ -89,13 +213,15 @@ struct ChatMessage: Identifiable {
     let type: ChatMessageType
     var content: String
     var toolUI: ToolUIContent?
+    var toolData: ToolCallData?
     let timestamp: Date
-    
-    init(id: String = UUID().uuidString, type: ChatMessageType, content: String, toolUI: ToolUIContent? = nil, timestamp: Date = Date()) {
+
+    init(id: String = UUID().uuidString, type: ChatMessageType, content: String, toolUI: ToolUIContent? = nil, toolData: ToolCallData? = nil, timestamp: Date = Date()) {
         self.id = id
         self.type = type
         self.content = content
         self.toolUI = toolUI
+        self.toolData = toolData
         self.timestamp = timestamp
     }
     

--- a/ios_dashboard/OpenAgentDashboard/Views/Components/RunningMissionsBar.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Components/RunningMissionsBar.swift
@@ -151,6 +151,17 @@ struct RunningMissionsBar: View {
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
 
+                    // Queue indicator
+                    if mission.queueLen > 0 {
+                        Text("\(mission.queueLen)Q")
+                            .font(.system(size: 9, weight: .medium).monospaced())
+                            .foregroundStyle(Theme.warning)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Theme.warning.opacity(0.15))
+                            .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                    }
+
                     // Stalled indicator
                     if isStalled {
                         HStack(spacing: 2) {

--- a/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/OpenAgentDashboard/Views/Control/ControlView.swift
@@ -1288,8 +1288,31 @@ struct ControlView: View {
                     }
                 }
 
-                // Remove any incomplete thinking messages, phase messages, and active tool calls
-                messages.removeAll { ($0.isThinking && !$0.thinkingDone) || $0.isPhase || ($0.isToolCall && $0.isActiveToolCall) }
+                // Remove any incomplete thinking messages and phase messages
+                // Mark active tool calls as completed instead of removing them
+                messages.removeAll { ($0.isThinking && !$0.thinkingDone) || $0.isPhase }
+
+                // Mark any remaining active tool calls as completed
+                for i in messages.indices {
+                    if messages[i].isToolCall && messages[i].isActiveToolCall {
+                        if var toolData = messages[i].toolData {
+                            toolData.endTime = Date()
+                            if toolData.result == nil {
+                                toolData.state = .success // Assume success if no result yet
+                            }
+                            messages[i].toolData = toolData
+                        }
+                        if let name = messages[i].toolCallName {
+                            messages[i] = ChatMessage(
+                                id: messages[i].id,
+                                type: .toolCall(name: name, isActive: false),
+                                content: messages[i].content,
+                                toolData: messages[i].toolData,
+                                timestamp: messages[i].timestamp
+                            )
+                        }
+                    }
+                }
 
                 let message = ChatMessage(
                     id: id,
@@ -1394,25 +1417,92 @@ struct ControlView: View {
                     )
                     messages.append(message)
                 } else {
-                    // Non-UI tool call: replace the previous active tool indicator
-                    // to show only the latest tool being used
-                    messages.removeAll { $0.isToolCall && $0.isActiveToolCall }
+                    // Mark any previous active tool calls as completed (success by default, will update if error)
+                    for i in messages.indices {
+                        if messages[i].isToolCall && messages[i].isActiveToolCall {
+                            if var toolData = messages[i].toolData {
+                                toolData.endTime = Date()
+                                toolData.state = .success
+                                messages[i].toolData = toolData
+                            }
+                            // Update the type to mark as not active
+                            if let name = messages[i].toolCallName {
+                                messages[i] = ChatMessage(
+                                    id: messages[i].id,
+                                    type: .toolCall(name: name, isActive: false),
+                                    content: messages[i].content,
+                                    toolData: messages[i].toolData,
+                                    timestamp: messages[i].timestamp
+                                )
+                            }
+                        }
+                    }
+
+                    // Create tool call data for tracking
+                    let toolData = ToolCallData(
+                        toolCallId: toolCallId,
+                        name: name,
+                        args: args,
+                        startTime: Date(),
+                        endTime: nil,
+                        result: nil,
+                        state: .running
+                    )
+
                     let message = ChatMessage(
                         id: "tool-\(toolCallId)",
                         type: .toolCall(name: name, isActive: true),
-                        content: ""
+                        content: "",
+                        toolData: toolData
                     )
                     messages.append(message)
                 }
             }
 
         case "tool_result":
-            if let name = data["name"] as? String {
+            if let toolCallId = data["tool_call_id"] as? String {
+                let result = data["result"]
+                let name = data["name"] as? String ?? ""
+
+                // Find the matching tool call message and update it
+                if let index = messages.firstIndex(where: { $0.id == "tool-\(toolCallId)" }) {
+                    if var toolData = messages[index].toolData {
+                        toolData.endTime = Date()
+                        toolData.result = result
+
+                        // Determine state based on result
+                        if let resultDict = result as? [String: Any] {
+                            if resultDict["status"] as? String == "cancelled" {
+                                toolData.state = .cancelled
+                            } else if toolData.isErrorResult {
+                                toolData.state = .error
+                            } else {
+                                toolData.state = .success
+                            }
+                        } else if toolData.isErrorResult {
+                            toolData.state = .error
+                        } else {
+                            toolData.state = .success
+                        }
+
+                        messages[index].toolData = toolData
+                        // Update the type to mark as not active
+                        messages[index] = ChatMessage(
+                            id: messages[index].id,
+                            type: .toolCall(name: toolData.name, isActive: false),
+                            content: messages[index].content,
+                            toolData: toolData,
+                            timestamp: messages[index].timestamp
+                        )
+                    }
+                }
+
                 // Extract display ID from desktop_start_session tool result
-                if name == "desktop_start_session" || name == "desktop_desktop_start_session" {
+                if name == "desktop_start_session" || name == "desktop_desktop_start_session" ||
+                   name.contains("desktop_start_session") {
                     // Handle result as either a dictionary or a JSON string
-                    var resultDict: [String: Any]? = data["result"] as? [String: Any]
-                    if resultDict == nil, let resultString = data["result"] as? String,
+                    var resultDict: [String: Any]? = result as? [String: Any]
+                    if resultDict == nil, let resultString = result as? String,
                        let jsonData = resultString.data(using: .utf8),
                        let parsed = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
                         resultDict = parsed
@@ -1423,6 +1513,49 @@ struct ControlView: View {
                         showDesktopStream = true
                     }
                 }
+            }
+
+        case "mission_status_changed":
+            // Handle mission status changes (e.g., completed, failed, interrupted)
+            if let statusStr = data["status"] as? String,
+               let missionId = data["mission_id"] as? String {
+                let newStatus = MissionStatus(rawValue: statusStr)
+
+                // If mission is no longer active, mark all pending tools as cancelled
+                if newStatus != .active {
+                    for i in messages.indices {
+                        if messages[i].isToolCall && messages[i].isActiveToolCall {
+                            if var toolData = messages[i].toolData {
+                                toolData.endTime = Date()
+                                toolData.state = .cancelled
+                                messages[i].toolData = toolData
+                            }
+                            // Update the type to mark as not active
+                            if let name = messages[i].toolCallName {
+                                messages[i] = ChatMessage(
+                                    id: messages[i].id,
+                                    type: .toolCall(name: name, isActive: false),
+                                    content: messages[i].content,
+                                    toolData: messages[i].toolData,
+                                    timestamp: messages[i].timestamp
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Update the viewing mission status if it matches
+                if viewingMissionId == missionId {
+                    viewingMission?.status = newStatus ?? .active
+                }
+
+                // Update the current mission status if it matches
+                if currentMission?.id == missionId {
+                    currentMission?.status = newStatus ?? .active
+                }
+
+                // Refresh running missions list
+                Task { await refreshRunningMissions() }
             }
 
         default:
@@ -1799,45 +1932,218 @@ private struct PhaseBubble: View {
     }
 }
 
-// MARK: - Tool Call Bubble
+// MARK: - Tool Call Bubble (Enhanced)
 
 private struct ToolCallBubble: View {
     let message: ChatMessage
+    @State private var isExpanded = false
+    @State private var elapsedSeconds: Int = 0
+    @State private var timerTask: Task<Void, Never>?
+
+    private var toolData: ToolCallData? {
+        message.toolData
+    }
+
+    private var isRunning: Bool {
+        toolData?.state == .running
+    }
+
+    private var stateColor: Color {
+        guard let state = toolData?.state else {
+            return message.isActiveToolCall ? Theme.warning : Theme.textMuted
+        }
+        switch state {
+        case .running: return Theme.warning
+        case .success: return Theme.success
+        case .error: return Theme.error
+        case .cancelled: return Theme.warning
+        }
+    }
+
+    private var stateIcon: String {
+        guard let state = toolData?.state else {
+            return message.isActiveToolCall ? "circle.fill" : "checkmark.circle.fill"
+        }
+        switch state {
+        case .running: return "circle.fill"
+        case .success: return "checkmark.circle.fill"
+        case .error: return "xmark.circle.fill"
+        case .cancelled: return "xmark.circle.fill"
+        }
+    }
 
     var body: some View {
         if let name = message.toolCallName {
-            HStack(spacing: 8) {
-                Image(systemName: toolIcon(for: name))
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.textSecondary)
-                    .frame(width: 24, height: 24)
-                    .background(Theme.backgroundTertiary)
-                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            VStack(alignment: .leading, spacing: 0) {
+                // Compact header button
+                Button {
+                    withAnimation(.spring(duration: 0.25)) {
+                        isExpanded.toggle()
+                    }
+                    HapticService.selectionChanged()
+                } label: {
+                    HStack(spacing: 6) {
+                        // Tool icon
+                        Image(systemName: toolIcon(for: name))
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(stateColor)
+                            .frame(width: 18, height: 18)
+                            .background(stateColor.opacity(0.15))
+                            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
 
-                Text(name)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(Theme.textSecondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                        // Tool name
+                        Text(name)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(Theme.accent)
+                            .lineLimit(1)
 
-                Spacer()
+                        // Args preview
+                        if let preview = toolData?.argsPreview, !preview.isEmpty {
+                            Text("(\(preview))")
+                                .font(.caption2)
+                                .foregroundStyle(Theme.textMuted)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
 
-                if message.isActiveToolCall {
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .scaleEffect(0.6)
-                        .tint(Theme.textMuted)
+                        Spacer()
+
+                        // Duration
+                        if let data = toolData {
+                            Text(isRunning ? "\(formattedElapsed)..." : data.durationFormatted)
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(Theme.textMuted)
+                        }
+
+                        // State indicator
+                        if isRunning {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .scaleEffect(0.5)
+                                .tint(stateColor)
+                        } else {
+                            Image(systemName: stateIcon)
+                                .font(.system(size: 12))
+                                .foregroundStyle(stateColor)
+                        }
+
+                        // Chevron
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(Theme.textMuted)
+                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(stateColor.opacity(0.05))
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule()
+                            .stroke(stateColor.opacity(0.2), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+
+                // Expandable content
+                if isExpanded {
+                    VStack(alignment: .leading, spacing: 10) {
+                        // Arguments section
+                        if let data = toolData, !data.args.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Arguments")
+                                    .font(.caption2)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(Theme.textMuted)
+                                    .textCase(.uppercase)
+
+                                ScrollView(.horizontal, showsIndicators: false) {
+                                    Text(data.argsString)
+                                        .font(.caption.monospaced())
+                                        .foregroundStyle(Theme.textSecondary)
+                                        .padding(8)
+                                        .background(Theme.backgroundTertiary.opacity(0.5))
+                                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                                }
+                                .frame(maxHeight: 120)
+                            }
+                        }
+
+                        // Result section
+                        if let data = toolData, let resultStr = data.resultString {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(data.isErrorResult ? "Error" : "Result")
+                                    .font(.caption2)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(data.isErrorResult ? Theme.error : Theme.success)
+                                    .textCase(.uppercase)
+
+                                ScrollView(.horizontal, showsIndicators: false) {
+                                    Text(resultStr)
+                                        .font(.caption.monospaced())
+                                        .foregroundStyle(data.isErrorResult ? Theme.error : Theme.textSecondary)
+                                        .padding(8)
+                                        .background((data.isErrorResult ? Theme.error : Theme.backgroundTertiary).opacity(0.1))
+                                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                                }
+                                .frame(maxHeight: 120)
+                            }
+                        }
+
+                        // Still running indicator
+                        if isRunning {
+                            HStack(spacing: 6) {
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                    .scaleEffect(0.5)
+                                    .tint(Theme.warning)
+                                Text("Running for \(formattedElapsed)...")
+                                    .font(.caption2)
+                                    .foregroundStyle(Theme.warning)
+                            }
+                        }
+                    }
+                    .padding(.top, 8)
+                    .padding(.horizontal, 4)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(.ultraThinMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Theme.textMuted.opacity(0.15), lineWidth: 1)
-            )
-            .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            .animation(.spring(duration: 0.25), value: isExpanded)
+            .onAppear {
+                if isRunning {
+                    startTimer()
+                }
+            }
+            .onDisappear {
+                timerTask?.cancel()
+            }
+            .onChange(of: isRunning) { _, running in
+                if running {
+                    startTimer()
+                } else {
+                    timerTask?.cancel()
+                }
+            }
+        }
+    }
+
+    private var formattedElapsed: String {
+        if elapsedSeconds <= 0 { return "<1s" }
+        if elapsedSeconds < 60 { return "\(elapsedSeconds)s" }
+        let mins = elapsedSeconds / 60
+        let secs = elapsedSeconds % 60
+        return secs > 0 ? "\(mins)m \(secs)s" : "\(mins)m"
+    }
+
+    private func startTimer() {
+        timerTask?.cancel()
+        elapsedSeconds = Int(toolData?.duration ?? 0)
+        timerTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                if !Task.isCancelled {
+                    elapsedSeconds = Int(toolData?.duration ?? 0)
+                }
+            }
         }
     }
 
@@ -1855,6 +2161,10 @@ private struct ToolCallBubble: View {
             return "chevron.left.forwardslash.chevron.right"
         } else if lower.contains("task") || lower.contains("agent") || lower.contains("subagent") {
             return "person.2"
+        } else if lower.contains("desktop") || lower.contains("screenshot") {
+            return "display"
+        } else if lower.contains("todo") {
+            return "checklist"
         } else {
             return "wrench"
         }


### PR DESCRIPTION
## Summary
Major improvements to iOS dashboard to match web dashboard functionality for tool call display.

## Changes

### Tool Call Display
- Add `ToolCallData` struct to store tool call arguments, results, timing
- Add `ToolCallState` enum (running/success/error/cancelled) for visual feedback
- Update `ToolCallBubble` to show:
  - Tool name with color-coded icon based on state
  - Arguments preview in collapsed view
  - Live duration timer while running, final duration when complete
  - Expandable section showing full JSON args and results
  - Error detection with red highlighting
  - Cancelled state with amber indicators

### Event Handling
- `tool_call`: Store full args, mark previous tools as complete (not remove)
- `tool_result`: Match to tool call, store result, detect errors
- `mission_status_changed`: Mark active tools as cancelled when mission ends
- `assistant_message`: Preserve completed tool calls in history

### Running Missions Bar
- Add queue length indicator showing "XQ" when messages queued

## Before vs After

**Before:** iOS only showed tool name with spinner while running, then completely removed tool calls when done. Users couldn't see what tools were used or their results.

**After:** Tool calls remain visible in the conversation with:
- Arguments preview (e.g., "Bash (command, timeout)")
- Duration tracking (e.g., "5s" while running, "12s" when complete)
- Success/error/cancelled state indicators
- Expandable view with full JSON args and results
- Error detection with red highlighting

## Test plan
- [ ] Create a new mission and observe tool calls appearing with arguments preview
- [ ] Verify duration timer updates every second while tool is running
- [ ] Expand a completed tool to see full arguments and results
- [ ] Verify error results show with red highlighting
- [ ] Cancel a mission and verify active tools are marked as cancelled
- [ ] Verify queue indicator appears in running missions bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SSE event handling and chat rendering logic; incorrect matching/state transitions could mislabel tool outcomes or leave tools stuck in the wrong state, though changes are UI-focused and local to the dashboard.
> 
> **Overview**
> Brings iOS tool-call UX closer to the web dashboard by **persisting tool calls in the chat timeline** and enriching them with structured metadata (arguments, results, timing) via new `ToolCallData`/`ToolCallState` attached to `ChatMessage`.
> 
> Updates streaming event handling so `tool_call` no longer removes prior tool entries, `tool_result` backfills the matching tool call with result + success/error/cancelled state, `assistant_message` finalizes any still-active tools, and a new `mission_status_changed` handler cancels pending tools when missions end.
> 
> Revamps the tool-call bubble UI to show an args preview, live duration timer, color-coded status, and an expandable view for full JSON arguments/results; `RunningMissionsBar` now shows queue length (e.g., `2Q`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b2f2050d52fc2862364f975a5c3d022ecfb6639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->