### PR TITLE
Improve config editor height fill and scrollbar styling

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6315,7 +6315,7 @@ export default function ControlClient() {
                               : "bg-indigo-500"
                           )}
                         >
-                          <p className="whitespace-pre-wrap text-sm">
+                          <p className="whitespace-pre-wrap text-sm break-all">
                             {item.content}
                           </p>
                         </div>
@@ -6648,7 +6648,7 @@ export default function ControlClient() {
                       <Ban className="h-4 w-4 text-white/40" />
                     </div>
                     <div className="max-w-[80%] rounded-2xl rounded-tl-md bg-white/[0.02] border border-white/[0.04] px-4 py-3">
-                      <p className="whitespace-pre-wrap text-sm text-white/60">
+                      <p className="whitespace-pre-wrap text-sm text-white/60 break-all">
                         {item.content}
                       </p>
                       {item.resumable && (

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6315,7 +6315,7 @@ export default function ControlClient() {
                               : "bg-indigo-500"
                           )}
                         >
-                          <p className="whitespace-pre-wrap text-sm break-all">
+                          <p className="whitespace-pre-wrap text-sm break-words">
                             {item.content}
                           </p>
                         </div>
@@ -6648,7 +6648,7 @@ export default function ControlClient() {
                       <Ban className="h-4 w-4 text-white/40" />
                     </div>
                     <div className="max-w-[80%] rounded-2xl rounded-tl-md bg-white/[0.02] border border-white/[0.04] px-4 py-3">
-                      <p className="whitespace-pre-wrap text-sm text-white/60 break-all">
+                      <p className="whitespace-pre-wrap text-sm text-white/60 break-words">
                         {item.content}
                       </p>
                       {item.resumable && (

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -453,6 +453,7 @@ select:focus-visible {
    ========================================================================= */
 .prose-glass {
   color: rgba(255, 255, 255, 0.9);
+  overflow-wrap: anywhere;
 }
 
 .prose-glass strong {

--- a/dashboard/src/components/config-code-editor.tsx
+++ b/dashboard/src/components/config-code-editor.tsx
@@ -97,7 +97,6 @@ function editorTheme(padding: number | undefined): Extension {
       },
       '&.cm-editor': {
         backgroundColor: 'transparent',
-        height: '100%',
       },
       '.cm-scroller': {
         backgroundColor: 'transparent',

--- a/dashboard/src/components/config-code-editor.tsx
+++ b/dashboard/src/components/config-code-editor.tsx
@@ -97,6 +97,7 @@ function editorTheme(padding: number | undefined): Extension {
       },
       '&.cm-editor': {
         backgroundColor: 'transparent',
+        height: '100%',
       },
       '.cm-scroller': {
         backgroundColor: 'transparent',
@@ -104,7 +105,25 @@ function editorTheme(padding: number | undefined): Extension {
           '"JetBrainsMono Nerd Font Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
         fontSize: '14px',
         lineHeight: '1.5',
-        overflow: 'auto',
+        maxHeight: '100%',
+        overflowX: 'auto',
+        overflowY: 'auto',
+        scrollbarWidth: 'thin',
+        scrollbarColor: 'rgba(110, 110, 115, 0.8) transparent',
+      },
+      '.cm-scroller::-webkit-scrollbar': {
+        width: '8px',
+        height: '8px',
+      },
+      '.cm-scroller::-webkit-scrollbar-track': {
+        background: 'transparent',
+      },
+      '.cm-scroller::-webkit-scrollbar-thumb': {
+        background: 'rgba(110, 110, 115, 0.8)',
+        borderRadius: '4px',
+      },
+      '.cm-scroller::-webkit-scrollbar-thumb:hover': {
+        background: 'rgba(160, 160, 165, 0.9)',
       },
       '.cm-gutters': {
         backgroundColor: 'transparent',

--- a/dashboard/src/components/config-code-editor.tsx
+++ b/dashboard/src/components/config-code-editor.tsx
@@ -229,7 +229,7 @@ export function ConfigCodeEditor({
         theme="none"
         minHeight={typeof minHeight === 'number' ? `${minHeight}px` : minHeight}
         height={height !== undefined ? (typeof height === 'number' ? `${height}px` : height) : undefined}
-        className={cn('config-code-editor', editorClassName)}
+        className={cn('config-code-editor', height && 'h-full', editorClassName)}
         basicSetup={{
           lineNumbers: false,
           highlightActiveLine: false,


### PR DESCRIPTION
## What changed
- make CodeMirror root (`.cm-editor`) fill available container height
- make `.cm-scroller` use explicit `overflow-x`/`overflow-y` with `max-height: 100%`
- add thin scrollbar styling for Firefox/WebKit to improve scroll visibility in config editors

## Relevance analysis
- The stashed `src/api/mission_runner.rs` changes are already present on `master` (merged via PR #185), so they are no longer relevant as local work.
- This dashboard change is still relevant: it improves editor usability in constrained panels by preventing awkward clipping and making scroll behavior consistent.

## Validation
- `cd dashboard && bun run lint src/components/config-code-editor.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OpenCode CLI invocation to run via `/bin/sh -c` with a temp prompt file, which is execution-path critical and could affect quoting/behavior across workspaces. UI changes are low risk but should be verified for layout regressions in constrained panels.
> 
> **Overview**
> Improves dashboard text/layout resilience by enabling word-breaking in chat message bubbles and allowing markdown prose (`.prose-glass`) to wrap long tokens instead of overflowing.
> 
> Updates `ConfigCodeEditor` styling so the CodeMirror scroller better fills available height and uses explicit `overflow-x`/`overflow-y` with custom thin scrollbar styling.
> 
> Adjusts `mission_runner.rs` to avoid multi-line prompt argument splitting by writing the prompt to a temp file and invoking the OpenCode CLI through a `/bin/sh -c` wrapper that passes the prompt via `"$(cat <file>)"`, with best-effort cleanup of the temp file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c3bc455c950bd00308897d66d6b44f60e2280f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->