### PR TITLE
Fix queued control message and automation ordering

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5060,6 +5060,20 @@ struct RoutedAutomationMessage {
     target_mission_id: Uuid,
 }
 
+fn enqueue_agent_finished_messages(
+    queue: &mut VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+    messages: Vec<RoutedAutomationMessage>,
+) {
+    for message in messages {
+        queue.push_back((
+            Uuid::new_v4(),
+            message.content,
+            None,
+            Some(message.target_mission_id),
+        ));
+    }
+}
+
 fn next_session_id_from_automation_variables(
     automation: &super::mission_store::Automation,
 ) -> Option<Uuid> {
@@ -7210,15 +7224,7 @@ async fn control_actor_loop(
                                 &workspaces,
                             )
                             .await;
-                            for message in messages.into_iter().rev() {
-                                // Push to front so it runs before unrelated queued items, but preserve order.
-                                queue.push_front((
-                                    Uuid::new_v4(),
-                                    message.content,
-                                    None,
-                                    Some(message.target_mission_id),
-                                ));
-                            }
+                            enqueue_agent_finished_messages(&mut queue, messages);
                         }
                     }
                 }
@@ -11840,6 +11846,45 @@ Investigate <service/> failures.
         assert_eq!(
             automation_library_command_body("  Echo current status. \n"),
             "Echo current status."
+        );
+    }
+
+    #[test]
+    fn test_enqueue_agent_finished_messages_appends_after_existing_queue_items() {
+        let existing_target = Uuid::new_v4();
+        let restart_target = Uuid::new_v4();
+        let mut queue = VecDeque::from([(
+            Uuid::new_v4(),
+            "queued user message".to_string(),
+            None,
+            Some(existing_target),
+        )]);
+
+        enqueue_agent_finished_messages(
+            &mut queue,
+            vec![
+                RoutedAutomationMessage {
+                    content: "restart 1".to_string(),
+                    target_mission_id: restart_target,
+                },
+                RoutedAutomationMessage {
+                    content: "restart 2".to_string(),
+                    target_mission_id: restart_target,
+                },
+            ],
+        );
+
+        let ordered: Vec<(String, Option<Uuid>)> = queue
+            .into_iter()
+            .map(|(_, content, _, mission_id)| (content, mission_id))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                ("queued user message".to_string(), Some(existing_target)),
+                ("restart 1".to_string(), Some(restart_target)),
+                ("restart 2".to_string(), Some(restart_target)),
+            ]
         );
     }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -1588,6 +1588,11 @@ impl MissionStore for SqliteMissionStore {
     // === Event logging methods ===
 
     async fn log_event(&self, mission_id: Uuid, event: &AgentEvent) -> Result<(), String> {
+        if matches!(event, AgentEvent::UserMessage { queued: true, .. }) {
+            // Keep queued messages out of persisted mission history until they actually start.
+            return Ok(());
+        }
+
         let conn = self.conn.clone();
         let content_dir = self.content_dir.clone();
         let now = now_string();
@@ -1742,7 +1747,6 @@ impl MissionStore for SqliteMissionStore {
 
             // If this event has an event_id that already exists for this mission,
             // update the existing row's metadata instead of inserting a duplicate.
-            // This happens when a queued UserMessage is re-emitted with queued: false.
             if let Some(ref eid) = event_id {
                 let existing: Option<i64> = conn
                     .query_row(
@@ -3154,5 +3158,126 @@ mod tests {
         assert_eq!(actual, 30);
         assert_eq!(estimated, 15);
         assert_eq!(unknown, 0);
+    }
+
+    #[tokio::test]
+    async fn queued_user_messages_are_not_persisted_until_processing_starts() {
+        use crate::api::control::AgentEvent;
+        use uuid::Uuid;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Queue order"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        let queued_id = Uuid::new_v4();
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::UserMessage {
+                    id: queued_id,
+                    content: "B".to_string(),
+                    queued: true,
+                    mission_id: Some(mission.id),
+                },
+            )
+            .await
+            .expect("queued event should be ignored");
+
+        let events = store
+            .get_events(mission.id, None, None, None)
+            .await
+            .expect("events");
+        assert!(
+            events.is_empty(),
+            "queued messages should not be stored yet"
+        );
+
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::UserMessage {
+                    id: Uuid::new_v4(),
+                    content: "A".to_string(),
+                    queued: false,
+                    mission_id: Some(mission.id),
+                },
+            )
+            .await
+            .expect("first user");
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::AssistantMessage {
+                    id: Uuid::new_v4(),
+                    content: "reply A".to_string(),
+                    success: true,
+                    cost_cents: 0,
+                    cost_source: CostSource::Unknown,
+                    usage: None,
+                    model: None,
+                    model_normalized: None,
+                    mission_id: Some(mission.id),
+                    shared_files: None,
+                    resumable: false,
+                },
+            )
+            .await
+            .expect("reply A");
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::UserMessage {
+                    id: queued_id,
+                    content: "B".to_string(),
+                    queued: false,
+                    mission_id: Some(mission.id),
+                },
+            )
+            .await
+            .expect("dequeued B");
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::AssistantMessage {
+                    id: Uuid::new_v4(),
+                    content: "reply B".to_string(),
+                    success: true,
+                    cost_cents: 0,
+                    cost_source: CostSource::Unknown,
+                    usage: None,
+                    model: None,
+                    model_normalized: None,
+                    mission_id: Some(mission.id),
+                    shared_files: None,
+                    resumable: false,
+                },
+            )
+            .await
+            .expect("reply B");
+
+        let mission = store
+            .get_mission(mission.id)
+            .await
+            .expect("get mission")
+            .expect("mission exists");
+        let history: Vec<(String, String)> = mission
+            .history
+            .into_iter()
+            .map(|entry| (entry.role, entry.content))
+            .collect();
+        assert_eq!(
+            history,
+            vec![
+                ("user".to_string(), "A".to_string()),
+                ("assistant".to_string(), "reply A".to_string()),
+                ("user".to_string(), "B".to_string()),
+                ("assistant".to_string(), "reply B".to_string()),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- append `agent_finished` restart automations behind existing queued control messages instead of pushing them to the front
- stop persisting `queued: true` user messages into mission history until they actually begin processing
- add regression tests for both behaviors

## Testing
- `cargo build`
- `cargo test -q queued_user_messages_are_not_persisted_until_processing_starts -- --nocapture`
- `cargo test -q test_enqueue_agent_finished_messages_appends_after_existing_queue_items -- --nocapture`
- `cargo test -q resolve_agent_finished_target_mission -- --nocapture`

## Manual validation
- deployed this branch to `https://agent-backend-dev.thomas.md`
- used a local dashboard pointed at the dev backend and verified with Playwright MCP
- mission `927d9306-ddd7-41fe-96b0-bbf48597260e`: queued messages `B` and `C` completed before the `After agent finishes (restart)` automation message was injected
- mission `c78d57d0-d3fe-4f79-89d9-7761a699ab74`: after reload, transcript order remained interleaved as `A2, reply A2, B2, reply B2, C2, reply C2`

## Notes
- the existing dashboard Playwright spec `tests/queue-order.spec.ts` currently fails in this repo before reaching its visibility assertion, so I did not use it as the final gate for this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-session queueing and mission event persistence, which can affect execution order and stored transcripts if incorrect. Scope is small and covered by new regression tests.
> 
> **Overview**
> Fixes ordering issues between queued control messages and `agent_finished` restart automations by appending the generated automation messages to the back of the queue (via `enqueue_agent_finished_messages`) instead of pushing them to the front.
> 
> Stops persisting `AgentEvent::UserMessage` events with `queued: true` in the SQLite mission store so mission history only records messages once processing actually starts. Adds regression tests covering both the queue ordering and the deferred persistence behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4310f6baefc5f251c71b4d300eb5a7c18b3c962a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->