### PR TITLE
refactor: extract clone_library and merge_build_result in workspaces.rs

### DIFF
--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -845,10 +845,7 @@ async fn build_workspace(
     let working_dir = state.config.working_dir.clone();
     let mut workspace_for_build = workspace.clone();
     // Get library for init script assembly
-    let library = {
-        let guard = state.library.read().await;
-        guard.as_ref().map(Arc::clone)
-    };
+    let library = clone_library(&state.library).await;
 
     tokio::spawn(async move {
         let result = crate::workspace::build_container_workspace(


### PR DESCRIPTION
## Summary
- Extracts `clone_library` helper to replace 3 identical read-lock-and-clone blocks that acquire an `Option<Arc<LibraryStore>>` from the shared `RwLock`
- Extracts `merge_build_result` helper to replace 2 identical 8-line blocks that apply build-related fields (status, error_message, distro) back to the latest stored workspace after a background container build finishes
- Net: -3 lines (26 insertions, 29 deletions) — the main value is deduplication and self-documenting helpers

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D clippy::all` passes
- [x] `cargo test --workspace` passes (334 tests, 332 passed, 2 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no functional changes intended; risk is limited to accidentally altering workspace update behavior after background builds.
> 
> **Overview**
> Refactors `src/api/workspaces.rs` by extracting two helpers: `clone_library` (dedupes the read-lock + `Arc` clone of the optional `LibraryStore`) and `merge_build_result` (dedupes the post-build “apply status/error/distro to latest workspace” logic).
> 
> The create-from-template auto-build path and the `POST /:id/build` background build path now call these helpers, keeping behavior the same while centralizing the concurrency-safe merge of build results into the stored workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f143ea4c07af52759f893ac4067431e98fe37ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->