### PR TITLE
Fix/network check retry signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="https://sandboxed.sh">Website</a> ·
+  <a href="https://relens.ai/community">Discord</a> ·
   <a href="#vision">Vision</a> ·
   <a href="#features">Features</a> ·
   <a href="#ecosystem">Ecosystem</a> ·


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily dashboard UI/state changes with a straightforward `updateAutomation` call; low risk aside from potential UX/state edge cases when editing/saving.
> 
> **Overview**
> Adds an **inline prompt editor** to `MissionAutomationsDialog`, letting users edit and save an existing inline automation’s prompt via `updateAutomation`, with new UI state for edit/saving, validation, and toast feedback.
> 
> Updates `README.md` header links to include a **Discord** community link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3800845f07dfcbae32bbf77dea85f04a75406271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->