### PR TITLE
Refactor: simplify backend checks and deduplicate terminal validation

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3064,7 +3064,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
         }
 
         // Collect skills (for backends that use skill contents directly)
-        if backend_id == "claudecode" || backend_id == "amp" || backend_id == "codex" {
+        if matches!(backend_id, "claudecode" | "amp" | "codex") {
             let skill_names = match resolve_workspace_skill_names(workspace, lib).await {
                 Ok(names) => {
                     tracing::debug!(


### PR DESCRIPTION
## Summary
Two focused improvements for code simplicity and maintainability.

## Changes

### 1. workspace.rs: Use matches! macro for backend ID check (line 3067)
```rust
// Before
if backend_id == "claudecode" || backend_id == "amp" || backend_id == "codex" {

// After
if matches!(backend_id, "claudecode" | "amp" | "codex") {
```
Consistent with the pattern established in control.rs (PR #121).

### 2. terminal.rs: Extract duplicated pattern validation into helper
Lines 222-228 and 239-248 had **identical exception-checking logic** for find and grep patterns.

```rust
// Before (14 lines duplicated)
if (pattern == &"find /" || pattern == &"find / ") && is_safe_root_find {
    continue;
}
if (pattern == &"grep -r /" || pattern == &"grep -rn /" || pattern == &"grep -R /")
    && is_safe_root_grep
{
    continue;
}
// ... same 7 lines repeated again below

// After (single helper closure)
let is_pattern_allowed = |pattern: &str| -> bool {
    if matches!(pattern, "find /" | "find / ") && is_safe_root_find {
        return true;
    }
    if matches!(pattern, "grep -r /" | "grep -rn /" | "grep -R /") && is_safe_root_grep {
        return true;
    }
    false
};
```

## Benefits
- **DRY principle**: Eliminates 14 lines of duplicated validation logic
- **Single source of truth**: Pattern exception rules defined in one place
- **Consistency**: Uses `matches!` macro throughout (both changes)
- **Maintainability**: Future changes to validation logic only need updating in one location

## Test Coverage
No behavioral changes - purely refactoring existing logic into clearer patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of conditional logic with no intended behavior changes; risk is limited to accidental changes in command-blocking edge cases.
> 
> **Overview**
> Refactors terminal command validation in `src/tools/terminal.rs` by deduplicating repeated exception logic for otherwise-blocked root `find`/`grep` patterns into a single `is_pattern_allowed` helper.
> 
> Simplifies backend ID branching in `src/workspace.rs` by replacing chained `||` comparisons with a `matches!` check when deciding which backends should collect skill contents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ebff5f9f645a2a65749800a49e6b1feba736687. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->