### PR TITLE
Extract duplicated utility functions into shared util module

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -27,6 +27,7 @@ use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 use crate::ai_providers::{AuthMethod, PendingOAuth, ProviderType};
+use crate::util::home_dir;
 
 /// Anthropic OAuth client ID (from opencode-anthropic-auth plugin)
 const ANTHROPIC_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
@@ -40,11 +41,6 @@ const OPENAI_REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
 const OPENAI_SCOPE: &str = "openid profile email offline_access";
 const OPENAI_TOKEN_EXCHANGE_GRANT: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
 const OPENAI_ID_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:id_token";
-
-/// Get the HOME directory path, defaulting to /root if not set.
-fn home_dir() -> String {
-    std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())
-}
 
 async fn exchange_openai_id_token_for_api_key(
     client: &reqwest::Client,

--- a/src/api/ampcode.rs
+++ b/src/api/ampcode.rs
@@ -2,6 +2,8 @@ use axum::http::StatusCode;
 use axum::Json;
 use serde_json::Value;
 
+use crate::util::home_dir;
+
 fn resolve_amp_config_path() -> std::path::PathBuf {
     if let Ok(path) = std::env::var("AMP_CONFIG") {
         if !path.trim().is_empty() {
@@ -14,8 +16,7 @@ fn resolve_amp_config_path() -> std::path::PathBuf {
         }
     }
 
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    std::path::PathBuf::from(home)
+    std::path::PathBuf::from(home_dir())
         .join(".config")
         .join("amp")
         .join("settings.json")

--- a/src/api/claudecode.rs
+++ b/src/api/claudecode.rs
@@ -2,6 +2,8 @@ use axum::http::StatusCode;
 use axum::Json;
 use serde_json::Value;
 
+use crate::util::home_dir;
+
 fn resolve_claudecode_config_path() -> std::path::PathBuf {
     if let Ok(path) = std::env::var("CLAUDE_CONFIG") {
         if !path.trim().is_empty() {
@@ -21,8 +23,7 @@ fn resolve_claudecode_config_path() -> std::path::PathBuf {
         return opencode_home;
     }
 
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    std::path::PathBuf::from(home)
+    std::path::PathBuf::from(home_dir())
         .join(".claude")
         .join("settings.json")
 }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -28,6 +28,7 @@ use crate::agents::{AgentContext, AgentRef, TerminalReason};
 use crate::config::Config;
 use crate::mcp::McpRegistry;
 use crate::secrets::SecretsStore;
+use crate::util::build_history_context;
 use crate::workspace;
 
 use super::auth::AuthUser;
@@ -162,23 +163,6 @@ fn extract_title_from_assistant(content: &str) -> Option<String> {
     } else {
         Some(cleaned.to_string())
     }
-}
-
-/// Build a simple history context from conversation history.
-fn build_history_context(history: &[(String, String)], max_chars: usize) -> String {
-    let mut result = String::new();
-    let mut total_chars = 0;
-
-    for (role, content) in history.iter().rev() {
-        let entry = format!("{}: {}\n\n", role.to_uppercase(), content);
-        if total_chars + entry.len() > max_chars && !result.is_empty() {
-            break;
-        }
-        result = format!("{}{}", entry, result);
-        total_chars += entry.len();
-    }
-
-    result
 }
 
 async fn mission_has_active_automation(

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -16,6 +16,7 @@ use tokio::io::AsyncWriteExt;
 use tokio_util::io::ReaderStream;
 
 use super::routes::AppState;
+use crate::util::home_dir;
 use crate::workspace::WorkspaceType;
 
 #[derive(Debug, Deserialize)]
@@ -33,8 +34,7 @@ fn runtime_workspace_path() -> PathBuf {
             return PathBuf::from(path);
         }
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    PathBuf::from(home)
+    PathBuf::from(home_dir())
         .join(".sandboxed-sh")
         .join("runtime")
         .join("current_workspace.json")

--- a/src/api/library.rs
+++ b/src/api/library.rs
@@ -29,6 +29,7 @@ use crate::library::{
     WorkspaceTemplate, WorkspaceTemplateSummary,
 };
 use crate::nspawn::NspawnDistro;
+use crate::util::sanitize_skill_list;
 use crate::workspace::{self, WorkspaceType, DEFAULT_WORKSPACE_ID};
 
 /// Shared library state.
@@ -382,21 +383,6 @@ pub struct CreateConfigProfileRequest {
     /// Optional base profile to copy settings from
     #[serde(default)]
     pub base_profile: Option<String>,
-}
-
-fn sanitize_skill_list(skills: Vec<String>) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    let mut out = Vec::new();
-    for skill in skills {
-        let trimmed = skill.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if seen.insert(trimmed.to_string()) {
-            out.push(trimmed.to_string());
-        }
-    }
-    out
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -26,6 +26,7 @@ use crate::mcp::McpRegistry;
 use crate::opencode::{extract_reasoning, extract_text};
 use crate::secrets::SecretsStore;
 use crate::task::{extract_deliverables, DeliverableSet};
+use crate::util::{build_history_context, env_var_bool, home_dir};
 use crate::workspace::{self, Workspace, WorkspaceType};
 use crate::workspace_exec::WorkspaceExec;
 
@@ -1135,21 +1136,6 @@ impl MissionRunner {
             .map(|h| h.is_finished())
             .unwrap_or(false)
     }
-}
-
-/// Build a history context string from conversation history.
-fn build_history_context(history: &[(String, String)], max_chars: usize) -> String {
-    let mut result = String::new();
-    let mut total_chars = 0;
-    for (role, content) in history.iter().rev() {
-        let entry = format!("{}: {}\n\n", role.to_uppercase(), content);
-        if total_chars + entry.len() > max_chars && !result.is_empty() {
-            break;
-        }
-        result = format!("{}{}", entry, result);
-        total_chars += entry.len();
-    }
-    result
 }
 
 /// Try to resolve a library command from a user message starting with `/`.
@@ -3626,7 +3612,7 @@ fn prepend_opencode_bin_to_path(env: &mut HashMap<String, String>, workspace: &W
     {
         "/root".to_string()
     } else {
-        std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())
+        home_dir()
     };
     let bin_dir = format!("{}/.opencode/bin", home);
 
@@ -5296,10 +5282,8 @@ fn opencode_storage_roots(workspace: &Workspace) -> Vec<std::path::PathBuf> {
         return roots;
     }
 
-    let data_home = std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-        format!("{}/.local/share", home)
-    });
+    let data_home =
+        std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{}/.local/share", home_dir()));
     vec![std::path::PathBuf::from(data_home)
         .join("opencode")
         .join("storage")]
@@ -5877,16 +5861,6 @@ fn resolve_opencode_model_from_config(
         .get("model")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-}
-
-fn env_var_bool(name: &str, default: bool) -> bool {
-    match std::env::var(name) {
-        Ok(value) => matches!(
-            value.trim().to_lowercase().as_str(),
-            "1" | "true" | "yes" | "y" | "on"
-        ),
-        Err(_) => default,
-    }
 }
 
 async fn command_available(
@@ -10491,50 +10465,6 @@ mod tests {
     fn running_health_healthy_for_finished_state() {
         let health = running_health(MissionRunState::Finished, STALL_SEVERE_SECS + 100);
         assert!(matches!(health, MissionHealth::Healthy));
-    }
-
-    // ── build_history_context tests ───────────────────────────────────
-
-    #[test]
-    fn build_history_context_formats_entries() {
-        let history = vec![
-            ("user".to_string(), "hello".to_string()),
-            ("assistant".to_string(), "world".to_string()),
-        ];
-        let result = build_history_context(&history, 10000);
-        assert!(result.contains("USER: hello"));
-        assert!(result.contains("ASSISTANT: world"));
-    }
-
-    #[test]
-    fn build_history_context_respects_max_chars() {
-        let history = vec![
-            ("user".to_string(), "first message".to_string()),
-            ("assistant".to_string(), "second message".to_string()),
-            ("user".to_string(), "third message".to_string()),
-        ];
-        // Set max_chars to only allow one or two entries
-        let result = build_history_context(&history, 30);
-        // Should always include the most recent entry
-        assert!(result.contains("USER: third message"));
-    }
-
-    #[test]
-    fn build_history_context_empty_history() {
-        let history: Vec<(String, String)> = vec![];
-        let result = build_history_context(&history, 10000);
-        assert_eq!(result, "");
-    }
-
-    #[test]
-    fn build_history_context_always_includes_most_recent() {
-        let history = vec![(
-            "user".to_string(),
-            "a very long message that exceeds the max".to_string(),
-        )];
-        let result = build_history_context(&history, 5);
-        // Should still include the only entry even if it exceeds max_chars
-        assert!(result.contains("USER: a very long message"));
     }
 
     // ── is_session_corruption_error tests ─────────────────────────────

--- a/src/api/opencode.rs
+++ b/src/api/opencode.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use crate::opencode_config::OpenCodeConnection;
+use crate::util::home_dir;
 
 /// Create OpenCode connection routes.
 pub fn routes() -> Router<Arc<super::routes::AppState>> {
@@ -44,8 +45,7 @@ fn resolve_oh_my_opencode_path() -> std::path::PathBuf {
         }
     }
     // Fall back to ~/.config/opencode/oh-my-opencode.json
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    std::path::PathBuf::from(home)
+    std::path::PathBuf::from(home_dir())
         .join(".config")
         .join("opencode")
         .join("oh-my-opencode.json")
@@ -63,8 +63,7 @@ fn resolve_opencode_config_path() -> std::path::PathBuf {
             return std::path::PathBuf::from(dir).join("opencode.json");
         }
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    std::path::PathBuf::from(home)
+    std::path::PathBuf::from(home_dir())
         .join(".config")
         .join("opencode")
         .join("opencode.json")

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 
 use super::routes::AppState;
 use crate::ai_providers::{AIProviderStore, ProviderType};
+use crate::util::home_dir;
 
 /// Cached model lists fetched from provider APIs at startup.
 /// Maps provider ID (e.g. "anthropic") -> Vec<ProviderModel>
@@ -699,7 +700,7 @@ pub fn get_api_key_for_provider(
     }
 
     // 2. Check OpenCode auth.json
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let home = home_dir();
     let auth_paths = {
         let mut paths = Vec::new();
         if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
@@ -915,7 +916,7 @@ fn has_valid_auth(value: &serde_json::Value) -> bool {
 /// Get the set of configured provider IDs from OpenCode's auth files.
 fn get_configured_provider_ids(working_dir: &std::path::Path) -> HashSet<String> {
     let mut configured = HashSet::new();
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let home = home_dir();
 
     // 1. Read OpenCode auth.json (~/.local/share/opencode/auth.json)
     let auth_path = {

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 
 use crate::library::WorkspaceTemplate;
 use crate::nspawn::NspawnDistro;
+use crate::util::sanitize_skill_list;
 use crate::workspace::{self, TailscaleMode, Workspace, WorkspaceStatus, WorkspaceType};
 
 /// Create workspace routes.
@@ -772,21 +773,6 @@ fn sanitize_env_vars(env_vars: HashMap<String, String>) -> HashMap<String, Strin
         .into_iter()
         .filter(|(key, _)| !key.trim().is_empty())
         .collect()
-}
-
-fn sanitize_skill_list(skills: Vec<String>) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    let mut out = Vec::new();
-    for skill in skills {
-        let trimmed = skill.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if seen.insert(trimmed.to_string()) {
-            out.push(trimmed.to_string());
-        }
-    }
-    out
 }
 
 /// Escape a string for safe use in shell commands.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod settings;
 pub mod skills_registry;
 pub mod task;
 pub mod tools;
+pub mod util;
 pub mod workspace;
 pub mod workspace_exec;
 

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -37,15 +37,7 @@ pub enum NspawnError {
 
 pub type NspawnResult<T> = Result<T, NspawnError>;
 
-fn env_var_bool(name: &str, default: bool) -> bool {
-    match std::env::var(name) {
-        Ok(value) => matches!(
-            value.trim().to_lowercase().as_str(),
-            "1" | "true" | "yes" | "y" | "on"
-        ),
-        Err(_) => default,
-    }
-}
+use crate::util::env_var_bool;
 
 fn command_on_path(cmd: &str) -> bool {
     if cmd.contains('/') {

--- a/src/opencode_config.rs
+++ b/src/opencode_config.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 use crate::library::Plugin;
 use crate::mcp::{McpRegistry, McpScope, McpTransport};
+use crate::util::home_dir;
 
 /// OpenCode connection configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -245,7 +246,7 @@ fn resolve_command_path(cmd: &str) -> String {
 
     // User-local paths are checked first so that non-root installs (bun, npm,
     // the official OpenCode installer) take precedence over system-wide copies.
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let home = home_dir();
     let candidates = [
         PathBuf::from(&home).join(".opencode/bin").join(cmd),
         PathBuf::from(&home).join(".local/bin").join(cmd),
@@ -298,7 +299,7 @@ fn resolve_opencode_config_path() -> PathBuf {
             return PathBuf::from(dir).join("opencode.json");
         }
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let home = home_dir();
     // OpenCode stores its config under ~/.config/opencode by default.
     PathBuf::from(home)
         .join(".config")

--- a/src/tools/desktop.rs
+++ b/src/tools/desktop.rs
@@ -19,24 +19,15 @@ use serde_json::{json, Value};
 use tokio::process::Command;
 
 use super::Tool;
+use crate::util::env_var_bool;
 
 /// Global counter for display numbers to avoid conflicts
 static DISPLAY_COUNTER: AtomicU32 = AtomicU32::new(99);
 
 /// Check if desktop tools are enabled
 pub(crate) fn desktop_enabled() -> bool {
-    env_var_bool("DESKTOP_ENABLED") || env_var_bool("SANDBOXED_SH_ENABLE_DESKTOP_TOOLS")
-}
-
-fn env_var_bool(name: &str) -> bool {
-    std::env::var(name)
-        .map(|v| {
-            matches!(
-                v.trim().to_lowercase().as_str(),
-                "1" | "true" | "yes" | "y" | "on"
-            )
-        })
-        .unwrap_or(false)
+    env_var_bool("DESKTOP_ENABLED", false)
+        || env_var_bool("SANDBOXED_SH_ENABLE_DESKTOP_TOOLS", false)
 }
 
 fn kill_pid(pid: u32) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,111 @@
+//! Shared utility functions used across the codebase.
+
+/// Parse an environment variable as a boolean, returning `default` if unset.
+///
+/// Recognises `1`, `true`, `yes`, `y`, `on` (case-insensitive) as `true`;
+/// everything else (including unset) maps to `default`.
+pub fn env_var_bool(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(value) => matches!(
+            value.trim().to_lowercase().as_str(),
+            "1" | "true" | "yes" | "y" | "on"
+        ),
+        Err(_) => default,
+    }
+}
+
+/// Return the value of `$HOME`, falling back to `/root`.
+pub fn home_dir() -> String {
+    std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())
+}
+
+/// Build a truncated context string from conversation history.
+///
+/// Walks `history` from most-recent to oldest, accumulating entries until
+/// `max_chars` is reached. The most-recent entry is always included.
+pub fn build_history_context(history: &[(String, String)], max_chars: usize) -> String {
+    let mut result = String::new();
+    let mut total_chars = 0;
+    for (role, content) in history.iter().rev() {
+        let entry = format!("{}: {}\n\n", role.to_uppercase(), content);
+        if total_chars + entry.len() > max_chars && !result.is_empty() {
+            break;
+        }
+        result = format!("{}{}", entry, result);
+        total_chars += entry.len();
+    }
+    result
+}
+
+/// Deduplicate and trim a list of skill names, preserving order.
+pub fn sanitize_skill_list(skills: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for skill in skills {
+        let trimmed = skill.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if seen.insert(trimmed.to_string()) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_history_context_formats_entries() {
+        let history = vec![
+            ("user".to_string(), "hello".to_string()),
+            ("assistant".to_string(), "world".to_string()),
+        ];
+        let result = build_history_context(&history, 10000);
+        assert!(result.contains("USER: hello"));
+        assert!(result.contains("ASSISTANT: world"));
+    }
+
+    #[test]
+    fn build_history_context_respects_max_chars() {
+        let history = vec![
+            ("user".to_string(), "first message".to_string()),
+            ("assistant".to_string(), "second message".to_string()),
+            ("user".to_string(), "third message".to_string()),
+        ];
+        let result = build_history_context(&history, 30);
+        assert!(result.contains("USER: third message"));
+    }
+
+    #[test]
+    fn build_history_context_empty_history() {
+        let history: Vec<(String, String)> = vec![];
+        let result = build_history_context(&history, 10000);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn build_history_context_always_includes_most_recent() {
+        let history = vec![(
+            "user".to_string(),
+            "a very long message that exceeds the max".to_string(),
+        )];
+        let result = build_history_context(&history, 5);
+        assert!(result.contains("USER: a very long message"));
+    }
+
+    #[test]
+    fn sanitize_skill_list_deduplicates_and_trims() {
+        let skills = vec![
+            " foo ".to_string(),
+            "bar".to_string(),
+            "foo".to_string(),
+            "".to_string(),
+            "  ".to_string(),
+            "bar".to_string(),
+        ];
+        assert_eq!(sanitize_skill_list(skills), vec!["foo", "bar"]);
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -28,6 +28,7 @@ use crate::library::LibraryStore;
 use crate::mcp::{McpRegistry, McpScope, McpServerConfig, McpTransport};
 use crate::nspawn::{self, NspawnDistro};
 use crate::tools::terminal::{rtk_binary_path, rtk_enabled};
+use crate::util::{env_var_bool, home_dir};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Workspace Types
@@ -1818,8 +1819,7 @@ fn resolve_codex_dir(
         return workspace_root.join("root").join(".codex");
     }
 
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    PathBuf::from(home).join(".codex")
+    PathBuf::from(home_dir()).join(".codex")
 }
 
 fn resolve_claudecode_dir(
@@ -1841,8 +1841,7 @@ fn resolve_claudecode_dir(
         return workspace_root.join("root").join(".claude");
     }
 
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    PathBuf::from(home).join(".claude")
+    PathBuf::from(home_dir()).join(".claude")
 }
 
 fn codex_entry_from_mcp(
@@ -3178,7 +3177,7 @@ fn read_custom_providers_from_file(workspace_root: &Path) -> Vec<AIProvider> {
         workspace_root
             .join(".sandboxed-sh")
             .join("ai_providers.json"),
-        std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/root".to_string()))
+        std::path::PathBuf::from(home_dir())
             .join(".sandboxed-sh")
             .join("ai_providers.json"),
     ];
@@ -4075,16 +4074,6 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn env_var_bool(name: &str, default: bool) -> bool {
-    match std::env::var(name) {
-        Ok(value) => matches!(
-            value.trim().to_lowercase().as_str(),
-            "1" | "true" | "yes" | "y" | "on"
-        ),
-        Err(_) => default,
-    }
-}
-
 async fn bootstrap_workspace_harnesses(workspace: &Workspace) -> anyhow::Result<()> {
     if workspace.workspace_type != WorkspaceType::Container || !use_nspawn_for_workspace(workspace)
     {
@@ -4359,8 +4348,7 @@ fn resolve_opencode_config_dir() -> std::path::PathBuf {
     if let Ok(dir) = std::env::var("OPENCODE_CONFIG_DIR") {
         return std::path::PathBuf::from(dir);
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    std::path::PathBuf::from(home)
+    std::path::PathBuf::from(home_dir())
         .join(".config")
         .join("opencode")
 }


### PR DESCRIPTION
## Summary

- Consolidates 4 duplicated utility functions into a new `src/util.rs` module:
  - **`env_var_bool`**: was copy-pasted in 4 files (`workspace.rs`, `nspawn.rs`, `mission_runner.rs`, `tools/desktop.rs`)
  - **`home_dir`**: the pattern `std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())` appeared 25 times across 12 files
  - **`build_history_context`**: identical 14-line function in `control.rs` and `mission_runner.rs`
  - **`sanitize_skill_list`**: identical 14-line function in `library.rs` and `workspaces.rs`
- Removes ~140 lines of duplicated code across 16 files
- Adds a `sanitize_skill_list` unit test that was missing; moves existing `build_history_context` tests to the shared module

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D clippy::all` — clean
- [x] `cargo test --workspace` — 321 passed, 0 failed (was 320; +1 new test)
- [x] No public API changes; all replaced functions were file-private

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that centralizes previously duplicated functions with minimal behavioral change, mainly affecting path/env parsing helpers.
> 
> **Overview**
> Refactors duplicated helper logic into a new shared `src/util.rs` module and wires it into the crate via `lib.rs`.
> 
> Multiple modules now import `util::{home_dir, env_var_bool, build_history_context, sanitize_skill_list}` instead of maintaining local copies, and related tests are moved into `util` with a new unit test for `sanitize_skill_list`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c311be6a48538a595380733ffaa91f7efe4d163f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->