### PR TITLE
fix(dashboard): unify queue UI and keep tool events ordered

### DIFF
--- a/dashboard/src/components/queue-strip.tsx
+++ b/dashboard/src/components/queue-strip.tsx
@@ -27,46 +27,53 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
     return text.slice(0, maxLen - 3) + '...';
   };
 
-  // Collapsed view: show first item preview
-  if (!expanded && items.length === 1) {
-    const item = items[0];
-    return (
-      <div className={cn(
-        "flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs",
-        className
-      )}>
-        <span className="text-amber-400 font-medium shrink-0">Queue (1)</span>
-        <span className="text-white/60 truncate flex-1">
-          {item.agent && <span className="text-emerald-400">@{item.agent} </span>}
-          {truncate(item.content, 60)}
-        </span>
-        <button
-          onClick={() => onRemove(item.id)}
-          className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors shrink-0"
-          title="Remove from queue"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-      </div>
-    );
-  }
-
-  // Collapsed view with multiple items
   if (!expanded) {
     return (
-      <div className={cn(
-        "flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs",
-        className
-      )}>
-        <span className="text-amber-400 font-medium shrink-0">Queue ({items.length})</span>
-        <span className="text-white/50 truncate flex-1">
-          {truncate(items[0].content, 40)}
+      <div
+        className={cn(
+          "flex items-center gap-2 px-3 py-2 rounded-lg text-xs cursor-pointer select-none",
+          "bg-indigo-500/20 border-2 border-dotted border-indigo-500/60",
+          "hover:bg-indigo-500/25 hover:border-indigo-500/70 transition-colors",
+          className
+        )}
+        onClick={() => setExpanded(true)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(true);
+          }
+        }}
+        title="Click to expand queued message(s)"
+      >
+        <span className="text-indigo-300 font-medium shrink-0">
+          Queued ({items.length})
+        </span>
+        <span className="text-white/60 truncate flex-1">
+          {items[0].agent && <span className="text-emerald-400">@{items[0].agent} </span>}
+          {truncate(items[0].content, items.length === 1 ? 60 : 40)}
           {items.length > 1 && <span className="text-white/30"> +{items.length - 1} more</span>}
         </span>
+        {items.length === 1 ? (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(items[0].id);
+            }}
+            className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors shrink-0"
+            title="Remove from queue"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
         <button
-          onClick={() => setExpanded(true)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(true);
+          }}
           className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors shrink-0"
-          title="Expand queue"
+          title="Expand"
         >
           <ChevronDown className="h-3.5 w-3.5" />
         </button>
@@ -77,12 +84,12 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
   // Expanded view
   return (
     <div className={cn(
-      "rounded-lg bg-amber-500/10 border border-amber-500/20 overflow-hidden",
+      "rounded-lg bg-indigo-500/20 border-2 border-dotted border-indigo-500/60 overflow-hidden",
       className
     )}>
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-amber-500/20">
-        <span className="text-amber-400 font-medium text-xs">Queued Messages ({items.length})</span>
+      <div className="flex items-center justify-between px-3 py-2 border-b border-indigo-500/20">
+        <span className="text-indigo-300 font-medium text-xs">Queued Messages ({items.length})</span>
         <div className="flex items-center gap-1">
           {items.length > 1 && (
             <button
@@ -111,7 +118,7 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
             key={item.id}
             className={cn(
               "flex items-start gap-2 px-3 py-2 text-xs",
-              index < items.length - 1 && "border-b border-amber-500/10"
+              index < items.length - 1 && "border-b border-indigo-500/10"
             )}
           >
             <span className="text-white/30 font-mono shrink-0 w-4">{index + 1}.</span>
@@ -122,7 +129,10 @@ export function QueueStrip({ items, onRemove, onClearAll, className }: QueueStri
               </p>
             </div>
             <button
-              onClick={() => onRemove(item.id)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(item.id);
+              }}
               className="p-1 rounded hover:bg-white/10 text-white/40 hover:text-red-400 transition-colors shrink-0"
               title="Remove from queue"
             >


### PR DESCRIPTION
## Summary
- **Unified queue strip styles**: collapsed single-item and multi-item views now share one code path with indigo/dotted-border styling (replacing the amber theme), making the queued-messages strip visually distinct from chat
- **Filtered queued messages from chat**: queued user messages no longer render inline in the chat timeline — they only appear in the `QueueStrip` above the input, preventing duplicate display
- **Tool event ordering fix**: new tool-call events are now inserted *before* any queued user messages in the timeline, so the assistant reply and tool results stay visible instead of being pushed off-screen behind a long tail of tools

## Test plan
- [ ] Queue one message while a mission is running — verify it shows in the indigo strip above the input and not in the chat
- [ ] Queue multiple messages — verify collapsed "+N more" and expanded list both render correctly
- [ ] Confirm tool calls from the running mission appear in order above the queued strip
- [ ] Dequeue a message (mission finishes) — verify it appears in chat normally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat timeline rendering and event insertion order; mistakes could cause missing/duplicated messages or confusing ordering, but changes are localized to UI state handling.
> 
> **Overview**
> Queued user messages are now filtered out of the main chat timeline in `control-client.tsx` so they render only in the `QueueStrip` until dequeued.
> 
> Tool-call events are inserted *before* the first queued user message to keep assistant/tool activity visible and ordered, rather than being appended after queued items.
> 
> `QueueStrip` UI is unified for collapsed single vs multi-item states, switches to an indigo dotted-border style, adds click/keyboard-to-expand behavior, and prevents accidental expand clicks when removing items via `stopPropagation()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc332fcd74a8553a8d7dd5ac04820778f1047b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->