### PR TITLE
Fix/network check retry signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="https://sandboxed.sh">Website</a> ·
+  <a href="https://relens.ai/community">Discord</a> ·
   <a href="#vision">Vision</a> ·
   <a href="#features">Features</a> ·
   <a href="#ecosystem">Ecosystem</a> ·


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches automation update flows and local caching/state in the dashboard; failures could leave the UI out of sync with backend automation definitions, though changes are limited to client-side behavior and an existing API call.
> 
> **Overview**
> Adds an in-place editor for **inline/prompt-based mission automations** in `MissionAutomationsDialog`, including an edit button, textarea UI, validation, and save/cancel flows that persist changes via `updateAutomation`.
> 
> Updates the README header links to include a Discord/community link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3800845f07dfcbae32bbf77dea85f04a75406271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->