### PR TITLE
Refactor: use functional style in strip_opencode_status_lines

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -155,14 +155,12 @@ fn is_opencode_status_line(line: &str) -> bool {
 }
 
 fn strip_opencode_status_lines(text: &str) -> String {
-    let mut out = Vec::new();
-    for line in text.lines() {
-        if is_opencode_status_line(line) {
-            continue;
-        }
-        out.push(line);
-    }
-    out.join("\n").trim().to_string()
+    text.lines()
+        .filter(|line| !is_opencode_status_line(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
 }
 
 fn handle_tool_part_update(


### PR DESCRIPTION
## Summary

Refactors `strip_opencode_status_lines` to use functional programming style with iterators instead of imperative loops, making the code more idiomatic Rust.

## Changes

**Before:**
```rust
fn strip_opencode_status_lines(text: &str) -> String {
    let mut out = Vec::new();
    for line in text.lines() {
        if is_opencode_status_line(line) {
            continue;
        }
        out.push(line);
    }
    out.join("\n").trim().to_string()
}
```

**After:**
```rust
fn strip_opencode_status_lines(text: &str) -> String {
    text.lines()
        .filter(|line| !is_opencode_status_line(line))
        .collect::<Vec<_>>()
        .join("\n")
        .trim()
        .to_string()
}
```

## Benefits

- **More idiomatic Rust:** Uses iterator chains instead of manual loops
- **Eliminates mutable state:** No need for `let mut out = Vec::new()`
- **Clearer intent:** Declarative filtering instead of imperative continue
- **More readable:** Functional composition makes the data flow obvious
- **Slightly more concise:** 7 lines vs 9 lines

## Impact

- **Lines removed:** 8
- **Lines added:** 6  
- **Net reduction:** 2 lines
- **Risk:** Very low - pure refactoring with identical behavior
- **File:** src/api/mission_runner.rs

## Pattern

This follows common Rust patterns for filtering collections:
- `.lines()` creates an iterator
- `.filter()` keeps only lines that don't match status patterns
- `.collect::<Vec<_>>()` gathers into a vector
- `.join()` concatenates with newlines
- `.trim()` removes leading/trailing whitespace

## Testing

This change maintains identical behavior. The functional approach produces the same output as the imperative loop.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of text-filtering logic with no behavioral intent changes; risk is limited to subtle differences in line collection/joining if assumptions about input formatting were incorrect.
> 
> **Overview**
> Refactors `strip_opencode_status_lines` in `src/api/mission_runner.rs` from an imperative loop to an iterator chain (`lines` + `filter` + `collect` + `join`), removing mutable state while keeping the same newline-joining and trimming behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86784ea2f250e70c07dfe157e50c2ebdaf3a2edb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->