### PR TITLE
Refactor: use extract_str helper for tool field extraction

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -173,17 +173,11 @@ fn handle_tool_part_update(
     let state_obj = part.get("state")?;
     let status = state_obj.get("status").and_then(|v| v.as_str())?;
 
-    let tool_call_id = part
-        .get("callID")
-        .or_else(|| part.get("id"))
-        .and_then(|v| v.as_str())
+    let tool_call_id = extract_str(part, &["callID", "id"])
         .unwrap_or("unknown")
         .to_string();
 
-    let tool_name = part
-        .get("tool")
-        .or_else(|| part.get("name"))
-        .and_then(|v| v.as_str())
+    let tool_name = extract_str(part, &["tool", "name"])
         .unwrap_or("unknown")
         .to_string();
 


### PR DESCRIPTION
## Summary

Eliminates code duplication by reusing the existing `extract_str` helper function for tool field extraction in `handle_tool_part_update`.

## Problem

The code was manually implementing multi-key field extraction for `tool_call_id` and `tool_name` using `.get().or_else().and_then()` chains, duplicating the exact pattern that the `extract_str` helper function was designed to handle.

## Solution

Refactor to use the existing `extract_str` helper instead of duplicating the extraction logic.

**Before:**
```rust
let tool_call_id = part
    .get("callID")
    .or_else(|| part.get("id"))
    .and_then(|v| v.as_str())
    .unwrap_or("unknown")
    .to_string();

let tool_name = part
    .get("tool")
    .or_else(|| part.get("name"))
    .and_then(|v| v.as_str())
    .unwrap_or("unknown")
    .to_string();
```

**After:**
```rust
let tool_call_id = extract_str(part, &["callID", "id"])
    .unwrap_or("unknown")
    .to_string();

let tool_name = extract_str(part, &["tool", "name"])
    .unwrap_or("unknown")
    .to_string();
```

## Benefits

- **Single source of truth:** Reuses existing helper for multi-key extraction
- **Code reduction:** Eliminates 6 lines of duplicated logic
- **Consistency:** Same pattern used throughout the file (e.g., `extract_part_text`)
- **Readability:** Clearer intent with dedicated helper function
- **Maintainability:** Changes to extraction logic only need one location

## Impact

- **Lines removed:** 8
- **Lines added:** 2
- **Net reduction:** 6 lines
- **Risk:** Very low - pure refactoring with identical behavior
- **File:** src/api/mission_runner.rs

## Testing

This change maintains identical behavior. The `extract_str` helper implements the exact same multi-key extraction pattern that was being manually duplicated.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to JSON field extraction for tool events; logic and defaults remain the same, with minimal behavioral risk.
> 
> **Overview**
> Refactors `handle_tool_part_update` in `mission_runner.rs` to use the shared `extract_str` helper for extracting `tool_call_id` (from `callID`/`id`) and `tool_name` (from `tool`/`name`), replacing duplicated `.get().or_else().and_then()` chains.
> 
> Behavior is intended to be unchanged (still defaulting to `"unknown"` when missing), while reducing duplication and keeping extraction logic consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea19abaaa46f5ffa37a84ede81fe4bc20be4e9cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->