### PR TITLE
Docs: remove hardcoded version from getting-started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ Click on **System** to configure your backend connection:
 The System page shows:
 - **API URL** - Backend endpoint (currently connected status)
 - **System Components** - Installed harnesses and versions
-  - Sandboxed.sh (v0.5.1)
+  - Sandboxed.sh (current version shown)
   - OpenCode (with update notifications)
   - Claude Code (with update notifications)
   - Amp


### PR DESCRIPTION
## Summary

Updates the getting-started.md documentation to remove a hardcoded version reference that was outdated.

## Problem

The getting-started guide referenced version `v0.5.1` in the System Components section, but the current version is `v0.7.9`. Hardcoding specific versions in documentation leads to:
- Outdated information that confuses users
- Manual maintenance burden to keep versions current
- Documentation that ages poorly

## Solution

Replace the hardcoded version with generic text that describes what users will see without specifying a version number.

**Before:**
```markdown
- Sandboxed.sh (v0.5.1)
```

**After:**
```markdown
- Sandboxed.sh (current version shown)
```

## Benefits

- **Stays accurate:** Documentation remains correct regardless of version
- **Reduces maintenance:** No need to update docs with every release
- **Best practice:** Follows documentation guidelines to avoid hardcoded versions
- **User clarity:** Describes what users will see without confusion from old versions

## Impact

- **Risk:** None - pure documentation improvement
- **Lines changed:** 1 line updated
- **Scope:** docs/getting-started.md only

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording change with no impact on runtime behavior.
> 
> **Overview**
> Removes a hardcoded `Sandboxed.sh (v0.5.1)` reference from `docs/getting-started.md`, replacing it with generic wording (`current version shown`) so the System Components section doesn’t become stale as releases change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90c349603bd6fc577ef160c740040c7b88a02d29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->