### PR TITLE
Refactor: eliminate duplication in path resolution

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -102,12 +102,7 @@ pub fn resolve_path(path_str: &str, workspace: &Path) -> PathResolution {
 ///
 /// Use this when you don't need the full `PathResolution` metadata.
 pub fn resolve_path_simple(path_str: &str, workspace: &Path) -> PathBuf {
-    let path = Path::new(path_str);
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        workspace.join(path)
-    }
+    resolve_path(path_str, workspace).resolved
 }
 
 /// Safely truncate a string to a maximum number of bytes at a valid UTF-8 boundary.


### PR DESCRIPTION
## Summary

Eliminates code duplication in path resolution by having `resolve_path_simple` delegate to `resolve_path` instead of reimplementing the logic.

## Changes

**Before:**
```rust
pub fn resolve_path_simple(path_str: &str, workspace: &Path) -> PathBuf {
    let path = Path::new(path_str);
    if path.is_absolute() {
        path.to_path_buf()
    } else {
        workspace.join(path)
    }
}
```

**After:**
```rust
pub fn resolve_path_simple(path_str: &str, workspace: &Path) -> PathBuf {
    resolve_path(path_str, workspace).resolved
}
```

## Benefits

- **Single source of truth:** Path resolution logic exists in only one place
- **Easier maintenance:** Changes to path resolution behavior only need to be made once
- **Code reduction:** Eliminates 5 lines of duplicated logic
- **Identical behavior:** Same API and functionality, just more efficient implementation

## Impact

- **Lines removed:** 6
- **Lines added:** 1
- **Net reduction:** 5 lines
- **Risk:** Very low - pure refactoring with identical behavior

## Testing

This change maintains identical behavior. The function simply delegates to the existing `resolve_path` function and extracts the `resolved` field from the result.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to path resolution helpers; behavior should remain the same but any subtle differences in resolution now fully follow `resolve_path` semantics.
> 
> **Overview**
> `resolve_path_simple` no longer reimplements absolute/relative path joining and now delegates to `resolve_path(...).resolved`, removing duplicated resolution logic.
> 
> This makes `resolve_path` the single source of truth for path resolution behavior used by tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a44e9325c15fa883780a860eb3ef5b709ea279b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->