### PR TITLE
fix: add timeout detection for stalled missions with better error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandboxed_sh"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Self-hosted orchestrator for AI coding agents (formerly Open Agent)"
 authors = ["sandboxed.sh Contributors"]

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ isolation, and Library-based configuration management.
 ### Docker (recommended for most users)
 
 ```bash
-git clone https://github.com/Th0rgal/sandboxed-sh.git
+git clone https://github.com/Th0rgal/sandboxed.sh.git
 cd sandboxed-sh
 cp .env.example .env
 # Edit .env with your settings

--- a/agents.md
+++ b/agents.md
@@ -1,5 +1,15 @@
 # Agents and Execution Architecture
 
+> **⚠️ Debugging Issues?** Before investigating any runtime problems, **always
+> read [DEBUGGING.md](DEBUGGING.md) first**. It contains:
+> - Remote server SSH access (Thomas/Ben servers)
+> - Systemd service management commands
+> - Log viewing and common troubleshooting steps
+> - Deployment procedures
+>
+> The dashboard typically runs locally but connects to **remote backends**. Debug
+> on the server, not locally.
+
 This document describes how Sandboxed.sh executes missions after the per-workspace
 harness refactor ("ralph" plan). The core change: **OpenCode and Claude Code run
 inside the target workspace**, so native bash and file effects are scoped to the

--- a/agents.md
+++ b/agents.md
@@ -10,6 +10,18 @@
 > The dashboard typically runs locally but connects to **remote backends**. Debug
 > on the server, not locally.
 
+> **⚠️ IMPORTANT: Format Check Before Pushing**
+>
+> **ALWAYS run `cargo fmt --all` before committing Rust code changes!**
+>
+> The CI pipeline will fail if code is not properly formatted. To check locally:
+> ```bash
+> cargo fmt --all --check  # Check if formatting is needed
+> cargo fmt --all          # Apply formatting
+> ```
+>
+> Make this part of your pre-commit routine to avoid CI failures.
+
 This document describes how Sandboxed.sh executes missions after the per-workspace
 harness refactor ("ralph" plan). The core change: **OpenCode and Claude Code run
 inside the target workspace**, so native bash and file effects are scoped to the

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,6 +1,6 @@
-# OpenAgent Dashboard
+# Sandboxed.sh Dashboard
 
-Developer-focused UI for monitoring and controlling the OpenAgent backend.
+Developer-focused UI for monitoring and controlling the Sandboxed.sh backend.
 
 ## Prerequisites
 - **Bun** (required): `bun@1.x`

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "packageManager": "bun@1.3.4",
   "scripts": {

--- a/dashboard/src/app/config/settings/page.tsx
+++ b/dashboard/src/app/config/settings/page.tsx
@@ -48,7 +48,7 @@ const HARNESS_CONFIG = {
     ],
   },
   openagent: {
-    name: 'OpenAgent',
+    name: 'Sandboxed.sh',
     dir: '.openagent',
     libraryDir: 'openagent',
     files: [

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -18,8 +18,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "OpenAgent Dashboard",
-  description: "Monitor and control your OpenCode agents",
+  title: "Sandboxed.sh",
+  description: "Autonomous coding agents in isolated environments",
   icons: {
     icon: "/favicon.svg",
   },

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
 import { toast } from '@/components/toast';
 import { StatsCard } from '@/components/stats-card';
@@ -130,8 +130,20 @@ function CompactMissionCard({
 
 export default function OverviewPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [creatingMission, setCreatingMission] = useState(false);
   const hasShownErrorRef = useRef(false);
+
+  // Check if we should auto-open the new mission dialog (e.g., from workspaces page)
+  const initialWorkspaceId = searchParams.get('workspace');
+  const shouldAutoOpen = Boolean(initialWorkspaceId);
+
+  // Clear URL params when dialog closes
+  const handleDialogClose = useCallback(() => {
+    if (initialWorkspaceId) {
+      router.replace('/', { scroll: false });
+    }
+  }, [initialWorkspaceId, router]);
 
   // SWR: poll stats every 3 seconds
   const { data: stats, isLoading: statsLoading, error: statsError } = useSWR(
@@ -296,6 +308,9 @@ export default function OverviewPage() {
             workspaces={workspaces}
             disabled={creatingMission}
             onCreate={handleNewMission}
+            autoOpen={shouldAutoOpen}
+            initialValues={initialWorkspaceId ? { workspaceId: initialWorkspaceId } : undefined}
+            onClose={handleDialogClose}
           />
         </div>
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
@@ -128,7 +128,7 @@ function CompactMissionCard({
   );
 }
 
-export default function OverviewPage() {
+function OverviewPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [creatingMission, setCreatingMission] = useState(false);
@@ -403,5 +403,13 @@ export default function OverviewPage() {
         <RecentTasks />
       </div>
     </div>
+  );
+}
+
+export default function OverviewPage() {
+  return (
+    <Suspense fallback={<div className="flex h-screen items-center justify-center"><Loader className="h-6 w-6 animate-spin text-white/50" /></div>}>
+      <OverviewPageContent />
+    </Suspense>
   );
 }

--- a/dashboard/src/app/settings/system/page.tsx
+++ b/dashboard/src/app/settings/system/page.tsx
@@ -106,7 +106,7 @@ export default function SystemSettingsPage() {
         <div className="mb-8">
           <h1 className="text-2xl font-semibold text-white">System</h1>
           <p className="mt-1 text-sm text-white/50">
-            OpenAgent server connection settings
+            Server connection settings
           </p>
         </div>
 

--- a/dashboard/src/app/workspaces/page.tsx
+++ b/dashboard/src/app/workspaces/page.tsx
@@ -39,6 +39,7 @@ import {
   Save,
   Bookmark,
   Sparkles,
+  Play,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/components/toast';
@@ -1013,12 +1014,25 @@ export default function WorkspacesPage() {
 
             {/* Footer */}
             <div className="px-6 py-4 border-t border-white/[0.06] flex items-center justify-between gap-4">
-              <button
-                onClick={() => setSelectedWorkspace(null)}
-                className="text-sm text-white/50 hover:text-white/80 transition-colors"
-              >
-                Close
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setSelectedWorkspace(null)}
+                  className="text-sm text-white/50 hover:text-white/80 transition-colors"
+                >
+                  Close
+                </button>
+                {selectedWorkspace.status === 'ready' && (
+                  <button
+                    onClick={() => {
+                      router.push(`/console?workspace=${selectedWorkspace.id}&name=${encodeURIComponent(selectedWorkspace.name)}`);
+                    }}
+                    className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-white/[0.06] hover:bg-white/[0.1] rounded-lg transition-colors"
+                  >
+                    <Terminal className="h-3.5 w-3.5" />
+                    Shell
+                  </button>
+                )}
+              </div>
               <div className="flex items-center gap-2">
                 {selectedWorkspace.id !== DEFAULT_WORKSPACE_ID && (
                   <button
@@ -1046,12 +1060,12 @@ export default function WorkspacesPage() {
                 {selectedWorkspace.status === 'ready' && (
                   <button
                     onClick={() => {
-                      router.push(`/console?workspace=${selectedWorkspace.id}&name=${encodeURIComponent(selectedWorkspace.name)}`);
+                      router.push(`/?workspace=${selectedWorkspace.id}`);
                     }}
                     className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 rounded-lg transition-colors"
                   >
-                    <Terminal className="h-3.5 w-3.5" />
-                    Shell
+                    <Play className="h-3.5 w-3.5" />
+                    Start Mission
                   </button>
                 )}
               </div>

--- a/dashboard/src/app/workspaces/page.tsx
+++ b/dashboard/src/app/workspaces/page.tsx
@@ -457,15 +457,15 @@ export default function WorkspacesPage() {
         </button>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {workspaces.length === 0 ? (
-          <div className="col-span-full p-12 text-center">
-            <Server className="h-12 w-12 text-white/20 mx-auto mb-4" />
-            <p className="text-white/40">No workspaces yet</p>
-            <p className="text-sm text-white/30 mt-1">Create a workspace to get started</p>
-          </div>
-        ) : (
-          workspaces.map((workspace) => (
+      {workspaces.length === 0 ? (
+        <div className="flex flex-col items-center justify-center min-h-[calc(100vh-12rem)]">
+          <Server className="h-12 w-12 text-white/20 mb-4" />
+          <p className="text-white/40">No workspaces yet</p>
+          <p className="text-sm text-white/30 mt-1">Create a workspace to get started</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {workspaces.map((workspace) => (
             <div
               key={workspace.id}
               className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.06] hover:border-white/[0.12] transition-colors cursor-pointer"
@@ -520,9 +520,9 @@ export default function WorkspacesPage() {
                 </div>
               </div>
             </div>
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
 
       {/* Workspace Details Modal */}
       {selectedWorkspace && (

--- a/dashboard/src/app/workspaces/page.tsx
+++ b/dashboard/src/app/workspaces/page.tsx
@@ -312,11 +312,20 @@ export default function WorkspacesPage() {
 
   const handleDeleteWorkspace = async (id: string, name: string) => {
     if (!confirm(`Delete workspace "${name}"?`)) return;
+
+    // Optimistically remove from UI immediately
+    mutateWorkspaces(
+      (current) => current?.filter((w) => w.id !== id),
+      { revalidate: false }
+    );
+    setSelectedWorkspace(null);
+
     try {
       await deleteWorkspace(id);
-      setSelectedWorkspace(null);
-      await mutateWorkspaces();
+      showInfo(`Workspace "${name}" deleted`);
     } catch (err) {
+      // Rollback: refetch to restore the workspace
+      mutateWorkspaces();
       showError(err instanceof Error ? err.message : 'Failed to delete workspace');
     }
   };

--- a/dashboard/src/components/icons/BrainLogo.tsx
+++ b/dashboard/src/components/icons/BrainLogo.tsx
@@ -8,7 +8,7 @@ interface BrainLogoProps {
 }
 
 /**
- * Brain logo icon - the OpenAgent branding icon.
+ * Brain logo icon - the Sandboxed.sh branding icon.
  * Uses the same path as favicon.svg.
  */
 export function BrainLogo({ className, size = 24 }: BrainLogoProps) {

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -279,7 +279,7 @@ export function NewMissionDialog({
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [open]);
+  }, [open, onClose]);
 
   // Set initial values when dialog opens (only once per open)
   useEffect(() => {

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -316,15 +316,38 @@ export function NewMissionDialog({
       }
     }
 
-    // Fallback: try Sisyphus in OpenCode
+    // Fallback: use first available backend with priority claudecode → opencode → amp
+    // Try Claude Code first
+    const claudeCodeAgent = allAgents.find(a => a.backend === 'claudecode');
+    if (claudeCodeAgent) {
+      setSelectedAgentValue(claudeCodeAgent.value);
+      setDefaultSet(true);
+      return;
+    }
+
+    // Try OpenCode second (prefer Sisyphus if available)
     const sisyphus = allAgents.find(a => a.backend === 'opencode' && a.agent === 'Sisyphus');
     if (sisyphus) {
       setSelectedAgentValue(sisyphus.value);
       setDefaultSet(true);
       return;
     }
+    const openCodeAgent = allAgents.find(a => a.backend === 'opencode');
+    if (openCodeAgent) {
+      setSelectedAgentValue(openCodeAgent.value);
+      setDefaultSet(true);
+      return;
+    }
 
-    // Fallback: use first available agent
+    // Try Amp third
+    const ampAgent = allAgents.find(a => a.backend === 'amp');
+    if (ampAgent) {
+      setSelectedAgentValue(ampAgent.value);
+      setDefaultSet(true);
+      return;
+    }
+
+    // Final fallback: use first available agent (shouldn't reach here)
     if (allAgents.length > 0) {
       setSelectedAgentValue(allAgents[0].value);
     }
@@ -350,7 +373,7 @@ export function NewMissionDialog({
       workspaceId: newMissionWorkspace || undefined,
       agent: parsed?.agent || undefined,
       configProfile: selectedConfigProfile || undefined,
-      backend: parsed?.backend || 'opencode',
+      backend: parsed?.backend || 'claudecode',
     };
   };
 

--- a/dashboard/src/components/server-connection-card.tsx
+++ b/dashboard/src/components/server-connection-card.tsx
@@ -376,11 +376,10 @@ export function ServerConnectionCard({
                       <button
                         onClick={() => handleUninstall(component)}
                         disabled={updatingComponent !== null || uninstallingComponent !== null}
-                        className="flex items-center gap-1.5 rounded-lg bg-red-500/10 border border-red-500/20 px-2.5 py-1 text-xs text-red-300 hover:bg-red-500/20 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="p-1.5 rounded-lg text-white/30 hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                         title={`Uninstall ${componentNames[component.name] || component.name}`}
                       >
-                        <Trash2 className="h-3 w-3" />
-                        Uninstall
+                        <Trash2 className="h-3.5 w-3.5" />
                       </button>
                     )}
                   </div>

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -152,7 +152,7 @@ export function Sidebar() {
       <div className="flex h-16 items-center gap-2 border-b border-white/[0.06] px-4">
         <BrainLogo size={32} />
         <div className="flex flex-col">
-          <span className="text-sm font-medium text-white">OpenAgent</span>
+          <span className="text-sm font-medium text-white">Sandboxed.sh</span>
           <span className="tag">v0.1.0</span>
         </div>
       </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -2417,6 +2417,8 @@ export interface BackendConfig {
   name: string;
   enabled: boolean;
   settings: Record<string, unknown>;
+  /** Whether the CLI for this backend is available on the system */
+  cli_available?: boolean;
 }
 
 // List all available backends

--- a/docs/install-native.md
+++ b/docs/install-native.md
@@ -480,18 +480,20 @@ cd /opt/sandboxed_sh/vaduz-v1
 source /root/.cargo/env
 
 # Debug build (fast) - recommended for rapid iteration
-cargo build --bin sandboxed_sh
+cargo build --bin sandboxed_sh --bin workspace-mcp --bin desktop-mcp
 install -m 0755 target/debug/sandboxed_sh /usr/local/bin/sandboxed_sh
+install -m 0755 target/debug/workspace-mcp /usr/local/bin/workspace-mcp
+install -m 0755 target/debug/desktop-mcp /usr/local/bin/desktop-mcp
 
 # Or: Release build (slower compile, faster runtime)
-# cargo build --release --bin sandboxed_sh
+# cargo build --release --bin sandboxed_sh --bin workspace-mcp --bin desktop-mcp
 # install -m 0755 target/release/sandboxed_sh /usr/local/bin/sandboxed_sh
-
-# Optional: build MCP helpers if you want legacy workspace/desktop tools
-# cargo build --release --bin workspace-mcp --bin desktop-mcp
 # install -m 0755 target/release/workspace-mcp /usr/local/bin/workspace-mcp
 # install -m 0755 target/release/desktop-mcp /usr/local/bin/desktop-mcp
 ```
