### PR TITLE
fix(dashboard): sync queue state when tab regains visibility

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3632,16 +3632,23 @@ export default function ControlClient() {
         // Merge queued messages that belong to this mission
         const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === id);
         if (missionQueuedMessages.length > 0) {
-          const queuedChatItems: ChatItem[] = missionQueuedMessages.map((qm) => ({
-            kind: "user" as const,
-            id: qm.id,
-            content: qm.content,
-            timestamp: Date.now(),
-            agent: qm.agent ?? undefined,
-            queued: true,
-          }));
+          const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
+          // Mark existing items as queued
+          historyItems = historyItems.map((item) =>
+            item.kind === "user" && queuedIds.has(item.id) ? { ...item, queued: true } : item
+          );
+          // Add any queued messages not already in history
           const existingIds = new Set(historyItems.map((item) => item.id));
-          const newQueuedItems = queuedChatItems.filter((item) => !existingIds.has(item.id));
+          const newQueuedItems: ChatItem[] = missionQueuedMessages
+            .filter((qm) => !existingIds.has(qm.id))
+            .map((qm) => ({
+              kind: "user" as const,
+              id: qm.id,
+              content: qm.content,
+              timestamp: Date.now(),
+              agent: qm.agent ?? undefined,
+              queued: true,
+            }));
           historyItems = [...historyItems, ...newQueuedItems];
         }
         setItems(historyItems);
@@ -3711,16 +3718,21 @@ export default function ControlClient() {
               // Merge queued messages that belong to this mission
               const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === mission.id);
               if (missionQueuedMessages.length > 0) {
-                const queuedChatItems: ChatItem[] = missionQueuedMessages.map((qm) => ({
-                  kind: "user" as const,
-                  id: qm.id,
-                  content: qm.content,
-                  timestamp: Date.now(),
-                  agent: qm.agent ?? undefined,
-                  queued: true,
-                }));
+                const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
+                historyItems = historyItems.map((item) =>
+                  item.kind === "user" && queuedIds.has(item.id) ? { ...item, queued: true } : item
+                );
                 const existingIds = new Set(historyItems.map((item) => item.id));
-                const newQueuedItems = queuedChatItems.filter((item) => !existingIds.has(item.id));
+                const newQueuedItems: ChatItem[] = missionQueuedMessages
+                  .filter((qm) => !existingIds.has(qm.id))
+                  .map((qm) => ({
+                    kind: "user" as const,
+                    id: qm.id,
+                    content: qm.content,
+                    timestamp: Date.now(),
+                    agent: qm.agent ?? undefined,
+                    queued: true,
+                  }));
                 historyItems = [...historyItems, ...newQueuedItems];
               }
               setItems(historyItems);
@@ -4102,17 +4114,21 @@ export default function ControlClient() {
         // Merge queued messages that belong to this mission
         const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === missionId);
         if (missionQueuedMessages.length > 0) {
-          const queuedChatItems: ChatItem[] = missionQueuedMessages.map((qm) => ({
-            kind: "user" as const,
-            id: qm.id,
-            content: qm.content,
-            timestamp: Date.now(),
-            agent: qm.agent ?? undefined,
-            queued: true,
-          }));
-          // Filter out any queued messages that already exist in history (by ID)
+          const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
+          historyItems = historyItems.map((item) =>
+            item.kind === "user" && queuedIds.has(item.id) ? { ...item, queued: true } : item
+          );
           const existingIds = new Set(historyItems.map((item) => item.id));
-          const newQueuedItems = queuedChatItems.filter((item) => !existingIds.has(item.id));
+          const newQueuedItems: ChatItem[] = missionQueuedMessages
+            .filter((qm) => !existingIds.has(qm.id))
+            .map((qm) => ({
+              kind: "user" as const,
+              id: qm.id,
+              content: qm.content,
+              timestamp: Date.now(),
+              agent: qm.agent ?? undefined,
+              queued: true,
+            }));
           historyItems = [...historyItems, ...newQueuedItems];
         }
 
@@ -4426,16 +4442,21 @@ export default function ControlClient() {
               // Merge queued messages that belong to this mission
               const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === viewingId);
               if (missionQueuedMessages.length > 0) {
-                const queuedChatItems: ChatItem[] = missionQueuedMessages.map((qm) => ({
-                  kind: "user" as const,
-                  id: qm.id,
-                  content: qm.content,
-                  timestamp: Date.now(),
-                  agent: qm.agent ?? undefined,
-                  queued: true,
-                }));
+                const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
+                historyItems = historyItems.map((item) =>
+                  item.kind === "user" && queuedIds.has(item.id) ? { ...item, queued: true } : item
+                );
                 const existingIds = new Set(historyItems.map((item) => item.id));
-                const newQueuedItems = queuedChatItems.filter((item) => !existingIds.has(item.id));
+                const newQueuedItems: ChatItem[] = missionQueuedMessages
+                  .filter((qm) => !existingIds.has(qm.id))
+                  .map((qm) => ({
+                    kind: "user" as const,
+                    id: qm.id,
+                    content: qm.content,
+                    timestamp: Date.now(),
+                    agent: qm.agent ?? undefined,
+                    queued: true,
+                  }));
                 historyItems = [...historyItems, ...newQueuedItems];
               }
               setItems(historyItems);

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -5507,6 +5507,17 @@ export default function ControlClient() {
     }
   }, []);
 
+  // Re-sync queue when the tab regains visibility (e.g. user navigated away and back)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && viewingMissionId) {
+        syncQueueForMission(viewingMissionId);
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [viewingMissionId, syncQueueForMission]);
+
   // Compute queued items for the queue strip
   const queuedItems: QueueItem[] = useMemo(() => {
     return items


### PR DESCRIPTION
## Summary
- Queued messages appeared stale after navigating away from the control page and returning, requiring a hard refresh to see updated state
- Root cause: the mission loading effect short-circuits when the mission ID hasn't changed (`viewingMissionRef.current?.id === id`), skipping the queue re-fetch
- Added a `visibilitychange` event listener that calls `syncQueueForMission` when the tab becomes visible again, reconciling local queue state with the server

## Test plan
- [ ] Queue a message on a mission, navigate away from the tab, wait for it to process, switch back — queue should clear without hard refresh
- [ ] Verify no duplicate fetches when staying on the page (listener only fires on visibility change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI-side change that adds an event listener and triggers an existing fetch on tab visibility; minimal impact beyond potential extra network calls.
> 
> **Overview**
> Keeps the control page’s queued-message strip from going stale by **re-syncing queue state when the browser tab becomes visible again**.
> 
> Adds a `visibilitychange` listener that calls `syncQueueForMission(viewingMissionId)` on visibility regain, updating local `items[].queued` to match the server without requiring a hard refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5effe2c7cd31caf2396537c42a3e88bfdd6e26a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->