### PR TITLE
Filter mission input slash autocomplete by selected backend

### DIFF
--- a/dashboard/src/components/enhanced-input.test.tsx
+++ b/dashboard/src/components/enhanced-input.test.tsx
@@ -1,6 +1,12 @@
-import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  getBuiltinCommands,
+  getVisibleAgents,
+  listLibraryCommands,
+} from "@/lib/api";
 import { EnhancedInput } from "./enhanced-input";
 
 vi.mock("@/lib/api", () => ({
@@ -10,6 +16,15 @@ vi.mock("@/lib/api", () => ({
     .mockResolvedValue({ opencode: [], claudecode: [] }),
   getVisibleAgents: vi.fn().mockResolvedValue([]),
 }));
+
+beforeEach(() => {
+  vi.mocked(listLibraryCommands).mockResolvedValue([]);
+  vi.mocked(getVisibleAgents).mockResolvedValue([]);
+  vi.mocked(getBuiltinCommands).mockResolvedValue({
+    opencode: [],
+    claudecode: [],
+  });
+});
 
 describe("EnhancedInput file paste handling", () => {
   it("passes textarea selection to onFilePaste", async () => {
@@ -51,5 +66,65 @@ describe("EnhancedInput file paste handling", () => {
 
     unmount();
     await Promise.resolve();
+  });
+});
+
+describe("EnhancedInput command autocomplete backend filtering", () => {
+  it("does not show OpenCode or Claude builtins for codex backend", async () => {
+    vi.mocked(getBuiltinCommands).mockResolvedValue({
+      opencode: [{ name: "ralph-loop", description: null, path: "builtin" }],
+      claudecode: [{ name: "plan", description: null, path: "builtin-claude" }],
+    });
+
+    function ControlledInput() {
+      const [value, setValue] = useState("");
+      return (
+        <EnhancedInput
+          value={value}
+          onChange={setValue}
+          onSubmit={() => {}}
+          backend="codex"
+        />
+      );
+    }
+
+    const { container } = render(<ControlledInput />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: "/" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("plan")).not.toBeInTheDocument();
+      expect(screen.queryByText("ralph-loop")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows only Claude builtins for claudecode backend", async () => {
+    vi.mocked(getBuiltinCommands).mockResolvedValue({
+      opencode: [{ name: "ralph-loop", description: null, path: "builtin" }],
+      claudecode: [{ name: "plan", description: null, path: "builtin-claude" }],
+    });
+
+    function ControlledInput() {
+      const [value, setValue] = useState("");
+      return (
+        <EnhancedInput
+          value={value}
+          onChange={setValue}
+          onSubmit={() => {}}
+          backend="claudecode"
+        />
+      );
+    }
+
+    const { container } = render(<ControlledInput />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: "/" } });
+
+    expect(await screen.findByText("plan")).toBeInTheDocument();
+    expect(screen.queryByText("ralph-loop")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -88,21 +88,26 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
       let builtinCommands: CommandSummary[] = [];
       try {
         const builtinResponse = await fetchBuiltinCommands();
-        // Select commands based on backend type
-        if (backend === 'claudecode') {
-          builtinCommands = builtinResponse.claudecode;
-        } else if (backend === 'opencode') {
-          builtinCommands = builtinResponse.opencode;
+        // Select commands based on backend type.
+        // For known backends with no native slash commands (e.g., codex), show none.
+        const builtinByBackend: Record<string, CommandSummary[]> = {
+          claudecode: builtinResponse.claudecode,
+          opencode: builtinResponse.opencode,
+        };
+        if (backend) {
+          builtinCommands = builtinByBackend[backend] ?? [];
         } else {
-          // No backend specified, show both
+          // No backend selected yet, show both known builtin sets.
           builtinCommands = [...builtinResponse.opencode, ...builtinResponse.claudecode];
         }
       } catch {
         // Use fallback commands if API fails
-        if (backend === 'claudecode') {
-          builtinCommands = FALLBACK_CLAUDECODE_COMMANDS;
-        } else if (backend === 'opencode') {
-          builtinCommands = FALLBACK_OPENCODE_COMMANDS;
+        const fallbackByBackend: Record<string, CommandSummary[]> = {
+          claudecode: FALLBACK_CLAUDECODE_COMMANDS,
+          opencode: FALLBACK_OPENCODE_COMMANDS,
+        };
+        if (backend) {
+          builtinCommands = fallbackByBackend[backend] ?? [];
         } else {
           builtinCommands = [...FALLBACK_OPENCODE_COMMANDS, ...FALLBACK_CLAUDECODE_COMMANDS];
         }


### PR DESCRIPTION
## Summary
- stop mixing OpenCode + Claude builtin slash commands when a specific backend is selected
- for unknown/other backends (including `codex`), show no builtin slash command suggestions instead of unrelated ones
- keep existing behavior when no backend is selected yet (show both known builtin sets)
- add regression tests for codex and claudecode filtering in `EnhancedInput`

## Validation
- `bun --cwd dashboard test:unit -- src/components/enhanced-input.test.tsx`
- `bunx eslint src/components/enhanced-input.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit faf4f3a5aa8224791b2ee8c6b1fda942a2c756fc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->