+
+> **Note:** The MCP binaries (`workspace-mcp`, `desktop-mcp`) are required for
+> host workspace missions and the Extensions page. They must be in PATH.
 
 ---
 
@@ -831,14 +833,16 @@ install -m 0755 target/debug/desktop-mcp /usr/local/bin/desktop-mcp
 systemctl restart sandboxed_sh.service
 ```
 
-Optional: if you no longer use legacy workspace/desktop MCP tools, build only
-`sandboxed_sh`:
+Quick rebuild (main binary only, if MCP binaries haven't changed):
 
 ```bash
 cargo build --bin sandboxed_sh
 install -m 0755 target/debug/sandboxed_sh /usr/local/bin/sandboxed_sh
 systemctl restart sandboxed_sh.service
 ```
+
+> **Note:** Always rebuild and install all binaries after pulling changes that
+> modify the MCP tools, otherwise the Extensions page will show connection errors.
 
 Or to follow the latest master branch:
 

--- a/src/api/console.rs
+++ b/src/api/console.rs
@@ -802,7 +802,7 @@ async fn handle_new_workspace_shell(
                 cmd.arg("-c");
                 // Run tailscale bootstrap, then exec to interactive shell
                 cmd.arg(format!(
-                    "/usr/local/bin/openagent-tailscale-up 2>/dev/null; exec {} --login -i",
+                    "/usr/local/bin/sandboxed-tailscale-up 2>/dev/null; exec {} --login -i",
                     shell
                 ));
             } else if shell == "/bin/bash" {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1983,12 +1983,14 @@ pub fn run_claudecode_turn<'a>(
                                             // "thinking_delta" -> thinking panel (uses delta.thinking field)
                                             // "text_delta" -> text output (uses delta.text field)
                                             if delta.delta_type == "thinking_delta" {
-                                                // For thinking deltas, content is in the `thinking` field, not `text`
-                                                if let Some(thinking_text) = delta.thinking {
-                                                    if !thinking_text.is_empty() {
+                                                // For thinking deltas, check both `thinking` and `text` fields
+                                                // Extended thinking uses `thinking`, but some versions use `text`
+                                                let thinking_text = delta.thinking.or(delta.text.clone());
+                                                if let Some(thinking_content) = thinking_text {
+                                                    if !thinking_content.is_empty() {
                                                         // Accumulate thinking content
                                                         let buffer = thinking_buffer.entry(index).or_default();
-                                                        buffer.push_str(&thinking_text);
+                                                        buffer.push_str(&thinking_content);
 
                                                         // Send accumulated thinking content (cumulative, like OpenCode)
                                                         // Only send if we have new content since last emit

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -703,6 +703,22 @@ impl MissionRunner {
         }
     }
 
+    /// Remove a specific message from the queue by ID.
+    /// Returns true if the message was found and removed.
+    pub fn remove_from_queue(&mut self, message_id: Uuid) -> bool {
+        let before_len = self.queue.len();
+        self.queue.retain(|qm| qm.id != message_id);
+        self.queue.len() < before_len
+    }
+
+    /// Clear all queued messages.
+    /// Returns the number of messages that were cleared.
+    pub fn clear_queue(&mut self) -> usize {
+        let cleared = self.queue.len();
+        self.queue.clear();
+        cleared
+    }
+
     /// Start executing the next queued message (if any and not already running).
     /// Returns true if execution was started.
     pub fn start_next(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1765,18 +1765,27 @@ pub fn run_claudecode_turn<'a>(
                 }
                 Ok(Ok(false)) => {
                     tracing::error!(mission_id = %mission_id, "Stdin write failed");
-                    return AgentResult::failure("Failed to write prompt to Claude CLI".to_string(), 0)
-                        .with_terminal_reason(TerminalReason::LlmError);
+                    return AgentResult::failure(
+                        "Failed to write prompt to Claude CLI".to_string(),
+                        0,
+                    )
+                    .with_terminal_reason(TerminalReason::LlmError);
                 }
                 Ok(Err(e)) => {
                     tracing::error!(mission_id = %mission_id, "Stdin task panicked: {:?}", e);
-                    return AgentResult::failure("Failed to write prompt to Claude CLI (task panic)".to_string(), 0)
-                        .with_terminal_reason(TerminalReason::LlmError);
+                    return AgentResult::failure(
+                        "Failed to write prompt to Claude CLI (task panic)".to_string(),
+                        0,
+                    )
+                    .with_terminal_reason(TerminalReason::LlmError);
                 }
                 Err(_) => {
                     tracing::error!(mission_id = %mission_id, "Stdin write timed out after 5s");
-                    return AgentResult::failure("Timed out writing prompt to Claude CLI".to_string(), 0)
-                        .with_terminal_reason(TerminalReason::LlmError);
+                    return AgentResult::failure(
+                        "Timed out writing prompt to Claude CLI".to_string(),
+                        0,
+                    )
+                    .with_terminal_reason(TerminalReason::LlmError);
                 }
             }
         }

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1548,8 +1548,7 @@ pub fn run_claudecode_turn<'a>(
         // This catches DNS/network issues immediately instead of waiting for a timeout
         if let Err(err_msg) = check_api_connectivity(&workspace_exec, work_dir).await {
             tracing::error!(mission_id = %mission_id, "{}", err_msg);
-            return AgentResult::failure(err_msg, 0)
-                .with_terminal_reason(TerminalReason::LlmError);
+            return AgentResult::failure(err_msg, 0).with_terminal_reason(TerminalReason::LlmError);
         }
 
         tracing::info!(
@@ -4186,33 +4185,25 @@ async fn check_api_connectivity(
 
     // Check for common DNS/network error patterns
     if combined.contains("Could not resolve host") {
-        return Err(
-            "Cannot connect to Anthropic API: DNS resolution failed. \
+        return Err("Cannot connect to Anthropic API: DNS resolution failed. \
              The workspace network is not properly configured. \
              For Tailscale workspaces, ensure the VPN connection is established."
-                .to_string(),
-        );
+            .to_string());
     }
     if combined.contains("Connection refused") {
-        return Err(
-            "Cannot connect to Anthropic API: Connection refused. \
+        return Err("Cannot connect to Anthropic API: Connection refused. \
              Check if network access is blocked or if a proxy is required."
-                .to_string(),
-        );
+            .to_string());
     }
     if combined.contains("Network is unreachable") {
-        return Err(
-            "Cannot connect to Anthropic API: Network is unreachable. \
+        return Err("Cannot connect to Anthropic API: Network is unreachable. \
              The workspace has no network connectivity."
-                .to_string(),
-        );
+            .to_string());
     }
     if combined.contains("Connection timed out") || combined.contains("Operation timed out") {
-        return Err(
-            "Cannot connect to Anthropic API: Connection timed out. \
+        return Err("Cannot connect to Anthropic API: Connection timed out. \
              The network may be slow or firewalled."
-                .to_string(),
-        );
+            .to_string());
     }
 
     // Check for successful HTTP response (any HTTP response means connectivity works)

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2132,8 +2132,8 @@ pub fn run_claudecode_turn<'a>(
                                             let result_value = if let Some(ref extra) = evt.tool_use_result {
                                                 serde_json::json!({
                                                     "content": content_str,
-                                                    "stdout": extra.stdout,
-                                                    "stderr": extra.stderr,
+                                                    "stdout": extra.stdout(),
+                                                    "stderr": extra.stderr(),
                                                     "is_error": is_error,
                                                 })
                                             } else {
@@ -6213,10 +6213,10 @@ pub async fn run_amp_turn(
                                         let result_value = if let Some(ref extra) = evt.tool_use_result {
                                             serde_json::json!({
                                                 "content": content_str,
-                                                "stdout": extra.stdout,
-                                                "stderr": extra.stderr,
+                                                "stdout": extra.stdout(),
+                                                "stderr": extra.stderr(),
                                                 "is_error": is_error,
-                                                "interrupted": extra.interrupted,
+                                                "interrupted": extra.interrupted(),
                                             })
                                         } else {
                                             serde_json::json!(content_str)

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1763,6 +1763,7 @@ pub fn run_claudecode_turn<'a>(
                 // Flush to ensure data is sent
                 if let Err(e) = stdin.flush().await {
                     tracing::error!(mission_id = %mission_id_for_stdin, "Failed to flush Claude stdin: {}", e);
+                    return false;
                 }
                 // Close stdin to signal end of input
                 drop(stdin);
@@ -1781,6 +1782,7 @@ pub fn run_claudecode_turn<'a>(
                 }
                 Ok(Ok(false)) => {
                     tracing::error!(mission_id = %mission_id, "Stdin write failed");
+                    let _ = child.kill().await;
                     return AgentResult::failure(
                         "Failed to write prompt to Claude CLI".to_string(),
                         0,
@@ -1789,6 +1791,7 @@ pub fn run_claudecode_turn<'a>(
                 }
                 Ok(Err(e)) => {
                     tracing::error!(mission_id = %mission_id, "Stdin task panicked: {:?}", e);
+                    let _ = child.kill().await;
                     return AgentResult::failure(
                         "Failed to write prompt to Claude CLI (task panic)".to_string(),
                         0,
@@ -1797,6 +1800,7 @@ pub fn run_claudecode_turn<'a>(
                 }
                 Err(_) => {
                     tracing::error!(mission_id = %mission_id, "Stdin write timed out after 5s");
+                    let _ = child.kill().await;
                     return AgentResult::failure(
                         "Timed out writing prompt to Claude CLI".to_string(),
                         0,

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -114,7 +114,7 @@ impl MissionStore for FileMissionStore {
             workspace_name: None,
             agent: agent.map(|s| s.to_string()),
             model_override: model_override.map(|s| s.to_string()),
-            backend: backend.unwrap_or("opencode").to_string(),
+            backend: backend.unwrap_or("claudecode").to_string(),
             config_profile: config_profile.map(|s| s.to_string()),
             history: vec![],
             created_at: now.clone(),

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -65,7 +65,7 @@ impl MissionStore for InMemoryMissionStore {
             workspace_name: None,
             agent: agent.map(|s| s.to_string()),
             model_override: model_override.map(|s| s.to_string()),
-            backend: backend.unwrap_or("opencode").to_string(),
+            backend: backend.unwrap_or("claudecode").to_string(),
             config_profile: config_profile.map(|s| s.to_string()),
             history: vec![],
             created_at: now.clone(),

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -65,7 +65,7 @@ pub struct Mission {
 }
 
 fn default_backend() -> String {
-    "opencode".to_string()
+    "claudecode".to_string()
 }
 
 fn default_workspace_id() -> Uuid {
@@ -92,6 +92,24 @@ pub struct StoredEvent {
     pub tool_name: Option<String>,
     pub content: String,
     pub metadata: serde_json::Value,
+}
+
+/// An automation that triggers commands at intervals.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Automation {
+    pub id: Uuid,
+    pub mission_id: Uuid,
+    /// Command name from library to execute
+    pub command_name: String,
+    /// Interval in seconds between executions
+    pub interval_seconds: u64,
+    /// Whether this automation is currently active
+    pub active: bool,
+    /// When this automation was created
+    pub created_at: String,
+    /// When this automation was last triggered
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_triggered_at: Option<String>,
 }
 
 /// Get current timestamp as RFC3339 string.
@@ -224,6 +242,49 @@ pub trait MissionStore: Send + Sync {
     /// Aggregates cost_cents from all assistant_message events.
     async fn get_total_cost_cents(&self) -> Result<u64, String> {
         Ok(0)
+    }
+
+    // === Automation methods (default no-op for backward compatibility) ===
+
+    /// Create an automation for a mission.
+    async fn create_automation(
+        &self,
+        mission_id: Uuid,
+        command_name: &str,
+        interval_seconds: u64,
+    ) -> Result<Automation, String> {
+        let _ = (mission_id, command_name, interval_seconds);
+        Err("Automations not supported by this store".to_string())
+    }
+
+    /// Get all automations for a mission.
+    async fn get_mission_automations(&self, mission_id: Uuid) -> Result<Vec<Automation>, String> {
+        let _ = mission_id;
+        Ok(vec![])
+    }
+
+    /// Get an automation by ID.
+    async fn get_automation(&self, id: Uuid) -> Result<Option<Automation>, String> {
+        let _ = id;
+        Ok(None)
+    }
+
+    /// Update automation active status.
+    async fn update_automation_active(&self, id: Uuid, active: bool) -> Result<(), String> {
+        let _ = (id, active);
+        Err("Automations not supported by this store".to_string())
+    }
+
+    /// Update automation last triggered time.
+    async fn update_automation_last_triggered(&self, id: Uuid) -> Result<(), String> {
+        let _ = id;
+        Err("Automations not supported by this store".to_string())
+    }
+
+    /// Delete an automation.
+    async fn delete_automation(&self, id: Uuid) -> Result<bool, String> {
+        let _ = id;
+        Ok(false)
     }
 }
 

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -107,6 +107,7 @@ pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/components", get(get_components))
         .route("/components/:name/update", post(update_component))
+        .route("/components/:name/uninstall", post(uninstall_component))
         .route("/plugins/installed", get(get_installed_plugins))
         .route("/plugins/:package/update", get(update_plugin))
 }
@@ -651,6 +652,27 @@ async fn update_component(
     }
 }
 
+/// Uninstall a system component.
+async fn uninstall_component(
+    State(_state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Result<Sse<UpdateStream>, (StatusCode, String)> {
+    match name.as_str() {
+        "sandboxed_sh" => Err((
+            StatusCode::BAD_REQUEST,
+            "Cannot uninstall sandboxed.sh - it is the main application".to_string(),
+        )),
+        "opencode" => Ok(Sse::new(Box::pin(stream_opencode_uninstall()))),
+        "claude_code" => Ok(Sse::new(Box::pin(stream_claude_code_uninstall()))),
+        "amp" => Ok(Sse::new(Box::pin(stream_amp_uninstall()))),
+        "oh_my_opencode" => Ok(Sse::new(Box::pin(stream_oh_my_opencode_uninstall()))),
+        _ => Err((
+            StatusCode::BAD_REQUEST,
+            format!("Unknown component: {}", name),
+        )),
+    }
+}
+
 /// Stream the Open Agent update process.
 /// Builds from source using git tags (no pre-built binaries needed).
 fn stream_sandboxed_update() -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
@@ -1060,6 +1082,251 @@ fn stream_oh_my_opencode_update() -> impl Stream<Item = Result<Event, std::conve
                 yield sse("error", format!("Failed to run update: {}", e), None);
             }
         }
+    }
+}
+
+/// Stream the OpenCode uninstall process.
+fn stream_opencode_uninstall() -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    async_stream::stream! {
+        yield sse("log", "Starting OpenCode uninstall...", Some(0));
+
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+        let is_root = unsafe { libc::geteuid() } == 0;
+
+        // Stop the service first if running as root
+        if is_root {
+            yield sse("log", "Stopping opencode service...", Some(10));
+            let _ = Command::new("systemctl")
+                .args(["stop", "opencode.service"])
+                .output()
+                .await;
+        }
+
+        // Remove the binary from system location
+        yield sse("log", "Removing OpenCode binary...", Some(30));
+
+        let mut removed = false;
+
+        // Remove from /usr/local/bin if exists
+        if std::path::Path::new("/usr/local/bin/opencode").exists() {
+            match Command::new("rm")
+                .args(["-f", "/usr/local/bin/opencode"])
+                .output()
+                .await
+            {
+                Ok(o) if o.status.success() => {
+                    yield sse("log", "Removed /usr/local/bin/opencode", Some(50));
+                    removed = true;
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    yield sse("log", format!("Warning: Failed to remove /usr/local/bin/opencode: {}", stderr), Some(50));
+                }
+                Err(e) => {
+                    yield sse("log", format!("Warning: Failed to remove /usr/local/bin/opencode: {}", e), Some(50));
+                }
+            }
+        }
+
+        // Remove from user-local location
+        let user_bin = format!("{}/.opencode/bin/opencode", home);
+        if std::path::Path::new(&user_bin).exists() {
+            match Command::new("rm")
+                .args(["-f", &user_bin])
+                .output()
+                .await
+            {
+                Ok(o) if o.status.success() => {
+                    yield sse("log", format!("Removed {}", user_bin), Some(60));
+                    removed = true;
+                }
+                _ => {}
+            }
+        }
+
+        // Optionally remove the entire .opencode directory
+        let opencode_dir = format!("{}/.opencode", home);
+        if std::path::Path::new(&opencode_dir).exists() {
+            yield sse("log", "Removing OpenCode configuration directory...", Some(70));
+            match Command::new("rm")
+                .args(["-rf", &opencode_dir])
+                .output()
+                .await
+            {
+                Ok(o) if o.status.success() => {
+                    yield sse("log", format!("Removed {}", opencode_dir), Some(80));
+                }
+                _ => {}
+            }
+        }
+
+        // Disable the systemd service if root
+        if is_root {
+            yield sse("log", "Disabling opencode service...", Some(90));
+            let _ = Command::new("systemctl")
+                .args(["disable", "opencode.service"])
+                .output()
+                .await;
+        }
+
+        if removed {
+            yield sse("complete", "OpenCode uninstalled successfully!", Some(100));
+        } else {
+            yield sse("complete", "OpenCode was not installed or already removed.", Some(100));
+        }
+    }
+}
+
+/// Stream the Claude Code uninstall process.
+fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    async_stream::stream! {
+        yield sse("log", "Starting Claude Code uninstall...", Some(0));
+
+        // Check if npm is available
+        let npm_check = Command::new("npm").arg("--version").output().await;
+        if npm_check.is_err() || !npm_check.unwrap().status.success() {
+            yield sse("error", "npm is required to uninstall Claude Code.", None);
+            return;
+        }
+
+        yield sse("log", "Uninstalling @anthropic-ai/claude-code globally...", Some(20));
+
+        match Command::new("npm")
+            .args(["uninstall", "-g", "@anthropic-ai/claude-code"])
+            .output()
+            .await
+        {
+            Ok(output) if output.status.success() => {
+                yield sse("log", "Package removed from npm", Some(60));
+
+                // Remove Claude Code configuration
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+                let claude_config = format!("{}/.claude", home);
+                if std::path::Path::new(&claude_config).exists() {
+                    yield sse("log", "Removing Claude Code configuration...", Some(80));
+                    let _ = Command::new("rm")
+                        .args(["-rf", &claude_config])
+                        .output()
+                        .await;
+                }
+
+                yield sse("complete", "Claude Code uninstalled successfully!", Some(100));
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                // npm uninstall returns success even if package wasn't installed
+                if stderr.contains("not installed") || stdout.contains("not installed") {
+                    yield sse("complete", "Claude Code was not installed.", Some(100));
+                } else {
+                    yield sse("error", format!("Failed to uninstall Claude Code: {} {}", stderr, stdout), None);
+                }
+            }
+            Err(e) => {
+                yield sse("error", format!("Failed to run npm uninstall: {}", e), None);
+            }
+        }
+    }
+}
+
+/// Stream the Amp uninstall process.
+fn stream_amp_uninstall() -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
+    async_stream::stream! {
+        yield sse("log", "Starting Amp uninstall...", Some(0));
+
+        // Check if npm is available
+        let npm_check = Command::new("npm").arg("--version").output().await;
+        if npm_check.is_err() || !npm_check.unwrap().status.success() {
+            yield sse("error", "npm is required to uninstall Amp.", None);
+            return;
+        }
+
+        yield sse("log", "Uninstalling @sourcegraph/amp globally...", Some(20));
+
+        match Command::new("npm")
+            .args(["uninstall", "-g", "@sourcegraph/amp"])
+            .output()
+            .await
+        {
+            Ok(output) if output.status.success() => {
+                yield sse("log", "Package removed from npm", Some(60));
+
+                // Remove Amp configuration
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+                let amp_config = format!("{}/.agents", home);
+                if std::path::Path::new(&amp_config).exists() {
+                    yield sse("log", "Removing Amp configuration...", Some(80));
+                    let _ = Command::new("rm")
+                        .args(["-rf", &amp_config])
+                        .output()
+                        .await;
+                }
+
+                yield sse("complete", "Amp uninstalled successfully!", Some(100));
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if stderr.contains("not installed") || stdout.contains("not installed") {
+                    yield sse("complete", "Amp was not installed.", Some(100));
+                } else {
+                    yield sse("error", format!("Failed to uninstall Amp: {} {}", stderr, stdout), None);
+                }
+            }
+            Err(e) => {
+                yield sse("error", format!("Failed to run npm uninstall: {}", e), None);
+            }
+        }
+    }
+}
+
+/// Stream the oh-my-opencode uninstall process.
+fn stream_oh_my_opencode_uninstall() -> impl Stream<Item = Result<Event, std::convert::Infallible>>
+{
+    async_stream::stream! {
+        yield sse("log", "Starting oh-my-opencode uninstall...", Some(0));
+
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+
+        // Remove npm global install if exists
+        yield sse("log", "Removing npm global install...", Some(10));
+        let _ = Command::new("npm")
+            .args(["uninstall", "-g", "oh-my-opencode"])
+            .output()
+            .await;
+
+        // Clear bun cache for oh-my-opencode
+        yield sse("log", "Clearing oh-my-opencode caches...", Some(30));
+        let cache_clear_script = format!(
+            r#"
+            rm -rf {home}/.bun/install/cache/oh-my-opencode* 2>/dev/null
+            rm -rf {home}/.cache/.bun/install/cache/oh-my-opencode* 2>/dev/null
+            rm -rf {home}/.npm/_npx/*/node_modules/oh-my-opencode* 2>/dev/null
+            "#,
+            home = home
+        );
+        let _ = Command::new("bash")
+            .args(["-c", &cache_clear_script])
+            .output()
+            .await;
+
+        // Remove the oh-my-opencode config file
+        yield sse("log", "Removing oh-my-opencode configuration...", Some(60));
+        let config_path = format!("{}/.config/opencode/oh-my-opencode.json", home);
+        if std::path::Path::new(&config_path).exists() {
+            match Command::new("rm")
+                .args(["-f", &config_path])
+                .output()
+                .await
+            {
+                Ok(o) if o.status.success() => {
+                    yield sse("log", "Removed oh-my-opencode.json", Some(80));
+                }
+                _ => {}
+            }
+        }
+
+        yield sse("complete", "oh-my-opencode uninstalled successfully!", Some(100));
     }
 }
 

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -63,6 +63,26 @@ pub enum CliEvent {
     Result(ResultEvent),
 }
 
+/// MCP server status in the init event.
+/// Claude Code 2.1+ returns objects with name/status, older versions return strings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum McpServerInfo {
+    /// New format: object with name and status
+    Object { name: String, status: String },
+    /// Legacy format: just the server name as a string
+    String(String),
+}
+
+impl McpServerInfo {
+    pub fn name(&self) -> &str {
+        match self {
+            McpServerInfo::Object { name, .. } => name,
+            McpServerInfo::String(s) => s,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct SystemEvent {
     pub subtype: String,
@@ -75,9 +95,10 @@ pub struct SystemEvent {
     pub agents: Vec<String>,
     #[serde(default)]
     pub cwd: Option<String>,
-    /// Amp extension.
+    /// MCP servers configured for this session.
+    /// Claude Code 2.1+ returns objects with {name, status}, older versions return strings.
     #[serde(default)]
-    pub mcp_servers: Vec<String>,
+    pub mcp_servers: Vec<McpServerInfo>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -761,9 +761,10 @@ pub async fn execute_in_container_streaming(
     });
 
     // Wait for the child process to complete
-    let status = child.wait().await.map_err(|e| {
-        NspawnError::NspawnExecution(format!("Failed to wait for process: {}", e))
-    })?;
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| NspawnError::NspawnExecution(format!("Failed to wait for process: {}", e)))?;
 
     // Wait for the reader tasks to finish
     let _ = stdout_task.await;

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -384,7 +384,8 @@ impl WorkspaceExec {
                 // check, so the nsenter path can also include the bootstrap.
                 let tailscale_enabled_check = nspawn::tailscale_enabled(&env);
                 let tailscale_args = nspawn::tailscale_nspawn_extra_args(&env);
-                let needs_tailscale_bootstrap = tailscale_enabled_check && !tailscale_args.is_empty();
+                let needs_tailscale_bootstrap =
+                    tailscale_enabled_check && !tailscale_args.is_empty();
 
                 tracing::info!(
                     workspace = %self.workspace.name,


### PR DESCRIPTION
## Summary
- Add startup timeout (120s) for all CLI harnesses (Claude Code, OpenCode, Amp)
- Add inactivity timeout (5min) for missions that stop producing output
- Detect network-related errors from stderr (DNS, connection refused, etc.)
- Show descriptive error messages with diagnostic info when missions timeout

## Problem
Missions would "hang forever" with no indication to users about what was wrong. This was particularly problematic for workspaces with network/DNS issues.

## Solution
The timeout detection now shows clear error messages like:
- "Claude Code appears stuck due to network issues. Check workspace DNS/network configuration."
- "Claude Code produced no output after 120s. This may indicate network connectivity issues..."
- "Claude Code stopped responding after 300s of inactivity. This may indicate a network issue or API timeout."

## Test plan
- [ ] Start a mission on a workspace with broken DNS - should timeout with network error message
- [ ] Start a mission without API credentials - should timeout with auth error message
- [ ] Start a mission that runs normally - should complete without timeout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core mission control/execution paths (timeouts, process IO, queue routing, default backend selection) and adds new persistent automation scheduling/DB schema and system uninstall operations, which could impact mission reliability and state transitions.
> 
> **Overview**
> Improves mission execution robustness by adding proactive network/DNS/API reachability checks plus startup/inactivity/tool-wait timeouts across Claude Code/OpenCode/Amp, with clearer failure diagnostics and safer stdin handling/streamed deltas.
> 
> Introduces mission *automations* persisted in SQLite and exposed via new control API endpoints, plus scheduling that injects library commands into idle missions; also hardens control queue targeting/status updates (esp. parallel runners) to avoid cross-mission race conditions.
> 
> Dashboard updates include component uninstall support via SSE, better backend selection/availability UX (CLI detection, default backend now `claudecode` with `DEFAULT_BACKEND` override), config profile “default” semantics + JSONC parsing, and assorted branding/workspace navigation tweaks; container init now streams logs to file in real time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20228f459579c302e389ba9f2746bd0ebc569a3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->