### PR TITLE
Fix CI format, RTK prefix matching, and deduplicate RTK helpers

### DIFF
--- a/src/api/model_routing.rs
+++ b/src/api/model_routing.rs
@@ -17,8 +17,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::tools::terminal::rtk_stats;
 use crate::provider_health::{ChainEntry, ModelChain};
+use crate::tools::terminal::rtk_stats;
 
 /// Register model routing routes.
 pub fn routes() -> Router<Arc<super::routes::AppState>> {


### PR DESCRIPTION
## Summary

Fixes three issues identified during bugbot review of PR #144:

- **CI format fix**: `cargo fmt` violations in `model_routing.rs` (import ordering) and `workspace.rs` (line wrapping) that would fail the format CI check
- **RTK prefix matching bug**: `should_wrap_with_rtk()` used `starts_with(pattern)` without word boundary checks, causing false matches — e.g., `"ls"` matched `"lsof"`, `"cat"` matched `"catkin_make"`, `"head"` matched `"headless-chrome"`. Now verifies the character after the pattern is a space or end-of-string
- **Deduplicate RTK helpers**: `rtk_enabled()` and `rtk_binary_path()` were duplicated between `terminal.rs` and `workspace.rs` with slightly different candidate lists. Made `terminal.rs` versions `pub` (superset of candidates) and removed the `workspace.rs` copies (`rtk_binary_path_on_host` deleted)

## Test plan

- [ ] `cargo fmt -- --check` passes (CI format)
- [ ] `cargo build --release` succeeds
- [ ] RTK wrapping works correctly: `ls -la` → wrapped, `lsof` → not wrapped
- [ ] RTK hooks still write correctly for container workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix/refactor affecting only RTK command-wrapping heuristics and helper function visibility. Main behavior change is avoiding accidental RTK wrapping for commands whose names merely start with an allowlisted prefix (e.g., `lsof`).
> 
> **Overview**
> Fixes RTK command wrapping to avoid false-positive prefix matches by requiring a word-boundary when checking the allowlist in `should_wrap_with_rtk()`.
> 
> Deduplicates RTK enablement/binary lookup logic by making `rtk_enabled()` and `rtk_binary_path()` public in `terminal.rs` and reusing them from `workspace.rs` (removing the local host-path helper), plus minor `cargo fmt` import/line-wrapping cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b169f2b648fd1e9cb432cf78a35329515ececf7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->