### PR TITLE
Add tests for RTK command wrapping word boundary fix

### DIFF
--- a/src/tools/terminal.rs
+++ b/src/tools/terminal.rs
@@ -225,6 +225,42 @@ mod tests {
 
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn should_wrap_with_rtk_matches_exact_commands() {
+        assert!(should_wrap_with_rtk("ls"));
+        assert!(should_wrap_with_rtk("git status"));
+        assert!(should_wrap_with_rtk("cargo test"));
+    }
+
+    #[test]
+    fn should_wrap_with_rtk_matches_with_args() {
+        assert!(should_wrap_with_rtk("ls -la"));
+        assert!(should_wrap_with_rtk("git status --short"));
+        assert!(should_wrap_with_rtk("cargo test --release"));
+    }
+
+    #[test]
+    fn should_wrap_with_rtk_rejects_false_prefix_matches() {
+        assert!(!should_wrap_with_rtk("lsof"));
+        assert!(!should_wrap_with_rtk("lsof -i"));
+        assert!(!should_wrap_with_rtk("catkin_make"));
+        assert!(!should_wrap_with_rtk("headless-chrome"));
+    }
+
+    #[test]
+    fn should_wrap_with_rtk_rejects_compound_commands() {
+        assert!(!should_wrap_with_rtk("ls && echo done"));
+        assert!(!should_wrap_with_rtk("ls || echo failed"));
+        assert!(!should_wrap_with_rtk("ls | grep foo"));
+        assert!(!should_wrap_with_rtk("cat <<EOF"));
+    }
+
+    #[test]
+    fn should_wrap_with_rtk_rejects_already_wrapped() {
+        assert!(!should_wrap_with_rtk("rtk ls"));
+        assert!(!should_wrap_with_rtk("rtk git status"));
+    }
 }
 
 /// Read context information from the local context file or fall back to env vars.


### PR DESCRIPTION
## Summary
- Add unit tests for `should_wrap_with_rtk()` function to prevent regressions
- Tests verify the word boundary fix from PR #160 works correctly
- Covers exact command matching, argument handling, false prefix rejection, compound command rejection

## Test Coverage
- ✅ Exact command matches (ls, git status, cargo test)
- ✅ Commands with arguments (ls -la, git status --short)  
- ✅ False prefix rejection (lsof ≠ ls, catkin_make ≠ cat, headless-chrome ≠ head)
- ✅ Compound command rejection (pipes, chains, heredocs)
- ✅ Already-wrapped command rejection (rtk ls)

## Why This Matters
PR #160 fixed a bug where `should_wrap_with_rtk()` matched `"ls"` against `"lsof"` and `"cat"` against `"catkin_make"` because it used `starts_with()` without word boundary checks. These tests ensure this bug doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic modifications; risk is limited to potential brittleness/over-constraining expected matching behavior.
> 
> **Overview**
> Adds a focused unit-test suite for `should_wrap_with_rtk()` to prevent regressions in RTK command wrapping selection.
> 
> Tests cover **exact allowlist matches and matches-with-args**, and assert non-wrapping for **false prefix matches** (word-boundary behavior), **compound shell commands** (pipes/chains/heredocs), and **commands already prefixed with `rtk`**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e47b5240dc9b9da27d42f8359c19dc4df619a68c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->