### PR TITLE
Codex: classify capacity exhaustion as terminal reason

### DIFF
--- a/src/agents/types.rs
+++ b/src/agents/types.rs
@@ -143,6 +143,8 @@ pub enum TerminalReason {
     MaxIterations,
     /// Provider rate-limited all retry attempts
     RateLimited,
+    /// Provider rejected turn due to concurrent mission capacity exhaustion
+    CapacityLimited,
 }
 
 /// Errors that can occur in agent operations.

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4713,6 +4713,7 @@ async fn control_actor_loop(
                                                     TerminalReason::InfiniteLoop => "infinite_loop",
                                                     TerminalReason::MaxIterations => "max_iterations",
                                                     TerminalReason::RateLimited => "rate_limited",
+                                                    TerminalReason::CapacityLimited => "capacity_limited",
                                                 });
                                                 if new_status == MissionStatus::Completed
                                                     && mission_has_active_automation(&mission_store, mission_id).await
@@ -4743,6 +4744,7 @@ async fn control_actor_loop(
                                                             Some(TerminalReason::InfiniteLoop) => Some("Detected repetitive behavior".to_string()),
                                                             Some(TerminalReason::LlmError) => Some("Model error".to_string()),
                                                             Some(TerminalReason::RateLimited) => Some("Provider rate limited".to_string()),
+                                                            Some(TerminalReason::CapacityLimited) => Some("Provider capacity limit reached".to_string()),
                                                             None if agent_result.success => None,
                                                             None => Some("Unexpected termination".to_string()),
                                                         };


### PR DESCRIPTION
## Summary
Implements Phase A of #238 by adding a dedicated Codex capacity terminal reason and wiring it through classification + mission status mapping.

## Changes
- Added `TerminalReason::CapacityLimited` in `src/agents/types.rs`.
- Added control-plane mappings in `src/api/control.rs`:
  - persisted reason string: `capacity_limited`
  - mission status summary: `Provider capacity limit reached`
- Added Codex capacity classifier in `src/api/mission_runner.rs`:
  - new `is_capacity_limited_error(...)`
  - Codex failures map to `CapacityLimited` before `RateLimited`
- Updated Codex account rotation to treat both `RateLimited` and `CapacityLimited` as retryable on alternate keys.
- Added unit test coverage for capacity classifier markers.

## Why
Codex concurrent-run failures (e.g. "already have five missions running") were previously classified as generic `LlmError`, so account rotation did not trigger. This patch distinguishes capacity exhaustion and makes current reactive key rotation behavior handle it.

## Validation
- `cargo fmt`
- `cargo test -p sandboxed_sh mission_runner::tests::is_capacity_limited_error_detects_codex_concurrency_markers`
- `cargo test -p sandboxed_sh mission_runner::tests::is_rate_limited_error_detects_markers_case_insensitively`
- `cargo test -p sandboxed_sh control --no-run`

Refs #238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only affects how certain Codex failure strings are classified and retried, plus how the reason is persisted/displayed.
> 
> **Overview**
> Introduces `TerminalReason::CapacityLimited` to distinguish provider concurrency/capacity exhaustion from generic `LlmError` and classic rate limiting.
> 
> Codex turn failures now classify capacity-exhaustion messages via a new `is_capacity_limited_error` (checked before `is_rate_limited_error`), and the OpenAI key-rotation retry logic treats both `RateLimited` and `CapacityLimited` as retryable.
> 
> Control-plane mission auto-completion now persists `capacity_limited` as the terminal reason string and emits a clearer mission status summary (“Provider capacity limit reached”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62c6d8f01a8f116aee84f5330780f5932564bd3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->