### PR TITLE
Refactor: use matches! macro in control.rs

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -1511,9 +1511,7 @@ pub async fn create_mission(
     // Skip validation for Claude Code, Amp, and Codex - they have their own built-in agents
     if let Some(ref agent_name) = agent {
         let backend_id = backend.as_deref();
-        let skip_validation = backend_id == Some("claudecode")
-            || backend_id == Some("amp")
-            || backend_id == Some("codex");
+        let skip_validation = matches!(backend_id, Some("claudecode" | "amp" | "codex"));
         if !skip_validation {
             super::library::validate_agent_exists(
                 &state,
@@ -2613,8 +2611,7 @@ async fn automation_scheduler_loop(
                     Ok(running) => running.iter().any(|r| {
                         r.mission_id == mission.id
                             && (r.queue_len > 0
-                                || r.state == "running"
-                                || r.state == "waiting_for_tool")
+                                || matches!(r.state.as_str(), "running" | "waiting_for_tool"))
                     }),
                     Err(_) => {
                         tracing::warn!(
@@ -3335,12 +3332,10 @@ async fn control_actor_loop(
                     if path.is_dir() {
                         let dir_name = path.file_name().unwrap_or_default().to_string_lossy();
                         // Skip common non-artifact directories
-                        if dir_name == "venv"
-                            || dir_name == ".venv"
-                            || dir_name == ".sandboxed_sh"
-                            || dir_name == ".sandboxed-sh"
-                            || dir_name == "temp"
-                        {
+                        if matches!(
+                            dir_name.as_ref(),
+                            "venv" | ".venv" | ".sandboxed_sh" | ".sandboxed-sh" | "temp"
+                        ) {
                             continue;
                         }
                         // List files in subdirectory


### PR DESCRIPTION
## Summary
Simplifies three instances of multiple equality checks with `||` operators by using the more idiomatic `matches!` macro.

## Changes
1. **Backend ID validation** (line 1514): Checks if backend is `claudecode`, `amp`, or `codex`
   ```rust
   // Before
   let skip_validation = backend_id == Some("claudecode")
       || backend_id == Some("amp")
       || backend_id == Some("codex");
   
   // After
   let skip_validation = matches!(backend_id, Some("claudecode" | "amp" | "codex"));
   ```

2. **Running state check** (line 2616): Checks if state is `"running"` or `"waiting_for_tool"`
   ```rust
   // Before
   r.queue_len > 0
       || r.state == "running"
       || r.state == "waiting_for_tool"
   
   // After
   r.queue_len > 0
       || matches!(r.state.as_str(), "running" | "waiting_for_tool")
   ```

3. **Directory name filtering** (line 3338): Checks if dir is `venv`, `.venv`, `temp`, etc.
   ```rust
   // Before
   if dir_name == "venv"
       || dir_name == ".venv"
       || dir_name == ".sandboxed_sh"
       || dir_name == ".sandboxed-sh"
       || dir_name == "temp"
   
   // After
   if matches!(
       dir_name.as_ref(),
       "venv" | ".venv" | ".sandboxed_sh" | ".sandboxed-sh" | "temp"
   )
   ```

## Benefits
- Improves readability with more concise pattern matching
- Maintains consistency with existing `matches!` usage in the codebase (e.g., mission_runner.rs:65)
- Reduces line count by 5 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of conditional expressions with no behavioral intent; risk is limited to accidental mismatch in string/value patterns.
> 
> **Overview**
> Replaces three instances of chained `||` equality checks in `control.rs` with `matches!` for more concise, idiomatic comparisons.
> 
> This affects the skip-agent-validation backend allowlist check, the automation busy-state check for `running`/`waiting_for_tool`, and the work-directory scan’s exclusion of common non-artifact directories (e.g., `venv`, `.venv`, `temp`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a42841a58ae3d6f67da3585c6670177013d5ed1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->