### PR TITLE
feat(ios): Add tool grouping, mission switcher, improved thoughts panel and fix thinking events

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -176,6 +176,8 @@ struct RunningMissionInfo: Codable, Identifiable {
     let historyLen: Int
     let secondsSinceActivity: Int
     let expectedDeliverables: Int
+    let currentActivity: String?
+    let title: String?
 
     var id: String { missionId }
 
@@ -186,16 +188,33 @@ struct RunningMissionInfo: Codable, Identifiable {
         case historyLen = "history_len"
         case secondsSinceActivity = "seconds_since_activity"
         case expectedDeliverables = "expected_deliverables"
+        case currentActivity = "current_activity"
+        case title
+    }
+
+    // Custom decoder to handle optional fields
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        missionId = try container.decode(String.self, forKey: .missionId)
+        state = try container.decode(String.self, forKey: .state)
+        queueLen = try container.decode(Int.self, forKey: .queueLen)
+        historyLen = try container.decode(Int.self, forKey: .historyLen)
+        secondsSinceActivity = try container.decode(Int.self, forKey: .secondsSinceActivity)
+        expectedDeliverables = try container.decode(Int.self, forKey: .expectedDeliverables)
+        currentActivity = try container.decodeIfPresent(String.self, forKey: .currentActivity)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
     }
 
     // Memberwise initializer for previews and testing
-    init(missionId: String, state: String, queueLen: Int, historyLen: Int, secondsSinceActivity: Int, expectedDeliverables: Int) {
+    init(missionId: String, state: String, queueLen: Int, historyLen: Int, secondsSinceActivity: Int, expectedDeliverables: Int, currentActivity: String? = nil, title: String? = nil) {
         self.missionId = missionId
         self.state = state
         self.queueLen = queueLen
         self.historyLen = historyLen
         self.secondsSinceActivity = secondsSinceActivity
         self.expectedDeliverables = expectedDeliverables
+        self.currentActivity = currentActivity
+        self.title = title
     }
 
     var isRunning: Bool {


### PR DESCRIPTION
## Summary
- Implement tool grouping with 'show N previous' collapse/expand (like dashboard)
- Replace workspace selector with mission switcher for quick switching between missions
- Enhance ThoughtsSheet with deduplication and active thinking indicators
- **Fix thinking events not showing in Thoughts panel** (critical bug fix)

## Changes

### 1. Tool Grouping (like dashboard)
Groups consecutive tool calls and shows "Show N previous tools" button when collapsed. Shows only the last tool in collapsed state, expands to show all tools when clicked.

### 2. Mission Switcher (replaced workspace selector)
- Moved thoughts panel button to top-left
- Added mission switcher button in top-right (shows count of running missions)
- New `MissionSwitcherSheet` with:
  - "Create New Mission" button at top
  - Running missions section with cancel buttons
  - Recent missions section
  - Search functionality
  - Visual indicators for currently viewing mission

### 3. Enhanced Thoughts Panel
- Deduplication of completed thoughts (same as dashboard)
- Separated thoughts into `activeThoughts` and `completedThoughts`
- Dynamic title: "Thinking" when active, "Thoughts" when complete
- Pulsing brain icon when actively thinking

### 4. Thinking Events Bug Fix
**The bug:** Previously, the code had:
```swift
} else if !done {
    // Create thinking message
}
```
This meant completed thinking events (`done: true`) without an existing active thought were **silently dropped**. This happens when:
- Joining a mission mid-thought
- Reconnecting to SSE
- Receiving a thought that completed very quickly

**The fix:** Changed to always create thinking messages regardless of `done` state, and skip empty content.

### 5. Model Updates
- Added `currentActivity` and `title` optional fields to `RunningMissionInfo`
- Custom decoder to handle backward compatibility

### 6. Rich File Sharing
Verified the implementation is already complete - no changes needed.

## XCode Cloud Build Issue
The build fails because the project was renamed from `OpenAgentDashboard` to `SandboxedDashboard`. Update the Xcode Cloud workflow in App Store Connect to use the correct project path.

## Test plan
- [ ] Test tool grouping by having agent make multiple tool calls
- [ ] Test mission switcher by creating/switching between missions  
- [ ] Test thoughts panel shows thoughts during agent execution
- [ ] Test Rich File Sharing with image and document files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat rendering and streaming-event handling plus mission switching UX; mistakes could cause missing/duplicated messages or incorrect mission navigation, but changes are localized to iOS UI/state logic.
> 
> **Overview**
> Adds a new in-chat mission switcher sheet (searchable running + recent missions, cancel running missions, quick create) and updates toolbar layout to launch it, including fetching recent missions via `api.listMissions()`.
> 
> Improves chat readability by grouping consecutive non-UI tool calls into collapsible/expandable blocks, and enhances the Thoughts sheet with active/completed separation, deduplication, and a live “Thinking” indicator.
> 
> Fixes SSE `thinking` event handling so completed thoughts aren’t dropped when no active thinking message exists, and skips empty thought payloads; `RunningMissionInfo` now decodes optional `currentActivity`/`title` for richer mission display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498129e76f28731db8d5cb062fdc140c4dce69a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->