### PR TITLE
test: add cross-harness invariant tests for CLI event conversion

### DIFF
--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -1064,4 +1064,105 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert!(results.is_empty());
     }
+
+    #[test]
+    fn text_delta_does_not_contain_thinking_content() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "stream_event",
+            "session_id": "s1",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "content_block_delta",
+                    "text": "Hello world"
+                }
+            }
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExecutionEvent::TextDelta { content } => {
+                assert_eq!(content, "Hello world");
+            }
+            ExecutionEvent::Thinking { .. } => {
+                panic!("Thinking content should not appear in TextDelta event");
+            }
+            other => panic!("Expected TextDelta, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn thinking_produces_thinking_event() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "stream_event",
+            "session_id": "s1",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "thinking_delta",
+                    "thinking": "Let me think about this..."
+                }
+            }
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExecutionEvent::Thinking { content } => {
+                assert_eq!(content, "Let me think about this...");
+            }
+            ExecutionEvent::TextDelta { .. } => {
+                panic!("Thinking content should produce Thinking event, not TextDelta");
+            }
+            other => panic!("Expected Thinking, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn tool_call_stored_for_result_correlation() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "stream_event",
+            "session_id": "s1",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "tool_123",
+                    "name": "Bash"
+                }
+            }
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert!(results.is_empty());
+        assert_eq!(pending.get("tool_123"), Some(&"Bash".to_string()));
+    }
+
+    #[test]
+    fn error_result_preserves_message() {
+        let event: CliEvent = serde_json::from_value(json!({
+            "type": "result",
+            "subtype": "error",
+            "session_id": "s1",
+            "is_error": true,
+            "error": "Rate limit exceeded"
+        }))
+        .unwrap();
+        let mut pending = HashMap::new();
+        let results = convert_cli_event(event, &mut pending);
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExecutionEvent::Error { message } => {
+                assert_eq!(message, "Rate limit exceeded");
+            }
+            other => panic!("Expected Error, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds unit tests that verify cross-harness invariants for CLI event processing in the backend.

## Problem

The existing tests don't cover important cross-harness invariants:
- Text content should produce TextDelta events, not Thinking events
- Thinking content should produce Thinking events
- Tool use IDs should be stored for result correlation
- Error results should preserve the error message

## Solution

Add 4 new unit tests in src/backend/shared.rs:
1. text_delta_does_not_contain_thinking_content - Verifies text deltas produce TextDelta events
2. thinking_produces_thinking_event - Verifies thinking deltas produce Thinking events
3. tool_call_stored_for_result_correlation - Verifies tool use IDs are stored
4. error_result_preserves_message - Verifies error results produce Error events

## Acceptance Criteria

- [x] Cross-harness invariant tests in CI (issue #230)
- [x] Tests pass on all CI jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that don’t affect runtime behavior; risk is limited to potential brittleness if upstream CLI event shapes change.
> 
> **Overview**
> Adds **four new unit tests** around `convert_cli_event` to enforce cross-harness invariants: text deltas must emit only `ExecutionEvent::TextDelta`, thinking deltas must emit `ExecutionEvent::Thinking`, `tool_use` block starts must be recorded in `pending_tools` for later correlation, and error `result` events must preserve the CLI-provided error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9cee8809cea0cb5df48251514d6992af09acc03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->