### PR TITLE
Fix model overrides, add provider health check, rename Configs to Profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandboxed_sh"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Self-hosted orchestrator for AI coding agents (formerly Open Agent)"
 authors = ["sandboxed.sh Contributors"]

--- a/PROVIDER_HEALTH_CHECK.md
+++ b/PROVIDER_HEALTH_CHECK.md
@@ -1,0 +1,148 @@
+# Provider Health Check
+
+This feature adds a health check endpoint for AI providers to validate credentials and test connectivity before using them in missions.
+
+## Endpoint
+
+```
+POST /api/ai/providers/:id/health
+```
+
+## Usage
+
+Test a provider's health status:
+
+```bash
+curl -X POST https://YOUR-BACKEND/api/ai/providers/cerebras/health
+```
+
+## Response Format
+
+### Healthy Provider
+```json
+{
+  "healthy": true,
+  "status": "connected",
+  "message": "Provider API key is valid and working"
+}
+```
+
+### Invalid Credentials
+```json
+{
+  "healthy": false,
+  "status": "api_error",
+  "message": "API returned status 401: Invalid API key",
+  "status_code": 401
+}
+```
+
+### No Credentials
+```json
+{
+  "healthy": false,
+  "status": "no_credentials",
+  "message": "Provider has no API key or OAuth credentials configured"
+}
+```
+
+### Connection Error
+```json
+{
+  "healthy": false,
+  "status": "connection_error",
+  "message": "Failed to connect to provider API: connection timeout"
+}
+```
+
+## Supported Providers
+
+The health check performs actual API validation for:
+- **Cerebras** - Tests with `llama-3.1-8b` model
+- **Z.AI** - Tests with `glm-4-flash` model
+- **DeepInfra** - Tests with `Meta-Llama-3.1-8B-Instruct` model
+
+For OAuth-based providers (Anthropic, OpenAI, Google), it verifies credentials exist without making test API calls.
+
+## Examples
+
+### Test Cerebras Provider
+```bash
+# Configure provider
+curl -X POST https://YOUR-BACKEND/api/ai/providers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_type": "cerebras",
+    "name": "Cerebras",
+    "api_key": "csk-...",
+    "enabled": true,
+    "use_for_backends": ["opencode"]
+  }'
+
+# Test health
+curl -X POST https://YOUR-BACKEND/api/ai/providers/cerebras/health
+```
+
+### Test Z.AI Provider
+```bash
+# Configure provider
+curl -X POST https://YOUR-BACKEND/api/ai/providers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider_type": "zai",
+    "name": "Z.AI",
+    "api_key": "YOUR_KEY",
+    "enabled": true,
+    "use_for_backends": ["opencode"]
+  }'
+
+# Test health
+curl -X POST https://YOUR-BACKEND/api/ai/providers/zai/health
+```
+
+## Integration with Dashboard
+
+The dashboard can use this endpoint to:
+1. **Validate on Save** - Test credentials immediately when adding a provider
+2. **Show Status** - Display health status in provider list
+3. **Troubleshooting** - Help users diagnose authentication issues
+
+Example dashboard integration:
+```typescript
+async function addProvider(config: ProviderConfig) {
+  // Create provider
+  const provider = await api.post('/api/ai/providers', config);
+
+  // Immediately test health
+  const health = await api.post(`/api/ai/providers/${provider.id}/health`);
+
+  if (!health.healthy) {
+    throw new Error(`Provider validation failed: ${health.message}`);
+  }
+
+  return provider;
+}
+```
+
+## Benefits
+
+1. **Early Error Detection** - Catch invalid API keys before missions fail
+2. **Better UX** - Immediate feedback when configuring providers
+3. **Troubleshooting** - Clear error messages help users fix issues
+4. **Reliability** - Verify connectivity to provider APIs
+
+## Error Codes
+
+| Status | Description |
+|--------|-------------|
+| `connected` | Provider is healthy and working |
+| `configured` | Provider has credentials (OAuth not tested) |
+| `no_credentials` | No API key or OAuth token configured |
+| `api_error` | API call failed (invalid key, rate limit, etc.) |
+| `connection_error` | Network error connecting to provider |
+
+## Status Codes
+
+- **200 OK** - Health check completed (see `healthy` field for result)
+- **404 Not Found** - Provider not configured
+- **500 Internal Server Error** - Health check system error

--- a/dashboard/src/app/config/commands/page.tsx
+++ b/dashboard/src/app/config/commands/page.tsx
@@ -363,6 +363,7 @@ Describe what this command does.
                             setCommandDirty(true);
                           }}
                           className="h-full"
+                          height="100%"
                           disabled={commandSaving}
                           language="markdown"
                         />

