### PR TITLE
refactor: replace 5 backend config readers with generic helpers

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1894,7 +1894,7 @@ fn get_backend_string_setting(backend_id: &str, key: &str) -> Option<String> {
             {
                 if !val.is_empty() {
                     if key == "api_key" {
-                        tracing::info!("Using {} {} from backend config", backend_id, key);
+                        tracing::debug!("Using {} {} from backend config", backend_id, key);
                     } else {
                         tracing::info!("Using {} {} from backend config: {}", backend_id, key, val);
                     }


### PR DESCRIPTION
## Summary
- Extracts `get_backend_string_setting(backend_id, key)` and `get_backend_bool_setting(backend_id, key)` to replace 5 near-identical functions that each iterated over backend configs looking for a specific setting
- Replaces: `get_claudecode_cli_path_from_config`, `get_codex_cli_path_from_config`, `get_opencode_cli_path_from_config`, `get_opencode_permissive_from_config`
- Simplifies `get_amp_api_key_from_config` to use the new helper (keeps its extra redaction validation)
- Net: **-53 lines** (29 insertions, 82 deletions)

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D clippy::all` passes
- [x] `cargo test --workspace` passes (334 tests, 332 passed, 2 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a deduping refactor of config reads; behavior should be unchanged aside from logging paths/keys, with minimal risk limited to mis-reading config types/keys.
> 
> **Overview**
> Refactors backend config access in `mission_runner.rs` by introducing generic helpers `get_backend_string_setting` and `get_backend_bool_setting`, removing several near-duplicate backend-specific readers.
> 
> Updates Claude Code, OpenCode, and Codex runners to use the new helpers for `cli_path`, and switches OpenCode’s `permissive` env injection to the boolean helper. Amp API key loading is simplified to the helper while preserving redaction masking checks and avoiding logging the key value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6442f15d45d590555bb393a21062b7d705da55f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->