### PR TITLE
Fix symlink loop crashes, LLM title logging, gzip compression & input history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Web framework
 axum = { version = "0.7", features = ["ws", "multipart"] }
-tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "compression-gzip"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Web framework
 axum = { version = "0.7", features = ["ws", "multipart"] }
-tower-http = { version = "0.5", features = ["cors", "trace", "compression-gzip"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -2934,16 +2934,26 @@ export default function ControlClient() {
     return viewingRunningInfo.health;
   }, [viewingMissionId, viewingRunningInfo]);
 
-  const hasPendingQuestion = useMemo(
-    () =>
-      items.some(
-        (item) =>
-          item.kind === "tool" &&
-          (item.name === "question" || item.name === "AskUserQuestion") &&
-          item.result === undefined
-      ),
-    [items]
-  );
+  const hasPendingQuestion = useMemo(() => {
+    // Find the index of the last user message — any question before it is
+    // implicitly answered (the user continued the conversation).
+    let lastUserIdx = -1;
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (items[i].kind === "user") {
+        lastUserIdx = i;
+        break;
+      }
+    }
+    // Only consider questions that appear AFTER the last user message
+    // and have no result — these are genuinely pending.
+    return items.some(
+      (item, idx) =>
+        item.kind === "tool" &&
+        (item.name === "question" || item.name === "AskUserQuestion") &&
+        item.result === undefined &&
+        idx > lastUserIdx
+    );
+  }, [items]);
 
   const viewingMissionStallSeconds = viewingMissionStallInfo?.seconds_since_activity ?? 0;
   const isViewingMissionStalled = Boolean(viewingMissionStallInfo);
@@ -6389,8 +6399,8 @@ export default function ControlClient() {
         missionLabel={
           activeMission
             ? activeWorkspaceLabel
-              ? `${activeWorkspaceLabel} · ${getMissionShortName(activeMission.id)}`
-              : getMissionShortName(activeMission.id)
+              ? `${activeWorkspaceLabel} · ${activeMission.title?.trim() || getMissionShortName(activeMission.id)}`
+              : activeMission.title?.trim() || getMissionShortName(activeMission.id)
             : null
         }
         onClose={() => setShowAutomationsDialog(false)}

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -387,12 +387,22 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
   }, [value, onChange]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Cmd/Ctrl+Z on empty input: restore last sent message
+    // Cmd/Ctrl+Z: navigate history back (empty input or already browsing)
     if (e.key === 'z' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
       const isEmpty = displayValue.trim() === '';
-      if (isEmpty && sentHistoryRef.current.length > 0) {
+      const isBrowsing = historyIndexRef.current !== -1;
+      if ((isEmpty || isBrowsing) && sentHistoryRef.current.length > 0) {
         e.preventDefault();
         navigateHistory('back');
+        return;
+      }
+    }
+
+    // Cmd/Ctrl+Shift+Z: navigate history forward (while browsing)
+    if (e.key === 'z' && (e.metaKey || e.ctrlKey) && e.shiftKey) {
+      if (historyIndexRef.current !== -1) {
+        e.preventDefault();
+        navigateHistory('forward');
         return;
       }
     }

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -388,7 +388,7 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Cmd/Ctrl+Z: navigate history back (empty input or already browsing)
-    if (e.key === 'z' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+    if (e.key.toLowerCase() === 'z' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
       const isEmpty = displayValue.trim() === '';
       const isBrowsing = historyIndexRef.current !== -1;
       if ((isEmpty || isBrowsing) && sentHistoryRef.current.length > 0) {
@@ -399,7 +399,7 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
     }
 
     // Cmd/Ctrl+Shift+Z: navigate history forward (while browsing)
-    if (e.key === 'z' && (e.metaKey || e.ctrlKey) && e.shiftKey) {
+    if (e.key.toLowerCase() === 'z' && (e.metaKey || e.ctrlKey) && e.shiftKey) {
       if (historyIndexRef.current !== -1) {
         e.preventDefault();
         navigateHistory('forward');

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -394,18 +394,20 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
       const isEmpty = displayValue.trim() === '';
       const isBrowsing = historyIndexRef.current !== -1;
       if ((isEmpty || isBrowsing) && sentHistoryRef.current.length > 0) {
-        e.preventDefault();
-        navigateHistory('back');
-        return;
+        if (navigateHistory('back')) {
+          e.preventDefault();
+          return;
+        }
       }
     }
 
     // Cmd/Ctrl+Shift+Z: navigate history forward (while browsing)
     if (e.key.toLowerCase() === 'z' && (e.metaKey || e.ctrlKey) && e.shiftKey) {
       if (historyIndexRef.current !== -1) {
-        e.preventDefault();
-        navigateHistory('forward');
-        return;
+        if (navigateHistory('forward')) {
+          e.preventDefault();
+          return;
+        }
       }
     }
 

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -76,6 +76,33 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
   // Track locked agent badge separately for cleaner UX
   const [lockedAgent, setLockedAgent] = useState<string | null>(null);
 
+  // Message history for undo / arrow-key recall
+  const HISTORY_KEY = 'enhanced-input-message-history';
+  const MAX_HISTORY = 10;
+  const sentHistoryRef = useRef<string[]>([]);
+  const historyIndexRef = useRef(-1); // -1 = not browsing history
+  const savedDraftRef = useRef(''); // saves current draft when entering history
+
+  // Load history from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(HISTORY_KEY);
+      if (stored) sentHistoryRef.current = JSON.parse(stored);
+    } catch { /* ignore */ }
+  }, []);
+
+  const pushToHistory = useCallback((message: string) => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    const history = sentHistoryRef.current;
+    // Deduplicate: remove if already most recent
+    if (history.length > 0 && history[history.length - 1] === trimmed) return;
+    history.push(trimmed);
+    if (history.length > MAX_HISTORY) history.splice(0, history.length - MAX_HISTORY);
+    try { localStorage.setItem(HISTORY_KEY, JSON.stringify(history)); } catch { /* ignore */ }
+    historyIndexRef.current = -1;
+  }, []);
+
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const autocompleteRef = useRef<HTMLDivElement>(null);
 
@@ -324,7 +351,52 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
     return descriptions[name] || 'Specialized agent';
   };
 
+  const navigateHistory = useCallback((direction: 'back' | 'forward') => {
+    const history = sentHistoryRef.current;
+    if (history.length === 0) return false;
+
+    if (direction === 'back') {
+      if (historyIndexRef.current === -1) {
+        // Entering history mode — save current draft
+        savedDraftRef.current = value;
+        historyIndexRef.current = history.length - 1;
+      } else if (historyIndexRef.current > 0) {
+        historyIndexRef.current--;
+      } else {
+        return false; // Already at oldest
+      }
+      const msg = history[historyIndexRef.current];
+      setLockedAgent(null);
+      onChange(msg);
+      return true;
+    } else {
+      if (historyIndexRef.current === -1) return false; // Not in history mode
+      if (historyIndexRef.current < history.length - 1) {
+        historyIndexRef.current++;
+        const msg = history[historyIndexRef.current];
+        setLockedAgent(null);
+        onChange(msg);
+      } else {
+        // Past newest → restore draft
+        historyIndexRef.current = -1;
+        setLockedAgent(null);
+        onChange(savedDraftRef.current);
+      }
+      return true;
+    }
+  }, [value, onChange]);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Cmd/Ctrl+Z on empty input: restore last sent message
+    if (e.key === 'z' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+      const isEmpty = displayValue.trim() === '';
+      if (isEmpty && sentHistoryRef.current.length > 0) {
+        e.preventDefault();
+        navigateHistory('back');
+        return;
+      }
+    }
+
     // Handle backspace on locked agent badge
     if (e.key === 'Backspace' && lockedAgent && displayValue === '') {
       e.preventDefault();
@@ -362,6 +434,26 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
       }
     }
 
+    // Up arrow on empty input or at position 0: navigate history back
+    if (e.key === 'ArrowUp' && !showAutocomplete) {
+      const textarea = textareaRef.current;
+      const isEmpty = displayValue.trim() === '';
+      const atStart = textarea && textarea.selectionStart === 0 && textarea.selectionEnd === 0;
+      if (isEmpty || (atStart && !displayValue.includes('\n'))) {
+        if (navigateHistory('back')) {
+          e.preventDefault();
+          return;
+        }
+      }
+    }
+
+    // Down arrow while browsing history: navigate forward
+    if (e.key === 'ArrowDown' && !showAutocomplete && historyIndexRef.current !== -1) {
+      e.preventDefault();
+      navigateHistory('forward');
+      return;
+    }
+
     // Normal Enter to submit (without Shift)
     if (e.key === 'Enter' && !e.shiftKey && !showAutocomplete) {
       e.preventDefault();
@@ -389,6 +481,12 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
     const trimmedValue = displayValue.trim();
     if (!trimmedValue && !lockedAgent) return;
     if (disabled) return;
+
+    // Save to history before clearing (include agent prefix for full recall)
+    const fullMessage = lockedAgent
+      ? (trimmedValue ? `@${lockedAgent} ${trimmedValue}` : `@${lockedAgent}`)
+      : value.trim();
+    pushToHistory(fullMessage);
 
     if (lockedAgent) {
       // Locked agent badge mode
@@ -488,6 +586,8 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
       }
     }
 
