### PR TITLE
fix: clear DEFAULT_MODEL for Codex backend in control.rs

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5492,13 +5492,11 @@ async fn run_single_control_turn(
         {
             config.default_model = Some(default_model);
         }
-    } else if backend_id.as_deref() == Some("opencode")
+    } else if (backend_id.as_deref() == Some("opencode")
         && effective_config_profile.is_some()
-        && requested_model.is_none()
+        && requested_model.is_none())
+        || (backend_id.as_deref() == Some("codex") && requested_model.is_none())
     {
-        // For OpenCode with a config profile but no explicit model override,
-        // clear the global default so the profile's oh-my-opencode agent
-        // models take precedence instead of being overridden.
         config.default_model = None;
     }
     if let Some(ref agent) = agent_override {


### PR DESCRIPTION
## Summary
- Add missing logic to clear `DEFAULT_MODEL` for Codex backend in `control.rs`
- Matches the existing logic in `mission_runner.rs` that was already handling this correctly

## Problem
Issue #153 reports that Codex missions show an Anthropic model (e.g., `anthropic/claude-opus-4-6`) in error messages even though the backend is Codex. This happens because the global `DEFAULT_MODEL` env var is not cleared for Codex in `control.rs`, only in `mission_runner.rs`.

## Fix
Added the same model-clearing logic that exists in `mission_runner.rs:1277-1280` to `control.rs:5502-5503`:
```rust
} else if backend_id.as_deref() == Some("codex") && requested_model.is_none() {
    config.default_model = None;
}
```

Fixes #153

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change to backend-specific config selection; risk is limited to potentially altering default model resolution for `codex`/`opencode` runs when no model override is provided.
> 
> **Overview**
> Ensures `codex` missions no longer inherit a global `DEFAULT_MODEL` by clearing `config.default_model` in `control.rs` when the backend is `codex` and no explicit model override is provided.
> 
> The existing `opencode` behavior (clearing the default model when a config profile is active and no model override is set) is preserved, and the conditional is refactored to cover both cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92110aada4c13a0c499543997d803c30bbfbb6e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->