### PR TITLE
fix: correct cross-harness invariant tests and fix build errors

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1436,7 +1436,7 @@ export async function renameWorkspaceTemplate(oldName: string, newName: string):
     shared_network: template.shared_network,
     tailscale_mode: template.tailscale_mode,
     config_profile: template.config_profile,
-    container_memory_limit: template.container_memory_limit,
+    container_memory_limit: template.container_memory_limit ?? undefined,
   });
   // Delete old template
   await deleteWorkspaceTemplate(oldName);

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -1064,4 +1064,105 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert!(results.is_empty());
     }
+
+    #[test]
+    fn text_delta_does_not_contain_thinking_content() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "stream_event",
+            "session_id": "s1",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "content_block_delta",
+                    "text": "Hello world"
+                }
+            }
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExecutionEvent::TextDelta { content } => {
+                assert_eq!(content, "Hello world");
+            }
+            ExecutionEvent::Thinking { .. } => {
+                panic!("Thinking content should not appear in TextDelta event");
+            }
+            other => panic!("Expected TextDelta, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn thinking_produces_thinking_event() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "stream_event",
+            "session_id": "s1",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "thinking_delta",
+                    "thinking": "Let me think about this..."
+                }
+            }
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExecutionEvent::Thinking { content } => {
+                assert_eq!(content, "Let me think about this...");
+            }
+            ExecutionEvent::TextDelta { .. } => {
+                panic!("Thinking content should produce Thinking event, not TextDelta");
+            }
+            other => panic!("Expected Thinking, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn tool_call_stored_for_result_correlation() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "stream_event",
+            "session_id": "s1",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "tool_123",
+                    "name": "Bash"
+                }
+            }
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert!(results.is_empty());
+        assert_eq!(pending.get("tool_123"), Some(&"Bash".to_string()));
+    }
+
+    #[test]
+    fn error_result_preserves_message() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "result",
+            "subtype": "error",
+            "session_id": "s1",
+            "is_error": true,
+            "error": "Rate limit exceeded"
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExecutionEvent::Error { message } => {
+                assert_eq!(message, "Rate limit exceeded");
+            }
+            other => panic!("Expected Error, got {:?}", other),
+        }
+    }
 }

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -21,7 +21,6 @@ use crate::workspace::{use_nspawn_for_workspace, TailscaleMode, Workspace, Works
 fn get_container_memory_limit(workspace: &crate::workspace::Workspace) -> String {
     nspawn::effective_memory_limit(workspace.container_memory_limit.as_deref())
 }
-}
 
 fn select_container_resolv_conf() -> Option<PathBuf> {
     let default_path = PathBuf::from("/etc/resolv.conf");


### PR DESCRIPTION
## Summary

This PR fixes several issues:

### 1. Build Error Fixes
- **workspace_exec.rs**: Removed extra closing brace that was causing compilation failure
- **api.ts**: Fixed TypeScript error where `container_memory_limit` could be `null` but type expected `string | undefined`

### 2. Cross-harness Invariant Tests

Fixed the tests that were using incorrect event types. The tests now use the correct event structure (`type: "stream_event"` with nested `event: {...}`):

- **text_delta_does_not_contain_thinking_content**: Verifies text_delta events contain plain text, not thinking content
- **thinking_produces_thinking_event**: Verifies thinking content produces Thinking events
- **tool_call_stored_for_result_correlation**: Verifies tool calls are tracked for result correlation
- **error_result_preserves_message**: Verifies error messages are preserved in Result events

## Acceptance Criteria Addressed

- [x] Cross-harness invariants in tests (thinking content filtering, tool call correlation, error handling consistency)

This addresses issue #230's acceptance criteria for cross-harness invariant tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily build fixes and additional unit coverage; functional behavior changes are limited to normalizing a nullable field in a dashboard API payload.
> 
> **Overview**
> Fixes a dashboard type mismatch by ensuring `container_memory_limit` is omitted (set to `undefined`) when the workspace template field is `null`, avoiding invalid payloads during `renameWorkspaceTemplate`.
> 
> Resolves a Rust build failure in `workspace_exec.rs` by removing an extra closing brace.
> 
> Adds cross-harness invariant tests in `src/backend/shared.rs` to validate `convert_cli_event` correctly separates text vs thinking deltas, tracks tool calls for correlating results, and preserves error messages in result events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d658fe4f83ad18829f83a4fb443043c1e4f4df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->