### PR TITLE
fix(dashboard): merge queued message UI + preserve tool order

### DIFF
--- a/dashboard/src/components/queue-strip.tsx
+++ b/dashboard/src/components/queue-strip.tsx
@@ -27,46 +27,53 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
     return text.slice(0, maxLen - 3) + '...';
   };
 
-  // Collapsed view: show first item preview
-  if (!expanded && items.length === 1) {
-    const item = items[0];
-    return (
-      <div className={cn(
-        "flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs",
-        className
-      )}>
-        <span className="text-amber-400 font-medium shrink-0">Queue (1)</span>
-        <span className="text-white/60 truncate flex-1">
-          {item.agent && <span className="text-emerald-400">@{item.agent} </span>}
-          {truncate(item.content, 60)}
-        </span>
-        <button
-          onClick={() => onRemove(item.id)}
-          className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors shrink-0"
-          title="Remove from queue"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-      </div>
-    );
-  }
-
-  // Collapsed view with multiple items
   if (!expanded) {
     return (
-      <div className={cn(
-        "flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs",
-        className
-      )}>
-        <span className="text-amber-400 font-medium shrink-0">Queue ({items.length})</span>
-        <span className="text-white/50 truncate flex-1">
-          {truncate(items[0].content, 40)}
+      <div
+        className={cn(
+          "flex items-center gap-2 px-3 py-2 rounded-lg text-xs cursor-pointer select-none",
+          "bg-indigo-500/20 border-2 border-dotted border-indigo-500/60",
+          "hover:bg-indigo-500/25 hover:border-indigo-500/70 transition-colors",
+          className
+        )}
+        onClick={() => setExpanded(true)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(true);
+          }
+        }}
+        title="Click to expand queued message(s)"
+      >
+        <span className="text-indigo-300 font-medium shrink-0">
+          Queued ({items.length})
+        </span>
+        <span className="text-white/60 truncate flex-1">
+          {items[0].agent && <span className="text-emerald-400">@{items[0].agent} </span>}
+          {truncate(items[0].content, items.length === 1 ? 60 : 40)}
           {items.length > 1 && <span className="text-white/30"> +{items.length - 1} more</span>}
         </span>
+        {items.length === 1 ? (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(items[0].id);
+            }}
+            className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors shrink-0"
+            title="Remove from queue"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
         <button
-          onClick={() => setExpanded(true)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(true);
+          }}
           className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors shrink-0"
-          title="Expand queue"
+          title="Expand"
         >
           <ChevronDown className="h-3.5 w-3.5" />
         </button>
@@ -77,12 +84,12 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
   // Expanded view
   return (
     <div className={cn(
-      "rounded-lg bg-amber-500/10 border border-amber-500/20 overflow-hidden",
+      "rounded-lg bg-indigo-500/20 border-2 border-dotted border-indigo-500/60 overflow-hidden",
       className
     )}>
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-amber-500/20">
-        <span className="text-amber-400 font-medium text-xs">Queued Messages ({items.length})</span>
+      <div className="flex items-center justify-between px-3 py-2 border-b border-indigo-500/20">
+        <span className="text-indigo-300 font-medium text-xs">Queued Messages ({items.length})</span>
         <div className="flex items-center gap-1">
           {items.length > 1 && (
             <button
@@ -111,7 +118,7 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
             key={item.id}
             className={cn(
               "flex items-start gap-2 px-3 py-2 text-xs",
-              index < items.length - 1 && "border-b border-amber-500/10"
+              index < items.length - 1 && "border-b border-indigo-500/10"
             )}
           >
             <span className="text-white/30 font-mono shrink-0 w-4">{index + 1}.</span>
@@ -122,7 +129,10 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
               </p>
             </div>
             <button
-              onClick={() => onRemove(item.id)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(item.id);
+              }}
               className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-red-400 transition-colors shrink-0"
               title="Remove from queue"
             >


### PR DESCRIPTION
## What\n\nThis fixes two UX issues in the Mission chat:\n\n1. Queued user messages were rendered twice (a dotted chat bubble + a yellow strip above the input). This change renders queued messages only in the queue strip, and restyles that strip to match the chat bubble (blue + dotted). The strip can be expanded to view the full queued content.\n2. When a message is queued while the agent is running, subsequent tool_call events were appended after the queued message. That could push the assistant final reply above a long tail of tools (making it look like the agent never replied). Tool calls are now inserted before any queued user messages so the timeline stays consistent.\n\n## Repro (before)\n\n1. Start a mission that emits multiple tool calls.\n2. While it is running, send a second message (queued).\n3. Observe tool calls continue after the queued message and the assistant reply appears above them (easy to miss).\n\n## Fix\n\n- Queue strip is the single source of truth for queued user messages.\n- Tool calls are inserted before the first queued user message in the live SSE stream.\n\n## Files\n\n- dashboard/src/app/control/control-client.tsx\n- dashboard/src/components/queue-strip.tsx\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect chat timeline ordering and rendering filters, so regressions could hide or reorder messages/tools in the control UI, but scope is limited to frontend presentation/state updates.
> 
> **Overview**
> Queued user messages are now filtered out of the main chat render path in `control-client.tsx`, making the `QueueStrip` the only place they appear until dequeued.
> 
> During SSE `tool_call` handling, new tool items are inserted before the first queued user message (instead of always appended) to keep queued messages at the end of the timeline and prevent assistant replies from being pushed out of view.
> 
> `QueueStrip` is restyled to match the dotted “queued” chat treatment (indigo) and made fully clickable/keyboard-expandable, with improved event handling so remove/expand actions don’t conflict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc332fcd74a8553a8d7dd5ac04820778f1047b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->