### PR TITLE
fix: add simpler codex binary search path

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -6640,14 +6640,14 @@ fn resolve_codex_native_binary_search_paths(
     }
 
     if let Ok(npm_prefix) = std::env::var("npm_config_prefix") {
-        let npm_optional = std::path::PathBuf::from(&npm_prefix)
+        let npm_root = std::path::PathBuf::from(&npm_prefix)
             .join("lib")
             .join("node_modules")
             .join("@openai")
-            .join("codex")
-            .join("node_modules")
-            .join("@openai")
-            .join(npm_pkg);
+            .join("codex");
+        paths.push(binary_path(&npm_root));
+
+        let npm_optional = npm_root.join("node_modules").join("@openai").join(npm_pkg);
         paths.push(binary_path(&npm_optional));
     }
 


### PR DESCRIPTION
## Summary
- Add /usr/local/lib/node_modules/@openai/codex path before the nested node_modules path
- Fixes Codex mission startup when installed via npm in standard location

## Problem
The Codex CLI binary search was only checking nested paths like:
/usr/local/lib/node_modules/@openai/codex/node_modules/@openai/codex-cli

This missed the simpler installation path where the binary is directly in:
/usr/local/lib/node_modules/@openai/codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to path resolution order/targets; main risk is missing an uncommon installation layout due to the updated search paths.
> 
> **Overview**
> Improves Codex native binary discovery by adding the *non-nested* npm install root (`.../lib/node_modules/@openai/codex`) to the search path before falling back to the nested `.../codex/node_modules/@openai/<platform-pkg>` location.
> 
> This is applied both for `npm_config_prefix` installs and standard global prefixes (`/usr/local`, `/usr`), increasing the chance missions start correctly when Codex is installed in the common global layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f55d370a6640e192a79ad5967e2b62db07572d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->