### PR TITLE
refactor(library): drop legacy directory backward compatibility

### DIFF
--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -122,6 +122,7 @@ pub struct WorkspaceResponse {
     pub init_script: Option<String>,
     pub shared_network: Option<bool>,
     pub mcps: Vec<String>,
+    pub config_profile: Option<String>,
 }
 
 impl From<Workspace> for WorkspaceResponse {
@@ -144,6 +145,7 @@ impl From<Workspace> for WorkspaceResponse {
             init_script: w.init_script,
             shared_network: w.shared_network,
             mcps: w.mcps,
+            config_profile: w.config_profile,
         }
     }
 }
@@ -365,6 +367,11 @@ async fn create_workspace(
             .unwrap_or_default()
     };
 
+    // Config profile from template
+    let config_profile = template_data
+        .as_ref()
+        .and_then(|t| t.config_profile.clone());
+
     let mut workspace = match workspace_type {
         WorkspaceType::Host => Workspace {
             id: Uuid::new_v4(),
@@ -385,6 +392,7 @@ async fn create_workspace(
             plugins: req.plugins,
             shared_network,
             mcps: mcps.clone(),
+            config_profile: config_profile.clone(),
         },
         WorkspaceType::Container => {
             let mut ws = Workspace::new_container(req.name, path);
@@ -398,6 +406,7 @@ async fn create_workspace(
             ws.init_script = init_script;
             ws.shared_network = shared_network;
             ws.mcps = mcps;
+            ws.config_profile = config_profile;
             ws
         }
     };

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -153,6 +153,10 @@ pub struct Workspace {
     /// Non-empty = allowlist of MCP names.
     #[serde(default)]
     pub mcps: Vec<String>,
+    /// Config profile to use for this workspace (from workspace template).
+    /// Defaults to "default" if not specified.
+    #[serde(default)]
+    pub config_profile: Option<String>,
 }
 
 impl Workspace {
@@ -177,6 +181,7 @@ impl Workspace {
             plugins: Vec::new(),
             shared_network: None,
             mcps: Vec::new(),
+            config_profile: None,
         }
     }
 
@@ -197,6 +202,7 @@ impl Workspace {
             init_script: None,
             created_at: Utc::now(),
             skills: Vec::new(),
+            config_profile: None,
             tools: Vec::new(),
             plugins: Vec::new(),
             shared_network: None,
@@ -391,6 +397,7 @@ impl WorkspaceStore {
                     plugins: Vec::new(),
                     shared_network: None, // Default to shared network
                     mcps: Vec::new(),
+                    config_profile: None,
                 };
 
                 orphaned.push(workspace);


### PR DESCRIPTION
- Remove OPENCODE_DIR, OPENAGENT_DIR, CLAUDECODE_DIR constants
- Simplify legacy config methods to delegate to profile methods (default profile)
- Remove backward compatibility fallbacks from profile-specific methods
- Add config_profile field to Workspace struct
- Propagate workspace config_profile from workspace template to workspace creation
- Update resolve_claudecode_default_model to accept profile parameter
- Add config_profile to WorkspaceResponse API type

When creating a workspace from a template, the workspace now inherits the template's config_profile. When starting a mission with Claude Code backend, the model is resolved from the workspace's config profile instead of always using the default profile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for existing installs that relied on legacy `opencode/`, `openagent/`, or `claudecode/` directories; they will no longer be read unless migrated into `configs/default`. Also adds a new field to workspace API responses and changes Claude Code model selection based on workspace state.
> 
> **Overview**
> **Config profiles are now the sole source of truth for library settings.** Legacy directory constants and backward-compat fallbacks were removed; top-level `get_*`/`save_*` helpers now simply delegate to the `configs/{profile}` implementations (defaulting to `default`).
> 
> **Workspaces gain an explicit `config_profile`.** Workspace templates can set a `config_profile`, it is persisted on the `Workspace` model and returned via `WorkspaceResponse`, and Claude Code default model resolution in both control and mission runner paths now selects the model from the workspace’s profile (with improved warning logs including the profile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c1922920337488fb1b8d472fdfec2dc71b8027f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->