### PR TITLE
fix(ios): Enable automatic code signing for Xcode Cloud

### DIFF
--- a/ios_dashboard/project.yml
+++ b/ios_dashboard/project.yml
@@ -9,10 +9,7 @@ options:
 settings:
   base:
     SWIFT_VERSION: "6.0"
-    DEVELOPMENT_TEAM: ""
-    CODE_SIGN_IDENTITY: ""
-    CODE_SIGNING_REQUIRED: "NO"
-    CODE_SIGN_ENTITLEMENTS: ""
+    CODE_SIGN_STYLE: "Automatic"
     ENABLE_PREVIEWS: "YES"
 
 targets:


### PR DESCRIPTION
## Summary
- Enables automatic code signing in `project.yml` so Xcode Cloud can manage provisioning profiles
- Removes manual code signing settings that were blocking archive export

## Test plan
- [ ] Xcode Cloud build should complete without exit code 70
- [ ] Archive should export successfully for TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build configuration-only change; main risk is CI/archive signing behavior differing if the project relied on previous manual/disabled signing settings.
> 
> **Overview**
> Switches the iOS `project.yml` to **automatic code signing** by setting `CODE_SIGN_STYLE: "Automatic"` and removing previously explicit/disabled signing overrides (team/identity/required/entitlements) so Xcode/Xcode Cloud can manage provisioning and archive export.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa206240b9ba90848d8306742e3274ea029b469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->