### PR TITLE
fix(claudecode): use CLAUDE_CODE_EFFORT_LEVEL env var instead of --effort CLI flag

### DIFF
--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -745,7 +745,7 @@ export function NewMissionDialog({
                   <option value="high">High</option>
                 </select>
                 <p className="text-xs text-white/30 mt-1.5">
-                  {selectedBackend === 'codex' ? 'Passed to Codex as reasoning effort.' : 'Passed to Claude Code as --effort flag.'}
+                  {selectedBackend === 'codex' ? 'Passed to Codex as reasoning effort.' : 'Controls Claude Code adaptive reasoning depth (via CLAUDE_CODE_EFFORT_LEVEL).'}
                 </p>
               </div>
             )}

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2699,10 +2699,8 @@ pub fn run_claudecode_turn<'a>(
             args.push(bare.to_string());
         }
 
-        if let Some(effort) = model_effort {
-            args.push("--effort".to_string());
-            args.push(effort.to_string());
-        }
+        // Note: model_effort is set via CLAUDE_CODE_EFFORT_LEVEL env var below,
+        // not as a CLI flag (Claude Code CLI does not have an --effort flag).
 
         // For continuation turns, use --resume to resume existing session.
         // For first turn, use --session-id to create new session with that ID.
@@ -2871,6 +2869,17 @@ pub fn run_claudecode_turn<'a>(
         env.insert("CLAUDE_CONFIG_DIR".to_string(), claude_config_dir.clone());
         let claude_config_path = format!("{}/settings.json", claude_config_dir);
         env.insert("CLAUDE_CONFIG".to_string(), claude_config_path);
+
+        // Set effort level via environment variable.
+        // Claude Code reads CLAUDE_CODE_EFFORT_LEVEL to control adaptive reasoning depth.
+        if let Some(effort) = model_effort {
+            env.insert("CLAUDE_CODE_EFFORT_LEVEL".to_string(), effort.to_string());
+            tracing::info!(
+                mission_id = %mission_id,
+                effort = %effort,
+                "Setting Claude Code effort level via CLAUDE_CODE_EFFORT_LEVEL"
+            );
+        }
 
         // Trigger auto-compaction at 80% context capacity to prevent "Prompt is too long"
         // errors on long-running missions. Claude Code's default (95%) is too aggressive


### PR DESCRIPTION
## Summary
- Replace `--effort` CLI flag with `CLAUDE_CODE_EFFORT_LEVEL` environment variable when spawning Claude Code processes
- The `--effort` flag does not exist in Claude Code CLI, causing missions with effort settings to fail with `error: unknown option '--effort'`
- Update dashboard help text to reflect the correct mechanism

## Root Cause
Mission `770a5af9` failed because `run_claudecode_turn` was passing `--effort high` as a CLI argument to the `claude` binary. Claude Code CLI does not have an `--effort` flag. According to the [Claude Code docs](https://code.claude.com/docs/en/model-config), the correct way to set effort is via the `CLAUDE_CODE_EFFORT_LEVEL` environment variable.

## Changes
- **`src/api/mission_runner.rs`**: Removed `--effort` CLI arg construction; added `CLAUDE_CODE_EFFORT_LEVEL` env var to the process environment
- **`dashboard/src/components/new-mission-dialog.tsx`**: Updated help text from "Passed to Claude Code as --effort flag" to accurate description

## Test plan
- [x] `cargo check` passes
- [x] All 506 tests pass (`cargo test`)
- [x] Deployed to dev backend and created mission with effort: high — completed successfully
- [x] Server logs confirm: `Setting Claude Code effort level via CLAUDE_CODE_EFFORT_LEVEL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Claude Code processes are spawned by removing a CLI arg and injecting a new environment variable; mistakes here could impact Claude Code mission execution when `model_effort` is set.
> 
> **Overview**
> Fixes Claude Code mission runs that previously failed due to passing a non-existent `--effort` flag.
> 
> The runner now sets `model_effort` via `CLAUDE_CODE_EFFORT_LEVEL` in the spawned process environment (with an added log line), and the dashboard’s model-effort helper text is updated to describe the env-var behavior instead of a CLI flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3940c286f228534ddfdd89312ea224fae499f1ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->