### PR TITLE
Fix gh CLI hanging indefinitely in Claude Code PTY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ workspaces/
 
 # Local experiments
 vllm-gb10-dgx-spark/
+
+# iOS build artifacts
+ios_dashboard/.build/
+ios_dashboard/SandboxedDashboard.xcodeproj/

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1213,13 +1213,13 @@ async fn write_opencode_config(
         write_commands_as_opencode_skills(workspace_dir, commands).await?;
     }
 
-    // Write RTK PreToolUse hook for Claude Code (which oh-my-opencode wraps).
-    // This enables RTK compression for the native Bash tool used by the agent.
-    // Since OpenCode wraps Claude Code, we need to write a minimal
-    // `.claude/settings.local.json` containing the hooks config so the
-    // underlying Claude Code process discovers the hook.
+    // Write Bash PreToolUse hook for Claude Code (which oh-my-opencode wraps).
+    // This fixes gh CLI hanging in PTY and enables RTK compression for the
+    // native Bash tool used by the agent. Since OpenCode wraps Claude Code,
+    // we need to write a minimal `.claude/settings.local.json` containing the
+    // hooks config so the underlying Claude Code process discovers the hook.
     if let Some(hooks) =
-        write_rtk_hook_if_enabled(workspace_dir, workspace_root, workspace_type).await?
+        write_bash_pretool_hook(workspace_dir, workspace_root, workspace_type).await?
     {
         let claude_dir = workspace_dir.join(".claude");
         tokio::fs::create_dir_all(&claude_dir).await?;
@@ -1244,18 +1244,16 @@ async fn write_opencode_config(
 ///
 /// For the OpenCode backend this is also called so that the underlying Claude
 /// Code process (wrapped by oh-my-opencode) picks up the hook.
-async fn write_rtk_hook_if_enabled(
+async fn write_bash_pretool_hook(
     workspace_dir: &Path,
     workspace_root: &Path,
     workspace_type: WorkspaceType,
 ) -> anyhow::Result<Option<serde_json::Value>> {
-    if !rtk_enabled() {
-        return Ok(None);
-    }
+    let use_rtk = rtk_enabled();
 
     // For container workspaces, copy the RTK binary from host into the container
     let is_container = workspace_type == WorkspaceType::Container && nspawn::nspawn_available();
-    if is_container {
+    if use_rtk && is_container {
         if let Some(host_rtk) = rtk_binary_path() {
             let dest_dir = workspace_root.join("usr").join("local").join("bin");
             std::fs::create_dir_all(&dest_dir).ok();
@@ -1282,19 +1280,24 @@ async fn write_rtk_hook_if_enabled(
             }
         } else {
             tracing::warn!("RTK enabled but binary not found on host");
-            return Ok(None);
         }
     }
 
-    // Write the hook script to .claude/hooks/rtk-wrap.sh
+    // Write the hook script to .claude/hooks/bash-pretool.sh
+    //
+    // This hook serves two purposes:
+    // 1. **gh terminal fix** (always): Wraps `gh` commands with `env TERM=dumb` to prevent
+    //    lipgloss from sending terminal capability queries (OSC 11, DSR) that hang forever
+    //    in our PTY environment (no terminal emulator to respond).
+    // 2. **RTK compression** (when enabled): Rewrites eligible commands to use RTK
+    //    subcommands for 60-90% token compression on CLI output.
     let hooks_dir = workspace_dir.join(".claude").join("hooks");
     tokio::fs::create_dir_all(&hooks_dir).await?;
-    let rtk_hook_path = hooks_dir.join("rtk-wrap.sh");
-    let rtk_hook_script = r#"#!/bin/bash
-# RTK PreToolUse hook: rewrites eligible bash commands to use RTK subcommands.
-# This reduces token consumption by 60-90% on common CLI output.
-# RTK has specific subcommands — we map the first word of the command to the
-# corresponding RTK subcommand and pass the rest as arguments after --.
+    let hook_path = hooks_dir.join("bash-pretool.sh");
+    let hook_script = r#"#!/bin/bash
+# PreToolUse hook for Bash commands.
+# 1. Fixes gh CLI hanging in PTY by setting TERM=dumb (prevents lipgloss terminal queries)
+# 2. Optionally rewrites commands to use RTK for token compression
 set -euo pipefail
 
 INPUT=$(cat)
@@ -1310,85 +1313,102 @@ case "$COMMAND" in
   *"&&"*|*"||"*|*"|"*|*"<<"*|*"("*|*";"*|*'`'*|*'$('*) exit 0 ;;
 esac
 
-# Find rtk binary
-RTK_PATH=""
-for p in /usr/local/bin/rtk /usr/bin/rtk; do
-  if [ -x "$p" ]; then RTK_PATH="$p"; break; fi
-done
-if [ -z "$RTK_PATH" ]; then exit 0; fi
-
 # Extract the base command (first word, ignoring path prefix)
 FIRST_WORD=$(echo "$COMMAND" | awk '{print $1}')
 BASE_CMD=$(basename "$FIRST_WORD")
 REST=$(echo "$COMMAND" | sed "s|^[^ ]* *||")
 
+emit_rewrite() {
+  jq -n --arg cmd "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      updatedInput: { command: $cmd }
+    }
+  }'
+}
+
+# Find rtk binary (for optional compression)
+RTK_PATH=""
+for p in /usr/local/bin/rtk /usr/bin/rtk; do
+  if [ -x "$p" ]; then RTK_PATH="$p"; break; fi
+done
+
 # Map base commands to RTK subcommands (only commands RTK natively supports)
 RTK_SUB=""
-case "$BASE_CMD" in
-  ls)        RTK_SUB="ls" ;;
-  tree)      RTK_SUB="tree" ;;
-  git)       RTK_SUB="git" ;;
-  gh)        RTK_SUB="gh" ;;
-  grep|rg)   RTK_SUB="grep" ;;
-  cargo)     RTK_SUB="cargo" ;;
-  npm)       RTK_SUB="npm" ;;
-  npx)       RTK_SUB="npx" ;;
-  bun)       RTK_SUB="npm" ;;
-  bunx)      RTK_SUB="npx" ;;
-  pnpm)      RTK_SUB="pnpm" ;;
-  docker)    RTK_SUB="docker" ;;
-  kubectl)   RTK_SUB="kubectl" ;;
-  vitest)    RTK_SUB="vitest" ;;
-  pytest)    RTK_SUB="pytest" ;;
-  go)        RTK_SUB="go" ;;
-  tsc)       RTK_SUB="tsc" ;;
-  eslint)    RTK_SUB="lint" ;;
-  ruff)      RTK_SUB="ruff" ;;
-  curl)      RTK_SUB="curl" ;;
-  pip|uv)    RTK_SUB="pip" ;;
-  diff)      RTK_SUB="diff" ;;
-esac
-
-if [ -z "$RTK_SUB" ]; then exit 0; fi
-
-# Build the rewritten command: rtk <sub> -- <original args>
-if [ -n "$REST" ]; then
-  NEW_CMD="$RTK_PATH $RTK_SUB -- $REST"
-else
-  NEW_CMD="$RTK_PATH $RTK_SUB"
+if [ -n "$RTK_PATH" ]; then
+  case "$BASE_CMD" in
+    ls)        RTK_SUB="ls" ;;
+    tree)      RTK_SUB="tree" ;;
+    git)       RTK_SUB="git" ;;
+    gh)        RTK_SUB="gh" ;;
+    grep|rg)   RTK_SUB="grep" ;;
+    cargo)     RTK_SUB="cargo" ;;
+    npm)       RTK_SUB="npm" ;;
+    npx)       RTK_SUB="npx" ;;
+    bun)       RTK_SUB="npm" ;;
+    bunx)      RTK_SUB="npx" ;;
+    pnpm)      RTK_SUB="pnpm" ;;
+    docker)    RTK_SUB="docker" ;;
+    kubectl)   RTK_SUB="kubectl" ;;
+    vitest)    RTK_SUB="vitest" ;;
+    pytest)    RTK_SUB="pytest" ;;
+    go)        RTK_SUB="go" ;;
+    tsc)       RTK_SUB="tsc" ;;
+    eslint)    RTK_SUB="lint" ;;
+    ruff)      RTK_SUB="ruff" ;;
+    curl)      RTK_SUB="curl" ;;
+    pip|uv)    RTK_SUB="pip" ;;
+    diff)      RTK_SUB="diff" ;;
+  esac
 fi
 
