### PR TITLE
Fix Codex model visibility and add mission model effort

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -178,6 +178,25 @@ Optional flags:
 Expected behavior per backend:
 - First message triggers tool calls + results
 - Second message is queued (`queued: true`)
+
+## Codex Model Effort Check
+
+To verify Codex `model_effort` end-to-end on dev:
+
+```bash
+# Create mission with Codex effort override
+curl -sS -X POST "https://agent-backend-dev.thomas.md/api/control/missions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Codex effort smoke",
+    "backend": "codex",
+    "model_override": "gpt-5-codex",
+    "model_effort": "high"
+  }'
+```
+
+Then load the mission in the dashboard and send a message. The mission metadata
+should show `model_effort: high`.
 - Stream includes `thinking`, `text_delta`, `tool_call`, `tool_result`, and `assistant_message`
 
 ## Troubleshooting

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4235,6 +4235,7 @@ export default function ControlClient() {
     workspaceId?: string;
     agent?: string;
     modelOverride?: string;
+    modelEffort?: "low" | "medium" | "high";
     configProfile?: string;
     backend?: string;
     openInNewTab?: boolean;
@@ -4245,6 +4246,7 @@ export default function ControlClient() {
         workspaceId: options?.workspaceId,
         agent: options?.agent,
         modelOverride: options?.modelOverride,
+        modelEffort: options?.modelEffort,
         configProfile: options?.configProfile,
         backend: options?.backend,
       });
@@ -5769,6 +5771,7 @@ export default function ControlClient() {
               agent: activeMission.agent,
               backend: activeMission.backend,
               modelOverride: activeMission.model_override,
+              modelEffort: activeMission.model_effort,
             } : undefined}
           />
 