+    // User is typing normally — exit history browsing mode
+    historyIndexRef.current = -1;
     onChange(newValue);
   };
 

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -82,6 +82,7 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
   const sentHistoryRef = useRef<string[]>([]);
   const historyIndexRef = useRef(-1); // -1 = not browsing history
   const savedDraftRef = useRef(''); // saves current draft when entering history
+  const savedLockedAgentRef = useRef<string | null>(null); // saves lockedAgent when entering history
 
   // Load history from localStorage on mount
   useEffect(() => {
@@ -357,8 +358,9 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
 
     if (direction === 'back') {
       if (historyIndexRef.current === -1) {
-        // Entering history mode — save current draft
+        // Entering history mode — save current draft and locked agent
         savedDraftRef.current = value;
+        savedLockedAgentRef.current = lockedAgent;
         historyIndexRef.current = history.length - 1;
       } else if (historyIndexRef.current > 0) {
         historyIndexRef.current--;
@@ -377,14 +379,14 @@ export const EnhancedInput = forwardRef<EnhancedInputHandle, EnhancedInputProps>
         setLockedAgent(null);
         onChange(msg);
       } else {
-        // Past newest → restore draft
+        // Past newest → restore draft and locked agent
         historyIndexRef.current = -1;
-        setLockedAgent(null);
+        setLockedAgent(savedLockedAgentRef.current);
         onChange(savedDraftRef.current);
       }
       return true;
     }
-  }, [value, onChange]);
+  }, [value, lockedAgent, onChange]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Cmd/Ctrl+Z: navigate history back (empty input or already browsing)

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -46,18 +46,24 @@ function getWorkspaceLabel(
 
 function getMissionDisplayName(
   mission: Mission,
-  workspaceNameById?: Record<string, string>
+  _workspaceNameById?: Record<string, string>
 ): string {
-  const parts: string[] = [];
-  const workspaceLabel = getWorkspaceLabel(mission, workspaceNameById);
-  if (workspaceLabel) {
-    parts.push(workspaceLabel);
+  // Use title as primary name when available, fall back to animal codename
+  const title = mission.title?.trim();
+  if (title) {
+    return title.length > 70 ? title.slice(0, 70) + '...' : title;
   }
-  parts.push(getMissionShortName(mission.id));
-  return parts.join(' · ');
+  return getMissionShortName(mission.id);
 }
 
 export function getMissionCardTitle(mission: Mission): string | null {
+  // When a backend title exists, it's already shown as the display name,
+  // so show the short_description as subtitle instead.
+  if (mission.title?.trim()) {
+    return mission.short_description?.trim() || null;
+  }
+  // No backend title: display name is the animal codename, so show the
+  // first user message as subtitle.
   const title = getMissionTitle(mission, { maxLength: 80, fallback: '' }).trim();
   if (!title) return null;
   return title;
@@ -87,12 +93,16 @@ export function hasMeaningfulExtraTokens(baseText: string, candidateText: string
 
 export function getMissionCardDescription(
   mission: Mission,
-  title?: string | null
+  cardTitle?: string | null
 ): string | null {
+  // When the backend title is used as display name, short_description is
+  // already surfaced as cardTitle — don't repeat it.
+  if (mission.title?.trim()) return null;
+
   const shortDescription = mission.short_description?.trim();
   if (!shortDescription) return null;
 
-  const normalizedTitle = (title ?? '').trim();
+  const normalizedTitle = (cardTitle ?? '').trim();
   if (normalizedTitle && !hasMeaningfulExtraTokens(normalizedTitle, shortDescription)) {
     return null;
   }
@@ -183,7 +193,12 @@ export function getMissionSearchText(mission: Mission): string {
   const status = mission.status ?? '';
   const textParts: string[] = [];
 
-  if (title) {
+  // Always include animal codename so it's searchable
+  textParts.push(getMissionShortName(mission.id));
+  if (mission.title?.trim()) {
+    textParts.push(mission.title.trim());
+  }
+  if (title && title !== mission.title?.trim()) {
     textParts.push(title);
   }
   if (shortDescription && (textParts.length === 0 || hasMeaningfulExtraTokens(title, shortDescription))) {
@@ -991,6 +1006,14 @@ export function MissionSwitcher({
                               ? getMissionDisplayName(mission, workspaceNameById)
                               : getMissionShortName(item.id)}
                           </span>
+                          {mission && (() => {
+                            const ws = getWorkspaceLabel(mission, workspaceNameById);
+                            return ws ? (
+                              <span className="inline-flex items-center rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] text-white/40 shrink-0 max-w-[80px] truncate">
+                                {ws}
+                              </span>
+                            ) : null;
+                          })()}
                           {isStalled && (
                             <span className="text-[10px] text-amber-400 tabular-nums shrink-0">
                               {Math.floor(stallInfo?.seconds_since_activity ?? 0)}s

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -304,8 +304,8 @@ export async function autoGenerateMissionTitle(
       await updateMissionTitle(missionId, title);
       return title;
     }
-  } catch {
-    // Silent failure — title generation is best-effort
+  } catch (err) {
+    console.warn("[AutoTitle] Failed to generate mission title:", err);
   }
   return null;
 }

--- a/dashboard/src/lib/llm.ts
+++ b/dashboard/src/lib/llm.ts
@@ -55,11 +55,18 @@ async function chatCompletion(
       }),
     });
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.warn(
+        `[LLM] Chat completion failed: HTTP ${res.status}${text ? ` — ${text.slice(0, 200)}` : ""}`,
+      );
+      return null;
+    }
 
     const data = (await res.json()) as ChatCompletionResponse;
     return data.choices?.[0]?.message?.content?.trim() ?? null;
-  } catch {
+  } catch (err) {
+    console.warn("[LLM] Chat completion error:", err);
     return null;
   }
 }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -3788,6 +3788,37 @@ fn extract_email_from_jwt(token: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Fetch account email from Anthropic's userinfo endpoint using an access token.
+///
+/// Calls `GET /v1/oauth/userinfo` on the Anthropic console. This is needed because
+/// Anthropic's OAuth token response doesn't include an `id_token` or email claim.
+async fn fetch_anthropic_account_email(access_token: &str) -> Option<String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("https://console.anthropic.com/v1/oauth/userinfo")
+        .header("Authorization", format!("Bearer {}", access_token))
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        tracing::debug!(
+            status = %resp.status(),
+            "Anthropic userinfo endpoint returned non-success"
+        );
+        return None;
+    }
+    let data: serde_json::Value = resp.json().await.ok()?;
+    data.get("email")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            // Some providers use "name" or "id" as fallback identifier
+            data.get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+}
+
 /// Extract account email from an OAuth token response and persist it.
 ///
 /// Tries `id_token` JWT first, then `access_token` JWT, then a plain `email` field.
@@ -5588,12 +5619,26 @@ async fn oauth_callback_inner(
                     }
                 }
 
-                let account_email = extract_and_save_account_email(
+                let mut account_email = extract_and_save_account_email(
                     &token_data,
                     &state.config.working_dir,
                     provider_type.id(),
                     "Anthropic",
                 );
+
+                // Anthropic tokens don't include email claims — fetch via userinfo
+                if account_email.is_none() {
+                    if let Some(at) = token_data["access_token"].as_str() {
+                        if let Some(email) = fetch_anthropic_account_email(at).await {
+                            let _ = update_provider_account(
+                                &state.config.working_dir,
+                                provider_type.id(),
+                                email.clone(),
+                            );
+                            account_email = Some(email);
+                        }
+                    }
+                }
 
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);
@@ -5695,12 +5740,26 @@ async fn oauth_callback_inner(
                     }
                 }
 
