### PR TITLE
docs: fix references to former name Open Agent

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing sandboxed.sh
 
-There are two ways to install sandboxed.sh (formerly Sandboxed.sh):
+There are two ways to install sandboxed.sh (formerly Open Agent):
 
 ## Docker (recommended for most users)
 

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -1,6 +1,6 @@
 # Installing sandboxed.sh with Docker
 
-Docker is the easiest way to run sandboxed.sh (formerly Sandboxed.sh). One command gets you a complete environment with the Rust backend, Next.js dashboard, and all AI harness CLIs pre-installed.
+Docker is the easiest way to run sandboxed.sh (formerly Open Agent). One command gets you a complete environment with the Rust backend, Next.js dashboard, and all AI harness CLIs pre-installed.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fix what I believe is a wrong reference to the former name of sandboxed.sh, Open Agent.