### PR TITLE
Add user-facing RTK setting toggle in dashboard

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -2365,6 +2365,7 @@ export async function uninstallSystemComponent(
 export interface SettingsResponse {
   library_remote: string | null;
   sandboxed_repo_path: string | null;
+  rtk_enabled: boolean | null;
 }
 
 export interface UpdateLibraryRemoteResponse {
@@ -2405,6 +2406,22 @@ export async function updateLibraryRemote(
   if (!res.ok) {
     const text = await res.text();
     throw new Error(text || 'Failed to update library remote');
+  }
+  return res.json();
+}
+
+// Update the RTK enabled setting
+export async function updateRtkEnabled(
+  rtkEnabled: boolean
+): Promise<{ rtk_enabled: boolean; previous_value: boolean | null }> {
+  const res = await apiFetch('/api/settings/rtk-enabled', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rtk_enabled: rtkEnabled }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || 'Failed to update RTK setting');
   }
   return res.json();
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -185,6 +185,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
 
     // Initialize global settings store
     let settings = Arc::new(crate::settings::SettingsStore::new(&config.working_dir).await);
+    settings.init_cached_values();
 
     // Initialize backend config store (persisted settings).
     // Probe each CLI binary so backends whose CLI is missing default to disabled.

--- a/src/tools/terminal.rs
+++ b/src/tools/terminal.rs
@@ -62,6 +62,11 @@ fn rtk_gain_stats() -> Option<(u64, u64)> {
 }
 
 pub fn rtk_enabled() -> bool {
+    // Check the cached value from settings store first
+    if crate::settings::rtk_enabled_cached() {
+        return true;
+    }
+    // Fall back to env var for backwards compatibility
     env::var("SANDBOXED_SH_RTK_ENABLED")
         .map(|v| {
             matches!(


### PR DESCRIPTION
## Summary
- Add `rtk_enabled` field to Settings struct with persistence to disk
- Add cached RTK state using atomic bool for synchronous access from non-async contexts
- Update `rtk_enabled()` in terminal.rs to check cached value first, then fall back to env var
- Add API endpoint `PUT /api/settings/rtk-enabled` for updating the setting
- Add RTK toggle UI in settings/data page with clear description

## Details
Previously, RTK wrapping could only be controlled via the `SANDBOXED_SH_RTK_ENABLED` environment variable. This adds a user-facing toggle in the dashboard that:
1. Persists the setting to `.sandboxed-sh/settings.json`
2. Works immediately without server restart
3. Falls back to env var if not explicitly set in settings

## Test Plan
- [x] Toggle RTK on/off from dashboard Settings > Data page
- [x] Setting persists across page refreshes
- [x] Verify RTK wrapping is applied when enabled
- [x] Verify env var fallback still works when setting is not configured

Fixes #187

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches settings persistence and introduces a new runtime-cached flag that changes terminal command wrapping behavior immediately; failures could lead to unexpected RTK state until refresh/restart.
> 
> **Overview**
> Adds a persisted `rtk_enabled` global setting that can be toggled live from the dashboard instead of only via `SANDBOXED_SH_RTK_ENABLED`.
> 
> Backend now exposes `PUT /api/settings/rtk-enabled`, returns `rtk_enabled` in `GET /api/settings`, persists the value to `.sandboxed-sh/settings.json`, and maintains an atomic cached copy initialized at startup so synchronous terminal code can respect the new setting immediately (with env-var fallback when unset).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0893bbfa4fa7c49fe645bee121d93757d71991b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->