### PR TITLE
Fix dashboard hardcoding port 3000 for API calls

### DIFF
--- a/dashboard/src/lib/settings.ts
+++ b/dashboard/src/lib/settings.ts
@@ -37,6 +37,5 @@ export function getRuntimeApiBase(): string {
   const saved = readSavedSettings().apiUrl;
   if (saved) return normalizeBaseUrl(saved);
   if (envBase) return normalizeBaseUrl(envBase);
-  const { protocol, hostname } = window.location;
-  return normalizeBaseUrl(`${protocol}//${hostname}:3000`);
+  return normalizeBaseUrl(window.location.origin);
 }


### PR DESCRIPTION
## Summary
- Dashboard hardcodes `:3000` in API base URL, causing CORS errors when Docker maps to a different port (e.g. `3456:80`)
- Replace `${protocol}//${hostname}:3000` with `window.location.origin` which uses the actual port the page was loaded from
- Since Caddy proxies both dashboard and `/api/*` on the same port, this works correctly regardless of external port mapping

## Test plan
- [ ] `docker compose` with a non-default port (e.g. `"3456:80"`)
- [ ] Open dashboard — API calls in Network tab should go to the correct port
- [ ] Verify default port (`3000:80`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)