### PR TITLE
feat: show connected account email on provider cards

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -340,12 +340,19 @@ export default function ProvidersPage() {
                         !provider.enabled && 'opacity-40'
                       )}>
                         <span className="text-base">{config.icon}</span>
-                        <span className="text-sm text-white/80 flex-1 truncate">
-                          {provider.name}
-                          {provider.label && (
-                            <span className="ml-1.5 text-xs text-white/40">({provider.label})</span>
+                        <div className="flex-1 min-w-0">
+                          <span className="text-sm text-white/80 truncate block">
+                            {provider.name}
+                            {provider.label && (
+                              <span className="ml-1.5 text-xs text-white/40">({provider.label})</span>
+                            )}
+                          </span>
+                          {provider.account_email && (
+                            <span className="text-[11px] text-white/35 truncate block">
+                              {provider.account_email}
+                            </span>
                           )}
-                        </span>
+                        </div>
 
                         {provider.use_for_backends && provider.use_for_backends.length > 0 && (
                           <div className="flex items-center gap-1">

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -81,6 +81,8 @@ export interface AIProvider {
   auth_methods: AIProviderAuthMethod[];
   status: AIProviderStatus;
   use_for_backends: string[];
+  /** Account identifier (email) from the connected OAuth account */
+  account_email?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/dashboard/tests/ai-providers.spec.ts
+++ b/dashboard/tests/ai-providers.spec.ts
@@ -348,3 +348,140 @@ test.describe("AI Providers", () => {
     await expect(page.getByText("Delete Test Provider")).not.toBeVisible();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Account email display tests (using route mocking)
+// ---------------------------------------------------------------------------
+
+test.describe("AI Providers - Account Email Display", () => {
+  const mockProviders = [
+    {
+      id: "prov-1",
+      provider_type: "anthropic",
+      provider_type_name: "Anthropic",
+      name: "Anthropic",
+      label: null,
+      priority: 0,
+      has_api_key: false,
+      has_oauth: true,
+      base_url: null,
+      enabled: true,
+      is_default: true,
+      uses_oauth: true,
+      auth_methods: [],
+      status: { type: "connected" },
+      use_for_backends: ["claudecode"],
+      account_email: "alice@example.com",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    },
+    {
+      id: "prov-2",
+      provider_type: "anthropic",
+      provider_type_name: "Anthropic",
+      name: "Anthropic",
+      label: "Work",
+      priority: 1,
+      has_api_key: false,
+      has_oauth: true,
+      base_url: null,
+      enabled: true,
+      is_default: false,
+      uses_oauth: true,
+      auth_methods: [],
+      status: { type: "connected" },
+      use_for_backends: ["opencode"],
+      account_email: "bob@work.com",
+      created_at: "2025-01-02T00:00:00Z",
+      updated_at: "2025-01-02T00:00:00Z",
+    },
+    {
+      id: "prov-3",
+      provider_type: "openai",
+      provider_type_name: "OpenAI",
+      name: "OpenAI",
+      label: null,
+      priority: 2,
+      has_api_key: true,
+      has_oauth: false,
+      base_url: null,
+      enabled: true,
+      is_default: false,
+      uses_oauth: true,
+      auth_methods: [],
+      status: { type: "connected" },
+      use_for_backends: [],
+      account_email: null,
+      created_at: "2025-01-03T00:00:00Z",
+      updated_at: "2025-01-03T00:00:00Z",
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    // Set up localStorage with a mock API URL before navigating
+    await page.goto("/settings");
+    await page.evaluate(() => {
+      localStorage.clear();
+      localStorage.setItem(
+        "settings",
+        JSON.stringify({ apiUrl: "http://mock-api" })
+      );
+    });
+
+    // Intercept the provider list API call
+    await page.route("**/api/ai/providers", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockProviders),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Also intercept provider types
+    await page.route("**/api/ai/providers/types", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          { id: "anthropic", name: "Anthropic", uses_oauth: true, env_var: "ANTHROPIC_API_KEY" },
+          { id: "openai", name: "OpenAI", uses_oauth: true, env_var: "OPENAI_API_KEY" },
+        ]),
+      });
+    });
+
+    // Navigate to the providers page
+    await page.goto("/settings/providers");
+    await page.waitForTimeout(1000);
+  });
+
+  test("displays account_email below provider name when present", async ({ page }) => {
+    // The first Anthropic provider should show alice@example.com
+    const emailText = page.getByText("alice@example.com");
+    await expect(emailText).toBeVisible({ timeout: 10000 });
+  });
+
+  test("displays account_email for multiple providers of same type", async ({ page }) => {
+    // Both Anthropic providers should show their respective emails
+    await expect(page.getByText("alice@example.com")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("bob@work.com")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("does not show email line when account_email is null", async ({ page }) => {
+    // The OpenAI provider has no account_email, so no email text should appear for it
+    // Verify that the OpenAI provider name is visible
+    await expect(page.getByText("OpenAI").first()).toBeVisible({ timeout: 10000 });
+
+    // There should be exactly 2 email texts (alice and bob), not 3
+    const emailElements = page.locator("text=/.*@.*\\.com/");
+    await expect(emailElements).toHaveCount(2);
+  });
+
+  test("shows label alongside provider name for labeled providers", async ({ page }) => {
+    // The second Anthropic provider should show "(Work)" label
+    await expect(page.getByText("(Work)")).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -330,6 +330,9 @@ pub struct AIProvider {
     /// Whether this is the default provider
     #[serde(default)]
     pub is_default: bool,
+    /// Account identifier (email or username) from OAuth or user-provided
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_email: Option<String>,
     /// Connection status (populated at runtime)
     #[serde(skip)]
     pub status: ProviderStatus,
@@ -372,6 +375,7 @@ impl AIProvider {
             npm_package: None,
             enabled: true,
             is_default: false,
+            account_email: None,
             status: ProviderStatus::Unknown,
             created_at: now,
             updated_at: now,

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -20,7 +20,7 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use base64::{engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}, Engine as _};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1739,6 +1739,9 @@ pub struct ProviderResponse {
     pub status: ProviderStatusResponse,
     /// Which backends this provider is used for (e.g., ["opencode", "claudecode"])
     pub use_for_backends: Vec<String>,
+    /// Account identifier (email or username) from the connected OAuth account
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_email: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -1815,6 +1818,7 @@ fn build_provider_response(
     auth: Option<AuthKind>,
     default_provider: Option<ProviderType>,
     backends: Option<Vec<String>>,
+    account_email: Option<String>,
 ) -> ProviderResponse {
     let now = chrono::Utc::now();
     let name = config
@@ -1857,6 +1861,7 @@ fn build_provider_response(
         auth_methods: provider_type.auth_methods(),
         status,
         use_for_backends,
+        account_email,
         created_at: now,
         updated_at: now,
     }
@@ -3713,6 +3718,84 @@ fn remove_provider_backends(working_dir: &Path, provider_id: &str) -> Result<(),
     write_provider_backends_state(working_dir, &state)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider Account Info State (provider_accounts.json)
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn provider_accounts_state_path(working_dir: &Path) -> PathBuf {
+    working_dir
+        .join(".sandboxed-sh")
+        .join("provider_accounts.json")
+}
+
+/// Read provider account info state from the state file.
+/// Returns a map of provider_id -> account email (e.g., "anthropic" -> "user@example.com")
+fn read_provider_accounts_state(working_dir: &Path) -> HashMap<String, String> {
+    let path = provider_accounts_state_path(working_dir);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&contents).unwrap_or_default()
+}
+
+/// Write provider account info state to the state file.
+fn write_provider_accounts_state(
+    working_dir: &Path,
+    accounts: &HashMap<String, String>,
+) -> Result<(), String> {
+    let path = provider_accounts_state_path(working_dir);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create provider accounts directory: {}", e))?;
+    }
+    let contents = serde_json::to_string_pretty(accounts)
+        .map_err(|e| format!("Failed to serialize provider accounts: {}", e))?;
+    std::fs::write(path, contents)
+        .map_err(|e| format!("Failed to write provider accounts: {}", e))?;
+    Ok(())
+}
+
+/// Update account email for a specific provider in the state file.
+fn update_provider_account(
+    working_dir: &Path,
+    provider_id: &str,
+    email: String,
+) -> Result<(), String> {
+    let mut state = read_provider_accounts_state(working_dir);
+    state.insert(provider_id.to_string(), email);
+    write_provider_accounts_state(working_dir, &state)
+}
+
+/// Remove a provider from the accounts state file.
+fn remove_provider_account(working_dir: &Path, provider_id: &str) -> Result<(), String> {
+    let mut state = read_provider_accounts_state(working_dir);
+    state.remove(provider_id);
+    write_provider_accounts_state(working_dir, &state)
+}
+
+/// Extract email from a JWT id_token by decoding the payload (no signature verification).
+/// JWT format: header.payload.signature, where payload is base64url-encoded JSON.
+fn extract_email_from_jwt(token: &str) -> Option<String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let payload = parts[1];
+    // base64url decode: replace URL-safe chars and add padding
+    let padded = match payload.len() % 4 {
+        2 => format!("{}==", payload),
+        3 => format!("{}=", payload),
+        _ => payload.to_string(),
+    };
+    let decoded = padded.replace('-', "+").replace('_', "/");
+    let bytes = STANDARD.decode(&decoded).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("email")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 /// Read OpenCode's current auth.json contents.
 fn read_opencode_auth() -> Result<serde_json::Value, String> {
     let auth_path = get_opencode_auth_path();
@@ -4006,6 +4089,7 @@ async fn list_providers(
     let default_provider = read_default_provider_state(&state.config.working_dir)
         .or_else(|| get_default_provider(&opencode_config));
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
 
     let mut provider_ids: BTreeSet<String> = BTreeSet::new();
     for provider in auth_map.keys() {
@@ -4027,12 +4111,14 @@ async fn list_providers(
             let config_entry = get_provider_config_entry(&opencode_config, provider_type);
             let auth_kind = auth_map.get(&provider_type).copied();
             let backends = backends_state.get(provider_type.id()).cloned();
+            let account_email = accounts_state.get(provider_type.id()).cloned();
             Some(build_provider_response(
                 provider_type,
                 config_entry,
                 auth_kind,
                 default_provider,
                 backends,
+                account_email,
             ))
         })
         .collect();
@@ -4072,6 +4158,7 @@ async fn list_providers(
                     ProviderStatusResponse::NeedsAuth { auth_url: None }
                 },
                 use_for_backends: vec![default_backend],
+                account_email: provider.account_email.clone(),
                 created_at: now,
                 updated_at: now,
             });
@@ -4533,6 +4620,7 @@ async fn create_provider(
             use_for_backends: req
                 .use_for_backends
                 .unwrap_or_else(|| vec![default_backend]),
+            account_email: provider.account_email.clone(),
             created_at: now,
             updated_at: now,
         }));
@@ -4589,6 +4677,7 @@ async fn create_provider(
         auth_kind,
         default_provider,
         use_for_backends,
+        None,
     );
 
     tracing::info!(
@@ -4613,15 +4702,18 @@ async fn get_provider(
     let default_provider = read_default_provider_state(&state.config.working_dir)
         .or_else(|| get_default_provider(&opencode_config));
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
     let config_entry = get_provider_config_entry(&opencode_config, provider_type);
     let auth_kind = auth_map.get(&provider_type).copied();
     let backends = backends_state.get(provider_type.id()).cloned();
+    let account_email = accounts_state.get(provider_type.id()).cloned();
     let response = build_provider_response(
         provider_type,
         config_entry,
         auth_kind,
         default_provider,
         backends,
+        account_email,
     );
     Ok(Json(response))
 }
@@ -4712,15 +4804,18 @@ async fn update_provider(
     let default_provider = read_default_provider_state(&state.config.working_dir)
         .or_else(|| get_default_provider(&opencode_config));
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
     let config_entry = get_provider_config_entry(&opencode_config, provider_type);
     let auth_kind = auth_map.get(&provider_type).copied();
     let backends = backends_state.get(provider_type.id()).cloned();
+    let account_email = accounts_state.get(provider_type.id()).cloned();
     let response = build_provider_response(
         provider_type,
         config_entry,
         auth_kind,
         default_provider,
         backends,
+        account_email,
     );
 
     tracing::info!("Updated AI provider config: {} ({})", response.name, id);
@@ -4808,6 +4903,7 @@ async fn update_store_provider(
             ProviderStatusResponse::NeedsAuth { auth_url: None }
         },
         use_for_backends: vec![default_backend],
+        account_email: result.account_email.clone(),
         created_at: now,
         updated_at: result.updated_at,
     };
@@ -4863,6 +4959,11 @@ async fn delete_provider(
     // Remove provider backends state
     if let Err(e) = remove_provider_backends(&state.config.working_dir, provider_type.id()) {
         tracing::error!("Failed to remove provider backends state: {}", e);
+    }
+
+    // Clean up account email state
+    if let Err(e) = remove_provider_account(&state.config.working_dir, provider_type.id()) {
+        tracing::error!("Failed to remove provider account state: {}", e);
     }
 
     Ok((
@@ -4992,6 +5093,7 @@ async fn set_default(
                 ProviderStatusResponse::NeedsAuth { auth_url: None }
             },
             use_for_backends: vec![default_backend],
+            account_email: provider.account_email.clone(),
             created_at: now,
             updated_at: provider.updated_at,
         };
@@ -5009,16 +5111,19 @@ async fn set_default(
     let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
     let auth_map = read_opencode_auth_map().map_err(internal_error)?;
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
     let default_provider = Some(provider_type);
     let config_entry = get_provider_config_entry(&opencode_config, provider_type);
     let auth_kind = auth_map.get(&provider_type).copied();
     let backends = backends_state.get(provider_type.id()).cloned();
+    let account_email = accounts_state.get(provider_type.id()).cloned();
     let response = build_provider_response(
         provider_type,
         config_entry,
         auth_kind,
         default_provider,
         backends,
+        account_email,
     );
 
     tracing::info!("Set default AI provider: {} ({})", response.name, id);
@@ -5457,6 +5562,28 @@ async fn oauth_callback_inner(
                     }
                 }
 
+                // Try to extract account email from token response
+                let account_email = token_data
+                    .get("id_token")
+                    .or_else(|| token_data.get("access_token"))
+                    .and_then(|v| v.as_str())
+                    .and_then(extract_email_from_jwt)
+                    .or_else(|| {
+                        token_data
+                            .get("email")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    });
+                if let Some(ref email) = account_email {
+                    if let Err(e) = update_provider_account(
+                        &state.config.working_dir,
+                        provider_type.id(),
+                        email.clone(),
+                    ) {
+                        tracing::warn!("Failed to save Anthropic account email: {}", e);
+                    }
+                }
+
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
                 let config_entry = get_provider_config_entry(&opencode_config, provider_type);
@@ -5467,6 +5594,7 @@ async fn oauth_callback_inner(
                     Some(AuthKind::ApiKey),
                     default_provider,
                     backends,
+                    account_email,
                 );
 
                 tracing::info!("Created API key for provider: {} ({})", response.name, id);
@@ -5556,6 +5684,28 @@ async fn oauth_callback_inner(
                     }
                 }
 
+                // Try to extract account email from token response
+                let account_email = token_data
+                    .get("id_token")
+                    .or_else(|| token_data.get("access_token"))
+                    .and_then(|v| v.as_str())
+                    .and_then(extract_email_from_jwt)
+                    .or_else(|| {
+                        token_data
+                            .get("email")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    });
+                if let Some(ref email) = account_email {
+                    if let Err(e) = update_provider_account(
+                        &state.config.working_dir,
+                        provider_type.id(),
+                        email.clone(),
+                    ) {
+                        tracing::warn!("Failed to save Anthropic account email: {}", e);
+                    }
+                }
+
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
                 let config_entry = get_provider_config_entry(&opencode_config, provider_type);
@@ -5566,6 +5716,7 @@ async fn oauth_callback_inner(
                     Some(AuthKind::OAuth),
                     default_provider,
                     backends,
+                    account_email,
                 );
 
                 Ok(Json(response))
@@ -5699,6 +5850,21 @@ async fn oauth_callback_inner(
                 }
             }
 
+            // Extract account email from id_token JWT if available
+            let account_email = token_data
+                .get("id_token")
+                .and_then(|v| v.as_str())
+                .and_then(extract_email_from_jwt);
+            if let Some(ref email) = account_email {
+                if let Err(e) = update_provider_account(
+                    &state.config.working_dir,
+                    provider_type.id(),
+                    email.clone(),
+                ) {
+                    tracing::warn!("Failed to save OpenAI account email: {}", e);
+                }
+            }
+
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
             let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5711,6 +5877,7 @@ async fn oauth_callback_inner(
                 Some(AuthKind::OAuth),
                 default_provider,
                 backends,
+                account_email,
             );
 
             Ok(Json(response))
@@ -5801,6 +5968,21 @@ async fn oauth_callback_inner(
                 tracing::error!("Failed to sync Google credentials to OpenCode: {}", e);
             }
 
+            // Extract account email from id_token JWT if available
+            let account_email = token_data
+                .get("id_token")
+                .and_then(|v| v.as_str())
+                .and_then(extract_email_from_jwt);
+            if let Some(ref email) = account_email {
+                if let Err(e) = update_provider_account(
+                    &state.config.working_dir,
+                    provider_type.id(),
+                    email.clone(),
+                ) {
+                    tracing::warn!("Failed to save Google account email: {}", e);
+                }
+            }
+
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
             let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5813,6 +5995,7 @@ async fn oauth_callback_inner(
                 Some(AuthKind::OAuth),
                 default_provider,
                 backends,
+                account_email,
             );
 
             tracing::info!("Google OAuth credentials saved for provider: {}", id);


### PR DESCRIPTION
## Summary
- Extract account email from OAuth JWT id_tokens during provider authentication (Anthropic, OpenAI, Google)
- Persist account emails in `provider_accounts.json` state file alongside existing `provider_backends.json`
- Display `account_email` as a subtitle below the provider name on provider cards in the settings page
- Enables users to differentiate multiple connections of the same provider type (e.g., two Anthropic accounts with different emails)

## Test plan
- [x] Frontend build passes (`next build`)
- [x] Playwright tests pass — 4 new tests with mocked API responses verify:
  - Account email displays below provider name when present
  - Multiple providers of the same type show their respective emails
  - No email line appears when `account_email` is null
  - Labels still display correctly alongside provider names
- [ ] Verify Rust backend compiles via CI
- [ ] Manual test: connect an OAuth provider and verify the email appears on the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth callback handling and adds JWT payload decoding plus new on-disk state, so bugs could affect provider auth flows or display incorrect account info (though it does not change credential storage or enforce auth decisions).
> 
> **Overview**
> Provider cards in Settings now render an optional `account_email` subtitle under the provider name, and the frontend API types include this new field.
> 
> The backend now extracts an email claim from OAuth token responses (JWT `id_token`/`access_token` payloads or explicit `email` fields) for Anthropic/OpenAI/Google callbacks, persists it in a new `.sandboxed-sh/provider_accounts.json` state file, and includes `account_email` in `GET /api/ai/providers` and related provider responses; provider deletion also cleans up this new state. Playwright coverage is extended with mocked-route tests to verify email/label rendering and null handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd8322313d651ed516d4a96af0b3007352280791. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->