### PR TITLE
Fix pasted upload token insertion at cursor in dashboard chat

### DIFF
--- a/dashboard/src/components/enhanced-input.test.tsx
+++ b/dashboard/src/components/enhanced-input.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EnhancedInput } from "./enhanced-input";
+
+vi.mock("@/lib/api", () => ({
+  listLibraryCommands: vi.fn().mockResolvedValue([]),
+  getBuiltinCommands: vi
+    .fn()
+    .mockResolvedValue({ opencode: [], claudecode: [] }),
+  getVisibleAgents: vi.fn().mockResolvedValue([]),
+}));
+
+describe("EnhancedInput file paste handling", () => {
+  it("passes textarea selection to onFilePaste", () => {
+    const onFilePaste = vi.fn();
+    const file = new File(["img"], "paste.png", { type: "image/png" });
+    const fileItem = {
+      kind: "file",
+      getAsFile: () => file,
+    };
+
+    const { container } = render(
+      <EnhancedInput
+        value={"hello world"}
+        onChange={() => {}}
+        onSubmit={() => {}}
+        onFilePaste={onFilePaste}
+      />,
+    );
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    textarea!.setSelectionRange(6, 11);
+
+    fireEvent.paste(textarea as HTMLTextAreaElement, {
+      clipboardData: {
+        items: [fileItem],
+        getData: () => "",
+      },
+    });
+
+    expect(onFilePaste).toHaveBeenCalledTimes(1);
+    expect(onFilePaste).toHaveBeenCalledWith([file], {
+      selectionStart: 6,
+      selectionEnd: 11,
+    });
+  });
+});

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -26,13 +26,18 @@ export interface EnhancedInputHandle {
   canSubmit: () => boolean;
 }
 
+export interface FilePasteContext {
+  selectionStart: number;
+  selectionEnd: number;
+}
+
 interface EnhancedInputProps {
   value: string;
   onChange: (value: string) => void;
   onSubmit: (payload: SubmitPayload) => void;
   onCanSubmitChange?: (canSubmit: boolean) => void;
   /** Called when files are pasted (e.g., images from clipboard) */
-  onFilePaste?: (files: File[]) => void;
+  onFilePaste?: (files: File[], context: FilePasteContext) => void;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -436,7 +441,10 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
 
       // Prevent default paste and handle file upload
       event.preventDefault();
-      onFilePaste(files);
+      onFilePaste(files, {
+        selectionStart: textarea.selectionStart ?? 0,
+        selectionEnd: textarea.selectionEnd ?? 0,
+      });
     };
 
     textarea.addEventListener("paste", handlePaste);

--- a/dashboard/src/lib/text-selection.test.ts
+++ b/dashboard/src/lib/text-selection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { insertTextAtSelection } from "./text-selection";
+
+describe("insertTextAtSelection", () => {
+  it("inserts into an empty value", () => {
+    const result = insertTextAtSelection("", "[Uploaded: ./context/a.png]", {
+      start: 0,
+      end: 0,
+    });
+    expect(result.value).toBe("[Uploaded: ./context/a.png]");
+    expect(result.cursor).toBe(27);
+  });
+
+  it("inserts at cursor in the middle", () => {
+    const result = insertTextAtSelection("hello world", "[Uploaded: file]", {
+      start: 6,
+      end: 6,
+    });
+    expect(result.value).toBe("hello [Uploaded: file]world");
+    expect(result.cursor).toBe(22);
+  });
+
+  it("replaces selected text", () => {
+    const result = insertTextAtSelection(
+      "line one\nline two",
+      "[Uploaded: x]",
+      { start: 5, end: 13 },
+    );
+    expect(result.value).toBe("line [Uploaded: x] two");
+    expect(result.cursor).toBe(18);
+  });
+
+  it("clamps out-of-range selection indices", () => {
+    const result = insertTextAtSelection("abc", "X", { start: -5, end: 99 });
+    expect(result.value).toBe("X");
+    expect(result.cursor).toBe(1);
+  });
+});

--- a/dashboard/src/lib/text-selection.ts
+++ b/dashboard/src/lib/text-selection.ts
@@ -1,0 +1,30 @@
+export type TextSelection = {
+  start: number;
+  end: number;
+};
+
+function clampIndex(value: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > max) return max;
+  return Math.floor(value);
+}
+
+export function insertTextAtSelection(
+  value: string,
+  insertText: string,
+  selection: TextSelection,
+): { value: string; cursor: number } {
+  const safeValue = value ?? "";
+  const safeInsert = insertText ?? "";
+  const max = safeValue.length;
+
+  const start = clampIndex(Math.min(selection.start, selection.end), max);
+  const end = clampIndex(Math.max(selection.start, selection.end), max);
+
+  const nextValue = `${safeValue.slice(0, start)}${safeInsert}${safeValue.slice(end)}`;
+  return {
+    value: nextValue,
+    cursor: start + safeInsert.length,
+  };
+}


### PR DESCRIPTION
## Summary
Fixes dashboard chat paste behavior so image upload tokens are inserted at the current caret/selection instead of always prepending to the draft.

Closes #232.

## Changes
- Capture textarea selection on file paste in `EnhancedInput` and pass it via `onFilePaste` context.
- Add shared `insertTextAtSelection` helper for deterministic selection replacement.
- Use selection-aware insertion for pasted uploads in `control-client`.
- Preserve existing prepend behavior for non-paste file uploads (attach button).
- Add unit tests for insertion semantics and paste-selection propagation.

## Validation
- `cd dashboard && bun run test:unit -- src/lib/text-selection.test.ts src/components/enhanced-input.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 0c7029b3a7bb12859efbadeaf5f8a45d6b0148c2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->