### PR TITLE
Fix automation stop policy: track actual agent outcome

### DIFF
--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -527,6 +527,18 @@ pub trait MissionStore: Send + Sync {
         let _ = (mission_id, limit);
         Ok(vec![])
     }
+
+    /// Complete all running automation executions for a mission, setting them
+    /// to either Success or Failed based on the agent outcome.
+    async fn complete_running_executions_for_mission(
+        &self,
+        mission_id: Uuid,
+        success: bool,
+        error: Option<String>,
+    ) -> Result<u32, String> {
+        let _ = (mission_id, success, error);
+        Ok(0)
+    }
 }
 
 /// Mission store type selection.


### PR DESCRIPTION
## Summary

- Fixes automation executions being marked as `Success` when the message was merely queued, not when the agent actually finished. This caused the "stop after N consecutive failures" policy to never trigger.
- Adds `complete_running_executions_for_mission()` to the `MissionStore` trait and SQLite implementation to update running executions based on actual agent outcomes.
- All trigger types (interval, webhook, agent_finished, start_immediately) now keep executions in `Running` status until the agent completes, then set `Success` or `Failed` based on `AgentResult`.

Fixes #324

## Test plan

- [ ] Deploy to dev backend and create an automation with "stop after 2 consecutive failures" policy
- [ ] Trigger the automation with a failing model request (e.g., rate-limited endpoint)
- [ ] Verify execution records show `Failed` status instead of `Success`
- [ ] Verify the automation is automatically disabled after the configured number of consecutive failures
- [ ] Verify successful executions still record `Success` status correctly

**Deployed to dev backend**: https://agent-backend-dev.thomas.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution status semantics and adds a bulk UPDATE affecting persisted automation execution records; misclassification could impact stop-policy behavior and UI history accuracy.
> 
> **Overview**
> Automation execution tracking is changed to **stop marking executions as `Success` when a message is merely queued**; executions now remain `Running` (with `completed_at` unset) until the agent finishes.
> 
> Adds `MissionStore::complete_running_executions_for_mission()` with a SQLite implementation that bulk-updates `running`/`pending` executions for a mission to `success` or `failed` (including `completed_at` and optional error), and wires this up in `control.rs` for both normal completion and join-error paths. Queue-send success paths now only update `retry_count`/`last_triggered_at`, while immediate send failures still mark the execution `Failed` right away.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bca5ff03c0e7ff7e7779b3d36288cc05e2e99f96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->