### PR TITLE
Fix automation command selector and auto-detect variables

### DIFF
--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -708,21 +708,21 @@ export function MissionAutomationsDialog({
                 {commandSourceType === 'library' ? (
                   <div>
                     <label className="block text-xs text-white/50 mb-1.5">Command</label>
-                    <input
-                      list="automation-command-list"
+                    <select
                       value={commandName}
                       onChange={(e) => handleCommandNameChange(e.target.value)}
-                      placeholder={
-                        commandsLoading ? 'Loading commands...' : 'Select or type a command'
-                      }
-                      className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-indigo-500/50 appearance-none"
+                      className={cn(selectClass, 'w-full')}
                       style={selectStyle}
-                    />
-                    <datalist id="automation-command-list">
+                    >
+                      <option value="" className="bg-[#1a1a1a]">
+                        {commandsLoading ? 'Loading commands...' : 'Select a command'}
+                      </option>
                       {commands.map((command) => (
-                        <option key={command.name} value={command.name} />
+                        <option key={command.name} value={command.name} className="bg-[#1a1a1a]">
+                          {command.name}
+                        </option>
                       ))}
-                    </datalist>
+                    </select>
                     <div className="mt-1 text-[11px] text-white/30">
                       {commandName && commandsByName.get(commandName)?.description}
                       {!commandName && (

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -32,6 +32,7 @@ import {
   updateAutomation,
   deleteAutomation,
   getAutomationExecutions,
+  getLibraryCommand,
 } from '@/lib/api';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { toast } from '@/components/toast';
@@ -189,6 +190,16 @@ export function MissionAutomationsDialog({
       const cmd = commandsByName.get(name);
       if (cmd?.params?.length) {
         addAutoVariables(cmd.params.map((p) => p.name));
+      } else if (name) {
+        // Fetch full command content to extract <variable/> placeholders
+        getLibraryCommand(name)
+          .then((full) => {
+            const fromParams = full.params?.map((p) => p.name) ?? [];
+            const fromContent = extractPromptVariables(full.content);
+            const all = [...new Set([...fromParams, ...fromContent])];
+            if (all.length > 0) addAutoVariables(all);
+          })
+          .catch(() => {});
       }
     },
     [commandsByName, addAutoVariables]


### PR DESCRIPTION
## Summary
- Replace the native `<input>` + `<datalist>` command selector in Mission Automations with a styled `<select>` matching the Source and Trigger dropdowns
- Auto-detect `<variable/>` placeholders in command body text and surface them as implicit params in the library API, so the frontend auto-populates the variables section when a command is selected
- Applies to both `list_commands` and `get_command` endpoints; built-in variables (`timestamp`, `date`, `encrypted`, etc.) are excluded

## Test plan
- [ ] Open Mission Automations dialog, verify the Command dropdown matches the Source/Trigger styling
- [ ] Select a command with `<variable/>` in its body (e.g. `maintain-repo` which uses `<repo/>`), verify the variable appears in the Variables section automatically
- [ ] Verify commands with explicit frontmatter `params` still work and don't get duplicated
- [ ] Verify built-in variables like `<encrypted>` are not shown as params

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect library command metadata and automation variable auto-population; main risk is incorrect param inference or regressions in clients relying on prior `params` behavior.
> 
> **Overview**
> Mission Automations now uses a styled `<select>` for library command selection instead of an `<input>`/`<datalist>`.
> 
> Selecting a library command now auto-populates variables from both declared command `params` and `<variable/>` placeholders found in the command body by fetching full command content, with built-ins (including `encrypted`) and `webhook.*` excluded and stale async responses guarded.
> 
> On the backend, `list_commands` and `get_command` now include these placeholder-derived *implicit* params in their returned `params` list so clients can surface required variables even when not declared in frontmatter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3251c0bf5b2491ee51749cfd0efb41339d3a556f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->