### PR TITLE
Aggregate cost from normalized telemetry shape with legacy fallback

### DIFF
--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -436,7 +436,7 @@ pub trait MissionStore: Send + Sync {
     }
 
     /// Get total cost in cents across all missions.
-    /// Aggregates cost_cents from all assistant_message events.
+    /// Aggregates assistant_message metadata cost across all events.
     async fn get_total_cost_cents(&self) -> Result<u64, String> {
         Ok(0)
     }


### PR DESCRIPTION
## Summary
Small follow-up for #251.

- Updated SQLite aggregate cost query to prefer normalized metadata (`cost.amount_cents`).
- Kept backward compatibility by falling back to legacy `cost_cents` when normalized shape is missing.
- Added a regression test that verifies:
  - normalized and legacy shapes are both counted
  - normalized value wins when both fields exist in the same event

## Why
Recent telemetry work standardized assistant metadata around nested `cost` shape. Aggregate queries should read the same canonical field to reduce contract drift, while preserving support for legacy rows.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D clippy::all`
- `cargo test --workspace`
- `dashboard: bun run test:unit`
- `dashboard: bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to a read-only SQLite aggregate query plus a regression test; minimal risk aside from potential differences in cost totals for previously double-populated metadata.
> 
> **Overview**
> Updates the SQLite implementation of `get_total_cost_cents` to **prefer the normalized telemetry field** `metadata.cost.amount_cents` when summing assistant message costs, while **falling back** to legacy `metadata.cost_cents` for older rows.
> 
> Adjusts the `MissionStore` docstring to match the new aggregation semantics and adds a Tokio integration test that inserts mixed/overlapping metadata shapes to verify legacy rows are counted and the normalized value wins when both are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a0892ff1830cef843c383e9cfa747d7320b1187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->