### PR TITLE
Add harness-contract CI gate and OpenCode SSE parser regressions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,31 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  harness-contract:
+    name: Harness Contract Tests
+    runs-on: ubuntu-latest
+    # Skip CI on draft PRs unless explicitly requested
+    if: github.event.pull_request.draft == false || github.event_name == 'push' || github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run harness contract tests
+        run: scripts/harness_contract_tests.sh
+
   capability-matrix:
     name: Capability Matrix Contract Check
     runs-on: ubuntu-latest

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,10 @@ Runs:
 
 Use `--help` for all options, including backend-specific model overrides and expected model assertions.
 
+### harness_contract_tests.sh
+Runs a curated set of fast cross-harness contract tests that guard event-conversion invariants and OpenCode SSE parsing behavior.
+Used by CI job `harness-contract`.
+
 ### proxy_smoke.py
 Smoke test for the OpenAI-compatible proxy routes:
 - `GET /v1/models`

--- a/scripts/harness_contract_tests.sh
+++ b/scripts/harness_contract_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "== Harness contract tests: shared CLI invariants =="
+cargo test --workspace text_delta_does_not_contain_thinking_content
+cargo test --workspace thinking_produces_thinking_event
+cargo test --workspace tool_call_stored_for_result_correlation
+cargo test --workspace error_result_preserves_message
+
+echo "== Harness contract tests: OpenCode SSE parser invariants =="
+cargo test --workspace opencode_sse_
+
+echo "== Harness contract tests: harness event parser baselines =="
+cargo test --workspace test_parse_stream_event_delta
+cargo test --workspace test_parse_assistant_event
+cargo test --workspace test_parse_result_event
+
+echo "Harness contract tests passed."


### PR DESCRIPTION
## Summary
This PR restores and strengthens cross-harness regression protection by:

- adding a dedicated `harness-contract` CI job in `.github/workflows/ci.yml`
- adding `scripts/harness_contract_tests.sh` as a curated, fast contract test entrypoint
- adding focused OpenCode SSE parser unit tests in `src/opencode/mod.rs`

## Why
Issue #230 tracks reliability hardening work and calls out contract tests/replay-style regression protection. In the current branch state, CI had no dedicated `harness-contract` job despite prior progress updates.

This change makes those invariants explicit and continuously enforced.

## Details
### CI gate
- New `harness-contract` job in CI workflow.
- Runs on push/PR/schedule with the same draft-skip logic as other jobs.
- Executes `scripts/harness_contract_tests.sh`.

### Contract test script
- Adds a scripted set of targeted checks for:
  - shared cross-harness conversion invariants (`backend/shared`)
  - OpenCode SSE parser invariants (`opencode_sse_*` tests)
  - harness parser baselines for Claude/Amp clients

### New OpenCode SSE tests
Added parser regression tests for:
- text delta accumulation by response id
- empty delta suppression
- session ID mismatch filtering
- `response.incomplete` producing `MessageComplete`
- function-call arg delta assembly + single ToolCall emission
- event-name fallback when payload omits `type`

## Validation
Executed locally:

```bash
scripts/harness_contract_tests.sh
```

All targeted tests passed.

Closes #230

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI/workflow and test-only additions; no production runtime behavior changes, with minimal risk beyond potential CI flakiness if tests are brittle.
> 
> **Overview**
> Adds a dedicated `harness-contract` CI job that runs on non-draft PRs/push/schedule and executes a new `scripts/harness_contract_tests.sh` entrypoint with cargo caching.
> 
> Introduces `scripts/harness_contract_tests.sh` and updates `scripts/README.md` to document it; the script runs a curated subset of existing cross-harness contract tests plus newly added OpenCode SSE parser invariants.
> 
> Extends `src/opencode/mod.rs` with unit tests covering SSE parsing regressions (text delta accumulation, empty delta suppression, session ID filtering, `response.incomplete` completion, tool call arg assembly/dedup, and event-name fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2818fbd040403dd32e05c14049422991d5c796c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->