### PR TITLE
Fix false 'Completed' status for intermediate assistant turns

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -7108,7 +7108,7 @@ export default function ControlClient() {
                               item.success ? "text-emerald-400" : "text-red-400"
                             )}
                           />
-                          <span>{item.success ? "Completed" : "Failed"}</span>
+                          <span>{item.success ? "Turn complete" : "Failed"}</span>
                           {displayModel && (
                             <>
                               <span>•</span>

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -724,7 +724,7 @@ impl Agent for OpenCodeAgent {
                 "agent": "OpenCodeAgent",
                 "session_id": session.id,
             })),
-            terminal_reason: Some(TerminalReason::Completed),
+            terminal_reason: Some(TerminalReason::TurnComplete),
         }
     }
 }
@@ -811,7 +811,7 @@ impl OpenCodeAgent {
                 "agent": "OpenCodeAgent",
                 "session_id": session_id,
             })),
-            terminal_reason: Some(TerminalReason::Completed),
+            terminal_reason: Some(TerminalReason::TurnComplete),
         }
     }
 }

--- a/src/agents/types.rs
+++ b/src/agents/types.rs
@@ -160,6 +160,8 @@ impl AgentResult {
 /// Reason why agent execution terminated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TerminalReason {
+    /// A single assistant turn ended successfully, but mission may continue
+    TurnComplete,
     /// Task completed successfully
     Completed,
     /// Task was cancelled by user

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6903,69 +6903,86 @@ async fn control_actor_loop(
                                             // Auto-complete if mission is Active OR Interrupted (resumed missions may
                                             // still have Interrupted status if the status update event was not persisted)
                                             if matches!(mission.status, MissionStatus::Active | MissionStatus::Interrupted) {
-                                                let new_status = match agent_result.terminal_reason {
-                                                    Some(TerminalReason::Completed) => MissionStatus::Completed,
-                                                    Some(TerminalReason::Cancelled) => MissionStatus::Interrupted,
-                                                    Some(TerminalReason::MaxIterations) => MissionStatus::Blocked,
-                                                    _ if agent_result.success => MissionStatus::Completed,
-                                                    _ => MissionStatus::Failed,
-                                                };
-                                                // Convert terminal_reason to string for storage
-                                                let terminal_reason_str = agent_result.terminal_reason.map(|r| match r {
-                                                    TerminalReason::Completed => "completed",
-                                                    TerminalReason::Cancelled => "cancelled",
-                                                    TerminalReason::LlmError => "llm_error",
-                                                    TerminalReason::Stalled => "stalled",
-                                                    TerminalReason::InfiniteLoop => "infinite_loop",
-                                                    TerminalReason::MaxIterations => "max_iterations",
-                                                    TerminalReason::RateLimited => "rate_limited",
-                                                    TerminalReason::CapacityLimited => "capacity_limited",
+                                                let status_and_reason = agent_result.terminal_reason.and_then(|reason| {
+                                                    match reason {
+                                                        TerminalReason::TurnComplete => None,
+                                                        TerminalReason::Completed => {
+                                                            Some((reason, MissionStatus::Completed, "completed"))
+                                                        }
+                                                        TerminalReason::Cancelled => {
+                                                            Some((reason, MissionStatus::Interrupted, "cancelled"))
+                                                        }
+                                                        TerminalReason::MaxIterations => {
+                                                            Some((reason, MissionStatus::Blocked, "max_iterations"))
+                                                        }
+                                                        TerminalReason::LlmError => {
+                                                            Some((reason, MissionStatus::Failed, "llm_error"))
+                                                        }
+                                                        TerminalReason::Stalled => {
+                                                            Some((reason, MissionStatus::Failed, "stalled"))
+                                                        }
+                                                        TerminalReason::InfiniteLoop => {
+                                                            Some((reason, MissionStatus::Failed, "infinite_loop"))
+                                                        }
+                                                        TerminalReason::RateLimited => {
+                                                            Some((reason, MissionStatus::Failed, "rate_limited"))
+                                                        }
+                                                        TerminalReason::CapacityLimited => {
+                                                            Some((reason, MissionStatus::Failed, "capacity_limited"))
+                                                        }
+                                                    }
                                                 });
-                                                if new_status == MissionStatus::Completed
-                                                    && mission_has_active_automation(&mission_store, mission_id).await
-                                                {
-                                                    tracing::info!(
-                                                        "Skipping auto-complete for mission {} because active automations are enabled",
+                                                if let Some((reason, new_status, terminal_reason_str)) = status_and_reason {
+                                                    if new_status == MissionStatus::Completed
+                                                        && mission_has_active_automation(&mission_store, mission_id).await
+                                                    {
+                                                        tracing::info!(
+                                                            "Skipping auto-complete for mission {} because active automations are enabled",
+                                                            mission_id
+                                                        );
+                                                    } else {
+                                                        tracing::info!(
+                                                            "Auto-completing mission {} with status '{:?}' (terminal_reason: {:?})",
+                                                            mission_id, new_status, agent_result.terminal_reason
+                                                        );
+                                                        if let Err(e) = mission_store
+                                                            .update_mission_status_with_reason(mission_id, new_status, Some(terminal_reason_str))
+                                                            .await
+                                                        {
+                                                            tracing::warn!("Failed to auto-complete mission: {}", e);
+                                                        } else {
+                                                            maybe_schedule_mission_metadata_refresh_for_status(
+                                                                &mission_store,
+                                                                &events_tx,
+                                                                mission_id,
+                                                                new_status,
+                                                            );
+                                                            // Send status change event - the actual completion content
+                                                            // is already in the assistant_message event, so we just provide
+                                                            // a clean summary based on how the mission ended
+                                                            let summary = match reason {
+                                                                TerminalReason::TurnComplete => None,
+                                                                TerminalReason::Completed => None,
+                                                                TerminalReason::MaxIterations => Some("Reached iteration limit".to_string()),
+                                                                TerminalReason::Cancelled => Some("Cancelled by user".to_string()),
+                                                                TerminalReason::Stalled => Some("No progress detected".to_string()),
+                                                                TerminalReason::InfiniteLoop => Some("Detected repetitive behavior".to_string()),
+                                                                TerminalReason::LlmError => Some("Model error".to_string()),
+                                                                TerminalReason::RateLimited => Some("Provider rate limited".to_string()),
+                                                                TerminalReason::CapacityLimited => Some("Provider capacity limit reached".to_string()),
+                                                            };
+                                                            let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                                                mission_id,
+                                                                status: new_status,
+                                                                summary,
+                                                            });
+                                                        }
+                                                    }
+                                                } else {
+                                                    tracing::debug!(
+                                                        "Skipping auto-complete for mission {}: turn ended but mission is not explicitly completed",
                                                         mission_id
                                                     );
-                                                } else {
-                                                    tracing::info!(
-                                                        "Auto-completing mission {} with status '{:?}' (terminal_reason: {:?})",
-                                                        mission_id, new_status, agent_result.terminal_reason
-                                                    );
-                                                    if let Err(e) = mission_store
-                                                        .update_mission_status_with_reason(mission_id, new_status, terminal_reason_str)
-                                                        .await
-                                                    {
-                                                        tracing::warn!("Failed to auto-complete mission: {}", e);
-                                                    } else {
-                                                        maybe_schedule_mission_metadata_refresh_for_status(
-                                                            &mission_store,
-                                                            &events_tx,
-                                                            mission_id,
-                                                            new_status,
-                                                        );
-                                                        // Send status change event - the actual completion content
-                                                        // is already in the assistant_message event, so we just provide
-                                                        // a clean summary based on how the mission ended
-                                                        let summary = match agent_result.terminal_reason {
-                                                            Some(TerminalReason::Completed) => None, // Normal completion, no extra explanation needed
-                                                            Some(TerminalReason::MaxIterations) => Some("Reached iteration limit".to_string()),
-                                                            Some(TerminalReason::Cancelled) => Some("Cancelled by user".to_string()),
-                                                            Some(TerminalReason::Stalled) => Some("No progress detected".to_string()),
-                                                            Some(TerminalReason::InfiniteLoop) => Some("Detected repetitive behavior".to_string()),
-                                                            Some(TerminalReason::LlmError) => Some("Model error".to_string()),
-                                                            Some(TerminalReason::RateLimited) => Some("Provider rate limited".to_string()),
-                                                            Some(TerminalReason::CapacityLimited) => Some("Provider capacity limit reached".to_string()),
-                                                            None if agent_result.success => None,
-                                                            None => Some("Unexpected termination".to_string()),
-                                                        };
-                                                        let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                            mission_id,
-                                                            status: new_status,
-                                                            summary,
-                                                        });
-                                                    }
                                                 }
                                             } else {
                                                 tracing::debug!(
@@ -7433,38 +7450,77 @@ async fn control_actor_loop(
                                             MissionStatus::Pending | MissionStatus::Active | MissionStatus::Interrupted
                                         );
                                         if should_update {
-                                            let new_status = if result.success {
-                                                MissionStatus::Completed
+                                            let status_and_summary = result.terminal_reason.and_then(|reason| {
+                                                match reason {
+                                                    TerminalReason::TurnComplete => None,
+                                                    TerminalReason::Completed => {
+                                                        Some((MissionStatus::Completed, None))
+                                                    }
+                                                    TerminalReason::Cancelled => Some((
+                                                        MissionStatus::Interrupted,
+                                                        Some("Cancelled by user".to_string()),
+                                                    )),
+                                                    TerminalReason::MaxIterations => Some((
+                                                        MissionStatus::Blocked,
+                                                        Some("Reached iteration limit".to_string()),
+                                                    )),
+                                                    TerminalReason::Stalled => Some((
+                                                        MissionStatus::Failed,
+                                                        Some("No progress detected".to_string()),
+                                                    )),
+                                                    TerminalReason::InfiniteLoop => Some((
+                                                        MissionStatus::Failed,
+                                                        Some("Detected repetitive behavior".to_string()),
+                                                    )),
+                                                    TerminalReason::LlmError => Some((
+                                                        MissionStatus::Failed,
+                                                        Some("Model error".to_string()),
+                                                    )),
+                                                    TerminalReason::RateLimited => Some((
+                                                        MissionStatus::Failed,
+                                                        Some("Provider rate limited".to_string()),
+                                                    )),
+                                                    TerminalReason::CapacityLimited => Some((
+                                                        MissionStatus::Failed,
+                                                        Some("Provider capacity limit reached".to_string()),
+                                                    )),
+                                                }
+                                            });
+
+                                            if let Some((new_status, summary)) = status_and_summary {
+                                                if new_status == MissionStatus::Completed
+                                                    && mission_has_active_automation(&mission_store, *mission_id).await
+                                                {
+                                                    tracing::info!(
+                                                        "Skipping parallel completion for mission {} because active automations are enabled",
+                                                        mission_id
+                                                    );
+                                                } else if let Err(e) = mission_store
+                                                    .update_mission_status(*mission_id, new_status)
+                                                    .await
+                                                {
+                                                    tracing::warn!(
+                                                        "Failed to update parallel mission status: {}",
+                                                        e
+                                                    );
+                                                } else {
+                                                    maybe_schedule_mission_metadata_refresh_for_status(
+                                                        &mission_store,
+                                                        &events_tx,
+                                                        *mission_id,
+                                                        new_status,
+                                                    );
+                                                    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                                        mission_id: *mission_id,
+                                                        status: new_status,
+                                                        summary,
+                                                    });
+                                                }
                                             } else {
-                                                MissionStatus::Failed
-                                            };
-                                            if new_status == MissionStatus::Completed
-                                                && mission_has_active_automation(&mission_store, *mission_id).await
-                                            {
-                                                tracing::info!(
-                                                    "Skipping parallel completion for mission {} because active automations are enabled",
+                                                tracing::debug!(
+                                                    "Skipping parallel auto-complete for mission {}: turn ended but mission is not explicitly completed",
                                                     mission_id
                                                 );
-                                            } else if let Err(e) = mission_store
-                                                .update_mission_status(*mission_id, new_status)
-                                                .await
-                                            {
-                                                tracing::warn!(
-                                                    "Failed to update parallel mission status: {}",
-                                                    e
-                                                );
-                                            } else {
-                                                maybe_schedule_mission_metadata_refresh_for_status(
-                                                    &mission_store,
-                                                    &events_tx,
-                                                    *mission_id,
-                                                    new_status,
-                                                );
-                                                let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                    mission_id: *mission_id,
-                                                    status: new_status,
-                                                    summary: None,
-                                                });
                                             }
                                         }
                                     }

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3561,7 +3561,7 @@ pub fn run_claudecode_turn<'a>(
             AgentResult::failure(final_result, cost_cents).with_terminal_reason(reason)
         } else {
             AgentResult::success(final_result, cost_cents)
-                .with_terminal_reason(TerminalReason::Completed)
+                .with_terminal_reason(TerminalReason::TurnComplete)
         };
         if let Some(model) = model_for_cost {
             result = result.with_model(model.to_string());
@@ -9164,7 +9164,7 @@ pub async fn run_opencode_turn(
         };
         AgentResult::failure(final_result, 0).with_terminal_reason(reason)
     } else {
-        AgentResult::success(final_result, 0).with_terminal_reason(TerminalReason::Completed)
+        AgentResult::success(final_result, 0).with_terminal_reason(TerminalReason::TurnComplete)
     };
     if model_used.is_none() {
         if let Some(model) = resolved_model.as_deref() {
@@ -9924,7 +9924,7 @@ pub async fn run_amp_turn(
 
     let mut result = if success {
         AgentResult::success(final_result, cost_cents)
-            .with_terminal_reason(TerminalReason::Completed)
+            .with_terminal_reason(TerminalReason::TurnComplete)
     } else {
         // Detect rate limit / overloaded errors for account rotation.
         let reason = if is_rate_limited_error(&final_result) {
@@ -10254,7 +10254,7 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
 
     let mut result = if success {
         AgentResult::success(final_message, cost_cents)
-            .with_terminal_reason(TerminalReason::Completed)
+            .with_terminal_reason(TerminalReason::TurnComplete)
     } else {
         // Distinguish provider concurrency exhaustion from classic rate limits.
         let reason = if is_capacity_limited_error(&final_message) {


### PR DESCRIPTION
## Problem
Assistant messages that are intermediate reasoning/progress updates were displayed as `Completed` and could auto-close missions, because successful turn execution was conflated with mission completion.

## What changed
- Introduced `TerminalReason::TurnComplete` to represent a successful assistant turn that does **not** imply mission completion.
- Updated runners (`claudecode`, `opencode`, `amp`, `codex`, `OpenCodeAgent`) to emit `TurnComplete` for successful turns.
- Hardened mission status transitions in control loop:
  - `TurnComplete` no longer updates mission status.
  - Mission is only auto-transitioned on explicit terminal reasons (`Completed`, `Cancelled`, `MaxIterations`, and failure reasons).
- Applied the same logic to parallel mission runner path (removed fallback `result.success => MissionStatus::Completed`).
- UI assistant-message badge changed from `Completed` to `Turn complete`.

## True completion semantics after this PR
A mission is marked truly `Completed` only when:
1. an explicit completion signal is emitted (`TerminalReason::Completed`), or
2. the agent calls `complete_mission(status='completed')`, or
3. stale mission safety net auto-closes inactive missions.

A successful assistant turn by itself is no longer treated as mission completion.

## Validation
- `cargo check -q` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission auto-completion/state-transition logic based on a new terminal reason, which can affect when missions are marked completed/failed (including parallel missions). Risk is moderate due to behavior changes in core control/runner paths, but scoped and deterministic.
> 
> **Overview**
> Prevents intermediate successful assistant turns from being treated as mission completion by introducing `TerminalReason::TurnComplete` and emitting it from successful agent/runner executions (instead of `Completed`).
> 
> Updates the control loop (including parallel missions) to **skip auto-status transitions** on `TurnComplete` and only persist mission status/emit `MissionStatusChanged` events for explicit terminal reasons (completed/cancelled/limits/errors), removing the prior `success => Completed` fallback. The UI badge label is updated from "Completed" to "Turn complete" for these turn-end messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40808eeea9728ab84aba1d9c5492c5a1ef11ed27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->