### PR TITLE
fix(opencode): avoid global leak of workspace binary hint

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2121,7 +2121,6 @@ fn resolve_opencode_runner_setting(workspace: &Workspace) -> Option<String> {
 fn resolve_opencode_binary_hint(workspace: &Workspace) -> Option<String> {
     workspace_env_setting(workspace, "SANDBOXED_SH_OPENCODE_BINARY_PATH")
         .or_else(|| workspace_env_setting(workspace, "OPENCODE_BINARY_PATH"))
-        .or_else(|| std::env::var("SANDBOXED_SH_OPENCODE_BINARY_PATH").ok())
         .or_else(|| std::env::var("OPENCODE_BINARY_PATH").ok())
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())


### PR DESCRIPTION
## Summary
Follow-up fix to PR #312.

`resolve_opencode_binary_hint` was reading `SANDBOXED_SH_OPENCODE_BINARY_PATH` from process env, which leaked a workspace-scoped setting globally across all workspaces.

This patch removes that process-level fallback and keeps `SANDBOXED_SH_` handling workspace-only.

## Why this matters
With the previous behavior, a stale backend process env value could force every workspace into a bogus custom binary path, disabling auto-install and producing persistent "not found at configured path" errors.

## Changes
- Remove `std::env::var("SANDBOXED_SH_OPENCODE_BINARY_PATH")` fallback from `resolve_opencode_binary_hint`.

## Validation
- `cargo test resolve_opencode_ -- --nocapture`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to config resolution order; low risk aside from potential behavior change for deployments relying on the removed process env fallback.
> 
> **Overview**
> Fixes `resolve_opencode_binary_hint` to **only** read `SANDBOXED_SH_OPENCODE_BINARY_PATH` from `workspace.env_vars`, removing the fallback to `std::env::var`.
> 
> This prevents a backend process environment variable from globally overriding per-workspace OpenCode binary hints and causing persistent misconfiguration across workspaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54d024fa3a001294e9542e41ab1fd9e86d009f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->