### PR TITLE
docs: add mission automation API documentation

### DIFF
--- a/docs/MISSION_API.md
+++ b/docs/MISSION_API.md
@@ -147,6 +147,149 @@ data: {"id":"uuid","content":"Done!","success":true,"cost_cents":5,"model":"clau
 | `/api/control/tree` | GET | Get live agent tree |
 | `/api/control/progress` | GET | Get execution progress |
 
+## Automations
+
+Automations trigger commands based on intervals, webhooks, or agent events.
+
+### List Mission Automations
+
+```
+GET /api/control/missions/:id/automations
+```
+
+**Response**: Array of `Automation` objects.
+
+### List All Active Automations
+
+```
+GET /api/control/automations
+```
+
+**Response**: Array of `Automation` objects across all missions.
+
+### Create an Automation
+
+```
+POST /api/control/missions/:id/automations
+```
+
+**Body**:
+```json
+{
+  "command_source": {"library": {"name": "my-command"}},
+  "trigger": {"interval": {"seconds": 300}},
+  "variables": {"key": "value"},
+  "retry_config": {
+    "max_retries": 3,
+    "retry_delay_seconds": 60,
+    "backoff_multiplier": 2.0
+  },
+  "start_immediately": false
+}
+```
+
+**Trigger types**:
+- `{"interval": {"seconds": 300}}` — Run every N seconds
+- `{"webhook": {"config": {"webhook_id": "optional-uuid"}}}` — Trigger via webhook
+- `"agent_finished"` — Trigger after each agent turn completes
+
+**Command sources**:
+- `{"library": {"name": "command-name"}}` — Use a library command
+- `{"inline": {"command": "echo hello"}}` — Inline shell command
+
+**Response**: `Automation` object.
+
+### Get Automation
+
+```
+GET /api/control/automations/:id
+```
+
+**Response**: `Automation` object.
+
+### Update Automation
+
+```
+PATCH /api/control/automations/:id
+```
+
+**Body** (all fields optional):
+```json
+{
+  "command_source": {"library": {"name": "new-command"}},
+  "trigger": {"interval": {"seconds": 600}},
+  "variables": {"key": "new-value"},
+  "retry_config": {"max_retries": 5},
+  "active": false
+}
+```
+
+**Response**: Updated `Automation` object.
+
+### Delete Automation
+
+```
+DELETE /api/control/automations/:id
+```
+
+**Response**: `204 No Content` on success.
+
+### Get Automation Executions
+
+```
+GET /api/control/automations/:id/executions
+```
+
+**Response**: Array of `AutomationExecution` objects.
+
+### Get Mission Automation Executions
+
+```
+GET /api/control/missions/:id/automation-executions
+```
+
+**Response**: Array of `AutomationExecution` objects for all automations on a mission.
+
+## Automation Object
+
+```json
+{
+  "id": "uuid",
+  "mission_id": "uuid",
+  "command_source": {"library": {"name": "my-command"}},
+  "trigger": {"interval": {"seconds": 300}},
+  "variables": {"key": "value"},
+  "active": true,
+  "created_at": "2025-01-13T10:00:00Z",
+  "last_triggered_at": "2025-01-13T10:05:00Z",
+  "retry_config": {
+    "max_retries": 3,
+    "retry_delay_seconds": 60,
+    "backoff_multiplier": 2.0
+  }
+}
+```
+
+## AutomationExecution Object
+
+```json
+{
+  "id": "uuid",
+  "automation_id": "uuid",
+  "mission_id": "uuid",
+  "triggered_at": "2025-01-13T10:05:00Z",
+  "trigger_source": "interval",
+  "status": "success",
+  "webhook_payload": null,
+  "started_at": "2025-01-13T10:05:00Z",
+  "completed_at": "2025-01-13T10:05:05Z",
+  "result_message": "Command completed successfully",
+  "retry_count": 0
+}
+```
+
+**Execution statuses**: `pending`, `running`, `success`, `failed`, `cancelled`, `skipped`.
+
 ## Mission Object
 
 ```json


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for mission automation API endpoints
- Document trigger types (interval, webhook, agent_finished)
- Document command sources (library, inline)
- Add Automation and AutomationExecution object schemas
- Addresses documentation gap identified in issue #176

## Test plan
- [x] Verify markdown formatting is correct
- [x] Confirm endpoint paths match routes.rs
- [x] Confirm request/response schemas match control.rs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds new API reference material without altering runtime behavior; risk is limited to potential mismatch with actual server routes/schemas.
> 
> **Overview**
> Adds a new **Automations** section to `docs/MISSION_API.md`, documenting CRUD and listing endpoints for mission automations plus execution history endpoints (including per-mission aggregation).
> 
> Defines supported trigger types (interval, webhook, `agent_finished`), command sources (library vs inline), and includes example request bodies along with `Automation` and `AutomationExecution` JSON schemas and execution status values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abc0d0b088255b0524e37e791210f31111e24e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->