### PR TITLE
Add harness contract tests to CI (issue #230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
           # - Thinking/reasoning content must never appear in final assistant message
           # - Tool calls and results are properly correlated
           # - Error handling is consistent across harnesses
-          cargo test --package sandboxed-sh --lib -- backend::codex:: --nocapture
-          cargo test --package sandboxed-sh --lib -- backend::shared:: --nocapture
+          cargo test --package sandboxed_sh --lib -- backend::codex:: --nocapture
+          cargo test --package sandboxed_sh --lib -- backend::shared:: --nocapture
 
   dashboard-test:
     name: Dashboard Unit Tests


### PR DESCRIPTION
## Summary

Adds a new CI job that runs backend adapter tests to validate the harness event contract. This addresses acceptance criteria from issue #230: "CI includes harness-contract jobs".

## Changes

- Added `harness-contract` job to `.github/workflows/ci.yml`
- Runs backend tests for `codex` and `shared` modules
- These tests verify cross-harness invariants:
  - Thinking/reasoning content must never appear in final assistant message
  - Tool calls and results are properly correlated
  - Error handling is consistent across harnesses

## Why this matters

The issue #230 highlights that harness-specific protocol differences can silently break mission behavior. Having dedicated CI tests for harness contracts helps catch regressions early.

## Acceptance criteria addressed

- [x] CI includes harness-contract jobs

## Testing

The existing tests in `backend/codex/mod.rs` already validate:
- `extract_text_field_from_content_array_skips_reasoning_blocks` - ensures thinking doesn't leak
- Various event conversion tests

This CI job ensures these tests run on every PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes that increase coverage; main risk is longer runtimes or occasional flakiness causing CI failures.
> 
> **Overview**
> Adds a new `harness-contract` job to the GitHub Actions CI workflow to run targeted Rust tests that validate the harness event contract.
> 
> The job installs the Rust toolchain, caches Cargo artifacts with a separate key, and executes `cargo test` for the `sandboxed_sh` backend `codex` and `shared` adapter modules with `--nocapture` on PRs, pushes, and scheduled runs (skipping draft PRs like other jobs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d1b5b6a837eb35d9fc895da75b505329feda51e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->