### PR TITLE
Fix "formerly known as" snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <em>Formerly known as "Open Agent"</em>
+  <em>Formerly known as Open Agent</em>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The "formerly known as" section at the top of README.md uses the current name of the project (sandboxed.sh) but the previous name was "Open Agent".  This change fixes that.

This is a slight assumption on my part but I am pretty sure this is what it should be.