### PR TITLE
feat: Telegram HTML rendering, proactive messaging API, Ana improvements

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -10166,12 +10166,14 @@ pub async fn send_telegram_message_api(
         })?
     };
 
-    // Send the message via Telegram Bot API
+    // Send the message via Telegram Bot API with HTML rendering
+    let html_text = super::telegram::markdown_to_telegram_html(&req.text);
     let base_url = format!("https://api.telegram.org/bot{}", channel.bot_token);
     let http = reqwest::Client::new();
     let body = serde_json::json!({
         "chat_id": req.chat_id,
-        "text": req.text,
+        "text": html_text,
+        "parse_mode": "HTML",
     });
     let response = http
         .post(format!("{}/sendMessage", base_url))

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4583,6 +4583,7 @@ pub async fn stream(
 }
 
 /// Spawn the global control session actor.
+#[allow(clippy::too_many_arguments)]
 fn spawn_control_session(
     config: Config,
     root_agent: AgentRef,

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -10167,39 +10167,14 @@ pub async fn send_telegram_message_api(
         })?
     };
 
-    // Send the message via Telegram Bot API with HTML rendering
-    let html_text = super::telegram::markdown_to_telegram_html(&req.text);
+    // Send the message via Telegram Bot API with HTML rendering and chunking
     let base_url = format!("https://api.telegram.org/bot{}", channel.bot_token);
     let http = reqwest::Client::new();
-    let body = serde_json::json!({
-        "chat_id": req.chat_id,
-        "text": html_text,
-        "parse_mode": "HTML",
-    });
-    let response = http
-        .post(format!("{}/sendMessage", base_url))
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::BAD_GATEWAY,
-                format!("Telegram API error: {}", e),
-            )
-        })?;
-
-    let status = response.status();
-    let resp_body: serde_json::Value = response
-        .json()
-        .await
-        .unwrap_or(serde_json::json!({"ok": false}));
-
-    if !status.is_success() {
-        return Err((
-            StatusCode::BAD_GATEWAY,
-            format!("Telegram sendMessage failed: {}", resp_body),
-        ));
-    }
+    let msg_id =
+        super::telegram::send_telegram_text(&http, &base_url, req.chat_id, &req.text, None)
+            .await
+            .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
+    let resp_body = serde_json::json!({"ok": true, "message_id": msg_id});
 
     // Optionally dispatch to the associated mission
     if req.dispatch_to_mission {

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -10115,6 +10115,120 @@ pub async fn list_bot_chats(
     Ok(Json(mappings))
 }
 
+/// Send a message to a Telegram chat via the bot and optionally dispatch it to
+/// the associated mission. Used by agents (e.g. Ana) to proactively message users.
+#[derive(Debug, Deserialize)]
+pub struct SendTelegramMessageRequest {
+    /// Telegram chat ID to send to
+    pub chat_id: i64,
+    /// Message text
+    pub text: String,
+    /// Bot channel ID (if omitted, uses the first active bot)
+    #[serde(default)]
+    pub channel_id: Option<Uuid>,
+    /// Also dispatch as a user message to the chat's associated mission
+    #[serde(default)]
+    pub dispatch_to_mission: bool,
+}
+
+pub async fn send_telegram_message_api(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Json(req): Json<SendTelegramMessageRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+
+    // Resolve which bot to use
+    let channel = if let Some(channel_id) = req.channel_id {
+        control
+            .mission_store
+            .get_telegram_channel(channel_id)
+            .await
+            .map_err(internal_error)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    format!("Telegram channel {} not found", channel_id),
+                )
+            })?
+    } else {
+        // Use first active bot
+        let channels = control
+            .mission_store
+            .list_all_telegram_channels()
+            .await
+            .map_err(internal_error)?;
+        channels.into_iter().find(|c| c.active).ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "No active Telegram bot found".to_string(),
+            )
+        })?
+    };
+
+    // Send the message via Telegram Bot API
+    let base_url = format!("https://api.telegram.org/bot{}", channel.bot_token);
+    let http = reqwest::Client::new();
+    let body = serde_json::json!({
+        "chat_id": req.chat_id,
+        "text": req.text,
+    });
+    let response = http
+        .post(format!("{}/sendMessage", base_url))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("Telegram API error: {}", e),
+            )
+        })?;
+
+    let status = response.status();
+    let resp_body: serde_json::Value = response
+        .json()
+        .await
+        .unwrap_or(serde_json::json!({"ok": false}));
+
+    if !status.is_success() {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!("Telegram sendMessage failed: {}", resp_body),
+        ));
+    }
+
+    // Optionally dispatch to the associated mission
+    if req.dispatch_to_mission {
+        if let Ok(Some(mapping)) = control
+            .mission_store
+            .get_telegram_chat_mission(channel.id, req.chat_id)
+            .await
+        {
+            let msg_id = Uuid::new_v4();
+            let (tx, _rx) = tokio::sync::oneshot::channel();
+            let content = format!(
+                "[Telegram from @{} in chat {}] {}",
+                channel.bot_username.as_deref().unwrap_or("bot"),
+                req.chat_id,
+                req.text
+            );
+            let _ = control
+                .cmd_tx
+                .send(ControlCommand::UserMessage {
+                    id: msg_id,
+                    content,
+                    agent: None,
+                    target_mission_id: Some(mapping.mission_id),
+                    respond: tx,
+                })
+                .await;
+        }
+    }
+
+    Ok(Json(resp_body))
+}
+
 /// Telegram webhook receiver (unauthenticated — verified via secret token header).
 pub async fn telegram_webhook_receiver(
     State(state): State<Arc<AppState>>,

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -10319,8 +10319,13 @@ pub async fn run_opencode_turn(
                                 }
                             }
 
