### PR TITLE
fix: add type:http field to claude_entry_from_mcp for HTTP MCPs

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -875,6 +875,7 @@ fn claude_entry_from_mcp(
     match &config.transport {
         McpTransport::Http { endpoint, headers } => {
             let mut entry = serde_json::Map::new();
+            entry.insert("type".to_string(), json!("http"));
             entry.insert("url".to_string(), json!(endpoint));
             if !headers.is_empty() {
                 entry.insert("headers".to_string(), json!(headers));


### PR DESCRIPTION
## Summary

- `claude_entry_from_mcp` was emitting `{"url": "..."}` for HTTP MCP servers, but Claude Code requires `{"type": "http", "url": "..."}` to recognize them as HTTP transports
- Without the `"type"` field, Claude Code rejects the config with *"Does not adhere to MCP server configuration schema"*
- The parallel function `opencode_entry_from_mcp` already included `"type": "http"` — this was only missing from the Claude Code path
- One-line fix in `src/workspace.rs`

## Test plan

- [x] Configured an HTTP MCP server (vault-search on `127.0.0.1:8181/mcp`) as a global MCP in sandboxed.sh
- [x] Started a Claude Code mission — MCP server was recognized and tools were available
- [x] Verified stdio MCPs still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)