### PR TITLE
Fix GLM-5 thinking tokens + reduce OpenCode cold-start latency

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -281,7 +281,7 @@ function parseQuestionArgs(args: unknown): QuestionInfo[] {
             }))
             .filter((opt) => opt.label.length > 0)
         : [],
-      multiple: Boolean(entry["multiple"]),
+      multiple: Boolean(entry["multiple"] ?? entry["multiSelect"]),
     }))
     .filter((q) => (q.question?.length ?? 0) > 0);
 }
@@ -2808,7 +2808,7 @@ export default function ControlClient() {
       items.some(
         (item) =>
           item.kind === "tool" &&
-          item.name === "question" &&
+          (item.name === "question" || item.name === "AskUserQuestion") &&
           item.result === undefined
       ),
     [items]
@@ -3510,7 +3510,7 @@ export default function ControlClient() {
           finalizePendingThinking(timestamp);
           const toolCallId = event.tool_call_id || `unknown-${event.id}`;
           const name = event.tool_name || "unknown";
-          const isUiTool = name.startsWith("ui_") || name === "question";
+          const isUiTool = name.startsWith("ui_") || name === "question" || name === "AskUserQuestion";
           // Parse args from content (stored as JSON string)
           let args: unknown = undefined;
           try {
@@ -4922,7 +4922,7 @@ export default function ControlClient() {
 
       if (event.type === "tool_call" && isRecord(data)) {
         const name = String(data["name"] ?? "");
-        const isUiTool = name.startsWith("ui_") || name === "question";
+        const isUiTool = name.startsWith("ui_") || name === "question" || name === "AskUserQuestion";
         const toolCallId = String(data["tool_call_id"] ?? "");
 
         setItems((prev) => {
@@ -6465,7 +6465,7 @@ export default function ControlClient() {
                 if (item.kind === "tool") {
                   // UI tools get special interactive rendering
                   if (item.isUiTool) {
-                    if (item.name === "question") {
+                    if (item.name === "question" || item.name === "AskUserQuestion") {
                       return (
                         <QuestionToolItem
                           key={item.id}

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5461,7 +5461,10 @@ async fn run_single_control_turn(
         {
             config.default_model = Some(default_model);
         }
-    } else if !is_claudecode && effective_config_profile.is_some() && requested_model.is_none() {
+    } else if backend_id.as_deref() == Some("opencode")
+        && effective_config_profile.is_some()
+        && requested_model.is_none()
+    {
         // For OpenCode with a config profile but no explicit model override,
         // clear the global default so the profile's oh-my-opencode agent
         // models take precedence instead of being overridden.

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5461,6 +5461,11 @@ async fn run_single_control_turn(
         {
             config.default_model = Some(default_model);
         }
+    } else if !is_claudecode && effective_config_profile.is_some() && requested_model.is_none() {
+        // For OpenCode with a config profile but no explicit model override,
+        // clear the global default so the profile's oh-my-opencode agent
+        // models take precedence instead of being overridden.
+        config.default_model = None;
     }
     if let Some(ref agent) = agent_override {
         config.opencode_agent = Some(agent.clone());

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -62,7 +62,10 @@ fn extract_str<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<&'a st
 }
 
 fn extract_part_text<'a>(part: &'a serde_json::Value, part_type: &str) -> Option<&'a str> {
-    if matches!(part_type, "thinking" | "reasoning" | "step-start" | "step-finish") {
+    if matches!(
+        part_type,
+        "thinking" | "reasoning" | "step-start" | "step-finish"
+    ) {
         extract_str(part, &["thinking", "reasoning", "text", "content"])
     } else {
         extract_str(part, &["text", "content", "output_text"])
@@ -245,7 +248,10 @@ fn handle_part_update(
         return handle_tool_part_update(part, state, mission_id);
     }
 
-    let is_thinking = matches!(part_type, "thinking" | "reasoning" | "step-start" | "step-finish");
+    let is_thinking = matches!(
+        part_type,
+        "thinking" | "reasoning" | "step-start" | "step-finish"
+    );
     let is_text = matches!(part_type, "text" | "output_text");
 
     if !is_thinking && !is_text {

--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -832,7 +832,10 @@ fn extract_str<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<&'a st
 }
 
 fn extract_part_text<'a>(part: &'a serde_json::Value, part_type: &str) -> Option<&'a str> {
-    if matches!(part_type, "thinking" | "reasoning" | "step-start" | "step-finish") {
+    if matches!(
+        part_type,
+        "thinking" | "reasoning" | "step-start" | "step-finish"
+    ) {
         extract_str(part, &["thinking", "reasoning", "text", "content"])
     } else {
         extract_str(part, &["text", "content", "output_text"])
@@ -855,7 +858,10 @@ fn handle_part_update(props: &serde_json::Value, state: &mut SseState) -> Option
         return handle_tool_part_update(part, state);
     }
 
-    if !matches!(part_type, "text" | "output_text" | "reasoning" | "thinking" | "step-start" | "step-finish") {
+    if !matches!(
+        part_type,
+        "text" | "output_text" | "reasoning" | "thinking" | "step-start" | "step-finish"
+    ) {
         tracing::debug!(
             part_type = %part_type,
             "Unhandled part type in handle_part_update"
@@ -902,7 +908,10 @@ fn handle_part_update(props: &serde_json::Value, state: &mut SseState) -> Option
         return None;
     }
 
-    if matches!(part_type, "reasoning" | "thinking" | "step-start" | "step-finish") {
+    if matches!(
+        part_type,
+        "reasoning" | "thinking" | "step-start" | "step-finish"
+    ) {
         // Skip if content is identical to last emitted thinking
         if state.last_emitted_thinking.as_ref() == Some(&content) {
             tracing::debug!(


### PR DESCRIPTION
## Summary

Fixes the two issues reported in #138: GLM-5 thinking/reasoning tokens not being streamed to the UI, and excessive cold-start latency when connecting to the OpenCode SSE event stream.

### Changes

- **Handle `step-start`/`step-finish` as thinking signals** in both SSE parsers (`mission_runner.rs` and `opencode/mod.rs`) — these are reasoning step boundary markers emitted by GLM-5
- **Inject `reasoning_content` capability** into Z.AI provider definition for GLM-5+ models, so the AI-SDK adapter maps `reasoning_content` to `part.type = "reasoning"` events (defense-in-depth: works if/when OpenCode starts honoring this config)
- **Fix `extract_part_text`** in both SSE parsers to look for `"reasoning"` field alongside `"thinking"`
- **Fix `response.output_text.delta` being a no-op** in `mission_runner.rs` — this event was silently dropped in CLI mode while correctly handled in `opencode/mod.rs`
- **Deduplicate `model_def`/`model_entry` construction** in `ensure_opencode_provider_for_model` — was maintaining two identical capability blocks
- **Replace flat 300ms SSE retry** with exponential backoff (50ms → 100ms → 200ms → ...), cutting worst-case overhead from ~1.8s to ~0.45s
- **Fix SSE backoff off-by-one** — first retry delay is now 50ms as documented (was 100ms due to pre-increment of attempts counter)
- **Reduce SSE readiness sleep** from 300ms to 100ms in the backend client
- **Downgrade verbose diagnostic logs** from WARN to DEBUG/INFO level

## Root cause analysis

**Thinking tokens**: Z.AI is configured as a generic OpenAI-compatible provider without an `npm` package (unlike `@ai-sdk/cerebras` or `@ai-sdk/xai`). GLM-5 sends reasoning tokens via the `reasoning_content` field in streaming deltas, but the current OpenCode version delivers reasoning inline in the text response rather than as separate `reasoning`/`thinking` part types. The model emits `step-start`/`step-finish` boundary markers (empty content, no delta) to delimit reasoning steps. These markers were previously logged as "unhandled part types" — now they're gracefully handled as thinking signals.

**Cold-start latency**: The SSE curl retry loop used flat 300ms delays between all attempts (up to 6 retries = ~1.8s worst case). Changed to exponential backoff starting at 50ms with up to 8 attempts.

## Test plan

- [x] `cargo build` compiles without errors
- [x] Deployed to dev backend (`agent-backend-dev.thomas.md`)
- [x] Simple test: "What is 2+2?" with `zai/glm-5` — completed correctly ✓
- [x] Simple test: "Write a haiku about programming" — completed correctly ✓
- [x] Reasoning test: train meeting time problem — completed with correct step-by-step solution ✓
- [x] Verified `step-start`/`step-finish` events handled gracefully (no WARN logs)
- [x] Verified `response.output_text.delta` now emits text events in CLI mode
- [x] Verified SSE backoff starts at 50ms (not 100ms)

## Notes

GLM-5 currently delivers reasoning inline in the text response (not as separate `reasoning_content` fields in the stream). The `capabilities.interleaved` config and `step-start`/`step-finish` handling are defense-in-depth: they'll correctly surface thinking tokens if/when OpenCode starts extracting `reasoning_content` from the raw API response into separate part types.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenCode mission execution/streaming and completion detection; mistakes could cause missions to hang, terminate early, or mis-stream output for some models.
> 
> **Overview**
> Fixes OpenCode/GLM streaming and completion behavior by treating `step-start`/`step-finish` and `reasoning` fields as thinking signals, emitting `response.output_text.delta` in CLI-mode parsing, and considering `response.incomplete`/`session.idle`/idle `session.status` as turn completion to prevent hangs.
> 
> Reduces SSE cold-start and reconnect overhead via shorter readiness delay, exponential backoff with more attempts, and additional inactivity/retry safeguards (including abort after repeated automatic retries).
> 
> Improves compatibility by recognizing the `AskUserQuestion` tool name in the dashboard (including `multiSelect` parsing) and tightening backend session handling by refreshing/updating cached `session_id` and ensuring OpenCode config-profile model selection doesn’t get overridden by global defaults (plus injecting GLM reasoning capabilities into generated provider model entries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fc8b483d3624709a52d5f938770a45827339f67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->