### PR TITLE
Enforce clippy warnings as errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run clippy
-        run: cargo clippy --workspace -- -W clippy::all
+        run: cargo clippy --workspace -- -D clippy::all
 
   fmt:
     name: Format

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -845,6 +845,7 @@ pub struct MissionRunner {
 
 impl MissionRunner {
     /// Create a new mission runner.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mission_id: Uuid,
         workspace_id: Uuid,

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -255,6 +255,7 @@ pub fn sanitize_filename(value: &str) -> String {
 }
 
 /// Mission store trait - implemented by all storage backends.
+#[allow(clippy::too_many_arguments)]
 #[async_trait]
 pub trait MissionStore: Send + Sync {
     /// Whether this store persists data across restarts.


### PR DESCRIPTION
## Summary
- Promote clippy from `-W clippy::all` (warn) to `-D clippy::all` (deny) in CI so new warnings fail the build
- Add `#[allow(clippy::too_many_arguments)]` to the two remaining unsuppressed sites to establish a clean baseline

## Why
Clippy currently runs with `-W` which only prints warnings without failing CI. This means clippy regressions can land unnoticed. Switching to `-D` ensures every warning is a build failure, enforcing code quality going forward.

The two existing warnings (both `too_many_arguments`) are on:
- `MissionRunner::new` in `src/api/mission_runner.rs:848`
- `MissionStore` trait in `src/api/mission_store/mod.rs:258`

Both already have the same suppress pattern used throughout the codebase (15 other instances of `#[allow(clippy::too_many_arguments)]`).

## Test plan
- [ ] CI clippy job passes with `-D clippy::all`
- [ ] No new warnings introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this primarily tightens CI linting (warnings now fail builds) and only adds targeted `#[allow(clippy::too_many_arguments)]` suppressions without changing runtime behavior.
> 
> **Overview**
> **Clippy is now enforced as a hard gate in CI** by switching from `-W clippy::all` to `-D clippy::all`, causing any new clippy warning to fail the workflow.
> 
> To keep CI green with the stricter linting, adds `#[allow(clippy::too_many_arguments)]` on `MissionRunner::new` and on the `MissionStore` trait to baseline existing `too_many_arguments` warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f56b0d3cac74aadf86142cd642d91171711bef58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->