### PR TITLE
fix: create Gemini missions without invalid default agent

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4760,7 +4760,7 @@ export default function ControlClient() {
       return { id: mission.id };
     } catch (err) {
       console.error("Failed to create mission:", err);
-      toast.error("Failed to create new mission");
+      toast.error(err instanceof Error ? err.message : "Failed to create new mission");
       throw err; // Re-throw so dialog knows creation failed
     } finally {
       setMissionLoading(false);

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -114,6 +114,7 @@ import {
   File,
   ExternalLink,
   MessageSquare,
+  Users,
 } from "lucide-react";
 import { IMAGE_PATH_PATTERN } from "@/lib/file-extensions";
 import { insertTextAtSelection, type TextSelection } from "@/lib/text-selection";
@@ -194,6 +195,7 @@ import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { DesktopStream } from "@/components/desktop-stream";
 import { NewMissionDialog } from "@/components/new-mission-dialog";
 import { MissionSwitcher, normalizeMetadataText } from "@/components/mission-switcher";
+import { WorkerPanel } from "@/components/worker-panel";
 
 import type { SharedFile } from "@/lib/api";
 
@@ -2529,6 +2531,7 @@ export default function ControlClient() {
     []
   );
   const [showMissionSwitcher, setShowMissionSwitcher] = useState(false);
+  const [showWorkerPanel, setShowWorkerPanel] = useState(false);
   const [highlightedItemId, setHighlightedItemId] = useState<string | null>(null);
   const deepLinkFocusKeyRef = useRef<string | null>(null);
   const [showAutomationsDialog, setShowAutomationsDialog] = useState(false);
@@ -4289,7 +4292,7 @@ export default function ControlClient() {
   // Global keyboard shortcut for mission switcher (Cmd+K / Ctrl+K)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k' && !e.shiftKey) {
         e.preventDefault();
         setShowMissionSwitcher(true);
       }
@@ -6435,6 +6438,14 @@ export default function ControlClient() {
     return recentMissions.filter((m) => m.parent_mission_id === activeMission.id);
   }, [activeMission, recentMissions]);
   const activeMissionRole = activeMission ? inferMissionRole(activeMission) : null;
+  const isBossMission = childMissions.length > 0 || activeMissionRole === "boss";
+
+  // Auto-show worker panel when viewing a boss mission with workers
+  useEffect(() => {
+    if (childMissions.length > 0) {
+      setShowWorkerPanel(true);
+    }
+  }, [activeMission?.id, childMissions.length]);
 
   // Determine if we should show the resume UI for interrupted/blocked/failed missions
   // Don't show resume UI if:
@@ -6590,6 +6601,26 @@ export default function ControlClient() {
               <span className="text-xs opacity-60">({thinkingItemsCount})</span>
             )}
           </button>
