### PR TITLE
fix(settings): stabilize RTK toggle state and persistence

### DIFF
--- a/dashboard/src/app/settings/data/page.test.tsx
+++ b/dashboard/src/app/settings/data/page.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+
+import DataSettingsPage from './page';
+import { getSettings, updateRtkEnabled } from '@/lib/api';
+
+vi.mock('@/components/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  getSettings: vi.fn(),
+  updateLibraryRemote: vi.fn(),
+  updateSettings: vi.fn(),
+  downloadBackup: vi.fn(),
+  restoreBackup: vi.fn(),
+  updateRtkEnabled: vi.fn(),
+}));
+
+const mockedGetSettings = vi.mocked(getSettings);
+const mockedUpdateRtkEnabled = vi.mocked(updateRtkEnabled);
+
+function renderPage() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <DataSettingsPage />
+    </SWRConfig>
+  );
+}
+
+describe('DataSettingsPage RTK toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetSettings.mockResolvedValue({
+      library_remote: null,
+      sandboxed_repo_path: null,
+      rtk_enabled: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('optimistically updates toggle state and persists on success', async () => {
+    mockedUpdateRtkEnabled.mockResolvedValue({ rtk_enabled: true, previous_value: false });
+    renderPage();
+
+    const toggle = await screen.findByRole('button', { name: 'Toggle RTK compression' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(mockedUpdateRtkEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('rolls back toggle state when API update fails', async () => {
+    mockedUpdateRtkEnabled.mockRejectedValue(new Error('network failed'));
+    renderPage();
+
+    const toggle = await screen.findByRole('button', { name: 'Toggle RTK compression' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(mockedUpdateRtkEnabled).toHaveBeenCalledWith(true);
+    });
+
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Make the RTK toggle in Settings update optimistically so users see immediate visual feedback.
- Roll back toggle state automatically when the API request fails.
- Add an accessibility label/pressed state to the switch.
- Add unit tests for success and rollback behavior.

## Problem
Issue #304 reported that the RTK token-savings toggle looked buggy (incorrect or non-persistent visual state).

Previously, the page waited for a refetch after `updateRtkEnabled`, which could leave the toggle temporarily stale and feel unreliable.

## Solution
- Switched `handleToggleRtk` to use SWR `mutate` with:
  - `optimisticData`
  - `rollbackOnError`
  - `revalidate: true`
- Added `aria-label` and `aria-pressed` so the switch has explicit semantics.
- Added tests in `dashboard/src/app/settings/data/page.test.tsx` to verify:
  - optimistic update on success
  - rollback on failed update

Fixes #304

## Validation
- `bun run test:unit -- src/app/settings/data/page.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/state-management change with added tests; main risk is subtle SWR mutate behavior/regressions in the settings page toggle state.
> 
> **Overview**
> Makes the RTK compression toggle in `DataSettingsPage` update **optimistically** via SWR `mutate` and automatically **roll back on API failure**, while still revalidating with the server.
> 
> Improves toggle accessibility by adding `type="button"`, `aria-label`, and `aria-pressed`, and adds Vitest coverage to assert optimistic UI update on success and rollback behavior on error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04b76130e5194e380ff6891dbac6d93146b52ac8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->