### PR TITLE
Simplify: extract opencode.json load/write helpers in mission_runner

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4300,12 +4300,17 @@ fn load_opencode_json(config_dir: &std::path::Path) -> (std::path::PathBuf, serd
 }
 
 /// Write a JSON value to a path, logging a warning on failure.
-fn save_json_warn(path: &std::path::Path, value: &serde_json::Value, context: &str) {
-    if let Err(err) = std::fs::write(
+/// Returns `true` if the write succeeded, `false` otherwise.
+fn save_json_warn(path: &std::path::Path, value: &serde_json::Value, context: &str) -> bool {
+    match std::fs::write(
         path,
         serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string()),
     ) {
-        tracing::warn!("Failed to update {context} at {}: {err}", path.display());
+        Ok(()) => true,
+        Err(err) => {
+            tracing::warn!("Failed to update {context} at {}: {err}", path.display());
+            false
+        }
     }
 }
 
@@ -4938,13 +4943,14 @@ fn ensure_opencode_provider_for_model(opencode_config_dir: &std::path::Path, mod
         providers_map.insert(provider_id.to_string(), provider_def);
     }
 
-    save_json_warn(&opencode_path, &root, "OpenCode provider config");
-    tracing::info!(
-        "Injected OpenCode provider definition for {}/{} into {}",
-        provider_id,
-        model_id,
-        opencode_path.display()
-    );
+    if save_json_warn(&opencode_path, &root, "OpenCode provider config") {
+        tracing::info!(
+            "Injected OpenCode provider definition for {}/{} into {}",
+            provider_id,
+            model_id,
+            opencode_path.display()
+        );
+    }
 }
 
 /// Scan the oh-my-opencode config for all model references (top-level, agents,


### PR DESCRIPTION
## Summary
- Extract `load_opencode_json(dir) -> (PathBuf, Value)` — replaces 5 identical 10-line blocks that read `opencode.json` with a fallback to `{}`
- Extract `save_json_warn(path, value, context)` — replaces 4 identical write-with-warning blocks
- Both helpers are local to `mission_runner.rs` (not public API)
- Net reduction: **~66 lines**, single file change

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D clippy::all` — clean
- [x] `cargo test --workspace` — 332 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized refactor that primarily changes how config file I/O is factored and logged, with minimal behavioral impact beyond standardized error handling.
> 
> **Overview**
> Refactors `mission_runner.rs` to deduplicate `opencode.json` handling by introducing `load_opencode_json` (read+parse with `{}` fallback) and `save_json_warn` (pretty-write with contextual warning and success boolean).
> 
> Updates all OpenCode config mutation sites (plugin specs, Google `projectId`, agent config, provider injection, and model resolution) to use these helpers, keeping behavior the same while simplifying and standardizing error handling/logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12df5f9011e18403e98f3bfc8677cb94ce1e9d18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->