### PR TITLE
Docs: update README to reflect three supported runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ literature. Local inference, isolated containers, nothing leaves your machines.
 
 ## Features
 
-- **Dual Runtime Support**: Run Claude Code or OpenCode agents in the same
+- **Multi-Runtime Support**: Run Claude Code, OpenCode, or Amp agents in the same
   infrastructure
 - **Mission Control**: Start, stop, and monitor agents remotely with real-time
   streaming


### PR DESCRIPTION
## Summary
Fixes an inconsistency in the README where the Features section claimed "Dual Runtime Support" while the Ecosystem section correctly lists three supported runtimes.

## Problem
The README had conflicting information:
- **Features section** (line 57): "Dual Runtime Support: Run Claude Code or OpenCode agents"
- **Ecosystem section** (lines 76-81): Lists three runtimes - Claude Code, OpenCode, **and Amp**

This makes the documentation misleading since Amp support is a key feature that was missing from the Features list.

## Solution
Changed "Dual Runtime Support" to "Multi-Runtime Support" to accurately reflect that the system supports three distinct agent runtimes.

```diff
- **Dual Runtime Support**: Run Claude Code or OpenCode agents in the same
+ **Multi-Runtime Support**: Run Claude Code, OpenCode, or Amp agents in the same
   infrastructure
```

## Impact
- More accurate representation of current capabilities
- Consistency between Features and Ecosystem sections  
- Highlights Amp support as a first-class feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or interfaces.
> 
> **Overview**
> Updates the README Features list to reflect support for **three agent runtimes** by renaming **Dual Runtime Support** to **Multi-Runtime Support** and explicitly adding `Amp` alongside `Claude Code` and `OpenCode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7455255c3f1f0a74ab2878f73a4f3041138bee8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->