### PR TITLE
feat: add API endpoint for renaming missions

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -629,6 +629,11 @@ pub enum AgentEvent {
         status: MissionStatus,
         summary: Option<String>,
     },
+    /// Mission title changed (by user)
+    MissionTitleChanged {
+        mission_id: Uuid,
+        title: String,
+    },
     /// Agent phase update (for showing preparation steps)
     AgentPhase {
         /// Phase name: "executing", "delegating", etc.
@@ -829,6 +834,12 @@ pub enum ControlCommand {
         status: MissionStatus,
         respond: oneshot::Sender<Result<(), String>>,
     },
+    /// Update mission title
+    SetMissionTitle {
+        id: Uuid,
+        title: String,
+        respond: oneshot::Sender<Result<(), String>>,
+    },
     /// Start a mission in parallel (if slots available)
     StartParallel {
         mission_id: Uuid,
@@ -935,6 +946,12 @@ pub struct DesktopSessionInfo {
 #[derive(Debug, Clone, Deserialize)]
 pub struct SetMissionStatusRequest {
     pub status: MissionStatus,
+}
+
+/// Request to rename a mission.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SetMissionTitleRequest {
+    pub title: String,
 }
 
 // MissionStore trait and implementations are in mission_store module
@@ -1629,6 +1646,32 @@ pub async fn set_mission_status(
         .send(ControlCommand::SetMissionStatus {
             id,
             status: req.status,
+            respond: tx,
+        })
+        .await
+        .map_err(session_unavailable)?;
+
+    rx.await
+        .map_err(recv_failed)?
+        .map(|_| ok_json())
+        .map_err(internal_error)
+}
+
+/// Set mission title (rename mission).
+pub async fn set_mission_title(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<SetMissionTitleRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let (tx, rx) = oneshot::channel();
+
+    let control = control_for_user(&state, &user).await;
+    control
+        .cmd_tx
+        .send(ControlCommand::SetMissionTitle {
+            id,
+            title: req.title,
             respond: tx,
         })
         .await
@@ -3958,6 +4001,16 @@ async fn control_actor_loop(
                                 mission_id: id,
                                 status: new_status,
                                 summary: None,
+                            });
+                        }
+                        let _ = respond.send(result);
+                    }
+                    ControlCommand::SetMissionTitle { id, title, respond } => {
+                        let result = mission_store.update_mission_title(id, &title).await;
+                        if result.is_ok() {
+                            let _ = events_tx.send(AgentEvent::MissionTitleChanged {
+                                mission_id: id,
+                                title: title.clone(),
                             });
                         }
                         let _ = respond.send(result);

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -534,6 +534,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             post(control::set_mission_status),
         )
         .route(
+            "/api/control/missions/:id/title",
+            post(control::set_mission_title),
+        )
+        .route(
             "/api/control/missions/:id/cancel",
             post(control::cancel_mission),
         )


### PR DESCRIPTION
## Summary
- Add `POST /api/control/missions/:id/title` endpoint to allow renaming missions from the dashboard
- Add `SetMissionTitleRequest` struct for the JSON request body (`{"title": "new name"}`)
- Add `SetMissionTitle` variant to `ControlCommand` enum
- Add `MissionTitleChanged` event to `AgentEvent` for real-time UI updates via SSE
- Implement handler in control actor loop that calls existing `update_mission_title` on the mission store

## Details
This is the backend implementation for issue #188. The `update_mission_title` method already existed in the mission store trait but wasn't exposed via API.

Frontend changes will be needed to add the UI for renaming (edit icon, double-click, or context menu option).

## Test Plan
- [ ] Verify `POST /api/control/missions/:id/title` with `{"title": "new name"}` updates the mission title
- [ ] Verify `MissionTitleChanged` event is sent via SSE after successful update
- [ ] Verify title persists across server restarts (SQLite storage)

Fixes #188

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission management and event streaming paths; small change but event consumers may need updates to handle the new `MissionTitleChanged` type correctly.
> 
> **Overview**
> Adds a new mission-renaming API: `POST /api/control/missions/:id/title` with a `SetMissionTitleRequest` body to persist an updated title.
> 
> Wires the request through the control actor via a new `ControlCommand::SetMissionTitle`, updates storage via `mission_store.update_mission_title`, and emits a new SSE event `AgentEvent::MissionTitleChanged` on success for real-time UI updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c76c887b0068f304b88745b65a3ecea5455328b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->