-# Rewrite the command to use RTK
-jq -n --arg cmd "$NEW_CMD" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "allow",
-    updatedInput: { command: $cmd }
-  }
-}'
+# If RTK supports this command, rewrite to use RTK (which pipes internally, fixing PTY too)
+if [ -n "$RTK_SUB" ]; then
+  if [ -n "$REST" ]; then
+    emit_rewrite "$RTK_PATH $RTK_SUB -- $REST"
+  else
+    emit_rewrite "$RTK_PATH $RTK_SUB"
+  fi
+  exit 0
+fi
+
+# No RTK available — still fix gh commands that hang in PTY environments.
+# The gh CLI (via lipgloss/glamour) sends terminal capability queries like
+# OSC 11 (background color) and DSR (cursor position) when TERM != dumb.
+# Our PTY has no terminal emulator to respond, causing indefinite hangs.
+case "$BASE_CMD" in
+  gh)
+    emit_rewrite "env TERM=dumb $COMMAND"
+    exit 0
+    ;;
+esac
+
+exit 0
 "#;
-    tokio::fs::write(&rtk_hook_path, rtk_hook_script).await?;
+    tokio::fs::write(&hook_path, hook_script).await?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&rtk_hook_path, perms)?;
+        std::fs::set_permissions(&hook_path, perms)?;
     }
 
     // For container workspaces, translate the hook path from host to container-relative
     let hook_command = if is_container {
-        if let Ok(rel) = rtk_hook_path.strip_prefix(workspace_root) {
+        if let Ok(rel) = hook_path.strip_prefix(workspace_root) {
             format!("/{}", rel.to_string_lossy())
         } else {
-            rtk_hook_path.to_string_lossy().to_string()
+            hook_path.to_string_lossy().to_string()
         }
     } else {
-        rtk_hook_path.to_string_lossy().to_string()
+        hook_path.to_string_lossy().to_string()
     };
     tracing::info!(
         hook_path = %hook_command,
         is_container = is_container,
-        "RTK PreToolUse hook written"
+        use_rtk = use_rtk,
+        "Bash PreToolUse hook written"
     );
 
     Ok(Some(json!({
@@ -1476,10 +1496,10 @@ async fn write_claudecode_config(
         }
     });
 
-    // Add RTK PreToolUse hook if enabled — rewrites eligible Bash commands
-    // to prefix them with `rtk` for token compression.
+    // Add Bash PreToolUse hook — fixes gh CLI hanging in PTY environments
+    // and optionally rewrites commands with RTK for token compression.
     if let Some(hooks) =
-        write_rtk_hook_if_enabled(workspace_dir, workspace_root, workspace_type).await?
+        write_bash_pretool_hook(workspace_dir, workspace_root, workspace_type).await?
     {
         settings
             .as_object_mut()


### PR DESCRIPTION
## Summary
- **Root cause**: Claude Code runs in a PTY with `TERM=xterm-256color`. When its Bash tool spawns `gh`, lipgloss sends terminal capability queries (OSC 11 background color, DSR cursor position) that our PTY has no terminal emulator to respond to, causing indefinite hangs. Codex is unaffected because it uses piped stdio.
- **Fix**: Refactored the RTK-only `write_rtk_hook_if_enabled` into a general `write_bash_pretool_hook` that is **always written** (not gated on RTK being enabled). When RTK is unavailable, `gh` commands are rewritten to `env TERM=dumb gh ...`, preventing lipgloss terminal queries. When RTK is available, commands use RTK as before (which pipes internally, also avoiding the issue).
- Also gitignores iOS build artifacts (`.build/`, `.xcodeproj/`)

## Test plan
- [x] Deployed to dev server and created a test Claude Code mission
- [x] Ran `gh pr list` and `gh pr view --json` — both completed in <1s (previously hung indefinitely)
- [x] Verified `bash-pretool.sh` hook is written to workspace and referenced in `settings.local.json`
- [x] `cargo check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace config generation and command rewriting for all Claude Code/OpenCode sessions; a bug in the hook script or path translation could break shell command execution or alter behavior in container workspaces.
> 
> **Overview**
> Fixes `gh` commands hanging in Claude Code’s PTY by replacing the RTK-only hook with an always-written Bash `PreToolUse` hook that rewrites `gh` invocations to `env TERM=dumb ...` when RTK isn’t available, while still using RTK rewriting for supported commands when present.
> 
> Refactors `write_rtk_hook_if_enabled` into `write_bash_pretool_hook`, renames the hook script to `.claude/hooks/bash-pretool.sh`, updates both Claude Code and OpenCode workspace config generation to reference it, and adjusts container RTK binary copying to occur only when RTK is enabled.
> 
> Updates `.gitignore` to exclude iOS dashboard build artifacts (`ios_dashboard/.build/`, `ios_dashboard/SandboxedDashboard.xcodeproj/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d400778dabddefcfd24c5344d5534e692060ac8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->