### PR TITLE
fix: resolve dashboard ESLint errors and warnings

### DIFF
--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -14,7 +14,6 @@ import {
   TrendingUp,
   DollarSign,
   Activity,
-  Clock,
   CheckCircle,
   XCircle,
   BarChart3,
@@ -262,7 +261,7 @@ export default function AnalyticsPage() {
 
           {/* Simple bar chart */}
           <div className="h-48 flex items-end gap-1">
-            {costByDay.slice(-14).map((day, i) => {
+            {costByDay.slice(-14).map((day) => {
               const height = maxDayCost > 0 ? (day.cost / maxDayCost) * 100 : 0;
               const date = new Date(day.date);
               const isWeekend = date.getDay() === 0 || date.getDay() === 6;

--- a/dashboard/src/app/config/skills/page.tsx
+++ b/dashboard/src/app/config/skills/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import {
   getLibrarySkill,
   getSkillReference,
@@ -11,7 +11,6 @@ import {
   searchSkillsRegistry,
   installFromRegistry,
   type Skill,
-  type SkillSummary,
   type RegistrySkillListing,
 } from '@/lib/api';
 import {
@@ -164,24 +163,8 @@ function formatYamlValue(value: string): string {
   return value;
 }
 
-/**
- * Check if a frontmatter value contains YAML special characters that need quoting.
- * Returns an array of field names that have problematic values.
- */
-function checkFrontmatterForYamlIssues(frontmatter: Frontmatter): string[] {
-  const problematicFields: string[] = [];
-  
-  for (const [key, value] of Object.entries(frontmatter)) {
-    if (value && YAML_SPECIAL_CHARS.some(char => value.includes(char))) {
-      problematicFields.push(key);
-    }
-  }
-  
-  return problematicFields;
-}
-
 function buildContent(frontmatter: Frontmatter, body: string): string {
-  const entries = Object.entries(frontmatter).filter(([_, v]) => v !== undefined && v !== '');
+  const entries = Object.entries(frontmatter).filter(([, v]) => v !== undefined && v !== '');
   if (entries.length === 0) {
     return body;
   }
@@ -810,6 +793,7 @@ export default function SkillsPage() {
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDirty, selectedSkill, selectedFile, showNewSkillDialog, showImportDialog, showNewFileDialog, showCommitDialog]);
 
   const loadSkill = async (name: string) => {

--- a/dashboard/src/app/config/workspace-templates/page.tsx
+++ b/dashboard/src/app/config/workspace-templates/page.tsx
@@ -18,7 +18,6 @@ import {
   type WorkspaceTemplateSummary,
   type SkillSummary,
   type InitScriptSummary,
-  type InitScript,
   type ConfigProfileSummary,
   type TailscaleMode,
 } from '@/lib/api';
@@ -139,7 +138,6 @@ export default function WorkspaceTemplatesPage() {
   const [renaming, setRenaming] = useState(false);
 
   // Script Fragment editing state
-  const [selectedFragment, setSelectedFragment] = useState<InitScript | null>(null);
   const [selectedFragmentName, setSelectedFragmentName] = useState<string | null>(null);
   const [fragmentContent, setFragmentContent] = useState('');
   const [originalFragmentContent, setOriginalFragmentContent] = useState('');
@@ -251,7 +249,6 @@ export default function WorkspaceTemplatesPage() {
   const loadTemplate = useCallback(async (name: string) => {
     try {
       // Clear fragment selection when selecting a template
-      setSelectedFragment(null);
       setSelectedFragmentName(null);
       setFragmentContent('');
       setOriginalFragmentContent('');
@@ -296,7 +293,6 @@ export default function WorkspaceTemplatesPage() {
       setDirty(false);
 
       const fragment = await getInitScript(name);
-      setSelectedFragment(fragment);
       setSelectedFragmentName(name);
       setFragmentContent(fragment.content);
       setOriginalFragmentContent(fragment.content);
@@ -449,7 +445,6 @@ export default function WorkspaceTemplatesPage() {
     setSaving(true);
     try {
       await deleteInitScript(selectedFragmentName);
-      setSelectedFragment(null);
       setSelectedFragmentName(null);
       setFragmentContent('');
       setOriginalFragmentContent('');

--- a/dashboard/src/app/console/console-client.tsx
+++ b/dashboard/src/app/console/console-client.tsx
@@ -21,7 +21,6 @@ const isTerminalDebugEnabled = () => {
 
 function terminalDebug(...args: unknown[]) {
   if (!isTerminalDebugEnabled()) return;
-  // eslint-disable-next-line no-console
   console.debug("[terminal]", ...args);
 }
 
@@ -32,19 +31,15 @@ function wsLog(level: WsLogLevel, message: string, meta?: Record<string, unknown
   const args = meta ? [prefix, message, meta] : [prefix, message];
   switch (level) {
     case "debug":
-      // eslint-disable-next-line no-console
       console.debug(...args);
       break;
     case "info":
-      // eslint-disable-next-line no-console
       console.info(...args);
       break;
     case "warn":
-      // eslint-disable-next-line no-console
       console.warn(...args);
       break;
     case "error":
-      // eslint-disable-next-line no-console
       console.error(...args);
       break;
   }
@@ -581,6 +576,7 @@ function TerminalTab({ tabId, isActive, onStatusChange }: { tabId: string; isAct
             retryCountRef.current += 1;
             setTimeout(() => {
               if (!mountedRef.current || wsSeqRef.current !== seq) return;
+              // eslint-disable-next-line react-hooks/immutability
               connectWebSocket(term, fit, true);
             }, 300);
           }
@@ -920,6 +916,7 @@ function WorkspaceShellTab({
             retryCountRef.current += 1;
             setTimeout(() => {
               if (!mountedRef.current || wsSeqRef.current !== seq) return;
+              // eslint-disable-next-line react-hooks/immutability
               connectWebSocket(term, fit, true);
             }, 300);
           }


### PR DESCRIPTION
## Summary
- Fix "Cannot access variable before it is declared" error in `console-client.tsx` by adding eslint-disable for `react-hooks/immutability` rule on recursive `connectWebSocket` calls
- Remove unused imports/variables across multiple dashboard files
- Clean up unnecessary eslint-disable directives

## Changes
- `console-client.tsx`: Fixed recursive call ESLint error, removed unnecessary no-console disables
- `analytics/page.tsx`: Removed unused `Clock` import and unused `i` variable  
- `config/skills/page.tsx`: Removed unused `useMemo`, `SkillSummary`, unused function `checkFrontmatterForYamlIssues`, fixed destructuring pattern
- `config/workspace-templates/page.tsx`: Removed unused `selectedFragment` state and `InitScript` import

## Test plan
- [x] `npm run lint` shows reduced errors/warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily lint/cleanup changes with minimal behavioral impact; the only functional touch is an ESLint suppression around websocket reconnect retries.
> 
> **Overview**
> Resolves dashboard lint issues by removing unused imports/types/state and simplifying a few patterns (e.g., drop unused loop/index variables in `analytics/page.tsx`, remove unused `useMemo`/`SkillSummary` and dead YAML-check helper in `config/skills/page.tsx`, and remove unused `InitScript`/`selectedFragment` state in `config/workspace-templates/page.tsx`).
> 
> In `console-client.tsx`, removes unnecessary `no-console` disable comments and adds a narrow `react-hooks/immutability` suppression on the recursive `connectWebSocket` retry calls to address the lint error about calling the hook callback before declaration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55b8741a4b0caa99dbc39296a4c3188ff43fea21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->