### PR TITLE
fix(codex): prevent interim updates from polluting final assistant response

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9760,7 +9760,10 @@ pub async fn run_codex_turn(
             Some(event) = event_rx.recv() => {
                 match event {
                     ExecutionEvent::TextDelta { content } => {
-                        assistant_message.push_str(&content);
+                        // For Codex backend, TextDelta is handled as the latest snapshot for
+                        // the currently active assistant message item. Replacing here avoids
+                        // concatenating intermediate assistant updates into the final message.
+                        assistant_message = content;
                         let _ = events_tx.send(AgentEvent::TextDelta {
                             content: assistant_message.clone(),
                             mission_id: Some(mission_id),


### PR DESCRIPTION
## Summary
- treat Codex text events as per-item snapshots in `src/backend/codex/mod.rs`
- update mission runner Codex path to keep the latest snapshot instead of concatenating every text event
- prevent interim/progress assistant updates from being glued into the final displayed response

## Tests
- `cargo test -p sandboxed_sh convert_codex_event_text_snapshot_updates -- --nocapture`
- `cargo test -p sandboxed_sh convert_codex_event_text_snapshot_skips_unchanged -- --nocapture`
- `cargo test -p sandboxed_sh convert_codex_event_item_completed_message -- --nocapture`

Closes #233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming aggregation semantics for Codex responses, which could affect how partial updates display and how final messages are constructed across clients; scope is limited to the Codex backend path and is covered by targeted unit tests.
> 
> **Overview**
> Prevents Codex interim/progress assistant updates from being glued into the final displayed response by switching text handling to *snapshot semantics*.
> 
> `convert_codex_event` now emits the full current text for a message item (and skips unchanged repeats) rather than computing/appending a deduplicated suffix, and the mission runner’s Codex path replaces `assistant_message` with the latest `TextDelta` snapshot instead of concatenating. Tests are updated/added to assert the new snapshot behavior and unchanged-skip logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1260a6d08a10577c640a4bb17f9ddfb4bf992c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->