### PR TITLE
Automation UX: prefill inline prompt from selected library command

### DIFF
--- a/dashboard/src/components/mission-automations-dialog.test.tsx
+++ b/dashboard/src/components/mission-automations-dialog.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldPrefillInlinePromptOnSourceSwitch } from "./mission-automations-dialog";
+import {
+  clearInlinePrefillCache,
+  shouldPrefillInlinePromptOnSourceSwitch,
+} from "./mission-automations-dialog";
 
 describe("shouldPrefillInlinePromptOnSourceSwitch", () => {
   it("prefills only for library -> inline when inline prompt is empty", () => {
@@ -25,5 +28,15 @@ describe("shouldPrefillInlinePromptOnSourceSwitch", () => {
     expect(firstSwitch).toBe(true);
     expect(withExistingText).toBe(false);
     expect(afterClearing).toBe(true);
+  });
+
+  it("clears command selection refs on form reset", () => {
+    const commandNameRef = { current: "daily-check" };
+    const libraryCommandContentRef = { current: "Run diagnostics" };
+
+    clearInlinePrefillCache(commandNameRef, libraryCommandContentRef);
+
+    expect(commandNameRef.current).toBe("");
+    expect(libraryCommandContentRef.current).toBe("");
   });
 });

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -130,6 +130,14 @@ export function shouldPrefillInlinePromptOnSourceSwitch(
   );
 }
 
+export function clearInlinePrefillCache(
+  commandNameRef: { current: string },
+  libraryCommandContentRef: { current: string }
+): void {
+  commandNameRef.current = '';
+  libraryCommandContentRef.current = '';
+}
+
 export function MissionAutomationsDialog({
   open,
   missionId,
@@ -530,6 +538,7 @@ export function MissionAutomationsDialog({
       ]);
       // Reset form
       setCommandName('');
+      clearInlinePrefillCache(commandNameRef, libraryCommandContentRef);
       setInlinePromptState('');
       setIntervalValue('5');
       setIntervalUnit('minutes');


### PR DESCRIPTION
## Summary
Implements issue #246 by preserving the selected library command content and using it to prefill inline prompt mode when switching `Library command -> Inline prompt`.

Behavior now:
- If inline prompt is empty, switching from library to inline auto-populates from the selected command content.
- If inline prompt already has text, switch does not overwrite user input.
- Repeated back/forth switching in the same draft keeps this behavior consistent.

## Changes
- `dashboard/src/components/mission-automations-dialog.tsx`
  - Added `shouldPrefillInlinePromptOnSourceSwitch(...)` guard helper.
  - Tracked selected library command content in a ref.
  - Added `handleSourceTypeChange(...)` to perform safe prefill only when appropriate.
  - Wired source `<select>` to new handler.
- `dashboard/src/components/mission-automations-dialog.test.tsx`
  - Added unit coverage for switch behavior, including repeated toggles and non-overwrite case.

## Validation
- `dashboard: bun run test:unit`
- `dashboard: bun run build`
- `cargo test --workspace`

Closes #246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change limited to `MissionAutomationsDialog`, with added guards/refs to avoid overwriting user input or applying stale async command fetches.
> 
> **Overview**
> **Improves automation creation UX** by auto-prefilling the inline prompt when switching `Library command -> Inline prompt`, but only when the inline prompt is empty.
> 
> Adds a small prefill/cache mechanism in `mission-automations-dialog.tsx` (guards, refs, and a dedicated source-switch handler) to safely reuse already-fetched library command content and avoid stale async overwrites, and clears this cache on form reset.
> 
> Introduces unit tests in `mission-automations-dialog.test.tsx` covering the prefill decision logic and cache clearing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9bac4b48a63054a0e2f3bcaa5585107a8bbe1d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->