### PR TITLE
fix: filter skill activation messages from opencode stderr

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3801,6 +3801,7 @@ fn summarize_recent_opencode_stderr(lines: &std::collections::VecDeque<String>) 
             || lower.contains("message.part.updated")
             || lower.contains("session.status: busy")
             || lower.contains("session.status: idle")
+            || (lower.contains("using") && lower.contains("skill") && !lower.contains("error"))
         {
             continue;
         }
@@ -10169,6 +10170,17 @@ mod tests {
             summarize_recent_opencode_stderr(&lines).as_deref(),
             Some("response.error: 404 Not Found")
         );
+    }
+
+    #[test]
+    fn summarize_recent_opencode_stderr_filters_skill_activation_messages() {
+        use std::collections::VecDeque;
+
+        let mut lines = VecDeque::new();
+        lines.push_back("server.connected".to_string());
+        lines.push_back("Start now using github-cli skill".to_string());
+
+        assert_eq!(summarize_recent_opencode_stderr(&lines), None);
     }
     #[test]
     fn strip_opencode_banner_lines_handles_ansi_codes() {


### PR DESCRIPTION
## Summary

- Fix: skill activation messages no longer appear as "last stderr" when OpenCode CLI exits with status 1
- The `summarize_recent_opencode_stderr` function now filters out lines containing both "using" and "skill" keywords (unless they also contain "error")

## Problem

When OpenCode CLI exits with status 1, the `summarize_recent_opencode_stderr` function captures skill activation messages like `"Start now using github-cli skill"` as the "last stderr", making them appear as error context even though they're informational.

## Solution

Added a filter condition in `src/api/mission_runner.rs:3804`:
```rust
|| (lower.contains("using") && lower.contains("skill") && !lower.contains("error"))
```

This excludes informational skill activation messages while still allowing actual error messages containing these keywords to be captured.

## Test plan

- Added unit test `summarize_recent_opencode_stderr_filters_skill_activation_messages` to verify the filter works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized string-filtering change with a targeted unit test; main risk is accidentally filtering legitimate stderr lines that match the new heuristic.
> 
> **Overview**
> Prevents OpenCode “skill activation” info lines from being treated as the most recent stderr by extending `summarize_recent_opencode_stderr` to skip messages containing both “using” and “skill” unless they also include “error”.
> 
> Adds a unit test ensuring lines like `Start now using github-cli skill` are filtered out and result in no stderr summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d6f3f7f4f7e91da498a88cd4c85cf481a4fa21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->