### PR TITLE
Add SAFETY comments to all unsafe blocks

### DIFF
--- a/src/api/desktop.rs
+++ b/src/api/desktop.rs
@@ -567,6 +567,8 @@ pub(crate) async fn close_desktop_session(
                 for pid_key in ["xvfb_pid", "i3_pid", "browser_pid"] {
                     if let Some(pid) = session_info[pid_key].as_u64() {
                         let pid = pid as i32;
+                        // SAFETY: PIDs are read from a session file we wrote;
+                        // SIGTERM is a safe signal to send to any process.
                         unsafe {
                             libc::kill(pid, libc::SIGTERM);
                         }

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1164,6 +1164,7 @@ fn stream_opencode_update() -> impl Stream<Item = Result<Event, std::convert::In
 
         let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
         let source_path = format!("{}/.opencode/bin/opencode", home);
+        // SAFETY: geteuid() is a trivial syscall with no preconditions.
         let is_root = unsafe { libc::geteuid() } == 0;
 
         if is_root {
@@ -1442,6 +1443,7 @@ fn stream_opencode_uninstall() -> impl Stream<Item = Result<Event, std::convert:
         yield sse("log", "Starting OpenCode uninstall...", Some(0));
 
         let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+        // SAFETY: geteuid() is a trivial syscall with no preconditions.
         let is_root = unsafe { libc::geteuid() } == 0;
 
         // Stop the service first if running as root

--- a/src/bin/desktop_mcp.rs
+++ b/src/bin/desktop_mcp.rs
@@ -412,6 +412,8 @@ fn tool_stop_session(args: &Value) -> Result<String, String> {
                 for pid_key in ["xvfb_pid", "i3_pid", "browser_pid"] {
                     if let Some(pid) = session_info.get(pid_key).and_then(|v| v.as_u64()) {
                         let pid = pid as i32;
+                        // SAFETY: PIDs are read from a session file we wrote;
+                        // SIGTERM is a safe signal to send to any process.
                         unsafe {
                             libc::kill(pid, libc::SIGTERM);
                         }

--- a/src/tools/desktop.rs
+++ b/src/tools/desktop.rs
@@ -43,6 +43,8 @@ fn kill_pid(pid: u32) {
     if pid == 0 {
         return;
     }
+    // SAFETY: Sending SIGTERM to a valid PID. The pid == 0 guard above
+    // prevents accidentally signalling the caller's process group.
     unsafe {
         libc::kill(pid as i32, libc::SIGTERM);
     }
@@ -398,6 +400,8 @@ impl Tool for StopSession {
                     for pid_key in ["xvfb_pid", "i3_pid", "browser_pid"] {
                         if let Some(pid) = session_info[pid_key].as_u64() {
                             let pid = pid as i32;
+                            // SAFETY: PIDs are read from a session file we wrote;
+                            // SIGTERM is a safe signal to send to any process.
                             unsafe {
                                 libc::kill(pid, libc::SIGTERM);
                             }


### PR DESCRIPTION
## Summary

- Document the safety invariants for every `unsafe` block in the codebase, following the Rust convention that Clippy's `undocumented_unsafe_blocks` lint enforces

### Files affected

- **workspace_exec.rs** (8 unsafe blocks): PTY fd duplication (`dup`/`from_raw_fd`), `openpty()`, `ioctl(TIOCSWINSZ)`, slave fd wiring with `pre_exec` closure, and parent-side fd cleanup
- **tools/desktop.rs** (2 blocks): `libc::kill(SIGTERM)` for desktop session cleanup
- **api/desktop.rs** (1 block): Same `kill(SIGTERM)` pattern for API-driven cleanup
- **bin/desktop_mcp.rs** (1 block): Same pattern in MCP server
- **api/system.rs** (2 blocks): `libc::geteuid()` for root detection

### What this enables

- Prepares the codebase for enabling Clippy's `undocumented_unsafe_blocks` lint
- Makes the safety reasoning explicit for code reviewers and future maintainers
- No behavioral changes — comments only

## Test plan

- [ ] Verify CI passes (clippy, tests, fmt, dashboard)
- [ ] No behavioral changes — purely documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that document existing `unsafe` usage; no functional logic changes, but touches low-level process/FD handling where reviewers should confirm behavior is unchanged.
> 
> **Overview**
> Adds Rust-style `// SAFETY:` annotations to all existing `unsafe` blocks to make invariants explicit and prepare for Clippy’s `undocumented_unsafe_blocks` lint.
> 
> This documents safety reasoning around PTY fd operations in `workspace_exec.rs` (`dup`, `from_raw_fd`, `openpty`, `ioctl`, `pre_exec`), process termination via `libc::kill` in desktop session cleanup (`api/desktop.rs`, `tools/desktop.rs`, `bin/desktop_mcp.rs`), and root detection via `libc::geteuid()` in `api/system.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8fe1e9b9d1d9b693215ba41789ba7a137060aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->