### PR TITLE
Replace is_err/unwrap anti-pattern in npm checks

### DIFF
--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1235,7 +1235,7 @@ fn stream_claude_code_update() -> impl Stream<Item = Result<Event, std::convert:
             .arg("--version")
             .output()
             .await
-            .map_or(false, |o| o.status.success());
+            .is_ok_and(|o| o.status.success());
         if !npm_ok {
             yield sse("error", "npm is required to install Claude Code. Please install Node.js first.", None);
             return;
@@ -1318,7 +1318,7 @@ fn stream_codex_update() -> impl Stream<Item = Result<Event, std::convert::Infal
             .arg("--version")
             .output()
             .await
-            .map_or(false, |o| o.status.success());
+            .is_ok_and(|o| o.status.success());
         if !npm_ok {
             yield sse("error", "npm is required to install Codex. Please install Node.js first.", None);
             return;
@@ -1542,7 +1542,7 @@ fn stream_npm_package_uninstall(
             .arg("--version")
             .output()
             .await
-            .map_or(false, |o| o.status.success());
+            .is_ok_and(|o| o.status.success());
         if !npm_ok {
             yield sse("error", format!("npm is required to uninstall {}.", display_name), None);
             return;


### PR DESCRIPTION
## Summary

- Replace the `if x.is_err() || !x.unwrap().status.success()` anti-pattern with idiomatic `.map_or(false, |o| o.status.success())` in all three npm availability checks (Claude Code install, Codex install, and generic uninstall)

The previous pattern split `Result` handling across two separate method calls (`is_err()` then `unwrap()`), which is confusing and a known Rust anti-pattern that Clippy warns about in some configurations. The `map_or` version is both clearer and more concise.

## Test plan

- [ ] Verify CI passes (clippy, tests, fmt, dashboard)
- [ ] Behavior is identical: npm availability check still correctly detects missing or broken npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `npm --version` success is checked before install/uninstall; behavior should remain the same aside from avoiding a potential unwrap misuse.
> 
> **Overview**
> Refactors the npm availability guard in the SSE update/uninstall flows for Claude Code, Codex, and generic npm package uninstall (`stream_claude_code_update`, `stream_codex_update`, `stream_npm_package_uninstall`).
> 
> Replaces the `is_err() || !unwrap().status.success()` pattern with a single `is_ok_and(|o| o.status.success())` check to make the logic more idiomatic and remove the unwrap anti-pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47b90ae50719b138f23251583994fb435bbacc10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->