### PR TITLE
Handle serialization errors in MCP servers and SSE streams

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -199,7 +199,9 @@ pub async fn login(
                 ));
             }
 
-            let account = account.unwrap();
+            // account is guaranteed Some here: the None branch above sets valid=false,
+            // and we returned early on !valid.
+            let account = account.expect("account must be Some when valid is true");
             let effective_id = effective_user_id(account);
 
             AuthUser {
@@ -435,10 +437,10 @@ pub async fn change_password(
         let current_valid = if has_stored_hash {
             let hash = stored_auth
                 .as_ref()
-                .unwrap()
+                .expect("stored_auth must be Some when has_stored_hash is true")
                 .password_hash
                 .as_ref()
-                .unwrap();
+                .expect("password_hash must be Some when has_stored_hash is true");
             verify_password_hash(current, hash)
         } else {
             let expected = state

--- a/src/bin/automation_manager_mcp.rs
+++ b/src/bin/automation_manager_mcp.rs
@@ -620,16 +620,20 @@ async fn main() {
             Err(e) => {
                 let error_resp =
                     JsonRpcResponse::error(Value::Null, -32700, format!("Parse error: {}", e));
-                let response_json = serde_json::to_string(&error_resp).unwrap();
-                writeln!(stdout, "{}", response_json).ok();
+                if let Ok(json) = serde_json::to_string(&error_resp) {
+                    writeln!(stdout, "{}", json).ok();
+                }
                 stdout.flush().ok();
                 continue;
             }
         };
 
         let response = server.handle_request(request).await;
-        let response_json = serde_json::to_string(&response).unwrap();
-        writeln!(stdout, "{}", response_json).ok();
+        if let Ok(json) = serde_json::to_string(&response) {
+            writeln!(stdout, "{}", json).ok();
+        } else {
+            eprintln!("[automation-mcp] Failed to serialize response");
+        }
         stdout.flush().ok();
     }
 }

--- a/src/bin/workspace_mcp.rs
+++ b/src/bin/workspace_mcp.rs
@@ -740,7 +740,9 @@ fn main() {
             Ok(req) => req,
             Err(e) => {
                 let response = JsonRpcResponse::error(Value::Null, -32700, e.to_string());
-                let _ = writeln!(stdout, "{}", serde_json::to_string(&response).unwrap());
+                if let Ok(json) = serde_json::to_string(&response) {
+                    let _ = writeln!(stdout, "{}", json);
+                }
                 let _ = stdout.flush();
                 continue;
             }


### PR DESCRIPTION
## Summary

- **MCP JSON-RPC serialization** (`workspace_mcp.rs`, `desktop_mcp.rs`, `automation_manager_mcp.rs`): Replace `serde_json::to_string().unwrap()` with graceful error handling via `if let Ok(json)` or `match`. If a JSON-RPC response contains unserializable data (e.g. invalid UTF-8 from tool output), the MCP server previously panicked, killing the client connection. Now serialization failures are logged and the response is skipped.

- **SSE task streaming** (`routes.rs`): Replace `json_data().unwrap()` in the task log/done event stream with `match` + `tracing::error!` pattern. This mirrors the same fix applied to `control.rs` SSE streams in PR #179.

- **Auth invariant documentation** (`auth.rs`): Replace bare `.unwrap()` calls with `.expect()` messages documenting the invariants that guarantee values are present (e.g. "account must be Some when valid is true").

## Test plan

- [ ] Verify CI passes (clippy, tests, fmt, dashboard)
- [ ] MCP servers continue to work normally for valid JSON-RPC requests
- [ ] Task SSE streaming continues to emit log and done events correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to error handling: previously panicking `.unwrap()` calls in SSE streaming and MCP JSON-RPC responders now log/skip on serialization failure, reducing crash risk but potentially dropping a response/event when data is not serializable.
> 
> **Overview**
> Prevents process/stream crashes by replacing several `.unwrap()`s on JSON serialization with graceful handling.
> 
> Task SSE streaming in `src/api/routes.rs` now logs and skips events when `json_data` serialization fails (for both `log` and `done` events) instead of panicking.
> 
> The MCP stdio JSON-RPC servers (`automation_manager_mcp.rs`, `desktop_mcp.rs`, `workspace_mcp.rs`) now handle `serde_json::to_string` failures by conditionally writing the response and emitting an error message rather than crashing. `src/api/auth.rs` also replaces a few `unwrap()`s with `expect()` messages to document invariants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 297e771915c462c228547d0c50f867086884db41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->