### PR TITLE
feat(dashboard): option to create automation paused

### DIFF
--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -105,6 +105,7 @@ export function MissionAutomationsDialog({
   const [triggerKind, setTriggerKind] = useState<TriggerKind>('interval');
   const [intervalValue, setIntervalValue] = useState('5');
   const [intervalUnit, setIntervalUnit] = useState<IntervalUnit>('minutes');
+  const [startImmediately, setStartImmediately] = useState(true);
   const [variables, setVariables] = useState<Array<{ key: string; value: string }>>([]);
   const [creating, setCreating] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
@@ -305,7 +306,15 @@ export function MissionAutomationsDialog({
 
     setCreating(true);
     try {
-      const created = await createMissionAutomation(missionId, input);
+      let created = await createMissionAutomation(missionId, input);
+
+      // Allow users to create an automation in a paused state.
+      // The backend create endpoint does not currently accept `active`,
+      // so we create then immediately update.
+      if (!startImmediately) {
+        created = await updateAutomation(created.id, { active: false });
+      }
+
       setAutomationsForMission(missionId, [
         created,
         ...automationsRef.current.filter((a) => a.id !== created.id),
@@ -316,7 +325,7 @@ export function MissionAutomationsDialog({
       setIntervalValue('5');
       setIntervalUnit('minutes');
       setVariables([]);
-      toast.success('Automation created');
+      toast.success(startImmediately ? 'Automation created' : 'Automation created (paused)');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create automation';
       toast.error(message);
@@ -669,6 +678,27 @@ export function MissionAutomationsDialog({
                       </div>
                     </div>
                   )}
+                </div>
+
+                {/* Start behavior */}
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+                  <div className="min-w-0">
+                    <div className="text-xs font-medium text-white/70">Start immediately</div>
+                    <div className="text-[11px] text-white/35">
+                      If off, the automation is created paused and will not trigger until enabled.
+                    </div>
+                  </div>
+                  <label className="flex items-center gap-2 shrink-0 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={startImmediately}
+                      onChange={(e) => setStartImmediately(e.target.checked)}
+                      className="h-4 w-4 rounded border-white/20 bg-white/5 text-indigo-500 focus:ring-indigo-500/40"
+                    />
+                    <span className="text-xs text-white/50">
+                      {startImmediately ? 'On' : 'Off'}
+                    </span>
+                  </label>
                 </div>
 
                 {/* Create button */}


### PR DESCRIPTION
Adds a **Start immediately** toggle when creating a mission automation.\n\n- If on: behaves like today.\n- If off: automation is created, then immediately updated to  (paused) so it will not trigger until enabled.\n\nFile: dashboard/src/components/mission-automations-dialog.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change with a small sequencing addition (create then update) that could cause minor UX inconsistency if the pause update fails, but no auth or data model changes.
> 
> **Overview**
> Adds a **Start immediately** toggle to the Mission Automations create form, allowing an automation to be created in a paused state.
> 
> When toggled off, creation now performs a follow-up `updateAutomation(..., { active: false })` after `createMissionAutomation`, updates the list using the post-update record, and adjusts toast messaging (including an explicit error path if pausing fails).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 669b8b41a119e3d8ad7a7f803ab2d230e6ca069a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->