### PR TITLE
Fix OpenCode runner logs appearing in assistant message (issue #151)

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9809,7 +9809,8 @@ mod tests {
         assert_eq!(result.trim(), "Hello, I am the model.");
 
         // Pure ANSI-wrapped banners should become empty
-        let ansi_only = "\x1b[32mStarting opencode server\x1b[0m\n\x1b[33mAll tasks completed.\x1b[0m";
+        let ansi_only =
+            "\x1b[32mStarting opencode server\x1b[0m\n\x1b[33mAll tasks completed.\x1b[0m";
         let result = strip_opencode_banner_lines(ansi_only);
         assert!(result.trim().is_empty());
     }


### PR DESCRIPTION
## Summary
- Add `strip_opencode_banner_lines()` function to remove runner status lines from output
- Apply banner stripping as final safeguard before returning result
- Add comprehensive tests for banner line detection and filtering

## Problem
OpenCode missions were returning runner logs in `assistant_message` instead of the model's actual response. This happened when:
1. The SSE stream failed (curl not available or network issue)
2. stdout contained banner lines that leaked through
3. Fallback sources didn't provide the model response

## Solution
Added a final safeguard that strips any remaining banner lines from `final_result` before returning. This ensures that even if banner lines somehow make it through the existing filtering, they won't appear in the assistant message.

## Tests Added
- `is_opencode_banner_line_detects_runner_status` - verifies all known banner patterns are detected
- `is_opencode_banner_line_rejects_model_text` - ensures model responses aren't incorrectly filtered
- `strip_opencode_banner_lines_removes_runner_status` - tests the stripping function
- `opencode_output_needs_fallback_detects_banner_only` - tests the fallback detection

Fixes #151

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the final-response assembly and streaming emission path for OpenCode missions; incorrect filtering/ordering could hide valid model output or change when errors are surfaced.
> 
> **Overview**
> Prevents OpenCode runner status/banner lines (including ANSI-colored variants) from leaking into the assistant response by centralizing filtering in `strip_opencode_banner_lines()` and using it as a final cleanup step on `final_result`.
> 
> Adjusts the emission order so banner-only output is detected *before* sending `TextDelta`, and suppresses `TextDelta` when the run ends in an error/fallback state. Adds unit tests covering banner detection, mixed outputs, ANSI handling, and fallback behavior (issue #151).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0018c4ce7cd2a633a4f52c3d971ecd470463e412. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->