### PR TITLE
fix: remove --timeout flag for oh-my-opencode 3.7.2+ compat

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9817,11 +9817,10 @@ mod tests {
         build_history_context, extract_opencode_session_id, extract_part_text, extract_str,
         extract_thought_line, is_rate_limited_error, is_session_corruption_error,
         is_tool_call_only_output, opencode_output_needs_fallback, opencode_session_token_from_line,
-        parse_opencode_session_token, parse_opencode_stderr_text_part, remap_legacy_codex_model,
-        running_health, sanitized_opencode_stdout, stall_severity, strip_ansi_codes,
-        strip_opencode_banner_lines, strip_opencode_status_lines, strip_think_tags,
-        summarize_recent_opencode_stderr, sync_opencode_agent_config, MissionHealth,
-        MissionRunState, MissionStallSeverity, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        parse_opencode_session_token, parse_opencode_stderr_text_part, running_health,
+        sanitized_opencode_stdout, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
+        strip_think_tags, summarize_recent_opencode_stderr, sync_opencode_agent_config,
+        MissionHealth, MissionRunState, MissionStallSeverity, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use crate::agents::{AgentResult, TerminalReason};
     use serde_json::json;


### PR DESCRIPTION
## Summary

- **Root cause**: oh-my-opencode 3.7.2 removed the `--timeout` CLI flag from the `run` subcommand
- When `bunx oh-my-opencode` fetches the latest version (3.7.3), the unrecognized `--timeout` flag causes Commander.js to treat `--timeout`, `0`, and the message as 3 positional arguments instead of the expected 1 (`<message>`)
- This produces the exact error: `error: too many arguments for 'run'. Expected 1 argument but got 3.`
- The fix removes the `--timeout 0` arguments from the CLI invocation. The timeout is no longer needed since oh-my-opencode handles completion detection internally (waiting for all todos and child sessions to finish)
- Also fixes pre-existing test compilation failures from PR #185 (stale imports of `remap_legacy_codex_model` and `strip_opencode_status_lines`)

## Reproduction

```bash
# This reproduces the exact error:
bunx oh-my-opencode@3.7.3 run --directory /tmp --timeout 0 "test"
# error: too many arguments for 'run'. Expected 1 argument but got 3.

# Without --timeout, it works:
bunx oh-my-opencode@3.7.3 run --directory /tmp "test"
# starts successfully
```

Confirmed via dashboard: missions on `dumbcontracts` workspace fail consistently with this error, while `sandboxed-sh-dev` workspace (which has a cached older version) succeeds.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --workspace -- -D clippy::all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (320 tests, 0 failures)
- [x] All CI checks pass (Test, Clippy, Format, Dashboard Unit Tests)
- [x] Reproduced bug via dashboard on `dumbcontracts` workspace
- [x] Verified fix locally: `bunx oh-my-opencode@3.7.3 run --directory /tmp "test"` succeeds
- [ ] Deploy and run an OpenCode mission from the dashboard frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)