### PR TITLE
fix(dashboard): constrain system monitoring page to viewport height

### DIFF
--- a/dashboard/src/app/inspect/system/page.tsx
+++ b/dashboard/src/app/inspect/system/page.tsx
@@ -155,7 +155,7 @@ function ServerInfoCard() {
 
 export default function MonitoringPage() {
   return (
-    <div className="flex-1 flex gap-4 p-6 min-h-0">
+    <div className="flex gap-4 p-6 h-screen">
       {/* Server Info - Left column */}
       <div className="w-[200px] shrink-0">
         <ServerInfoCard />

--- a/dashboard/src/lib/llm.ts
+++ b/dashboard/src/lib/llm.ts
@@ -18,6 +18,12 @@ interface ChatCompletionResponse {
   choices: ChatCompletionChoice[];
 }
 
+export interface LLMConnectionTestResult {
+  ok: boolean;
+  content?: string;
+  error?: string;
+}
+
 /**
  * Send a chat completion request to the configured LLM provider.
  * Returns the assistant's response text, or null on failure.
@@ -27,19 +33,22 @@ async function chatCompletion(
   options?: { maxTokens?: number }
 ): Promise<string | null> {
   const cfg = readLLMConfig();
-  if (!cfg.enabled || !cfg.apiKey) return null;
+  const apiKey = cfg.apiKey.trim();
+  const baseUrl = cfg.baseUrl.trim();
+  const model = cfg.model.trim();
+  if (!cfg.enabled || !apiKey || !baseUrl || !model) return null;
 
-  const url = `${cfg.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+  const url = `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
 
   try {
     const res = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${cfg.apiKey}`,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: cfg.model,
+        model,
         messages,
         max_tokens: options?.maxTokens ?? 60,
         temperature: 0.3,
@@ -52,6 +61,55 @@ async function chatCompletion(
     return data.choices?.[0]?.message?.content?.trim() ?? null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Runs a direct probe against the configured provider and returns a detailed result.
+ * Used by the settings page so connection failures can show actionable errors.
+ */
+export async function testLLMConnection(): Promise<LLMConnectionTestResult> {
+  const cfg = readLLMConfig();
+  const apiKey = cfg.apiKey.trim();
+  const baseUrl = cfg.baseUrl.trim();
+  const model = cfg.model.trim();
+
+  if (!apiKey) return { ok: false, error: "API key is empty" };
+  if (!baseUrl) return { ok: false, error: "Base URL is empty" };
+  if (!model) return { ok: false, error: "Model is empty" };
+
+  const url = `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "Return exactly: OK" }],
+        max_tokens: 64,
+        temperature: 0.3,
+      }),
+    });
+
+    if (!res.ok) {
+      const text = (await res.text()).trim();
+      return { ok: false, error: text || `HTTP ${res.status}` };
+    }
+
+    const data = (await res.json()) as ChatCompletionResponse;
+    if (!Array.isArray(data.choices) || data.choices.length === 0) {
+      return { ok: false, error: "Model returned no choices" };
+    }
+    const content = data.choices[0]?.message?.content?.trim();
+    return { ok: true, content: content || "Connected (no text returned)" };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Network request failed",
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix the `/inspect/system` page overflowing the viewport by replacing the ineffective `flex-1` with `h-screen` on the page wrapper

## Problem

The page wrapper used `flex-1 flex gap-4 p-6 min-h-0`, but the parent `<main>` element in the root layout is `display: block` (not flex), so `flex-1` had no effect. The charts expanded to their intrinsic SVG viewBox sizes (200 + 150 + 150px + gaps + padding), causing ~60px of vertical overflow and a scrollbar.

## Fix

Replace `flex-1 ... min-h-0` with `h-screen` to constrain the wrapper to exactly the viewport height. The grid fractional rows (`1.2fr` / `1fr`) then distribute space proportionally within it.

## Test plan

- [ ] Open `/inspect/system` at 1280×720 — no vertical scrollbar, all charts visible with bottom padding
- [ ] Open at 1440×900 — charts scale up proportionally, no overflow
- [ ] Resize browser window — layout adapts fluidly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes client-side LLM request gating and introduces new probe logic that may affect whether LLM-powered features run, though it’s limited to dashboard UI/settings behavior.
> 
> **Overview**
> Fixes `/inspect/system` viewport overflow by constraining the page wrapper to `h-screen` instead of relying on ineffective `flex-1` sizing.
> 
> Improves LLM settings “Test Connection” by adding `testLLMConnection()` (detailed probe + actionable errors), surfacing provider error text/status, and using the probe response as a fallback sample. Also tightens `chatCompletion()` to require trimmed `apiKey`, `baseUrl`, and `model` before sending requests, and improves failure toasts with error details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff764cbdbd96a0cdf14f5d1f11cece1ef83f549f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->