### PR TITLE
fix(ios): Add Xcode Cloud post-clone script to generate project

### DIFF
--- a/ios_dashboard/README.md
+++ b/ios_dashboard/README.md
@@ -74,11 +74,23 @@ The app connects to the Sandboxed.sh backend. Configure the server URL:
 
 In multi-user mode, the login screen also asks for a username.
 
+## Xcode Cloud
+
+The project uses XcodeGen to generate the Xcode project from `project.yml`. For Xcode Cloud builds:
+
+1. The `ci_scripts/ci_post_clone.sh` script automatically runs after cloning
+2. It installs XcodeGen via Homebrew and generates `SandboxedDashboard.xcodeproj`
+3. Configure your Xcode Cloud workflow to use:
+   - **Scheme**: `SandboxedDashboard`
+   - **Project**: `ios_dashboard/SandboxedDashboard.xcodeproj`
+
 ## Project Structure
 
 ```
 ios_dashboard/
 ├── project.yml                 # XcodeGen config
+├── ci_scripts/
+│   └── ci_post_clone.sh        # Xcode Cloud pre-build script
 ├── SandboxedDashboard/
 │   ├── SandboxedDashboardApp.swift
 │   ├── ContentView.swift       # Auth + Tab navigation

--- a/ios_dashboard/ci_scripts/ci_post_clone.sh
+++ b/ios_dashboard/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Xcode Cloud post-clone script
+# This script runs after the repository is cloned but before the build starts
+# It installs XcodeGen and generates the Xcode project from project.yml
+
+set -e
+
+echo "=== Installing XcodeGen ==="
+brew install xcodegen
+
+echo "=== Generating Xcode Project ==="
+cd "$CI_PRIMARY_REPOSITORY_PATH/ios_dashboard"
+xcodegen generate
+
+echo "=== Project generated successfully ==="
+ls -la *.xcodeproj


### PR DESCRIPTION
## Problem

Xcode Cloud build fails with:
```
Project SandboxedDashboard.xcodeproj does not exist at ios_dashboard/SandboxedDashboard.xcodeproj
```

This happens because the Xcode project is generated by XcodeGen from `project.yml` and isn't committed to the repo.

## Solution

Add a `ci_scripts/ci_post_clone.sh` script that Xcode Cloud automatically runs after cloning the repository. The script:

1. Installs XcodeGen via Homebrew
2. Runs `xcodegen generate` to create `SandboxedDashboard.xcodeproj`

This is the standard approach for XcodeGen-based projects with Xcode Cloud.

## Xcode Cloud Configuration

After merging, ensure your Xcode Cloud workflow is configured with:
- **Scheme**: `SandboxedDashboard`
- **Project**: `ios_dashboard/SandboxedDashboard.xcodeproj`

## Test plan
- [ ] Merge this PR
- [ ] Trigger an Xcode Cloud build
- [ ] Verify the build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI-only change that installs tooling and generates the Xcode project; main risk is CI environment/homebrew variability rather than app behavior changes.
> 
> **Overview**
> Adds Xcode Cloud support for the XcodeGen-based iOS dashboard by introducing `ci_scripts/ci_post_clone.sh` to install `xcodegen` and generate `SandboxedDashboard.xcodeproj` during CI builds.
> 
> Updates `ios_dashboard/README.md` with Xcode Cloud workflow setup guidance (scheme/project path) and documents the new `ci_scripts/` folder in the project structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71d7ae68a38d8680ea7914171cbe0c89c824ccb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->