### PR TITLE
Refactor: use matches! macro in extract_part_text

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -62,7 +62,7 @@ fn extract_str<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<&'a st
 }
 
 fn extract_part_text<'a>(part: &'a serde_json::Value, part_type: &str) -> Option<&'a str> {
-    if part_type == "thinking" || part_type == "reasoning" {
+    if matches!(part_type, "thinking" | "reasoning") {
         extract_str(part, &["thinking", "text", "content"])
     } else {
         extract_str(part, &["text", "content", "output_text"])


### PR DESCRIPTION
## Summary

Refactors `extract_part_text` to use the idiomatic `matches!` macro instead of multiple equality checks, improving consistency with the rest of the file.

## Changes

**Before:**
```rust
fn extract_part_text<'a>(part: &'a serde_json::Value, part_type: &str) -> Option<&'a str> {
    if part_type == "thinking" || part_type == "reasoning" {
        extract_str(part, &["thinking", "text", "content"])
    } else {
        extract_str(part, &["text", "content", "output_text"])
    }
}
```

**After:**
```rust
fn extract_part_text<'a>(part: &'a serde_json::Value, part_type: &str) -> Option<&'a str> {
    if matches!(part_type, "thinking" | "reasoning") {
        extract_str(part, &["thinking", "text", "content"])
    } else {
        extract_str(part, &["text", "content", "output_text"])
    }
}
```

## Benefits

- **More idiomatic Rust:** Uses the `matches!` macro which is designed for this use case
- **Better readability:** Pattern matching intent is clearer  
- **Consistency:** Lines 248-249 in the same file already use `matches!` for similar checks
- **Slightly more concise:** Cleaner syntax than multiple `||` operators

## Context

The same file already uses `matches!` for similar pattern matching:

```rust
let is_thinking = matches!(part_type, "thinking" | "reasoning");
let is_text = matches!(part_type, "text" | "output_text");
```

This change brings `extract_part_text` in line with that established pattern.

## Impact

- **Lines changed:** 1 line modified
- **Risk:** Very low - pure refactoring with identical behavior  
- **File:** src/api/mission_runner.rs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of a local conditional with no functional or data-flow changes, so regression risk is minimal.
> 
> **Overview**
> Refactors `extract_part_text` in `src/api/mission_runner.rs` to use Rust’s `matches!` macro when checking whether `part_type` is `"thinking"` or `"reasoning"`, replacing the explicit `||` string comparisons.
> 
> Behavior is unchanged; this is a small readability/idiomatic cleanup localized to part-type branching logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a7b07a71633e62c152cd83facc64253b3624824. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->