### PR TITLE
fix: skip agent_finished automation when queue has messages

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5223,11 +5223,12 @@ async fn control_actor_loop(
                     }
 
                     // If the mission is idle now, enqueue any agent_finished automations after a short delay.
+                    // Skip if there are already queued messages (from other missions) to maintain FIFO order.
                     if let Some(mission_id) = completed_mission_id {
                         let already_queued_for_mission = queue
                             .iter()
                             .any(|(_id, _msg, _agent, target_mid)| *target_mid == Some(mission_id));
-                        if !already_queued_for_mission {
+                        if !already_queued_for_mission && queue.is_empty() {
                             // Small delay so the UI can display the completion before restarting.
                             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                             let messages = agent_finished_automation_messages(


### PR DESCRIPTION
## Summary
Fixes issue #271: Queue and automation priority issues - Problem 1

## Problem
When a user manually queues a message while an agent is running, the message is added to the back of the queue. However, when the agent finishes and triggers an "agent_finished" automation, the automation message is added to the front. This means the automation always runs before any manually queued messages.

## Solution
Skip agent_finished automation if there are already queued messages to maintain FIFO order. This matches the existing behavior in parallel runners.

## Changes
- Modified `src/api/control.rs`: Added check to skip agent_finished automation when queue has messages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change to queueing behavior; main risk is unintentionally suppressing some `agent_finished` automations when other missions have backlog.
> 
> **Overview**
> Prevents `agent_finished` automation messages from jumping ahead of user-queued work by only enqueueing them when the global control queue is empty.
> 
> In `src/api/control.rs`, the post-mission completion logic now requires both *no existing messages for that mission* and an *empty queue* before adding `agent_finished` automation messages (after the existing 500ms delay).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 861e1a5f7b7859f1ff7cfd49b093b1fa36f6bee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->