--- a/dashboard/src/app/config/settings/page.tsx
+++ b/dashboard/src/app/config/settings/page.tsx
@@ -1301,6 +1301,7 @@ export default function SettingsPage() {
               placeholder='{\n  "key": "value"\n}'
               disabled={saving || !selectedFile}
               className="h-full"
+              height="100%"
               padding={16}
               language="json"
             />

--- a/dashboard/src/app/config/workspace-templates/page.tsx
+++ b/dashboard/src/app/config/workspace-templates/page.tsx
@@ -805,6 +805,7 @@ set -e
                   placeholder="#!/usr/bin/env bash"
                   padding={16}
                   minHeight="100%"
+                  height="100%"
                   language="bash"
                   className="h-full focus-within:border-emerald-500/50"
                   editorClassName="h-full"
@@ -1220,6 +1221,7 @@ set -e
                           placeholder={`#!/usr/bin/env bash\n# Additional setup that runs after fragments`}
                           padding={12}
                           minHeight="100%"
+                          height="100%"
                           language="bash"
                           className="flex-1 min-h-[150px] focus-within:border-indigo-500/50"
                           editorClassName="h-full"

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6159,7 +6159,7 @@ export default function ControlClient() {
                     Subtask
                   </span>
                   <span className="text-sm font-medium text-emerald-400 tabular-nums">
-                    {viewingProgress.completed + 1}/{viewingProgress.total}
+                    {Math.min(viewingProgress.completed + 1, viewingProgress.total)}/{viewingProgress.total}
                   </span>
                 </div>
               </>

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -5759,6 +5759,7 @@ export default function ControlClient() {
               workspaceId: activeMission.workspace_id,
               agent: activeMission.agent,
               backend: activeMission.backend,
+              modelOverride: activeMission.model_override,
             } : undefined}
           />
 

--- a/dashboard/src/components/config-code-editor.tsx
+++ b/dashboard/src/components/config-code-editor.tsx
@@ -26,6 +26,8 @@ interface ConfigCodeEditorProps {
   className?: string;
   editorClassName?: string;
   minHeight?: number | string;
+  /** Constrain the editor to this height (enables scrolling). Use "100%" to fill parent. */
+  height?: number | string;
   padding?: number;
   /** Enable highlighting of <encrypted>...</encrypted> tags */
   highlightEncrypted?: boolean;
@@ -148,6 +150,7 @@ export function ConfigCodeEditor({
   className,
   editorClassName,
   minHeight = '100%',
+  height,
   padding = 12,
   highlightEncrypted = false,
   language = 'plain',
@@ -183,7 +186,7 @@ export function ConfigCodeEditor({
   return (
     <div
       className={cn(
-        'rounded-lg bg-black/20 border border-white/[0.06] focus-within:border-indigo-500/50 transition-colors relative',
+        'rounded-lg bg-black/20 border border-white/[0.06] focus-within:border-indigo-500/50 transition-colors relative overflow-hidden',
         disabled && 'opacity-60',
         className
       )}
@@ -206,6 +209,7 @@ export function ConfigCodeEditor({
         extensions={extensions}
         theme="none"
         minHeight={typeof minHeight === 'number' ? `${minHeight}px` : minHeight}
+        height={height !== undefined ? (typeof height === 'number' ? `${height}px` : height) : undefined}
         className={cn('config-code-editor', editorClassName)}
         basicSetup={{
           lineNumbers: false,

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -449,11 +449,21 @@ export function NewMissionDialog({
     setDefaultSet(true);
   }, [open, defaultSet, allAgents, config, initialValues]);
 
+  // Track previous backend to detect switches
+  const prevBackendRef = useRef(selectedBackend);
   useEffect(() => {
     if (selectedBackend === 'amp' && modelOverride) {
       setModelOverride('');
     }
-  }, [selectedBackend, modelOverride]);
+    // When switching backends, clear model override if current value isn't valid for the new backend
+    if (prevBackendRef.current !== selectedBackend && modelOverride) {
+      const isValidForNewBackend = modelOptions.some(opt => opt.value === modelOverride);
+      if (!isValidForNewBackend) {
+        setModelOverride('');
+      }
+    }
+    prevBackendRef.current = selectedBackend;
+  }, [selectedBackend, modelOverride, modelOptions]);
 
   const resetForm = () => {
     setNewMissionWorkspace('');

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -213,7 +213,7 @@ export function NewMissionDialog({
     return targetWorkspace?.config_profile || null;
   }, [newMissionWorkspace, workspaces]);
 
-  const effectiveProfileForAgents = workspaceProfile || null;
+  const effectiveProfileForAgents = workspaceProfile || 'default';
 
   const { data: opencodeProfileSettings } = useSWR(
     effectiveProfileForAgents ? ['opencode-profile-settings', effectiveProfileForAgents] : null,

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -110,6 +110,7 @@ export function NewMissionDialog({
   const [submitting, setSubmitting] = useState(false);
   const [defaultSet, setDefaultSet] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const prevBackendRef = useRef<string | null>(null);
 
   // SWR: fetch backends
   const { data: backends } = useSWR<Backend[]>('backends', listBackends, {
@@ -449,14 +450,12 @@ export function NewMissionDialog({
     setDefaultSet(true);
   }, [open, defaultSet, allAgents, config, initialValues]);
 
-  // Track previous backend to detect switches
-  const prevBackendRef = useRef(selectedBackend);
   useEffect(() => {
     if (selectedBackend === 'amp' && modelOverride) {
       setModelOverride('');
     }
     // When switching backends, clear model override if current value isn't valid for the new backend
-    if (prevBackendRef.current !== selectedBackend && modelOverride) {
+    if (prevBackendRef.current !== null && prevBackendRef.current !== selectedBackend && modelOverride) {
       const isValidForNewBackend = modelOptions.some(opt => opt.value === modelOverride);
       if (!isValidForNewBackend) {
         setModelOverride('');

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -28,6 +28,7 @@ export interface InitialMissionValues {
   workspaceId?: string;
   agent?: string;
   backend?: string;
+  modelOverride?: string;
 }
 
 interface NewMissionDialogProps {
@@ -381,6 +382,11 @@ export function NewMissionDialog({
     // Set workspace from initialValues if provided
     if (initialValues?.workspaceId) {
       setNewMissionWorkspace(initialValues.workspaceId);
+    }
+
+    // Set model override from initialValues if provided
+    if (initialValues?.modelOverride) {
+      setModelOverride(initialValues.modelOverride);
     }
 
     // Try to use initialValues for agent (from current mission)

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -50,7 +50,7 @@ const navigation: NavItem[] = [
       { name: 'Commands', href: '/config/commands', icon: Terminal },
       { name: 'Skills', href: '/config/skills', icon: FileCode },
       { name: 'Workspaces', href: '/config/workspace-templates', icon: LayoutGrid },
-      { name: 'Configs', href: '/config/settings', icon: Cog },
+      { name: 'Profiles', href: '/config/settings', icon: Cog },
     ],
   },
   {

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -32,6 +32,7 @@ export interface Mission {
   workspace_id?: string;
   workspace_name?: string;
   agent?: string;
+  model_override?: string;
   backend?: string;
   history: MissionHistoryEntry[];
   desktop_sessions?: DesktopSessionInfo[];

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3739,8 +3739,10 @@ async fn check_provider_health(
     // Try to parse as UUID first (for custom providers), then as type ID
     let (api_key_opt, provider_type) = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
         // UUID lookup for custom providers
-        let provider = state.ai_providers.get(uuid).await
-            .ok_or((StatusCode::NOT_FOUND, format!("Provider with ID {} not found", id)))?;
+        let provider = state.ai_providers.get(uuid).await.ok_or((
+            StatusCode::NOT_FOUND,
+            format!("Provider with ID {} not found", id),
+        ))?;
 
         // Check if provider has credentials
         let has_credentials = provider.api_key.is_some()
@@ -3776,12 +3778,15 @@ async fn check_provider_health(
         } else {
             // Not in custom store - check OpenCode config for standard providers
             if matches!(provider_type, ProviderType::Custom) {
-                return Err((StatusCode::NOT_FOUND, format!("Provider {} not configured", id)));
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    format!("Provider {} not configured", id),
+                ));
             }
 
             // Read OpenCode auth to get API key for standard providers
-            let auth_map = read_opencode_auth_map()
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+            let auth_map =
+                read_opencode_auth_map().map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
             let auth_kind = auth_map.get(&provider_type);
 
@@ -3810,7 +3815,10 @@ async fn check_provider_health(
             (api_key_opt, provider_type)
         }
     } else {
-        return Err((StatusCode::NOT_FOUND, format!("Invalid provider ID: {}", id)));
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Invalid provider ID: {}", id),
+        ));
     };
 
     // Perform a test API call based on provider type

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3810,7 +3810,11 @@ async fn check_provider_health(
                             .into_iter()
                             .find_map(|key| {
                                 auth.get(key)
-                                    .and_then(|v| v.get("key").or_else(|| v.get("api_key")))
+                                    .and_then(|v| {
+                                        v.get("key")
+                                            .or_else(|| v.get("api_key"))
+                                            .or_else(|| v.get("apiKey"))
+                                    })
                                     .and_then(|v| v.as_str())
                                     .map(|s| s.to_string())
                             });

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3787,6 +3787,7 @@ async fn check_provider_health(
             // Read OpenCode auth to get API key for standard providers
             let auth_map =
                 read_opencode_auth_map().map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+            let auth = read_opencode_auth().map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
             let auth_kind = auth_map.get(&provider_type);
 
@@ -3801,10 +3802,12 @@ async fn check_provider_health(
                     })));
                 }
                 Some(AuthKind::ApiKey) => {
-                    // API key provider - get the key from environment variable
-                    let api_key_opt = provider_type
-                        .env_var_name()
-                        .and_then(|env_var| std::env::var(env_var).ok());
+                    // API key provider - read the actual key from auth.json
+                    let api_key_opt = auth
+                        .get(provider_type.id())
+                        .and_then(|v| v.get("key").or_else(|| v.get("api_key")))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
 
                     if api_key_opt.is_none() {
                         return Ok(Json(serde_json::json!({

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3739,8 +3739,8 @@ async fn check_provider_health(
     let provider_type = ProviderType::from_id(&id)
         .ok_or((StatusCode::NOT_FOUND, "Unknown provider type".to_string()))?;
 
-    let provider_store = &state.ai_provider_store;
-    let provider = provider_store
+    let provider = state
+        .ai_providers
         .get_by_type(provider_type)
         .await
         .ok_or((

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3791,8 +3791,7 @@ async fn check_provider_health(
             let auth_kind = auth_map.get(&provider_type);
 
             // Check if provider has credentials in OpenCode config
-            let api_key_opt = match auth_kind {
-                Some(AuthKind::EnvVar(env_var)) => std::env::var(env_var).ok(),
+            match auth_kind {
                 Some(AuthKind::OAuth) => {
                     // OAuth providers - just verify they're configured
                     return Ok(Json(serde_json::json!({
@@ -3801,18 +3800,30 @@ async fn check_provider_health(
                         "message": "Provider has OAuth credentials configured (OAuth providers not tested)"
                     })));
                 }
-                None => None,
-            };
+                Some(AuthKind::ApiKey) => {
+                    // API key provider - get the key from environment variable
+                    let api_key_opt = provider_type
+                        .env_var_name()
+                        .and_then(|env_var| std::env::var(env_var).ok());
 
-            if api_key_opt.is_none() {
-                return Ok(Json(serde_json::json!({
-                    "healthy": false,
-                    "status": "no_credentials",
-                    "message": format!("Provider {} has no API key configured", id)
-                })));
+                    if api_key_opt.is_none() {
+                        return Ok(Json(serde_json::json!({
+                            "healthy": false,
+                            "status": "no_credentials",
+                            "message": format!("Provider {} has no API key configured", id)
+                        })));
+                    }
+
+                    (api_key_opt, provider_type)
+                }
+                None => {
+                    return Ok(Json(serde_json::json!({
+                        "healthy": false,
+                        "status": "no_credentials",
+                        "message": format!("Provider {} is not configured", id)
+                    })));
+                }
             }
-
-            (api_key_opt, provider_type)
         }
     } else {
         return Err((

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3739,40 +3739,32 @@ async fn check_provider_health(
     let provider_type = ProviderType::from_id(&id)
         .ok_or((StatusCode::NOT_FOUND, "Unknown provider type".to_string()))?;
 
-    // Read OpenCode config to get credentials
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let opencode_config = read_opencode_config(&config_path)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    // Get provider from store - this will only return it if it's enabled
+    let provider_opt = state.ai_providers.get_by_type(provider_type).await;
 
-    let api_key = get_provider_api_key(&opencode_config, provider_type);
+    // If not found in enabled providers, check all providers
+    let provider = if provider_opt.is_some() {
+        provider_opt
+    } else {
+        // Check all providers, even disabled ones
+        let all_providers = state.ai_providers.list().await;
+        all_providers.into_iter().find(|p| p.provider_type == provider_type)
+    };
 
-    if api_key.is_none() {
-        // Also check the new ai_providers store
-        if let Some(provider) = state.ai_providers.get_by_type(provider_type).await {
-            if provider.api_key.is_none() && provider.oauth.is_none() {
-                return Ok(Json(serde_json::json!({
-                    "healthy": false,
-                    "status": "no_credentials",
-                    "message": "Provider has no API key or OAuth credentials configured"
-                })));
-            }
-        } else {
-            return Ok(Json(serde_json::json!({
-                "healthy": false,
-                "status": "no_credentials",
-                "message": "Provider has no API key or OAuth credentials configured"
-            })));
-        }
+    let provider = provider.ok_or((
+        StatusCode::NOT_FOUND,
+        format!("Provider {} not configured", id),
+    ))?;
+
+    // Check if provider has credentials
+    let api_key = provider.api_key.clone();
+    if api_key.is_none() && provider.oauth.is_none() {
+        return Ok(Json(serde_json::json!({
+            "healthy": false,
+            "status": "no_credentials",
+            "message": "Provider has no API key or OAuth credentials configured"
+        })));
     }
-
-    let api_key = api_key.or_else(|| {
-        // Try to get from ai_providers store as fallback
-        state.ai_providers
-            .get_by_type(provider_type)
-            .now_or_never()
-            .flatten()
-            .and_then(|p| p.api_key)
-    });
 
 
     // Perform a test API call based on provider type

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3737,54 +3737,81 @@ async fn check_provider_health(
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     // Try to parse as UUID first (for custom providers), then as type ID
-    let (provider, provider_type) = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+    let (api_key_opt, provider_type) = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
         // UUID lookup for custom providers
         let provider = state.ai_providers.get(uuid).await
             .ok_or((StatusCode::NOT_FOUND, format!("Provider with ID {} not found", id)))?;
-        let provider_type = provider.provider_type;
-        (Some(provider), provider_type)
-    } else if let Some(provider_type) = ProviderType::from_id(&id) {
-        // Type ID lookup - check custom provider store first
-        let provider_opt = state.ai_providers.get_by_type(provider_type).await;
 
-        // If not in custom store, it might be a standard provider configured via OpenCode
-        if provider_opt.is_none() && !matches!(provider_type, ProviderType::Custom) {
-            // Standard provider - check if it's configured (has credentials in config/auth files)
-            // For now, we'll return a basic "configured" status since we can't easily
-            // access the OpenCode config from here. This is acceptable because the
-            // list_providers endpoint already shows their status.
+        // Check if provider has credentials
+        let has_credentials = provider.api_key.is_some()
+            || provider.oauth.is_some()
+            || (provider.provider_type == ProviderType::Custom && provider.base_url.is_some());
+
+        if !has_credentials {
             return Ok(Json(serde_json::json!({
-                "healthy": true,
-                "status": "configured",
-                "message": format!("Provider {} is configured (health check only available for custom providers)", id)
+                "healthy": false,
+                "status": "no_credentials",
+                "message": "Provider has no API key, OAuth credentials, or base URL configured"
             })));
         }
 
-        (provider_opt, provider_type)
+        (provider.api_key.clone(), provider.provider_type)
+    } else if let Some(provider_type) = ProviderType::from_id(&id) {
+        // Type ID lookup - check custom provider store first
+        if let Some(provider) = state.ai_providers.get_by_type(provider_type).await {
+            // Found in custom store
+            let has_credentials = provider.api_key.is_some()
+                || provider.oauth.is_some()
+                || (provider_type == ProviderType::Custom && provider.base_url.is_some());
+
+            if !has_credentials {
+                return Ok(Json(serde_json::json!({
+                    "healthy": false,
+                    "status": "no_credentials",
+                    "message": "Provider has no API key, OAuth credentials, or base URL configured"
+                })));
+            }
+
+            (provider.api_key.clone(), provider_type)
+        } else {
+            // Not in custom store - check OpenCode config for standard providers
+            if matches!(provider_type, ProviderType::Custom) {
+                return Err((StatusCode::NOT_FOUND, format!("Provider {} not configured", id)));
+            }
+
+            // Read OpenCode auth to get API key for standard providers
+            let auth_map = read_opencode_auth_map()
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+            let auth_kind = auth_map.get(&provider_type);
+
+            // Check if provider has credentials in OpenCode config
+            let api_key_opt = match auth_kind {
+                Some(AuthKind::EnvVar(env_var)) => std::env::var(env_var).ok(),
+                Some(AuthKind::OAuth) => {
+                    // OAuth providers - just verify they're configured
+                    return Ok(Json(serde_json::json!({
+                        "healthy": true,
+                        "status": "configured",
+                        "message": "Provider has OAuth credentials configured (OAuth providers not tested)"
+                    })));
+                }
+                None => None,
+            };
+
+            if api_key_opt.is_none() {
+                return Ok(Json(serde_json::json!({
+                    "healthy": false,
+                    "status": "no_credentials",
+                    "message": format!("Provider {} has no API key configured", id)
+                })));
+            }
+
+            (api_key_opt, provider_type)
+        }
     } else {
         return Err((StatusCode::NOT_FOUND, format!("Invalid provider ID: {}", id)));
     };
-
-    let provider = provider.ok_or((
-        StatusCode::NOT_FOUND,
-        format!("Provider {} not configured", id),
-    ))?;
-
-    // Check if provider has credentials
-    // For custom providers, base_url alone is valid (e.g., local inference servers)
-    let api_key = provider.api_key.clone();
-    let has_credentials = api_key.is_some()
-        || provider.oauth.is_some()
-        || (provider_type == ProviderType::Custom && provider.base_url.is_some());
-
-    if !has_credentials {
-        return Ok(Json(serde_json::json!({
-            "healthy": false,
-            "status": "no_credentials",
-            "message": "Provider has no API key, OAuth credentials, or base URL configured"
-        })));
-    }
-
 
     // Perform a test API call based on provider type
     let client = reqwest::Client::builder()
@@ -3794,7 +3821,7 @@ async fn check_provider_health(
 
     let (api_url, test_body, auth_header) = match provider_type {
         ProviderType::Cerebras => {
-            let key = api_key
+            let key = api_key_opt
                 .as_ref()
                 .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
             (
@@ -3808,7 +3835,7 @@ async fn check_provider_health(
             )
         }
         ProviderType::Zai => {
-            let key = api_key
+            let key = api_key_opt
                 .as_ref()
                 .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
             (
@@ -3822,7 +3849,7 @@ async fn check_provider_health(
             )
         }
         ProviderType::DeepInfra => {
-            let key = api_key
+            let key = api_key_opt
                 .as_ref()
                 .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
             (

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -330,6 +330,7 @@ pub fn routes() -> Router<Arc<super::routes::AppState>> {
         .route("/:id/oauth/authorize", post(oauth_authorize))
         .route("/:id/oauth/callback", post(oauth_callback))
         .route("/:id/default", post(set_default))
+        .route("/:id/health", post(check_provider_health))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3728,6 +3729,141 @@ async fn get_provider_for_backend(
         oauth,
         has_credentials,
     }))
+}
+
+/// POST /api/ai/providers/:id/health - Check provider health and validate credentials.
+async fn check_provider_health(
+    State(state): State<Arc<super::routes::AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let provider_type = ProviderType::from_id(&id)
+        .ok_or((StatusCode::NOT_FOUND, "Unknown provider type".to_string()))?;
+
+    let provider_store = &state.ai_provider_store;
+    let provider = provider_store
+        .get_by_type(provider_type)
+        .await
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            format!("Provider {} not configured", id),
+        ))?;
+
+    // Check if provider has credentials
+    if provider.api_key.is_none() && provider.oauth.is_none() {
+        return Ok(Json(serde_json::json!({
+            "healthy": false,
+            "status": "no_credentials",
+            "message": "Provider has no API key or OAuth credentials configured"
+        })));
+    }
+
+    // Perform a test API call based on provider type
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let (api_url, test_body, auth_header) = match provider_type {
+        ProviderType::Cerebras => {
+            let api_key = provider
+                .api_key
+                .as_ref()
+                .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
+            (
+                "https://api.cerebras.ai/v1/chat/completions",
+                serde_json::json!({
+                    "model": "llama-3.1-8b",
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1
+                }),
+                format!("Bearer {}", api_key),
+            )
+        }
+        ProviderType::Zai => {
+            let api_key = provider
+                .api_key
+                .as_ref()
+                .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
+            (
+                "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+                serde_json::json!({
+                    "model": "glm-4-flash",
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1
+                }),
+                format!("Bearer {}", api_key),
+            )
+        }
+        ProviderType::DeepInfra => {
+            let api_key = provider
+                .api_key
+                .as_ref()
+                .ok_or((StatusCode::BAD_REQUEST, "No API key".to_string()))?;
+            (
+                "https://api.deepinfra.com/v1/openai/chat/completions",
+                serde_json::json!({
+                    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1
+                }),
+                format!("Bearer {}", api_key),
+            )
+        }
+        ProviderType::Anthropic | ProviderType::OpenAI | ProviderType::Google => {
+            // These providers use OAuth or have complex auth, skip API test
+            return Ok(Json(serde_json::json!({
+                "healthy": true,
+                "status": "configured",
+                "message": "Provider has credentials configured (OAuth providers not tested)"
+            })));
+        }
+        _ => {
+            // For other providers, just check if credentials exist
+            return Ok(Json(serde_json::json!({
+                "healthy": true,
+                "status": "configured",
+                "message": "Provider has credentials configured"
+            })));
+        }
+    };
+
+    // Make test request
+    match client
+        .post(api_url)
+        .header("Authorization", auth_header)
+        .header("Content-Type", "application/json")
+        .json(&test_body)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() || response.status().as_u16() == 402 {
+                // 402 = insufficient credits, but auth is valid
+                Ok(Json(serde_json::json!({
+                    "healthy": true,
+                    "status": "connected",
+                    "message": "Provider API key is valid and working"
+                })))
+            } else {
+                let status_code = response.status().as_u16();
+                let error_text = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                Ok(Json(serde_json::json!({
+                    "healthy": false,
+                    "status": "api_error",
+                    "message": format!("API returned status {}: {}", status_code, error_text),
+                    "status_code": status_code
+                })))
+            }
+        }
+        Err(e) => Ok(Json(serde_json::json!({
+            "healthy": false,
+            "status": "connection_error",
+            "message": format!("Failed to connect to provider API: {}", e)
+        }))),
+    }
 }
 
 /// POST /api/ai/providers - Create a new provider.

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3514,6 +3514,7 @@ async fn control_actor_loop(
                                                 Some(mission.backend.clone()),
                                                 mission.session_id.clone(),
                                                 mission.config_profile.clone(),
+                                                mission.model_override.clone(),
                                             );
                                             // Load existing history
                                             for entry in &mission.history {
@@ -4011,6 +4012,7 @@ async fn control_actor_loop(
                                 Some(mission.backend.clone()),
                                 mission.session_id.clone(),
                                 mission.config_profile.clone(),
+                                mission.model_override.clone(),
                             );
 
                             // Load existing history into runner to preserve conversation context

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -700,6 +700,9 @@ pub struct MissionRunner {
     /// Agent override for this mission
     pub agent_override: Option<String>,
 
+    /// Model override for this mission (e.g. "zai/glm-5")
+    pub model_override: Option<String>,
+
     /// Message queue for this mission
     pub queue: VecDeque<QueuedMessage>,
 
@@ -743,6 +746,7 @@ impl MissionRunner {
         backend_id: Option<String>,
         session_id: Option<String>,
         config_profile: Option<String>,
+        model_override: Option<String>,
     ) -> Self {
         Self {
             mission_id,
@@ -752,6 +756,7 @@ impl MissionRunner {
             config_profile,
             state: MissionRunState::Queued,
             agent_override,
+            model_override,
             queue: VecDeque::new(),
             history: Vec::new(),
             cancel_token: None,
@@ -897,6 +902,7 @@ impl MissionRunner {
         let mission_id = self.mission_id;
         let workspace_id = self.workspace_id;
         let agent_override = self.agent_override.clone();
+        let model_override = self.model_override.clone();
         let backend_id = self.backend_id.clone();
         let session_id = self.session_id.clone();
         let config_profile = self.config_profile.clone();
@@ -945,6 +951,7 @@ impl MissionRunner {
                 Some(workspace_id),
                 backend_id,
                 agent_override,
+                model_override,
                 secrets,
                 session_id,
                 config_profile,
@@ -1101,6 +1108,7 @@ async fn run_mission_turn(
     workspace_id: Option<Uuid>,
     backend_id: String,
     agent_override: Option<String>,
+    model_override: Option<String>,
     secrets: Option<Arc<SecretsStore>>,
     session_id: Option<String>,
     mission_config_profile: Option<String>,
@@ -1109,6 +1117,9 @@ async fn run_mission_turn(
     let effective_agent = agent_override.clone();
     if let Some(ref agent) = effective_agent {
         config.opencode_agent = Some(agent.clone());
+    }
+    if let Some(ref model) = model_override {
+        config.default_model = Some(model.clone());
     }
     // Get config profile: mission's config_profile takes priority over workspace's
     let workspace_config_profile = if let Some(ws_id) = workspace_id {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -271,6 +271,42 @@ fn default_providers_config() -> ProvidersConfig {
                     },
                 ],
             },
+            Provider {
+                id: "cerebras".to_string(),
+                name: "Cerebras (API Key)".to_string(),
+                billing: "pay-per-token".to_string(),
+                description: "Ultra-fast inference via Cerebras".to_string(),
+                models: vec![
+                    ProviderModel {
+                        id: "llama-3.3-70b".to_string(),
+                        name: "Llama 3.3 70B".to_string(),
+                        description: Some("Most capable Cerebras model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "llama-3.1-8b".to_string(),
+                        name: "Llama 3.1 8B".to_string(),
+                        description: Some("Fast and lightweight".to_string()),
+                    },
+                ],
+            },
+            Provider {
+                id: "zai".to_string(),
+                name: "Z.AI (API Key)".to_string(),
+                billing: "pay-per-token".to_string(),
+                description: "GLM models via Z.AI API key".to_string(),
+                models: vec![
+                    ProviderModel {
+                        id: "glm-5".to_string(),
+                        name: "GLM-5".to_string(),
+                        description: Some("Most capable GLM model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "glm-4-flash".to_string(),
+                        name: "GLM-4 Flash".to_string(),
+                        description: Some("Fast and economical".to_string()),
+                    },
+                ],
+            },
         ],
     }
 }
@@ -421,7 +457,8 @@ pub async fn list_backend_model_options(
     };
 
     // Add non-default providers from AIProviderStore (Custom, Cerebras, Zai, etc.)
-    let default_provider_ids: &[&str] = &["anthropic", "openai", "google", "xai"];
+    let default_provider_ids: &[&str] =
+        &["anthropic", "openai", "google", "xai", "cerebras", "zai"];
     let custom_providers = state.ai_providers.list().await;
     for provider in custom_providers {
         // Skip disabled providers and those already in the default catalog
@@ -519,7 +556,8 @@ pub async fn validate_model_override(
 
     // Load all providers (including configured and non-default)
     let mut providers = config.providers;
-    let default_provider_ids: &[&str] = &["anthropic", "openai", "google", "xai"];
+    let default_provider_ids: &[&str] =
+        &["anthropic", "openai", "google", "xai", "cerebras", "zai"];
     let custom_providers = state.ai_providers.list().await;
     for provider in custom_providers {
         // Skip disabled providers and those already in the default catalog

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -255,19 +255,24 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "Grok models via xAI API key".to_string(),
                 models: vec![
                     ProviderModel {
-                        id: "grok-2".to_string(),
-                        name: "Grok 2".to_string(),
+                        id: "grok-4-fast".to_string(),
+                        name: "Grok 4 Fast".to_string(),
                         description: Some("Most capable Grok model".to_string()),
                     },
                     ProviderModel {
-                        id: "grok-2-mini".to_string(),
-                        name: "Grok 2 Mini".to_string(),
-                        description: Some("Faster, lighter Grok model".to_string()),
+                        id: "grok-3".to_string(),
+                        name: "Grok 3".to_string(),
+                        description: Some("Balanced capability and speed".to_string()),
                     },
                     ProviderModel {
-                        id: "grok-2-vision".to_string(),
-                        name: "Grok 2 Vision".to_string(),
-                        description: Some("Vision-capable Grok model".to_string()),
+                        id: "grok-3-fast".to_string(),
+                        name: "Grok 3 Fast".to_string(),
+                        description: Some("Fast Grok model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "grok-3-mini".to_string(),
+                        name: "Grok 3 Mini".to_string(),
+                        description: Some("Fast and economical".to_string()),
                     },
                 ],
             },
@@ -278,14 +283,14 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "Ultra-fast inference via Cerebras".to_string(),
                 models: vec![
                     ProviderModel {
-                        id: "llama-3.3-70b".to_string(),
-                        name: "Llama 3.3 70B".to_string(),
+                        id: "gpt-oss-120b-cs".to_string(),
+                        name: "GPT-OSS 120B".to_string(),
                         description: Some("Most capable Cerebras model".to_string()),
                     },
                     ProviderModel {
-                        id: "llama-3.1-8b".to_string(),
-                        name: "Llama 3.1 8B".to_string(),
-                        description: Some("Fast and lightweight".to_string()),
+                        id: "zai-glm-4.6-cs".to_string(),
+                        name: "GLM-4.6 (Cerebras)".to_string(),
+                        description: Some("GLM-4.6 via Cerebras inference".to_string()),
                     },
                 ],
             },
@@ -296,14 +301,24 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "GLM models via Z.AI API key".to_string(),
                 models: vec![
                     ProviderModel {
-                        id: "glm-5".to_string(),
-                        name: "GLM-5".to_string(),
+                        id: "glm-4.7".to_string(),
+                        name: "GLM-4.7".to_string(),
                         description: Some("Most capable GLM model".to_string()),
                     },
                     ProviderModel {
-                        id: "glm-4-flash".to_string(),
-                        name: "GLM-4 Flash".to_string(),
+                        id: "glm-4.6".to_string(),
+                        name: "GLM-4.6".to_string(),
+                        description: Some("Balanced capability and speed".to_string()),
+                    },
+                    ProviderModel {
+                        id: "glm-4.5".to_string(),
+                        name: "GLM-4.5".to_string(),
                         description: Some("Fast and economical".to_string()),
+                    },
+                    ProviderModel {
+                        id: "glm-4.6v-flash".to_string(),
+                        name: "GLM-4.6V Flash".to_string(),
+                        description: Some("Vision model, fast variant".to_string()),
                     },
                 ],
             },

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -17,7 +17,7 @@ use crate::ai_providers::ProviderType;
 
 /// Provider IDs that are part of the default catalog and should not be duplicated
 /// from the AIProviderStore.
-const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] =
+pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] =
     &["anthropic", "openai", "google", "xai", "cerebras", "zai"];
 
 /// A model available from a provider.

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -15,6 +15,11 @@ use serde::{Deserialize, Serialize};
 use super::routes::AppState;
 use crate::ai_providers::ProviderType;
 
+/// Provider IDs that are part of the default catalog and should not be duplicated
+/// from the AIProviderStore.
+const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] =
+    &["anthropic", "openai", "google", "xai", "cerebras", "zai"];
+
 /// A model available from a provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderModel {
@@ -472,8 +477,7 @@ pub async fn list_backend_model_options(
     };
 
     // Add non-default providers from AIProviderStore (Custom, Cerebras, Zai, etc.)
-    let default_provider_ids: &[&str] =
-        &["anthropic", "openai", "google", "xai", "cerebras", "zai"];
+    let default_provider_ids = DEFAULT_CATALOG_PROVIDER_IDS;
     let custom_providers = state.ai_providers.list().await;
     for provider in custom_providers {
         // Skip disabled providers and those already in the default catalog
@@ -571,8 +575,7 @@ pub async fn validate_model_override(
 
     // Load all providers (including configured and non-default)
     let mut providers = config.providers;
-    let default_provider_ids: &[&str] =
-        &["anthropic", "openai", "google", "xai", "cerebras", "zai"];
+    let default_provider_ids = DEFAULT_CATALOG_PROVIDER_IDS;
     let custom_providers = state.ai_providers.list().await;
     for provider in custom_providers {
         // Skip disabled providers and those already in the default catalog

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -3,7 +3,8 @@
 //! Provides endpoints for listing available providers and their models for UI selection.
 //! Only returns providers that are actually configured and authenticated.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::Arc;
 
 use axum::{
@@ -11,9 +12,14 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 use super::routes::AppState;
-use crate::ai_providers::ProviderType;
+use crate::ai_providers::{AIProviderStore, ProviderType};
+
+/// Cached model lists fetched from provider APIs at startup.
+/// Maps provider ID (e.g. "anthropic") -> Vec<ProviderModel>
+pub type ModelCatalog = Arc<RwLock<HashMap<String, Vec<ProviderModel>>>>;
 
 /// Provider IDs that are part of the default catalog and should not be duplicated
 /// from the AIProviderStore.
@@ -331,6 +337,358 @@ fn default_providers_config() -> ProvidersConfig {
     }
 }
 
+// ==================== Dynamic Model Catalog Fetching ====================
+
+/// Convert a model ID to a human-readable display name by title-casing segments.
+/// e.g. "glm-5" → "GLM 5", "grok-4-fast" → "Grok 4 Fast", "gpt-5.3-codex" → "GPT 5.3 Codex"
+fn model_id_to_display_name(id: &str) -> String {
+    id.split('-')
+        .map(|segment| {
+            // If the segment is all-alpha and <= 4 chars, uppercase it (likely an acronym)
+            if segment.chars().all(|c| c.is_ascii_alphabetic()) && segment.len() <= 4 {
+                segment.to_uppercase()
+            } else {
+                // Title-case: capitalize first letter
+                let mut chars = segment.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(first) => {
+                        let mut s = first.to_uppercase().to_string();
+                        s.extend(chars);
+                        s
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Fetch models from an OpenAI-compatible /v1/models endpoint.
+/// Filters results by the given prefix (e.g. "grok-", "glm-").
+/// Returns model IDs and generated display names.
+pub async fn fetch_openai_compatible_models(
+    base_url: &str,
+    api_key: &str,
+    prefix_filters: &[&str],
+) -> Result<Vec<ProviderModel>, String> {
+    let client = reqwest::Client::new();
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("API returned status {}", resp.status()));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse JSON: {}", e))?;
+
+    let data = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| "Missing 'data' array in response".to_string())?;
+
+    let mut models: Vec<ProviderModel> = data
+        .iter()
+        .filter_map(|entry| {
+            let id = entry.get("id")?.as_str()?;
+            // Apply prefix filter if any
+            if !prefix_filters.is_empty()
+                && !prefix_filters.iter().any(|prefix| id.starts_with(prefix))
+            {
+                return None;
+            }
+            Some(ProviderModel {
+                id: id.to_string(),
+                name: model_id_to_display_name(id),
+                description: None,
+            })
+        })
+        .collect();
+
+    models.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(models)
+}
+
+/// Fetch models from the Anthropic /v1/models endpoint.
+/// Uses Anthropic's custom auth headers and `display_name` field.
+pub async fn fetch_anthropic_models(api_key: &str) -> Result<Vec<ProviderModel>, String> {
+    let client = reqwest::Client::new();
+    let url = "https://api.anthropic.com/v1/models?limit=100";
+
+    let resp = client
+        .get(url)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("API returned status {}", resp.status()));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse JSON: {}", e))?;
+
+    let data = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| "Missing 'data' array in response".to_string())?;
+
+    let mut models: Vec<ProviderModel> = data
+        .iter()
+        .filter_map(|entry| {
+            let id = entry.get("id")?.as_str()?;
+            let display_name = entry
+                .get("display_name")
+                .and_then(|n| n.as_str())
+                .unwrap_or(id);
+            Some(ProviderModel {
+                id: id.to_string(),
+                name: display_name.to_string(),
+                description: None,
+            })
+        })
+        .collect();
+
+    models.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(models)
+}
+
+/// Resolve an API key for a given provider type.
+///
+/// Checks three sources in order:
+/// 1. AIProviderStore (custom providers with stored keys)
+/// 2. OpenCode auth files (~/.local/share/opencode/auth.json, ~/.opencode/auth/{provider}.json)
+/// 3. Environment variable (e.g. ANTHROPIC_API_KEY)
+pub fn get_api_key_for_provider(
+    provider_type: ProviderType,
+    ai_providers: &[crate::ai_providers::AIProvider],
+) -> Option<String> {
+    // 1. Check AIProviderStore entries
+    for provider in ai_providers {
+        if provider.provider_type == provider_type && provider.enabled {
+            if let Some(ref key) = provider.api_key {
+                if !key.is_empty() {
+                    return Some(key.clone());
+                }
+            }
+            // OAuth access tokens can also be used as bearer tokens for some APIs
+            if let Some(ref oauth) = provider.oauth {
+                if !oauth.access_token.is_empty() {
+                    return Some(oauth.access_token.clone());
+                }
+            }
+        }
+    }
+
+    // 2. Check OpenCode auth.json
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let auth_paths = {
+        let mut paths = Vec::new();
+        if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+            paths.push(
+                std::path::PathBuf::from(data_home)
+                    .join("opencode")
+                    .join("auth.json"),
+            );
+        }
+        paths.push(std::path::PathBuf::from(&home).join(".local/share/opencode/auth.json"));
+        paths
+    };
+
+    let auth_keys: Vec<&str> = match provider_type {
+        ProviderType::OpenAI => vec!["openai", "codex"],
+        ProviderType::Custom => vec![],
+        _ => vec![provider_type.id()],
+    };
+
+    for auth_path in &auth_paths {
+        if let Ok(contents) = std::fs::read_to_string(auth_path) {
+            if let Ok(auth) = serde_json::from_str::<serde_json::Value>(&contents) {
+                for key in &auth_keys {
+                    if let Some(entry) = auth.get(*key) {
+                        // Check for API key fields
+                        for field in &["key", "api_key", "apiKey"] {
+                            if let Some(val) = entry.get(*field).and_then(|v| v.as_str()) {
+                                if !val.is_empty() {
+                                    return Some(val.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Also check provider-specific auth files (~/.opencode/auth/{provider}.json)
+    let provider_auth_file = std::path::PathBuf::from(&home)
+        .join(".opencode/auth")
+        .join(format!("{}.json", provider_type.id()));
+    if let Ok(contents) = std::fs::read_to_string(&provider_auth_file) {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) {
+            for field in &["key", "api_key", "apiKey"] {
+                if let Some(val) = value.get(*field).and_then(|v| v.as_str()) {
+                    if !val.is_empty() {
+                        return Some(val.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // 3. Check environment variable
+    if let Some(env_var) = provider_type.env_var_name() {
+        if let Ok(val) = std::env::var(env_var) {
+            if !val.is_empty() {
+                return Some(val);
+            }
+        }
+    }
+
+    None
+}
+
+/// Fetch model lists from all supported provider APIs concurrently.
+///
+/// Returns a map of provider ID -> fetched models. Providers that fail
+/// or lack credentials are simply omitted (hardcoded defaults will be used).
+pub async fn fetch_model_catalog(
+    ai_providers: &AIProviderStore,
+    _working_dir: &Path,
+) -> HashMap<String, Vec<ProviderModel>> {
+    let providers_list = ai_providers.list().await;
+    let mut result = HashMap::new();
+
+    // Define fetchable providers (Google uses OAuth which is complex, skip it)
+    struct FetchTarget {
+        provider_type: ProviderType,
+        provider_id: &'static str,
+        base_url: &'static str,
+        prefix_filters: Vec<&'static str>,
+    }
+
+    let targets = vec![
+        FetchTarget {
+            provider_type: ProviderType::OpenAI,
+            provider_id: "openai",
+            base_url: "https://api.openai.com/v1",
+            prefix_filters: vec!["gpt-", "o1-", "o3-", "o4-", "chatgpt-"],
+        },
+        FetchTarget {
+            provider_type: ProviderType::Xai,
+            provider_id: "xai",
+            base_url: "https://api.x.ai/v1",
+            prefix_filters: vec!["grok-"],
+        },
+        FetchTarget {
+            provider_type: ProviderType::Cerebras,
+            provider_id: "cerebras",
+            base_url: "https://api.cerebras.ai/v1",
+            prefix_filters: vec![],
+        },
+        FetchTarget {
+            provider_type: ProviderType::Zai,
+            provider_id: "zai",
+            base_url: "https://open.bigmodel.cn/api/paas/v4",
+            prefix_filters: vec!["glm-"],
+        },
+    ];
+
+    // Resolve API keys for all targets + Anthropic
+    let anthropic_key = get_api_key_for_provider(ProviderType::Anthropic, &providers_list);
+    let target_keys: Vec<(FetchTarget, Option<String>)> = targets
+        .into_iter()
+        .map(|t| {
+            let key = get_api_key_for_provider(t.provider_type, &providers_list);
+            (t, key)
+        })
+        .collect();
+
+    // Fetch Anthropic (special format)
+    let anthropic_handle = tokio::spawn(async move {
+        match anthropic_key {
+            Some(key) => match fetch_anthropic_models(&key).await {
+                Ok(models) => {
+                    tracing::info!("Fetched {} models from Anthropic API", models.len());
+                    Some(("anthropic".to_string(), models))
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to fetch Anthropic models: {}", e);
+                    None
+                }
+            },
+            None => {
+                tracing::debug!("No API key for Anthropic, skipping model fetch");
+                None
+            }
+        }
+    });
+
+    // Fetch OpenAI-compatible providers concurrently
+    let mut handles = vec![anthropic_handle];
+    for (target, key) in target_keys {
+        let provider_id = target.provider_id.to_string();
+        let base_url = target.base_url.to_string();
+        let prefix_filters: Vec<String> = target
+            .prefix_filters
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        handles.push(tokio::spawn(async move {
+            match key {
+                Some(api_key) => {
+                    let filters: Vec<&str> = prefix_filters.iter().map(|s| s.as_str()).collect();
+                    match fetch_openai_compatible_models(&base_url, &api_key, &filters).await {
+                        Ok(models) => {
+                            tracing::info!(
+                                "Fetched {} models from {} API",
+                                models.len(),
+                                provider_id
+                            );
+                            Some((provider_id, models))
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to fetch {} models: {}", provider_id, e);
+                            None
+                        }
+                    }
+                }
+                None => {
+                    tracing::debug!("No API key for {}, skipping model fetch", provider_id);
+                    None
+                }
+            }
+        }));
+    }
+
+    // Collect results
+    for handle in handles {
+        if let Ok(Some((provider_id, models))) = handle.await {
+            if !models.is_empty() {
+                result.insert(provider_id, models);
+            }
+        }
+    }
+
+    result
+}
+
 /// Check if a JSON value contains valid auth credentials.
 fn has_valid_auth(value: &serde_json::Value) -> bool {
     // Check for OAuth tokens (various field names used by different providers)
@@ -436,7 +794,16 @@ pub async fn list_providers(
     Query(query): Query<ProvidersQuery>,
 ) -> Json<ProvidersResponse> {
     let working_dir = state.config.working_dir.to_string_lossy().to_string();
-    let config = load_providers_config(&working_dir);
+    let mut config = load_providers_config(&working_dir);
+
+    // Merge cached models from dynamic catalog (replaces hardcoded model lists)
+    let cached = state.model_catalog.read().await;
+    for provider in &mut config.providers {
+        if let Some(models) = cached.get(&provider.id) {
+            provider.models = models.clone();
+        }
+    }
+    drop(cached);
 
     // Get the set of configured provider IDs
     let configured = get_configured_provider_ids(state.config.working_dir.as_path());
@@ -463,7 +830,16 @@ pub async fn list_backend_model_options(
     Query(query): Query<BackendModelsQuery>,
 ) -> Json<BackendModelOptionsResponse> {
     let working_dir = state.config.working_dir.to_string_lossy().to_string();
-    let config = load_providers_config(&working_dir);
+    let mut config = load_providers_config(&working_dir);
+
+    // Merge cached models from dynamic catalog
+    let cached = state.model_catalog.read().await;
+    for provider in &mut config.providers {
+        if let Some(models) = cached.get(&provider.id) {
+            provider.models = models.clone();
+        }
+    }
+    drop(cached);
 
     let configured = get_configured_provider_ids(state.config.working_dir.as_path());
     let mut providers = if query.include_all {
@@ -571,7 +947,16 @@ pub async fn validate_model_override(
     }
 
     let working_dir = state.config.working_dir.to_string_lossy().to_string();
-    let config = load_providers_config(&working_dir);
+    let mut config = load_providers_config(&working_dir);
+
+    // Merge cached models from dynamic catalog
+    let cached = state.model_catalog.read().await;
+    for provider in &mut config.providers {
+        if let Some(models) = cached.get(&provider.id) {
+            provider.models = models.clone();
+        }
+    }
+    drop(cached);
 
     // Load all providers (including configured and non-default)
     let mut providers = config.providers;
@@ -611,10 +996,14 @@ pub async fn validate_model_override(
         "opencode" => {
             // OpenCode expects "provider/model" format
             if let Some((provider_id, model_id)) = model_override.split_once('/') {
-                // Check if this is a known provider
+                // Check if this is a known provider with a model catalog
                 if let Some(provider) = providers.iter().find(|p| p.id == provider_id) {
-                    // Known provider - validate model exists
-                    if !provider.models.iter().any(|m| m.id == model_id) {
+                    // Only validate if the provider has a non-empty model list.
+                    // Providers with no catalog (e.g. typed providers without custom_models)
+                    // get the same escape-hatch treatment as unknown providers.
+                    if !provider.models.is_empty()
+                        && !provider.models.iter().any(|m| m.id == model_id)
+                    {
                         return Err(format!(
                             "Model '{}' not found for provider '{}'. Available models: {}",
                             model_id,
@@ -715,6 +1104,213 @@ pub async fn validate_model_override(
         _ => {
             // Unknown backend - skip validation
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_model_id_to_display_name() {
+        assert_eq!(model_id_to_display_name("glm-5"), "GLM 5");
+        assert_eq!(model_id_to_display_name("grok-4-fast"), "GROK 4 Fast");
+        assert_eq!(model_id_to_display_name("gpt-5.3-codex"), "GPT 5.3 Codex");
+        assert_eq!(
+            model_id_to_display_name("claude-opus-4-6"),
+            "Claude Opus 4 6"
+        );
+    }
+
+    /// Fetch models from all provider APIs that have credentials available,
+    /// then compare against the hardcoded defaults to detect staleness.
+    ///
+    /// Run with: `cargo test check_hardcoded_model_staleness -- --nocapture --ignored`
+    ///
+    /// This test is `#[ignore]` by default because it requires network access
+    /// and valid API keys. It prints warnings for any mismatches found.
+    #[tokio::test]
+    #[ignore]
+    async fn check_hardcoded_model_staleness() {
+        let defaults = default_providers_config();
+        let defaults_by_id: HashMap<String, Vec<String>> = defaults
+            .providers
+            .iter()
+            .map(|p| {
+                (
+                    p.id.clone(),
+                    p.models.iter().map(|m| m.id.clone()).collect(),
+                )
+            })
+            .collect();
+
+        // Providers we can fetch from (provider_id, base_url, prefix_filters, is_anthropic)
+        struct TestTarget {
+            provider_id: &'static str,
+            provider_type: ProviderType,
+            base_url: &'static str,
+            prefix_filters: Vec<&'static str>,
+            is_anthropic: bool,
+        }
+
+        let targets = vec![
+            TestTarget {
+                provider_id: "anthropic",
+                provider_type: ProviderType::Anthropic,
+                base_url: "",
+                prefix_filters: vec![],
+                is_anthropic: true,
+            },
+            TestTarget {
+                provider_id: "openai",
+                provider_type: ProviderType::OpenAI,
+                base_url: "https://api.openai.com/v1",
+                prefix_filters: vec!["gpt-", "o1-", "o3-", "o4-", "chatgpt-"],
+                is_anthropic: false,
+            },
+            TestTarget {
+                provider_id: "xai",
+                provider_type: ProviderType::Xai,
+                base_url: "https://api.x.ai/v1",
+                prefix_filters: vec!["grok-"],
+                is_anthropic: false,
+            },
+            TestTarget {
+                provider_id: "cerebras",
+                provider_type: ProviderType::Cerebras,
+                base_url: "https://api.cerebras.ai/v1",
+                prefix_filters: vec![],
+                is_anthropic: false,
+            },
+            TestTarget {
+                provider_id: "zai",
+                provider_type: ProviderType::Zai,
+                base_url: "https://open.bigmodel.cn/api/paas/v4",
+                prefix_filters: vec!["glm-"],
+                is_anthropic: false,
+            },
+        ];
+
+        let mut any_checked = false;
+        let mut any_stale = false;
+
+        for target in &targets {
+            let api_key = get_api_key_for_provider(target.provider_type, &[]);
+            let api_key = match api_key {
+                Some(k) => k,
+                None => {
+                    eprintln!(
+                        "[SKIP] {}: no API key found (set {} or configure in OpenCode auth)",
+                        target.provider_id,
+                        target.provider_type.env_var_name().unwrap_or("N/A"),
+                    );
+                    continue;
+                }
+            };
+
+            any_checked = true;
+
+            let fetched = if target.is_anthropic {
+                fetch_anthropic_models(&api_key).await
+            } else {
+                fetch_openai_compatible_models(target.base_url, &api_key, &target.prefix_filters)
+                    .await
+            };
+
+            match fetched {
+                Ok(models) => {
+                    let fetched_ids: HashSet<String> =
+                        models.iter().map(|m| m.id.clone()).collect();
+                    let hardcoded_ids: HashSet<String> = defaults_by_id
+                        .get(target.provider_id)
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect();
+
+                    // Models in API but not in hardcoded list (new models)
+                    let new_models: Vec<&String> = fetched_ids.difference(&hardcoded_ids).collect();
+                    // Models in hardcoded list but not in API (possibly removed/renamed)
+                    let removed_models: Vec<&String> =
+                        hardcoded_ids.difference(&fetched_ids).collect();
+
+                    if !new_models.is_empty() || !removed_models.is_empty() {
+                        any_stale = true;
+                    }
+
+                    eprintln!("\n=== {} ===", target.provider_id);
+                    eprintln!(
+                        "  API returned {} models, hardcoded has {}",
+                        fetched_ids.len(),
+                        hardcoded_ids.len()
+                    );
+
+                    if new_models.is_empty() && removed_models.is_empty() {
+                        eprintln!("  [OK] Hardcoded list is up to date");
+                    }
+
+                    if !new_models.is_empty() {
+                        eprintln!(
+                            "  [WARN] {} NEW models not in hardcoded list:",
+                            new_models.len()
+                        );
+                        let mut sorted: Vec<_> = new_models;
+                        sorted.sort();
+                        for id in sorted {
+                            eprintln!("    + {}", id);
+                        }
+                    }
+
+                    if !removed_models.is_empty() {
+                        eprintln!(
+                            "  [WARN] {} hardcoded models NOT found in API (possibly removed/renamed):",
+                            removed_models.len()
+                        );
+                        let mut sorted: Vec<_> = removed_models;
+                        sorted.sort();
+                        for id in sorted {
+                            eprintln!("    - {}", id);
+                        }
+                    }
+
+                    // Print suggested code for updating hardcoded defaults
+                    if !new_models.is_empty() {
+                        eprintln!("\n  Suggested additions to default_providers_config():");
+                        let mut new_sorted: Vec<_> = models
+                            .iter()
+                            .filter(|m| !hardcoded_ids.contains(&m.id))
+                            .collect();
+                        new_sorted.sort_by(|a, b| a.id.cmp(&b.id));
+                        for model in new_sorted {
+                            eprintln!("    ProviderModel {{");
+                            eprintln!("        id: \"{}\".to_string(),", model.id);
+                            eprintln!("        name: \"{}\".to_string(),", model.name);
+                            eprintln!("        description: None,");
+                            eprintln!("    }},");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[ERROR] {}: failed to fetch: {}", target.provider_id, e);
+                }
+            }
+        }
+
+        if !any_checked {
+            eprintln!("\n[INFO] No API keys were available. Set environment variables to check staleness:");
+            eprintln!(
+                "  ANTHROPIC_API_KEY, OPENAI_API_KEY, XAI_API_KEY, CEREBRAS_API_KEY, ZHIPU_API_KEY"
+            );
+        }
+
+        if any_stale {
+            eprintln!(
+                "\n[WARN] Hardcoded model catalog is STALE — update default_providers_config()"
+            );
+            eprintln!(
+                "  (This is a warning, not a failure. Dynamic fetching covers the gap at runtime.)"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Fix Z.AI/Cerebras missing from model list**: Provider filter only included `ProviderType::Custom`, excluding Cerebras/Zai which have their own enum variants. Now includes all non-default provider types.
- **Fix model override not prefilled**: Added `modelOverride` to `InitialMissionValues` so reopening the New Mission dialog preserves the previous selection.
- **Remove non-existent claude-sonnet-4-6**: Replaced with `claude-sonnet-4-5-20250929` which actually exists.
- **Rename Library "Configs" to "Profiles"** in sidebar navigation.
- **Add provider health check endpoint** (from #116)
- **Bump version to 0.8.1**

Incorporates commits from:
- #116 (provider health check endpoint)
- #128 (version bump, superseded by 0.8.1)

## Test plan
- [ ] Open New Mission dialog with OpenCode agent, verify Z.AI/Cerebras models appear
- [ ] Select a model override, create mission, reopen dialog — verify override is prefilled
- [ ] Verify Claude Sonnet 4.5 appears instead of non-existent Sonnet 4.6
- [ ] Check Library sidebar shows "Profiles" instead of "Configs"
- [ ] Verify provider health check endpoint works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new API surface and background outbound network calls to multiple provider endpoints, plus changes to how model overrides propagate into mission execution; failures could impact provider selection or mission startup behavior.
> 
> **Overview**
> Adds `POST /api/ai/providers/:id/health` to validate provider configuration and, for key-based providers (Cerebras/Z.AI/DeepInfra), perform a short live API call to confirm connectivity/credentials; includes new `PROVIDER_HEALTH_CHECK.md` documentation.
> 
> Improves model selection/override behavior by introducing a startup-fetched, cached model catalog (merged into provider/model listing + validation), expanding provider auth detection to track configured provider IDs (fixing missing Z.AI/Cerebras in lists), and threading `model_override` through mission creation/UI prefill into `MissionRunner` to set the effective `default_model`.
> 
> Minor dashboard tweaks: rename sidebar “Configs” to “Profiles”, constrain `ConfigCodeEditor` via new `height` prop to avoid layout overflow, clamp progress display, and bump version to `0.8.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c0cc23a93055fe306f17f50bd842ddcf0eab3c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->