### PR TITLE
Fix ~1s delay when expanding tool calls in Mission Control

### DIFF
--- a/dashboard/src/components/lazy-json-highlighter.test.tsx
+++ b/dashboard/src/components/lazy-json-highlighter.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { LazyJsonHighlighter } from "./lazy-json-highlighter";
+
+// Mock the heavy syntax highlighter modules so tests run instantly
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }: { children: string }) => (
+    <pre data-testid="syntax-highlighter">{children}</pre>
+  ),
+}));
+vi.mock("react-syntax-highlighter/dist/esm/styles/prism", () => ({
+  oneDark: {},
+}));
+
+describe("LazyJsonHighlighter", () => {
+  it("renders plain <pre> immediately before highlighter loads", () => {
+    const { container } = render(
+      <LazyJsonHighlighter>{'{"key": "value"}'}</LazyJsonHighlighter>
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre!.textContent).toBe('{"key": "value"}');
+  });
+
+  it("loads syntax highlighter asynchronously", async () => {
+    const { container } = render(
+      <LazyJsonHighlighter>{'{"async": true}'}</LazyJsonHighlighter>
+    );
+    // After the dynamic import resolves, the highlighted version appears
+    await waitFor(() => {
+      const highlighted = container.querySelector(
+        '[data-testid="syntax-highlighter"]'
+      );
+      expect(highlighted).not.toBeNull();
+      expect(highlighted!.textContent).toBe('{"async": true}');
+    });
+  });
+
+  it("applies custom background and text color to the plain fallback", () => {
+    const { container } = render(
+      <LazyJsonHighlighter
+        background="rgba(239, 68, 68, 0.1)"
+        textColor="rgb(248, 113, 113)"
+      >
+        error text
+      </LazyJsonHighlighter>
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre!.style.background).toBe("rgba(239, 68, 68, 0.1)");
+    expect(pre!.style.color).toBe("rgb(248, 113, 113)");
+  });
+});

--- a/dashboard/src/components/lazy-json-highlighter.tsx
+++ b/dashboard/src/components/lazy-json-highlighter.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useEffect, memo } from "react";
+import type { CSSProperties } from "react";
+
+/**
+ * A JSON code block that shows plain monospace text immediately and
+ * lazy-loads SyntaxHighlighter after mount. This avoids the ~200-800ms
+ * synchronous Prism tokenization that blocks the main thread when
+ * expanding tool calls. See issue #156.
+ */
+
+// Lazy-loaded module — only fetched on first render of a highlighted block.
+let highlighterModulePromise: Promise<{
+  Highlighter: typeof import("react-syntax-highlighter").default;
+  theme: Record<string, CSSProperties>;
+}> | null = null;
+
+function getHighlighterModule() {
+  if (!highlighterModulePromise) {
+    highlighterModulePromise = Promise.all([
+      import("react-syntax-highlighter").then((m) => m.Prism),
+      import("react-syntax-highlighter/dist/esm/styles/prism").then(
+        (m) => m.oneDark
+      ),
+    ]).then(([Highlighter, theme]) => ({ Highlighter, theme }));
+  }
+  return highlighterModulePromise;
+}
+
+interface LazyJsonHighlighterProps {
+  children: string;
+  background?: string;
+  textColor?: string;
+}
+
+export const LazyJsonHighlighter = memo(function LazyJsonHighlighter({
+  children,
+  background = "rgba(0, 0, 0, 0.2)",
+  textColor,
+}: LazyJsonHighlighterProps) {
+  const [Loaded, setLoaded] = useState<{
+    Highlighter: typeof import("react-syntax-highlighter").default;
+    theme: Record<string, CSSProperties>;
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getHighlighterModule().then((mod) => {
+      if (!cancelled) setLoaded(mod);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const monoFont =
+    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+
+  // Before the highlighter loads, show plain monospace text. This renders
+  // in <1ms vs 200-800ms for SyntaxHighlighter, making expand feel instant.
+  if (!Loaded) {
+    return (
+      <pre
+        style={{
+          margin: 0,
+          padding: "0.5rem",
+          fontSize: "0.75rem",
+          borderRadius: "0.25rem",
+          background,
+          color: textColor ?? "#abb2bf",
+          fontFamily: monoFont,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          overflow: "hidden",
+        }}
+      >
+        {children}
+      </pre>
+    );
+  }
+
+  const { Highlighter, theme } = Loaded;
+  return (
+    <Highlighter
+      language="json"
+      style={theme}
+      customStyle={{
+        margin: 0,
+        padding: "0.5rem",
+        fontSize: "0.75rem",
+        borderRadius: "0.25rem",
+        background,
+      }}
+      codeTagProps={{
+        style: {
+          fontFamily: monoFont,
+          color: textColor,
+        },
+      }}
+    >
+      {children}
+    </Highlighter>
+  );
+});


### PR DESCRIPTION
## Summary
Fixes the ~1 second delay when expanding collapsed tool calls in Mission Control by replacing synchronous `SyntaxHighlighter` rendering with a lazy-loading approach.

Closes #156

## Root Cause
When a tool call pill was clicked, React synchronously mounted `react-syntax-highlighter` (Prism-based) which tokenizes JSON and creates DOM elements for every token. For large tool args/results, this blocked the main thread for 200-800ms per highlighter instance. Two instances per tool call = ~1s perceived delay.

## Solution

### New `LazyJsonHighlighter` component
- Shows plain monospace `<pre>` text **instantly** (<1ms) on expand
- Lazy-loads `react-syntax-highlighter` via dynamic import (cached after first load)
- Swaps in syntax-highlighted version once the module resolves
- The visual transition is imperceptible — plain monospace JSON looks nearly identical to highlighted JSON

### Conditional rendering
- Changed from CSS `max-h-0 overflow-hidden` (React still mounts the tree) to `{expanded && ...}` (React doesn't mount until expand)
- This means zero cost for collapsed tool calls — no timer intervals, no `useMemo` computations, no DOM nodes

### `startTransition` for group expansion
- When "Show N previous tools" is clicked, many `ToolCallItem` components mount at once
- Wrapped in `startTransition` so the browser paints the click feedback before doing the heavy rendering

## Files Changed
- `dashboard/src/components/lazy-json-highlighter.tsx` — new component
- `dashboard/src/components/lazy-json-highlighter.test.tsx` — 3 unit tests
- `dashboard/src/app/control/control-client.tsx` — replaced `SyntaxHighlighter` in `ToolCallItem` and `SubagentToolItem`

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test:unit` — 92 passed (8 files), 0 failed
- [x] `bun run build` — compiled successfully
- [x] `cargo fmt --all -- --check` — clean (no Rust changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk UI/performance change: it alters rendering/mounting behavior for tool-call detail panels and introduces async dynamic imports, which could cause subtle layout/flash issues or hydration edge cases but doesn’t touch backend/data/security.
> 
> **Overview**
> Fixes the noticeable UI stall when expanding tool call details in Mission Control by avoiding synchronous Prism tokenization on expand.
> 
> Adds a new `LazyJsonHighlighter` that immediately renders a lightweight `<pre>` fallback, then dynamically imports `react-syntax-highlighter` and swaps in highlighted JSON once loaded (with cached module loading), plus unit tests for the fallback/async behavior.
> 
> Updates tool detail panels to **only mount when expanded** (instead of CSS-collapsing mounted content) and replaces direct `SyntaxHighlighter` usage for tool args/results; expands large tool groups via `startTransition` to keep click feedback responsive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f329cd451a7469ed6546a9fcabf88922872b4a0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->