+
+          {/* Worker panel toggle - only shown for boss missions */}
+          {isBossMission && (
+            <button
+              onClick={() => setShowWorkerPanel((prev) => !prev)}
+              className={cn(
+                "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
+                showWorkerPanel
+                  ? "border-violet-500/30 bg-violet-500/10 text-violet-400"
+                  : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
+              )}
+              title={showWorkerPanel ? "Hide worker panel" : "Show worker panel"}
+            >
+              <Users className="h-4 w-4" />
+              <span className="hidden sm:inline">Workers</span>
+              {childMissions.length > 0 && (
+                <span className="text-xs opacity-60">({childMissions.length})</span>
+              )}
+            </button>
+          )}
 
           {/* Desktop stream toggle with display selector - only shown when a desktop session is active */}
           {hasDesktopSession && (
@@ -7935,12 +7966,29 @@ export default function ControlClient() {
         </div>
       </div>
 
-        {/* Right column: Thinking Panel and Desktop Stream stacked */}
-        {(showThinkingPanel || showDesktopStream) && (
+        {/* Right column: Worker Panel, Thinking Panel, and Desktop Stream stacked */}
+        {(showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission)) && (
           <div className={cn(
             "min-h-0 flex flex-col gap-4 transition-all duration-300 animate-fade-in shrink-0",
             showDesktopStream ? "flex-1 max-w-md" : "w-80"
           )}>
+            {/* Worker Panel */}
+            {showWorkerPanel && isBossMission && (
+              <WorkerPanel
+                childMissions={childMissions}
+                runningMissions={runningMissions}
+                bossMissionId={activeMission?.id ?? ''}
+                viewingMissionId={viewingMissionId}
+                onSelectWorker={(missionId) => handleViewMission(missionId)}
+                onClose={() => setShowWorkerPanel(false)}
+                className={cn(
+                  showThinkingPanel || showDesktopStream
+                    ? "flex-shrink-0 max-h-[50%]"
+                    : "flex-1"
+                )}
+              />
+            )}
+
             {/* Thinking Panel */}
             {showThinkingPanel && (
               <ThinkingPanel

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -321,7 +321,7 @@ function OverviewPageContent() {
         return { id: mission.id };
       } catch (err) {
         console.error('Failed to create mission:', err);
-        toast.error('Failed to create new mission');
+        toast.error(err instanceof Error ? err.message : 'Failed to create new mission');
         throw err; // Re-throw so dialog knows creation failed
       } finally {
         setCreatingMission(false);

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import useSWR from 'swr';
 import { toast } from '@/components/toast';
 import {
@@ -10,8 +10,10 @@ import {
   deleteAIProvider,
   authenticateAIProvider,
   setDefaultAIProvider,
+  getProviderUsage,
   AIProvider,
   AIProviderTypeInfo,
+  ProviderUsage,
 } from '@/lib/api';
 import {
   Cpu,
@@ -21,6 +23,10 @@ import {
   ExternalLink,
   Loader,
   Key,
+  BarChart3,
+  ChevronDown,
+  ChevronUp,
+  RefreshCw,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AddProviderModal } from '@/components/ui/add-provider-modal';
@@ -65,10 +71,219 @@ const defaultProviderTypes: AIProviderTypeInfo[] = [
   { id: 'amp', name: 'Amp', uses_oauth: false, env_var: 'AMP_API_KEY' },
 ];
 
+/** Format a number with commas */
+function fmt(n: number | undefined | null): string {
+  if (n == null) return '-';
+  return n.toLocaleString();
+}
+
+/** Format a reset time (ISO string or relative like "2s", "1m30s") */
+function fmtReset(v: string | undefined | null): string {
+  if (!v) return '-';
+  // Try ISO timestamp
+  const d = new Date(v);
+  if (!isNaN(d.getTime())) {
+    const diff = d.getTime() - Date.now();
+    if (diff <= 0) return 'now';
+    if (diff < 60_000) return `${Math.ceil(diff / 1000)}s`;
+    if (diff < 3600_000) return `${Math.ceil(diff / 60_000)}m`;
+    return `${Math.round(diff / 3600_000)}h`;
+  }
+  // Already a relative string
+  return v;
+}
+
+/** Usage bar: shows used/limit with a mini progress bar */
+function UsageBar({ used, limit, label }: { used?: number | null; limit?: number | null; label: string }) {
+  if (limit == null && used == null) return null;
+  const remaining = used ?? 0;
+  const total = limit ?? 0;
+  const usedCount = total - remaining;
+  const pct = total > 0 ? Math.min(100, (usedCount / total) * 100) : 0;
+  const color = pct > 90 ? 'bg-red-400' : pct > 70 ? 'bg-amber-400' : 'bg-emerald-400';
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-[11px]">
+        <span className="text-white/40">{label}</span>
+        <span className="text-white/60 font-mono">
+          {fmt(usedCount)} / {fmt(total)}
+        </span>
+      </div>
+      <div className="h-1 rounded-full bg-white/[0.06] overflow-hidden">
+        <div className={cn('h-full rounded-full transition-all', color)} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+/** Render provider-specific usage details */
+function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading: boolean }) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Loader className="h-4 w-4 animate-spin text-white/30" />
+        <span className="ml-2 text-xs text-white/30">Fetching usage...</span>
+      </div>
+    );
+  }
+
+  if (!usage) return null;
+
+  if (usage.error) {
+    return (
+      <div className="py-2 text-xs text-red-400/70">{usage.error}</div>
+    );
+  }
+
+  const type = usage.provider_type;
+
+  return (
+    <div className="space-y-3">
+      {/* Account info row */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {usage.account_email && (
+          <div className="text-[11px] text-white/50">
+            <span className="text-white/30">Account:</span> {usage.account_email}
+          </div>
+        )}
+        {usage.account_name && (
+          <div className="text-[11px] text-white/50">
+            <span className="text-white/30">Name:</span> {usage.account_name}
+          </div>
+        )}
+        {usage.organization && (
+          <div className="text-[11px] text-white/50">
+            <span className="text-white/30">Org:</span> {usage.organization}
+          </div>
+        )}
+      </div>
+
+      {/* Anthropic unified rate limits (2025+) */}
+      {type === 'anthropic' && usage.unified_status && (
+        <div className="space-y-2">
+          {usage.organization_id && (
+            <div className="text-[11px] text-white/50">
+              <span className="text-white/30">Org ID:</span>{' '}
+              <span className="font-mono text-[10px]">{usage.organization_id}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] text-white/40">Status:</span>
+            <span className={cn(
+              'text-[11px] font-medium',
+              usage.unified_status === 'ok' ? 'text-emerald-400' :
+              usage.unified_status === 'warning' ? 'text-amber-400' : 'text-red-400'
+            )}>
+              {usage.unified_status}
+            </span>
+          </div>
+          {usage.unified_5h_utilization != null && (
+            <UsageBar
+              used={Math.round((1 - usage.unified_5h_utilization) * 100)}
+              limit={100}
+              label={`5h window (${usage.unified_5h_status || ''})`}
+            />
+          )}
+          {usage.unified_7d_utilization != null && (
+            <UsageBar
+              used={Math.round((1 - usage.unified_7d_utilization) * 100)}
+              limit={100}
+              label={`7d window (${usage.unified_7d_status || ''})`}
+            />
+          )}
+          <div className="flex gap-4 text-[10px] text-white/30 flex-wrap">
+            {usage.unified_5h_reset && (
+              <span>5h reset: {fmtReset(usage.unified_5h_reset)}</span>
+            )}
+            {usage.unified_7d_reset && (
+              <span>7d reset: {fmtReset(usage.unified_7d_reset)}</span>
+            )}
+            {usage.unified_representative_claim && (
+              <span>Claim: {usage.unified_representative_claim}</span>
+            )}
+            {usage.unified_fallback_pct != null && (
+              <span>Fallback: {usage.unified_fallback_pct}%</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Anthropic legacy rate limits */}
+      {type === 'anthropic' && !usage.unified_status && usage.requests_limit != null && (
+        <div className="space-y-2">
+          <UsageBar used={usage.requests_remaining} limit={usage.requests_limit} label="Requests" />
+          <UsageBar used={usage.tokens_remaining} limit={usage.tokens_limit} label="Tokens" />
+          <UsageBar used={usage.input_tokens_remaining} limit={usage.input_tokens_limit} label="Input tokens" />
+          <UsageBar used={usage.output_tokens_remaining} limit={usage.output_tokens_limit} label="Output tokens" />
+        </div>
+      )}
+
+      {/* OpenAI style rate limits */}
+      {type === 'openai' && (
+        <div className="space-y-2">
+          <UsageBar used={usage.requests_remaining} limit={usage.requests_limit} label="Requests" />
+          <UsageBar used={usage.tokens_remaining} limit={usage.tokens_limit} label="Tokens" />
+          <div className="flex gap-4 text-[10px] text-white/30">
+            {usage.requests_reset && (
+              <span>Requests reset: {fmtReset(usage.requests_reset)}</span>
+            )}
+            {usage.tokens_reset && (
+              <span>Tokens reset: {fmtReset(usage.tokens_reset)}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Cerebras style rate limits */}
+      {type === 'cerebras' && (
+        <div className="space-y-2">
+          <UsageBar used={usage.requests_remaining_day} limit={usage.requests_limit_day} label="Requests (daily)" />
+          <UsageBar used={usage.tokens_remaining_minute} limit={usage.tokens_limit_minute} label="Tokens (per minute)" />
+          <div className="flex gap-4 text-[10px] text-white/30">
+            {usage.requests_reset_day && (
+              <span>Daily reset: {fmtReset(usage.requests_reset_day)}</span>
+            )}
+            {usage.tokens_reset_minute && (
+              <span>Minute reset: {fmtReset(usage.tokens_reset_minute)}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Minimax coding plan */}
+      {type === 'minimax' && usage.coding_plan && (
+        <div className="text-[11px] text-white/50">
+          <span className="text-white/30">Coding plan:</span>{' '}
+          <span className="font-mono">{JSON.stringify(usage.coding_plan)}</span>
+        </div>
+      )}
+
+      {/* Z.AI - minimal info */}
+      {type === 'zai' && usage.status === 'connected' && (
+        <div className="text-[11px] text-emerald-400/70">Connected - Z.AI does not expose rate limit headers</div>
+      )}
+
+      {/* Google - account info only */}
+      {type === 'google' && usage.status === 'connected' && !usage.account_email && (
+        <div className="text-[11px] text-emerald-400/70">Connected</div>
+      )}
+
+      {/* Generic connected status */}
+      {!['anthropic', 'openai', 'cerebras', 'minimax', 'zai', 'google'].includes(type) && usage.status === 'connected' && (
+        <div className="text-[11px] text-emerald-400/70">Connected</div>
+      )}
+    </div>
+  );
+}
+
 export default function ProvidersPage() {
   const [showAddModal, setShowAddModal] = useState(false);
   const [authenticatingProviderId, setAuthenticatingProviderId] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
+  const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
+  const [usageData, setUsageData] = useState<Record<string, ProviderUsage>>({});
+  const [usageLoading, setUsageLoading] = useState<Record<string, boolean>>({});
   const [editForm, setEditForm] = useState<{
     name?: string;
     label?: string;
@@ -88,6 +303,38 @@ export default function ProvidersPage() {
     'ai-provider-types',
     listAIProviderTypes,
     { revalidateOnFocus: false, fallbackData: defaultProviderTypes }
+  );
+
+  const fetchUsage = useCallback(async (providerId: string) => {
+    setUsageLoading((prev) => ({ ...prev, [providerId]: true }));
+    try {
+      const data = await getProviderUsage(providerId);
+      setUsageData((prev) => ({ ...prev, [providerId]: data }));
+    } catch {
+      setUsageData((prev) => ({
+        ...prev,
+        [providerId]: {
+          provider_type: '',
+          provider_name: '',
+          error: 'Failed to fetch usage',
+        },
+      }));
+    } finally {
+      setUsageLoading((prev) => ({ ...prev, [providerId]: false }));
+    }
+  }, []);
+
+  const toggleUsage = useCallback(
+    (providerId: string) => {
+      if (expandedProvider === providerId) {
+        setExpandedProvider(null);
+      } else {
+        setExpandedProvider(providerId);
+        // Fetch fresh usage when expanding
+        fetchUsage(providerId);
+      }
+    },
+    [expandedProvider, fetchUsage]
   );
 
   const handleAuthenticate = async (provider: AIProvider) => {
@@ -249,6 +496,7 @@ export default function ProvidersPage() {
                   : provider.status.type === 'needs_auth'
                   ? 'bg-amber-400'
                   : 'bg-red-400';
+                const isExpanded = expandedProvider === provider.id;
 
                 return (
                   <div
@@ -335,93 +583,129 @@ export default function ProvidersPage() {
                         </div>
                       </div>
                     ) : (
-                      <div className={cn(
-                        'flex items-center gap-3 px-3 py-2.5',
-                        !provider.enabled && 'opacity-40'
-                      )}>
-                        <span className="text-base">{config.icon}</span>
-                        <div className="flex-1 min-w-0">
-                          <span className="text-sm text-white/80 truncate block">
-                            {provider.name}
-                            {provider.label && (
-                              <span className="ml-1.5 text-xs text-white/40">({provider.label})</span>
-                            )}
-                          </span>
-                          {provider.account_email && (
-                            <span className="text-[11px] text-white/35 truncate block">
-                              {provider.account_email}
+                      <>
+                        <div className={cn(
+                          'flex items-center gap-3 px-3 py-2.5',
+                          !provider.enabled && 'opacity-40'
+                        )}>
+                          <span className="text-base">{config.icon}</span>
+                          <div className="flex-1 min-w-0">
+                            <span className="text-sm text-white/80 truncate block">
+                              {provider.name}
+                              {provider.label && (
+                                <span className="ml-1.5 text-xs text-white/40">({provider.label})</span>
+                              )}
                             </span>
+                            {provider.account_email && (
+                              <span className="text-[11px] text-white/35 truncate block">
+                                {provider.account_email}
+                              </span>
+                            )}
+                          </div>
+
+                          {provider.use_for_backends && provider.use_for_backends.length > 0 && (
+                            <div className="flex items-center gap-1">
+                              {provider.use_for_backends.map((backend) => (
+                                <span
+                                  key={backend}
+                                  className="px-1.5 py-0.5 text-[10px] rounded bg-white/[0.06] text-white/50"
+                                >
+                                  {backend === 'claudecode'
+                                    ? 'Claude'
+                                    : backend === 'opencode'
+                                    ? 'OC'
+                                    : backend === 'codex'
+                                    ? 'Codex'
+                                    : backend === 'gemini'
+                                    ? 'Gemini'
+                                    : backend}
+                                </span>
+                              ))}
+                            </div>
                           )}
+
+                          <div className="flex items-center gap-2">
+                            {provider.is_default && (
+                              <Star className="h-3 w-3 text-indigo-400 fill-indigo-400" />
+                            )}
+                            <span className={cn('h-1.5 w-1.5 rounded-full', statusColor)} />
+                          </div>
+
+                          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                            {provider.status.type === 'connected' && (
+                              <button
+                                onClick={() => toggleUsage(provider.id)}
+                                className="p-1.5 rounded-md text-white/30 hover:text-white/60 hover:bg-white/[0.04] transition-colors cursor-pointer"
+                                title="View usage"
+                              >
+                                {isExpanded ? (
+                                  <ChevronUp className="h-3.5 w-3.5" />
+                                ) : (
+                                  <BarChart3 className="h-3.5 w-3.5" />
+                                )}
+                              </button>
+                            )}
+                            {provider.status.type === 'needs_auth' && (
+                              <button
+                                onClick={() => handleAuthenticate(provider)}
+                                disabled={authenticatingProviderId === provider.id}
+                                className="p-1.5 rounded-md text-amber-400 hover:bg-white/[0.04] transition-colors cursor-pointer disabled:opacity-50"
+                                title="Connect"
+                              >
+                                {authenticatingProviderId === provider.id ? (
+                                  <Loader className="h-3.5 w-3.5 animate-spin" />
+                                ) : (
+                                  <ExternalLink className="h-3.5 w-3.5" />
+                                )}
+                              </button>
+                            )}
+                            {!provider.is_default && provider.enabled && (
+                              <button
+                                onClick={() => handleSetDefault(provider.id)}
+                                className="p-1.5 rounded-md text-white/30 hover:text-white/60 hover:bg-white/[0.04] transition-colors cursor-pointer"
+                                title="Set as default"
+                              >
+                                <Star className="h-3.5 w-3.5" />
+                              </button>
+                            )}
+                            <button
+                              onClick={() => handleStartEdit(provider)}
+                              className="p-1.5 rounded-md text-white/30 hover:text-white/60 hover:bg-white/[0.04] transition-colors cursor-pointer"
+                              title="Edit"
+                            >
+                              <Key className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              onClick={() => handleDeleteProvider(provider.id)}
+                              className="p-1.5 rounded-md text-white/30 hover:text-red-400 hover:bg-white/[0.04] transition-colors cursor-pointer"
+                              title="Delete"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
                         </div>
 
-                        {provider.use_for_backends && provider.use_for_backends.length > 0 && (
-                          <div className="flex items-center gap-1">
-                            {provider.use_for_backends.map((backend) => (
-                              <span
-                                key={backend}
-                                className="px-1.5 py-0.5 text-[10px] rounded bg-white/[0.06] text-white/50"
+                        {/* Expandable usage panel */}
+                        {isExpanded && (
+                          <div className="px-3 pb-3 border-t border-white/[0.04]">
+                            <div className="flex items-center justify-between pt-2 pb-1">
+                              <span className="text-[11px] text-white/30 uppercase tracking-wider">Usage & Limits</span>
+                              <button
+                                onClick={() => fetchUsage(provider.id)}
+                                disabled={usageLoading[provider.id]}
+                                className="p-1 rounded text-white/20 hover:text-white/50 transition-colors cursor-pointer disabled:opacity-50"
+                                title="Refresh"
                               >
-                                {backend === 'claudecode'
-                                  ? 'Claude'
-                                  : backend === 'opencode'
-                                  ? 'OC'
-                                  : backend === 'codex'
-                                  ? 'Codex'
-                                  : backend === 'gemini'
-                                  ? 'Gemini'
-                                  : backend}
-                              </span>
-                            ))}
+                                <RefreshCw className={cn('h-3 w-3', usageLoading[provider.id] && 'animate-spin')} />
+                              </button>
+                            </div>
+                            <UsageDetails
+                              usage={usageData[provider.id] ?? null}
+                              loading={usageLoading[provider.id] ?? false}
+                            />
                           </div>
                         )}
-
-                        <div className="flex items-center gap-2">
-                          {provider.is_default && (
-                            <Star className="h-3 w-3 text-indigo-400 fill-indigo-400" />
-                          )}
-                          <span className={cn('h-1.5 w-1.5 rounded-full', statusColor)} />
-                        </div>
-
-                        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                          {provider.status.type === 'needs_auth' && (
-                            <button
-                              onClick={() => handleAuthenticate(provider)}
-                              disabled={authenticatingProviderId === provider.id}
-                              className="p-1.5 rounded-md text-amber-400 hover:bg-white/[0.04] transition-colors cursor-pointer disabled:opacity-50"
-                              title="Connect"
-                            >
-                              {authenticatingProviderId === provider.id ? (
-                                <Loader className="h-3.5 w-3.5 animate-spin" />
-                              ) : (
-                                <ExternalLink className="h-3.5 w-3.5" />
-                              )}
-                            </button>
-                          )}
-                          {!provider.is_default && provider.enabled && (
-                            <button
-                              onClick={() => handleSetDefault(provider.id)}
-                              className="p-1.5 rounded-md text-white/30 hover:text-white/60 hover:bg-white/[0.04] transition-colors cursor-pointer"
-                              title="Set as default"
-                            >
-                              <Star className="h-3.5 w-3.5" />
-                            </button>
-                          )}
-                          <button
-                            onClick={() => handleStartEdit(provider)}
-                            className="p-1.5 rounded-md text-white/30 hover:text-white/60 hover:bg-white/[0.04] transition-colors cursor-pointer"
-                            title="Edit"
-                          >
-                            <Key className="h-3.5 w-3.5" />
-                          </button>
-                          <button
-                            onClick={() => handleDeleteProvider(provider.id)}
-                            className="p-1.5 rounded-md text-white/30 hover:text-red-400 hover:bg-white/[0.04] transition-colors cursor-pointer"
-                            title="Delete"
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </button>
-                        </div>
-                      </div>
+                      </>
                     )}
                   </div>
                 );

--- a/dashboard/src/components/mission-switcher.test.ts
+++ b/dashboard/src/components/mission-switcher.test.ts
@@ -205,12 +205,14 @@ describe('mission switcher search helpers', () => {
   it('keeps running missions searchable even without hydrated mission metadata', () => {
     const runningInfo = {
       mission_id: 'mission-running-123',
-      state: 'running',
+      state: 'running' as const,
       queue_len: 0,
       history_len: 12,
       seconds_since_activity: 3,
       health: { status: 'healthy' as const },
       expected_deliverables: 0,
+      subtask_total: 0,
+      subtask_completed: 0,
     };
 
     expect(getRunningMissionSearchText(runningInfo)).toContain('mission-running-123');
@@ -222,14 +224,17 @@ describe('mission switcher search helpers', () => {
   it('supports synonym and stopword matching for running missions', () => {
     const runningInfo = {
       mission_id: 'mission-running-123',
-      state: 'blocked',
+      state: 'waiting_for_tool' as const,
       queue_len: 0,
       history_len: 12,
       seconds_since_activity: 3,
       health: { status: 'healthy' as const },
       expected_deliverables: 0,
+      subtask_total: 0,
+      subtask_completed: 0,
     };
 
+    // 'waiting_for_tool' contains 'waiting', which is a synonym for 'blocked' and 'stalled'
     expect(runningMissionMatchesSearchQuery(runningInfo, 'stalled mission')).toBe(true);
     expect(runningMissionMatchesSearchQuery(runningInfo, 'where is my blocked mission')).toBe(true);
   });
@@ -237,12 +242,14 @@ describe('mission switcher search helpers', () => {
   it('supports abbreviation phrase expansion for running mission fallback relevance', () => {
     const runningInfo = {
       mission_id: 'mission-login-pipeline-123',
-      state: 'running',
+      state: 'running' as const,
       queue_len: 0,
       history_len: 12,
       seconds_since_activity: 3,
       health: { status: 'healthy' as const },
       expected_deliverables: 0,
+      subtask_total: 0,
+      subtask_completed: 0,
     };
 
     expect(runningMissionMatchesSearchQuery(runningInfo, 'sso')).toBe(true);

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -650,41 +650,118 @@ export function MissionSwitcher({
     );
   }, [missions, currentMissionId, runningMissionIds]);
 
-  // Build flat list of all selectable items
+  // Build a map from boss mission id to its worker missions
+  const bossMissionWorkerIds = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const m of missions) {
+      if (m.parent_mission_id) {
+        let set = map.get(m.parent_mission_id);
+        if (!set) {
+          set = new Set();
+          map.set(m.parent_mission_id, set);
+        }
+        set.add(m.id);
+      }
+    }
+    return map;
+  }, [missions]);
+
+  // Build flat list of all selectable items, grouping workers under their boss
   const allItems = useMemo(() => {
     const items: Array<{
       type: 'running' | 'current' | 'recent';
       mission?: Mission;
       runningInfo?: RunningMissionInfo;
       id: string;
+      isWorkerOf?: string; // parent boss mission id
+      isBoss?: boolean;
     }> = [];
+
+    const addedIds = new Set<string>();
+
+    // Helper to add a running mission + its workers
+    const addRunningWithWorkers = (rm: RunningMissionInfo) => {
+      if (addedIds.has(rm.mission_id)) return;
+      addedIds.add(rm.mission_id);
+      const mission = missions.find((m) => m.id === rm.mission_id);
+      const workerIds = bossMissionWorkerIds.get(rm.mission_id);
+      const isBoss = Boolean(workerIds && workerIds.size > 0);
+      items.push({
+        type: 'running',
+        mission,
+        runningInfo: rm,
+        id: rm.mission_id,
+        isBoss,
+      });
+      // Add workers grouped under this boss
+      if (workerIds) {
+        for (const workerId of workerIds) {
+          if (addedIds.has(workerId)) continue;
+          addedIds.add(workerId);
+          const workerMission = missions.find((m) => m.id === workerId);
+          const workerRunningInfo = runningMissions.find((r) => r.mission_id === workerId);
+          items.push({
+            type: workerRunningInfo ? 'running' : 'recent',
+            mission: workerMission,
+            runningInfo: workerRunningInfo,
+            id: workerId,
+            isWorkerOf: rm.mission_id,
+          });
+        }
+      }
+    };
 
     // Current mission first if not running
     if (currentMissionId) {
       const currentMission = missions.find((m) => m.id === currentMissionId);
       if (currentMission && !runningMissionIds.has(currentMissionId)) {
-        items.push({ type: 'current', mission: currentMission, id: currentMissionId });
+        addedIds.add(currentMissionId);
+        const workerIds = bossMissionWorkerIds.get(currentMissionId);
+        items.push({
+          type: 'current',
+          mission: currentMission,
+          id: currentMissionId,
+          isBoss: Boolean(workerIds && workerIds.size > 0),
+        });
       }
     }
 
-    // Running missions
-    runningMissions.forEach((rm) => {
+    // Running missions (boss missions first, then standalone)
+    const bosses = runningMissions.filter((rm) => bossMissionWorkerIds.has(rm.mission_id));
+    const standalone = runningMissions.filter(
+      (rm) => !bossMissionWorkerIds.has(rm.mission_id) && !missions.find((m) => m.id === rm.mission_id)?.parent_mission_id
+    );
+    const workerOnlyRunning = runningMissions.filter((rm) => {
+      const m = missions.find((mi) => mi.id === rm.mission_id);
+      return m?.parent_mission_id && !bossMissionWorkerIds.has(rm.mission_id);
+    });
+
+    // Add bosses first (with their workers grouped)
+    for (const rm of bosses) addRunningWithWorkers(rm);
+    // Add standalone running missions
+    for (const rm of standalone) addRunningWithWorkers(rm);
+    // Add orphan worker running missions (boss not running)
+    for (const rm of workerOnlyRunning) {
+      if (addedIds.has(rm.mission_id)) continue;
+      addedIds.add(rm.mission_id);
       const mission = missions.find((m) => m.id === rm.mission_id);
       items.push({
         type: 'running',
         mission,
         runningInfo: rm,
         id: rm.mission_id,
+        isWorkerOf: mission?.parent_mission_id ?? undefined,
       });
-    });
+    }
 
     // Recent missions
     recentMissions.forEach((m) => {
+      if (addedIds.has(m.id)) return;
       items.push({ type: 'recent', mission: m, id: m.id });
     });
 
     return items;
-  }, [missions, currentMissionId, runningMissions, runningMissionIds, recentMissions]);
+  }, [missions, currentMissionId, runningMissions, runningMissionIds, recentMissions, bossMissionWorkerIds]);
 
   useEffect(() => {
     if (!open) return;
@@ -921,21 +998,24 @@ export function MissionSwitcher({
               )}
               {filteredItems.map((item, index) => {
                 // Show section headers only when not searching
+                const isWorkerItem = Boolean(item.isWorkerOf);
                 const showRunningHeader =
                   !normalizedSearchQuery &&
                   item.type === 'running' &&
+                  !isWorkerItem &&
                   (index === 0 ||
                     (index === 1 && hasCurrent) ||
                     filteredItems[index - 1]?.type !== 'running');
                 const showRecentHeader =
                   !normalizedSearchQuery &&
                   item.type === 'recent' &&
+                  !isWorkerItem &&
                   filteredItems[index - 1]?.type !== 'recent';
 
                 const mission = item.mission;
                 const isSelected = index === selectedIndex;
                 const isViewing = item.id === viewingMissionId;
-                const isRunning = item.type === 'running';
+                const isRunning = item.type === 'running' || Boolean(item.runningInfo);
                 const runningInfo = item.runningInfo;
                 const missionQuickActions = mission
                   ? getMissionQuickActions(mission, isRunning)
@@ -954,6 +1034,7 @@ export function MissionSwitcher({
                 const cardDescription = mission
                   ? getMissionCardDescription(mission, cardTitle)
                   : null;
+                const hasProgress = runningInfo && runningInfo.subtask_total > 0;
 
                 return (
                   <div key={item.id}>
@@ -979,7 +1060,8 @@ export function MissionSwitcher({
                         handleSelect(item.id);
                       }}
                       className={cn(
-                        'group flex items-center gap-3 px-3 py-2 mx-2 rounded-lg cursor-pointer transition-colors no-underline',
+                        'group flex items-center gap-3 py-2 mx-2 rounded-lg cursor-pointer transition-colors no-underline',
+                        isWorkerItem ? 'px-3 ml-6 border-l-2 border-white/[0.06]' : 'px-3',
                         isSelected
                           ? 'bg-indigo-500/15 text-white'
                           : 'text-white/70 hover:bg-white/[0.04]',
@@ -1009,7 +1091,7 @@ export function MissionSwitcher({
                       {/* Mission info */}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <span className="font-medium text-sm truncate">
+                          <span className={cn("font-medium truncate", isWorkerItem ? "text-[13px]" : "text-sm")}>
                             {mission
                               ? getMissionDisplayName(mission, workspaceNameById)
                               : getMissionShortName(item.id)}
@@ -1022,7 +1104,17 @@ export function MissionSwitcher({
                               </span>
                             ) : null;
                           })()}
-                          {mission?.parent_mission_id && (
+                          {item.isBoss && (
+                            <span className="inline-flex items-center rounded bg-violet-500/10 border border-violet-500/20 px-1 py-0.5 text-[8px] font-medium text-violet-400 shrink-0">
+                              Boss
+                            </span>
+                          )}
+                          {isWorkerItem && (
+                            <span className="inline-flex items-center rounded bg-cyan-500/10 border border-cyan-500/20 px-1 py-0.5 text-[8px] font-medium text-cyan-400 shrink-0">
+                              W
+                            </span>
+                          )}
+                          {!item.isBoss && !isWorkerItem && mission?.parent_mission_id && (
                             <span className="inline-flex items-center rounded bg-cyan-500/10 border border-cyan-500/20 px-1 py-0.5 text-[8px] font-medium text-cyan-400 shrink-0">
                               Worker
                             </span>
@@ -1046,6 +1138,21 @@ export function MissionSwitcher({
                               </p>
                             )}
                           </>
+                        )}
+                        {/* Activity + progress for running missions */}
+                        {isRunning && runningInfo && (
+                          <div className="flex items-center gap-2 mt-0.5">
+                            {runningInfo.current_activity && (
+                              <span className="text-[11px] text-white/40 truncate italic">
+                                {runningInfo.current_activity}
+                              </span>
+                            )}
+                            {hasProgress && (
+                              <span className="text-[10px] font-mono text-white/30 tabular-nums shrink-0">
+                                {runningInfo.subtask_completed}/{runningInfo.subtask_total}
+                              </span>
+                            )}
+                          </div>
                         )}
                       </div>
 

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -527,6 +527,10 @@ export function NewMissionDialog({
 
   const getCreateOptions = (): NewMissionDialogOptions => {
     const parsed = parseSelectedValue(selectedAgentValue);
+    const agentValue =
+      selectedBackend === 'gemini' && parsed?.agent === 'default'
+        ? undefined
+        : parsed?.agent || undefined;
     const trimmedModel = modelOverride.trim();
     const normalizedModel =
       selectedBackend === 'opencode'
@@ -540,7 +544,7 @@ export function NewMissionDialog({
       (selectedBackend === 'codex' || selectedBackend === 'claudecode') && modelEffort ? modelEffort : undefined;
     return {
       workspaceId: newMissionWorkspace || undefined,
-      agent: parsed?.agent || undefined,
+      agent: agentValue,
       backend: parsed?.backend || 'claudecode',
       modelOverride: modelOverrideValue,
       modelEffort: modelEffortValue,

--- a/dashboard/src/components/worker-panel.tsx
+++ b/dashboard/src/components/worker-panel.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  X,
+  Loader2,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Clock,
+  Ban,
+  ExternalLink,
+  Users,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getMissionShortName } from '@/lib/mission-display';
+import { WorkerPeekModal } from '@/components/worker-peek-modal';
+import type { Mission, RunningMissionInfo } from '@/lib/api';
+
+interface WorkerPanelProps {
+  childMissions: Mission[];
+  runningMissions: RunningMissionInfo[];
+  bossMissionId: string;
+  viewingMissionId?: string | null;
+  onSelectWorker: (missionId: string) => void;
+  onClose: () => void;
+  className?: string;
+}
+
+function getWorkerStatusInfo(
+  mission: Mission,
+  runningInfo?: RunningMissionInfo
+): {
+  icon: React.ReactNode;
+  label: string;
+  color: string;
+  bgColor: string;
+  isActive: boolean;
+} {
+  if (runningInfo) {
+    const state = runningInfo.state;
+    if (state === 'running') {
+      return {
+        icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
+        label: runningInfo.current_activity || 'Running',
+        color: 'text-indigo-400',
+        bgColor: 'bg-indigo-500/10 border-indigo-500/20',
+        isActive: true,
+      };
+    }
+    if (state === 'waiting_for_tool') {
+      return {
+        icon: <Clock className="h-3.5 w-3.5" />,
+        label: runningInfo.current_activity || 'Waiting for tool',
+        color: 'text-amber-400',
+        bgColor: 'bg-amber-500/10 border-amber-500/20',
+        isActive: true,
+      };
+    }
+    if (state === 'queued') {
+      return {
+        icon: <Clock className="h-3.5 w-3.5" />,
+        label: 'Queued',
+        color: 'text-white/50',
+        bgColor: 'bg-white/[0.03] border-white/[0.08]',
+        isActive: false,
+      };
+    }
+  }
+
+  switch (mission.status) {
+    case 'completed':
+      return {
+        icon: <CheckCircle className="h-3.5 w-3.5" />,
+        label: 'Completed',
+        color: 'text-emerald-400',
+        bgColor: 'bg-emerald-500/10 border-emerald-500/20',
+        isActive: false,
+      };
+    case 'failed':
+      return {
+        icon: <XCircle className="h-3.5 w-3.5" />,
+        label: 'Failed',
+        color: 'text-red-400',
+        bgColor: 'bg-red-500/10 border-red-500/20',
+        isActive: false,
+      };
+    case 'interrupted':
+      return {
+        icon: <AlertTriangle className="h-3.5 w-3.5" />,
+        label: 'Interrupted',
+        color: 'text-amber-400',
+        bgColor: 'bg-amber-500/10 border-amber-500/20',
+        isActive: false,
+      };
+    case 'not_feasible':
+      return {
+        icon: <Ban className="h-3.5 w-3.5" />,
+        label: 'Not feasible',
+        color: 'text-rose-400',
+        bgColor: 'bg-rose-500/10 border-rose-500/20',
+        isActive: false,
+      };
+    case 'active':
+      return {
+        icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
+        label: 'Active',
+        color: 'text-indigo-400',
+        bgColor: 'bg-indigo-500/10 border-indigo-500/20',
+        isActive: true,
+      };
+    default:
+      return {
+        icon: <Clock className="h-3.5 w-3.5" />,
+        label: mission.status || 'Unknown',
+        color: 'text-white/40',
+        bgColor: 'bg-white/[0.03] border-white/[0.08]',
+        isActive: false,
+      };
+  }
+}
+
+function ProgressBar({
+  completed,
+  total,
+  className,
+}: {
+  completed: number;
+  total: number;
+  className?: string;
+}) {
+  if (total <= 0) return null;
+  const pct = Math.min(100, Math.round((completed / total) * 100));
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <div className="flex-1 h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-500',
+            pct === 100 ? 'bg-emerald-400' : 'bg-indigo-400'
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-[10px] font-mono text-white/40 tabular-nums shrink-0">
+        {completed}/{total}
+      </span>
+    </div>
+  );
+}
+
+function WorkerCard({
+  mission,
+  runningInfo,
+  isViewing,
+  onSelect,
+}: {
+  mission: Mission;
+  runningInfo?: RunningMissionInfo;
+  isViewing: boolean;
+  onSelect: () => void;
+}) {
+  const status = getWorkerStatusInfo(mission, runningInfo);
+  const title = mission.title?.trim() || getMissionShortName(mission.id);
+  const shortDescription = mission.short_description?.trim();
+  const hasProgress =
+    runningInfo && runningInfo.subtask_total > 0;
+  const isStalled =
+    runningInfo?.health?.status === 'stalled';
+  const stallSeverity =
+    isStalled && runningInfo?.health?.status === 'stalled'
+      ? (runningInfo.health as { severity?: string }).severity
+      : null;
+
+  return (
+    <button
+      onClick={onSelect}
+      className={cn(
+        'w-full text-left rounded-lg border p-3 transition-all duration-200 group',
+        isViewing
+          ? 'border-indigo-500/30 bg-indigo-500/10 ring-1 ring-indigo-500/20'
+          : status.bgColor,
+        !isViewing && 'hover:bg-white/[0.06] hover:border-white/[0.12]',
+        isStalled && stallSeverity === 'severe' && 'border-red-500/30 bg-red-500/5',
+        isStalled && stallSeverity !== 'severe' && 'border-amber-500/20 bg-amber-500/5'
+      )}
+    >
+      {/* Header row */}
+      <div className="flex items-center gap-2 mb-1">
+        <span className={status.color}>{status.icon}</span>
+        <span className="text-sm font-medium text-white/90 truncate flex-1">
+          {title}
+        </span>
+        <ExternalLink className="h-3 w-3 text-white/20 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+      </div>
+
+      {/* Description */}
+      {shortDescription && shortDescription !== title && (
+        <p className="text-[11px] text-white/45 truncate mb-1.5 pl-[22px]">
+          {shortDescription}
+        </p>
+      )}
+
+      {/* Activity line */}
+      {status.isActive && status.label !== 'Active' && status.label !== 'Running' && (
+        <p className="text-[11px] text-white/50 truncate mb-1.5 pl-[22px] italic">
+          {status.label}
+        </p>
+      )}
+
+      {/* Progress bar */}
+      {hasProgress && (
+        <div className="pl-[22px]">
+          <ProgressBar
+            completed={runningInfo.subtask_completed}
+            total={runningInfo.subtask_total}
+          />
+        </div>
+      )}
+
+      {/* Stall warning */}
+      {isStalled && runningInfo && (
+        <div className={cn(
+          'flex items-center gap-1.5 mt-1.5 pl-[22px] text-[10px]',
+          stallSeverity === 'severe' ? 'text-red-400' : 'text-amber-400'
+        )}>
+          <AlertTriangle className="h-3 w-3" />
+          <span>
+            Stalled {Math.floor(runningInfo.seconds_since_activity)}s
+          </span>
+        </div>
+      )}
+    </button>
+  );
+}
+
+export function WorkerPanel({
+  childMissions,
+  runningMissions,
+  bossMissionId,
+  viewingMissionId,
+  onSelectWorker,
+  onClose,
+  className,
+}: WorkerPanelProps) {
+  const [peekMissionId, setPeekMissionId] = useState<string | null>(null);
+
+  const runningByMissionId = useMemo(() => {
+    const map = new Map<string, RunningMissionInfo>();
+    for (const rm of runningMissions) {
+      map.set(rm.mission_id, rm);
+    }
+    return map;
+  }, [runningMissions]);
+
+  // Sort: active first, then by most recently updated
+  const sortedWorkers = useMemo(() => {
+    return [...childMissions].sort((a, b) => {
+      const aRunning = runningByMissionId.has(a.id);
+      const bRunning = runningByMissionId.has(b.id);
+      if (aRunning !== bRunning) return aRunning ? -1 : 1;
+
+      const aActive = a.status === 'active';
+      const bActive = b.status === 'active';
+      if (aActive !== bActive) return aActive ? -1 : 1;
+
+      const aTime = a.updated_at || a.created_at || '';
+      const bTime = b.updated_at || b.created_at || '';
+      return bTime.localeCompare(aTime);
+    });
+  }, [childMissions, runningByMissionId]);
+
+  const activeCount = sortedWorkers.filter(
+    (m) => runningByMissionId.has(m.id) || m.status === 'active'
+  ).length;
+  const completedCount = sortedWorkers.filter(
+    (m) => m.status === 'completed'
+  ).length;
+  const failedCount = sortedWorkers.filter(
+    (m) => m.status === 'failed' || m.status === 'not_feasible'
+  ).length;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col rounded-2xl glass-panel border border-white/[0.06] overflow-hidden',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/[0.06]">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-violet-400" />
+          <span className="text-sm font-medium text-white/90">Workers</span>
+          <span className="text-xs text-white/40 font-mono">
+            {sortedWorkers.length}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 rounded hover:bg-white/[0.06] text-white/40 hover:text-white/70 transition-colors"
+          title="Close worker panel"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Summary stats */}
+      {sortedWorkers.length > 0 && (
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-white/[0.04] text-[10px]">
+          {activeCount > 0 && (
+            <span className="flex items-center gap-1 text-indigo-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-indigo-400 animate-pulse" />
+              {activeCount} active
+            </span>
+          )}
+          {completedCount > 0 && (
+            <span className="flex items-center gap-1 text-emerald-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+              {completedCount} done
+            </span>
+          )}
+          {failedCount > 0 && (
+            <span className="flex items-center gap-1 text-red-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-red-400" />
+              {failedCount} failed
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Worker list */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {sortedWorkers.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full py-8 text-center">
+            <Users className="h-8 w-8 text-white/10 mb-2" />
+            <p className="text-sm text-white/30">No workers yet</p>
+            <p className="text-[11px] text-white/20 mt-1">
+              Workers will appear here when the boss delegates tasks
+            </p>
+          </div>
+        ) : (
+          sortedWorkers.map((mission) => (
+            <WorkerCard
+              key={mission.id}
+              mission={mission}
+              runningInfo={runningByMissionId.get(mission.id)}
+              isViewing={mission.id === viewingMissionId}
+              onSelect={() => setPeekMissionId(mission.id)}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Peek modal */}
+      {peekMissionId && (() => {
+        const peekMission = childMissions.find((m) => m.id === peekMissionId);
+        if (!peekMission) return null;
+        return (
+          <WorkerPeekModal
+            mission={peekMission}
+            runningInfo={runningByMissionId.get(peekMissionId)}
+            onClose={() => setPeekMissionId(null)}
+            onOpenFull={onSelectWorker}
+          />
+        );
+      })()}
+    </div>
+  );
+}

--- a/dashboard/src/components/worker-peek-modal.tsx
+++ b/dashboard/src/components/worker-peek-modal.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Loader2,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Ban,
+  Clock,
+  ExternalLink,
+  Bot,
+  User,
+  Wrench,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getMissionShortName } from '@/lib/mission-display';
+import { MarkdownContent } from '@/components/markdown-content';
+import {
+  getMissionEvents,
+  type Mission,
+  type StoredEvent,
+  type RunningMissionInfo,
+} from '@/lib/api';
+
+interface WorkerPeekModalProps {
+  mission: Mission;
+  runningInfo?: RunningMissionInfo;
+  onClose: () => void;
+  onOpenFull: (missionId: string) => void;
+}
+
+function getStatusBadge(mission: Mission, runningInfo?: RunningMissionInfo) {
+  if (runningInfo) {
+    const state = runningInfo.state;
+    if (state === 'running') {
+      return {
+        icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
+        label: 'Running',
+        color: 'text-indigo-400',
+        bg: 'bg-indigo-500/10 border-indigo-500/20',
+      };
+    }
+    if (state === 'waiting_for_tool') {
+      return {
+        icon: <Clock className="h-3.5 w-3.5" />,
+        label: 'Waiting for tool',
+        color: 'text-amber-400',
+        bg: 'bg-amber-500/10 border-amber-500/20',
+      };
+    }
+    if (state === 'queued') {
+      return {
+        icon: <Clock className="h-3.5 w-3.5" />,
+        label: 'Queued',
+        color: 'text-white/50',
+        bg: 'bg-white/[0.04] border-white/[0.08]',
+      };
+    }
+  }
+
+  switch (mission.status) {
+    case 'completed':
+      return {
+        icon: <CheckCircle className="h-3.5 w-3.5" />,
+        label: 'Completed',
+        color: 'text-emerald-400',
+        bg: 'bg-emerald-500/10 border-emerald-500/20',
+      };
+    case 'failed':
+      return {
+        icon: <XCircle className="h-3.5 w-3.5" />,
+        label: 'Failed',
+        color: 'text-red-400',
+        bg: 'bg-red-500/10 border-red-500/20',
+      };
+    case 'interrupted':
+      return {
+        icon: <AlertTriangle className="h-3.5 w-3.5" />,
+        label: 'Interrupted',
+        color: 'text-amber-400',
+        bg: 'bg-amber-500/10 border-amber-500/20',
+      };
+    case 'not_feasible':
+      return {
+        icon: <Ban className="h-3.5 w-3.5" />,
+        label: 'Not feasible',
+        color: 'text-rose-400',
+        bg: 'bg-rose-500/10 border-rose-500/20',
+      };
+    default:
+      return {
+        icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
+        label: 'Active',
+        color: 'text-indigo-400',
+        bg: 'bg-indigo-500/10 border-indigo-500/20',
+      };
+  }
+}
+
+interface ParsedMessage {
+  role: 'user' | 'assistant' | 'tool';
+  content: string;
+  toolName?: string;
+  toolCallId?: string;
+  timestamp?: string;
+}
+
+function parseEventsToMessages(events: StoredEvent[]): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  const toolCalls = new Map<string, { name: string; args: string }>();
+
+  for (const event of events) {
+    switch (event.event_type) {
+      case 'user_message':
+        messages.push({ role: 'user', content: event.content, timestamp: event.timestamp });
+        break;
+      case 'assistant_message':
+        messages.push({ role: 'assistant', content: event.content, timestamp: event.timestamp });
+        break;
+      case 'tool_call':
+        if (event.tool_call_id) {
+          toolCalls.set(event.tool_call_id, {
+            name: event.tool_name || 'unknown',
+            args: event.content,
+          });
+        }
+        break;
+      case 'tool_result':
+        if (event.tool_call_id) {
+          const call = toolCalls.get(event.tool_call_id);
+          messages.push({
+            role: 'tool',
+            content: event.content,
+            toolName: call?.name || event.tool_name || 'tool',
+            toolCallId: event.tool_call_id,
+            timestamp: event.timestamp,
+          });
+        }
+        break;
+    }
+  }
+
+  return messages;
+}
+
+function ToolResultItem({
+  message,
+}: {
+  message: ParsedMessage;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const contentPreview = message.content.length > 200
+    ? message.content.slice(0, 200) + '...'
+    : message.content;
+
+  return (
+    <div className="border border-white/[0.06] rounded-lg overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-xs text-white/50 hover:bg-white/[0.03] transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        )}
+        <Wrench className="h-3 w-3 shrink-0 text-white/30" />
+        <span className="font-mono text-[11px] text-white/60 truncate">
+          {message.toolName}
+        </span>
+      </button>
+      {expanded && (
+        <div className="px-3 py-2 border-t border-white/[0.04] bg-white/[0.01]">
+          <pre className="text-[11px] text-white/50 whitespace-pre-wrap break-all font-mono max-h-[200px] overflow-y-auto">
+            {message.content}
+          </pre>
+        </div>
+      )}
+      {!expanded && contentPreview.length > 0 && (
+        <div className="px-3 pb-2 -mt-1">
+          <p className="text-[10px] text-white/25 truncate font-mono">
+            {contentPreview}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WorkerPeekModal({
+  mission,
+  runningInfo,
+  onClose,
+  onOpenFull,
+}: WorkerPeekModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [events, setEvents] = useState<StoredEvent[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const status = getStatusBadge(mission, runningInfo);
+
+  const title = mission.title?.trim() || getMissionShortName(mission.id);
+  const shortDescription = mission.short_description?.trim();
+  const backend = mission.backend?.trim() || 'claudecode';
+  const workingDir = mission.working_directory;
+
+  // Fetch events on mount
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getMissionEvents(mission.id, {
+      types: ['user_message', 'assistant_message', 'tool_call', 'tool_result'],
+      limit: 100,
+    })
+      .then((result) => {
+        if (!cancelled) setEvents(result);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch worker events:', err);
+        if (!cancelled) setEvents([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [mission.id]);
+
+  // Parse messages from events, falling back to mission.history
+  const messages = useMemo(() => {
+    if (events && events.length > 0) {
+      return parseEventsToMessages(events);
+    }
+    // Fallback: use mission.history (role/content pairs)
+    if (mission.history?.length > 0) {
+      return mission.history.map((h) => ({
+        role: h.role as 'user' | 'assistant',
+        content: h.content,
+      }));
+    }
+    return [];
+  }, [events, mission.history]);
+
+  // Only show the last N messages (assistant messages are most interesting)
+  const displayMessages = useMemo(() => {
+    // Show last 20 messages to give enough context
+    return messages.slice(-20);
+  }, [messages]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [onClose]);
+
+  // Close on click outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  const handleOpenFull = useCallback(() => {
+    onOpenFull(mission.id);
+    onClose();
+  }, [mission.id, onOpenFull, onClose]);
+
+  const modalContent = (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-in fade-in duration-150" />
+
+      {/* Modal */}
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-2xl max-h-[75vh] flex flex-col rounded-xl bg-[#1a1a1a] border border-white/[0.06] shadow-2xl animate-in fade-in zoom-in-95 duration-150 mx-4"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-white/[0.06] shrink-0">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <h2 className="text-base font-semibold text-white truncate">
+                {title}
+              </h2>
+              <span className={cn(
+                'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium shrink-0',
+                status.bg, status.color
+              )}>
+                {status.icon}
+                {status.label}
+              </span>
+            </div>
+            {shortDescription && shortDescription !== title && (
+              <p className="text-sm text-white/50 truncate">{shortDescription}</p>
+            )}
+            <div className="flex items-center gap-3 mt-1.5 text-[11px] text-white/30">
+              <span className="font-mono">{backend}</span>
+              {workingDir && (
+                <>
+                  <span className="text-white/15">|</span>
+                  <span className="font-mono truncate max-w-[200px]" title={workingDir}>
+                    {workingDir.split('/').pop()}
+                  </span>
+                </>
+              )}
+              {runningInfo?.current_activity && (
+                <>
+                  <span className="text-white/15">|</span>
+                  <span className="italic text-white/40 truncate">
+                    {runningInfo.current_activity}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-white/[0.06] text-white/40 hover:text-white/70 transition-colors shrink-0"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4 min-h-0">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 text-white/20 animate-spin mb-2" />
+              <p className="text-sm text-white/30">Loading messages...</p>
+            </div>
+          ) : displayMessages.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12">
+              <Bot className="h-8 w-8 text-white/10 mb-2" />
+              <p className="text-sm text-white/30">No messages yet</p>
+            </div>
+          ) : (
+            displayMessages.map((msg, i) => {
+              if (msg.role === 'tool') {
+                return (
+                  <ToolResultItem
+                    key={`tool-${i}`}
+                    message={msg}
+                  />
+                );
+              }
+
+              const isUser = msg.role === 'user';
+              return (
+                <div key={`msg-${i}`} className="flex gap-3">
+                  <div className={cn(
+                    'flex h-7 w-7 items-center justify-center rounded-full shrink-0 mt-0.5',
+                    isUser ? 'bg-white/[0.06]' : 'bg-indigo-500/20'
+                  )}>
+                    {isUser ? (
+                      <User className="h-3.5 w-3.5 text-white/50" />
+                    ) : (
+                      <Bot className="h-3.5 w-3.5 text-indigo-400" />
+                    )}
+                  </div>
+                  <div className={cn(
+                    'flex-1 min-w-0 rounded-xl px-4 py-3',
+                    isUser
+                      ? 'bg-white/[0.03] border border-white/[0.06]'
+                      : 'bg-indigo-500/[0.04] border border-indigo-500/[0.08]'
+                  )}>
+                    <div className="text-[10px] text-white/30 mb-1.5 font-medium uppercase tracking-wider">
+                      {isUser ? 'User' : 'Assistant'}
+                    </div>
+                    <div className="text-sm text-white/80 prose-compact">
+                      <MarkdownContent
+                        content={msg.content}
+                        basePath={workingDir ?? undefined}
+                        workspaceId={mission.workspace_id}
+                        missionId={mission.id}
+                      />
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 py-3 border-t border-white/[0.06] shrink-0">
+          <div className="text-[11px] text-white/25">
+            {messages.length > 0 && (
+              <span>{messages.filter((m) => m.role === 'assistant').length} assistant messages</span>
+            )}
+          </div>
+          <button
+            onClick={handleOpenFull}
+            className="flex items-center gap-2 rounded-lg bg-indigo-500/15 hover:bg-indigo-500/25 border border-indigo-500/20 px-3 py-1.5 text-sm text-indigo-400 transition-colors"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Open full mission
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  // Portal to document.body to escape any overflow:hidden ancestors
+  if (typeof document !== 'undefined') {
+    return createPortal(modalContent, document.body);
+  }
+  return modalContent;
+}

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -108,6 +108,8 @@ export {
   oauthCallback,
   listProviders,
   listBackendModelOptions,
+  type ProviderUsage,
+  getProviderUsage,
 } from "./providers";
 
 // Model Routing

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -83,6 +83,9 @@ export interface RunningMissionInfo {
   seconds_since_activity: number;
   health: MissionHealth;
   expected_deliverables: number;
+  current_activity?: string;
+  subtask_total: number;
+  subtask_completed: number;
 }
 
 export type MissionStallSeverity = "warning" | "severe";

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -193,7 +193,10 @@ export async function createMission(
     headers: { "Content-Type": "application/json" },
     body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
   });
-  if (!res.ok) throw new Error("Failed to create mission");
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || "Failed to create mission");
+  }
   return res.json();
 }
 

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -256,6 +256,63 @@ export async function oauthCallback(
   return res.json();
 }
 
+// ---------------------------------------------------------------------------
+// Usage / Rate Limits
+// ---------------------------------------------------------------------------
+
+export interface ProviderUsage {
+  provider_type: string;
+  provider_name: string;
+  account_email?: string | null;
+  account_name?: string | null;
+  account_picture?: string | null;
+  organization?: string | null;
+  organization_id?: string | null;
+  status?: string;
+  error?: string;
+  // Anthropic unified rate limits (2025+)
+  unified_status?: string;
+  unified_reset?: string;
+  unified_5h_status?: string;
+  unified_5h_reset?: string;
+  unified_5h_utilization?: number;
+  unified_7d_status?: string;
+  unified_7d_reset?: string;
+  unified_7d_utilization?: number;
+  unified_representative_claim?: string;
+  unified_fallback_pct?: number;
+  unified_overage_status?: string;
+  unified_overage_disabled_reason?: string;
+  // Anthropic legacy / OpenAI style
+  requests_limit?: number;
+  requests_remaining?: number;
+  requests_reset?: string;
+  tokens_limit?: number;
+  tokens_remaining?: number;
+  tokens_reset?: string;
+  input_tokens_limit?: number;
+  input_tokens_remaining?: number;
+  output_tokens_limit?: number;
+  output_tokens_remaining?: number;
+  // Cerebras style
+  requests_limit_day?: number;
+  requests_remaining_day?: number;
+  requests_reset_day?: string;
+  tokens_limit_minute?: number;
+  tokens_remaining_minute?: number;
+  tokens_reset_minute?: string;
+  // Minimax coding plan
+  coding_plan?: Record<string, unknown>;
+  // Z.AI last call usage
+  last_call_usage?: Record<string, unknown>;
+  // Any additional fields
+  [key: string]: unknown;
+}
+
+export async function getProviderUsage(id: string): Promise<ProviderUsage> {
+  return apiGet(`/api/ai/providers/${id}/usage`, "Failed to get provider usage");
+}
+
 export async function listProviders(options?: { includeAll?: boolean }): Promise<ProvidersResponse> {
   const params = new URLSearchParams();
   if (options?.includeAll) {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1888,10 +1888,16 @@ struct ControlView: View {
         }) {
             let existing = messages[index]
             let startTime = existing.thinkingStartTime ?? existing.timestamp
+            let mergedContent: String
+            if content.hasPrefix(existing.content) {
+                mergedContent = content
+            } else {
+                mergedContent = existing.content + content
+            }
             messages[index] = ChatMessage(
                 id: existing.id,
                 type: .thinking(done: done, startTime: startTime),
-                content: content,
+                content: mergedContent,
                 toolUI: existing.toolUI,
                 toolData: existing.toolData,
                 timestamp: existing.timestamp
@@ -2046,7 +2052,7 @@ struct ControlView: View {
             }
 
         case "text_delta":
-            if let content = data["content"] as? String {
+            if !isHistoricalReplay, let content = data["content"] as? String {
                 upsertStreamingFallbackThought(content: content, done: false)
             }
             

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1649,8 +1649,12 @@ struct ControlView: View {
                                     Task {
                                         do {
                                             let mission = try await self.api.getMission(id: viewingId)
+                                            let events = try await self.api.getMissionEvents(
+                                                id: viewingId,
+                                                types: self.historyEventTypes
+                                            )
                                             await MainActor.run {
-                                                self.applyViewingMission(mission)
+                                                self.applyViewingMissionWithEvents(mission, events: events)
                                             }
                                         } catch {
                                             // Ignore errors - we'll get updates via stream
@@ -1839,6 +1843,69 @@ struct ControlView: View {
     private var historyEventTypes: [String] {
         ["user_message", "assistant_message", "tool_call", "tool_result", "text_delta", "thinking"]
     }
+
+    private var streamingThoughtPrefix: String {
+        "stream-thinking-"
+    }
+
+    private func isStreamingFallbackThought(_ message: ChatMessage) -> Bool {
+        message.id.hasPrefix(streamingThoughtPrefix)
+    }
+
+    private func finalizeActiveThinkingMessages() {
+        for index in messages.indices {
+            guard messages[index].isThinking, !messages[index].thinkingDone else {
+                continue
+            }
+
+            let existing = messages[index]
+            let startTime = existing.thinkingStartTime ?? existing.timestamp
+            messages[index] = ChatMessage(
+                id: existing.id,
+                type: .thinking(done: true, startTime: startTime),
+                content: existing.content,
+                toolUI: existing.toolUI,
+                toolData: existing.toolData,
+                timestamp: existing.timestamp
+            )
+        }
+    }
+
+    private func upsertStreamingFallbackThought(content: String, done: Bool) {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        messages.removeAll { $0.isPhase }
+
+        if let activeRealThought = messages.last(where: {
+            $0.isThinking && !$0.thinkingDone && !isStreamingFallbackThought($0)
+        }), !activeRealThought.content.isEmpty {
+            return
+        }
+
+        if let index = messages.lastIndex(where: {
+            $0.isThinking && !$0.thinkingDone && isStreamingFallbackThought($0)
+        }) {
+            let existing = messages[index]
+            let startTime = existing.thinkingStartTime ?? existing.timestamp
+            messages[index] = ChatMessage(
+                id: existing.id,
+                type: .thinking(done: done, startTime: startTime),
+                content: content,
+                toolUI: existing.toolUI,
+                toolData: existing.toolData,
+                timestamp: existing.timestamp
+            )
+        } else {
+            messages.append(
+                ChatMessage(
+                    id: "\(streamingThoughtPrefix)\(Date().timeIntervalSince1970)",
+                    type: .thinking(done: done, startTime: Date()),
+                    content: content
+                )
+            )
+        }
+    }
     
     private func handleStreamEvent(type: String, data: [String: Any], isHistoricalReplay: Bool = false) {
         // Filter events by mission_id - only show events for the mission we're viewing
@@ -1903,6 +1970,7 @@ struct ControlView: View {
 
                     // Clear progress and auto-close desktop stream when idle
                     if newState == .idle {
+                        finalizeActiveThinkingMessages()
                         progress = nil
                         // Auto-close desktop stream when agent finishes
                         showDesktopStream = false
@@ -1916,6 +1984,7 @@ struct ControlView: View {
         case "user_message":
             if let content = data["content"] as? String,
                let id = data["id"] as? String {
+                finalizeActiveThinkingMessages()
                 // Skip if we already have this message with this ID
                 guard !messages.contains(where: { $0.id == id }) else { break }
 
@@ -1962,9 +2031,8 @@ struct ControlView: View {
                     }
                 }
 
-                // Remove any incomplete thinking messages and phase messages
-                // Mark active tool calls as completed instead of removing them
-                messages.removeAll { ($0.isThinking && !$0.thinkingDone) || $0.isPhase }
+                finalizeActiveThinkingMessages()
+                messages.removeAll { $0.isPhase }
 
                 // Mark any remaining active tool calls as completed
                 markActiveToolCallsAsCompleted(withState: .success)
@@ -1976,39 +2044,49 @@ struct ControlView: View {
                 )
                 messages.append(message)
             }
+
+        case "text_delta":
+            if let content = data["content"] as? String {
+                upsertStreamingFallbackThought(content: content, done: false)
+            }
             
         case "thinking":
-            if let content = data["content"] as? String {
-                let done = data["done"] as? Bool ?? false
+            let content = data["content"] as? String ?? ""
+            let done = data["done"] as? Bool ?? false
+            let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
 
-                // Skip empty thinking content
-                guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { break }
-
-                // Remove phase items when thinking starts
-                messages.removeAll { $0.isPhase }
-
-                // Find existing thinking message or create new
-                if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
-                    let existingStartTime = messages[index].thinkingStartTime ?? Date()
-                    messages[index].content = content
-                    if done {
-                        messages[index] = ChatMessage(
-                            id: messages[index].id,
-                            type: .thinking(done: true, startTime: existingStartTime),
-                            content: messages[index].content
-                        )
-                    }
-                } else {
-                    // Create new thinking message - whether done or not
-                    // This handles the case where we receive a completed thought without seeing it active first
-                    // (e.g., when joining a mission mid-thought or reconnecting)
-                    let message = ChatMessage(
-                        id: "thinking-\(Date().timeIntervalSince1970)",
-                        type: .thinking(done: done, startTime: Date()),
-                        content: content
-                    )
-                    messages.append(message)
+            if trimmed.isEmpty {
+                if done {
+                    finalizeActiveThinkingMessages()
                 }
+                break
+            }
+
+            // Remove phase items when thinking starts
+            messages.removeAll { $0.isPhase }
+
+            // Find existing thinking message or create new
+            if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
+                let existing = messages[index]
+                let existingStartTime = existing.thinkingStartTime ?? existing.timestamp
+                messages[index] = ChatMessage(
+                    id: existing.id,
+                    type: .thinking(done: done, startTime: existingStartTime),
+                    content: content,
+                    toolUI: existing.toolUI,
+                    toolData: existing.toolData,
+                    timestamp: existing.timestamp
+                )
+            } else {
+                // Create new thinking message - whether done or not
+                // This handles the case where we receive a completed thought without seeing it active first
+                // (e.g., when joining a mission mid-thought or reconnecting)
+                let message = ChatMessage(
+                    id: "thinking-\(Date().timeIntervalSince1970)",
+                    type: .thinking(done: done, startTime: Date()),
+                    content: content
+                )
+                messages.append(message)
             }
             
         case "agent_phase":
@@ -2044,6 +2122,7 @@ struct ControlView: View {
             
         case "error":
             if let errorMessage = data["message"] as? String {
+                finalizeActiveThinkingMessages()
                 // Filter out SSE-specific reconnection errors - these are handled by the reconnection logic
                 // Use specific patterns to avoid filtering legitimate agent errors
                 let lower = errorMessage.lowercased()
@@ -2068,6 +2147,7 @@ struct ControlView: View {
             if let toolCallId = data["tool_call_id"] as? String,
                let name = data["name"] as? String,
                let args = data["args"] as? [String: Any] {
+                finalizeActiveThinkingMessages()
                 // Parse UI tool calls
                 if let toolUI = ToolUIContent.parse(name: name, args: args) {
                     let message = ChatMessage(
@@ -2169,6 +2249,7 @@ struct ControlView: View {
                 // If mission is no longer active AND it's the currently viewed mission,
                 // mark all pending tools as cancelled
                 if newStatus != .active && viewingMissionId == missionId {
+                    finalizeActiveThinkingMessages()
                     markActiveToolCallsAsCompleted(withState: .cancelled)
                 }
 

--- a/skills/orchestrator-boss/SKILL.md
+++ b/skills/orchestrator-boss/SKILL.md
@@ -35,6 +35,7 @@ Always match `backend` to `model_override`.
 ## Tools
 
 - `get_workspace_layout`
+- `get_backend_auth_status`
 - `batch_create_workers`, `create_worker_mission`
 - `wait_for_any_worker`, `get_worker_status`, `list_worker_missions`
 - `resume_worker`, `retask_worker`, `send_message_to_worker`
@@ -44,14 +45,15 @@ Always match `backend` to `model_override`.
 ## Required Loop
 
 1. Call `get_workspace_layout` once. Use its paths in worker prompts and worktree setup.
-2. Build a task graph with `ready`, `blocked`, and `depends_on`.
-3. Spawn every ready task now.
-4. Wait with `wait_for_any_worker`.
-5. React immediately:
+2. If backend choice matters, call `get_backend_auth_status` once before spawning. Do not infer auth from shell env vars, CLI login status, or missing `*_API_KEY` in Bash.
+3. Build a task graph with `ready`, `blocked`, and `depends_on`.
+4. Spawn every ready task now.
+5. Wait with `wait_for_any_worker`.
+6. React immediately:
    - `completed`: verify the actual result, then integrate or reject and spawn newly-ready work
    - `failed` or `interrupted`: recover with `resume_worker` or replace the worker
    - `stalled`: cancel and replace
-6. Update `orchestrator-state.json` after every state change.
+7. Update `orchestrator-state.json` after every state change.
 
 ## Worker Prompt Checklist
 

--- a/skills/orchestrator-boss/SKILL.md
+++ b/skills/orchestrator-boss/SKILL.md
@@ -1,121 +1,72 @@
 ---
 name: orchestrator-boss
 description: >
-  Boss agent skill for orchestrating parallel worker missions. The boss coordinates,
-  delegates, and integrates — it NEVER does implementation work directly.
+  Boss skill for parallel worker orchestration. Analyze, split, delegate, monitor,
+  integrate. Do not implement directly.
 ---
 
 # Orchestrator Boss
 
-You are a **boss agent**. Your ONLY job is to coordinate parallel work across multiple worker agents.
+You coordinate worker missions. Prefer delegation over direct work.
 
-## CRITICAL RULES
+## Hard Rules
 
-1. **NEVER edit source code files directly.** You must not use Edit, Write, or similar tools on implementation files. Your job is to analyze, plan, delegate, monitor, integrate, and verify.
-2. **ALWAYS delegate implementation to workers.** If you identify work that needs doing, spawn a worker for it.
-3. **Maximize parallelism at all times.** Never leave easy parallelism unused. If there are N independent tasks, spawn N workers.
-4. **React to completion immediately.** When a worker finishes, integrate its result and spawn the next task within the same turn.
-5. **Never poll in a loop.** Use `wait_for_any_worker` to block until any worker finishes, then react.
+1. Never edit implementation files or run the main fix loop yourself.
+2. If a task can be delegated, delegate it.
+3. Keep the worker pool full: `active_workers = min(max_parallel, ready_tasks)`.
+4. Use `batch_create_workers` whenever 2+ ready tasks exist.
+5. Use `wait_for_any_worker` for concurrent workers. Do not wait on one worker while others are still running.
+6. Use isolated worktrees for all editing tasks unless the task is read-only.
+7. Never trust a worker summary by itself. Verify actual files, diffs, or commits before accepting the result.
+8. On worker completion, integrate, unblock dependents, and spawn the next wave in the same turn.
+9. On `failed` or `interrupted`, inspect once, then either `resume_worker` to recover or replace the worker immediately.
+10. If you choose not to delegate something, state the blocker explicitly.
+11. Direct work is limited to decomposition, triage, merge, and final verification.
 
-## Available Backends and Models
+## Backend Guide
 
-When creating workers, you MUST set the correct `backend` to match your chosen model:
+- `codex` + `gpt-5.4`: default for code changes
+- `gemini` + `gemini-3.1-pro-preview` or `gemini-2.5-pro`: good for proofs and parallel analysis
+- `claudecode` + Claude models: careful broad edits
+- `opencode`: cheap redundancy
 
-| Backend | Models | Best for | Cost |
-|---------|--------|----------|------|
-| `codex` | `gpt-5.4` (effort: high) | Software engineering, code edits, debugging | Medium |
-| `gemini` | `gemini-3.1-pro-preview` (default), `gemini-2.5-pro` | Long-context reasoning, proofs, analysis | Low-Medium |
-| `claudecode` | `claude-sonnet-4-5-20250929`, `claude-opus-4-6` | General coding, careful edits | Medium-High |
-| `opencode` | `builtin/smart` | Cheap general tasks, redundancy | Low |
-
-**Backend diversity:** For important tasks, race 2-3 workers on the same task using different backends. Keep the first correct result, cancel losers.
-
-**Model override:** Pass `model_override` and optionally `model_effort` (for codex: "high"/"medium"/"low") when creating workers. If omitted, the default model for the backend is used.
+Always match `backend` to `model_override`.
 
 ## Tools
 
-- **batch_create_workers**: Spawn multiple workers at once (preferred over individual calls)
-- **create_worker_mission**: Spawn a single worker with backend, model, and prompt
-- **wait_for_any_worker**: Block until any worker in a set finishes (preferred monitoring method)
-- **wait_for_worker**: Block until a specific worker finishes
-- **list_worker_missions**: See all workers and their status
-- **get_worker_status**: Get detailed status of one worker
-- **send_message_to_worker**: Send follow-up instructions
-- **cancel_worker** / **cancel_all_workers**: Stop workers
-- **create_worktree** / **remove_worktree**: Git worktree isolation
+- `get_workspace_layout`
+- `batch_create_workers`, `create_worker_mission`
+- `wait_for_any_worker`, `get_worker_status`, `list_worker_missions`
+- `resume_worker`, `retask_worker`, `send_message_to_worker`
+- `cancel_worker`, `cancel_all_workers`
+- `create_worktree`, `remove_worktree`
 
-## Workflow
+## Required Loop
 
-### Phase 1: Analyze (spend real time here)
-1. Understand the full scope of work
-2. Break it into the smallest independent units possible
-3. Identify dependencies and ordering constraints
-4. Classify each task: ready / depends-on / blocked
+1. Call `get_workspace_layout` once. Use its paths in worker prompts and worktree setup.
+2. Build a task graph with `ready`, `blocked`, and `depends_on`.
+3. Spawn every ready task now.
+4. Wait with `wait_for_any_worker`.
+5. React immediately:
+   - `completed`: verify the actual result, then integrate or reject and spawn newly-ready work
+   - `failed` or `interrupted`: recover with `resume_worker` or replace the worker
+   - `stalled`: cancel and replace
+6. Update `orchestrator-state.json` after every state change.
 
-### Phase 2: Spawn initial wave
-1. Create worktrees for file-level isolation (if the tasks touch different files)
-2. Use `batch_create_workers` to spawn ALL ready tasks at once
-3. For critical tasks, race multiple backends in parallel
-4. Write state to `orchestrator-state.json` for crash recovery
+## Worker Prompt Checklist
 
-### Phase 3: Monitor and react loop
-```
-while work_remains:
-    result = wait_for_any_worker(all_active_worker_ids)
-    if result.status == "completed":
-        integrate result (merge branch, cherry-pick, etc.)
-        unblock dependent tasks
-        spawn newly-ready tasks
-    elif result.status == "failed":
-        analyze failure
-        retry with different backend/model or narrower scope
-    update orchestrator-state.json
-    push integrated progress to integration branch
-```
+Every worker prompt must include:
+- exact scope and file paths
+- exact success condition
+- exact verification command
+- worktree/branch instructions
+- "do not widen scope"
+- "report blocker immediately"
 
-### Phase 4: Verify and finalize
-1. Run full verification (build, test, CI)
-2. Push final result
-3. Clean up worktrees
+## State File
 
-## Worker Prompts
+Maintain `orchestrator-state.json` as your recovery log. Record task IDs, worker IDs, branches, worktrees, attempts, and blockers.
 
-Give each worker a **fully self-contained** prompt:
-- Exact file(s) and line numbers to work on
-- Complete context (error messages, expected behavior)
-- Verification command to run when done
-- Commit instructions (branch, message format)
-- PATH setup or environment notes if needed
+## Default Behavior
 
-## State Management
-
-**You MUST maintain `orchestrator-state.json`** after every state change:
-```json
-{
-  "integration_branch": "main",
-  "tasks": [
-    {
-      "id": "task-1",
-      "description": "Fix simp overflow in Foo.lean:42",
-      "status": "in_progress",
-      "worker_id": "uuid-of-worker",
-      "backend": "codex",
-      "worktree": "/path/to/worktree",
-      "branch": "worker/task-1",
-      "depends_on": [],
-      "attempts": 1
-    }
-  ],
-  "completed_tasks": [...],
-  "blocked_tasks": [...]
-}
-```
-
-This file is your crash-recovery mechanism. On restart, read it first.
-
-## Failure Handling
-
-- If a worker fails, **immediately retry** with a different backend or narrower scope
-- If 2+ backends fail on the same task, mark it as blocked with a specific reason
-- Never wait more than 10 minutes for a single worker without checking on it
-- If a worker stalls (running > 15 min with no progress), cancel and retry
+Assume the user wants maximum safe parallelism. Do not sit on idle worker capacity.

--- a/skills/orchestrator-worker/SKILL.md
+++ b/skills/orchestrator-worker/SKILL.md
@@ -1,30 +1,32 @@
 ---
 name: orchestrator-worker
 description: >
-  Worker agent skill for missions spawned by an orchestrator boss. Focuses on
-  completing the assigned task quickly and reporting status clearly.
+  Worker skill for boss-spawned missions. Stay within scope, verify, and report
+  blockers quickly.
 ---
 
 # Orchestrator Worker
 
-You are a **worker agent** spawned by a boss orchestrator to complete a specific task.
+You are a worker spawned by a boss mission.
 
 ## Rules
 
-1. **Focus exclusively on your assigned task.** Your initial prompt is your full assignment. Do not deviate or take on extra work.
-2. **Work in your working directory.** If one was specified, stay within it. Do not modify files outside your scope.
-3. **Commit your work on your branch.** If working in a git worktree, commit on the worktree's branch. Do not push to shared branches unless explicitly told to.
-4. **Verify before finishing.** Run any verification steps mentioned in your prompt (build, test, lint) and fix issues before completing.
-5. **Fail fast.** If the task is not feasible (missing dependencies, impossible constraint, wrong assumptions), finish immediately with a clear explanation rather than spinning.
-6. **Be concise.** Do not write long explanations. Focus on making changes and verifying them.
+1. Stay inside the assigned scope. Do not widen the task on your own.
+2. Work only in the provided working directory or branch.
+3. Do not modify files outside your scope unless the boss explicitly expands it.
+4. Verify with the command from the prompt before finishing.
+5. Do not report `DONE` unless the files on disk actually match your claimed result.
+6. If the prompt is wrong, the task is impossible, or scope is insufficient, report that immediately instead of exploring unrelated work.
+7. Be concise. Prefer changes, verification, and a short status over long explanation.
 
 ## Communication
 
-The boss agent may send you follow-up messages during execution. These appear as new user messages. Follow any updated instructions.
+The boss may send follow-up messages or retask you. Treat them as updated instructions and reprioritize immediately.
 
 ## Completion
 
-When done:
-- Ensure all changes are committed on your branch
-- Run verification steps from your prompt
-- Your mission status is visible to the boss — make your work self-evident
+When done, make the result easy to integrate:
+- commit on your branch if you changed files
+- include the verification result
+- include the changed file paths
+- report one of: `DONE`, `BLOCKED`, or `NOT_FEASIBLE`

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -10,7 +10,7 @@
 //! - Set default provider
 //! - Get provider credentials for specific backend (Claude Code)
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use axum::{
@@ -1884,6 +1884,230 @@ fn build_provider_response(
         account_email,
         created_at: now,
         updated_at: now,
+    }
+}
+
+/// Build a ProviderResponse from an AIProvider store entry.
+/// Used for all provider types now that everything is stored in AIProviderStore.
+fn build_response_from_store(provider: &crate::ai_providers::AIProvider) -> ProviderResponse {
+    let pt = provider.provider_type;
+    let has_api_key = provider.api_key.is_some();
+    let has_oauth = provider.oauth.is_some();
+    let status = if has_api_key || has_oauth || provider.base_url.is_some() {
+        ProviderStatusResponse::Connected
+    } else {
+        ProviderStatusResponse::NeedsAuth { auth_url: None }
+    };
+    let use_for_backends = provider
+        .use_for_backends
+        .clone()
+        .unwrap_or_else(|| default_backends_for_provider(pt));
+
+    ProviderResponse {
+        id: provider.id.to_string(),
+        provider_type: pt,
+        provider_type_name: pt.display_name().to_string(),
+        name: provider.name.clone(),
+        label: provider.label.clone(),
+        priority: provider.priority,
+        google_project_id: provider.google_project_id.clone(),
+        has_api_key,
+        has_oauth,
+        base_url: provider.base_url.clone(),
+        custom_models: provider.custom_models.clone(),
+        custom_env_var: provider.custom_env_var.clone(),
+        npm_package: provider.npm_package.clone(),
+        enabled: provider.enabled,
+        is_default: provider.is_default,
+        uses_oauth: pt.uses_oauth(),
+        auth_methods: pt.auth_methods(),
+        status,
+        use_for_backends,
+        account_email: provider.account_email.clone(),
+        created_at: provider.created_at,
+        updated_at: provider.updated_at,
+    }
+}
+
+/// Sync the highest-priority enabled provider of a given type from the store
+/// to opencode.json and auth.json for runtime consumption by OpenCode.
+async fn sync_store_to_opencode(
+    store: &crate::ai_providers::AIProviderStore,
+    working_dir: &Path,
+    provider_type: ProviderType,
+) {
+    let providers = store.get_all_by_type(provider_type).await;
+    let active = providers.first(); // already sorted by priority
+
+    let config_path = get_opencode_config_path(working_dir);
+    let mut opencode_config = match read_opencode_config(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to read opencode config for sync: {}", e);
+            return;
+        }
+    };
+
+    if let Some(provider) = active {
+        // Sync provider config entry to opencode.json
+        set_provider_config_entry(
+            &mut opencode_config,
+            provider_type,
+            Some(provider.name.clone()),
+            Some(provider.base_url.clone()),
+            Some(provider.enabled),
+            provider.use_for_backends.clone(),
+            provider.google_project_id.clone().map(Some),
+        );
+        if let Err(e) = write_opencode_config(&config_path, &opencode_config) {
+            tracing::error!("Failed to write opencode config during sync: {}", e);
+        }
+
+        // Sync credentials to auth.json
+        if let Some(ref key) = provider.api_key {
+            if let Err(e) = sync_api_key_to_opencode_auth(provider_type, key) {
+                tracing::error!("Failed to sync API key to OpenCode during sync: {}", e);
+            }
+        }
+        if let Some(ref oauth) = provider.oauth {
+            if let Err(e) = sync_to_opencode_auth(
+                provider_type,
+                &oauth.refresh_token,
+                &oauth.access_token,
+                oauth.expires_at,
+            ) {
+                tracing::error!("Failed to sync OAuth to OpenCode during sync: {}", e);
+            }
+        }
+
+        // Sync backends
+        let backends = provider
+            .use_for_backends
+            .clone()
+            .unwrap_or_else(|| default_backends_for_provider(provider_type));
+        if let Err(e) = update_provider_backends(working_dir, provider_type.id(), backends) {
+            tracing::error!("Failed to sync provider backends during sync: {}", e);
+        }
+
+        // Sync account email
+        if let Some(ref email) = provider.account_email {
+            if let Err(e) = update_provider_account(working_dir, provider_type.id(), email.clone())
+            {
+                tracing::error!("Failed to sync provider account during sync: {}", e);
+            }
+        }
+    } else {
+        // No providers of this type - remove from opencode.json
+        remove_provider_config_entry(&mut opencode_config, provider_type);
+        if let Err(e) = write_opencode_config(&config_path, &opencode_config) {
+            tracing::error!("Failed to write opencode config during sync removal: {}", e);
+        }
+        if let Err(e) = remove_opencode_auth_entry(provider_type) {
+            tracing::error!("Failed to remove OpenCode auth entry during sync: {}", e);
+        }
+        let _ = remove_provider_backends(working_dir, provider_type.id());
+        let _ = remove_provider_account(working_dir, provider_type.id());
+    }
+}
+
+/// Migrate standard providers from opencode.json + auth.json into the AIProviderStore.
+/// Called on first list to ensure existing setups continue working.
+async fn migrate_opencode_providers_to_store(
+    store: &crate::ai_providers::AIProviderStore,
+    working_dir: &Path,
+) {
+    let config_path = get_opencode_config_path(working_dir);
+    let opencode_config = match read_opencode_config(&config_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let auth_map = read_opencode_auth_map().unwrap_or_default();
+    let backends_state = read_provider_backends_state(working_dir);
+    let accounts_state = read_provider_accounts_state(working_dir);
+
+    let provider_map = match opencode_config.get("provider").and_then(|v| v.as_object()) {
+        Some(m) => m.clone(),
+        None => return,
+    };
+
+    for (key, _entry) in &provider_map {
+        let Some(provider_type) = ProviderType::from_id(key) else {
+            continue;
+        };
+        // Skip Custom/Amp (already in store) and skip if already in store
+        if provider_type == ProviderType::Custom || provider_type == ProviderType::Amp {
+            continue;
+        }
+        let existing = store.get_all_by_type(provider_type).await;
+        if !existing.is_empty() {
+            continue;
+        }
+
+        // Create store entry from opencode.json + auth.json
+        let config_entry = get_provider_config_entry(&opencode_config, provider_type);
+        let name = config_entry
+            .as_ref()
+            .and_then(|c| c.name.clone())
+            .unwrap_or_else(|| provider_type.display_name().to_string());
+
+        let mut provider = crate::ai_providers::AIProvider::new(provider_type, name);
+        provider.base_url = config_entry.as_ref().and_then(|c| c.base_url.clone());
+        provider.google_project_id = config_entry
+            .as_ref()
+            .and_then(|c| c.google_project_id.clone());
+        provider.use_for_backends = backends_state.get(provider_type.id()).cloned();
+        provider.account_email = accounts_state.get(provider_type.id()).cloned();
+
+        // Check auth.json for credentials
+        if let Some(auth_kind) = auth_map.get(&provider_type) {
+            match auth_kind {
+                AuthKind::ApiKey => {
+                    // Read the actual key from auth.json
+                    if let Ok(auth) = read_opencode_auth() {
+                        if let Some(auth_entry) = auth.get(provider_type.id()) {
+                            let key = auth_entry
+                                .get("key")
+                                .or_else(|| auth_entry.get("api_key"))
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+                            provider.api_key = key;
+                        }
+                    }
+                }
+                AuthKind::OAuth => {
+                    // Read OAuth credentials from auth.json
+                    if let Ok(auth) = read_opencode_auth() {
+                        if let Some(auth_entry) = auth.get(provider_type.id()) {
+                            let refresh = auth_entry
+                                .get("refresh")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            let access = auth_entry
+                                .get("access")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            let expires = auth_entry
+                                .get("expires")
+                                .and_then(|v| v.as_i64())
+                                .unwrap_or(0);
+                            provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+                                refresh_token: refresh,
+                                access_token: access,
+                                expires_at: expires,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::info!(
+            "Migrating provider {} from opencode.json to AIProviderStore",
+            provider_type.id()
+        );
+        store.add(provider).await;
     }
 }
 
@@ -4187,82 +4411,15 @@ async fn list_provider_types() -> Json<Vec<ProviderTypeInfo>> {
 async fn list_providers(
     State(state): State<Arc<super::routes::AppState>>,
 ) -> Result<Json<Vec<ProviderResponse>>, (StatusCode, String)> {
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
-    let auth_map = read_opencode_auth_map().map_err(internal_error)?;
-    let default_provider = read_default_provider_state(&state.config.working_dir)
-        .or_else(|| get_default_provider(&opencode_config));
-    let backends_state = read_provider_backends_state(&state.config.working_dir);
-    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
+    // Migrate any standard providers from opencode.json to the store on first call
+    migrate_opencode_providers_to_store(&state.ai_providers, &state.config.working_dir).await;
 
-    let mut provider_ids: BTreeSet<String> = BTreeSet::new();
-    for provider in auth_map.keys() {
-        provider_ids.insert(provider.id().to_string());
-    }
-    if let Some(provider_map) = opencode_config.get("provider").and_then(|v| v.as_object()) {
-        for key in provider_map.keys() {
-            provider_ids.insert(key.to_string());
-        }
-    }
-    if let Some(provider) = default_provider {
-        provider_ids.insert(provider.id().to_string());
-    }
-
-    let mut providers: Vec<ProviderResponse> = provider_ids
-        .into_iter()
-        .filter_map(|provider_id| {
-            let provider_type = ProviderType::from_id(&provider_id)?;
-            let config_entry = get_provider_config_entry(&opencode_config, provider_type);
-            let auth_kind = auth_map.get(&provider_type).copied();
-            let backends = backends_state.get(provider_type.id()).cloned();
-            let account_email = accounts_state.get(provider_type.id()).cloned();
-            Some(build_provider_response(
-                provider_type,
-                config_entry,
-                auth_kind,
-                default_provider,
-                backends,
-                account_email,
-            ))
-        })
-        .collect();
-
-    // Also include providers from AIProviderStore (Custom and Amp)
+    // All providers live in AIProviderStore now
     let store_providers = state.ai_providers.list().await;
-    for provider in store_providers {
-        let pt = provider.provider_type;
-        if pt == ProviderType::Custom || pt == ProviderType::Amp {
-            let now = chrono::Utc::now();
-            providers.push(ProviderResponse {
-                id: provider.id.to_string(),
-                provider_type: pt,
-                provider_type_name: pt.display_name().to_string(),
-                name: provider.name.clone(),
-                label: provider.label.clone(),
-                priority: provider.priority,
-                google_project_id: None,
-                has_api_key: provider.api_key.is_some(),
-                has_oauth: false,
-                base_url: provider.base_url.clone(),
-                custom_models: provider.custom_models.clone(),
-                custom_env_var: provider.custom_env_var.clone(),
-                npm_package: provider.npm_package.clone(),
-                enabled: provider.enabled,
-                is_default: provider.is_default,
-                uses_oauth: false,
-                auth_methods: vec![],
-                status: if provider.api_key.is_some() || provider.base_url.is_some() {
-                    ProviderStatusResponse::Connected
-                } else {
-                    ProviderStatusResponse::NeedsAuth { auth_url: None }
-                },
-                use_for_backends: default_backends_for_provider(pt),
-                account_email: provider.account_email.clone(),
-                created_at: now,
-                updated_at: now,
-            });
-        }
-    }
+    let mut providers: Vec<ProviderResponse> = store_providers
+        .iter()
+        .map(|p| build_response_from_store(p))
+        .collect();
 
     providers.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(Json(providers))
@@ -4777,12 +4934,20 @@ async fn get_provider_usage(
 
             match resp {
                 Ok(r) => {
+                    let status_code = r.status().as_u16();
                     let headers = r.headers().clone();
                     let mut info = serde_json::json!({
                         "provider_type": "anthropic",
                         "provider_name": provider_name,
                         "account_email": account_email,
+                        "status_code": status_code,
                     });
+                    if status_code == 401 || status_code == 403 {
+                        info["error"] = serde_json::json!(format!(
+                            "Authentication failed (HTTP {})",
+                            status_code
+                        ));
+                    }
 
                     let map = info.as_object_mut().unwrap();
 
@@ -4913,12 +5078,20 @@ async fn get_provider_usage(
 
             match resp {
                 Ok(r) => {
+                    let status_code = r.status().as_u16();
                     let headers = r.headers().clone();
                     let mut info = serde_json::json!({
                         "provider_type": "openai",
                         "provider_name": provider_name,
                         "account_email": account_email,
+                        "status_code": status_code,
                     });
+                    if status_code == 401 || status_code == 403 {
+                        info["error"] = serde_json::json!(format!(
+                            "Authentication failed (HTTP {})",
+                            status_code
+                        ));
+                    }
 
                     let map = info.as_object_mut().unwrap();
                     for (hdr, key) in [
@@ -4980,11 +5153,17 @@ async fn get_provider_usage(
 
             match resp {
                 Ok(r) => {
+                    let status_code = r.status().as_u16();
                     let headers = r.headers().clone();
                     let mut info = serde_json::json!({
                         "provider_type": "cerebras",
                         "provider_name": provider_name,
+                        "status_code": status_code,
                     });
+                    if status_code == 401 || status_code == 403 || status_code == 429 {
+                        info["error"] =
+                            serde_json::json!(format!("API returned HTTP {}", status_code));
+                    }
 
                     let map = info.as_object_mut().unwrap();
                     for (hdr, key) in [
@@ -5042,15 +5221,16 @@ async fn get_provider_usage(
                 "provider_name": provider_name,
             });
 
-            if let Ok(r) = coding_resp {
-                if r.status().is_success() {
+            match coding_resp {
+                Ok(r) if r.status().is_success() => {
                     if let Ok(data) = r.json::<serde_json::Value>().await {
                         info.as_object_mut()
                             .unwrap()
                             .insert("coding_plan".to_string(), data);
                     }
-                } else {
-                    // Fall back to a test completion to verify the key works
+                }
+                Ok(_) => {
+                    // Coding plan endpoint failed; fall back to a test completion
                     let test_resp = client
                         .post("https://api.minimax.io/v1/chat/completions")
                         .header("Authorization", format!("Bearer {}", key))
@@ -5084,6 +5264,12 @@ async fn get_provider_usage(
                             );
                         }
                     }
+                }
+                Err(e) => {
+                    info.as_object_mut().unwrap().insert(
+                        "error".to_string(),
+                        serde_json::json!(format!("Failed to reach API: {}", e)),
+                    );
                 }
             }
             info
@@ -5154,13 +5340,13 @@ async fn get_provider_usage(
 
             if let Some(ref o) = oauth {
                 // Try to get additional account info from Google userinfo
-                if let Ok(r) = client
+                match client
                     .get("https://www.googleapis.com/oauth2/v2/userinfo")
                     .header("Authorization", format!("Bearer {}", o.access_token))
                     .send()
                     .await
                 {
-                    if r.status().is_success() {
+                    Ok(r) if r.status().is_success() => {
                         if let Ok(data) = r.json::<serde_json::Value>().await {
                             let map = info.as_object_mut().unwrap();
                             if let Some(name) = data.get("name").and_then(|v| v.as_str()) {
@@ -5174,6 +5360,16 @@ async fn get_provider_usage(
                             }
                             map.insert("status".to_string(), serde_json::json!("connected"));
                         }
+                    }
+                    Ok(r) => {
+                        let status_code = r.status().as_u16();
+                        info["error"] = serde_json::json!(format!(
+                            "OAuth verification failed (HTTP {})",
+                            status_code
+                        ));
+                    }
+                    Err(e) => {
+                        info["error"] = serde_json::json!(format!("Failed to verify OAuth: {}", e));
                     }
                 }
             } else if api_key_opt.is_some() {
@@ -5220,141 +5416,46 @@ async fn create_provider(
 
     let provider_type = req.provider_type;
 
-    // label and priority are only supported for providers stored in AIProviderStore
-    // (Custom and Amp). Standard providers are stored in OpenCode's config which
-    // doesn't support these fields.
-    if provider_type != ProviderType::Custom && provider_type != ProviderType::Amp {
-        if req.label.is_some() {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "label is only supported for custom/amp providers".to_string(),
-            ));
-        }
-        if req.priority.is_some() && req.priority != Some(0) {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "priority is only supported for custom/amp providers".to_string(),
-            ));
-        }
-    }
-
-    // For custom providers and Amp, store in AIProviderStore (ai_providers.json).
-    // Custom: workspace preparation reads custom models and base URL from here.
-    // Amp: keys are read by get_all_amp_keys_from_ai_providers() for rotation.
-    //       Amp doesn't use OpenCode's auth.json (opencode_auth_keys returns []).
-    if provider_type == ProviderType::Custom || provider_type == ProviderType::Amp {
-        let mut provider = crate::ai_providers::AIProvider::new(provider_type, req.name.clone());
-        provider.label = req.label.clone();
-        provider.priority = req.priority.unwrap_or(0);
-        provider.base_url = req.base_url.clone();
-        provider.api_key = req.api_key.clone();
-        provider.custom_models = req.custom_models.clone();
-        provider.custom_env_var = req.custom_env_var.clone();
-        provider.npm_package = req.npm_package.clone();
-        provider.enabled = req.enabled;
-
-        state.ai_providers.add(provider.clone()).await;
-
-        tracing::info!(
-            "Created {} AI provider: {} ({})",
-            provider_type.display_name(),
-            req.name,
-            provider.id
-        );
-
-        let now = chrono::Utc::now();
-        return Ok(Json(ProviderResponse {
-            id: provider.id.to_string(),
-            provider_type,
-            provider_type_name: provider_type.display_name().to_string(),
-            name: req.name,
-            label: req.label,
-            priority: req.priority.unwrap_or(0),
-            google_project_id: None,
-            has_api_key: req.api_key.is_some(),
-            has_oauth: false,
-            base_url: req.base_url,
-            custom_models: req.custom_models,
-            custom_env_var: req.custom_env_var,
-            npm_package: req.npm_package,
-            enabled: req.enabled,
-            is_default: false,
-            uses_oauth: false,
-            auth_methods: vec![],
-            status: if req.api_key.is_some() || provider.base_url.is_some() {
-                ProviderStatusResponse::Connected
-            } else {
-                ProviderStatusResponse::NeedsAuth { auth_url: None }
-            },
-            use_for_backends: req
-                .use_for_backends
-                .unwrap_or_else(|| default_backends_for_provider(provider_type)),
-            account_email: provider.account_email.clone(),
-            created_at: now,
-            updated_at: now,
-        }));
-    }
-
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let mut opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
-
-    // Default use_for_backends to ["opencode"] if not specified.
+    // All providers are now stored in AIProviderStore (ai_providers.json).
+    // Standard providers are additionally synced to opencode.json + auth.json
+    // for runtime consumption by OpenCode.
     let use_for_backends = req
         .use_for_backends
-        .or_else(|| Some(default_backends_for_provider(provider_type)));
+        .clone()
+        .unwrap_or_else(|| default_backends_for_provider(provider_type));
 
-    set_provider_config_entry(
-        &mut opencode_config,
-        provider_type,
-        Some(req.name),
-        Some(req.base_url),
-        Some(req.enabled),
-        use_for_backends.clone(),
-        req.google_project_id.map(Some),
-    );
+    let mut provider = crate::ai_providers::AIProvider::new(provider_type, req.name.clone());
+    provider.label = req.label.clone();
+    provider.priority = req.priority.unwrap_or(0);
+    provider.base_url = req.base_url.clone();
+    provider.api_key = req.api_key.clone();
+    provider.google_project_id = req.google_project_id.clone();
+    provider.custom_models = req.custom_models.clone();
+    provider.custom_env_var = req.custom_env_var.clone();
+    provider.npm_package = req.npm_package.clone();
+    provider.use_for_backends = Some(use_for_backends);
+    provider.enabled = req.enabled;
 
-    write_opencode_config(&config_path, &opencode_config).map_err(internal_error)?;
-
-    // Save backends to separate state file (not in opencode.json)
-    if let Some(ref backends) = use_for_backends {
-        if let Err(e) = update_provider_backends(
-            &state.config.working_dir,
-            provider_type.id(),
-            backends.clone(),
-        ) {
-            tracing::error!("Failed to save provider backends: {}", e);
-        }
-    }
-
-    if let Some(ref api_key) = req.api_key {
-        if let Err(e) = sync_api_key_to_opencode_auth(provider_type, api_key) {
-            tracing::error!("Failed to sync API key to OpenCode: {}", e);
-        }
-    }
-
-    let auth_kind = if req.api_key.is_some() {
-        Some(AuthKind::ApiKey)
-    } else {
-        None
-    };
-    let default_provider = read_default_provider_state(&state.config.working_dir)
-        .or_else(|| get_default_provider(&opencode_config));
-    let config_entry = get_provider_config_entry(&opencode_config, provider_type);
-    let response = build_provider_response(
-        provider_type,
-        config_entry,
-        auth_kind,
-        default_provider,
-        use_for_backends,
-        None,
-    );
+    state.ai_providers.add(provider.clone()).await;
 
     tracing::info!(
-        "Created AI provider config for: {} ({})",
-        response.name,
-        response.provider_type
+        "Created AI provider: {} ({}, {})",
+        provider_type.display_name(),
+        req.name,
+        provider.id
     );
 
+    // For standard providers, sync to opencode.json + auth.json for runtime compatibility
+    if provider_type != ProviderType::Custom && provider_type != ProviderType::Amp {
+        sync_store_to_opencode(
+            &state.ai_providers,
+            &state.config.working_dir,
+            provider_type,
+        )
+        .await;
+    }
+
+    let response = build_response_from_store(&provider);
     Ok(Json(response))
 }
 
@@ -5363,31 +5464,28 @@ async fn get_provider(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<ProviderResponse>, (StatusCode, String)> {
+    // Try UUID first (all providers are now in the store)
+    if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        if let Some(provider) = state.ai_providers.get(uuid).await {
+            return Ok(Json(build_response_from_store(&provider)));
+        }
+    }
+
+    // Fall back to provider type ID - find the first matching provider in the store
     let provider_type = ProviderType::from_id(&id)
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
-    let auth_map = read_opencode_auth_map().map_err(internal_error)?;
-    let default_provider = read_default_provider_state(&state.config.working_dir)
-        .or_else(|| get_default_provider(&opencode_config));
-    let backends_state = read_provider_backends_state(&state.config.working_dir);
-    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
-    let config_entry = get_provider_config_entry(&opencode_config, provider_type);
-    let auth_kind = auth_map.get(&provider_type).copied();
-    let backends = backends_state.get(provider_type.id()).cloned();
-    let account_email = accounts_state.get(provider_type.id()).cloned();
-    let response = build_provider_response(
-        provider_type,
-        config_entry,
-        auth_kind,
-        default_provider,
-        backends,
-        account_email,
-    );
-    Ok(Json(response))
+    let provider = state
+        .ai_providers
+        .get_by_type(provider_type)
+        .await
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+    Ok(Json(build_response_from_store(&provider)))
 }
 
 /// PUT /api/ai/providers/:id - Update a provider.
+///
+/// All providers are now in AIProviderStore. The `:id` can be a UUID or
+/// a provider type ID (for backwards compat, finds the first matching).
 async fn update_provider(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
@@ -5405,110 +5503,17 @@ async fn update_provider(
         }
     }
 
-    // Try UUID first (store-based providers: Amp, Custom)
-    if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
-        return update_store_provider(&state, uuid, req).await;
+    // Find the provider in the store - try UUID first, then provider type ID
+    let existing = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state.ai_providers.get(uuid).await
+    } else {
+        let provider_type = ProviderType::from_id(&id)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+        state.ai_providers.get_by_type(provider_type).await
     }
+    .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
 
-    // Otherwise, treat as provider type ID (standard providers)
-    let provider_type = ProviderType::from_id(&id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
-
-    // label and priority are only supported for providers stored in AIProviderStore
-    if req.label.is_some() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "label is only supported for custom/amp providers".to_string(),
-        ));
-    }
-    if req.priority.is_some() && req.priority != Some(0) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "priority is only supported for custom/amp providers".to_string(),
-        ));
-    }
-
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let mut opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
-
-    set_provider_config_entry(
-        &mut opencode_config,
-        provider_type,
-        req.name,
-        req.base_url,
-        req.enabled,
-        req.use_for_backends.clone(),
-        req.google_project_id,
-    );
-
-    write_opencode_config(&config_path, &opencode_config).map_err(internal_error)?;
-
-    // Save backends to separate state file if provided
-    if let Some(ref backends) = req.use_for_backends {
-        if let Err(e) = update_provider_backends(
-            &state.config.working_dir,
-            provider_type.id(),
-            backends.clone(),
-        ) {
-            tracing::error!("Failed to save provider backends: {}", e);
-        }
-    }
-
-    if let Some(api_key_update) = req.api_key {
-        match api_key_update {
-            Some(api_key) => {
-                if let Err(e) = sync_api_key_to_opencode_auth(provider_type, &api_key) {
-                    tracing::error!("Failed to sync API key to OpenCode: {}", e);
-                }
-            }
-            None => {
-                if let Err(e) = remove_opencode_auth_entry(provider_type) {
-                    tracing::error!("Failed to remove OpenCode auth entry: {}", e);
-                }
-            }
-        }
-    }
-
-    let auth_map = read_opencode_auth_map().map_err(internal_error)?;
-    let default_provider = read_default_provider_state(&state.config.working_dir)
-        .or_else(|| get_default_provider(&opencode_config));
-    let backends_state = read_provider_backends_state(&state.config.working_dir);
-    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
-    let config_entry = get_provider_config_entry(&opencode_config, provider_type);
-    let auth_kind = auth_map.get(&provider_type).copied();
-    let backends = backends_state.get(provider_type.id()).cloned();
-    let account_email = accounts_state.get(provider_type.id()).cloned();
-    let response = build_provider_response(
-        provider_type,
-        config_entry,
-        auth_kind,
-        default_provider,
-        backends,
-        account_email,
-    );
-
-    tracing::info!("Updated AI provider config: {} ({})", response.name, id);
-
-    Ok(Json(response))
-}
-
-/// Update a store-based provider (Amp, Custom) by UUID.
-async fn update_store_provider(
-    state: &Arc<super::routes::AppState>,
-    uuid: uuid::Uuid,
-    req: UpdateProviderRequest,
-) -> Result<Json<ProviderResponse>, (StatusCode, String)> {
-    let providers = state.ai_providers.list().await;
-    let existing = providers
-        .into_iter()
-        .find(|p| p.id == uuid)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Provider {} not found", uuid),
-            )
-        })?;
-
+    let uuid = existing.id;
     let mut updated = existing.clone();
     if let Some(name) = req.name {
         updated.name = name;
@@ -5519,6 +5524,9 @@ async fn update_store_provider(
     if let Some(priority) = req.priority {
         updated.priority = priority;
     }
+    if let Some(google_project_id) = req.google_project_id {
+        updated.google_project_id = google_project_id;
+    }
     if let Some(base_url) = req.base_url {
         updated.base_url = base_url;
     }
@@ -5528,10 +5536,13 @@ async fn update_store_provider(
     if let Some(api_key_update) = req.api_key {
         updated.api_key = api_key_update;
     }
+    if let Some(ref backends) = req.use_for_backends {
+        updated.use_for_backends = Some(backends.clone());
+    }
 
     let result = state
         .ai_providers
-        .update(uuid, updated.clone())
+        .update(uuid, updated)
         .await
         .ok_or_else(|| {
             (
@@ -5540,37 +5551,13 @@ async fn update_store_provider(
             )
         })?;
 
+    // Sync to opencode.json for standard providers
     let pt = result.provider_type;
-    let now = chrono::Utc::now();
-    let has_credentials = result.api_key.is_some() || result.base_url.is_some();
-    let response = ProviderResponse {
-        id: result.id.to_string(),
-        provider_type: pt,
-        provider_type_name: pt.display_name().to_string(),
-        name: result.name,
-        label: result.label,
-        priority: result.priority,
-        google_project_id: None,
-        has_api_key: result.api_key.is_some(),
-        has_oauth: false,
-        base_url: result.base_url,
-        custom_models: result.custom_models,
-        custom_env_var: result.custom_env_var,
-        npm_package: result.npm_package,
-        enabled: result.enabled,
-        is_default: result.is_default,
-        uses_oauth: false,
-        auth_methods: vec![],
-        status: if has_credentials {
-            ProviderStatusResponse::Connected
-        } else {
-            ProviderStatusResponse::NeedsAuth { auth_url: None }
-        },
-        use_for_backends: default_backends_for_provider(pt),
-        account_email: result.account_email.clone(),
-        created_at: now,
-        updated_at: result.updated_at,
-    };
+    if pt != ProviderType::Custom && pt != ProviderType::Amp {
+        sync_store_to_opencode(&state.ai_providers, &state.config.working_dir, pt).await;
+    }
+
+    let response = build_response_from_store(&result);
 
     tracing::info!(
         "Updated {} provider: {} ({})",
@@ -5590,44 +5577,43 @@ async fn delete_provider(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<(StatusCode, String), (StatusCode, String)> {
-    // Try UUID first (store-based providers: Amp, Custom)
-    if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
-        if state.ai_providers.delete(uuid).await {
-            return Ok((
-                StatusCode::OK,
-                format!("Provider {} deleted successfully", id),
-            ));
-        }
+    // Find the provider in the store - try UUID first, then provider type ID
+    let provider = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state.ai_providers.get(uuid).await
+    } else {
+        let provider_type = ProviderType::from_id(&id)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+        state.ai_providers.get_by_type(provider_type).await
+    }
+    .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+
+    let provider_type = provider.provider_type;
+    let uuid = provider.id;
+
+    // Delete from AIProviderStore
+    if !state.ai_providers.delete(uuid).await {
         return Err((StatusCode::NOT_FOUND, format!("Provider {} not found", id)));
     }
 
-    // Otherwise, treat as provider type ID (standard providers)
-    let provider_type = ProviderType::from_id(&id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let mut opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
-
-    remove_provider_config_entry(&mut opencode_config, provider_type);
-    write_opencode_config(&config_path, &opencode_config).map_err(internal_error)?;
-
-    if let Err(e) = remove_opencode_auth_entry(provider_type) {
-        tracing::error!("Failed to remove OpenCode auth entry: {}", e);
+    // Re-sync opencode.json for this provider type (will remove if no more of this type)
+    if provider_type != ProviderType::Custom && provider_type != ProviderType::Amp {
+        sync_store_to_opencode(
+            &state.ai_providers,
+            &state.config.working_dir,
+            provider_type,
+        )
+        .await;
     }
 
+    // Clear default if this was the default
     if read_default_provider_state(&state.config.working_dir) == Some(provider_type) {
-        if let Err(e) = clear_default_provider_state(&state.config.working_dir) {
-            tracing::error!("Failed to clear default provider state: {}", e);
+        // Check if there are still providers of this type
+        let remaining = state.ai_providers.get_all_by_type(provider_type).await;
+        if remaining.is_empty() {
+            if let Err(e) = clear_default_provider_state(&state.config.working_dir) {
+                tracing::error!("Failed to clear default provider state: {}", e);
+            }
         }
-    }
-
-    // Remove provider backends state
-    if let Err(e) = remove_provider_backends(&state.config.working_dir, provider_type.id()) {
-        tracing::error!("Failed to remove provider backends state: {}", e);
-    }
-
-    // Clean up account email state
-    if let Err(e) = remove_provider_account(&state.config.working_dir, provider_type.id()) {
-        tracing::error!("Failed to remove provider account state: {}", e);
     }
 
     Ok((
@@ -5641,47 +5627,34 @@ async fn authenticate_provider(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<AuthResponse>, (StatusCode, String)> {
-    // Try UUID first (store-based providers: Amp, Custom)
-    if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
-        let provider = state
-            .ai_providers
-            .get(uuid)
-            .await
+    // Find the provider in the store
+    let provider = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state.ai_providers.get(uuid).await
+    } else {
+        let provider_type = ProviderType::from_id(&id)
             .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+        state.ai_providers.get_by_type(provider_type).await
+    }
+    .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
 
-        // Store-based providers: connected if they have an API key or a base URL
-        let has_credentials = provider
-            .api_key
-            .as_ref()
-            .is_some_and(|k| !k.trim().is_empty())
-            || provider.base_url.is_some();
+    let provider_type = provider.provider_type;
+    let has_credentials = provider.has_credentials();
+
+    if has_credentials {
         return Ok(Json(AuthResponse {
-            success: has_credentials,
-            message: if has_credentials {
-                "Provider is authenticated".to_string()
-            } else {
-                "API key is required for this provider".to_string()
-            },
+            success: true,
+            message: "Provider is authenticated".to_string(),
             auth_url: None,
         }));
     }
 
-    let provider_type = ProviderType::from_id(&id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
-    let auth_map = read_opencode_auth_map().map_err(internal_error)?;
-
-    // For OAuth providers, we need to return an auth URL
+    // For OAuth providers, return an auth URL
     if provider_type.uses_oauth() {
         let auth_url = match provider_type {
             ProviderType::Anthropic => {
-                // For Anthropic/Claude, this would typically use Claude's OAuth flow
-                // For now, we'll indicate that manual auth is needed
                 Some("https://console.anthropic.com/settings/keys".to_string())
             }
-            ProviderType::GithubCopilot => {
-                // GitHub Copilot uses device code flow
-                Some("https://github.com/login/device".to_string())
-            }
+            ProviderType::GithubCopilot => Some("https://github.com/login/device".to_string()),
             _ => None,
         };
 
@@ -5695,20 +5668,11 @@ async fn authenticate_provider(
         }));
     }
 
-    // For API key providers, check if key is set
-    if auth_map.get(&provider_type) == Some(&AuthKind::ApiKey) {
-        Ok(Json(AuthResponse {
-            success: true,
-            message: "Provider is authenticated".to_string(),
-            auth_url: None,
-        }))
-    } else {
-        Ok(Json(AuthResponse {
-            success: false,
-            message: "API key is required for this provider".to_string(),
-            auth_url: None,
-        }))
-    }
+    Ok(Json(AuthResponse {
+        success: false,
+        message: "API key is required for this provider".to_string(),
+        auth_url: None,
+    }))
 }
 
 /// POST /api/ai/providers/:id/default - Set as default provider.
@@ -5716,87 +5680,49 @@ async fn set_default(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<ProviderResponse>, (StatusCode, String)> {
-    // Try UUID first (store-based providers: Amp, Custom)
-    if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
-        let provider = state
-            .ai_providers
-            .get(uuid)
-            .await
+    // Find the provider in the store - try UUID first, then provider type ID
+    let provider = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state.ai_providers.get(uuid).await
+    } else {
+        let provider_type = ProviderType::from_id(&id)
             .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
-        state.ai_providers.set_default(uuid).await;
-
-        let pt = provider.provider_type;
-        let now = chrono::Utc::now();
-        let has_credentials = provider.api_key.is_some() || provider.base_url.is_some();
-        let response = ProviderResponse {
-            id: provider.id.to_string(),
-            provider_type: pt,
-            provider_type_name: pt.display_name().to_string(),
-            name: provider.name,
-            label: provider.label,
-            priority: provider.priority,
-            google_project_id: None,
-            has_api_key: provider.api_key.is_some(),
-            has_oauth: false,
-            base_url: provider.base_url,
-            custom_models: provider.custom_models,
-            custom_env_var: provider.custom_env_var,
-            npm_package: provider.npm_package,
-            enabled: provider.enabled,
-            is_default: true,
-            uses_oauth: false,
-            auth_methods: vec![],
-            status: if has_credentials {
-                ProviderStatusResponse::Connected
-            } else {
-                ProviderStatusResponse::NeedsAuth { auth_url: None }
-            },
-            use_for_backends: default_backends_for_provider(pt),
-            account_email: provider.account_email.clone(),
-            created_at: now,
-            updated_at: provider.updated_at,
-        };
-        tracing::info!("Set default AI provider: {} ({})", response.name, id);
-        return Ok(Json(response));
+        state.ai_providers.get_by_type(provider_type).await
     }
+    .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
 
-    // Standard providers: by type ID
-    let provider_type = ProviderType::from_id(&id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
-    write_default_provider_state(&state.config.working_dir, provider_type)
-        .map_err(internal_error)?;
+    let uuid = provider.id;
+    state.ai_providers.set_default(uuid).await;
 
-    let config_path = get_opencode_config_path(&state.config.working_dir);
-    let opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
-    let auth_map = read_opencode_auth_map().map_err(internal_error)?;
-    let backends_state = read_provider_backends_state(&state.config.working_dir);
-    let accounts_state = read_provider_accounts_state(&state.config.working_dir);
-    let default_provider = Some(provider_type);
-    let config_entry = get_provider_config_entry(&opencode_config, provider_type);
-    let auth_kind = auth_map.get(&provider_type).copied();
-    let backends = backends_state.get(provider_type.id()).cloned();
-    let account_email = accounts_state.get(provider_type.id()).cloned();
-    let response = build_provider_response(
-        provider_type,
-        config_entry,
-        auth_kind,
-        default_provider,
-        backends,
-        account_email,
-    );
+    // Also persist default in legacy state file for backwards compat
+    let _ = write_default_provider_state(&state.config.working_dir, provider.provider_type);
 
+    // Re-read from store to get updated is_default flag
+    let updated = state
+        .ai_providers
+        .get(uuid)
+        .await
+        .unwrap_or(provider.clone());
+    let response = build_response_from_store(&updated);
     tracing::info!("Set default AI provider: {} ({})", response.name, id);
-
     Ok(Json(response))
 }
 
 /// GET /api/ai/providers/:id/auth/methods - Get available auth methods for a provider.
 async fn get_auth_methods(
-    State(_state): State<Arc<super::routes::AppState>>,
+    State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<Vec<AuthMethod>>, (StatusCode, String)> {
-    let provider_type = ProviderType::from_id(&id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+    let provider_type = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state
+            .ai_providers
+            .get(uuid)
+            .await
+            .map(|p| p.provider_type)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?
+    } else {
+        ProviderType::from_id(&id)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?
+    };
     Ok(Json(provider_type.auth_methods()))
 }
 
@@ -5868,8 +5794,18 @@ async fn oauth_authorize(
     AxumPath(id): AxumPath<String>,
     Json(req): Json<OAuthAuthorizeRequest>,
 ) -> Result<Json<OAuthAuthorizeResponse>, (StatusCode, String)> {
-    let provider_type = ProviderType::from_id(&id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+    // Resolve provider type from UUID or type ID
+    let provider_type = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state
+            .ai_providers
+            .get(uuid)
+            .await
+            .map(|p| p.provider_type)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?
+    } else {
+        ProviderType::from_id(&id)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?
+    };
 
     let auth_methods = provider_type.auth_methods();
     let method = auth_methods
@@ -6019,8 +5955,78 @@ async fn oauth_callback(
     AxumPath(id): AxumPath<String>,
     Json(req): Json<OAuthCallbackRequest>,
 ) -> axum::response::Response {
-    match oauth_callback_inner(State(state), AxumPath(id), Json(req)).await {
-        Ok(json) => json.into_response(),
+    let use_for_backends = req.use_for_backends.clone();
+    let provider_type_id = id.clone();
+    match oauth_callback_inner(State(state.clone()), AxumPath(id), Json(req)).await {
+        Ok(json) => {
+            // After successful OAuth, upsert the provider in AIProviderStore.
+            // The OAuth callback already synced creds to auth.json; now mirror that
+            // into the store so multiple accounts of the same type are tracked.
+            if let Some(provider_type) = ProviderType::from_id(&provider_type_id) {
+                let backends = use_for_backends
+                    .unwrap_or_else(|| default_backends_for_provider(provider_type));
+
+                // Read the credentials that oauth_callback_inner just wrote to auth.json
+                let auth = read_opencode_auth().unwrap_or_default();
+                let auth_entry = auth.get(provider_type.id());
+
+                let accounts_state = read_provider_accounts_state(&state.config.working_dir);
+                let account_email = accounts_state
+                    .get(provider_type.id())
+                    .cloned()
+                    .or_else(|| json.0.account_email.clone());
+
+                let name = if let Some(ref email) = account_email {
+                    format!("{} ({})", provider_type.display_name(), email)
+                } else {
+                    provider_type.display_name().to_string()
+                };
+
+                let mut provider = crate::ai_providers::AIProvider::new(provider_type, name);
+                provider.use_for_backends = Some(backends);
+                provider.account_email = account_email;
+
+                // Extract credentials from auth.json
+                if let Some(entry) = auth_entry {
+                    let auth_type = entry.get("type").and_then(|v| v.as_str());
+                    match auth_type {
+                        Some("api_key") | Some("api") => {
+                            provider.api_key = entry
+                                .get("key")
+                                .or_else(|| entry.get("api_key"))
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+                        }
+                        Some("oauth") => {
+                            let refresh = entry
+                                .get("refresh")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            let access = entry
+                                .get("access")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            let expires =
+                                entry.get("expires").and_then(|v| v.as_i64()).unwrap_or(0);
+                            provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+                                refresh_token: refresh,
+                                access_token: access,
+                                expires_at: expires,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+
+                let store_id = state.ai_providers.add(provider.clone()).await;
+                // Return a response with the store UUID so the frontend can reference it
+                let stored = state.ai_providers.get(store_id).await.unwrap_or(provider);
+                return Json(build_response_from_store(&stored)).into_response();
+            }
+            json.into_response()
+        }
         Err((status, message)) => (status, message).into_response(),
     }
 }
@@ -6030,12 +6036,27 @@ async fn oauth_callback_inner(
     AxumPath(id): AxumPath<String>,
     Json(req): Json<OAuthCallbackRequest>,
 ) -> Result<Json<ProviderResponse>, (axum::http::StatusCode, String)> {
-    let provider_type = ProviderType::from_id(&id).ok_or_else(|| {
-        (
-            axum::http::StatusCode::NOT_FOUND,
-            format!("Provider {} not found", id),
-        )
-    })?;
+    // Resolve provider type from UUID or type ID
+    let provider_type = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        state
+            .ai_providers
+            .get(uuid)
+            .await
+            .map(|p| p.provider_type)
+            .ok_or_else(|| {
+                (
+                    axum::http::StatusCode::NOT_FOUND,
+                    format!("Provider {} not found", id),
+                )
+            })?
+    } else {
+        ProviderType::from_id(&id).ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                format!("Provider {} not found", id),
+            )
+        })?
+    };
 
     // Get pending OAuth state
     let pending = {

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -434,6 +434,7 @@ pub fn routes() -> Router<Arc<super::routes::AppState>> {
         .route("/:id/oauth/callback", post(oauth_callback))
         .route("/:id/default", post(set_default))
         .route("/:id/health", post(check_provider_health))
+        .route("/:id/usage", get(get_provider_usage))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -453,6 +454,30 @@ pub struct ClaudeCodeAuthWithExpiry {
     pub auth: ClaudeCodeAuth,
     /// Expiry timestamp in milliseconds. None for API keys (never expire).
     pub expires_at: Option<i64>,
+}
+
+pub fn default_backends_for_provider(provider_type: ProviderType) -> Vec<String> {
+    match provider_type {
+        ProviderType::Anthropic => vec!["opencode".to_string(), "claudecode".to_string()],
+        ProviderType::OpenAI => vec!["opencode".to_string(), "codex".to_string()],
+        ProviderType::Google => vec!["opencode".to_string(), "gemini".to_string()],
+        ProviderType::Amp => vec!["amp".to_string()],
+        _ => vec!["opencode".to_string()],
+    }
+}
+
+pub fn provider_targets_backend(
+    working_dir: &Path,
+    provider_type: ProviderType,
+    backend: &str,
+) -> bool {
+    let backends_state = read_provider_backends_state(working_dir);
+    let configured = backends_state
+        .get(provider_type.id())
+        .cloned()
+        .unwrap_or_else(|| default_backends_for_provider(provider_type));
+
+    configured.iter().any(|candidate| candidate == backend)
 }
 
 /// Get the Anthropic API key or OAuth access token for the Claude Code backend.
@@ -479,9 +504,8 @@ pub fn get_anthropic_auth_for_claudecode(working_dir: &Path) -> Option<ClaudeCod
 
     // Check if Anthropic provider has claudecode in use_for_backends
     let anthropic_backends = backends_state.get(ProviderType::Anthropic.id());
-    let use_for_claudecode = anthropic_backends
-        .map(|backends| backends.iter().any(|b| b == "claudecode"))
-        .unwrap_or(false);
+    let use_for_claudecode =
+        provider_targets_backend(working_dir, ProviderType::Anthropic, "claudecode");
     tracing::debug!(
         anthropic_backends = ?anthropic_backends,
         use_for_claudecode = use_for_claudecode,
@@ -1207,11 +1231,7 @@ fn get_anthropic_auth_from_claude_cli_credentials() -> Option<ClaudeCodeAuth> {
 
 /// Check if the Anthropic provider is configured for the Claude Code backend.
 pub fn is_anthropic_configured_for_claudecode(working_dir: &Path) -> bool {
-    let backends_state = read_provider_backends_state(working_dir);
-    backends_state
-        .get(ProviderType::Anthropic.id())
-        .map(|backends| backends.iter().any(|b| b == "claudecode"))
-        .unwrap_or(false)
+    provider_targets_backend(working_dir, ProviderType::Anthropic, "claudecode")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1839,7 +1859,7 @@ fn build_provider_response(
     // Most providers are only usable via OpenCode, but we still store and render
     // `use_for_backends` generically so the UI can express intent and we can grow
     // support without special-casing a single provider forever.
-    let use_for_backends = backends.unwrap_or_else(|| vec!["opencode".to_string()]);
+    let use_for_backends = backends.unwrap_or_else(|| default_backends_for_provider(provider_type));
 
     ProviderResponse {
         id: provider_type.id().to_string(),
@@ -4213,11 +4233,6 @@ async fn list_providers(
         let pt = provider.provider_type;
         if pt == ProviderType::Custom || pt == ProviderType::Amp {
             let now = chrono::Utc::now();
-            let default_backend = if pt == ProviderType::Amp {
-                "amp".to_string()
-            } else {
-                "opencode".to_string()
-            };
             providers.push(ProviderResponse {
                 id: provider.id.to_string(),
                 provider_type: pt,
@@ -4241,7 +4256,7 @@ async fn list_providers(
                 } else {
                     ProviderStatusResponse::NeedsAuth { auth_url: None }
                 },
-                use_for_backends: vec![default_backend],
+                use_for_backends: default_backends_for_provider(pt),
                 account_email: provider.account_email.clone(),
                 created_at: now,
                 updated_at: now,
@@ -4273,13 +4288,11 @@ async fn get_provider_for_backend(
     }
 
     // Read the provider backends state to find provider with claudecode in use_for_backends
-    let backends_state = read_provider_backends_state(&state.config.working_dir);
-
-    // Check if Anthropic provider has claudecode in use_for_backends
-    let use_for_claudecode = backends_state
-        .get(ProviderType::Anthropic.id())
-        .map(|backends| backends.iter().any(|b| b == "claudecode"))
-        .unwrap_or(false);
+    let use_for_claudecode = provider_targets_backend(
+        &state.config.working_dir,
+        ProviderType::Anthropic,
+        "claudecode",
+    );
 
     if !use_for_claudecode {
         return Ok(Json(BackendProviderResponse {
@@ -4520,7 +4533,7 @@ async fn check_provider_health(
             (
                 "https://open.bigmodel.cn/api/paas/v4/chat/completions",
                 serde_json::json!({
-                    "model": "glm-4-flash",
+                    "model": "glm-4.7-flash",
                     "messages": [{"role": "user", "content": "test"}],
                     "max_tokens": 1
                 }),
@@ -4612,6 +4625,583 @@ async fn check_provider_health(
     }
 }
 
+/// GET /api/ai/providers/:id/usage - Fetch live usage/rate-limit info from the provider API.
+///
+/// Makes a minimal API call to the provider and captures rate-limit headers
+/// from the response. Also returns any account info we have stored.
+async fn get_provider_usage(
+    State(state): State<Arc<super::routes::AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    // Resolve provider credentials: check AIProviderStore first, then OpenCode auth
+    let (provider_type, api_key_opt, oauth, account_email, provider_name) = if let Ok(uuid) =
+        uuid::Uuid::parse_str(&id)
+    {
+        // UUID lookup for custom providers
+        let provider = state
+            .ai_providers
+            .get(uuid)
+            .await
+            .ok_or((StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+        (
+            provider.provider_type,
+            provider.api_key.clone(),
+            provider.oauth.clone(),
+            provider.account_email.clone(),
+            provider.name.clone(),
+        )
+    } else if let Some(pt) = ProviderType::from_id(&id) {
+        // Try AIProviderStore first
+        if let Some(provider) = state.ai_providers.get_by_type(pt).await {
+            (
+                provider.provider_type,
+                provider.api_key.clone(),
+                provider.oauth.clone(),
+                provider.account_email.clone(),
+                provider.name.clone(),
+            )
+        } else {
+            // Fall back to OpenCode auth: check both central auth.json
+            // and per-provider auth files (~/.opencode/auth/{provider}.json)
+            let auth = read_opencode_auth().map_err(internal_error)?;
+            let accounts_state = read_provider_accounts_state(&state.config.working_dir);
+            let account_email = accounts_state.get(pt.id()).cloned();
+
+            // Collect all auth entries: central + per-provider file
+            let mut auth_entries: Vec<&serde_json::Value> = opencode_auth_keys(pt)
+                .into_iter()
+                .filter_map(|key| auth.get(key))
+                .collect();
+            // Also read per-provider auth file
+            let provider_auth_path = get_opencode_provider_auth_path(pt);
+            let provider_auth_value: Option<serde_json::Value> = if provider_auth_path.exists() {
+                std::fs::read_to_string(&provider_auth_path)
+                    .ok()
+                    .and_then(|c| serde_json::from_str(&c).ok())
+            } else {
+                None
+            };
+            if let Some(ref pav) = provider_auth_value {
+                auth_entries.push(pav);
+            }
+
+            let api_key = auth_entries.iter().find_map(|v| {
+                v.get("key")
+                    .or_else(|| v.get("api_key"))
+                    .or_else(|| v.get("apiKey"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            });
+
+            let oauth_creds = auth_entries.iter().find_map(|entry| {
+                let access = entry
+                    .get("access")
+                    .or_else(|| entry.get("access_token"))
+                    .and_then(|v| v.as_str())?;
+                let refresh = entry
+                    .get("refresh")
+                    .or_else(|| entry.get("refresh_token"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let expires_at = entry
+                    .get("expires")
+                    .or_else(|| entry.get("expires_at"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                Some(crate::ai_providers::OAuthCredentials {
+                    access_token: access.to_string(),
+                    refresh_token: refresh,
+                    expires_at,
+                })
+            });
+
+            if api_key.is_none() && oauth_creds.is_none() {
+                return Ok(Json(serde_json::json!({
+                    "provider_type": pt.id(),
+                    "provider_name": pt.display_name(),
+                    "error": "No credentials found"
+                })));
+            }
+
+            (
+                pt,
+                api_key,
+                oauth_creds,
+                account_email,
+                pt.display_name().to_string(),
+            )
+        }
+    } else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Invalid provider ID: {}", id),
+        ));
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(internal_error)?;
+
+    // Determine how to call each provider for rate-limit info
+    let usage_result = match provider_type {
+        ProviderType::Anthropic => {
+            // Use API key or OAuth access token
+            let auth = if let Some(ref key) = api_key_opt {
+                format!("{}", key)
+            } else if let Some(ref o) = oauth {
+                format!("{}", o.access_token)
+            } else {
+                return Ok(Json(serde_json::json!({
+                    "provider_type": provider_type.id(),
+                    "provider_name": provider_name,
+                    "account_email": account_email,
+                    "error": "No credentials configured"
+                })));
+            };
+
+            // Minimal messages API call to get rate limit headers
+            let resp = client
+                .post("https://api.anthropic.com/v1/messages")
+                .header("x-api-key", &auth)
+                .header("anthropic-version", "2023-06-01")
+                .header("Content-Type", "application/json")
+                .json(&serde_json::json!({
+                    "model": "claude-haiku-4-5-20251001",
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "hi"}]
+                }))
+                .send()
+                .await;
+
+            match resp {
+                Ok(r) => {
+                    let headers = r.headers().clone();
+                    let mut info = serde_json::json!({
+                        "provider_type": "anthropic",
+                        "provider_name": provider_name,
+                        "account_email": account_email,
+                    });
+
+                    let map = info.as_object_mut().unwrap();
+
+                    // Extract organization ID
+                    if let Some(org) = headers
+                        .get("anthropic-organization-id")
+                        .and_then(|v| v.to_str().ok())
+                    {
+                        map.insert("organization_id".to_string(), serde_json::json!(org));
+                    }
+
+                    // Try new unified rate limit headers (Anthropic 2025+)
+                    let has_unified = headers.get("anthropic-ratelimit-unified-status").is_some();
+                    if has_unified {
+                        for (hdr, key) in [
+                            ("anthropic-ratelimit-unified-status", "unified_status"),
+                            ("anthropic-ratelimit-unified-reset", "unified_reset"),
+                            ("anthropic-ratelimit-unified-5h-status", "unified_5h_status"),
+                            ("anthropic-ratelimit-unified-5h-reset", "unified_5h_reset"),
+                            (
+                                "anthropic-ratelimit-unified-5h-utilization",
+                                "unified_5h_utilization",
+                            ),
+                            ("anthropic-ratelimit-unified-7d-status", "unified_7d_status"),
+                            ("anthropic-ratelimit-unified-7d-reset", "unified_7d_reset"),
+                            (
+                                "anthropic-ratelimit-unified-7d-utilization",
+                                "unified_7d_utilization",
+                            ),
+                            (
+                                "anthropic-ratelimit-unified-representative-claim",
+                                "unified_representative_claim",
+                            ),
+                            (
+                                "anthropic-ratelimit-unified-fallback-percentage",
+                                "unified_fallback_pct",
+                            ),
+                            (
+                                "anthropic-ratelimit-unified-overage-status",
+                                "unified_overage_status",
+                            ),
+                            (
+                                "anthropic-ratelimit-unified-overage-disabled-reason",
+                                "unified_overage_disabled_reason",
+                            ),
+                        ] {
+                            if let Some(v) = headers.get(hdr).and_then(|v| v.to_str().ok()) {
+                                if let Ok(n) = v.parse::<f64>() {
+                                    map.insert(key.to_string(), serde_json::json!(n));
+                                } else {
+                                    map.insert(key.to_string(), serde_json::json!(v));
+                                }
+                            }
+                        }
+                    } else {
+                        // Legacy per-resource rate limit headers
+                        for (hdr, key) in [
+                            ("anthropic-ratelimit-requests-limit", "requests_limit"),
+                            (
+                                "anthropic-ratelimit-requests-remaining",
+                                "requests_remaining",
+                            ),
+                            ("anthropic-ratelimit-requests-reset", "requests_reset"),
+                            ("anthropic-ratelimit-tokens-limit", "tokens_limit"),
+                            ("anthropic-ratelimit-tokens-remaining", "tokens_remaining"),
+                            ("anthropic-ratelimit-tokens-reset", "tokens_reset"),
+                            (
+                                "anthropic-ratelimit-input-tokens-limit",
+                                "input_tokens_limit",
+                            ),
+                            (
+                                "anthropic-ratelimit-input-tokens-remaining",
+                                "input_tokens_remaining",
+                            ),
+                            (
+                                "anthropic-ratelimit-output-tokens-limit",
+                                "output_tokens_limit",
+                            ),
+                            (
+                                "anthropic-ratelimit-output-tokens-remaining",
+                                "output_tokens_remaining",
+                            ),
+                        ] {
+                            if let Some(v) = headers.get(hdr).and_then(|v| v.to_str().ok()) {
+                                if let Ok(n) = v.parse::<u64>() {
+                                    map.insert(key.to_string(), serde_json::json!(n));
+                                } else {
+                                    map.insert(key.to_string(), serde_json::json!(v));
+                                }
+                            }
+                        }
+                    }
+                    info
+                }
+                Err(e) => serde_json::json!({
+                    "provider_type": "anthropic",
+                    "provider_name": provider_name,
+                    "account_email": account_email,
+                    "error": format!("Failed to reach API: {}", e)
+                }),
+            }
+        }
+        ProviderType::OpenAI => {
+            let auth = if let Some(ref key) = api_key_opt {
+                key.clone()
+            } else if let Some(ref o) = oauth {
+                o.access_token.clone()
+            } else {
+                return Ok(Json(serde_json::json!({
+                    "provider_type": "openai",
+                    "provider_name": provider_name,
+                    "account_email": account_email,
+                    "error": "No credentials configured"
+                })));
+            };
+
+            let resp = client
+                .post("https://api.openai.com/v1/chat/completions")
+                .header("Authorization", format!("Bearer {}", auth))
+                .header("Content-Type", "application/json")
+                .json(&serde_json::json!({
+                    "model": "gpt-4.1-nano",
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "hi"}]
+                }))
+                .send()
+                .await;
+
+            match resp {
+                Ok(r) => {
+                    let headers = r.headers().clone();
+                    let mut info = serde_json::json!({
+                        "provider_type": "openai",
+                        "provider_name": provider_name,
+                        "account_email": account_email,
+                    });
+
+                    let map = info.as_object_mut().unwrap();
+                    for (hdr, key) in [
+                        ("x-ratelimit-limit-requests", "requests_limit"),
+                        ("x-ratelimit-remaining-requests", "requests_remaining"),
+                        ("x-ratelimit-reset-requests", "requests_reset"),
+                        ("x-ratelimit-limit-tokens", "tokens_limit"),
+                        ("x-ratelimit-remaining-tokens", "tokens_remaining"),
+                        ("x-ratelimit-reset-tokens", "tokens_reset"),
+                    ] {
+                        if let Some(v) = headers.get(hdr).and_then(|v| v.to_str().ok()) {
+                            if let Ok(n) = v.parse::<u64>() {
+                                map.insert(key.to_string(), serde_json::json!(n));
+                            } else {
+                                map.insert(key.to_string(), serde_json::json!(v));
+                            }
+                        }
+                    }
+                    // Also extract organization header if present
+                    if let Some(org) = headers
+                        .get("openai-organization")
+                        .and_then(|v| v.to_str().ok())
+                    {
+                        map.insert("organization".to_string(), serde_json::json!(org));
+                    }
+                    info
+                }
+                Err(e) => serde_json::json!({
+                    "provider_type": "openai",
+                    "provider_name": provider_name,
+                    "account_email": account_email,
+                    "error": format!("Failed to reach API: {}", e)
+                }),
+            }
+        }
+        ProviderType::Cerebras => {
+            let key = match api_key_opt.as_ref() {
+                Some(k) => k,
+                None => {
+                    return Ok(Json(serde_json::json!({
+                        "provider_type": "cerebras",
+                        "provider_name": provider_name,
+                        "error": "No API key configured"
+                    })));
+                }
+            };
+
+            let resp = client
+                .post("https://api.cerebras.ai/v1/chat/completions")
+                .header("Authorization", format!("Bearer {}", key))
+                .header("Content-Type", "application/json")
+                .json(&serde_json::json!({
+                    "model": "llama-3.1-8b",
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "hi"}]
+                }))
+                .send()
+                .await;
+
+            match resp {
+                Ok(r) => {
+                    let headers = r.headers().clone();
+                    let mut info = serde_json::json!({
+                        "provider_type": "cerebras",
+                        "provider_name": provider_name,
+                    });
+
+                    let map = info.as_object_mut().unwrap();
+                    for (hdr, key) in [
+                        ("x-ratelimit-limit-requests-day", "requests_limit_day"),
+                        (
+                            "x-ratelimit-remaining-requests-day",
+                            "requests_remaining_day",
+                        ),
+                        ("x-ratelimit-reset-requests-day", "requests_reset_day"),
+                        ("x-ratelimit-limit-tokens-minute", "tokens_limit_minute"),
+                        (
+                            "x-ratelimit-remaining-tokens-minute",
+                            "tokens_remaining_minute",
+                        ),
+                        ("x-ratelimit-reset-tokens-minute", "tokens_reset_minute"),
+                    ] {
+                        if let Some(v) = headers.get(hdr).and_then(|v| v.to_str().ok()) {
+                            if let Ok(n) = v.parse::<u64>() {
+                                map.insert(key.to_string(), serde_json::json!(n));
+                            } else {
+                                map.insert(key.to_string(), serde_json::json!(v));
+                            }
+                        }
+                    }
+                    info
+                }
+                Err(e) => serde_json::json!({
+                    "provider_type": "cerebras",
+                    "provider_name": provider_name,
+                    "error": format!("Failed to reach API: {}", e)
+                }),
+            }
+        }
+        ProviderType::Minimax => {
+            let key = match api_key_opt.as_ref() {
+                Some(k) => k,
+                None => {
+                    return Ok(Json(serde_json::json!({
+                        "provider_type": "minimax",
+                        "provider_name": provider_name,
+                        "error": "No API key configured"
+                    })));
+                }
+            };
+
+            // Minimax doesn't return rate-limit headers; try coding plan remains
+            let coding_resp = client
+                .get("https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
+                .header("Authorization", format!("Bearer {}", key))
+                .send()
+                .await;
+
+            let mut info = serde_json::json!({
+                "provider_type": "minimax",
+                "provider_name": provider_name,
+            });
+
+            if let Ok(r) = coding_resp {
+                if r.status().is_success() {
+                    if let Ok(data) = r.json::<serde_json::Value>().await {
+                        info.as_object_mut()
+                            .unwrap()
+                            .insert("coding_plan".to_string(), data);
+                    }
+                } else {
+                    // Fall back to a test completion to verify the key works
+                    let test_resp = client
+                        .post("https://api.minimax.io/v1/chat/completions")
+                        .header("Authorization", format!("Bearer {}", key))
+                        .header("Content-Type", "application/json")
+                        .json(&serde_json::json!({
+                            "model": "MiniMax-M2",
+                            "max_tokens": 1,
+                            "messages": [{"role": "user", "content": "hi"}]
+                        }))
+                        .send()
+                        .await;
+
+                    match test_resp {
+                        Ok(r) if r.status().is_success() => {
+                            info.as_object_mut()
+                                .unwrap()
+                                .insert("status".to_string(), serde_json::json!("connected"));
+                        }
+                        Ok(r) => {
+                            let status = r.status().as_u16();
+                            let body = r.text().await.unwrap_or_default();
+                            info.as_object_mut().unwrap().insert(
+                                "error".to_string(),
+                                serde_json::json!(format!("API returned {}: {}", status, body)),
+                            );
+                        }
+                        Err(e) => {
+                            info.as_object_mut().unwrap().insert(
+                                "error".to_string(),
+                                serde_json::json!(format!("Failed to reach API: {}", e)),
+                            );
+                        }
+                    }
+                }
+            }
+            info
+        }
+        ProviderType::Zai => {
+            let key = match api_key_opt.as_ref() {
+                Some(k) => k,
+                None => {
+                    return Ok(Json(serde_json::json!({
+                        "provider_type": "zai",
+                        "provider_name": provider_name,
+                        "error": "No API key configured"
+                    })));
+                }
+            };
+
+            // Z.AI doesn't expose rate-limit headers; do a health-check style call
+            let resp = client
+                .post("https://open.bigmodel.cn/api/paas/v4/chat/completions")
+                .header("Authorization", format!("Bearer {}", key))
+                .header("Content-Type", "application/json")
+                .json(&serde_json::json!({
+                    "model": "glm-4.7-flash",
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "hi"}]
+                }))
+                .send()
+                .await;
+
+            match resp {
+                Ok(r) => {
+                    let status_code = r.status().as_u16();
+                    let body = r.json::<serde_json::Value>().await.unwrap_or_default();
+                    let mut info = serde_json::json!({
+                        "provider_type": "zai",
+                        "provider_name": provider_name,
+                        "status": if status_code < 400 { "connected" } else { "error" },
+                    });
+                    // Z.AI returns usage in response body for completed requests
+                    if let Some(usage) = body.get("usage") {
+                        info.as_object_mut()
+                            .unwrap()
+                            .insert("last_call_usage".to_string(), usage.clone());
+                    }
+                    if status_code >= 400 {
+                        info.as_object_mut().unwrap().insert(
+                            "error".to_string(),
+                            serde_json::json!(format!("API returned {}", status_code)),
+                        );
+                    }
+                    info
+                }
+                Err(e) => serde_json::json!({
+                    "provider_type": "zai",
+                    "provider_name": provider_name,
+                    "error": format!("Failed to reach API: {}", e)
+                }),
+            }
+        }
+        ProviderType::Google => {
+            // Google doesn't expose rate-limit headers via the standard Gemini API
+            // Check if we have OAuth credentials and try userinfo
+            let mut info = serde_json::json!({
+                "provider_type": "google",
+                "provider_name": provider_name,
+                "account_email": account_email,
+            });
+
+            if let Some(ref o) = oauth {
+                // Try to get additional account info from Google userinfo
+                if let Ok(r) = client
+                    .get("https://www.googleapis.com/oauth2/v2/userinfo")
+                    .header("Authorization", format!("Bearer {}", o.access_token))
+                    .send()
+                    .await
+                {
+                    if r.status().is_success() {
+                        if let Ok(data) = r.json::<serde_json::Value>().await {
+                            let map = info.as_object_mut().unwrap();
+                            if let Some(name) = data.get("name").and_then(|v| v.as_str()) {
+                                map.insert("account_name".to_string(), serde_json::json!(name));
+                            }
+                            if let Some(email) = data.get("email").and_then(|v| v.as_str()) {
+                                map.insert("account_email".to_string(), serde_json::json!(email));
+                            }
+                            if let Some(pic) = data.get("picture").and_then(|v| v.as_str()) {
+                                map.insert("account_picture".to_string(), serde_json::json!(pic));
+                            }
+                            map.insert("status".to_string(), serde_json::json!("connected"));
+                        }
+                    }
+                }
+            } else if api_key_opt.is_some() {
+                info.as_object_mut()
+                    .unwrap()
+                    .insert("status".to_string(), serde_json::json!("connected"));
+            } else {
+                info.as_object_mut().unwrap().insert(
+                    "error".to_string(),
+                    serde_json::json!("No credentials configured"),
+                );
+            }
+            info
+        }
+        _ => {
+            // Generic: just return what we know
+            serde_json::json!({
+                "provider_type": provider_type.id(),
+                "provider_name": provider_name,
+                "account_email": account_email,
+                "status": if api_key_opt.is_some() || oauth.is_some() { "connected" } else { "no_credentials" },
+            })
+        }
+    };
+
+    Ok(Json(usage_result))
+}
+
 /// POST /api/ai/providers - Create a new provider.
 async fn create_provider(
     State(state): State<Arc<super::routes::AppState>>,
@@ -4673,11 +5263,6 @@ async fn create_provider(
         );
 
         let now = chrono::Utc::now();
-        let default_backend = if provider_type == ProviderType::Amp {
-            "amp".to_string()
-        } else {
-            "opencode".to_string()
-        };
         return Ok(Json(ProviderResponse {
             id: provider.id.to_string(),
             provider_type,
@@ -4703,7 +5288,7 @@ async fn create_provider(
             },
             use_for_backends: req
                 .use_for_backends
-                .unwrap_or_else(|| vec![default_backend]),
+                .unwrap_or_else(|| default_backends_for_provider(provider_type)),
             account_email: provider.account_email.clone(),
             created_at: now,
             updated_at: now,
@@ -4716,7 +5301,7 @@ async fn create_provider(
     // Default use_for_backends to ["opencode"] if not specified.
     let use_for_backends = req
         .use_for_backends
-        .or_else(|| Some(vec!["opencode".to_string()]));
+        .or_else(|| Some(default_backends_for_provider(provider_type)));
 
     set_provider_config_entry(
         &mut opencode_config,
@@ -4956,11 +5541,6 @@ async fn update_store_provider(
         })?;
 
     let pt = result.provider_type;
-    let default_backend = if pt == ProviderType::Amp {
-        "amp".to_string()
-    } else {
-        "opencode".to_string()
-    };
     let now = chrono::Utc::now();
     let has_credentials = result.api_key.is_some() || result.base_url.is_some();
     let response = ProviderResponse {
@@ -4986,7 +5566,7 @@ async fn update_store_provider(
         } else {
             ProviderStatusResponse::NeedsAuth { auth_url: None }
         },
-        use_for_backends: vec![default_backend],
+        use_for_backends: default_backends_for_provider(pt),
         account_email: result.account_email.clone(),
         created_at: now,
         updated_at: result.updated_at,
@@ -5146,11 +5726,6 @@ async fn set_default(
         state.ai_providers.set_default(uuid).await;
 
         let pt = provider.provider_type;
-        let default_backend = if pt == ProviderType::Amp {
-            "amp".to_string()
-        } else {
-            "opencode".to_string()
-        };
         let now = chrono::Utc::now();
         let has_credentials = provider.api_key.is_some() || provider.base_url.is_some();
         let response = ProviderResponse {
@@ -5176,7 +5751,7 @@ async fn set_default(
             } else {
                 ProviderStatusResponse::NeedsAuth { auth_url: None }
             },
-            use_for_backends: vec![default_backend],
+            use_for_backends: default_backends_for_provider(pt),
             account_email: provider.account_email.clone(),
             created_at: now,
             updated_at: provider.updated_at,
@@ -5884,11 +6459,11 @@ async fn oauth_callback_inner(
                 tracing::error!("Failed to sync credentials to OpenCode: {}", e);
             }
 
-            // Persist backend targeting for OpenAI (defaults to ["opencode"]).
+            // Persist backend targeting for OpenAI.
             let backends = req
                 .use_for_backends
                 .clone()
-                .unwrap_or_else(|| vec!["opencode".to_string()]);
+                .unwrap_or_else(|| default_backends_for_provider(provider_type));
             if let Err(e) = update_provider_backends(
                 &state.config.working_dir,
                 provider_type.id(),
@@ -6061,30 +6636,32 @@ async fn oauth_callback_inner(
                 }
             }
 
-            // Save backend targeting if provided in the callback request
+            // Persist backend targeting for Google even if the callback omitted it.
             let config_path = get_opencode_config_path(&state.config.working_dir);
             let mut opencode_config = read_opencode_config(&config_path).map_err(internal_error)?;
 
-            if let Some(ref backends_list) = req.use_for_backends {
-                set_provider_config_entry(
-                    &mut opencode_config,
-                    provider_type,
-                    None,
-                    None,
-                    None,
-                    req.use_for_backends.clone(),
-                    None,
-                );
-                if let Err(e) = write_opencode_config(&config_path, &opencode_config) {
-                    tracing::error!("Failed to write OpenCode config: {}", e);
-                }
-                if let Err(e) = update_provider_backends(
-                    &state.config.working_dir,
-                    provider_type.id(),
-                    backends_list.clone(),
-                ) {
-                    tracing::error!("Failed to save provider backends: {}", e);
-                }
+            let backends_list = req
+                .use_for_backends
+                .clone()
+                .unwrap_or_else(|| default_backends_for_provider(provider_type));
+            set_provider_config_entry(
+                &mut opencode_config,
+                provider_type,
+                None,
+                None,
+                None,
+                Some(backends_list.clone()),
+                None,
+            );
+            if let Err(e) = write_opencode_config(&config_path, &opencode_config) {
+                tracing::error!("Failed to write OpenCode config: {}", e);
+            }
+            if let Err(e) = update_provider_backends(
+                &state.config.working_dir,
+                provider_type.id(),
+                backends_list,
+            ) {
+                tracing::error!("Failed to save provider backends: {}", e);
             }
             let backends_state = read_provider_backends_state(&state.config.working_dir);
             let default_provider = get_default_provider(&opencode_config);

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5275,6 +5275,32 @@ fn mission_status_summary_for_terminal_reason(reason: TerminalReason) -> Option<
     }
 }
 
+/// If the turn ended with `LlmError` but the agent produced substantive output,
+/// downgrade the reason to `TurnComplete` so the mission stays active and can
+/// be picked up by the next automation cycle or user message. This prevents
+/// transient backend errors (e.g. Codex "Failed to shutdown rollout recorder")
+/// from killing missions that actually completed their work.
+fn maybe_recover_soft_llm_error(result: &mut crate::agents::AgentResult) {
+    if result.terminal_reason != Some(TerminalReason::LlmError) {
+        return;
+    }
+    let output = result.output.trim();
+    // Only recover when we have real content — not just an error message.
+    // Heuristic: at least 20 chars and doesn't look like a bare error.
+    if output.len() >= 20
+        && !output.starts_with("Codex produced no output")
+        && !output.starts_with("Codex CLI produced no JSON")
+        && !output.starts_with("No response from")
+    {
+        tracing::info!(
+            output_len = output.len(),
+            "Recovering from soft LlmError: agent produced valid output, upgrading to TurnComplete"
+        );
+        result.success = true;
+        result.terminal_reason = Some(TerminalReason::TurnComplete);
+    }
+}
+
 async fn maybe_finalize_terminal_mission(
     mission_store: &Arc<dyn MissionStore>,
     events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
@@ -7272,7 +7298,8 @@ async fn control_actor_loop(
                     main_runner_activity = None;
                     let mut completed_terminal_reason = None;
                     match res {
-                        Ok((_mid, _user_msg, agent_result)) => {
+                        Ok((_mid, _user_msg, mut agent_result)) => {
+                            maybe_recover_soft_llm_error(&mut agent_result);
                             completed_terminal_reason = agent_result.terminal_reason;
                             // Only append assistant to local history if this mission is still the current mission.
                             // Note: User message was already added before execution started.
@@ -7639,7 +7666,8 @@ async fn control_actor_loop(
 
                 for (mission_id, runner) in parallel_runners.iter_mut() {
                     if runner.check_finished() {
-                        if let Some((_msg_id, _user_msg, result)) = runner.poll_completion().await {
+                        if let Some((_msg_id, _user_msg, mut result)) = runner.poll_completion().await {
+                            maybe_recover_soft_llm_error(&mut result);
                             tracing::info!(
                                 "Parallel mission {} completed (success: {}, cost: {} cents)",
                                 mission_id, result.success, result.cost_cents

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -286,6 +286,15 @@ fn should_persist_synthetic_thought(candidate: &str, assistant_content: &str) ->
     assistant_content != candidate && !assistant_content.starts_with(candidate)
 }
 
+fn merge_pending_text_delta(existing: &mut String, content: &str) {
+    if content.starts_with(existing.as_str()) {
+        existing.clear();
+        existing.push_str(content);
+    } else {
+        existing.push_str(content);
+    }
+}
+
 fn synthetic_thought_from_text_delta(
     pending_text_deltas: &mut HashMap<Uuid, String>,
     mission_id: Uuid,
@@ -296,7 +305,10 @@ fn synthetic_thought_from_text_delta(
             if content.trim().is_empty() {
                 pending_text_deltas.remove(&mission_id);
             } else {
-                pending_text_deltas.insert(mission_id, content.clone());
+                pending_text_deltas
+                    .entry(mission_id)
+                    .and_modify(|existing| merge_pending_text_delta(existing, content))
+                    .or_insert_with(|| content.clone());
             }
             None
         }
@@ -9408,6 +9420,62 @@ mod tests {
             Some("Now let me run the build to see how many errors remain.".to_string())
         );
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn synthetic_thought_from_text_delta_accumulates_incremental_fragments() {
+        let mission_id = Uuid::new_v4();
+        let mut pending = HashMap::new();
+
+        let first = AgentEvent::TextDelta {
+            content: "Now let me run ".to_string(),
+            mission_id: Some(mission_id),
+        };
+        let second = AgentEvent::TextDelta {
+            content: "the build.".to_string(),
+            mission_id: Some(mission_id),
+        };
+        let tool_call = AgentEvent::ToolCall {
+            tool_call_id: "tool-1".to_string(),
+            name: "Bash".to_string(),
+            args: serde_json::json!({ "command": "cargo test" }),
+            mission_id: Some(mission_id),
+        };
+
+        let _ = synthetic_thought_from_text_delta(&mut pending, mission_id, &first);
+        let _ = synthetic_thought_from_text_delta(&mut pending, mission_id, &second);
+        assert_eq!(
+            synthetic_thought_from_text_delta(&mut pending, mission_id, &tool_call),
+            Some("Now let me run the build.".to_string())
+        );
+    }
+
+    #[test]
+    fn synthetic_thought_from_text_delta_replaces_accumulated_fragments() {
+        let mission_id = Uuid::new_v4();
+        let mut pending = HashMap::new();
+
+        let first = AgentEvent::TextDelta {
+            content: "Now let me run".to_string(),
+            mission_id: Some(mission_id),
+        };
+        let second = AgentEvent::TextDelta {
+            content: "Now let me run the build".to_string(),
+            mission_id: Some(mission_id),
+        };
+        let tool_call = AgentEvent::ToolCall {
+            tool_call_id: "tool-1".to_string(),
+            name: "Bash".to_string(),
+            args: serde_json::json!({ "command": "cargo test" }),
+            mission_id: Some(mission_id),
+        };
+
+        let _ = synthetic_thought_from_text_delta(&mut pending, mission_id, &first);
+        let _ = synthetic_thought_from_text_delta(&mut pending, mission_id, &second);
+        assert_eq!(
+            synthetic_thought_from_text_delta(&mut pending, mission_id, &tool_call),
+            Some("Now let me run the build".to_string())
+        );
     }
 
     #[test]

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -261,6 +261,62 @@ fn assistant_reply_is_successful(content: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn is_terminal_mission_status(status: &MissionStatus) -> bool {
+    matches!(
+        status,
+        MissionStatus::Completed
+            | MissionStatus::Failed
+            | MissionStatus::Interrupted
+            | MissionStatus::Blocked
+            | MissionStatus::NotFeasible
+    )
+}
+
+fn should_persist_synthetic_thought(candidate: &str, assistant_content: &str) -> bool {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return false;
+    }
+
+    let assistant_content = assistant_content.trim();
+    if assistant_content.is_empty() {
+        return true;
+    }
+
+    assistant_content != candidate && !assistant_content.starts_with(candidate)
+}
+
+fn synthetic_thought_from_text_delta(
+    pending_text_deltas: &mut HashMap<Uuid, String>,
+    mission_id: Uuid,
+    event: &AgentEvent,
+) -> Option<String> {
+    match event {
+        AgentEvent::TextDelta { content, .. } => {
+            if content.trim().is_empty() {
+                pending_text_deltas.remove(&mission_id);
+            } else {
+                pending_text_deltas.insert(mission_id, content.clone());
+            }
+            None
+        }
+        AgentEvent::Thinking { .. } => {
+            pending_text_deltas.remove(&mission_id);
+            None
+        }
+        AgentEvent::ToolCall { .. } | AgentEvent::UserMessage { .. } | AgentEvent::Error { .. } => {
+            pending_text_deltas.remove(&mission_id)
+        }
+        AgentEvent::AssistantMessage { content, .. } => pending_text_deltas
+            .remove(&mission_id)
+            .filter(|candidate| should_persist_synthetic_thought(candidate, content)),
+        AgentEvent::MissionStatusChanged { status, .. } if is_terminal_mission_status(status) => {
+            pending_text_deltas.remove(&mission_id)
+        }
+        _ => None,
+    }
+}
+
 fn extract_short_description_from_content(content: &str, max_len: usize) -> Option<String> {
     let lines: Vec<&str> = content.lines().collect();
     let mut inside_fenced_block: Option<char> = None;
@@ -4612,11 +4668,26 @@ fn spawn_control_session(
         let store = Arc::clone(&state.mission_store);
         let mut event_rx = events_tx.subscribe();
         tokio::spawn(async move {
+            let mut pending_text_deltas: HashMap<Uuid, String> = HashMap::new();
             loop {
                 match event_rx.recv().await {
                     Ok(event) => {
                         // Extract mission_id from event
                         if let Some(mid) = event.mission_id() {
+                            if let Some(content) = synthetic_thought_from_text_delta(
+                                &mut pending_text_deltas,
+                                mid,
+                                &event,
+                            ) {
+                                let synthetic = AgentEvent::Thinking {
+                                    content,
+                                    done: true,
+                                    mission_id: Some(mid),
+                                };
+                                if let Err(e) = store.log_event(mid, &synthetic).await {
+                                    tracing::warn!("Failed to log synthetic thinking event: {}", e);
+                                }
+                            }
                             if let Err(e) = store.log_event(mid, &event).await {
                                 tracing::warn!("Failed to log event: {}", e);
                             }
@@ -9310,6 +9381,93 @@ mod tests {
             &automation,
         );
         assert_eq!(target, source_mission_id);
+    }
+
+    #[test]
+    fn synthetic_thought_from_text_delta_flushes_before_tool_call() {
+        let mission_id = Uuid::new_v4();
+        let mut pending = HashMap::new();
+
+        let text_delta = AgentEvent::TextDelta {
+            content: "Now let me run the build to see how many errors remain.".to_string(),
+            mission_id: Some(mission_id),
+        };
+        assert_eq!(
+            synthetic_thought_from_text_delta(&mut pending, mission_id, &text_delta),
+            None
+        );
+
+        let tool_call = AgentEvent::ToolCall {
+            tool_call_id: "tool-1".to_string(),
+            name: "Bash".to_string(),
+            args: serde_json::json!({ "command": "lake build" }),
+            mission_id: Some(mission_id),
+        };
+        assert_eq!(
+            synthetic_thought_from_text_delta(&mut pending, mission_id, &tool_call),
+            Some("Now let me run the build to see how many errors remain.".to_string())
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn synthetic_thought_from_text_delta_skips_assistant_echoes() {
+        let mission_id = Uuid::new_v4();
+        let mut pending = HashMap::new();
+
+        let text_delta = AgentEvent::TextDelta {
+            content: "Here is the final answer".to_string(),
+            mission_id: Some(mission_id),
+        };
+        let assistant = AgentEvent::AssistantMessage {
+            id: Uuid::new_v4(),
+            content: "Here is the final answer with more detail".to_string(),
+            success: true,
+            cost_cents: 0,
+            cost_source: crate::agents::CostSource::Unknown,
+            usage: None,
+            model: None,
+            model_normalized: None,
+            mission_id: Some(mission_id),
+            shared_files: None,
+            resumable: false,
+        };
+
+        let _ = synthetic_thought_from_text_delta(&mut pending, mission_id, &text_delta);
+        assert_eq!(
+            synthetic_thought_from_text_delta(&mut pending, mission_id, &assistant),
+            None
+        );
+    }
+
+    #[test]
+    fn synthetic_thought_from_text_delta_keeps_tool_narration_before_assistant() {
+        let mission_id = Uuid::new_v4();
+        let mut pending = HashMap::new();
+
+        let text_delta = AgentEvent::TextDelta {
+            content: "I'll inspect the failing theorem before I answer.".to_string(),
+            mission_id: Some(mission_id),
+        };
+        let assistant = AgentEvent::AssistantMessage {
+            id: Uuid::new_v4(),
+            content: "I found the issue in the induction step.".to_string(),
+            success: true,
+            cost_cents: 0,
+            cost_source: crate::agents::CostSource::Unknown,
+            usage: None,
+            model: None,
+            model_normalized: None,
+            mission_id: Some(mission_id),
+            shared_files: None,
+            resumable: false,
+        };
+
+        let _ = synthetic_thought_from_text_delta(&mut pending, mission_id, &text_delta);
+        assert_eq!(
+            synthetic_thought_from_text_delta(&mut pending, mission_id, &assistant),
+            Some("I'll inspect the failing theorem before I answer.".to_string())
+        );
     }
 
     #[tokio::test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -8875,10 +8875,19 @@ pub async fn run_opencode_turn(
         escaped
     };
 
+    let use_plain_opencode = workspace
+        .config
+        .get("disable_oh_my_opencode")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     let mut shell_cmd = String::new();
     if runner_is_direct {
         shell_cmd.push_str(&shell_escape(&cli_runner));
         shell_cmd.push_str(" run");
+    } else if use_plain_opencode {
+        shell_cmd.push_str(&shell_escape(&cli_runner));
+        shell_cmd.push_str(" opencode run");
     } else {
         shell_cmd.push_str(&shell_escape(&cli_runner));
         shell_cmd.push_str(" oh-my-opencode run");

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11329,8 +11329,20 @@ pub async fn run_codex_turn(
                         total_output_tokens = total_output_tokens.saturating_add(output_tokens);
                     }
                     ExecutionEvent::Error { message } => {
-                        error_message = Some(message.clone());
-                        tracing::error!("Codex error: {}", message);
+                        // Codex CLI sometimes emits non-fatal internal errors (e.g.
+                        // "Failed to shutdown rollout recorder") after the agent has
+                        // already produced a valid response. Ignore these if we
+                        // already have assistant output.
+                        if assistant_message.trim().is_empty() {
+                            error_message = Some(message.clone());
+                            tracing::error!("Codex error: {}", message);
+                        } else {
+                            tracing::warn!(
+                                "Ignoring post-response Codex error (have {}B assistant output): {}",
+                                assistant_message.len(),
+                                message
+                            );
+                        }
                     }
                     ExecutionEvent::MessageComplete { session_id: _ } => {
                         success = error_message.is_none();

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11251,6 +11251,7 @@ pub async fn run_codex_turn(
         std::collections::HashMap::new();
     let mut thinking_emitted = false;
     let mut thinking_done_emitted = false;
+    let mut thinking_accumulated = String::new();
     let mut last_summary: Option<String> = None;
     let mut total_input_tokens: u64 = 0;
     let mut total_output_tokens: u64 = 0;
@@ -11276,14 +11277,31 @@ pub async fn run_codex_turn(
                         });
                     }
                     ExecutionEvent::Thinking { content } => {
+                        // Stream incrementally for real-time UI
                         let _ = events_tx.send(AgentEvent::Thinking {
-                            content,
+                            content: content.clone(),
                             done: false,
                             mission_id: Some(mission_id),
                         });
+                        // Accumulate for persistence: Codex sends snapshot-style
+                        // thinking updates (each one replaces the previous), so
+                        // keep the latest (longest) content.
+                        if content.len() >= thinking_accumulated.len() {
+                            thinking_accumulated = content;
+                        }
                         thinking_emitted = true;
                     }
                     ExecutionEvent::ToolCall { id, name, args } => {
+                        // Flush accumulated thinking as done before tool call,
+                        // so the event logger persists the full thought block.
+                        if !thinking_accumulated.is_empty() {
+                            let _ = events_tx.send(AgentEvent::Thinking {
+                                content: std::mem::take(&mut thinking_accumulated),
+                                done: true,
+                                mission_id: Some(mission_id),
+                            });
+                            thinking_done_emitted = true;
+                        }
                         pending_tools.insert(id.clone(), name.clone());
                         let _ = events_tx.send(AgentEvent::ToolCall {
                             tool_call_id: id,
@@ -11340,9 +11358,11 @@ pub async fn run_codex_turn(
         }
     }
 
+    // Flush any remaining accumulated thinking with full content so
+    // the event logger persists it for replay/history.
     if thinking_emitted && !thinking_done_emitted {
         let _ = events_tx.send(AgentEvent::Thinking {
-            content: String::new(),
+            content: thinking_accumulated,
             done: true,
             mission_id: Some(mission_id),
         });
@@ -11626,6 +11646,7 @@ pub async fn run_gemini_turn(
         std::collections::HashMap::new();
     let mut thinking_emitted = false;
     let mut thinking_done_emitted = false;
+    let mut thinking_accumulated = String::new();
     let mut total_input_tokens: u64 = 0;
     let mut total_output_tokens: u64 = 0;
 
@@ -11650,14 +11671,28 @@ pub async fn run_gemini_turn(
                         });
                     }
                     ExecutionEvent::Thinking { content } => {
+                        // Stream incrementally for real-time UI
                         let _ = events_tx.send(AgentEvent::Thinking {
-                            content,
+                            content: content.clone(),
                             done: false,
                             mission_id: Some(mission_id),
                         });
+                        // Accumulate for persistence (keep longest snapshot)
+                        if content.len() >= thinking_accumulated.len() {
+                            thinking_accumulated = content;
+                        }
                         thinking_emitted = true;
                     }
                     ExecutionEvent::ToolCall { id, name, args } => {
+                        // Flush accumulated thinking before tool call
+                        if !thinking_accumulated.is_empty() {
+                            let _ = events_tx.send(AgentEvent::Thinking {
+                                content: std::mem::take(&mut thinking_accumulated),
+                                done: true,
+                                mission_id: Some(mission_id),
+                            });
+                            thinking_done_emitted = true;
+                        }
                         pending_tools.insert(id.clone(), name.clone());
                         let _ = events_tx.send(AgentEvent::ToolCall {
                             tool_call_id: id,
@@ -11713,9 +11748,10 @@ pub async fn run_gemini_turn(
         }
     }
 
+    // Flush any remaining accumulated thinking with full content
     if thinking_emitted && !thinking_done_emitted {
         let _ = events_tx.send(AgentEvent::Thinking {
-            content: String::new(),
+            content: thinking_accumulated,
             done: true,
             mission_id: Some(mission_id),
         });

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11800,26 +11800,11 @@ fn get_google_credentials_for_gemini(working_dir: &std::path::Path) -> GeminiCre
         return GeminiCredentials::ApiKey(key);
     }
 
-    // Read provider_backends.json to check backend targeting.
-    // If the Google provider has use_for_backends configured but "gemini" is
-    // not included, skip using credentials from that provider.
-    let backends_path = working_dir
-        .join(".sandboxed-sh")
-        .join("provider_backends.json");
-    let google_targets_gemini = if let Ok(data) = std::fs::read_to_string(&backends_path) {
-        if let Ok(map) = serde_json::from_str::<serde_json::Value>(&data) {
-            match map.get("google").and_then(|v| v.as_array()) {
-                Some(backends) => backends.iter().any(|b| b.as_str() == Some("gemini")),
-                // No entry for google means no explicit targeting; allow by default
-                None => true,
-            }
-        } else {
-            true
-        }
-    } else {
-        // No backends state file; allow by default
-        true
-    };
+    let google_targets_gemini = crate::api::ai_providers::provider_targets_backend(
+        working_dir,
+        crate::ai_providers::ProviderType::Google,
+        "gemini",
+    );
 
     if !google_targets_gemini {
         tracing::info!(

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -561,6 +561,11 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "GLM models via Z.AI API key".to_string(),
                 models: vec![
                     ProviderModel {
+                        id: "glm-5-turbo".to_string(),
+                        name: "GLM-5 Turbo".to_string(),
+                        description: Some("Fast reasoning model with deep thinking".to_string()),
+                    },
+                    ProviderModel {
                         id: "glm-4.7".to_string(),
                         name: "GLM-4.7".to_string(),
                         description: Some("Most capable GLM model".to_string()),

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -115,6 +115,8 @@ pub struct UpdateWorkspaceRequest {
     pub mcps: Option<Vec<String>>,
     /// Optional config profile to apply to this workspace.
     pub config_profile: Option<String>,
+    /// Freeform workspace configuration (merged with existing config).
+    pub config: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -137,6 +139,7 @@ pub struct WorkspaceResponse {
     pub tailscale_mode: Option<TailscaleMode>,
     pub mcps: Vec<String>,
     pub config_profile: Option<String>,
+    pub config: serde_json::Value,
 }
 
 impl From<Workspace> for WorkspaceResponse {
@@ -160,6 +163,7 @@ impl From<Workspace> for WorkspaceResponse {
             tailscale_mode: w.tailscale_mode,
             mcps: w.mcps,
             config_profile: w.config_profile,
+            config: w.config,
         }
     }
 }
@@ -635,6 +639,19 @@ async fn update_workspace(
             workspace.config_profile = None;
         } else {
             workspace.config_profile = Some(trimmed.to_string());
+        }
+    }
+
+    // Merge freeform config (shallow merge of top-level keys)
+    if let Some(config) = req.config {
+        if let Some(new_obj) = config.as_object() {
+            let mut existing = workspace.config.as_object().cloned().unwrap_or_default();
+            for (k, v) in new_obj {
+                existing.insert(k.clone(), v.clone());
+            }
+            workspace.config = serde_json::Value::Object(existing);
+        } else {
+            workspace.config = config;
         }
     }
 

--- a/src/backend/gemini/client.rs
+++ b/src/backend/gemini/client.rs
@@ -391,6 +391,8 @@ pub enum GeminiEvent {
         #[serde(default)]
         status: Option<String>,
         #[serde(default)]
+        error: Option<GeminiErrorDetail>,
+        #[serde(default)]
         stats: Option<GeminiStats>,
     },
 
@@ -528,7 +530,11 @@ mod tests {
         let json = r#"{"type":"result","status":"success","stats":{"total_input_tokens":1000,"total_output_tokens":250}}"#;
         let event: GeminiEvent = serde_json::from_str(json).unwrap();
         match event {
-            GeminiEvent::Result { status, stats } => {
+            GeminiEvent::Result {
+                status,
+                error: _,
+                stats,
+            } => {
                 assert_eq!(status.as_deref(), Some("success"));
                 let stats = stats.unwrap();
                 assert_eq!(stats.total_input_tokens, Some(1000));

--- a/src/backend/gemini/mod.rs
+++ b/src/backend/gemini/mod.rs
@@ -275,12 +275,27 @@ fn convert_gemini_event(
             }
         }
 
-        GeminiEvent::Result { status, stats } => {
+        GeminiEvent::Result {
+            status,
+            error,
+            stats,
+        } => {
             // Check if the result status indicates an error
             if let Some(ref s) = status {
                 if s != "success" && s != "ok" {
+                    let detail = error
+                        .as_ref()
+                        .and_then(|e| e.message.as_deref())
+                        .unwrap_or("no details provided");
+                    let error_type = error
+                        .as_ref()
+                        .and_then(|e| e.error_type.as_deref())
+                        .unwrap_or("unknown");
                     results.push(ExecutionEvent::Error {
-                        message: format!("Gemini CLI finished with status: {}", s),
+                        message: format!(
+                            "Gemini CLI finished with status: {} (type: {}, detail: {})",
+                            s, error_type, detail
+                        ),
                     });
                 }
             }
@@ -488,6 +503,7 @@ mod tests {
         let mut tool_names = HashMap::new();
         let event = GeminiEvent::Result {
             status: Some("success".to_string()),
+            error: None,
             stats: Some(client::GeminiStats {
                 total_input_tokens: Some(1500),
                 total_output_tokens: Some(300),
@@ -513,6 +529,7 @@ mod tests {
         let mut tool_names = HashMap::new();
         let event = GeminiEvent::Result {
             status: Some("error".to_string()),
+            error: None,
             stats: None,
         };
         let events = convert_gemini_event(event, &mut tool_names);
@@ -526,10 +543,33 @@ mod tests {
     }
 
     #[test]
+    fn convert_gemini_event_result_error_with_detail() {
+        let mut tool_names = HashMap::new();
+        let event = GeminiEvent::Result {
+            status: Some("error".to_string()),
+            error: Some(client::GeminiErrorDetail {
+                error_type: Some("api_error".to_string()),
+                message: Some("Rate limit exceeded".to_string()),
+            }),
+            stats: None,
+        };
+        let events = convert_gemini_event(event, &mut tool_names);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ExecutionEvent::Error { message } => {
+                assert!(message.contains("api_error"));
+                assert!(message.contains("Rate limit exceeded"));
+            }
+            other => panic!("Expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn convert_gemini_event_result_zero_usage() {
         let mut tool_names = HashMap::new();
         let event = GeminiEvent::Result {
             status: Some("success".to_string()),
+            error: None,
             stats: Some(client::GeminiStats {
                 total_input_tokens: Some(0),
                 total_output_tokens: Some(0),

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -250,6 +250,14 @@ impl OrchestratorMcp {
     fn get_tools() -> Vec<ToolDefinition> {
         vec![
             ToolDefinition {
+                name: "get_workspace_layout".to_string(),
+                description: "Return the boss mission's workspace paths so you can stop guessing where the real project root is before delegating.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {}
+                }),
+            },
+            ToolDefinition {
                 name: "create_worker_mission".to_string(),
                 description: "Create a new worker mission (child of the current boss mission). The worker will start executing immediately. IMPORTANT: You must set the 'backend' field to match the harness you want (claudecode, codex, gemini, opencode). If omitted, defaults to the workspace default (usually claudecode).".to_string(),
                 input_schema: json!({
@@ -367,7 +375,43 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "send_message_to_worker".to_string(),
-                description: "Send a text message/instruction to a running worker mission.".to_string(),
+                description: "Send a follow-up message to a worker mission. This can continue a running worker and can also reactivate an interrupted, failed, completed, or pending worker by queuing new targeted work.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id", "content"],
+                    "properties": {
+                        "mission_id": {
+                            "type": "string",
+                            "description": "UUID of the worker mission"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Message content to send to the worker"
+                        }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "resume_worker".to_string(),
+                description: "Resume or retry a worker by sending it a targeted follow-up message. Use this when a worker was interrupted, failed, blocked, or needs corrective guidance.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id", "content"],
+                    "properties": {
+                        "mission_id": {
+                            "type": "string",
+                            "description": "UUID of the worker mission"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Recovery or retry instructions for the worker"
+                        }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "retask_worker".to_string(),
+                description: "Change a worker's assignment by sending it a new targeted prompt. Use this instead of abandoning a worker when its scope should change.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id", "content"],
@@ -665,6 +709,47 @@ impl OrchestratorMcp {
         Ok(result)
     }
 
+    async fn resume_worker(&self, params: SendMessageParams) -> Result<Value, String> {
+        let mission_id = params.mission_id.clone();
+        let result = self.send_message(params).await?;
+        Ok(json!({
+            "success": true,
+            "action": "resume_worker",
+            "mission_id": mission_id,
+            "result": result,
+        }))
+    }
+
+    async fn retask_worker(&self, params: SendMessageParams) -> Result<Value, String> {
+        let mission_id = params.mission_id.clone();
+        let result = self.send_message(params).await?;
+        Ok(json!({
+            "success": true,
+            "action": "retask_worker",
+            "mission_id": mission_id,
+            "result": result,
+        }))
+    }
+
+    fn get_workspace_layout(&self) -> Value {
+        let workspace_dir = std::env::var("WORKING_DIR").ok();
+        let workspace_root = std::env::var("SANDBOXED_SH_WORKSPACE_ROOT").ok();
+        let workspace_mount = std::env::var("SANDBOXED_SH_WORKSPACE").ok();
+        let workspace_type = std::env::var("SANDBOXED_SH_WORKSPACE_TYPE").ok();
+        let runtime_workspace_file = std::env::var("SANDBOXED_SH_RUNTIME_WORKSPACE_FILE").ok();
+
+        let git_root = workspace_dir.as_deref().and_then(find_git_root);
+
+        json!({
+            "workspace_dir": workspace_dir,
+            "workspace_root": workspace_root,
+            "workspace_mount": workspace_mount,
+            "workspace_type": workspace_type,
+            "runtime_workspace_file": runtime_workspace_file,
+            "git_root": git_root,
+        })
+    }
+
     fn create_worktree(&self, params: CreateWorktreeParams) -> Result<Value, String> {
         let path = &params.path;
         let branch = &params.branch;
@@ -918,6 +1003,7 @@ impl OrchestratorMcp {
 
     async fn handle_call(&self, method: &str, params: Value) -> Result<Value, String> {
         match method {
+            "get_workspace_layout" => Ok(self.get_workspace_layout()),
             "create_worker_mission" => {
                 let params: CreateWorkerParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
@@ -944,6 +1030,16 @@ impl OrchestratorMcp {
                 let params: SendMessageParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
                 self.send_message(params).await
+            }
+            "resume_worker" => {
+                let params: SendMessageParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.resume_worker(params).await
+            }
+            "retask_worker" => {
+                let params: SendMessageParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.retask_worker(params).await
             }
             "create_worktree" => {
                 let params: CreateWorktreeParams =
@@ -1025,6 +1121,25 @@ impl OrchestratorMcp {
             }
             _ => JsonRpcResponse::error(req.id, -32601, format!("Unknown method: {}", req.method)),
         }
+    }
+}
+
+fn find_git_root(path: &str) -> Option<String> {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .current_dir(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if root.is_empty() {
+        None
+    } else {
+        Some(root)
     }
 }
 

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -9,6 +9,11 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use jsonwebtoken::{EncodingKey, Header};
+use sandboxed_sh::ai_providers::ProviderType;
+use sandboxed_sh::api::ai_providers::{
+    default_backends_for_provider, get_openai_api_key_for_codex_default, provider_targets_backend,
+    read_oauth_token_entry,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -151,6 +156,12 @@ struct SendMessageParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct BackendAuthStatusParams {
+    #[serde(default)]
+    backend: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct CreateWorktreeParams {
     /// Path relative to the workspace root where the worktree will be created
     path: String,
@@ -255,6 +266,20 @@ impl OrchestratorMcp {
                 input_schema: json!({
                     "type": "object",
                     "properties": {}
+                }),
+            },
+            ToolDefinition {
+                name: "get_backend_auth_status".to_string(),
+                description: "Report which backends are actually usable from the backend's credential store and provider targeting. Use this instead of guessing from shell env vars or CLI login checks.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "backend": {
+                            "type": "string",
+                            "enum": ["claudecode", "codex", "gemini", "opencode", "amp"],
+                            "description": "Optional single backend to inspect. If omitted, returns all common backends."
+                        }
+                    }
                 }),
             },
             ToolDefinition {
@@ -750,6 +775,94 @@ impl OrchestratorMcp {
         })
     }
 
+    fn get_backend_auth_status(&self, params: BackendAuthStatusParams) -> Value {
+        let backends = params
+            .backend
+            .map(|backend| vec![backend])
+            .unwrap_or_else(|| {
+                vec![
+                    "claudecode".to_string(),
+                    "codex".to_string(),
+                    "gemini".to_string(),
+                    "opencode".to_string(),
+                ]
+            });
+
+        let data_dir = openagent_data_dir();
+        let auth_json_path = opencode_auth_json_path();
+        let codex_auth_path = codex_auth_json_path();
+
+        let statuses: Vec<Value> = backends
+            .into_iter()
+            .map(|backend| match backend.as_str() {
+                "claudecode" => backend_auth_entry(
+                    "claudecode",
+                    ProviderType::Anthropic,
+                    &data_dir,
+                    provider_targets_backend(&data_dir, ProviderType::Anthropic, "claudecode"),
+                    read_oauth_token_entry(ProviderType::Anthropic).is_some(),
+                    false,
+                    None,
+                ),
+                "codex" => {
+                    let has_oauth = read_oauth_token_entry(ProviderType::OpenAI).is_some();
+                    let has_api_key =
+                        get_openai_api_key_for_codex_default(&data_dir).is_some();
+                    let has_host_auth = looks_like_json_file(&codex_auth_path);
+                    let targeted =
+                        provider_targets_backend(&data_dir, ProviderType::OpenAI, "codex");
+                    backend_auth_entry(
+                        "codex",
+                        ProviderType::OpenAI,
+                        &data_dir,
+                        targeted,
+                        has_oauth || has_api_key || has_host_auth,
+                        has_host_auth,
+                        Some(json!({
+                            "has_api_key": has_api_key,
+                            "has_oauth": has_oauth,
+                            "has_host_auth_json": has_host_auth,
+                        })),
+                    )
+                }
+                "gemini" => backend_auth_entry(
+                    "gemini",
+                    ProviderType::Google,
+                    &data_dir,
+                    provider_targets_backend(&data_dir, ProviderType::Google, "gemini"),
+                    read_oauth_token_entry(ProviderType::Google).is_some()
+                        || opencode_auth_has_provider(&auth_json_path, "google")
+                        || opencode_auth_has_provider(&auth_json_path, "gemini"),
+                    false,
+                    Some(json!({
+                        "default_backends": default_backends_for_provider(ProviderType::Google),
+                    })),
+                ),
+                "opencode" => json!({
+                    "backend": "opencode",
+                    "ready": true,
+                    "reason": "OpenCode routes through configured providers; inspect provider selection separately.",
+                }),
+                "amp" => json!({
+                    "backend": "amp",
+                    "ready": true,
+                    "reason": "Amp auth is handled by AMP_API_KEY or provider store, not this tool.",
+                }),
+                other => json!({
+                    "backend": other,
+                    "ready": false,
+                    "reason": "Unknown backend",
+                }),
+            })
+            .collect();
+
+        json!({
+            "openagent_data_dir": data_dir,
+            "statuses": statuses,
+            "note": "Shell env vars and CLI login status inside a worker shell are not authoritative for backend auth.",
+        })
+    }
+
     fn create_worktree(&self, params: CreateWorktreeParams) -> Result<Value, String> {
         let path = &params.path;
         let branch = &params.branch;
@@ -1004,6 +1117,11 @@ impl OrchestratorMcp {
     async fn handle_call(&self, method: &str, params: Value) -> Result<Value, String> {
         match method {
             "get_workspace_layout" => Ok(self.get_workspace_layout()),
+            "get_backend_auth_status" => {
+                let params: BackendAuthStatusParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                Ok(self.get_backend_auth_status(params))
+            }
             "create_worker_mission" => {
                 let params: CreateWorkerParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
@@ -1141,6 +1259,93 @@ fn find_git_root(path: &str) -> Option<String> {
     } else {
         Some(root)
     }
+}
+
+fn openagent_data_dir() -> std::path::PathBuf {
+    std::env::var("OPENAGENT_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("/root/.sandboxed-sh"))
+}
+
+fn opencode_auth_json_path() -> std::path::PathBuf {
+    if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+        return std::path::PathBuf::from(data_home)
+            .join("opencode")
+            .join("auth.json");
+    }
+
+    std::path::PathBuf::from("/var/lib/opencode/.local/share/opencode/auth.json")
+}
+
+fn codex_auth_json_path() -> std::path::PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        let candidate = std::path::PathBuf::from(&home)
+            .join(".codex")
+            .join("auth.json");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    std::path::PathBuf::from("/var/lib/opencode/.codex/auth.json")
+}
+
+fn looks_like_json_file(path: &std::path::Path) -> bool {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .is_some()
+}
+
+fn opencode_auth_has_provider(path: &std::path::Path, provider: &str) -> bool {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .and_then(|value| value.get(provider).cloned())
+        .is_some()
+}
+
+fn backend_auth_entry(
+    backend: &str,
+    provider_type: ProviderType,
+    data_dir: &std::path::Path,
+    targeted: bool,
+    has_credentials: bool,
+    has_cli_auth: bool,
+    extra: Option<Value>,
+) -> Value {
+    let ready = targeted && (has_credentials || has_cli_auth);
+    let reason = if ready {
+        "backend is targeted and credentials are available"
+    } else if has_credentials || has_cli_auth {
+        "credentials exist, but this provider is not targeted to that backend"
+    } else if targeted {
+        "backend is targeted, but no credentials were found"
+    } else {
+        "backend is not targeted and no credentials were found"
+    };
+
+    let mut value = json!({
+        "backend": backend,
+        "provider": provider_type.id(),
+        "ready": ready,
+        "targeted": targeted,
+        "has_credentials": has_credentials,
+        "has_cli_auth": has_cli_auth,
+        "default_backends": default_backends_for_provider(provider_type),
+        "data_dir": data_dir,
+        "reason": reason,
+    });
+
+    if let Some(extra) = extra {
+        if let (Some(map), Some(extra_map)) = (value.as_object_mut(), extra.as_object()) {
+            for (key, entry) in extra_map {
+                map.insert(key.clone(), entry.clone());
+            }
+        }
+    }
+
+    value
 }
 
 // =============================================================================

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -789,6 +789,13 @@ impl OrchestratorMcp {
             });
 
         let data_dir = openagent_data_dir();
+        // provider_targets_backend / load_ai_providers expect a workspace root
+        // and internally append `.sandboxed-sh/...`. The data_dir already IS
+        // `.sandboxed-sh`, so we use its parent as the workspace root.
+        let workspace_root = data_dir
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| data_dir.clone());
         let auth_json_path = opencode_auth_json_path();
         let codex_auth_path = codex_auth_json_path();
 
@@ -798,8 +805,8 @@ impl OrchestratorMcp {
                 "claudecode" => backend_auth_entry(
                     "claudecode",
                     ProviderType::Anthropic,
-                    &data_dir,
-                    provider_targets_backend(&data_dir, ProviderType::Anthropic, "claudecode"),
+                    &workspace_root,
+                    provider_targets_backend(&workspace_root, ProviderType::Anthropic, "claudecode"),
                     read_oauth_token_entry(ProviderType::Anthropic).is_some(),
                     false,
                     None,
@@ -807,14 +814,14 @@ impl OrchestratorMcp {
                 "codex" => {
                     let has_oauth = read_oauth_token_entry(ProviderType::OpenAI).is_some();
                     let has_api_key =
-                        get_openai_api_key_for_codex_default(&data_dir).is_some();
+                        get_openai_api_key_for_codex_default(&workspace_root).is_some();
                     let has_host_auth = looks_like_json_file(&codex_auth_path);
                     let targeted =
-                        provider_targets_backend(&data_dir, ProviderType::OpenAI, "codex");
+                        provider_targets_backend(&workspace_root, ProviderType::OpenAI, "codex");
                     backend_auth_entry(
                         "codex",
                         ProviderType::OpenAI,
-                        &data_dir,
+                        &workspace_root,
                         targeted,
                         has_oauth || has_api_key || has_host_auth,
                         has_host_auth,
@@ -828,8 +835,8 @@ impl OrchestratorMcp {
                 "gemini" => backend_auth_entry(
                     "gemini",
                     ProviderType::Google,
-                    &data_dir,
-                    provider_targets_backend(&data_dir, ProviderType::Google, "gemini"),
+                    &workspace_root,
+                    provider_targets_backend(&workspace_root, ProviderType::Google, "gemini"),
                     read_oauth_token_entry(ProviderType::Google).is_some()
                         || opencode_auth_has_provider(&auth_json_path, "google")
                         || opencode_auth_has_provider(&auth_json_path, "gemini"),

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -658,6 +658,21 @@ impl ModelChainStore {
             changed = true;
         }
 
+        if !chains.iter().any(|c| c.id == "builtin/fast") {
+            chains.push(ModelChain {
+                id: "builtin/fast".to_string(),
+                name: "Fast".to_string(),
+                entries: vec![ChainEntry {
+                    provider_id: "zai".to_string(),
+                    model_id: "glm-5-turbo".to_string(),
+                }],
+                is_default: false,
+                created_at: now,
+                updated_at: now,
+            });
+            changed = true;
+        }
+
         if changed {
             if let Err(e) = self.save_chains_to_disk(&chains) {
                 tracing::error!("Failed to save default model chains: {}", e);


### PR DESCRIPTION
## Summary
- omit the placeholder Gemini `default` agent from create-mission requests
- surface backend error text in create-mission toasts instead of a generic failure
- keep the existing behavior for other backends

## Reproduction
- open the dashboard on `localhost:3001`
- create a new mission with `Gemini Agent`
- before this patch the UI sent `agent: "default"` and prod returned `400 Agent 'default' not found`

## Verification
- reproduced the failing POST against prod
- confirmed raw Gemini mission creation succeeds when `agent` is omitted
- ran `git diff --check`
- ran `bunx eslint src/components/new-mission-dialog.tsx src/lib/api/missions.ts --quiet`

## Notes
- repo-wide dashboard lint still has many pre-existing failures unrelated to this patch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new UI surfaces and a new backend endpoint that makes live provider API calls and migrates provider storage, which could impact provider configuration/credentials handling and introduce external-call failure modes.
> 
> **Overview**
> Improves mission creation UX by omitting Gemini’s placeholder `agent: "default"` from requests and surfacing backend error text in create-mission failure toasts (web control page and dashboard root).
> 
> Adds boss/worker mission visibility features: a new right-side `WorkerPanel` (with peek modal) for navigating and monitoring child missions, automatic display for boss missions, and mission switcher grouping/indentation plus progress/activity display based on expanded `RunningMissionInfo` fields.
> 
> Expands AI provider management with an expandable “Usage & Limits” view that fetches and displays live rate-limit/account info via a new `GET /api/ai/providers/:id/usage` endpoint, and refactors the backend provider system to store all providers in `AIProviderStore` (migrating from `opencode.json` on list, syncing back to OpenCode config/auth for runtime compatibility, and updating default backends/targeting helpers). Also updates iOS control streaming to better finalize/merge thinking messages and show fallback streaming thoughts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dee50366078389e519a1b8f58556a6213a28b67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->