### PR TITLE
feat: provider account email + fix UTF-8 emoji panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ workspaces/
 
 # Local experiments
 vllm-gb10-dgx-spark/
+
+# iOS build artifacts
+ios_dashboard/.build/
+ios_dashboard/SandboxedDashboard.xcodeproj/

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -340,12 +340,19 @@ export default function ProvidersPage() {
                         !provider.enabled && 'opacity-40'
                       )}>
                         <span className="text-base">{config.icon}</span>
-                        <span className="text-sm text-white/80 flex-1 truncate">
-                          {provider.name}
-                          {provider.label && (
-                            <span className="ml-1.5 text-xs text-white/40">({provider.label})</span>
+                        <div className="flex-1 min-w-0">
+                          <span className="text-sm text-white/80 truncate block">
+                            {provider.name}
+                            {provider.label && (
+                              <span className="ml-1.5 text-xs text-white/40">({provider.label})</span>
+                            )}
+                          </span>
+                          {provider.account_email && (
+                            <span className="text-[11px] text-white/35 truncate block">
+                              {provider.account_email}
+                            </span>
                           )}
-                        </span>
+                        </div>
 
                         {provider.use_for_backends && provider.use_for_backends.length > 0 && (
                           <div className="flex items-center gap-1">

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -81,6 +81,8 @@ export interface AIProvider {
   auth_methods: AIProviderAuthMethod[];
   status: AIProviderStatus;
   use_for_backends: string[];
+  /** Account identifier (email) from the connected OAuth account */
+  account_email?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/dashboard/tests/ai-providers.spec.ts
+++ b/dashboard/tests/ai-providers.spec.ts
@@ -348,3 +348,140 @@ test.describe("AI Providers", () => {
     await expect(page.getByText("Delete Test Provider")).not.toBeVisible();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Account email display tests (using route mocking)
+// ---------------------------------------------------------------------------
+
+test.describe("AI Providers - Account Email Display", () => {
+  const mockProviders = [
+    {
+      id: "prov-1",
+      provider_type: "anthropic",
+      provider_type_name: "Anthropic",
+      name: "Anthropic",
+      label: null,
+      priority: 0,
+      has_api_key: false,
+      has_oauth: true,
+      base_url: null,
+      enabled: true,
+      is_default: true,
+      uses_oauth: true,
+      auth_methods: [],
+      status: { type: "connected" },
+      use_for_backends: ["claudecode"],
+      account_email: "alice@example.com",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    },
+    {
+      id: "prov-2",
+      provider_type: "anthropic",
+      provider_type_name: "Anthropic",
+      name: "Anthropic",
+      label: "Work",
+      priority: 1,
+      has_api_key: false,
+      has_oauth: true,
+      base_url: null,
+      enabled: true,
+      is_default: false,
+      uses_oauth: true,
+      auth_methods: [],
+      status: { type: "connected" },
+      use_for_backends: ["opencode"],
+      account_email: "bob@work.com",
+      created_at: "2025-01-02T00:00:00Z",
+      updated_at: "2025-01-02T00:00:00Z",
+    },
+    {
+      id: "prov-3",
+      provider_type: "openai",
+      provider_type_name: "OpenAI",
+      name: "OpenAI",
+      label: null,
+      priority: 2,
+      has_api_key: true,
+      has_oauth: false,
+      base_url: null,
+      enabled: true,
+      is_default: false,
+      uses_oauth: true,
+      auth_methods: [],
+      status: { type: "connected" },
+      use_for_backends: [],
+      account_email: null,
+      created_at: "2025-01-03T00:00:00Z",
+      updated_at: "2025-01-03T00:00:00Z",
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    // Set up localStorage with a mock API URL before navigating
+    await page.goto("/settings");
+    await page.evaluate(() => {
+      localStorage.clear();
+      localStorage.setItem(
+        "settings",
+        JSON.stringify({ apiUrl: "http://mock-api" })
+      );
+    });
+
+    // Intercept the provider list API call
+    await page.route("**/api/ai/providers", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockProviders),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Also intercept provider types
+    await page.route("**/api/ai/providers/types", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          { id: "anthropic", name: "Anthropic", uses_oauth: true, env_var: "ANTHROPIC_API_KEY" },
+          { id: "openai", name: "OpenAI", uses_oauth: true, env_var: "OPENAI_API_KEY" },
+        ]),
+      });
+    });
+
+    // Navigate to the providers page
+    await page.goto("/settings/providers");
+    await page.waitForTimeout(1000);
+  });
+
+  test("displays account_email below provider name when present", async ({ page }) => {
+    // The first Anthropic provider should show alice@example.com
+    const emailText = page.getByText("alice@example.com");
+    await expect(emailText).toBeVisible({ timeout: 10000 });
+  });
+
+  test("displays account_email for multiple providers of same type", async ({ page }) => {
+    // Both Anthropic providers should show their respective emails
+    await expect(page.getByText("alice@example.com")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("bob@work.com")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("does not show email line when account_email is null", async ({ page }) => {
+    // The OpenAI provider has no account_email, so no email text should appear for it
+    // Verify that the OpenAI provider name is visible
+    await expect(page.getByText("OpenAI").first()).toBeVisible({ timeout: 10000 });
+
+    // There should be exactly 2 email texts (alice and bob), not 3
+    const emailElements = page.locator("text=/.*@.*\\.com/");
+    await expect(emailElements).toHaveCount(2);
+  });
+
+  test("shows label alongside provider name for labeled providers", async ({ page }) => {
+    // The second Anthropic provider should show "(Work)" label
+    await expect(page.getByText("(Work)")).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -330,6 +330,9 @@ pub struct AIProvider {
     /// Whether this is the default provider
     #[serde(default)]
     pub is_default: bool,
+    /// Account identifier (email or username) from OAuth or user-provided
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_email: Option<String>,
     /// Connection status (populated at runtime)
     #[serde(skip)]
     pub status: ProviderStatus,
@@ -372,6 +375,7 @@ impl AIProvider {
             npm_package: None,
             enabled: true,
             is_default: false,
+            account_email: None,
             status: ProviderStatus::Unknown,
             created_at: now,
             updated_at: now,

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -20,7 +20,10 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
-use base64::{engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}, Engine as _};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine as _,
+};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -20,7 +20,7 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use base64::{engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}, Engine as _};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1739,6 +1739,9 @@ pub struct ProviderResponse {
     pub status: ProviderStatusResponse,
     /// Which backends this provider is used for (e.g., ["opencode", "claudecode"])
     pub use_for_backends: Vec<String>,
+    /// Account identifier (email or username) from the connected OAuth account
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_email: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -1815,6 +1818,7 @@ fn build_provider_response(
     auth: Option<AuthKind>,
     default_provider: Option<ProviderType>,
     backends: Option<Vec<String>>,
+    account_email: Option<String>,
 ) -> ProviderResponse {
     let now = chrono::Utc::now();
     let name = config
@@ -1857,6 +1861,7 @@ fn build_provider_response(
         auth_methods: provider_type.auth_methods(),
         status,
         use_for_backends,
+        account_email,
         created_at: now,
         updated_at: now,
     }
@@ -3713,6 +3718,84 @@ fn remove_provider_backends(working_dir: &Path, provider_id: &str) -> Result<(),
     write_provider_backends_state(working_dir, &state)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider Account Info State (provider_accounts.json)
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn provider_accounts_state_path(working_dir: &Path) -> PathBuf {
+    working_dir
+        .join(".sandboxed-sh")
+        .join("provider_accounts.json")
+}
+
+/// Read provider account info state from the state file.
+/// Returns a map of provider_id -> account email (e.g., "anthropic" -> "user@example.com")
+fn read_provider_accounts_state(working_dir: &Path) -> HashMap<String, String> {
+    let path = provider_accounts_state_path(working_dir);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&contents).unwrap_or_default()
+}
+
+/// Write provider account info state to the state file.
+fn write_provider_accounts_state(
+    working_dir: &Path,
+    accounts: &HashMap<String, String>,
+) -> Result<(), String> {
+    let path = provider_accounts_state_path(working_dir);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create provider accounts directory: {}", e))?;
+    }
+    let contents = serde_json::to_string_pretty(accounts)
+        .map_err(|e| format!("Failed to serialize provider accounts: {}", e))?;
+    std::fs::write(path, contents)
+        .map_err(|e| format!("Failed to write provider accounts: {}", e))?;
+    Ok(())
+}
+
+/// Update account email for a specific provider in the state file.
+fn update_provider_account(
+    working_dir: &Path,
+    provider_id: &str,
+    email: String,
+) -> Result<(), String> {
+    let mut state = read_provider_accounts_state(working_dir);
+    state.insert(provider_id.to_string(), email);
+    write_provider_accounts_state(working_dir, &state)
+}
+
+/// Remove a provider from the accounts state file.
+fn remove_provider_account(working_dir: &Path, provider_id: &str) -> Result<(), String> {
+    let mut state = read_provider_accounts_state(working_dir);
+    state.remove(provider_id);
+    write_provider_accounts_state(working_dir, &state)
+}
+
+/// Extract email from a JWT id_token by decoding the payload (no signature verification).
+/// JWT format: header.payload.signature, where payload is base64url-encoded JSON.
+fn extract_email_from_jwt(token: &str) -> Option<String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let payload = parts[1];
+    // base64url decode: replace URL-safe chars and add padding
+    let padded = match payload.len() % 4 {
+        2 => format!("{}==", payload),
+        3 => format!("{}=", payload),
+        _ => payload.to_string(),
+    };
+    let decoded = padded.replace('-', "+").replace('_', "/");
+    let bytes = STANDARD.decode(&decoded).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("email")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 /// Read OpenCode's current auth.json contents.
 fn read_opencode_auth() -> Result<serde_json::Value, String> {
     let auth_path = get_opencode_auth_path();
@@ -4006,6 +4089,7 @@ async fn list_providers(
     let default_provider = read_default_provider_state(&state.config.working_dir)
         .or_else(|| get_default_provider(&opencode_config));
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
 
     let mut provider_ids: BTreeSet<String> = BTreeSet::new();
     for provider in auth_map.keys() {
@@ -4027,12 +4111,14 @@ async fn list_providers(
             let config_entry = get_provider_config_entry(&opencode_config, provider_type);
             let auth_kind = auth_map.get(&provider_type).copied();
             let backends = backends_state.get(provider_type.id()).cloned();
+            let account_email = accounts_state.get(provider_type.id()).cloned();
             Some(build_provider_response(
                 provider_type,
                 config_entry,
                 auth_kind,
                 default_provider,
                 backends,
+                account_email,
             ))
         })
         .collect();
@@ -4072,6 +4158,7 @@ async fn list_providers(
                     ProviderStatusResponse::NeedsAuth { auth_url: None }
                 },
                 use_for_backends: vec![default_backend],
+                account_email: provider.account_email.clone(),
                 created_at: now,
                 updated_at: now,
             });
@@ -4533,6 +4620,7 @@ async fn create_provider(
             use_for_backends: req
                 .use_for_backends
                 .unwrap_or_else(|| vec![default_backend]),
+            account_email: provider.account_email.clone(),
             created_at: now,
             updated_at: now,
         }));
@@ -4589,6 +4677,7 @@ async fn create_provider(
         auth_kind,
         default_provider,
         use_for_backends,
+        None,
     );
 
     tracing::info!(
@@ -4613,15 +4702,18 @@ async fn get_provider(
     let default_provider = read_default_provider_state(&state.config.working_dir)
         .or_else(|| get_default_provider(&opencode_config));
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
     let config_entry = get_provider_config_entry(&opencode_config, provider_type);
     let auth_kind = auth_map.get(&provider_type).copied();
     let backends = backends_state.get(provider_type.id()).cloned();
+    let account_email = accounts_state.get(provider_type.id()).cloned();
     let response = build_provider_response(
         provider_type,
         config_entry,
         auth_kind,
         default_provider,
         backends,
+        account_email,
     );
     Ok(Json(response))
 }
@@ -4712,15 +4804,18 @@ async fn update_provider(
     let default_provider = read_default_provider_state(&state.config.working_dir)
         .or_else(|| get_default_provider(&opencode_config));
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
     let config_entry = get_provider_config_entry(&opencode_config, provider_type);
     let auth_kind = auth_map.get(&provider_type).copied();
     let backends = backends_state.get(provider_type.id()).cloned();
+    let account_email = accounts_state.get(provider_type.id()).cloned();
     let response = build_provider_response(
         provider_type,
         config_entry,
         auth_kind,
         default_provider,
         backends,
+        account_email,
     );
 
     tracing::info!("Updated AI provider config: {} ({})", response.name, id);
@@ -4808,6 +4903,7 @@ async fn update_store_provider(
             ProviderStatusResponse::NeedsAuth { auth_url: None }
         },
         use_for_backends: vec![default_backend],
+        account_email: result.account_email.clone(),
         created_at: now,
         updated_at: result.updated_at,
     };
@@ -4863,6 +4959,11 @@ async fn delete_provider(
     // Remove provider backends state
     if let Err(e) = remove_provider_backends(&state.config.working_dir, provider_type.id()) {
         tracing::error!("Failed to remove provider backends state: {}", e);
+    }
+
+    // Clean up account email state
+    if let Err(e) = remove_provider_account(&state.config.working_dir, provider_type.id()) {
+        tracing::error!("Failed to remove provider account state: {}", e);
     }
 
     Ok((
@@ -4992,6 +5093,7 @@ async fn set_default(
                 ProviderStatusResponse::NeedsAuth { auth_url: None }
             },
             use_for_backends: vec![default_backend],
+            account_email: provider.account_email.clone(),
             created_at: now,
             updated_at: provider.updated_at,
         };
@@ -5009,16 +5111,19 @@ async fn set_default(
     let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
     let auth_map = read_opencode_auth_map().map_err(internal_error)?;
     let backends_state = read_provider_backends_state(&state.config.working_dir);
+    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
     let default_provider = Some(provider_type);
     let config_entry = get_provider_config_entry(&opencode_config, provider_type);
     let auth_kind = auth_map.get(&provider_type).copied();
     let backends = backends_state.get(provider_type.id()).cloned();
+    let account_email = accounts_state.get(provider_type.id()).cloned();
     let response = build_provider_response(
         provider_type,
         config_entry,
         auth_kind,
         default_provider,
         backends,
+        account_email,
     );
 
     tracing::info!("Set default AI provider: {} ({})", response.name, id);
@@ -5457,6 +5562,28 @@ async fn oauth_callback_inner(
                     }
                 }
 
+                // Try to extract account email from token response
+                let account_email = token_data
+                    .get("id_token")
+                    .or_else(|| token_data.get("access_token"))
+                    .and_then(|v| v.as_str())
+                    .and_then(extract_email_from_jwt)
+                    .or_else(|| {
+                        token_data
+                            .get("email")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    });
+                if let Some(ref email) = account_email {
+                    if let Err(e) = update_provider_account(
+                        &state.config.working_dir,
+                        provider_type.id(),
+                        email.clone(),
+                    ) {
+                        tracing::warn!("Failed to save Anthropic account email: {}", e);
+                    }
+                }
+
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
                 let config_entry = get_provider_config_entry(&opencode_config, provider_type);
@@ -5467,6 +5594,7 @@ async fn oauth_callback_inner(
                     Some(AuthKind::ApiKey),
                     default_provider,
                     backends,
+                    account_email,
                 );
 
                 tracing::info!("Created API key for provider: {} ({})", response.name, id);
@@ -5556,6 +5684,28 @@ async fn oauth_callback_inner(
                     }
                 }
 
+                // Try to extract account email from token response
+                let account_email = token_data
+                    .get("id_token")
+                    .or_else(|| token_data.get("access_token"))
+                    .and_then(|v| v.as_str())
+                    .and_then(extract_email_from_jwt)
+                    .or_else(|| {
+                        token_data
+                            .get("email")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    });
+                if let Some(ref email) = account_email {
+                    if let Err(e) = update_provider_account(
+                        &state.config.working_dir,
+                        provider_type.id(),
+                        email.clone(),
+                    ) {
+                        tracing::warn!("Failed to save Anthropic account email: {}", e);
+                    }
+                }
+
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
                 let config_entry = get_provider_config_entry(&opencode_config, provider_type);
@@ -5566,6 +5716,7 @@ async fn oauth_callback_inner(
                     Some(AuthKind::OAuth),
                     default_provider,
                     backends,
+                    account_email,
                 );
 
                 Ok(Json(response))
@@ -5699,6 +5850,21 @@ async fn oauth_callback_inner(
                 }
             }
 
+            // Extract account email from id_token JWT if available
+            let account_email = token_data
+                .get("id_token")
+                .and_then(|v| v.as_str())
+                .and_then(extract_email_from_jwt);
+            if let Some(ref email) = account_email {
+                if let Err(e) = update_provider_account(
+                    &state.config.working_dir,
+                    provider_type.id(),
+                    email.clone(),
+                ) {
+                    tracing::warn!("Failed to save OpenAI account email: {}", e);
+                }
+            }
+
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
             let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5711,6 +5877,7 @@ async fn oauth_callback_inner(
                 Some(AuthKind::OAuth),
                 default_provider,
                 backends,
+                account_email,
             );
 
             Ok(Json(response))
@@ -5801,6 +5968,21 @@ async fn oauth_callback_inner(
                 tracing::error!("Failed to sync Google credentials to OpenCode: {}", e);
             }
 
+            // Extract account email from id_token JWT if available
+            let account_email = token_data
+                .get("id_token")
+                .and_then(|v| v.as_str())
+                .and_then(extract_email_from_jwt);
+            if let Some(ref email) = account_email {
+                if let Err(e) = update_provider_account(
+                    &state.config.working_dir,
+                    provider_type.id(),
+                    email.clone(),
+                ) {
+                    tracing::warn!("Failed to save Google account email: {}", e);
+                }
+            }
+
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
             let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5813,6 +5995,7 @@ async fn oauth_callback_inner(
                 Some(AuthKind::OAuth),
                 default_provider,
                 backends,
+                account_email,
             );
 
             tracing::info!("Google OAuth credentials saved for provider: {}", id);

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -20,10 +20,7 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
-use base64::{
-    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
-    Engine as _,
-};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -3784,19 +3781,40 @@ fn extract_email_from_jwt(token: &str) -> Option<String> {
     if parts.len() != 3 {
         return None;
     }
-    let payload = parts[1];
-    // base64url decode: replace URL-safe chars and add padding
-    let padded = match payload.len() % 4 {
-        2 => format!("{}==", payload),
-        3 => format!("{}=", payload),
-        _ => payload.to_string(),
-    };
-    let decoded = padded.replace('-', "+").replace('_', "/");
-    let bytes = STANDARD.decode(&decoded).ok()?;
+    let bytes = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
     let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
     json.get("email")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
+}
+
+/// Extract account email from an OAuth token response and persist it.
+///
+/// Tries `id_token` JWT first, then `access_token` JWT, then a plain `email` field.
+/// If an email is found, saves it to the provider accounts state file.
+fn extract_and_save_account_email(
+    token_data: &serde_json::Value,
+    working_dir: &Path,
+    provider_id: &str,
+    provider_label: &str,
+) -> Option<String> {
+    let email = token_data
+        .get("id_token")
+        .or_else(|| token_data.get("access_token"))
+        .and_then(|v| v.as_str())
+        .and_then(extract_email_from_jwt)
+        .or_else(|| {
+            token_data
+                .get("email")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+    if let Some(ref e) = email {
+        if let Err(err) = update_provider_account(working_dir, provider_id, e.clone()) {
+            tracing::warn!("Failed to save {} account email: {}", provider_label, err);
+        }
+    }
+    email
 }
 
 /// Read OpenCode's current auth.json contents.
@@ -5565,27 +5583,12 @@ async fn oauth_callback_inner(
                     }
                 }
 
-                // Try to extract account email from token response
-                let account_email = token_data
-                    .get("id_token")
-                    .or_else(|| token_data.get("access_token"))
-                    .and_then(|v| v.as_str())
-                    .and_then(extract_email_from_jwt)
-                    .or_else(|| {
-                        token_data
-                            .get("email")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    });
-                if let Some(ref email) = account_email {
-                    if let Err(e) = update_provider_account(
-                        &state.config.working_dir,
-                        provider_type.id(),
-                        email.clone(),
-                    ) {
-                        tracing::warn!("Failed to save Anthropic account email: {}", e);
-                    }
-                }
+                let account_email = extract_and_save_account_email(
+                    &token_data,
+                    &state.config.working_dir,
+                    provider_type.id(),
+                    "Anthropic",
+                );
 
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5687,27 +5690,12 @@ async fn oauth_callback_inner(
                     }
                 }
 
-                // Try to extract account email from token response
-                let account_email = token_data
-                    .get("id_token")
-                    .or_else(|| token_data.get("access_token"))
-                    .and_then(|v| v.as_str())
-                    .and_then(extract_email_from_jwt)
-                    .or_else(|| {
-                        token_data
-                            .get("email")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    });
-                if let Some(ref email) = account_email {
-                    if let Err(e) = update_provider_account(
-                        &state.config.working_dir,
-                        provider_type.id(),
-                        email.clone(),
-                    ) {
-                        tracing::warn!("Failed to save Anthropic account email: {}", e);
-                    }
-                }
+                let account_email = extract_and_save_account_email(
+                    &token_data,
+                    &state.config.working_dir,
+                    provider_type.id(),
+                    "Anthropic",
+                );
 
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5853,20 +5841,12 @@ async fn oauth_callback_inner(
                 }
             }
 
-            // Extract account email from id_token JWT if available
-            let account_email = token_data
-                .get("id_token")
-                .and_then(|v| v.as_str())
-                .and_then(extract_email_from_jwt);
-            if let Some(ref email) = account_email {
-                if let Err(e) = update_provider_account(
-                    &state.config.working_dir,
-                    provider_type.id(),
-                    email.clone(),
-                ) {
-                    tracing::warn!("Failed to save OpenAI account email: {}", e);
-                }
-            }
+            let account_email = extract_and_save_account_email(
+                &token_data,
+                &state.config.working_dir,
+                provider_type.id(),
+                "OpenAI",
+            );
 
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
@@ -5971,20 +5951,12 @@ async fn oauth_callback_inner(
                 tracing::error!("Failed to sync Google credentials to OpenCode: {}", e);
             }
 
-            // Extract account email from id_token JWT if available
-            let account_email = token_data
-                .get("id_token")
-                .and_then(|v| v.as_str())
-                .and_then(extract_email_from_jwt);
-            if let Some(ref email) = account_email {
-                if let Err(e) = update_provider_account(
-                    &state.config.working_dir,
-                    provider_type.id(),
-                    email.clone(),
-                ) {
-                    tracing::warn!("Failed to save Google account email: {}", e);
-                }
-            }
+            let account_email = extract_and_save_account_email(
+                &token_data,
+                &state.config.working_dir,
+                provider_type.id(),
+                "Google",
+            );
 
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3800,9 +3800,14 @@ fn extract_and_save_account_email(
 ) -> Option<String> {
     let email = token_data
         .get("id_token")
-        .or_else(|| token_data.get("access_token"))
         .and_then(|v| v.as_str())
         .and_then(extract_email_from_jwt)
+        .or_else(|| {
+            token_data
+                .get("access_token")
+                .and_then(|v| v.as_str())
+                .and_then(extract_email_from_jwt)
+        })
         .or_else(|| {
             token_data
                 .get("email")

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -273,17 +273,22 @@ fn strip_think_tags(text: &str) -> String {
     while pos < text.len() {
         if let Some(rel_start) = find_ci(&text[pos..], "<think>") {
             let abs_start = pos + rel_start;
-            result.push_str(&text[pos..abs_start]);
+            // rel_start is a byte index from as_bytes(); walk back to a char boundary
+            let safe_start = (0..=abs_start)
+                .rev()
+                .find(|&i| text.is_char_boundary(i))
+                .unwrap_or(0);
+            result.push_str(&text[pos..safe_start]);
 
-            let after_open = abs_start + 7; // len("<think>")
+            let after_open = safe_start + 7; // "<think>" is 7 ASCII bytes — always safe
             if after_open <= text.len() {
                 if let Some(rel_close) = find_ci(&text[after_open..], "</think>") {
-                    pos = after_open + rel_close + 8; // len("</think>")
+                    pos = after_open + rel_close + 8; // "</think>" is 8 ASCII bytes — always safe
                 } else {
-                    break;
+                    break; // unclosed tag: drop everything from <think> onwards
                 }
             } else {
-                break;
+                break; // unclosed tag: drop everything from <think> onwards
             }
         } else {
             result.push_str(&text[pos..]);
@@ -11391,6 +11396,20 @@ mod tests {
     fn strip_think_tags_empty_content() {
         let input = "<think></think>";
         assert_eq!(strip_think_tags(input), "");
+    }
+
+    #[test]
+    fn strip_think_tags_with_emoji_no_panic() {
+        let input = "Hello 🛡 world <think>reasoning</think> done";
+        let result = strip_think_tags(input);
+        assert_eq!(result, "Hello 🛡 world  done");
+    }
+
+    #[test]
+    fn strip_think_tags_emoji_inside_think_no_panic() {
+        let input = "before<think>🛡 reasoning 🎯</think>after";
+        let result = strip_think_tags(input);
+        assert_eq!(result, "beforeafter");
     }
 
     // ── extract_thought_line tests ────────────────────────────────────

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3877,6 +3877,15 @@ fn strip_ansi_codes(input: &str) -> Cow<'_, str> {
     let mut idx = 0;
 
     while idx < bytes.len() {
+        // UTF-8 continuation bytes (0x80-0xBF) cannot be standalone control
+        // characters. Without this guard, a byte like 0x9B (C1 CSI) matched
+        // as a control character when it is actually the 3rd byte of a 4-byte
+        // emoji (e.g. 🛠 = F0 9F 9B A0) causes a slice panic at a non-char
+        // boundary.
+        if !input.is_char_boundary(idx) {
+            idx += 1;
+            continue;
+        }
         match bytes[idx] {
             0x1b => {
                 cleaned.push_str(&input[last_copy..idx]);
@@ -11478,6 +11487,27 @@ mod tests {
     #[test]
     fn strip_ansi_codes_empty_string() {
         assert_eq!(strip_ansi_codes(""), "");
+    }
+
+    #[test]
+    fn strip_ansi_codes_emoji_with_0x9b_continuation_byte_does_not_panic() {
+        // 🛠 = U+1F6E0, UTF-8: F0 9F 9B A0.  The 0x9B byte is the C1 CSI
+        // character when standalone, but here it is a UTF-8 continuation byte.
+        // strip_ansi_codes must not panic or slice at a non-char boundary.
+        let input = "prefix 🛠 suffix";
+        let result = strip_ansi_codes(input);
+        assert!(result.contains("🛠"), "emoji must be preserved: {result}");
+        assert!(result.contains("prefix"));
+        assert!(result.contains("suffix"));
+    }
+
+    #[test]
+    fn strip_ansi_codes_camoufox_snapshot_with_emoji_preserved() {
+        // Regression: camoufox Twitter snapshot containing 🛠 caused a panic
+        // at byte index 21675 (inside the emoji) via the 0x9B match arm.
+        let snapshot = format!("{}{}{}", "a".repeat(20000), "🛠", "b".repeat(2000));
+        let result = strip_ansi_codes(&snapshot);
+        assert!(result.contains("🛠"), "emoji in large string must survive");
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -273,14 +273,11 @@ fn strip_think_tags(text: &str) -> String {
     while pos < text.len() {
         if let Some(rel_start) = find_ci(&text[pos..], "<think>") {
             let abs_start = pos + rel_start;
-            // rel_start is a byte index from as_bytes(); walk back to a char boundary
-            let safe_start = (0..=abs_start)
-                .rev()
-                .find(|&i| text.is_char_boundary(i))
-                .unwrap_or(0);
-            result.push_str(&text[pos..safe_start]);
+            // find_ci searches for ASCII "<think>", so abs_start always lands on
+            // a char boundary (the `<` byte). No boundary walk-back needed.
+            result.push_str(&text[pos..abs_start]);
 
-            let after_open = safe_start + 7; // "<think>" is 7 ASCII bytes — always safe
+            let after_open = abs_start + 7; // "<think>" is 7 ASCII bytes
             if after_open <= text.len() {
                 if let Some(rel_close) = find_ci(&text[after_open..], "</think>") {
                     pos = after_open + rel_close + 8; // "</think>" is 8 ASCII bytes — always safe

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3864,7 +3864,7 @@ fn strip_ansi_codes(input: &str) -> Cow<'_, str> {
     let bytes = input.as_bytes();
     if !bytes
         .iter()
-        .any(|byte| *byte == 0x1b || *byte == 0x9b || is_disallowed_control(*byte))
+        .any(|byte| *byte == 0x1b || is_disallowed_control(*byte))
     {
         return Cow::Borrowed(input);
     }
@@ -3874,11 +3874,9 @@ fn strip_ansi_codes(input: &str) -> Cow<'_, str> {
     let mut idx = 0;
 
     while idx < bytes.len() {
-        // UTF-8 continuation bytes (0x80-0xBF) cannot be standalone control
-        // characters. Without this guard, a byte like 0x9B (C1 CSI) matched
-        // as a control character when it is actually the 3rd byte of a 4-byte
-        // emoji (e.g. 🛠 = F0 9F 9B A0) causes a slice panic at a non-char
-        // boundary.
+        // Skip UTF-8 continuation bytes (0x80-0xBF). These are never
+        // standalone control characters in valid UTF-8 — they only appear
+        // as trailing bytes of multi-byte sequences (e.g. 🛠 = F0 9F 9B A0).
         if !input.is_char_boundary(idx) {
             idx += 1;
             continue;
@@ -3887,11 +3885,6 @@ fn strip_ansi_codes(input: &str) -> Cow<'_, str> {
             0x1b => {
                 cleaned.push_str(&input[last_copy..idx]);
                 idx = consume_escape_sequence(bytes, idx);
-                last_copy = idx;
-            }
-            0x9b => {
-                cleaned.push_str(&input[last_copy..idx]);
-                idx = consume_csi_sequence(bytes, idx + 1);
                 last_copy = idx;
             }
             byte if is_disallowed_control(byte) => {

--- a/src/backend/amp/client.rs
+++ b/src/backend/amp/client.rs
@@ -146,7 +146,7 @@ impl AmpClient {
                     Err(e) => {
                         warn!(
                             error = %e,
-                            line = %if line.len() > 200 { &line[..200] } else { &line },
+                            line = %if line.len() > 200 { let mut i = 200; while i > 0 && !line.is_char_boundary(i) { i -= 1; } &line[..i] } else { &line },
                             "Failed to parse Amp event"
                         );
                     }

--- a/src/backend/claudecode/client.rs
+++ b/src/backend/claudecode/client.rs
@@ -178,7 +178,9 @@ impl ClaudeCodeClient {
                             "Failed to parse Claude event: {} - line: {}",
                             e,
                             if line.len() > 200 {
-                                format!("{}...", &line[..200])
+                                let mut i = 200;
+                                while i > 0 && !line.is_char_boundary(i) { i -= 1; }
+                                format!("{}...", &line[..i])
                             } else {
                                 line.clone()
                             }

--- a/src/backend/claudecode/client.rs
+++ b/src/backend/claudecode/client.rs
@@ -179,7 +179,9 @@ impl ClaudeCodeClient {
                             e,
                             if line.len() > 200 {
                                 let mut i = 200;
-                                while i > 0 && !line.is_char_boundary(i) { i -= 1; }
+                                while i > 0 && !line.is_char_boundary(i) {
+                                    i -= 1;
+                                }
                                 format!("{}...", &line[..i])
                             } else {
                                 line.clone()

--- a/src/backend/codex/client.rs
+++ b/src/backend/codex/client.rs
@@ -182,7 +182,9 @@ impl CodexClient {
                 // Avoid exploding logs from very long lines.
                 if trimmed.len() > 400 {
                     let mut i = 400;
-                    while i > 0 && !trimmed.is_char_boundary(i) { i -= 1; }
+                    while i > 0 && !trimmed.is_char_boundary(i) {
+                        i -= 1;
+                    }
                     captured.push_str(&trimmed[..i]);
                     captured.push_str("...");
                 } else {

--- a/src/backend/codex/client.rs
+++ b/src/backend/codex/client.rs
@@ -181,7 +181,9 @@ impl CodexClient {
                 }
                 // Avoid exploding logs from very long lines.
                 if trimmed.len() > 400 {
-                    captured.push_str(&trimmed[..400]);
+                    let mut i = 400;
+                    while i > 0 && !trimmed.is_char_boundary(i) { i -= 1; }
+                    captured.push_str(&trimmed[..i]);
                     captured.push_str("...");
                 } else {
                     captured.push_str(trimmed);

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1213,13 +1213,13 @@ async fn write_opencode_config(
         write_commands_as_opencode_skills(workspace_dir, commands).await?;
     }
 
-    // Write RTK PreToolUse hook for Claude Code (which oh-my-opencode wraps).
-    // This enables RTK compression for the native Bash tool used by the agent.
-    // Since OpenCode wraps Claude Code, we need to write a minimal
-    // `.claude/settings.local.json` containing the hooks config so the
-    // underlying Claude Code process discovers the hook.
+    // Write Bash PreToolUse hook for Claude Code (which oh-my-opencode wraps).
+    // This fixes gh CLI hanging in PTY and enables RTK compression for the
+    // native Bash tool used by the agent. Since OpenCode wraps Claude Code,
+    // we need to write a minimal `.claude/settings.local.json` containing the
+    // hooks config so the underlying Claude Code process discovers the hook.
     if let Some(hooks) =
-        write_rtk_hook_if_enabled(workspace_dir, workspace_root, workspace_type).await?
+        write_bash_pretool_hook(workspace_dir, workspace_root, workspace_type).await?
     {
         let claude_dir = workspace_dir.join(".claude");
         tokio::fs::create_dir_all(&claude_dir).await?;
@@ -1244,18 +1244,16 @@ async fn write_opencode_config(
 ///
 /// For the OpenCode backend this is also called so that the underlying Claude
 /// Code process (wrapped by oh-my-opencode) picks up the hook.
-async fn write_rtk_hook_if_enabled(
+async fn write_bash_pretool_hook(
     workspace_dir: &Path,
     workspace_root: &Path,
     workspace_type: WorkspaceType,
 ) -> anyhow::Result<Option<serde_json::Value>> {
-    if !rtk_enabled() {
-        return Ok(None);
-    }
+    let use_rtk = rtk_enabled();
 
     // For container workspaces, copy the RTK binary from host into the container
     let is_container = workspace_type == WorkspaceType::Container && nspawn::nspawn_available();
-    if is_container {
+    if use_rtk && is_container {
         if let Some(host_rtk) = rtk_binary_path() {
             let dest_dir = workspace_root.join("usr").join("local").join("bin");
             std::fs::create_dir_all(&dest_dir).ok();
@@ -1282,19 +1280,24 @@ async fn write_rtk_hook_if_enabled(
             }
         } else {
             tracing::warn!("RTK enabled but binary not found on host");
-            return Ok(None);
         }
     }
 
-    // Write the hook script to .claude/hooks/rtk-wrap.sh
+    // Write the hook script to .claude/hooks/bash-pretool.sh
+    //
+    // This hook serves two purposes:
+    // 1. **gh terminal fix** (always): Wraps `gh` commands with `env TERM=dumb` to prevent
+    //    lipgloss from sending terminal capability queries (OSC 11, DSR) that hang forever
+    //    in our PTY environment (no terminal emulator to respond).
+    // 2. **RTK compression** (when enabled): Rewrites eligible commands to use RTK
+    //    subcommands for 60-90% token compression on CLI output.
     let hooks_dir = workspace_dir.join(".claude").join("hooks");
     tokio::fs::create_dir_all(&hooks_dir).await?;
-    let rtk_hook_path = hooks_dir.join("rtk-wrap.sh");
-    let rtk_hook_script = r#"#!/bin/bash
-# RTK PreToolUse hook: rewrites eligible bash commands to use RTK subcommands.
-# This reduces token consumption by 60-90% on common CLI output.
-# RTK has specific subcommands — we map the first word of the command to the
-# corresponding RTK subcommand and pass the rest as arguments after --.
+    let hook_path = hooks_dir.join("bash-pretool.sh");
+    let hook_script = r#"#!/bin/bash
+# PreToolUse hook for Bash commands.
+# 1. Fixes gh CLI hanging in PTY by setting TERM=dumb (prevents lipgloss terminal queries)
+# 2. Optionally rewrites commands to use RTK for token compression
 set -euo pipefail
 
 INPUT=$(cat)
@@ -1310,85 +1313,102 @@ case "$COMMAND" in
   *"&&"*|*"||"*|*"|"*|*"<<"*|*"("*|*";"*|*'`'*|*'$('*) exit 0 ;;
 esac
 
-# Find rtk binary
-RTK_PATH=""
-for p in /usr/local/bin/rtk /usr/bin/rtk; do
-  if [ -x "$p" ]; then RTK_PATH="$p"; break; fi
-done
-if [ -z "$RTK_PATH" ]; then exit 0; fi
-
 # Extract the base command (first word, ignoring path prefix)
 FIRST_WORD=$(echo "$COMMAND" | awk '{print $1}')
 BASE_CMD=$(basename "$FIRST_WORD")
 REST=$(echo "$COMMAND" | sed "s|^[^ ]* *||")
 
+emit_rewrite() {
+  jq -n --arg cmd "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      updatedInput: { command: $cmd }
+    }
+  }'
+}
+
+# Find rtk binary (for optional compression)
+RTK_PATH=""
+for p in /usr/local/bin/rtk /usr/bin/rtk; do
+  if [ -x "$p" ]; then RTK_PATH="$p"; break; fi
+done
+
 # Map base commands to RTK subcommands (only commands RTK natively supports)
 RTK_SUB=""
-case "$BASE_CMD" in
-  ls)        RTK_SUB="ls" ;;
-  tree)      RTK_SUB="tree" ;;
-  git)       RTK_SUB="git" ;;
-  gh)        RTK_SUB="gh" ;;
-  grep|rg)   RTK_SUB="grep" ;;
-  cargo)     RTK_SUB="cargo" ;;
-  npm)       RTK_SUB="npm" ;;
-  npx)       RTK_SUB="npx" ;;
-  bun)       RTK_SUB="npm" ;;
-  bunx)      RTK_SUB="npx" ;;
-  pnpm)      RTK_SUB="pnpm" ;;
-  docker)    RTK_SUB="docker" ;;
-  kubectl)   RTK_SUB="kubectl" ;;
-  vitest)    RTK_SUB="vitest" ;;
-  pytest)    RTK_SUB="pytest" ;;
-  go)        RTK_SUB="go" ;;
-  tsc)       RTK_SUB="tsc" ;;
-  eslint)    RTK_SUB="lint" ;;
-  ruff)      RTK_SUB="ruff" ;;
-  curl)      RTK_SUB="curl" ;;
-  pip|uv)    RTK_SUB="pip" ;;
-  diff)      RTK_SUB="diff" ;;
-esac
-
-if [ -z "$RTK_SUB" ]; then exit 0; fi
-
-# Build the rewritten command: rtk <sub> -- <original args>
-if [ -n "$REST" ]; then
-  NEW_CMD="$RTK_PATH $RTK_SUB -- $REST"
-else
-  NEW_CMD="$RTK_PATH $RTK_SUB"
+if [ -n "$RTK_PATH" ]; then
+  case "$BASE_CMD" in
+    ls)        RTK_SUB="ls" ;;
+    tree)      RTK_SUB="tree" ;;
+    git)       RTK_SUB="git" ;;
+    gh)        RTK_SUB="gh" ;;
+    grep|rg)   RTK_SUB="grep" ;;
+    cargo)     RTK_SUB="cargo" ;;
+    npm)       RTK_SUB="npm" ;;
+    npx)       RTK_SUB="npx" ;;
+    bun)       RTK_SUB="npm" ;;
+    bunx)      RTK_SUB="npx" ;;
+    pnpm)      RTK_SUB="pnpm" ;;
+    docker)    RTK_SUB="docker" ;;
+    kubectl)   RTK_SUB="kubectl" ;;
+    vitest)    RTK_SUB="vitest" ;;
+    pytest)    RTK_SUB="pytest" ;;
+    go)        RTK_SUB="go" ;;
+    tsc)       RTK_SUB="tsc" ;;
+    eslint)    RTK_SUB="lint" ;;
+    ruff)      RTK_SUB="ruff" ;;
+    curl)      RTK_SUB="curl" ;;
+    pip|uv)    RTK_SUB="pip" ;;
+    diff)      RTK_SUB="diff" ;;
+  esac
 fi
 