@@ -6099,6 +6102,14 @@ export default function ControlClient() {
                           <span className="text-white/40">Model override</span>
                           <span className="font-mono text-[11px] text-indigo-400 truncate max-w-[160px]" title={activeMission.model_override}>
                             {activeMission.model_override}
+                          </span>
+                        </div>
+                      )}
+                      {activeMission.model_effort && (
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-white/40">Model effort</span>
+                          <span className="font-mono text-[11px] text-amber-300 truncate max-w-[160px]" title={activeMission.model_effort}>
+                            {activeMission.model_effort}
                           </span>
                         </div>
                       )}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -283,13 +283,14 @@ function OverviewPageContent() {
   );
 
   const handleNewMission = useCallback(
-    async (options?: { workspaceId?: string; agent?: string; modelOverride?: string; configProfile?: string; backend?: string; openInNewTab?: boolean }) => {
+    async (options?: { workspaceId?: string; agent?: string; modelOverride?: string; modelEffort?: "low" | "medium" | "high"; configProfile?: string; backend?: string; openInNewTab?: boolean }) => {
       try {
         setCreatingMission(true);
         const mission = await createMission({
           workspaceId: options?.workspaceId,
           agent: options?.agent,
           modelOverride: options?.modelOverride,
+          modelEffort: options?.modelEffort,
           configProfile: options?.configProfile,
           backend: options?.backend,
         });

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -33,6 +33,7 @@ export interface Mission {
   workspace_name?: string;
   agent?: string;
   model_override?: string;
+  model_effort?: "low" | "medium" | "high";
   backend?: string;
   history: MissionHistoryEntry[];
   desktop_sessions?: DesktopSessionInfo[];
@@ -60,6 +61,7 @@ export interface CreateMissionOptions {
   workspaceId?: string;
   agent?: string;
   modelOverride?: string;
+  modelEffort?: "low" | "medium" | "high";
   configProfile?: string;
   backend?: string;
 }
@@ -123,6 +125,7 @@ export async function createMission(
     workspace_id?: string;
     agent?: string;
     model_override?: string;
+    model_effort?: "low" | "medium" | "high";
     config_profile?: string;
     backend?: string;
   } = {};
@@ -131,6 +134,7 @@ export async function createMission(
   if (options?.workspaceId) body.workspace_id = options.workspaceId;
   if (options?.agent) body.agent = options.agent;
   if (options?.modelOverride) body.model_override = options.modelOverride;
+  if (options?.modelEffort) body.model_effort = options.modelEffort;
   if (options?.configProfile) body.config_profile = options.configProfile;
   if (options?.backend) body.backend = options.backend;
 

--- a/dashboard/tests/queue-order.spec.ts
+++ b/dashboard/tests/queue-order.spec.ts
@@ -33,7 +33,11 @@ test.describe('Queue Ordering', () => {
       };
       const originalFetch = window.fetch.bind(window);
       window.fetch = async (input, init) => {
-        const url = typeof input === 'string' ? input : input.url;
+        const url = typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
         if (url.includes('/api/control/stream')) {
           const encoder = new TextEncoder();
           const stream = new ReadableStream({

--- a/docs-site/content/api.mdx
+++ b/docs-site/content/api.mdx
@@ -32,11 +32,13 @@ POST /api/control/missions
   "title": "My Mission",
   "workspace_id": "uuid",
   "agent": "code-reviewer",
-  "model_override": "anthropic/claude-sonnet-4-20250514"
+  "model_override": "gpt-5-codex",
+  "model_effort": "medium"
 }
 ```
 
 All fields optional. Returns `Mission` object.
+`model_effort` currently supports: `low`, `medium`, `high` (Codex backend).
 
 ### Load Mission
 
@@ -127,6 +129,7 @@ Server-Sent Events for real-time updates:
   "workspace_name": "my-workspace",
   "agent": "code-reviewer",
   "model_override": null,
+  "model_effort": null,
   "created_at": "2025-01-13T10:00:00Z",
   "updated_at": "2025-01-13T10:05:00Z"
 }

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -102,6 +102,7 @@ impl MissionStore for FileMissionStore {
         workspace_id: Option<Uuid>,
         agent: Option<&str>,
         model_override: Option<&str>,
+        model_effort: Option<&str>,
         backend: Option<&str>,
         config_profile: Option<&str>,
     ) -> Result<Mission, String> {
@@ -114,6 +115,7 @@ impl MissionStore for FileMissionStore {
             workspace_name: None,
             agent: agent.map(|s| s.to_string()),
             model_override: model_override.map(|s| s.to_string()),
+            model_effort: model_effort.map(|s| s.to_string()),
             backend: backend.unwrap_or("claudecode").to_string(),
             config_profile: config_profile.map(|s| s.to_string()),
             history: vec![],

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -53,6 +53,7 @@ impl MissionStore for InMemoryMissionStore {
         workspace_id: Option<Uuid>,
         agent: Option<&str>,
         model_override: Option<&str>,
+        model_effort: Option<&str>,
         backend: Option<&str>,
         config_profile: Option<&str>,
     ) -> Result<Mission, String> {
@@ -65,6 +66,7 @@ impl MissionStore for InMemoryMissionStore {
             workspace_name: None,
             agent: agent.map(|s| s.to_string()),
             model_override: model_override.map(|s| s.to_string()),
+            model_effort: model_effort.map(|s| s.to_string()),
             backend: backend.unwrap_or("claudecode").to_string(),
             config_profile: config_profile.map(|s| s.to_string()),
             history: vec![],

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -39,6 +39,9 @@ pub struct Mission {
     /// Optional model override (provider/model)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_override: Option<String>,
+    /// Optional model effort override (e.g. low/medium/high)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_effort: Option<String>,
     /// Backend to use for this mission ("opencode" or "claudecode")
     #[serde(default = "default_backend")]
     pub backend: String,
@@ -270,6 +273,7 @@ pub trait MissionStore: Send + Sync {
         workspace_id: Option<Uuid>,
         agent: Option<&str>,
         model_override: Option<&str>,
+        model_effort: Option<&str>,
         backend: Option<&str>,
         config_profile: Option<&str>,
     ) -> Result<Mission, String>;
@@ -521,7 +525,7 @@ mod tests {
         let store = InMemoryMissionStore::new();
 
         let mission = store
-            .create_mission(Some("Test Mission"), None, None, None, None, None)
+            .create_mission(Some("Test Mission"), None, None, None, None, None, None)
             .await
             .expect("Failed to create mission");
 
@@ -541,7 +545,7 @@ mod tests {
 
         // Create a pending mission
         let mission = store
-            .create_mission(Some("Pending Mission"), None, None, None, None, None)
+            .create_mission(Some("Pending Mission"), None, None, None, None, None, None)
             .await
             .expect("Failed to create mission");
 
@@ -566,7 +570,7 @@ mod tests {
 
         // Create a pending mission
         let mission = store
-            .create_mission(Some("Test Mission"), None, None, None, None, None)
+            .create_mission(Some("Test Mission"), None, None, None, None, None, None)
             .await
             .expect("Failed to create mission");
 
@@ -613,12 +617,12 @@ mod tests {
 
         // Create two missions
         let pending_mission = store
-            .create_mission(Some("Pending"), None, None, None, None, None)
+            .create_mission(Some("Pending"), None, None, None, None, None, None)
             .await
             .expect("Failed to create pending mission");
 
         let active_mission = store
-            .create_mission(Some("Will be Active"), None, None, None, None, None)
+            .create_mission(Some("Will be Active"), None, None, None, None, None, None)
             .await
             .expect("Failed to create mission");
 

--- a/src/api/model_routing.rs
+++ b/src/api/model_routing.rs
@@ -17,8 +17,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::tools::terminal::rtk_stats;
 use crate::provider_health::{ChainEntry, ModelChain};
+use crate::tools::terminal::rtk_stats;
 
 /// Register model routing routes.
 pub fn routes() -> Router<Arc<super::routes::AppState>> {

--- a/src/backend/codex/client.rs
+++ b/src/backend/codex/client.rs
@@ -20,6 +20,7 @@ pub struct CodexConfig {
     pub cli_path: String,
     pub oauth_token: Option<String>,
     pub default_model: Option<String>,
+    pub model_effort: Option<String>,
 }
 
 impl Default for CodexConfig {
@@ -28,6 +29,7 @@ impl Default for CodexConfig {
             cli_path: std::env::var("CODEX_CLI_PATH").unwrap_or_else(|_| "codex".to_string()),
             oauth_token: std::env::var("OPENAI_OAUTH_TOKEN").ok(),
             default_model: None,
+            model_effort: None,
         }
     }
 }
@@ -85,14 +87,18 @@ impl CodexClient {
             args.push("--model".to_string());
             args.push(m.to_string());
         }
+        if let Some(effort) = self.config.model_effort.as_deref() {
+            args.push("-c".to_string());
+            args.push(format!("reasoning.effort=\"{}\"", effort));
+        }
 
         // Add the message as a positional arg (guard prompts starting with '-')
         args.push("--".to_string());
         args.push(message.to_string());
 
         info!(
-            "Spawning Codex CLI: directory={}, model={:?}",
-            directory, effective_model
+            "Spawning Codex CLI: directory={}, model={:?}, effort={:?}",
+            directory, effective_model, self.config.model_effort
         );
 
         let (program, full_args) = if self.config.cli_path.contains(' ') {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1319,8 +1319,7 @@ async fn write_rtk_hook_if_enabled(
     }
 
     // For container workspaces, copy the RTK binary from host into the container
-    let is_container =
-        workspace_type == WorkspaceType::Container && nspawn::nspawn_available();
+    let is_container = workspace_type == WorkspaceType::Container && nspawn::nspawn_available();
     if is_container {
         if let Some(host_rtk) = rtk_binary_path_on_host() {
             let dest_dir = workspace_root.join("usr").join("local").join("bin");
@@ -1337,10 +1336,8 @@ async fn write_rtk_hook_if_enabled(
                     #[cfg(unix)]
                     {
                         use std::os::unix::fs::PermissionsExt;
-                        let _ = std::fs::set_permissions(
-                            &dest,
-                            std::fs::Permissions::from_mode(0o755),
-                        );
+                        let _ =
+                            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
                     }
                     tracing::info!(
                         dest = %dest.display(),


### PR DESCRIPTION
## Summary
- filter Codex model options to account-supported models via lightweight OpenAI probe with cache
- add `model_effort` (`low|medium|high`) across mission creation, persistence, runner, and Codex CLI invocation
- wire dashboard mission creation UI/API for Codex effort selection and display
- update API/debugging docs and fix Playwright test typing for `fetch` URL input union

## Validation
- `cargo fmt --all --check`
- `cargo check`
- `cd dashboard && bunx tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes mission creation/persistence and Codex execution parameters (model selection and reasoning effort), plus adds a new OpenAI probing path that could affect model listings and availability in the UI.
> 
> **Overview**
> Adds a new per-mission `model_effort` (`low|medium|high`) setting, wiring it through the control API request/validation, mission storage (including SQLite migration), mission runners, and the Codex CLI invocation (passed as `reasoning.effort`). The dashboard mission creation flow now lets users select effort for Codex missions and displays `model_effort` in mission metadata.
> 
> Improves Codex model handling by filtering the dashboard’s Codex model options to those likely supported by the account via a lightweight, cached OpenAI probe, and remaps legacy Codex model IDs (e.g. `gpt-5.3-codex*`) to `gpt-5-codex` with clearer guidance when model-not-found errors occur. Updates API/debug docs accordingly and fixes a Playwright test to handle `fetch` URL input types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef1692546cb2f67424308954384f5313b7780a29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->