### PR TITLE
feat: Add attribution settings support for Claude Code

### DIFF
--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -474,6 +474,19 @@ impl Default for SandboxedConfig {
     }
 }
 
+/// Claude Code attribution settings for commits and PRs.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ClaudeCodeAttribution {
+    /// Text to add to commit messages. Empty string disables attribution.
+    /// Default: "Co-Authored-By: Claude <noreply@anthropic.com>"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    /// Text to add to PR descriptions. Empty string disables attribution.
+    /// Default: "Generated with Claude Code"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<String>,
+}
+
 /// Claude Code configuration stored in the Library.
 /// Controls default model, agent preferences, and visibility for Claude Code backend.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -489,6 +502,10 @@ pub struct ClaudeCodeConfig {
     /// These agents won't appear in the dropdown but can still be used via API.
     #[serde(default)]
     pub hidden_agents: Vec<String>,
+    /// Attribution settings for commits and PRs.
+    /// Set commit/pr to empty strings to disable co-author attribution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<ClaudeCodeAttribution>,
 }
 
 /// Amp Code configuration stored in the Library.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use crate::ai_providers::{AIProvider, ProviderType};
 use crate::config::Config;
 use crate::library::env_crypto::strip_encrypted_tags;
+use crate::library::types::ClaudeCodeConfig;
 use crate::library::LibraryStore;
 use crate::mcp::{McpRegistry, McpScope, McpServerConfig, McpTransport};
 use crate::nspawn::{self, NspawnDistro};
@@ -1290,6 +1291,7 @@ async fn write_claudecode_config(
     skill_contents: Option<&[SkillContent]>,
     command_contents: Option<&[CommandContent]>,
     shared_network: Option<bool>,
+    claudecode_config: Option<&ClaudeCodeConfig>,
 ) -> anyhow::Result<()> {
     // Create .claude directory
     let claude_dir = workspace_dir.join(".claude");
@@ -1345,12 +1347,31 @@ async fn write_claudecode_config(
         WorkspaceType::Container => vec!["Bash", "Edit", "Write", "Read", "mcp__*"],
         WorkspaceType::Host => vec!["Bash", "Edit", "Write", "Read", "mcp__*"],
     };
-    let settings = json!({
+
+    // Build base settings
+    let mut settings = json!({
         "mcpServers": mcp_servers,
         "permissions": {
             "allow": permissions
         }
     });
+
+    // Add attribution settings if configured (allows disabling co-author in commits)
+    if let Some(config) = claudecode_config {
+        if let Some(attribution) = &config.attribution {
+            let mut attr_obj = serde_json::Map::new();
+            if let Some(commit) = &attribution.commit {
+                attr_obj.insert("commit".to_string(), json!(commit));
+            }
+            if let Some(pr) = &attribution.pr {
+                attr_obj.insert("pr".to_string(), json!(pr));
+            }
+            if !attr_obj.is_empty() {
+                settings["attribution"] = json!(attr_obj);
+            }
+        }
+    }
+
     let settings_path = claude_dir.join("settings.local.json");
     let settings_content = serde_json::to_string_pretty(&settings)?;
     tokio::fs::write(&settings_path, &settings_content).await?;
@@ -2000,6 +2021,7 @@ pub async fn write_backend_config(
     command_contents: Option<&[CommandContent]>,
     shared_network: Option<bool>,
     custom_providers: Option<&[AIProvider]>,
+    claudecode_config: Option<&ClaudeCodeConfig>,
 ) -> anyhow::Result<()> {
     match backend_id {
         "opencode" => {
@@ -2039,6 +2061,7 @@ pub async fn write_backend_config(
                 skill_contents,
                 command_contents,
                 shared_network,
+                claudecode_config,
             )
             .await
         }
@@ -3115,6 +3138,37 @@ pub async fn prepare_mission_workspace_with_skills_backend(
         );
     }
 
+    // Fetch Claude Code config from library for attribution settings
+    let claudecode_config = if backend_id == "claudecode" {
+        if let Some(lib) = library {
+            let profile = config_profile.unwrap_or("default");
+            match lib.get_claudecode_config_for_profile(profile).await {
+                Ok(config) => {
+                    tracing::debug!(
+                        mission = %mission_id,
+                        profile = %profile,
+                        has_attribution = config.attribution.is_some(),
+                        "Loaded Claude Code config from profile"
+                    );
+                    Some(config)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        mission = %mission_id,
+                        profile = %profile,
+                        error = %e,
+                        "Failed to load Claude Code config from profile"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     write_backend_config(
         &dir,
         backend_id,
@@ -3127,6 +3181,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
         command_contents.as_deref(),
         workspace.shared_network,
         effective_custom_providers,
+        claudecode_config.as_ref(),
     )
     .await?;
 


### PR DESCRIPTION
Allow disabling the co-author attribution in Claude Code commits by configuring the `attribution` field in the Claude Code config profile.

Changes:
- Add ClaudeCodeAttribution struct in library/types.rs
- Add attribution field to ClaudeCodeConfig
- Pass attribution settings to Claude Code settings.json when writing workspace config
- Fetch Claude Code config from library profile when preparing mission workspace

Usage:
Set `attribution.commit` and `attribution.pr` to empty strings in the config profile's .claudecode/settings.json to disable co-author attribution:

```json
{
  "attribution": {
    "commit": "",
    "pr": ""
  }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive config plumbing that only affects generated Claude Code settings output; minimal impact outside the `claudecode` backend path.
> 
> **Overview**
> Adds an optional `attribution` block to `ClaudeCodeConfig` (via new `ClaudeCodeAttribution`) so profiles can customize or disable Claude Code commit/PR attribution text.
> 
> When preparing Claude Code mission workspaces, the profile’s Claude Code config is now loaded from the library and any configured attribution values are written into `.claude/settings*.json` as an `attribution` object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56918902263de0e72919fb987fe8580a6a052171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->