### PR TITLE
Re-enable gpt-5.3-codex and add outdated Codex CLI hint

### DIFF
--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -379,6 +379,11 @@ fn default_providers_config() -> ProvidersConfig {
                         description: Some("Fast and economical".to_string()),
                     },
                     ProviderModel {
+                        id: "gpt-5.3-codex".to_string(),
+                        name: "GPT-5.3 Codex".to_string(),
+                        description: Some("Newest Codex coding model".to_string()),
+                    },
+                    ProviderModel {
                         id: "gpt-5.2-codex".to_string(),
                         name: "GPT-5.2 Codex".to_string(),
                         description: Some("Smart and precise coding agent".to_string()),

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -379,14 +379,14 @@ fn default_providers_config() -> ProvidersConfig {
                         description: Some("Fast and economical".to_string()),
                     },
                     ProviderModel {
-                        id: "gpt-5.3-codex".to_string(),
-                        name: "GPT-5.3 Codex".to_string(),
-                        description: Some("Newest Codex coding model".to_string()),
-                    },
-                    ProviderModel {
                         id: "gpt-5.2-codex".to_string(),
                         name: "GPT-5.2 Codex".to_string(),
                         description: Some("Smart and precise coding agent".to_string()),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.3-codex".to_string(),
+                        name: "GPT-5.3 Codex".to_string(),
+                        description: Some("Newest Codex coding model".to_string()),
                     },
                     // General-purpose models (API key only)
                     ProviderModel {


### PR DESCRIPTION
## Summary
- re-add `gpt-5.3-codex` to the OpenAI Codex model catalog used by backend model options
- remove the forced remap that downgraded `gpt-5.3-codex` / `gpt-5.3-codex-spark` to `gpt-5-codex`
- improve Codex model-not-found messaging: when GPT-5.3 Codex is requested, include a hint to update Codex CLI (`npm install -g @openai/codex@latest`)

## Why
Codex 5.3 is available with newer Codex CLI versions, but we were forcing a fallback due to an earlier compatibility issue. This restores explicit GPT-5.3 Codex selection while still giving users a clear remediation path if they hit older CLI behavior.

## Validation
- `cargo fmt --all`
- `cargo test --lib model_id_to_display_name -- --nocapture`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex mission model resolution by removing the automatic downgrade from `gpt-5.3-codex` to `gpt-5-codex`, which can alter runtime behavior and expose CLI compatibility issues. Risk is mitigated by improved error messaging but could still impact users on older Codex CLI versions.
> 
> **Overview**
> Codex missions now **honor the requested model ID** instead of forcibly remapping legacy `gpt-5.3-codex` / `gpt-5.3-codex-spark` to `gpt-5-codex` (and removes the associated tests/warnings).
> 
> When a Codex run fails with *model-not-found* messaging, the response now suggests fallback models and, if `gpt-5.3-codex` was requested, adds a hint to update the Codex CLI (`npm install -g @openai/codex@latest`).
> 
> The OpenAI subscription model catalog adds `gpt-5.3-codex` as an explicit selectable Codex model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2ec424b4799b14d2b8eb586e9abb625c6f7a497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->