### PR TITLE
Fix RTK binary install on ARM64 Docker hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,8 @@ RUN npm install -g @sourcegraph/amp@latest \
     || echo "[docker] WARNING: Amp CLI install failed (will be installed on first mission)"
 
 # -- RTK (CLI output compressor for token savings) --
-RUN curl -fsSL https://github.com/rtk-ai/rtk/releases/latest/download/rtk-x86_64-unknown-linux-gnu.tar.gz \
+RUN RTK_ARCH=$(case "$(uname -m)" in aarch64|arm64) echo "aarch64";; *) echo "x86_64";; esac) \
+    && curl -fsSL "https://github.com/rtk-ai/rtk/releases/latest/download/rtk-${RTK_ARCH}-unknown-linux-gnu.tar.gz" \
     | tar xz -C /usr/local/bin rtk \
     && chmod +x /usr/local/bin/rtk \
     && echo "[docker] RTK installed: $(rtk --version 2>/dev/null || echo 'unknown')" \


### PR DESCRIPTION
## Summary
- RTK install in Docker silently failed on ARM64 hosts (Apple Silicon) because the URL was hardcoded to `x86_64`
- Detect architecture at build time (`uname -m`) and download the matching binary (`aarch64` or `x86_64`)
- RTK now installs correctly as `0.20.1` on ARM64

## Test plan
- [ ] `docker compose build` on Apple Silicon Mac — build log should show `RTK installed: rtk 0.20.1`
- [ ] `docker compose build` on x86_64 Linux — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)