### PR TITLE
fix(ios): Use correct bundle ID md.thomas.openagent.dashboard

### DIFF
--- a/ios_dashboard/project.yml
+++ b/ios_dashboard/project.yml
@@ -1,6 +1,6 @@
 name: SandboxedDashboard
 options:
-  bundleIdPrefix: sh.sandboxed-sh
+  bundleIdPrefix: md.thomas.openagent
   deploymentTarget:
     iOS: "18.0"
   xcodeVersion: "16.0"
@@ -24,7 +24,7 @@ targets:
     settings:
       base:
         INFOPLIST_FILE: SandboxedDashboard/Info.plist
-        PRODUCT_BUNDLE_IDENTIFIER: sh.sandboxed-sh.dashboard
+        PRODUCT_BUNDLE_IDENTIFIER: md.thomas.openagent.dashboard
         PRODUCT_NAME: "sandboxed.sh"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
@@ -44,7 +44,7 @@ targets:
           - "**/.DS_Store"
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: sh.sandboxed-sh.dashboard.tests
+        PRODUCT_BUNDLE_IDENTIFIER: md.thomas.openagent.dashboard.tests
         PRODUCT_NAME: SandboxedDashboardTests
         GENERATE_INFOPLIST_FILE: "YES"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/sandboxed.sh.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/sandboxed.sh"


### PR DESCRIPTION
## Summary
- Updates bundle ID from `sh.sandboxed-sh.dashboard` to `md.thomas.openagent.dashboard`
- Updates bundle ID prefix from `sh.sandboxed-sh` to `md.thomas.openagent`
- Updates test target bundle ID to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-configuration-only change that updates bundle identifiers; low functional risk but may affect signing/provisioning if mismatched with Apple developer settings.
> 
> **Overview**
> Updates the iOS dashboard XcodeGen config (`ios_dashboard/project.yml`) to use the new bundle ID namespace.
> 
> This changes `bundleIdPrefix` and both the app and unit test `PRODUCT_BUNDLE_IDENTIFIER` values to `md.thomas.openagent.*`, aligning build/signing identifiers with the intended bundle IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2885e4ca742fafc64f3a0182d35a1d0f4afe27d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->