### PR TITLE
fix(dashboard): support text input in agent questions

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -273,6 +273,7 @@ type QuestionInfo = {
   question?: string;
   options?: QuestionOption[];
   multiple?: boolean;
+  inputType?: "text" | "number" | "email" | "url" | "password";
 };
 
 function parseQuestionArgs(args: unknown): QuestionInfo[] {
@@ -282,22 +283,31 @@ function parseQuestionArgs(args: unknown): QuestionInfo[] {
   return raw
     .map((entry) => (isRecord(entry) ? entry : null))
     .filter((entry): entry is Record<string, unknown> => Boolean(entry))
-    .map((entry) => ({
-      header: typeof entry["header"] === "string" ? entry["header"] : undefined,
-      question: typeof entry["question"] === "string" ? entry["question"] : undefined,
-      options: Array.isArray(entry["options"])
-        ? entry["options"]
-            .map((opt) => (isRecord(opt) ? opt : null))
-            .filter((opt): opt is Record<string, unknown> => Boolean(opt))
-            .map((opt) => ({
-              label: String(opt["label"] ?? ""),
-              description:
-                typeof opt["description"] === "string" ? opt["description"] : undefined,
-            }))
-            .filter((opt) => opt.label.length > 0)
-        : [],
-      multiple: Boolean(entry["multiple"] ?? entry["multiSelect"]),
-    }))
+    .map((entry) => {
+      const rawInputType = entry["inputType"] ?? entry["type"];
+      const inputType =
+        typeof rawInputType === "string" &&
+        ["text", "number", "email", "url", "password"].includes(rawInputType)
+          ? (rawInputType as QuestionInfo["inputType"])
+          : undefined;
+      return {
+        header: typeof entry["header"] === "string" ? entry["header"] : undefined,
+        question: typeof entry["question"] === "string" ? entry["question"] : undefined,
+        options: Array.isArray(entry["options"])
+          ? entry["options"]
+              .map((opt) => (isRecord(opt) ? opt : null))
+              .filter((opt): opt is Record<string, unknown> => Boolean(opt))
+              .map((opt) => ({
+                label: String(opt["label"] ?? ""),
+                description:
+                  typeof opt["description"] === "string" ? opt["description"] : undefined,
+              }))
+              .filter((opt) => opt.label.length > 0)
+          : [],
+        multiple: Boolean(entry["multiple"] ?? entry["multiSelect"]),
+        inputType,
+      };
+    })
     .filter((q) => (q.question?.length ?? 0) > 0);
 }
 
@@ -324,8 +334,21 @@ function QuestionToolItem({
 
   const canSubmit = useMemo(() => {
     if (questions.length === 0) return false;
-    return questions.every((_, idx) => (answers[idx] ?? []).length > 0);
-  }, [answers, questions]);
+    return questions.every((q, idx) => {
+      if (q.inputType || (q.options ?? []).length === 0) {
+        return (otherText[idx] ?? "").trim().length > 0;
+      }
+      const selections = answers[idx] ?? [];
+      if (selections.length === 0) return false;
+      const otherLabel = q.options?.find((opt) =>
+        opt.label.toLowerCase().includes("other")
+      )?.label;
+      if (otherLabel && selections.includes(otherLabel)) {
+        return (otherText[idx] ?? "").trim().length > 0;
+      }
+      return true;
+    });
+  }, [answers, questions, otherText]);
 
   const handleToggle = (idx: number, label: string, multiple: boolean) => {
     setAnswers((prev) => {
@@ -351,6 +374,10 @@ function QuestionToolItem({
     setSubmitting(true);
     try {
       const payload = questions.map((q, idx) => {
+        if (q.inputType || (q.options ?? []).length === 0) {
+          const text = otherText[idx]?.trim();
+          return text ? [text] : [];
+        }
         const selections = answers[idx] ?? [];
         if (!selections.length) return [];
         const otherLabel = q.options?.find((opt) =>
@@ -395,6 +422,31 @@ function QuestionToolItem({
                     {q.question}
                   </div>
                   <div className="space-y-2">
+                    {(q.inputType || (q.options ?? []).length === 0) && (
+                      <input
+                        type={q.inputType || "text"}
+                        value={otherText[idx] ?? ""}
+                        onChange={(e) =>
+                          setOtherText((prev) => ({
+                            ...prev,
+                            [idx]: e.target.value,
+                          }))
+                        }
+                        placeholder={
+                          q.inputType === "number"
+                            ? "Enter a number…"
+                            : q.inputType === "email"
+                              ? "Enter email address…"
+                              : q.inputType === "url"
+                                ? "Enter URL…"
+                                : q.inputType === "password"
+                                  ? "Enter value…"
+                                  : "Enter text…"
+                        }
+                        disabled={hasResult || submitting}
+                        className="w-full rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-sm text-white/80 focus:border-indigo-500/40 focus:outline-none"
+                      />
+                    )}
                     {(q.options ?? []).map((opt) => {
                       const checked = selections.has(opt.label);
                       return (


### PR DESCRIPTION
## Summary

Add support for text input types in the agent question tool. Previously, only multiple choice options were supported. Now when a question has `inputType` set (text, number, email, url, password) or has no options, a text input field is shown instead of option buttons.

This fixes issue #273 where users couldn't fill in text answers for questions like "Enter URL manually".

## Changes

- Added `inputType` field to `QuestionInfo` type supporting: text, number, email, url, password
- Updated `parseQuestionArgs` to extract `inputType` from question payload
- Updated UI rendering to show text input when `inputType` is set or when there are no options
- Updated `canSubmit` logic to require text input when inputType is set
- Updated `handleSubmit` to properly send text input as the answer

## Testing

Build succeeded. The change is backward compatible - existing multiple-choice questions continue to work as before.

## Fixes

- Fixes issue #273: bug: agent questions not properly supported

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes localized to question rendering/validation; main risk is subtle payload/validation behavior differences for mixed option vs text questions.
> 
> **Overview**
> Adds support for free-form answers in the dashboard’s agent `question` tool by introducing `QuestionInfo.inputType` (also accepted as `type`) and rendering a typed `<input>` when `inputType` is set or when a question has no options.
> 
> Updates validation and submission so text questions require non-empty input and submit the entered value (while preserving existing multi-select/"Other" option behavior for option-based questions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa336de40ae8843c8f518db4110dc18f386ffdce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->