### PR TITLE
Update RTK message to reference Settings page

### DIFF
--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -895,7 +895,7 @@ export default function ModelRoutingPage() {
           ) : !rtkStats || rtkStats.commands_processed === 0 ? (
             <div className="text-center py-4">
               <p className="text-xs text-white/30">
-                No RTK data yet. Enable with <code className="text-white/50">SANDBOXED_SH_RTK_ENABLED=1</code>
+                No RTK data yet. Enable RTK in <a href="/settings/data" className="text-white/50 underline">Settings</a>
               </p>
             </div>
           ) : (


### PR DESCRIPTION
## Summary

Updates the RTK empty state message in model-routing to reference the Settings page instead of the deprecated `SANDBOXED_SH_RTK_ENABLED` environment variable.

## Context

RTK toggle is already fully implemented as a persisted setting:
- `rtk_enabled: Option<bool>` in Settings struct
- Persisted to `.sandboxed-sh/settings.json`
- API endpoint `/api/settings/rtk-enabled`
- UI toggle in Settings > Data page

The env var is only kept as a fallback for backwards compatibility.

Closes #224

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change with a static link; no logic, API, or data-flow changes.
> 
> **Overview**
> Updates the Model Routing page’s RTK empty-state text to direct users to enable RTK via the **Settings** UI (linking to `/settings/data`) instead of referencing the deprecated `SANDBOXED_SH_RTK_ENABLED` environment variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fd5d87d54fb1d9ea05aa9b88eb1fa3d091961e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->