### PR TITLE
fix(docs-site): rename Open Agent to sandboxed.sh with emoji

### DIFF
--- a/docs-site/app/[[...mdxPath]]/layout.tsx
+++ b/docs-site/app/[[...mdxPath]]/layout.tsx
@@ -15,7 +15,7 @@ function Logo() {
           color: "rgb(var(--foreground))",
         }}
       >
-        Open Agent
+        🏝️ sandboxed.sh
       </span>
     </div>
   );
@@ -30,7 +30,7 @@ export default async function DocsLayout({
     <Navbar
       logo={<Logo />}
       logoLink="/"
-      projectLink="https://github.com/Th0rgal/openagent"
+      projectLink="https://github.com/Th0rgal/sandboxed.sh"
     />
   );
   // Get the full page map
@@ -39,7 +39,7 @@ export default async function DocsLayout({
     <Layout
       navbar={navbar}
       editLink="Edit this page on GitHub"
-      docsRepositoryBase="https://github.com/Th0rgal/openagent/blob/main/docs-site"
+      docsRepositoryBase="https://github.com/Th0rgal/sandboxed.sh/blob/main/docs-site"
       sidebar={{ defaultMenuCollapseLevel: 1 }}
       pageMap={pageMap}
       footer={null}


### PR DESCRIPTION
- Update logo text from "Open Agent" to "🏝️ sandboxed.sh"
- Fix GitHub project link to point to Th0rgal/sandboxed.sh
- Fix docs repository base URL for edit links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure docs-site branding/link updates (logo text and repository URLs) with no runtime logic or data/security impact beyond navigation/edit-link destinations.
> 
> **Overview**
> Updates the docs site branding by changing the navbar logo text from "Open Agent" to "🏝️ sandboxed.sh".
> 
> Repoints the navbar `projectLink` and the `docsRepositoryBase` used for “Edit this page on GitHub” links from `Th0rgal/openagent` to `Th0rgal/sandboxed.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b598f68f184e06c59a68cdc555fb265b402614e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->