### PR TITLE
fix: Dont show Agent is working when mission status is not active

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6365,7 +6365,7 @@ export default function ControlClient() {
             <div className="flex h-full items-center justify-center">
               <div className="text-center">
                 <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-500/10">
-                  {viewingMissionIsRunning ? (
+                  {viewingMissionIsRunning && activeMission?.status === "active" ? (
                     <Loader className="h-8 w-8 text-indigo-400 animate-spin" />
                   ) : (
                     <Bot className="h-8 w-8 text-indigo-400" />
@@ -6373,7 +6373,7 @@ export default function ControlClient() {
                 </div>
                 {missionLoading ? (
                   <Shimmer className="max-w-xs mx-auto" />
-                ) : viewingMissionIsRunning ? (
+                ) : viewingMissionIsRunning && activeMission?.status === "active" ? (
                   <>
                     <h2 className="text-lg font-medium text-white">
                       Agent is working...
@@ -6873,6 +6873,7 @@ export default function ControlClient() {
 
               {/* Show streaming indicator when running but no active thinking/phase visible inline */}
               {viewingMissionIsRunning &&
+                activeMission?.status === "active" &&
                 items.length > 0 &&
                 !items.some(
                   (it) =>


### PR DESCRIPTION
## Summary

When a mission has status 'interrupted' (e.g., after server restart or cancellation), the UI was incorrectly showing "Agent is working..." because it only checked the running state without verifying the actual mission status.

This fix adds explicit checks for `activeMission?.status === "active"` before showing the "Agent is working..." indicator, ensuring that interrupted, blocked, failed, or completed missions display the correct status message instead.

## Changes

- Added `activeMission?.status === "active"` check in 3 places in `control-client.tsx`:
  1. Line ~6368: Loader icon condition
  2. Line ~6376: "Agent is working..." text condition
  3. Line ~6875: Streaming indicator condition

## Fixes

- Fixes issue #272: Mission shows 'Agent is working...' despite being completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-logic conditional changes that only affect status messaging/indicators and do not touch data handling or security-critical code.
> 
> **Overview**
> Prevents misleading "Agent is working..." UI states when a mission is running but no longer `active` (e.g., `interrupted`).
> 
> `control-client.tsx` now additionally requires `activeMission?.status === "active"` before showing the loader icon, empty-state working message, and the streaming indicator, so non-active missions show their appropriate status messaging instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f94c93b4b371a3374b5b6fd2df17e5b1a1223776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->