### PR TITLE
Fix debootstrap failing on ARM64 with wrong Ubuntu mirror

### DIFF
--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -139,7 +139,13 @@ impl NspawnDistro {
 
     pub fn mirror_url(&self) -> &'static str {
         match self {
-            Self::UbuntuNoble | Self::UbuntuJammy => "http://archive.ubuntu.com/ubuntu",
+            Self::UbuntuNoble | Self::UbuntuJammy => {
+                if std::env::consts::ARCH == "aarch64" {
+                    "http://ports.ubuntu.com/ubuntu-ports"
+                } else {
+                    "http://archive.ubuntu.com/ubuntu"
+                }
+            }
             Self::DebianBookworm => "http://deb.debian.org/debian",
             Self::ArchLinux => "https://geo.mirror.pkgbuild.com/",
         }


### PR DESCRIPTION
## Summary
- Workspace builds fail on ARM64 (Apple Silicon) because `debootstrap` tries to fetch packages from `archive.ubuntu.com`, which doesn't host ARM64 binaries
- Use runtime architecture detection (`std::env::consts::ARCH`) to select `ports.ubuntu.com/ubuntu-ports` for `aarch64` and `archive.ubuntu.com/ubuntu` for `x86_64`

## Test plan
- [ ] Create an isolated workspace (Ubuntu 24.04) on an ARM64 Docker host — should build successfully
- [ ] Verify x86_64 hosts still use `archive.ubuntu.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)