### PR TITLE
refactor: extract require_connection helper in opencode.rs

### DIFF
--- a/src/api/opencode.rs
+++ b/src/api/opencode.rs
@@ -300,17 +300,17 @@ pub async fn fetch_opencode_agents_for_profile(
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn not_found_connection(id: Uuid) -> (StatusCode, String) {
-    (StatusCode::NOT_FOUND, format!("Connection {} not found", id))
+    (
+        StatusCode::NOT_FOUND,
+        format!("Connection {} not found", id),
+    )
 }
 
 async fn require_connection(
     store: &crate::opencode_config::OpenCodeStore,
     id: Uuid,
 ) -> Result<OpenCodeConnection, (StatusCode, String)> {
-    store
-        .get(id)
-        .await
-        .ok_or_else(|| not_found_connection(id))
+    store.get(id).await.ok_or_else(|| not_found_connection(id))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extracts `not_found_connection` helper for consistent 404 error format
- Extracts `require_connection` helper to replace 7 identical connection lookup patterns with NOT_FOUND error handling
- Net: **-17 lines** (26 insertions, 43 deletions)

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D clippy::all` passes
- [x] `cargo test --workspace` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of API handler error-paths with no behavioral change intended beyond standardizing the 404 response formatting.
> 
> **Overview**
> Refactors `src/api/opencode.rs` to remove repeated connection lookup and `404 Connection ... not found` construction across the OpenCode connection endpoints.
> 
> Introduces `not_found_connection` and `require_connection`, and updates `get_connection`, `update_connection`, `delete_connection`, `test_connection`, and `set_default` to use these helpers for consistent error handling and reduced duplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce5f268cc7e2f08d9cb8280d972bf6297cfb191a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->