-                            // Route through SSE event parser for thinking/tool events
+                            // Route through SSE event parser for thinking/tool events.
+                            // Skip events already handled inline to avoid double processing
+                            // (e.g. step_finish would set message_complete in the SSE parser
+                            // even for tool-call steps, conflicting with the inline handler).
+                            let skip_sse = matches!(event_type, "step_finish" | "step_start" | "text");
                             let current_session = session_id_capture.lock().unwrap_or_else(|e| e.into_inner()).clone();
+                            if !skip_sse {
                             if let Some(parsed) = parse_opencode_sse_event(
                                 trimmed,
                                 None,
@@ -10400,6 +10405,7 @@ pub async fn run_opencode_turn(
                                     sse_retry_tx.send_modify(|v| *v += 1);
                                 }
                             }
+                            } // !skip_sse
                         } else {
                             // Non-JSON line - this is the expected output format without --format json
                             tracing::debug!(mission_id = %mission_id, line = %trimmed, "OpenCode stdout");

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9412,6 +9412,7 @@ pub async fn run_opencode_turn(
     let mut final_result = String::new();
     let mut had_error = false;
     let mut final_result_from_nonzero_exit = false;
+    let mut tool_call_step_count: u32 = 0;
     let session_id_capture: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let stderr_text_buffer: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
     let stderr_recent_lines: Arc<Mutex<VecDeque<String>>> =
@@ -10262,10 +10263,6 @@ pub async fn run_opencode_turn(
                                     }
                                 }
                             } else if event_type == "step_finish" {
-                                // Only treat as completion if reason is "stop".
-                                // Tool-use steps have reason "tool_use" and are
-                                // followed by more steps — killing early would
-                                // abort the multi-step execution.
                                 let reason = json
                                     .get("part")
                                     .and_then(|p| p.get("reason"))
@@ -10274,10 +10271,23 @@ pub async fn run_opencode_turn(
                                 tracing::info!(
                                     mission_id = %mission_id,
                                     reason = %reason,
+                                    tool_call_steps = tool_call_step_count,
                                     "OpenCode JSON step_finish event"
                                 );
                                 if reason == "stop" {
                                     let _ = sse_complete_tx.send(true);
+                                } else {
+                                    // Track consecutive tool-call steps to detect runaway loops
+                                    tool_call_step_count += 1;
+                                    const MAX_TOOL_CALL_STEPS: u32 = 15;
+                                    if tool_call_step_count >= MAX_TOOL_CALL_STEPS {
+                                        tracing::warn!(
+                                            mission_id = %mission_id,
+                                            steps = tool_call_step_count,
+                                            "OpenCode tool-call step limit reached, forcing completion"
+                                        );
+                                        let _ = sse_complete_tx.send(true);
+                                    }
                                 }
                             } else if event_type == "step_start" {
                                 // Extract session ID from step_start

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -710,6 +710,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             "/api/control/telegram/bots/:id/chats",
             get(control::list_bot_chats),
         )
+        .route(
+            "/api/control/telegram/send",
+            post(control::send_telegram_message_api),
+        )
         // Parallel execution endpoints
         .route("/api/control/running", get(control::list_running_missions))
         .route(

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1324,9 +1324,9 @@ fn char_boundary_at(text: &str, max_chars: usize) -> usize {
         .unwrap_or(text.len())
 }
 
-/// Truncate text to fit Telegram's 4096 character limit.
 /// Convert markdown to Telegram HTML for rich rendering.
 /// Handles **bold**, *italic*, `code`, ```blocks```, # headers, [links](url).
+#[allow(clippy::while_let_on_iterator)]
 pub fn markdown_to_telegram_html(text: &str) -> String {
     // Escape HTML special chars first
     let escaped = text

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -962,7 +962,8 @@ pub async fn stream_response(
             if let Some(msg_id) = sent_message_id {
                 if !accumulated_text.is_empty() {
                     let final_text = format!("{}...\n\n_(timed out)_", accumulated_text);
-                    let _ = edit_message(http, &base_url, chat_id, msg_id, &final_text).await;
+                    let display = truncate_for_telegram(&final_text);
+                    let _ = edit_message(http, &base_url, chat_id, msg_id, &display.html).await;
                 }
             }
             return Err("Timeout waiting for agent response".to_string());
@@ -982,7 +983,7 @@ pub async fn stream_response(
                             if last_edit.elapsed() >= edit_interval {
                                 // Throttled edit
                                 let display = truncate_for_telegram(&accumulated_text);
-                                if let Err(e) = edit_message(http, &base_url, chat_id, msg_id, &display).await {
+                                if let Err(e) = edit_message(http, &base_url, chat_id, msg_id, &display.html).await {
                                     tracing::warn!(
                                         mission_id = %mission_id,
                                         "Failed to edit Telegram message during streaming: {}",
@@ -1015,7 +1016,7 @@ pub async fn stream_response(
                         if let Some(msg_id) = sent_message_id {
                             // Edit existing message with final content
                             let display = truncate_for_telegram(&content);
-                            if let Err(e) = edit_message(http, &base_url, chat_id, msg_id, &display).await {
+                            if let Err(e) = edit_message(http, &base_url, chat_id, msg_id, &display.html).await {
                                 tracing::warn!(
                                     mission_id = %mission_id,
                                     "Failed to edit Telegram message with final response, sending as new message: {}",
@@ -1025,7 +1026,14 @@ pub async fn stream_response(
                                 let _ = send_chunked_message(http, &base_url, chat_id, &content, None).await;
                             }
                             // If content exceeds 4096 chars, send overflow as new messages
-                            send_overflow_chunks(http, &base_url, chat_id, &content).await;
+                            send_overflow_chunks(
+                                http,
+                                &base_url,
+                                chat_id,
+                                &content,
+                                display.source_boundary,
+                            )
+                            .await;
                         } else {
                             // No streaming happened, send the full response directly
                             send_chunked_message(http, &base_url, chat_id, &content, Some(reply_to)).await?;
@@ -1054,7 +1062,8 @@ pub async fn stream_response(
                             } else {
                                 format!("{}\n\n_{}_", accumulated_text, error_msg)
                             };
-                            let _ = edit_message(http, &base_url, chat_id, msg_id, &final_text).await;
+                            let display = truncate_for_telegram(&final_text);
+                            let _ = edit_message(http, &base_url, chat_id, msg_id, &display.html).await;
                         } else {
                             let _ = send_message(http, &base_url, chat_id, &error_msg, Some(reply_to)).await;
                         }
@@ -1235,7 +1244,7 @@ async fn send_message(
     let display = truncate_for_telegram(text);
     let body = SendMessageRequest {
         chat_id,
-        text: &display,
+        text: &display.html,
         reply_to_message_id: reply_to,
         parse_mode: Some("HTML"),
     };
@@ -1271,16 +1280,15 @@ async fn edit_message(
     base_url: &str,
     chat_id: i64,
     message_id: i64,
-    text: &str,
+    html: &str,
 ) -> Result<(), String> {
-    if text.is_empty() {
+    if html.is_empty() {
         return Ok(());
     }
-    let html = markdown_to_telegram_html(text);
     let body = EditMessageRequest {
         chat_id,
         message_id,
-        text: &html,
+        text: html,
         parse_mode: Some("HTML"),
     };
 
@@ -1478,24 +1486,73 @@ pub fn markdown_to_telegram_html(text: &str) -> String {
     result
 }
 
-fn truncate_for_telegram(text: &str) -> String {
+struct TelegramRenderChunk {
+    html: String,
+    source_boundary: usize,
+}
+
+fn render_telegram_chunk(
+    text: &str,
+    max_chars: usize,
+    truncated_suffix: Option<&str>,
+) -> TelegramRenderChunk {
     let html = markdown_to_telegram_html(text);
-    if html.chars().count() <= 4096 {
-        html
-    } else {
-        let boundary = char_boundary_at(&html, 4090);
-        format!("{}...", &html[..boundary])
+    if html.chars().count() <= max_chars {
+        return TelegramRenderChunk {
+            html,
+            source_boundary: text.len(),
+        };
+    }
+
+    let suffix = truncated_suffix.unwrap_or("");
+    let suffix_chars = suffix.chars().count();
+    let available_chars = max_chars.saturating_sub(suffix_chars);
+    let total_chars = text.chars().count();
+    let mut low = 0usize;
+    let mut high = total_chars;
+    let mut best_chars = 0usize;
+
+    while low <= high {
+        let mid = (low + high) / 2;
+        let boundary = char_boundary_at(text, mid);
+        let candidate = markdown_to_telegram_html(&text[..boundary]);
+
+        if candidate.chars().count() <= available_chars {
+            best_chars = mid;
+            low = mid.saturating_add(1);
+        } else if mid == 0 {
+            break;
+        } else {
+            high = mid - 1;
+        }
+    }
+
+    let source_boundary = char_boundary_at(text, best_chars);
+    let mut html = markdown_to_telegram_html(&text[..source_boundary]);
+    html.push_str(suffix);
+
+    TelegramRenderChunk {
+        html,
+        source_boundary,
     }
 }
 
+fn truncate_for_telegram(text: &str) -> TelegramRenderChunk {
+    render_telegram_chunk(text, 4096, Some("..."))
+}
+
 /// Send overflow chunks (content beyond 4096 chars) as separate messages.
-async fn send_overflow_chunks(http: &Client, base_url: &str, chat_id: i64, text: &str) {
-    if text.chars().count() <= 4096 {
+async fn send_overflow_chunks(
+    http: &Client,
+    base_url: &str,
+    chat_id: i64,
+    text: &str,
+    source_boundary: usize,
+) {
+    if source_boundary >= text.len() {
         return;
     }
-    // The first 4096 chars were already sent via edit. Send the rest in chunks.
-    let boundary = char_boundary_at(text, 4090);
-    let rest = &text[boundary..];
+    let rest = &text[source_boundary..];
     if rest.is_empty() {
         return;
     }
@@ -1510,31 +1567,58 @@ async fn send_chunked_message(
     text: &str,
     reply_to: Option<i64>,
 ) -> Result<(), String> {
-    let max_chars = 4000;
-    if text.chars().count() <= max_chars {
-        send_message(http, base_url, chat_id, text, reply_to).await?;
-        return Ok(());
-    }
-
     let mut remaining = text;
     let mut first = true;
     while !remaining.is_empty() {
-        let boundary = {
-            let char_count = remaining.chars().count();
-            if char_count <= max_chars {
-                remaining.len()
-            } else {
-                char_boundary_at(remaining, max_chars)
-            }
-        };
-        let chunk = &remaining[..boundary];
-        remaining = &remaining[boundary..];
-
+        let rendered = render_telegram_chunk(remaining, 4096, None);
         let reply = if first { reply_to } else { None };
         first = false;
-        send_message(http, base_url, chat_id, chunk, reply).await?;
+        send_message(
+            http,
+            base_url,
+            chat_id,
+            &remaining[..rendered.source_boundary],
+            reply,
+        )
+        .await?;
+        remaining = &remaining[rendered.source_boundary..];
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{markdown_to_telegram_html, render_telegram_chunk, truncate_for_telegram};
+
+    #[test]
+    fn truncate_for_telegram_preserves_valid_html_boundaries() {
+        let text = "**bold** ".repeat(700);
+        let rendered = truncate_for_telegram(&text);
+
+        assert!(rendered.html.chars().count() <= 4096);
+        assert!(rendered.source_boundary < text.len());
+        assert!(
+            rendered.html.ends_with("...</b>...")
+                || rendered.html.ends_with("</b>...")
+                || rendered.html.ends_with("...")
+        );
+        assert!(!rendered.html.contains("&lt;b&gt;"));
+    }
+
+    #[test]
+    fn render_chunk_tracks_consumed_source_before_html_limit() {
+        let text = "[label](https://example.com) ".repeat(300);
+        let rendered = render_telegram_chunk(&text, 4096, None);
+        let full_html = markdown_to_telegram_html(&text);
+
+        assert!(rendered.html.chars().count() <= 4096);
+        assert!(rendered.source_boundary < text.len());
+        assert!(full_html.chars().count() > 4096);
+        assert_eq!(
+            rendered.html,
+            markdown_to_telegram_html(&text[..rendered.source_boundary])
+        );
+    }
 }
 
 /// Fetch the bot's username via getMe.

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1237,6 +1237,8 @@ async fn send_file_to_telegram(
 
 /// Public API for sending a text message to a Telegram chat.
 /// Handles markdown-to-HTML conversion and chunking for long messages.
+/// Public API for sending a text message to a Telegram chat.
+/// Handles markdown-to-HTML conversion and chunking for long messages.
 pub async fn send_telegram_text(
     http: &Client,
     base_url: &str,
@@ -1244,16 +1246,15 @@ pub async fn send_telegram_text(
     text: &str,
     reply_to: Option<i64>,
 ) -> Result<i64, String> {
-    let msg_id = send_message(http, base_url, chat_id, text, reply_to).await?;
-    // Send overflow chunks for content beyond the first 4096 chars
     let display = truncate_for_telegram(text);
+    let msg_id = send_message_html(http, base_url, chat_id, &display.html, reply_to).await?;
     if display.source_boundary < text.len() {
         send_overflow_chunks(http, base_url, chat_id, text, display.source_boundary).await;
     }
     Ok(msg_id)
 }
 
-/// Send a message and return the message_id.
+/// Send a message and return the message_id. Truncates to first 4096 HTML chars.
 async fn send_message(
     http: &Client,
     base_url: &str,
@@ -1262,9 +1263,20 @@ async fn send_message(
     reply_to: Option<i64>,
 ) -> Result<i64, String> {
     let display = truncate_for_telegram(text);
+    send_message_html(http, base_url, chat_id, &display.html, reply_to).await
+}
+
+/// Send pre-rendered HTML text.
+async fn send_message_html(
+    http: &Client,
+    base_url: &str,
+    chat_id: i64,
+    html: &str,
+    reply_to: Option<i64>,
+) -> Result<i64, String> {
     let body = SendMessageRequest {
         chat_id,
-        text: &display.html,
+        text: html,
         reply_to_message_id: reply_to,
         parse_mode: Some("HTML"),
     };
@@ -1469,11 +1481,20 @@ pub fn markdown_to_telegram_html(text: &str) -> String {
                         if chars.peek() == Some(&'(') {
                             chars.next();
                             let mut url = String::new();
+                            let mut paren_depth = 1u32;
                             while let Some(c) = chars.next() {
-                                if c == ')' {
-                                    break;
+                                if c == '(' {
+                                    paren_depth += 1;
+                                    url.push(c);
+                                } else if c == ')' {
+                                    paren_depth -= 1;
+                                    if paren_depth == 0 {
+                                        break;
+                                    }
+                                    url.push(c);
+                                } else {
+                                    url.push(c);
                                 }
-                                url.push(c);
                             }
                             result.push_str("<a href=\"");
                             result.push_str(&url.replace('"', "&quot;"));

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -980,7 +980,13 @@ pub async fn stream_response(
                             if last_edit.elapsed() >= edit_interval {
                                 // Throttled edit
                                 let display = truncate_for_telegram(&accumulated_text);
-                                let _ = edit_message(http, &base_url, chat_id, msg_id, &display).await;
+                                if let Err(e) = edit_message(http, &base_url, chat_id, msg_id, &display).await {
+                                    tracing::warn!(
+                                        mission_id = %mission_id,
+                                        "Failed to edit Telegram message during streaming: {}",
+                                        e
+                                    );
+                                }
                                 last_edit = tokio::time::Instant::now();
                             }
                         } else {
@@ -1007,7 +1013,15 @@ pub async fn stream_response(
                         if let Some(msg_id) = sent_message_id {
                             // Edit existing message with final content
                             let display = truncate_for_telegram(&content);
-                            let _ = edit_message(http, &base_url, chat_id, msg_id, &display).await;
+                            if let Err(e) = edit_message(http, &base_url, chat_id, msg_id, &display).await {
+                                tracing::warn!(
+                                    mission_id = %mission_id,
+                                    "Failed to edit Telegram message with final response, sending as new message: {}",
+                                    e
+                                );
+                                // Fallback: send as a new message if edit fails
+                                let _ = send_chunked_message(http, &base_url, chat_id, &content, None).await;
+                            }
                             // If content exceeds 4096 chars, send overflow as new messages
                             send_overflow_chunks(http, &base_url, chat_id, &content).await;
                         } else {

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1236,7 +1236,7 @@ async fn send_file_to_telegram(
 }
 
 /// Public API for sending a text message to a Telegram chat.
-/// Handles markdown-to-HTML conversion, truncation, and chunking for long messages.
+/// Handles markdown-to-HTML conversion and chunking for long messages.
 pub async fn send_telegram_text(
     http: &Client,
     base_url: &str,
@@ -1244,7 +1244,13 @@ pub async fn send_telegram_text(
     text: &str,
     reply_to: Option<i64>,
 ) -> Result<i64, String> {
-    send_message(http, base_url, chat_id, text, reply_to).await
+    let msg_id = send_message(http, base_url, chat_id, text, reply_to).await?;
+    // Send overflow chunks for content beyond the first 4096 chars
+    let display = truncate_for_telegram(text);
+    if display.source_boundary < text.len() {
+        send_overflow_chunks(http, base_url, chat_id, text, display.source_boundary).await;
+    }
+    Ok(msg_id)
 }
 
 /// Send a message and return the message_id.

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1022,18 +1022,20 @@ pub async fn stream_response(
                                     "Failed to edit Telegram message with final response, sending as new message: {}",
                                     e
                                 );
-                                // Fallback: send as a new message if edit fails
+                                // Fallback: send entire content as new chunked messages.
+                                // Skip overflow below since chunked send handles the full content.
                                 let _ = send_chunked_message(http, &base_url, chat_id, &content, None).await;
+                            } else {
+                                // Edit succeeded — send overflow chunks for content beyond the first 4096 chars
+                                send_overflow_chunks(
+                                    http,
+                                    &base_url,
+                                    chat_id,
+                                    &content,
+                                    display.source_boundary,
+                                )
+                                .await;
                             }
-                            // If content exceeds 4096 chars, send overflow as new messages
-                            send_overflow_chunks(
-                                http,
-                                &base_url,
-                                chat_id,
-                                &content,
-                                display.source_boundary,
-                            )
-                            .await;
                         } else {
                             // No streaming happened, send the full response directly
                             send_chunked_message(http, &base_url, chat_id, &content, Some(reply_to)).await?;
@@ -1231,6 +1233,18 @@ async fn send_file_to_telegram(
 
     tracing::info!("Sent file {} to Telegram chat {}", file.name, chat_id);
     Ok(())
+}
+
+/// Public API for sending a text message to a Telegram chat.
+/// Handles markdown-to-HTML conversion, truncation, and chunking for long messages.
+pub async fn send_telegram_text(
+    http: &Client,
+    base_url: &str,
+    chat_id: i64,
+    text: &str,
+    reply_to: Option<i64>,
+) -> Result<i64, String> {
+    send_message(http, base_url, chat_id, text, reply_to).await
 }
 
 /// Send a message and return the message_id.
@@ -1456,7 +1470,7 @@ pub fn markdown_to_telegram_html(text: &str) -> String {
                                 url.push(c);
                             }
                             result.push_str("<a href=\"");
-                            result.push_str(&url);
+                            result.push_str(&url.replace('"', "&quot;"));
                             result.push_str("\">");
                             result.push_str(&link_text);
                             result.push_str("</a>");

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -1313,12 +1313,60 @@ fn char_boundary_at(text: &str, max_chars: usize) -> usize {
 }
 
 /// Truncate text to fit Telegram's 4096 character limit.
+/// Strip common markdown syntax that looks ugly in plain Telegram messages.
+fn strip_markdown_for_telegram(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            // Strip **bold** and *italic* markers
+            '*' => {
+                if chars.peek() == Some(&'*') {
+                    chars.next(); // consume second *
+                } // drop the asterisk(s)
+            }
+            // Strip `code` and ```code blocks``` backticks
+            '`' => {
+                if chars.peek() == Some(&'`') {
+                    chars.next();
+                    if chars.peek() == Some(&'`') {
+                        chars.next();
+                        // Skip optional language tag after ```
+                        while chars.peek().map(|c| *c != '\n').unwrap_or(false) {
+                            chars.next();
+                        }
+                    }
+                } // drop backtick(s)
+            }
+            // Strip markdown headers: lines starting with # or ##
+            '#' if result.ends_with('\n') || result.is_empty() => {
+                while chars.peek() == Some(&'#') {
+                    chars.next();
+                }
+                // Skip the space after ###
+                if chars.peek() == Some(&' ') {
+                    chars.next();
+                }
+            }
+            // Replace "- " bullet lists at start of line with "  "
+            '-' if (result.ends_with('\n') || result.is_empty()) && chars.peek() == Some(&' ') => {
+                result.push_str("  ");
+                chars.next(); // consume the space
+            }
+            _ => result.push(ch),
+        }
+    }
+    result
+}
+
 fn truncate_for_telegram(text: &str) -> String {
-    if text.chars().count() <= 4096 {
-        text.to_string()
+    let cleaned = strip_markdown_for_telegram(text);
+    if cleaned.chars().count() <= 4096 {
+        cleaned
     } else {
-        let boundary = char_boundary_at(text, 4090);
-        format!("{}...", &text[..boundary])
+        let boundary = char_boundary_at(&cleaned, 4090);
+        format!("{}...", &cleaned[..boundary])
     }
 }
 

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -321,6 +321,8 @@ struct EditMessageRequest<'a> {
     chat_id: i64,
     message_id: i64,
     text: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parse_mode: Option<&'a str>,
 }
 
 /// Response from the Telegram `getFile` API.
@@ -1235,7 +1237,7 @@ async fn send_message(
         chat_id,
         text: &display,
         reply_to_message_id: reply_to,
-        parse_mode: None,
+        parse_mode: Some("HTML"),
     };
 
     let url = format!("{}/sendMessage", base_url);
@@ -1274,10 +1276,12 @@ async fn edit_message(
     if text.is_empty() {
         return Ok(());
     }
+    let html = markdown_to_telegram_html(text);
     let body = EditMessageRequest {
         chat_id,
         message_id,
-        text,
+        text: &html,
+        parse_mode: Some("HTML"),
     };
 
     let url = format!("{}/editMessageText", base_url);
@@ -1313,60 +1317,174 @@ fn char_boundary_at(text: &str, max_chars: usize) -> usize {
 }
 
 /// Truncate text to fit Telegram's 4096 character limit.
-/// Strip common markdown syntax that looks ugly in plain Telegram messages.
-fn strip_markdown_for_telegram(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut chars = text.chars().peekable();
+/// Convert markdown to Telegram HTML for rich rendering.
+/// Handles **bold**, *italic*, `code`, ```blocks```, # headers, [links](url).
+pub fn markdown_to_telegram_html(text: &str) -> String {
+    // Escape HTML special chars first
+    let escaped = text
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+
+    let mut result = String::with_capacity(escaped.len());
+    let mut chars = escaped.chars().peekable();
+    let mut at_line_start = true;
 
     while let Some(ch) = chars.next() {
         match ch {
-            // Strip **bold** and *italic* markers
-            '*' => {
-                if chars.peek() == Some(&'*') {
-                    chars.next(); // consume second *
-                } // drop the asterisk(s)
+            '*' if chars.peek() == Some(&'*') => {
+                chars.next();
+                let mut content = String::new();
+                while let Some(c) = chars.next() {
+                    if c == '*' && chars.peek() == Some(&'*') {
+                        chars.next();
+                        break;
+                    }
+                    content.push(c);
+                }
+                result.push_str("<b>");
+                result.push_str(&content);
+                result.push_str("</b>");
+                at_line_start = false;
             }
-            // Strip `code` and ```code blocks``` backticks
-            '`' => {
+            '*' => {
+                let mut content = String::new();
+                while let Some(c) = chars.next() {
+                    if c == '*' {
+                        break;
+                    }
+                    content.push(c);
+                }
+                if content.is_empty() {
+                    result.push('*');
+                } else {
+                    result.push_str("<i>");
+                    result.push_str(&content);
+                    result.push_str("</i>");
+                }
+                at_line_start = false;
+            }
+            '`' if chars.peek() == Some(&'`') => {
+                chars.next();
                 if chars.peek() == Some(&'`') {
                     chars.next();
-                    if chars.peek() == Some(&'`') {
+                    // Skip language tag
+                    while chars.peek().map(|c| *c != '\n').unwrap_or(false) {
                         chars.next();
-                        // Skip optional language tag after ```
-                        while chars.peek().map(|c| *c != '\n').unwrap_or(false) {
-                            chars.next();
-                        }
                     }
-                } // drop backtick(s)
+                    if chars.peek() == Some(&'\n') {
+                        chars.next();
+                    }
+                    let mut code = String::new();
+                    while let Some(c) = chars.next() {
+                        if c == '`' && chars.peek() == Some(&'`') {
+                            chars.next();
+                            if chars.peek() == Some(&'`') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                        code.push(c);
+                    }
+                    result.push_str("<pre>");
+                    result.push_str(code.trim_end());
+                    result.push_str("</pre>");
+                } else {
+                    let mut code = String::new();
+                    while let Some(c) = chars.next() {
+                        if c == '`' && chars.peek() == Some(&'`') {
+                            chars.next();
+                            break;
+                        }
+                        code.push(c);
+                    }
+                    result.push_str("<code>");
+                    result.push_str(&code);
+                    result.push_str("</code>");
+                }
+                at_line_start = false;
             }
-            // Strip markdown headers: lines starting with # or ##
-            '#' if result.ends_with('\n') || result.is_empty() => {
+            '`' => {
+                let mut code = String::new();
+                while let Some(c) = chars.next() {
+                    if c == '`' {
+                        break;
+                    }
+                    code.push(c);
+                }
+                result.push_str("<code>");
+                result.push_str(&code);
+                result.push_str("</code>");
+                at_line_start = false;
+            }
+            '#' if at_line_start => {
                 while chars.peek() == Some(&'#') {
                     chars.next();
                 }
-                // Skip the space after ###
                 if chars.peek() == Some(&' ') {
                     chars.next();
                 }
+                let mut header = String::new();
+                while chars.peek().map(|c| *c != '\n').unwrap_or(false) {
+                    header.push(chars.next().unwrap());
+                }
+                result.push_str("<b>");
+                result.push_str(&header);
+                result.push_str("</b>");
+                at_line_start = false;
             }
-            // Replace "- " bullet lists at start of line with "  "
-            '-' if (result.ends_with('\n') || result.is_empty()) && chars.peek() == Some(&' ') => {
-                result.push_str("  ");
-                chars.next(); // consume the space
+            '[' => {
+                let mut link_text = String::new();
+                let mut found_link = false;
+                while let Some(c) = chars.next() {
+                    if c == ']' {
+                        if chars.peek() == Some(&'(') {
+                            chars.next();
+                            let mut url = String::new();
+                            while let Some(c) = chars.next() {
+                                if c == ')' {
+                                    break;
+                                }
+                                url.push(c);
+                            }
+                            result.push_str("<a href=\"");
+                            result.push_str(&url);
+                            result.push_str("\">");
+                            result.push_str(&link_text);
+                            result.push_str("</a>");
+                            found_link = true;
+                        }
+                        break;
+                    }
+                    link_text.push(c);
+                }
+                if !found_link {
+                    result.push('[');
+                    result.push_str(&link_text);
+                    result.push(']');
+                }
+                at_line_start = false;
             }
-            _ => result.push(ch),
+            '\n' => {
+                result.push('\n');
+                at_line_start = true;
+            }
+            _ => {
+                result.push(ch);
+                at_line_start = false;
+            }
         }
     }
     result
 }
 
 fn truncate_for_telegram(text: &str) -> String {
-    let cleaned = strip_markdown_for_telegram(text);
-    if cleaned.chars().count() <= 4096 {
-        cleaned
+    let html = markdown_to_telegram_html(text);
+    if html.chars().count() <= 4096 {
+        html
     } else {
-        let boundary = char_boundary_at(&cleaned, 4090);
-        format!("{}...", &cleaned[..boundary])
+        let boundary = char_boundary_at(&html, 4090);
+        format!("{}...", &html[..boundary])
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `POST /api/control/telegram/send` endpoint for agents to proactively send messages to any Telegram chat
- Convert markdown to Telegram HTML (bold, italic, code, pre, links) instead of stripping it
- Add server-side markdown-to-HTML conversion for all outgoing Telegram messages (`parse_mode: HTML`)
- Store non-trigger group chat messages as context in mission history
- Security: outbound file path traversal fix, download size cap, env var key sanitization
- Fix Claude Code "produced no output" when text arrives via streaming deltas only
- Fix opencode multi-step execution (step_finish reason check in both stdout and SSE parsers)

## Test plan
- [x] Telegram HTML rendering verified (bold, italic, code, links render correctly)
- [x] Send API tested — messages delivered to Thomas's private chat
- [x] Ana agent tested via webhook simulation — multi-step tool use works
- [x] Group chat context storage verified
- [x] `cargo check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated control API that can message arbitrary Telegram chats and changes Telegram message rendering/chunking behavior; also tweaks OpenCode step completion logic, which could affect mission termination/streaming in edge cases.
> 
> **Overview**
> Adds `POST /api/control/telegram/send`, letting authenticated clients/agents send bot messages to a specified Telegram `chat_id`, optionally selecting a bot channel and optionally dispatching the same text into the mapped mission as a `UserMessage`.
> 
> Updates Telegram outbound messaging to render markdown as Telegram `parse_mode: HTML` (basic bold/italic/code/pre/links), and reworks truncation/chunking so long messages are split based on rendered HTML length with overflow sent as additional messages (with fallback behavior when edits fail).
> 
> Adjusts OpenCode stdout JSON handling to avoid double-processing events via the SSE parser and adds a hard cap on consecutive tool-call `step_finish` events to prevent runaway loops from never completing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df4ea8685f3e0008db7d91123006c58b9371a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->