### PR TITLE
Fix zombie curl processes and remove glob_match unwraps

### DIFF
--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -219,6 +219,8 @@ impl OpenCodeClient {
                 Some(s) => s,
                 None => {
                     tracing::error!(session_id = %session_id_clone, "Failed to get curl stdout");
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
                     return;
                 }
             };
@@ -273,6 +275,7 @@ impl OpenCodeClient {
                                             "SSE receiver dropped"
                                         );
                                         let _ = child.kill().await;
+                                        let _ = child.wait().await;
                                         return;
                                     }
                                     if is_complete {
@@ -282,6 +285,7 @@ impl OpenCodeClient {
                                             "OpenCode message completed"
                                         );
                                         let _ = child.kill().await;
+                                        let _ = child.wait().await;
                                         return;
                                     }
                                 }
@@ -314,6 +318,7 @@ impl OpenCodeClient {
             }
 
             let _ = child.kill().await;
+            let _ = child.wait().await;
         });
 
         // Spawn message sending task

--- a/src/tools/directory.rs
+++ b/src/tools/directory.rs
@@ -214,8 +214,12 @@ fn glob_match(pattern: &str, text: &str) -> bool {
     }
 
     // Last part must be at end if pattern doesn't end with *
-    if !pattern.ends_with('*') && !parts.last().unwrap().is_empty() {
-        return text.ends_with(parts.last().unwrap());
+    if !pattern.ends_with('*') {
+        if let Some(last) = parts.last() {
+            if !last.is_empty() {
+                return text.ends_with(last);
+            }
+        }
     }
 
     true

--- a/src/tools/index.rs
+++ b/src/tools/index.rs
@@ -326,8 +326,12 @@ fn glob_match(pattern: &str, text: &str) -> bool {
         }
     }
 
-    if !pattern.ends_with('*') && !parts.last().unwrap().is_empty() {
-        return text.ends_with(parts.last().unwrap());
+    if !pattern.ends_with('*') {
+        if let Some(last) = parts.last() {
+            if !last.is_empty() {
+                return text.ends_with(last);
+            }
+        }
     }
 
     true


### PR DESCRIPTION
## Summary

- **Zombie process leak** (`opencode/mod.rs`): Add `child.wait().await` after every `child.kill().await` on the curl SSE subprocess. Without `wait()`, killed child processes become zombies that accumulate in the process table. On busy servers with frequent OpenCode missions, this can eventually exhaust PIDs. Also fixes a leak when `stdout.take()` fails — the child was previously left running with no reference to it.

- **glob_match unwraps** (`tools/index.rs`, `tools/directory.rs`): Replace `parts.last().unwrap()` with `if let Some(last)` pattern. While `split('*')` always yields at least one element making the unwrap technically safe, the explicit match is more defensive and won't break under refactoring.

## Test plan

- [ ] Verify CI passes (clippy, tests, fmt, dashboard)
- [ ] Run an OpenCode mission and verify no zombie `curl` processes remain after completion (`ps aux | grep curl`)
- [ ] Glob pattern matching continues to work correctly for file search/index tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized lifecycle and defensive-coding changes; main risk is accidentally altering SSE shutdown timing or edge-case glob matching behavior.
> 
> **Overview**
> Prevents zombie `curl` SSE subprocesses in `src/opencode/mod.rs` by calling `child.wait().await` after every `child.kill().await` (including the `stdout.take()` failure path), ensuring the subprocess is properly reaped on early exits and completion.
> 
> Hardens `glob_match` in `src/tools/directory.rs` and `src/tools/index.rs` by removing `parts.last().unwrap()` and safely checking the last segment when the pattern does not end with `*`, avoiding panics if the split logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c4f244be3dafaafd3e195a748dab30f17522be9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->