### PR TITLE
Add 46 unit tests for terminal and settings modules

### DIFF
--- a/dashboard/src/lib/settings.test.ts
+++ b/dashboard/src/lib/settings.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  readSavedSettings,
+  writeSavedSettings,
+  getRuntimeApiBase,
+} from "./settings";
+
+describe("readSavedSettings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty object when nothing is saved", () => {
+    expect(readSavedSettings()).toEqual({});
+  });
+
+  it("reads a valid apiUrl from localStorage", () => {
+    localStorage.setItem("settings", JSON.stringify({ apiUrl: "http://myhost:4000" }));
+    expect(readSavedSettings()).toEqual({ apiUrl: "http://myhost:4000" });
+  });
+
+  it("ignores non-string apiUrl values", () => {
+    localStorage.setItem("settings", JSON.stringify({ apiUrl: 42 }));
+    expect(readSavedSettings()).toEqual({});
+  });
+
+  it("returns empty object for invalid JSON", () => {
+    localStorage.setItem("settings", "not-json");
+    expect(readSavedSettings()).toEqual({});
+  });
+});
+
+describe("writeSavedSettings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("persists apiUrl to localStorage", () => {
+    writeSavedSettings({ apiUrl: "http://test:5000" });
+    const raw = localStorage.getItem("settings");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual({ apiUrl: "http://test:5000" });
+  });
+});
+
+describe("getRuntimeApiBase", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_API_URL;
+
+  beforeEach(() => {
+    localStorage.clear();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.NEXT_PUBLIC_API_URL = originalEnv;
+    } else {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    }
+  });
+
+  it("returns saved setting when present", () => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({ apiUrl: "http://custom:9999/" })
+    );
+    expect(getRuntimeApiBase()).toBe("http://custom:9999");
+  });
+
+  it("returns env var when no saved setting", () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://env-host:8080";
+    expect(getRuntimeApiBase()).toBe("http://env-host:8080");
+  });
+
+  it("falls back to window.location.origin when no saved setting or env var", () => {
+    // The key behavior: uses window.location.origin instead of hardcoding :3000.
+    // In jsdom the origin is 'http://localhost' by default.
+    const result = getRuntimeApiBase();
+    expect(result).toBe(window.location.origin);
+  });
+
+  it("strips trailing slash from returned URL", () => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({ apiUrl: "http://host:3000/" })
+    );
+    expect(getRuntimeApiBase()).toBe("http://host:3000");
+  });
+});


### PR DESCRIPTION
## Summary
- **37 new Rust unit tests** for the terminal module covering critical paths that previously had zero or minimal coverage:
  - `should_wrap_with_rtk` (11 tests): word boundary matching, case sensitivity, pipes/chaining, heredocs, false positives (lsof, catkin_make, headless-chrome — the exact bug PR #160 fixed), already-wrapped commands, unknown commands
  - `validate_command` (8 tests): all dangerous patterns (rm -rf, find /, grep -r /), sudo prefix bypass, device writes, safe root paths, safe commands
  - `sanitize_output` (6 tests): binary detection, UTF-8 handling, null bytes, empty input, tabs/newlines
  - `parse_timeout` (5 tests): timeout_ms, timeout_secs, float, precedence, defaults
  - `parse_env` (3 tests): object parsing, missing, non-string values
  - `parse_max_output_chars` (4 tests): default, custom, clamping, minimum
- **9 new dashboard unit tests** for the settings module:
  - `readSavedSettings`: empty, valid, invalid types, bad JSON
  - `writeSavedSettings`: persistence
  - `getRuntimeApiBase`: saved setting, env var, origin fallback, trailing slash normalization

## Motivation
The terminal module's `should_wrap_with_rtk` was recently bugfixed in PR #160 (prefix matching `ls` → `lsof`, `cat` → `catkin_make`). That bug existed because **there were zero tests** for this function. This PR ensures regressions like that are caught immediately.

Adding tests is the highest-leverage way to improve reliability — every time a feature is added or changed, these tests catch unintended breakage across backends (Claude, Codex, OpenCode).

Total test count:
- Rust: 132 → 170 (+38)
- Dashboard unit: 80 → 89 (+9)

## Test plan
- [x] `cargo test --workspace` — 170 passed, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -W clippy::all` — clean
- [x] `bun run test:unit` — 89 passed, 0 failed
- [x] `bunx tsc --noEmit` — clean