### PR TITLE
fix: Add memory limit to systemd-nspawn to prevent OOM kills

### DIFF
--- a/src/api/console.rs
+++ b/src/api/console.rs
@@ -766,6 +766,9 @@ async fn handle_new_workspace_shell(
             cmd.arg(format!("--machine={}", workspace.name));
             cmd.arg("--quiet");
             cmd.arg("--timezone=off");
+            // Set memory limit to prevent OOM killer issues during npm install, etc.
+            let memory_limit = nspawn::effective_memory_limit();
+            cmd.arg(format!("--memory={}", memory_limit));
             for arg in nspawn::tailscale_nspawn_extra_args(&workspace.env_vars) {
                 cmd.arg(arg);
             }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1038,6 +1038,10 @@ async fn exec_workspace_command(
                 rel_cwd.clone(),
             ];
 
+            // Set memory limit to prevent OOM killer issues during npm install, etc.
+            let memory_limit = crate::nspawn::effective_memory_limit();
+            nspawn_args.push(format!("--memory={}", memory_limit));
+
             // Check network isolation settings
             let use_shared_network = workspace.shared_network.unwrap_or(true);
             let tailscale_mode = workspace.tailscale_mode.unwrap_or(TailscaleMode::ExitNode);

--- a/src/tools/terminal.rs
+++ b/src/tools/terminal.rs
@@ -1114,6 +1114,10 @@ async fn run_container_command(
         rel_str,
     ];
 
+    // Set memory limit to prevent OOM killer issues during npm install, etc.
+    let memory_limit = nspawn::effective_memory_limit();
+    args.push(format!("--memory={}", memory_limit));
+
     // Explicitly set HOME=/root inside the container.
     // The host process may have a different HOME (e.g., /var/lib/opencode for isolated OpenCode),
     // and nspawn inherits environment variables by default. Tools like `shard` use $HOME/.shard

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -18,6 +18,10 @@ use tokio::process::{Child, Command};
 use crate::nspawn;
 use crate::workspace::{use_nspawn_for_workspace, TailscaleMode, Workspace, WorkspaceType};
 
+fn get_container_memory_limit() -> String {
+    nspawn::effective_memory_limit()
+}
+
 fn select_container_resolv_conf() -> Option<PathBuf> {
     let default_path = PathBuf::from("/etc/resolv.conf");
     let content = fs::read_to_string(&default_path).ok()?;
@@ -600,6 +604,10 @@ impl WorkspaceExec {
                 cmd.arg("--console=pipe");
                 cmd.arg("--chdir").arg(&rel_cwd);
 
+                // Set memory limit to prevent OOM killer issues during npm install, etc.
+                let memory_limit = get_container_memory_limit();
+                cmd.arg(format!("--memory={}", memory_limit));
+
                 // Ensure /root/context is available if Open Agent configured it.
                 let context_dir_name = std::env::var("SANDBOXED_SH_CONTEXT_DIR_NAME")
                     .ok()
@@ -910,6 +918,10 @@ impl WorkspaceExec {
                         cmd.arg("--timezone=off");
                         cmd.arg("--chdir");
                         cmd.arg(rel_cwd.clone());
+
+                        // Set memory limit to prevent OOM killer issues during npm install, etc.
+                        let memory_limit = get_container_memory_limit();
+                        cmd.arg(format!("--memory={}", memory_limit));
 
                         // Ensure /root/context is available if Open Agent configured it.
                         let context_dir_name = std::env::var("SANDBOXED_SH_CONTEXT_DIR_NAME")


### PR DESCRIPTION
## Summary

This PR adds memory limit support to systemd-nspawn container invocations to prevent the Linux OOM killer from killing processes during memory-intensive operations like `npm install`.

## Problem

Production deployments were failing with "OpenCode CLI exited with status: signal: 9 (SIGKILL)" because the Linux OOM killer was terminating processes during npm install operations. The "Saved lockfile" message in stderr confirmed the process was running a package manager install.

## Solution

- Add `SANDBOXED_SH_CONTAINER_MEMORY_LIMIT` environment variable support
- Apply `--memory=` limit to all systemd-nspawn invocations
- Default to 8G if not specified (sufficient for npm install)
- Can be customized via env var, or disabled with empty/0

## Files Changed

- `src/nspawn.rs` - Add memory_limit field to NspawnConfig, add helper functions
- `src/workspace_exec.rs` - Add --memory= argument to nspawn commands
- `src/api/console.rs` - Add --memory= argument to nspawn commands  
- `src/api/workspaces.rs` - Add --memory= argument to nspawn commands
- `src/tools/terminal.rs` - Add --memory= argument to nspawn commands

## Usage

```bash
# Default 8GB limit (recommended - sufficient for npm install)
# No action needed - this is the default

# Use a custom limit if needed
export SANDBOXED_SH_CONTAINER_MEMORY_LIMIT=16G

# Disable memory limit entirely (use host defaults)
export SANDBOXED_SH_CONTAINER_MEMORY_LIMIT=0
```

## Related Issues

Fixes #267