### PR TITLE
fix: resolve Codex native binary from new npm package structure

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -6765,12 +6765,11 @@ fn is_codex_node_wrapper(path: &std::path::Path) -> bool {
     }
 
     let lower = content.to_lowercase();
-    let has_codex_ref = lower.contains("@openai/codex")
+    lower.contains("@openai/codex")
         || lower.contains("codex-linux-x64")
         || lower.contains("codex-linux-arm64")
         || lower.contains("codex-darwin-x64")
-        || lower.contains("codex-darwin-arm64");
-    has_codex_ref
+        || lower.contains("codex-darwin-arm64")
 }
 
 fn codex_npm_package_name(triple: &str) -> &'static str {


### PR DESCRIPTION
## Summary

Fixes Codex CLI resolution for newer versions of `@openai/codex` (v0.1.2505+) where the native binary is shipped as an optional dependency (`@openai/codex-linux-x64`) rather than bundled directly in the package.

### Changes

1. **Detect wrapper regardless of filename** - Previously only `codex.js` was recognized. Now we detect any Node.js wrapper by checking:
   - Node.js shebang (`#!/usr/bin/env node`)
   - Contains `@openai/codex` or `codex-linux-x64` references

2. **Search multiple paths for native binary**:
   - Legacy: `<package_root>/vendor/<triple>/codex/codex`
   - npm nested: `<package_root>/node_modules/@openai/codex-linux-x64/vendor/...`
   - bun sibling: `<node_modules>/@openai/codex-linux-x64/vendor/...`
   - System npm prefix paths (`/usr/local/lib/node_modules/...`, `/usr/lib/...`)
   - Bun global install paths (`~/.bun/install/global/...`, `~/.cache/.bun/...`)

3. **Added helper functions**:
   - `is_codex_node_wrapper()`: Detects if a file is the Node.js wrapper
   - `resolve_codex_native_binary_search_paths()`: Generates search paths for native binary

4. **Added unit tests** for `is_codex_node_wrapper()`

### Problem

When `npm install -g @openai/codex@latest` runs:
1. npm copies `bin/codex.js` to `/usr/local/bin/codex` (no `.js` extension)
2. The wrapper tries to `require.resolve('@openai/codex-linux-x64')` but Node can't find it from `/usr/local/bin/`
3. Every Codex invocation fails with: `Error: Missing optional dependency @openai/codex-linux-x64`

For containers, the broken Node.js wrapper was being copied in, causing immediate failures.

### Solution

Find and copy the actual native binary instead of the Node.js wrapper. The native binary at `.../vendor/<triple>/codex/codex` works standalone without Node.

Fixes #192

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib` — clean (no warnings)
- [x] `cargo test --lib` — 327 passed, 0 failed
- [x] New unit tests for `is_codex_node_wrapper` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how the Codex executable is detected and copied into container workspaces, which can break CLI availability if path detection is wrong; scope is localized and covered by new unit tests.
> 
> **Overview**
> Improves container Codex CLI setup by **detecting Node.js wrapper scripts even when they aren’t named `codex.js`** and resolving the actual native binary instead.
> 
> Adds wrapper detection via `is_codex_node_wrapper()` (node shebang + known Codex markers), expands native-binary lookup to search multiple npm/bun/global install locations via `resolve_codex_native_binary_search_paths()`, and includes unit tests covering wrapper/non-wrapper cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e161c7dae7039da05203d601290c58e9954d141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->