### PR TITLE
fix: prevent startup timeout on stale Claude session resume

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -8137,10 +8137,12 @@ async fn run_single_control_turn(
             .await;
 
             // Claude Code can fail when resuming a session due to stale/corrupt state:
-            // - CLI hangs and emits no parseable stream events
+            // - CLI hangs and emits no parseable stream events (startup timeout)
             // - API rejects reconstructed history (e.g. mismatched tool_use_id)
             // When that happens, auto-reset the session_id and retry once fresh.
-            if is_continuation && super::mission_runner::is_session_corruption_error(&result) {
+            // This fires regardless of `is_continuation` — startup timeouts can happen
+            // even on the first turn if the session marker was stale.
+            if super::mission_runner::is_session_corruption_error(&result) {
                 let new_session_id = Uuid::new_v4().to_string();
                 tracing::warn!(
                     mission_id = %mid,
@@ -8203,7 +8205,7 @@ async fn run_single_control_turn(
                     None, // secrets - not available in control context
                     &config.working_dir,
                     Some(&new_session_id),
-                    is_continuation,
+                    false, // Fresh session — don't pass is_continuation=true
                     Some(tool_hub.clone()),
                     Some(status.clone()),
                     None, // override_auth

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1694,15 +1694,22 @@ async fn run_mission_turn(
             .await;
 
             // Claude Code can fail when resuming a session due to stale/corrupt state:
-            // - CLI hangs and emits no parseable stream events
+            // - CLI hangs and emits no parseable stream events (startup timeout)
             // - API rejects reconstructed history (e.g. mismatched tool_use_id)
             // When that happens, auto-reset the session_id and retry once fresh.
-            if is_continuation && is_session_corruption_error(&result) {
+            //
+            // Previously this only fired when `is_continuation` was true, but startup
+            // timeouts can also happen on the first turn if the session marker file was
+            // stale (left over from a previous mission with the same session_id) or if
+            // the CLI hangs during initialization for other reasons.  Retrying with a
+            // fresh session is always safe regardless of turn count.
+            if is_session_corruption_error(&result) {
                 let new_session_id = Uuid::new_v4().to_string();
                 tracing::warn!(
                     mission_id = %mission_id,
                     old_session_id = ?session_id,
                     new_session_id = %new_session_id,
+                    is_continuation = is_continuation,
                     error = %result.output,
                     "Session corruption detected; resetting session and retrying once"
                 );
@@ -2708,7 +2715,37 @@ pub fn run_claudecode_turn<'a>(
         //
         // Using --resume with a non-existent session causes Claude Code to exit with
         // "No conversation found with session ID: ..." and code 1.
-        let use_resume = session_was_initiated;
+        //
+        // Additional safety: even when the marker file says the session was initiated,
+        // verify that Claude's session data directory actually exists on disk.
+        // A stale marker file (e.g., after container restart, HOME wipe, or service
+        // restart) combined with --resume causes the CLI to hang silently, triggering
+        // the startup timeout. This pre-validation avoids that entirely.
+        let session_data_exists = if session_was_initiated {
+            // Claude Code stores session data under $CLAUDE_CONFIG_DIR/projects/<hash>/
+            // or ~/.claude/projects/<hash>/.  We check the broader `.claude/projects`
+            // dir for *any* session data rather than guessing the exact hash, since the
+            // hash depends on the absolute cwd path inside the container.
+            let claude_projects_dir = work_dir.join(".claude").join("projects");
+            let has_projects = claude_projects_dir.exists()
+                && std::fs::read_dir(&claude_projects_dir)
+                    .map(|mut entries| entries.next().is_some())
+                    .unwrap_or(false);
+            if !has_projects {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    session_id = %session_id,
+                    projects_dir = %claude_projects_dir.display(),
+                    "Session marker exists but no Claude session data found on disk; \
+                     skipping --resume to avoid CLI hang"
+                );
+            }
+            has_projects
+        } else {
+            false
+        };
+
+        let use_resume = session_was_initiated && session_data_exists;
 
         if use_resume {
             args.push("--resume".to_string());
@@ -2718,9 +2755,16 @@ pub fn run_claudecode_turn<'a>(
                 session_id = %session_id,
                 is_continuation = is_continuation,
                 session_was_initiated = session_was_initiated,
+                session_data_exists = session_data_exists,
                 "Resuming existing Claude Code session"
             );
         } else {
+            // If the marker was stale (session data missing), remove it so it
+            // gets recreated with the current session ID.
+            if session_was_initiated && !session_data_exists {
+                let _ = std::fs::remove_file(&session_marker);
+            }
+
             // Create the marker file BEFORE starting the CLI to prevent races
             if let Err(e) = std::fs::write(&session_marker, &session_id) {
                 tracing::warn!(
@@ -3048,14 +3092,18 @@ pub fn run_claudecode_turn<'a>(
                 _ = tokio::time::sleep_until(startup_deadline), if !saw_non_init_event => {
                     tracing::warn!(
                         mission_id = %mission_id,
+                        use_resume = use_resume,
                         non_json_lines = non_json_output.len(),
                         non_json_sample = ?non_json_output.first(),
+                        cli_program = %program,
+                        cli_args_count = full_args.len(),
                         "Claude Code startup timeout - no stream events received"
                     );
                     pty.kill();
                     reader_handle.abort();
                     let mut msg = "Claude Code produced no stream events after startup timeout. The Claude CLI started but did not emit any stream-json events.".to_string();
                     msg.push_str("\n\nThis can happen when resuming an old/stuck Claude session or when the CLI hangs during initialization.");
+                    msg.push_str(&format!("\n\nDiagnostics: use_resume={}, session_id={}", use_resume, session_id));
                     if !non_json_output.is_empty() {
                         msg.push_str(&format!(
                             "\n\nNon-JSON output captured ({} lines):\n{}",
@@ -3439,6 +3487,14 @@ pub fn run_claudecode_turn<'a>(
                                         "Claude Code execution completed"
                                     );
                                     break;
+                                }
+                                ClaudeEvent::Unknown => {
+                                    // Forward-compatibility: unknown event types from
+                                    // newer CLI versions are silently ignored.
+                                    tracing::trace!(
+                                        mission_id = %mission_id,
+                                        "Ignoring unknown Claude event type"
+                                    );
                                 }
                             }
                 }
@@ -9791,6 +9847,9 @@ pub async fn run_amp_turn(
 
                                 // Result event means we're done
                                 break;
+                            }
+                            AmpEvent::Unknown => {
+                                // Forward-compatibility: silently ignore unknown events.
                             }
                         }
                     }

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -63,6 +63,12 @@ impl ProcessHandle {
 // ── NDJSON event types ────────────────────────────────────────────
 
 /// Events emitted by Claude Code / Amp CLIs in stream-json mode.
+///
+/// The `Unknown` variant acts as a forward-compatibility catch-all: if a future
+/// CLI version introduces a new event type, it will be deserialized as `Unknown`
+/// instead of causing a parse error.  This prevents startup timeouts caused by
+/// unrecognized event types being silently discarded (logged as warnings) before
+/// any known event arrives.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum CliEvent {
@@ -76,6 +82,9 @@ pub enum CliEvent {
     User(UserEvent),
     #[serde(rename = "result")]
     Result(ResultEvent),
+    /// Catch-all for unrecognized event types from newer CLI versions.
+    #[serde(other)]
+    Unknown,
 }
 
 /// MCP server status in the init event.
@@ -520,6 +529,10 @@ pub fn convert_cli_event(
                     res.subtype, res.total_cost_usd, res.duration_ms, res.num_turns
                 );
             }
+        }
+
+        CliEvent::Unknown => {
+            // Forward-compatibility: silently ignore unrecognized event types.
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the recurring "Claude Code produced no stream events after startup timeout" error that happens when `--resume` is used with a stale or missing Claude session. This has been hitting multiple missions including 11424f55, c188727b, and 25306b56.

**Three root causes addressed:**

- **Pre-validate session data before `--resume`**: Before deciding to use `--resume`, verify that Claude's `.claude/projects/` directory actually contains session data on disk. A stale marker file (left over after container restart, HOME wipe, or service restart) previously caused `--resume` with no backing data, making the CLI hang silently for 20s until the startup timeout.

- **Always retry on startup timeout**: The auto-recovery (reset session + retry fresh) was gated on `is_continuation` (requires assistant messages in history). This meant first-turn failures or missions with empty/corrupted history would fail permanently without retry. Removed the gate — any startup timeout now triggers a fresh-session retry.

- **Add `Unknown` catch-all to `CliEvent` enum**: Future CLI versions may introduce new event types. Without a catch-all, unrecognized events caused serde parse errors that were silently skipped. If a new event type was emitted before any known type, the startup timeout would fire incorrectly.

Also improved diagnostics: timeout errors now include `use_resume` flag and `session_id`, and the structured log includes `cli_program` and `cli_args_count`.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 505 tests pass, 0 failures
- [ ] Deploy to dev backend and verify missions resume correctly
- [ ] Trigger a resume on a mission with stale session data — should skip `--resume` and start fresh
- [ ] Verify startup timeout retry fires even on first-turn failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude Code session resume/retry behavior and marker-file handling, which can affect whether conversations resume vs start fresh. Risk is moderate because mis-detection could drop session continuity or cause extra retries, but scope is limited to CLI execution paths and adds safer validation/forward-compat parsing.
> 
> **Overview**
> Reduces recurring Claude Code “no stream events after startup timeout” failures by **skipping `--resume` when session marker files are stale** (marker exists but no `.claude/projects` data) and cleaning up the marker so it can be recreated.
> 
> Updates the corruption/timeout recovery to **retry once with a new session ID regardless of `is_continuation`**, ensuring first-turn startup hangs also get auto-recovered, and forces the retry path to run as a fresh session.
> 
> Adds forward-compatibility by introducing `CliEvent::Unknown` (and corresponding `ClaudeEvent`/`AmpEvent` handling) so **new CLI event types don’t break parsing/startup**, and improves timeout diagnostics/logging with `use_resume`, `session_id`, and CLI invocation details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ae9d4370eaaf63f014b97bcdcfcbd951c9d76a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->