-                let account_email = extract_and_save_account_email(
+                let mut account_email = extract_and_save_account_email(
                     &token_data,
                     &state.config.working_dir,
                     provider_type.id(),
                     "Anthropic",
                 );
+
+                // Anthropic tokens don't include email claims — fetch via userinfo
+                if account_email.is_none() {
+                    if let Some(at) = token_data["access_token"].as_str() {
+                        if let Some(email) = fetch_anthropic_account_email(at).await {
+                            let _ = update_provider_account(
+                                &state.config.working_dir,
+                                provider_type.id(),
+                                email.clone(),
+                            );
+                            account_email = Some(email);
+                        }
+                    }
+                }
 
                 let default_provider = get_default_provider(&opencode_config);
                 let backends_state = read_provider_backends_state(&state.config.working_dir);

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -1367,7 +1367,59 @@ async fn generate_mission_metadata_updates(
         return (None, None);
     }
 
-    let title_candidate = if (title_missing || should_refresh) && !title_user_managed {
+    // ── Try LLM-powered summarization first ────────────────────────────
+    let needs_title = (title_missing || should_refresh) && !title_user_managed;
+    let needs_description = short_description_missing
+        || should_refresh
+        || should_bootstrap_short_description_from_first_assistant;
+
+    if (needs_title || needs_description) && has_successful_assistant_reply {
+        if let Some((llm_title, llm_status)) =
+            try_llm_metadata_summarization(history, mission, should_refresh).await
+        {
+            let mut updated_title: Option<String> = None;
+            let mut updated_short_description: Option<String> = None;
+
+            if needs_title {
+                if let Some(candidate) = llm_title {
+                    let candidate = diversify_generated_title_with_recent_context(
+                        mission_store,
+                        mission_id,
+                        candidate,
+                        history,
+                        fallback_user_content,
+                    )
+                    .await;
+                    if should_accept_metadata_candidate(
+                        mission.title.as_deref(),
+                        &candidate,
+                        should_bootstrap_title_from_first_assistant,
+                    ) {
+                        updated_title = Some(candidate);
+                    }
+                }
+            }
+
+            if needs_description {
+                if let Some(candidate) = llm_status {
+                    if should_accept_metadata_candidate(
+                        mission.short_description.as_deref(),
+                        &candidate,
+                        should_bootstrap_short_description_from_first_assistant,
+                    ) {
+                        updated_short_description = Some(candidate);
+                    }
+                }
+            }
+
+            if updated_title.is_some() || updated_short_description.is_some() {
+                return (updated_title, updated_short_description);
+            }
+        }
+    }
+
+    // ── Fallback: heuristic extraction from conversation text ──────────
+    let title_candidate = if needs_title {
         let assistant_title_candidate = if should_bootstrap_title_from_first_assistant {
             history
                 .iter()
@@ -1412,10 +1464,7 @@ async fn generate_mission_metadata_updates(
         None => None,
     };
 
-    let short_description_candidate = if short_description_missing
-        || should_refresh
-        || should_bootstrap_short_description_from_first_assistant
-    {
+    let short_description_candidate = if needs_description {
         if should_bootstrap_short_description_from_first_assistant {
             extract_short_description_from_first_successful_assistant(history, 160)
                 .or_else(|| extract_short_description_from_history(history, 160))
@@ -1433,54 +1482,129 @@ async fn generate_mission_metadata_updates(
 
     let mut updated_title: Option<String> = None;
     if let Some(candidate_title) = title_candidate {
-        let should_update = mission
-            .title
-            .as_deref()
-            .map(|existing| has_significant_metadata_drift(existing, &candidate_title))
-            .unwrap_or(true);
-        if should_update {
-            let differs_from_existing = mission
-                .title
-                .as_deref()
-                .map(|existing| {
-                    normalize_metadata_text(existing) != normalize_metadata_text(&candidate_title)
-                })
-                .unwrap_or(true);
-            if differs_from_existing {
-                updated_title = Some(candidate_title);
-            }
+        if should_accept_metadata_candidate(
+            mission.title.as_deref(),
+            &candidate_title,
+            should_bootstrap_title_from_first_assistant,
+        ) {
+            updated_title = Some(candidate_title);
         }
     }
 
     let mut updated_short_description: Option<String> = None;
     if let Some(candidate_short_description) = short_description_candidate {
-        let should_update = if should_bootstrap_short_description_from_first_assistant {
-            true
-        } else {
-            mission
-                .short_description
-                .as_deref()
-                .map(|existing| {
-                    has_significant_metadata_drift(existing, &candidate_short_description)
-                })
-                .unwrap_or(true)
-        };
-        if should_update {
-            let differs_from_existing = mission
-                .short_description
-                .as_deref()
-                .map(|existing| {
-                    normalize_metadata_text(existing)
-                        != normalize_metadata_text(&candidate_short_description)
-                })
-                .unwrap_or(true);
-            if differs_from_existing {
-                updated_short_description = Some(candidate_short_description);
-            }
+        if should_accept_metadata_candidate(
+            mission.short_description.as_deref(),
+            &candidate_short_description,
+            should_bootstrap_short_description_from_first_assistant,
+        ) {
+            updated_short_description = Some(candidate_short_description);
         }
     }
 
     (updated_title, updated_short_description)
+}
+
+/// Check if a metadata candidate should replace the existing value.
+fn should_accept_metadata_candidate(
+    existing: Option<&str>,
+    candidate: &str,
+    is_bootstrap: bool,
+) -> bool {
+    let should_update = if is_bootstrap {
+        true
+    } else {
+        existing
+            .map(|e| has_significant_metadata_drift(e, candidate))
+            .unwrap_or(true)
+    };
+    if !should_update {
+        return false;
+    }
+    existing
+        .map(|e| normalize_metadata_text(e) != normalize_metadata_text(candidate))
+        .unwrap_or(true)
+}
+
+/// Try to generate metadata using the configured LLM provider.
+/// Returns `Some((title, status))` if the LLM was called successfully,
+/// `None` if no LLM is configured or the call failed.
+async fn try_llm_metadata_summarization(
+    history: &[(String, String)],
+    mission: &Mission,
+    is_refresh: bool,
+) -> Option<(Option<String>, Option<String>)> {
+    let llm = match super::metadata_llm::metadata_llm() {
+        Some(l) => l,
+        None => {
+            tracing::debug!("[MetadataLLM] No LLM client available");
+            return None;
+        }
+    };
+
+    // Gather the most relevant user message and assistant reply
+    let (user_msg, assistant_msg) = if is_refresh {
+        // On refresh, use the most recent exchange
+        let user = history
+            .iter()
+            .rev()
+            .find(|(role, _)| role == "user")
+            .map(|(_, c)| c.as_str())
+            .unwrap_or("");
+        let assistant = history
+            .iter()
+            .rev()
+            .find(|(role, content)| role == "assistant" && assistant_reply_is_successful(content))
+            .map(|(_, c)| c.as_str())
+            .unwrap_or("");
+        (user, assistant)
+    } else {
+        // On bootstrap, use the first exchange
+        let user = history
+            .iter()
+            .find(|(role, _)| role == "user")
+            .map(|(_, c)| c.as_str())
+            .unwrap_or("");
+        let assistant = history
+            .iter()
+            .find(|(role, content)| role == "assistant" && assistant_reply_is_successful(content))
+            .map(|(_, c)| c.as_str())
+            .unwrap_or("");
+        (user, assistant)
+    };
+
+    if user_msg.is_empty() && assistant_msg.is_empty() {
+        return None;
+    }
+
+    tracing::info!(
+        "[MetadataLLM] Calling summarize_mission (is_refresh={}, user_len={}, assistant_len={})",
+        is_refresh,
+        user_msg.len(),
+        assistant_msg.len()
+    );
+
+    let (title, status) = llm
+        .summarize_mission(
+            user_msg,
+            assistant_msg,
+            mission.title.as_deref(),
+            is_refresh,
+        )
+        .await;
+
+    tracing::info!(
+        "[MetadataLLM] Result: title={:?}, status={:?}",
+        title,
+        status
+    );
+
+    // Only return Some if we got at least one result
+    if title.is_some() || status.is_some() {
+        Some((title, status))
+    } else {
+        None
+    }
 }
 
 async fn apply_generated_mission_metadata_updates(
@@ -5645,57 +5769,68 @@ async fn control_actor_loop(
             }
         }
 
-        // Scan work directory for artifacts (shared workspace root)
+        // Scan work directory for a compact top-level overview (not full file listing)
         if workspace_root.exists() {
-            resume_parts.push("\n## Work Directory Contents".to_string());
+            resume_parts.push("\n## Workspace Layout".to_string());
 
-            let mut files_found = Vec::new();
+            let mut top_level_dirs = Vec::new();
+            let mut top_level_files = Vec::new();
+            const SKIP_DIRS: &[&str] = &[
+                "venv",
+                ".venv",
+                ".sandboxed_sh",
+                ".sandboxed-sh",
+                ".git",
+                ".claude",
+                ".cargo",
+                ".rustup",
+                "node_modules",
+                "target",
+                "__pycache__",
+                ".next",
+                ".cache",
+                "temp",
+                ".local",
+                ".config",
+            ];
+
             if let Ok(entries) = std::fs::read_dir(&workspace_root) {
                 for entry in entries.filter_map(|e| e.ok()) {
+                    let name = entry.file_name().to_string_lossy().to_string();
                     let path = entry.path();
                     if path.is_dir() {
-                        let dir_name = path.file_name().unwrap_or_default().to_string_lossy();
-                        // Skip common non-artifact directories
-                        if matches!(
-                            dir_name.as_ref(),
-                            "venv" | ".venv" | ".sandboxed_sh" | ".sandboxed-sh" | "temp"
-                        ) {
+                        if SKIP_DIRS.contains(&name.as_str()) {
                             continue;
                         }
-                        // List files in subdirectory
-                        if let Ok(subentries) = std::fs::read_dir(&path) {
-                            for subentry in subentries.filter_map(|e| e.ok()) {
-                                let subpath = subentry.path();
-                                if subpath.is_file() {
-                                    let rel_path = subpath
-                                        .strip_prefix(&workspace_root)
-                                        .map(|p| p.display().to_string())
-                                        .unwrap_or_else(|_| subpath.display().to_string());
-                                    files_found.push(rel_path);
-                                }
-                            }
-                        }
+                        top_level_dirs.push(format!("{}/ ", name));
                     } else if path.is_file() {
-                        let rel_path = path
-                            .strip_prefix(&workspace_root)
-                            .map(|p| p.display().to_string())
-                            .unwrap_or_else(|_| path.display().to_string());
-                        files_found.push(rel_path);
+                        top_level_files.push(name);
                     }
                 }
             }
 
-            if !files_found.is_empty() {
-                resume_parts.push(format!(
-                    "Files created:\n{}",
-                    files_found
-                        .iter()
-                        .map(|f| format!("- {}", f))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                ));
+            top_level_dirs.sort();
+            top_level_files.sort();
+
+            if top_level_dirs.is_empty() && top_level_files.is_empty() {
+                resume_parts.push("Empty workspace.".to_string());
             } else {
-                resume_parts.push("No output files created yet.".to_string());
+                let mut listing = Vec::new();
+                for d in &top_level_dirs {
+                    listing.push(format!("- {}", d));
+                }
+                // Cap files at 20 to avoid token bloat
+                let file_cap = 20;
+                for f in top_level_files.iter().take(file_cap) {
+                    listing.push(format!("- {}", f));
+                }
+                if top_level_files.len() > file_cap {
+                    listing.push(format!(
+                        "- ... and {} more files",
+                        top_level_files.len() - file_cap
+                    ));
+                }
+                resume_parts.push(listing.join("\n"));
             }
         }
 

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -248,13 +248,40 @@ pub async fn resolve_path_for_workspace(
 
     // Canonicalize to resolve ".." and symlinks, then validate within workspace
     // For non-existent paths, we validate the parent directory exists and is within workspace
-    let canonical = if resolved.exists() {
-        resolved.canonicalize().map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to resolve path: {}", e),
-            )
-        })?
+    //
+    // Special handling for symlinks: if `canonicalize` fails with ELOOP (symlink loop)
+    // or the target is a dangling/looping symlink, fall back to the resolved path without
+    // canonicalization.  This avoids a 500 when the `context` directory is a stale symlink
+    // left over from a previous mission's workspace preparation.
+    let canonical = if resolved.exists() || std::fs::symlink_metadata(&resolved).is_ok() {
+        match resolved.canonicalize() {
+            Ok(c) => c,
+            Err(e) if e.raw_os_error() == Some(40) /* ELOOP */ => {
+                // Symlink loop — if the path itself is a symlink, try to clean it up
+                if std::fs::symlink_metadata(&resolved).map(|m| m.is_symlink()).unwrap_or(false) {
+                    tracing::warn!(
+                        path = %resolved.display(),
+                        "Stale symlink loop detected, removing"
+                    );
+                    let _ = std::fs::remove_file(&resolved);
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "Path was a stale symlink loop and has been cleaned up: {}. Please retry.",
+                            resolved.display()
+                        ),
+                    ));
+                }
+                // Not a symlink itself but something deeper loops — use as-is
+                resolved.clone()
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("Failed to resolve path: {}", e),
+                ));
+            }
+        }
     } else {
         // For new files, check that the parent is within workspace
         let parent = resolved.parent().ok_or_else(|| {
@@ -501,6 +528,26 @@ pub async fn list(
     State(_state): State<Arc<AppState>>,
     Query(q): Query<PathQuery>,
 ) -> Result<Json<Vec<FsEntry>>, (StatusCode, String)> {
+    let path = Path::new(&q.path);
+
+    // Check if path is a symlink loop before trying to read it
+    if let Ok(meta) = tokio::fs::symlink_metadata(path).await {
+        if meta.is_symlink() {
+            // Verify the symlink target is resolvable
+            if path.canonicalize().is_err() {
+                tracing::warn!(path = %path.display(), "Stale symlink loop detected in list(), cleaning up");
+                let _ = tokio::fs::remove_file(path).await;
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "Path was a stale symlink loop and has been cleaned up: {}. Please retry.",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+    }
+
     let entries = list_directory_local(&q.path)
         .await
         .map_err(internal_error)?;
@@ -515,20 +562,24 @@ async fn list_directory_local(path: &str) -> anyhow::Result<Vec<FsEntry>> {
     let mut dir = tokio::fs::read_dir(path).await?;
 
     while let Some(entry) = dir.next_entry().await? {
-        let metadata = match entry.metadata().await {
+        // Use symlink_metadata so we don't follow symlinks (avoids ELOOP on circular links)
+        let sym_meta = match tokio::fs::symlink_metadata(entry.path()).await {
             Ok(m) => m,
             Err(_) => continue,
         };
 
-        let kind = if metadata.is_dir() {
-            "dir"
-        } else if metadata.is_symlink() {
+        let kind = if sym_meta.is_symlink() {
             "link"
-        } else if metadata.is_file() {
+        } else if sym_meta.is_dir() {
+            "dir"
+        } else if sym_meta.is_file() {
             "file"
         } else {
             "other"
         };
+
+        // For size, use the symlink metadata (won't follow broken links)
+        let metadata = &sym_meta;
 
         let mtime = metadata.mtime();
 

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -257,20 +257,34 @@ pub async fn resolve_path_for_workspace(
         match resolved.canonicalize() {
             Ok(c) => c,
             Err(e) if crate::util::is_eloop(&e) => {
-                // Symlink loop — if the path itself is a symlink, try to clean it up
+                // Symlink loop — if the path itself is a symlink, try to clean it up,
+                // but only if it's within the workspace boundary (prevent path traversal).
                 if std::fs::symlink_metadata(&resolved)
                     .map(|m| m.is_symlink())
                     .unwrap_or(false)
                 {
-                    tracing::warn!(
-                        path = %resolved.display(),
-                        "Stale symlink loop detected, removing"
-                    );
-                    let _ = std::fs::remove_file(&resolved);
+                    let context_root_check = state.config.working_dir.join("context");
+                    let in_bounds = resolved.starts_with(&workspace_root)
+                        || (mission_id.is_some() && resolved.starts_with(&context_root_check));
+                    if in_bounds {
+                        tracing::warn!(
+                            path = %resolved.display(),
+                            "Stale symlink loop detected, removing"
+                        );
+                        let _ = std::fs::remove_file(&resolved);
+                        return Err((
+                            StatusCode::BAD_REQUEST,
+                            format!(
+                                "Path was a stale symlink loop and has been cleaned up: {}. Please retry.",
+                                resolved.display()
+                            ),
+                        ));
+                    }
+                    // Outside workspace — don't delete, just return error
                     return Err((
                         StatusCode::BAD_REQUEST,
                         format!(
-                            "Path was a stale symlink loop and has been cleaned up: {}. Please retry.",
+                            "Symlink loop detected outside workspace: {}",
                             resolved.display()
                         ),
                     ));

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -256,9 +256,12 @@ pub async fn resolve_path_for_workspace(
     let canonical = if resolved.exists() || std::fs::symlink_metadata(&resolved).is_ok() {
         match resolved.canonicalize() {
             Ok(c) => c,
-            Err(e) if e.raw_os_error() == Some(40) /* ELOOP */ => {
+            Err(e) if crate::util::is_eloop(&e) => {
                 // Symlink loop — if the path itself is a symlink, try to clean it up
-                if std::fs::symlink_metadata(&resolved).map(|m| m.is_symlink()).unwrap_or(false) {
+                if std::fs::symlink_metadata(&resolved)
+                    .map(|m| m.is_symlink())
+                    .unwrap_or(false)
+                {
                     tracing::warn!(
                         path = %resolved.display(),
                         "Stale symlink loop detected, removing"

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -533,19 +533,26 @@ pub async fn list(
 ) -> Result<Json<Vec<FsEntry>>, (StatusCode, String)> {
     let path = Path::new(&q.path);
 
-    // Check if path is a symlink loop before trying to read it
+    // Check if path is a symlink loop (ELOOP) before trying to read it.
+    // Only auto-clean on ELOOP — dangling symlinks or permission errors are left alone.
     if let Ok(meta) = tokio::fs::symlink_metadata(path).await {
         if meta.is_symlink() {
-            // Verify the symlink target is resolvable
-            if path.canonicalize().is_err() {
-                tracing::warn!(path = %path.display(), "Stale symlink loop detected in list(), cleaning up");
-                let _ = tokio::fs::remove_file(path).await;
+            if let Err(e) = path.canonicalize() {
+                if crate::util::is_eloop(&e) {
+                    tracing::warn!(path = %path.display(), "Stale symlink loop detected in list(), cleaning up");
+                    let _ = tokio::fs::remove_file(path).await;
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "Path was a stale symlink loop and has been cleaned up: {}. Please retry.",
+                            path.display()
+                        ),
+                    ));
+                }
+                // For other errors (dangling, permission), just return the error
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    format!(
-                        "Path was a stale symlink loop and has been cleaned up: {}. Please retry.",
-                        path.display()
-                    ),
+                    format!("Cannot resolve symlink: {}", e),
                 ));
             }
         }

--- a/src/api/library.rs
+++ b/src/api/library.rs
@@ -2280,7 +2280,7 @@ async fn install_from_registry(
         ));
     }
 
-    copy_dir_recursive(&source_dir, &target_dir)
+    crate::util::copy_dir_recursive(&source_dir, &target_dir)
         .await
         .map_err(internal_error)?;
 
@@ -2312,52 +2312,7 @@ async fn install_from_registry(
     Ok(Json(skill))
 }
 
-/// Recursively copy a directory (symlink-safe with depth limit).
-#[async_recursion::async_recursion]
-async fn copy_dir_recursive(
-    src: &std::path::Path,
-    dst: &std::path::Path,
-) -> Result<(), std::io::Error> {
-    copy_dir_recursive_inner(src, dst, 0).await
-}
-
-#[async_recursion::async_recursion]
-async fn copy_dir_recursive_inner(
-    src: &std::path::Path,
-    dst: &std::path::Path,
-    depth: u32,
-) -> Result<(), std::io::Error> {
-    if depth > 32 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "copy_dir_recursive: exceeded max depth (32) at {:?} — possible symlink loop",
-                src
-            ),
-        ));
-    }
-
-    tokio::fs::create_dir_all(dst).await?;
-
-    let mut entries = tokio::fs::read_dir(src).await?;
-    while let Some(entry) = entries.next_entry().await? {
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        let metadata = tokio::fs::symlink_metadata(&src_path).await?;
-        if metadata.is_symlink() {
-            let target = tokio::fs::read_link(&src_path).await?;
-            let _ = tokio::fs::remove_file(&dst_path).await;
-            tokio::fs::symlink(&target, &dst_path).await?;
-        } else if metadata.is_dir() {
-            copy_dir_recursive_inner(&src_path, &dst_path, depth + 1).await?;
-        } else {
-            tokio::fs::copy(&src_path, &dst_path).await?;
-        }
-    }
-
-    Ok(())
-}
+// Uses crate::util::copy_dir_recursive (shared implementation)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Unit Tests

--- a/src/api/library.rs
+++ b/src/api/library.rs
@@ -2312,12 +2312,31 @@ async fn install_from_registry(
     Ok(Json(skill))
 }
 
-/// Recursively copy a directory.
+/// Recursively copy a directory (symlink-safe with depth limit).
 #[async_recursion::async_recursion]
 async fn copy_dir_recursive(
     src: &std::path::Path,
     dst: &std::path::Path,
 ) -> Result<(), std::io::Error> {
+    copy_dir_recursive_inner(src, dst, 0).await
+}
+
+#[async_recursion::async_recursion]
+async fn copy_dir_recursive_inner(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    depth: u32,
+) -> Result<(), std::io::Error> {
+    if depth > 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "copy_dir_recursive: exceeded max depth (32) at {:?} — possible symlink loop",
+                src
+            ),
+        ));
+    }
+
     tokio::fs::create_dir_all(dst).await?;
 
     let mut entries = tokio::fs::read_dir(src).await?;
@@ -2325,8 +2344,13 @@ async fn copy_dir_recursive(
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
 
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path).await?;
+        let metadata = tokio::fs::symlink_metadata(&src_path).await?;
+        if metadata.is_symlink() {
+            let target = tokio::fs::read_link(&src_path).await?;
+            let _ = tokio::fs::remove_file(&dst_path).await;
+            tokio::fs::symlink(&target, &dst_path).await?;
+        } else if metadata.is_dir() {
+            copy_dir_recursive_inner(&src_path, &dst_path, depth + 1).await?;
         } else {
             tokio::fs::copy(&src_path, &dst_path).await?;
         }

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -1,0 +1,387 @@
+//! Lightweight LLM client for generating mission metadata (titles & descriptions).
+//!
+//! Uses a cheap/fast model via OpenAI-compatible chat completions to produce
+//! concise mission titles and status descriptions from conversation history.
+//! Falls back gracefully when no provider is configured.
+
+use std::sync::{Arc, OnceLock};
+use tokio::sync::RwLock;
+
+/// Global metadata LLM client, initialized once at startup.
+static METADATA_LLM: OnceLock<Arc<MetadataLlmClient>> = OnceLock::new();
+
+/// Configuration for the metadata LLM.
+#[derive(Debug, Clone)]
+pub struct MetadataLlmConfig {
+    /// OpenAI-compatible base URL (e.g. `https://openrouter.ai/api/v1`).
+    pub base_url: String,
+    /// API key for authentication.
+    pub api_key: String,
+    /// Model ID (e.g. `google/gemini-2.0-flash-001`).
+    pub model: String,
+}
+
+/// Lightweight client for metadata summarization.
+pub struct MetadataLlmClient {
+    config: RwLock<Option<MetadataLlmConfig>>,
+    ai_providers: RwLock<Option<Arc<crate::ai_providers::AIProviderStore>>>,
+    http: reqwest::Client,
+}
+
+impl std::fmt::Debug for MetadataLlmClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetadataLlmClient").finish()
+    }
+}
+
+impl MetadataLlmClient {
+    fn new(http: reqwest::Client) -> Self {
+        Self {
+            config: RwLock::new(None),
+            ai_providers: RwLock::new(None),
+            http,
+        }
+    }
+
+    /// Update the LLM configuration (called when providers change).
+    pub async fn set_config(&self, config: Option<MetadataLlmConfig>) {
+        let mut cfg = self.config.write().await;
+        *cfg = config;
+    }
+
+    /// Store a reference to the AI provider store for self-refresh.
+    pub async fn set_ai_providers(&self, providers: Arc<crate::ai_providers::AIProviderStore>) {
+        let mut store = self.ai_providers.write().await;
+        *store = Some(providers);
+    }
+
+    /// Refresh the LLM config from the AI provider store (picks up new OAuth tokens).
+    async fn ensure_config_fresh(&self) {
+        let store = self.ai_providers.read().await;
+        if let Some(providers) = store.as_ref() {
+            let new_config = try_build_config_from_providers(providers).await;
+            let mut cfg = self.config.write().await;
+            *cfg = new_config;
+        }
+    }
+
+    /// Generate a title and short description for a mission.
+    ///
+    /// Returns `(title, short_description)` — either or both may be `None` if
+    /// the LLM is unavailable or the call fails.
+    pub async fn summarize_mission(
+        &self,
+        user_message: &str,
+        assistant_reply: &str,
+        existing_title: Option<&str>,
+        is_refresh: bool,
+    ) -> (Option<String>, Option<String>) {
+        // Re-read provider config to pick up refreshed OAuth tokens
+        self.ensure_config_fresh().await;
+
+        let cfg = {
+            let guard = self.config.read().await;
+            match guard.as_ref() {
+                Some(c) if !c.api_key.is_empty() => c.clone(),
+                _ => return (None, None),
+            }
+        }; // lock released here before HTTP call
+
+        let user_excerpt = truncate_to(user_message, 600);
+        let assistant_excerpt = truncate_to(assistant_reply, 600);
+
+        let system_prompt = if is_refresh && existing_title.is_some() {
+            format!(
+                "You summarize coding missions. The current title is: \"{}\"\n\
+                 Based on the latest conversation, generate:\n\
+                 1. A short title (3-7 words) summarizing the mission goal. Keep it if still accurate, or update if the focus changed.\n\
+                 2. A one-sentence status description (max 15 words) of what's currently happening.\n\n\
+                 Reply ONLY in this exact format:\n\
+                 TITLE: <title>\nSTATUS: <status>",
+                existing_title.unwrap_or("")
+            )
+        } else {
+            "You summarize coding missions. Given a user request and assistant response, generate:\n\
+             1. A short title (3-7 words) summarizing the mission goal.\n\
+             2. A one-sentence status description (max 15 words) of what's currently happening.\n\n\
+             Reply ONLY in this exact format:\n\
+             TITLE: <title>\nSTATUS: <status>"
+                .to_string()
+        };
+
+        let body = serde_json::json!({
+            "model": cfg.model,
+            "messages": [
+                { "role": "system", "content": system_prompt },
+                {
+                    "role": "user",
+                    "content": format!(
+                        "User request:\n{}\n\nAssistant response:\n{}",
+                        user_excerpt, assistant_excerpt
+                    )
+                }
+            ],
+            "max_tokens": 80,
+            "temperature": 0.2,
+        });
+
+        let url = format!("{}/chat/completions", cfg.base_url.trim_end_matches('/'));
+
+        let result = self
+            .http
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", cfg.api_key))
+            .timeout(std::time::Duration::from_secs(10))
+            .json(&body)
+            .send()
+            .await;
+
+        let resp = match result {
+            Ok(r) if r.status().is_success() => r,
+            Ok(r) => {
+                tracing::debug!("[MetadataLLM] Request failed with status {}", r.status());
+                return (None, None);
+            }
+            Err(e) => {
+                tracing::debug!("[MetadataLLM] Request error: {}", e);
+                return (None, None);
+            }
+        };
+
+        let json: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!("[MetadataLLM] Failed to parse response: {}", e);
+                return (None, None);
+            }
+        };
+
+        let text = json["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap_or("")
+            .trim();
+
+        parse_title_status(text)
+    }
+}
+
+/// Parse the `TITLE: ...\nSTATUS: ...` format from the LLM response.
+fn parse_title_status(text: &str) -> (Option<String>, Option<String>) {
+    let mut title: Option<String> = None;
+    let mut status: Option<String> = None;
+
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("TITLE:") {
+            let t = rest.trim().trim_matches('"').trim();
+            if !t.is_empty() && t.len() <= 100 {
+                title = Some(t.to_string());
+            }
+        } else if let Some(rest) = line.strip_prefix("STATUS:") {
+            let s = rest.trim().trim_matches('"').trim();
+            if !s.is_empty() && s.len() <= 200 {
+                status = Some(s.to_string());
+            }
+        }
+    }
+
+    (title, status)
+}
+
+fn truncate_to(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+// ── Global initialization & access ──────────────────────────────────────────
+
+/// Initialize the global metadata LLM client. Call once at startup.
+pub fn init_metadata_llm(http: reqwest::Client) {
+    let _ = METADATA_LLM.set(Arc::new(MetadataLlmClient::new(http)));
+}
+
+/// Get a reference to the global metadata LLM client.
+pub fn metadata_llm() -> Option<&'static Arc<MetadataLlmClient>> {
+    METADATA_LLM.get()
+}
+
+/// Reconfigure the metadata LLM from the current AI provider store.
+/// Called at startup and whenever providers are updated.
+pub async fn refresh_metadata_llm_config(ai_providers: &crate::ai_providers::AIProviderStore) {
+    let client = match metadata_llm() {
+        Some(c) => c,
+        None => return,
+    };
+
+    // Prefer OpenRouter (cheap, fast models), then fall back to default provider.
+    let config = try_build_config_from_providers(ai_providers).await;
+    client.set_config(config).await;
+}
+
+async fn try_build_config_from_providers(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+) -> Option<MetadataLlmConfig> {
+    use crate::ai_providers::ProviderType;
+
+    // 1. Try OpenRouter — cheapest for metadata summarization
+    if let Some(provider) = ai_providers.get_by_type(ProviderType::OpenRouter).await {
+        if let Some(api_key) = &provider.api_key {
+            return Some(MetadataLlmConfig {
+                base_url: provider
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
+                api_key: api_key.clone(),
+                model: "google/gemini-2.0-flash-001".to_string(),
+            });
+        }
+    }
+
+    // 2. Try Groq (free tier, fast)
+    if let Some(provider) = ai_providers.get_by_type(ProviderType::Groq).await {
+        if let Some(api_key) = &provider.api_key {
+            return Some(MetadataLlmConfig {
+                base_url: provider
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.groq.com/openai/v1".to_string()),
+                api_key: api_key.clone(),
+                model: "llama-3.3-70b-versatile".to_string(),
+            });
+        }
+    }
+
+    // 3. Try Cerebras (free tier)
+    if let Some(provider) = ai_providers.get_by_type(ProviderType::Cerebras).await {
+        if let Some(api_key) = &provider.api_key {
+            return Some(MetadataLlmConfig {
+                base_url: provider
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.cerebras.ai/v1".to_string()),
+                api_key: api_key.clone(),
+                model: "llama-3.3-70b".to_string(),
+            });
+        }
+    }
+
+    // 4. Try OpenAI
+    if let Some(provider) = ai_providers.get_by_type(ProviderType::OpenAI).await {
+        if let Some(api_key) = &provider.api_key {
+            return Some(MetadataLlmConfig {
+                base_url: provider
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                api_key: api_key.clone(),
+                model: "gpt-4.1-nano".to_string(),
+            });
+        }
+    }
+
+    // 5. Try Google Gemini via OAuth (OpenAI-compatible endpoint)
+    if let Some(provider) = ai_providers.get_by_type(ProviderType::Google).await {
+        if let Some(oauth) = &provider.oauth {
+            if !oauth.access_token.is_empty() {
+                tracing::info!("[MetadataLLM] Using Google Gemini via OAuth");
+                return Some(MetadataLlmConfig {
+                    base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
+                    api_key: oauth.access_token.clone(),
+                    model: "gemini-2.0-flash".to_string(),
+                });
+            }
+        }
+    }
+
+    // 5. Fallback: check environment variables directly
+    let env_providers: &[(&str, &str, &str)] = &[
+        (
+            "OPENROUTER_API_KEY",
+            "https://openrouter.ai/api/v1",
+            "google/gemini-2.0-flash-001",
+        ),
+        (
+            "CEREBRAS_API_KEY",
+            "https://api.cerebras.ai/v1",
+            "llama-3.3-70b",
+        ),
+        (
+            "GROQ_API_KEY",
+            "https://api.groq.com/openai/v1",
+            "llama-3.3-70b-versatile",
+        ),
+        (
+            "OPENAI_API_KEY",
+            "https://api.openai.com/v1",
+            "gpt-4.1-nano",
+        ),
+    ];
+    for (env_var, base_url, model) in env_providers {
+        if let Ok(api_key) = std::env::var(env_var) {
+            if !api_key.trim().is_empty() {
+                tracing::info!("[MetadataLLM] Using {} from environment", env_var);
+                return Some(MetadataLlmConfig {
+                    base_url: base_url.to_string(),
+                    api_key,
+                    model: model.to_string(),
+                });
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_title_status_basic() {
+        let (title, status) =
+            parse_title_status("TITLE: Fix CI Pipeline Flaky Tests\nSTATUS: Investigating intermittent test failures in auth module");
+        assert_eq!(title.as_deref(), Some("Fix CI Pipeline Flaky Tests"));
+        assert_eq!(
+            status.as_deref(),
+            Some("Investigating intermittent test failures in auth module")
+        );
+    }
+
+    #[test]
+    fn test_parse_title_status_with_quotes() {
+        let (title, status) = parse_title_status(
+            "TITLE: \"Refactor Database Layer\"\nSTATUS: \"Migrating from raw SQL to ORM\"",
+        );
+        assert_eq!(title.as_deref(), Some("Refactor Database Layer"));
+        assert_eq!(status.as_deref(), Some("Migrating from raw SQL to ORM"));
+    }
+
+    #[test]
+    fn test_parse_title_status_missing_status() {
+        let (title, status) = parse_title_status("TITLE: Quick Fix\n");
+        assert_eq!(title.as_deref(), Some("Quick Fix"));
+        assert!(status.is_none());
+    }
+
+    #[test]
+    fn test_parse_title_status_empty() {
+        let (title, status) = parse_title_status("");
+        assert!(title.is_none());
+        assert!(status.is_none());
+    }
+
+    #[test]
+    fn test_truncate_to() {
+        assert_eq!(truncate_to("hello world", 5), "hello");
+        assert_eq!(truncate_to("hello", 10), "hello");
+        // Unicode boundary safety
+        assert_eq!(truncate_to("héllo", 2), "h");
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -29,6 +29,7 @@ mod desktop_stream;
 mod fs;
 pub mod library;
 pub mod mcp;
+pub mod metadata_llm;
 pub mod mission_runner;
 pub mod mission_store;
 mod model_routing;

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -310,7 +310,35 @@ impl MonitoringState {
             }
 
             let ws_id = ws.id.to_string();
-            let scope_name = format!("machine-{}.scope", ws.name);
+
+            // Derive the machine name from the workspace path (last path component),
+            // matching how systemd-nspawn auto-derives it when no --machine flag is used.
+            let machine_name = ws
+                .path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&ws.name);
+
+            // Escape the machine name for systemd unit naming. Hyphens within the
+            // name part must be escaped as `\x2d` because `-` is a path separator
+            // in systemd unit hierarchies. Without this, `systemctl show` and
+            // `is-active` silently return empty/inactive results for containers
+            // whose names contain hyphens (e.g., `dgx-spark`).
+            let escaped_name = systemd_escape(machine_name);
+            let scope_name = format!("machine-{}.scope", escaped_name);
+
+            // Check if the scope is actually active before querying properties.
+            // `systemctl show` returns exit 0 even for non-existent units (with
+            // `[not set]` for all values), so we need an explicit liveness check.
+            let is_active = tokio::process::Command::new("systemctl")
+                .args(["is-active", "--quiet", &scope_name])
+                .status()
+                .await
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if !is_active {
+                continue;
+            }
 
             let output = match tokio::process::Command::new("systemctl")
                 .args(["show", &scope_name])
@@ -600,4 +628,26 @@ async fn handle_monitoring_stream(socket: WebSocket) {
             recv_task.abort();
         }
     }
+}
+
+/// Escape a string for use as a systemd unit name component.
+///
+/// Systemd uses `-` as a path separator in unit hierarchies, so hyphens
+/// within a name must be escaped as `\x2d`. Other non-alphanumeric chars
+/// (except `_` and `.`) are also hex-escaped.
+fn systemd_escape(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        match ch {
+            '-' => out.push_str("\\x2d"),
+            c if c.is_ascii_alphanumeric() || c == '_' || c == '.' => out.push(c),
+            c => {
+                // Hex-escape other characters
+                for b in c.to_string().as_bytes() {
+                    out.push_str(&format!("\\x{:02x}", b));
+                }
+            }
+        }
+    }
+    out
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -18,7 +18,6 @@ use axum::{
 };
 use futures::stream::Stream;
 use serde::Deserialize;
-use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use uuid::Uuid;
@@ -737,13 +736,6 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let app = Router::new()
         .merge(public_routes)
         .merge(protected_routes)
-        .layer(
-            CompressionLayer::new()
-                .gzip(true)
-                .no_br()
-                .no_deflate()
-                .no_zstd(),
-        )
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(Arc::clone(&state));

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -425,6 +425,19 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         deferred_requests,
     });
 
+    // Initialize the metadata LLM client for AI-powered mission titles/descriptions
+    {
+        super::metadata_llm::init_metadata_llm(state.http_client.clone());
+        let ai_providers = Arc::clone(&state.ai_providers);
+        tokio::spawn(async move {
+            super::metadata_llm::refresh_metadata_llm_config(&ai_providers).await;
+            // Store the AI providers reference for self-refresh (picks up new OAuth tokens)
+            if let Some(client) = super::metadata_llm::metadata_llm() {
+                client.set_ai_providers(ai_providers).await;
+            }
+        });
+    }
+
     // Start background desktop session cleanup task
     {
         let state_clone = Arc::clone(&state);

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -18,6 +18,7 @@ use axum::{
 };
 use futures::stream::Stream;
 use serde::Deserialize;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use uuid::Uuid;
@@ -736,6 +737,13 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let app = Router::new()
         .merge(public_routes)
         .merge(protected_routes)
+        .layer(
+            CompressionLayer::new()
+                .gzip(true)
+                .no_br()
+                .no_deflate()
+                .no_zstd(),
+        )
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(Arc::clone(&state));

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -756,7 +756,7 @@ impl LibraryStore {
         }
 
         // Copy the skill directory to target
-        if let Err(e) = Self::copy_dir_recursive(&source_dir, &target_dir).await {
+        if let Err(e) = Self::copy_dir_recursive_skip_git(&source_dir, &target_dir).await {
             let _ = fs::remove_dir_all(&temp_dir).await;
             return Err(e);
         }
@@ -815,48 +815,14 @@ impl LibraryStore {
         Ok(())
     }
 
-    /// Recursively copy a directory (symlink-safe with depth limit).
-    #[async_recursion::async_recursion]
-    async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-        Self::copy_dir_recursive_inner(src, dst, 0).await
-    }
-
-    #[async_recursion::async_recursion]
-    async fn copy_dir_recursive_inner(src: &Path, dst: &Path, depth: u32) -> Result<()> {
-        if depth > 32 {
-            anyhow::bail!(
-                "copy_dir_recursive: exceeded max depth (32) at {:?} — possible symlink loop",
-                src
-            );
+    /// Recursively copy a directory, skipping `.git`.
+    async fn copy_dir_recursive_skip_git(src: &Path, dst: &Path) -> Result<()> {
+        // Remove .git from destination after copying
+        crate::util::copy_dir_recursive(src, dst).await?;
+        let git_dir = dst.join(".git");
+        if git_dir.exists() {
+            let _ = fs::remove_dir_all(&git_dir).await;
         }
-
-        fs::create_dir_all(dst).await?;
-
-        let mut entries = fs::read_dir(src).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            let entry_path = entry.path();
-            let file_name = entry.file_name();
-            let dst_path = dst.join(&file_name);
-
-            // Skip .git directory
-            if file_name == ".git" {
-                continue;
-            }
-
-            // Use symlink_metadata to avoid following symlinks into loops
-            let metadata = fs::symlink_metadata(&entry_path).await?;
-            if metadata.is_symlink() {
-                // Copy symlink as-is rather than following it
-                let target = fs::read_link(&entry_path).await?;
-                let _ = fs::remove_file(&dst_path).await;
-                fs::symlink(&target, &dst_path).await?;
-            } else if metadata.is_dir() {
-                Self::copy_dir_recursive_inner(&entry_path, &dst_path, depth + 1).await?;
-            } else {
-                fs::copy(&entry_path, &dst_path).await?;
-            }
-        }
-
         Ok(())
     }
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -815,15 +815,9 @@ impl LibraryStore {
         Ok(())
     }
 
-    /// Recursively copy a directory, skipping `.git`.
+    /// Recursively copy a directory, skipping `.git` at all levels.
     async fn copy_dir_recursive_skip_git(src: &Path, dst: &Path) -> Result<()> {
-        // Remove .git from destination after copying
-        crate::util::copy_dir_recursive(src, dst).await?;
-        let git_dir = dst.join(".git");
-        if git_dir.exists() {
-            let _ = fs::remove_dir_all(&git_dir).await;
-        }
-        Ok(())
+        crate::util::copy_dir_recursive_skip(src, dst, &[".git"]).await
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -815,9 +815,21 @@ impl LibraryStore {
         Ok(())
     }
 
-    /// Recursively copy a directory.
+    /// Recursively copy a directory (symlink-safe with depth limit).
     #[async_recursion::async_recursion]
     async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+        Self::copy_dir_recursive_inner(src, dst, 0).await
+    }
+
+    #[async_recursion::async_recursion]
+    async fn copy_dir_recursive_inner(src: &Path, dst: &Path, depth: u32) -> Result<()> {
+        if depth > 32 {
+            anyhow::bail!(
+                "copy_dir_recursive: exceeded max depth (32) at {:?} — possible symlink loop",
+                src
+            );
+        }
+
         fs::create_dir_all(dst).await?;
 
         let mut entries = fs::read_dir(src).await?;
@@ -831,9 +843,15 @@ impl LibraryStore {
                 continue;
             }
 
-            let metadata = fs::metadata(&entry_path).await?;
-            if metadata.is_dir() {
-                Self::copy_dir_recursive(&entry_path, &dst_path).await?;
+            // Use symlink_metadata to avoid following symlinks into loops
+            let metadata = fs::symlink_metadata(&entry_path).await?;
+            if metadata.is_symlink() {
+                // Copy symlink as-is rather than following it
+                let target = fs::read_link(&entry_path).await?;
+                let _ = fs::remove_file(&dst_path).await;
+                fs::symlink(&target, &dst_path).await?;
+            } else if metadata.is_dir() {
+                Self::copy_dir_recursive_inner(&entry_path, &dst_path, depth + 1).await?;
             } else {
                 fs::copy(&entry_path, &dst_path).await?;
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -280,6 +280,67 @@ pub fn not_found_or_internal(e: impl std::fmt::Display) -> (axum::http::StatusCo
     }
 }
 
+/// Maximum recursion depth for `copy_dir_recursive`.
+const MAX_COPY_DEPTH: u32 = 32;
+
+/// Recursively copy a directory, preserving symlinks as-is (symlink-safe with depth limit).
+///
+/// Uses `symlink_metadata` to avoid following symlinks into loops and caps
+/// recursion at [`MAX_COPY_DEPTH`] to prevent runaway traversal.
+pub async fn copy_dir_recursive(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+) -> anyhow::Result<()> {
+    copy_dir_recursive_inner(src, dst, 0).await
+}
+
+#[async_recursion::async_recursion]
+async fn copy_dir_recursive_inner(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    depth: u32,
+) -> anyhow::Result<()> {
+    if depth > MAX_COPY_DEPTH {
+        anyhow::bail!(
+            "copy_dir_recursive: exceeded max depth ({}) at {:?} — possible symlink loop",
+            MAX_COPY_DEPTH,
+            src
+        );
+    }
+
+    tokio::fs::create_dir_all(dst).await?;
+
+    let mut entries = tokio::fs::read_dir(src).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let entry_path = entry.path();
+        let file_name = entry.file_name();
+        let dest_path = dst.join(&file_name);
+
+        // Use symlink_metadata to avoid following symlinks into loops
+        let metadata = tokio::fs::symlink_metadata(&entry_path).await?;
+        if metadata.is_symlink() {
+            // Copy symlink as-is rather than following it
+            let target = tokio::fs::read_link(&entry_path).await?;
+            let _ = tokio::fs::remove_file(&dest_path).await;
+            tokio::fs::symlink(&target, &dest_path).await?;
+        } else if metadata.is_dir() {
+            copy_dir_recursive_inner(&entry_path, &dest_path, depth + 1).await?;
+        } else {
+            if let Some(parent) = dest_path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            tokio::fs::copy(&entry_path, &dest_path).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if the given IO error is an ELOOP (too many levels of symbolic links).
+pub fn is_eloop(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::ELOOP)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -291,7 +291,16 @@ pub async fn copy_dir_recursive(
     src: &std::path::Path,
     dst: &std::path::Path,
 ) -> anyhow::Result<()> {
-    copy_dir_recursive_inner(src, dst, 0).await
+    copy_dir_recursive_inner(src, dst, 0, &[]).await
+}
+
+/// Like [`copy_dir_recursive`] but skips directories whose name matches any entry in `skip`.
+pub async fn copy_dir_recursive_skip(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    skip: &[&str],
+) -> anyhow::Result<()> {
+    copy_dir_recursive_inner(src, dst, 0, skip).await
 }
 
 #[async_recursion::async_recursion]
@@ -299,6 +308,7 @@ async fn copy_dir_recursive_inner(
     src: &std::path::Path,
     dst: &std::path::Path,
     depth: u32,
+    skip: &'async_recursion [&'async_recursion str],
 ) -> anyhow::Result<()> {
     if depth > MAX_COPY_DEPTH {
         anyhow::bail!(
@@ -316,6 +326,15 @@ async fn copy_dir_recursive_inner(
         let file_name = entry.file_name();
         let dest_path = dst.join(&file_name);
 
+        // Skip directories by name (e.g. ".git")
+        if !skip.is_empty() {
+            if let Some(name) = file_name.to_str() {
+                if skip.contains(&name) {
+                    continue;
+                }
+            }
+        }
+
         // Use symlink_metadata to avoid following symlinks into loops
         let metadata = tokio::fs::symlink_metadata(&entry_path).await?;
         if metadata.is_symlink() {
@@ -324,7 +343,7 @@ async fn copy_dir_recursive_inner(
             let _ = tokio::fs::remove_file(&dest_path).await;
             tokio::fs::symlink(&target, &dest_path).await?;
         } else if metadata.is_dir() {
-            copy_dir_recursive_inner(&entry_path, &dest_path, depth + 1).await?;
+            copy_dir_recursive_inner(&entry_path, &dest_path, depth + 1, skip).await?;
         } else {
             if let Some(parent) = dest_path.parent() {
                 tokio::fs::create_dir_all(parent).await?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4072,8 +4072,23 @@ async fn seed_shard_data(container_root: &Path) -> anyhow::Result<bool> {
     Ok(true)
 }
 
+const MAX_COPY_DEPTH: u32 = 32;
+
 #[async_recursion]
 async fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    copy_dir_recursive_inner(src, dst, 0).await
+}
+
+#[async_recursion]
+async fn copy_dir_recursive_inner(src: &Path, dst: &Path, depth: u32) -> anyhow::Result<()> {
+    if depth > MAX_COPY_DEPTH {
+        anyhow::bail!(
+            "copy_dir_recursive: exceeded max depth ({}) at {:?} — possible symlink loop",
+            MAX_COPY_DEPTH,
+            src
+        );
+    }
+
     tokio::fs::create_dir_all(dst).await?;
 
     let mut entries = tokio::fs::read_dir(src).await?;
@@ -4082,9 +4097,15 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
         let file_name = entry.file_name();
         let dest_path = dst.join(&file_name);
 
-        let metadata = tokio::fs::metadata(&entry_path).await?;
-        if metadata.is_dir() {
-            copy_dir_recursive(&entry_path, &dest_path).await?;
+        // Use symlink_metadata to avoid following symlinks into loops
+        let metadata = tokio::fs::symlink_metadata(&entry_path).await?;
+        if metadata.is_symlink() {
+            // Copy symlink as-is rather than following it
+            let target = tokio::fs::read_link(&entry_path).await?;
+            let _ = tokio::fs::remove_file(&dest_path).await;
+            tokio::fs::symlink(&target, &dest_path).await?;
+        } else if metadata.is_dir() {
+            copy_dir_recursive_inner(&entry_path, &dest_path, depth + 1).await?;
         } else {
             if let Some(parent) = dest_path.parent() {
                 tokio::fs::create_dir_all(parent).await?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use async_recursion::async_recursion;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -4072,50 +4071,7 @@ async fn seed_shard_data(container_root: &Path) -> anyhow::Result<bool> {
     Ok(true)
 }
 
-const MAX_COPY_DEPTH: u32 = 32;
-
-#[async_recursion]
-async fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
-    copy_dir_recursive_inner(src, dst, 0).await
-}
-
-#[async_recursion]
-async fn copy_dir_recursive_inner(src: &Path, dst: &Path, depth: u32) -> anyhow::Result<()> {
-    if depth > MAX_COPY_DEPTH {
-        anyhow::bail!(
-            "copy_dir_recursive: exceeded max depth ({}) at {:?} — possible symlink loop",
-            MAX_COPY_DEPTH,
-            src
-        );
-    }
-
-    tokio::fs::create_dir_all(dst).await?;
-
-    let mut entries = tokio::fs::read_dir(src).await?;
-    while let Some(entry) = entries.next_entry().await? {
-        let entry_path = entry.path();
-        let file_name = entry.file_name();
-        let dest_path = dst.join(&file_name);
-
-        // Use symlink_metadata to avoid following symlinks into loops
-        let metadata = tokio::fs::symlink_metadata(&entry_path).await?;
-        if metadata.is_symlink() {
-            // Copy symlink as-is rather than following it
-            let target = tokio::fs::read_link(&entry_path).await?;
-            let _ = tokio::fs::remove_file(&dest_path).await;
-            tokio::fs::symlink(&target, &dest_path).await?;
-        } else if metadata.is_dir() {
-            copy_dir_recursive_inner(&entry_path, &dest_path, depth + 1).await?;
-        } else {
-            if let Some(parent) = dest_path.parent() {
-                tokio::fs::create_dir_all(parent).await?;
-            }
-            tokio::fs::copy(&entry_path, &dest_path).await?;
-        }
-    }
-
-    Ok(())
-}
+use crate::util::copy_dir_recursive;
 
 async fn bootstrap_workspace_harnesses(workspace: &Workspace) -> anyhow::Result<()> {
     if workspace.workspace_type != WorkspaceType::Container || !use_nspawn_for_workspace(workspace)


### PR DESCRIPTION
## Summary
- **Fix ELOOP crashes** in console/fs endpoints: all three `copy_dir_recursive` implementations now use `symlink_metadata` instead of `metadata` (avoids following symlinks into loops), with a depth limit of 32. The `list` endpoint and `resolve_path_for_workspace` auto-detect and clean up stale symlink loops.
- **Surface LLM title generation failures**: Cerebras auto-title was silently swallowing all errors, making misconfiguration invisible. Now logs `[LLM]` and `[AutoTitle]` warnings to the browser console.
- **Gzip response compression**: Added `tower-http` `CompressionLayer` to reduce API response sizes.
- **Input message history**: Enhanced input now supports Up/Down arrow recall and Cmd+Z undo of sent messages (persisted in localStorage).

## Test plan
- [x] Reproduced ELOOP error on dev server (`curl .../api/fs/list?path=./context`)
- [x] Deployed fix, confirmed stale symlink auto-cleaned and listing works
- [x] Dashboard builds clean (`next build`)
- [x] Rust compiles clean (`cargo check`) and formatted (`cargo fmt --all`)
- [x] Verified binary on server contains fix strings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem path resolution/listing and OAuth provider account identification, which can affect stability and security boundaries if incorrect. Also introduces new background-initialized LLM metadata calls and input history UX changes that could surface edge cases.
> 
> **Overview**
> **Mission naming/UX improvements:** mission selectors and dialogs now prefer backend `mission.title` (with better subtitle/description behavior and search including the codename), and pending-question detection ignores questions that occurred before the latest user reply.
> 
> **Input enhancements:** `EnhancedInput` gains persisted send-history (Up/Down recall + Cmd/Ctrl+Z undo/redo), including agent-prefixed messages.
> 
> **Backend robustness:** adds a new `metadata_llm` client and wires `control` to try LLM-generated mission `title`/`short_description` before heuristic extraction; adds warning logs for LLM/auto-title failures. Fixes symlink-loop (ELOOP) crashes by making path resolution and `fs/list` detect/clean stale looping symlinks and by centralizing symlink-safe, depth-limited recursive directory copy in `util` (used by library/workspace installs). Anthropic OAuth now fetches account email via the `userinfo` endpoint when token claims lack it, and container monitoring escapes systemd unit names + checks liveness before querying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51ecc859d287b98971ba2e3e9b60d67239ce0cf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->