### PR TITLE
Fix: remove unused import and use idiomatic range contains

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -10048,14 +10048,13 @@ fn cleanup_old_debug_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_history_context, extract_opencode_session_id, extract_part_text, extract_str,
-        extract_thought_line, is_codex_node_wrapper, is_rate_limited_error,
-        is_session_corruption_error, is_tool_call_only_output, opencode_output_needs_fallback,
-        opencode_session_token_from_line, parse_opencode_session_token,
-        parse_opencode_stderr_text_part, running_health, sanitized_opencode_stdout, stall_severity,
-        strip_ansi_codes, strip_opencode_banner_lines, strip_think_tags,
-        summarize_recent_opencode_stderr, sync_opencode_agent_config, MissionHealth,
-        MissionRunState, MissionStallSeverity, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        extract_opencode_session_id, extract_part_text, extract_str, extract_thought_line,
+        is_codex_node_wrapper, is_rate_limited_error, is_session_corruption_error,
+        is_tool_call_only_output, opencode_output_needs_fallback, opencode_session_token_from_line,
+        parse_opencode_session_token, parse_opencode_stderr_text_part, running_health,
+        sanitized_opencode_stdout, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
+        strip_think_tags, summarize_recent_opencode_stderr, sync_opencode_agent_config,
+        MissionHealth, MissionRunState, MissionStallSeverity, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use crate::agents::{AgentResult, TerminalReason};
     use serde_json::json;

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1657,7 +1657,7 @@ mod tests {
         assert!(d.is_some());
         let secs = d.unwrap().as_secs();
         // Should be roughly 60 seconds, with some tolerance
-        assert!(secs >= 55 && secs <= 65, "got {} seconds", secs);
+        assert!((55..=65).contains(&secs), "got {} seconds", secs);
     }
 
     #[test]
@@ -1698,6 +1698,6 @@ mod tests {
         let d = parse_rate_limit_headers(&headers, ProviderType::Anthropic);
         assert!(d.is_some());
         let secs = d.unwrap().as_secs();
-        assert!(secs >= 25 && secs <= 35, "got {} seconds", secs);
+        assert!((25..=35).contains(&secs), "got {} seconds", secs);
     }
 }


### PR DESCRIPTION
## Summary
Fix two clippy errors introduced in recent commits:
- Remove unused import `build_history_context` from test module in mission_runner.rs
- Replace manual range checks with idiomatic `(55..=65).contains(&secs)` pattern in proxy.rs tests

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D clippy::all` — clean  
- [x] `cargo test --workspace` — all tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 64480e84e094af5f8cdf0770e4d870f3f9d2a8c3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->