-# Rewrite the command to use RTK
-jq -n --arg cmd "$NEW_CMD" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "allow",
-    updatedInput: { command: $cmd }
-  }
-}'
+# If RTK supports this command, rewrite to use RTK (which pipes internally, fixing PTY too)
+if [ -n "$RTK_SUB" ]; then
+  if [ -n "$REST" ]; then
+    emit_rewrite "$RTK_PATH $RTK_SUB -- $REST"
+  else
+    emit_rewrite "$RTK_PATH $RTK_SUB"
+  fi
+  exit 0
+fi
+
+# No RTK available — still fix gh commands that hang in PTY environments.
+# The gh CLI (via lipgloss/glamour) sends terminal capability queries like
+# OSC 11 (background color) and DSR (cursor position) when TERM != dumb.
+# Our PTY has no terminal emulator to respond, causing indefinite hangs.
+case "$BASE_CMD" in
+  gh)
+    emit_rewrite "env TERM=dumb $COMMAND"
+    exit 0
+    ;;
+esac
+
+exit 0
 "#;
-    tokio::fs::write(&rtk_hook_path, rtk_hook_script).await?;
+    tokio::fs::write(&hook_path, hook_script).await?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&rtk_hook_path, perms)?;
+        std::fs::set_permissions(&hook_path, perms)?;
     }
 
     // For container workspaces, translate the hook path from host to container-relative
     let hook_command = if is_container {
-        if let Ok(rel) = rtk_hook_path.strip_prefix(workspace_root) {
+        if let Ok(rel) = hook_path.strip_prefix(workspace_root) {
             format!("/{}", rel.to_string_lossy())
         } else {
-            rtk_hook_path.to_string_lossy().to_string()
+            hook_path.to_string_lossy().to_string()
         }
     } else {
-        rtk_hook_path.to_string_lossy().to_string()
+        hook_path.to_string_lossy().to_string()
     };
     tracing::info!(
         hook_path = %hook_command,
         is_container = is_container,
-        "RTK PreToolUse hook written"
+        use_rtk = use_rtk,
+        "Bash PreToolUse hook written"
     );
 
     Ok(Some(json!({
@@ -1476,10 +1496,10 @@ async fn write_claudecode_config(
         }
     });
 
-    // Add RTK PreToolUse hook if enabled — rewrites eligible Bash commands
-    // to prefix them with `rtk` for token compression.
+    // Add Bash PreToolUse hook — fixes gh CLI hanging in PTY environments
+    // and optionally rewrites commands with RTK for token compression.
     if let Some(hooks) =
-        write_rtk_hook_if_enabled(workspace_dir, workspace_root, workspace_type).await?
+        write_bash_pretool_hook(workspace_dir, workspace_root, workspace_type).await?
     {
         settings
             .as_object_mut()


### PR DESCRIPTION
## Summary
Combines #347 and #346 with formatting fixes.

### Provider account email (#347)
- Extract account email from OAuth JWT id_tokens during provider authentication (Anthropic, OpenAI, Google)
- Persist account emails in `provider_accounts.json` state file
- Display `account_email` as subtitle on provider cards in settings

### UTF-8 emoji panic fix (#346)
- Fix `strip_think_tags()` panic when agent output contains multi-byte UTF-8 characters (emoji)
- Fix log truncation boundary issues in claudecode, codex, and amp clients

### Formatting
- Applied `cargo fmt --all` to fix CI format check failures from both PRs

Closes #347
Closes #346

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] All existing tests from both PRs included
- [ ] CI checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes OAuth callback handling to extract/persist account identifiers and threads a new `account_email` field through API/UI; it also adjusts output sanitization and log truncation logic to avoid UTF-8 boundary panics.
> 
> **Overview**
> **Adds connected-account identification for AI providers.** OAuth callbacks now extract an `account_email` from token responses, persist it in a new `provider_accounts.json` state file, return it via the providers API, and show it as a subtitle in the dashboard providers list (with Playwright route-mocking coverage).
> 
> **Fixes UTF-8/emoji-related panics and truncation bugs.** `strip_think_tags`/`strip_ansi_codes` and multiple backend clients now avoid slicing at non-char boundaries when scanning/truncating output, with new regression tests.
> 
> Also updates workspace Bash `PreToolUse` hook generation to include a `gh` PTY hang workaround (and optional RTK rewrites), and ignores iOS build artifacts in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f1638026a12c1b24cd5c0125c618a26499f384c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->