### PR TITLE
Automations: auto-populate variables from command params and inline prompts

### DIFF
--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -168,9 +168,6 @@ export function MissionAutomationsDialog({
     return new Map(commands.map((command) => [command.name, command]));
   }, [commands]);
 
-  // Track which variable keys were auto-populated (so we can distinguish from manual)
-  const autoPopulatedKeysRef = useRef<Set<string>>(new Set());
-
   // Helper to add auto-populated variables (merges with existing, never overwrites manual)
   const addAutoVariables = useCallback((names: string[]) => {
     setVariables((prev) => {
@@ -179,7 +176,6 @@ export function MissionAutomationsDialog({
       for (const name of names) {
         if (!existingKeys.has(name)) {
           newVars.push({ key: name, value: '' });
-          autoPopulatedKeysRef.current.add(name);
         }
       }
       return newVars;
@@ -455,7 +451,6 @@ export function MissionAutomationsDialog({
       setIntervalValue('5');
       setIntervalUnit('minutes');
       setVariables([]);
-      autoPopulatedKeysRef.current = new Set();
       if (promptTimerRef.current) {
         clearTimeout(promptTimerRef.current);
         promptTimerRef.current = null;


### PR DESCRIPTION
## Summary

Implements #131 — makes the automation variables section intelligent instead of fully manual.

### What changed

**1. Auto-populate from library command params**
When a user selects a library command that has `params` in its YAML frontmatter, the variables section automatically adds rows pre-filled with param names. Required params are marked with an amber border and asterisk (`*`). Param descriptions appear as placeholder text on value inputs.

**2. Parse `<variable/>` patterns from inline prompts**
When typing an inline prompt, a 400ms debounced parser scans for `<word/>` patterns and auto-adds variable rows for any custom variables detected. Built-in variables (`timestamp`, `date`, `unix_time`, `mission_id`, `mission_name`, `cwd`) and webhook patterns are excluded.

**3. Built-in variable detection hints**
When built-in variables are detected in the inline prompt, a hint appears below the textarea listing them (e.g., "Built-in variables detected: `<timestamp/>` — these are substituted automatically.").

**4. Validation warning for required params**
If a library command has required params that have no default value filled in, an amber warning appears: "Required params with no default: `environment`. Values can be provided at trigger time."

### Design decisions

- **Merge, don't replace**: Auto-population never overwrites manually-added variables — it only adds missing ones
- **Non-blocking warnings**: Required param warnings are informational (not blocking), since values can be overridden at trigger time via webhook payload or API
- **No backend changes**: This is purely frontend; the backend already exposes `params` on `CommandSummary` and handles all substitution in `automation_variables.rs`

## Test plan

- [x] `bun run build` passes
- [x] `bun run test:unit` — all 80 tests pass
- [ ] Select a library command with params → variables auto-populate
- [ ] Type inline prompt with `<var/>` patterns → variables auto-populate after debounce
- [ ] Type `<timestamp/>` in prompt → built-in hint appears
- [ ] Select command with required params, leave value empty → warning shows
- [ ] Manually add variable, then select command → manual variable preserved

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX enhancements to automation creation; main risk is subtle state/timing issues in the debounced parsing and variable auto-merge behavior.
> 
> **Overview**
> Makes the Mission Automations create form “smarter” by **auto-populating variable rows** from selected library command `params` (including a late-load rehydrate) and by **debounced parsing** of inline prompts for `<var/>` placeholders while excluding built-ins and webhook patterns.
> 
> Adds UI guidance: highlights required params (amber + `*`), uses param descriptions as value placeholders, shows an informational hint when built-in variables are detected in the prompt, and displays a non-blocking warning listing required params that have no default value. Also clears the prompt parsing timer when the form is reset after creating an automation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c947933839b4b846b2c072728ba2421aacdf0bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->