### PR TITLE
fix: prevent noisy retry loops on transient auth/rate-limit failures

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -7636,11 +7636,21 @@ async fn control_actor_loop(
                     }
 
                     // If the mission is idle now, enqueue any agent_finished automations after a short delay.
+                    // Skip automations for transient infrastructure failures (auth errors,
+                    // rate limits, capacity limits) — these aren't "the agent finished work",
+                    // they're transient failures that the retry/recovery logic handles.
+                    // Firing automations on these creates noisy retry loops.
                     if let Some(mission_id) = completed_mission_id {
+                        let is_transient_infra_failure = matches!(
+                            completed_terminal_reason,
+                            Some(TerminalReason::AuthError)
+                                | Some(TerminalReason::RateLimited)
+                                | Some(TerminalReason::CapacityLimited)
+                        );
                         let already_queued_for_mission = queue
                             .iter()
                             .any(|(_id, _msg, _agent, target_mid)| *target_mid == Some(mission_id));
-                        if !already_queued_for_mission {
+                        if !already_queued_for_mission && !is_transient_infra_failure {
                             // Small delay so the UI can display the completion before restarting.
                             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                             let messages = agent_finished_automation_messages(
@@ -7887,9 +7897,17 @@ async fn control_actor_loop(
                             )
                             .await;
 
-                            // Check if we should enqueue agent_finished automations
+                            // Check if we should enqueue agent_finished automations.
+                            // Skip for transient infrastructure failures (auth, rate limit,
+                            // capacity) to avoid noisy retry loops.
+                            let is_transient_infra_failure = matches!(
+                                result.terminal_reason,
+                                Some(TerminalReason::AuthError)
+                                    | Some(TerminalReason::RateLimited)
+                                    | Some(TerminalReason::CapacityLimited)
+                            );
                             let was_queue_empty = runner.queue.is_empty();
-                            if was_queue_empty {
+                            if was_queue_empty && !is_transient_infra_failure {
                                 // Small delay so the UI can display the completion before restarting.
                                 tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                                 let messages = agent_finished_automation_messages(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2331,6 +2331,32 @@ async fn run_mission_turn(
                 }
             }
 
+            // Proactive auth refresh for SIGKILL'd processes: when Claude Code is
+            // killed mid-turn (signal: Killed, no terminal result), the cause is often
+            // an expired OAuth token that caused Node.js to crash. Even if we can't
+            // detect "auth error" in the output, preemptively refresh credentials so
+            // the transport recovery retry (above) uses fresh tokens. This is cheap
+            // (just a token validity check) and prevents cascading auth failures.
+            if !cancel.is_cancelled()
+                && result.terminal_reason == Some(TerminalReason::LlmError)
+                && result.output.contains("signal: Some(\"Killed\")")
+            {
+                tracing::info!(
+                    mission_id = %mission_id,
+                    "SIGKILL detected — preemptively refreshing OAuth credentials"
+                );
+                let mission_creds = mission_work_dir.join(".claude").join(".credentials.json");
+                if mission_creds.exists() {
+                    let _ = std::fs::remove_file(&mission_creds);
+                }
+                if let Err(e) = super::ai_providers::force_refresh_anthropic_oauth_token().await {
+                    tracing::debug!(
+                        "Preemptive OAuth refresh after SIGKILL failed (non-fatal): {}",
+                        e
+                    );
+                }
+            }
+
             // Auth error recovery: if the token was revoked server-side but the
             // local expiry hadn't passed yet, invalidate stale credentials, force
             // an OAuth refresh, and retry once.
@@ -4634,9 +4660,19 @@ pub fn run_claudecode_turn<'a>(
             // We check for specific Anthropic error types and HTTP status codes.
             // Using "overloaded_error" rather than bare "overloaded" to avoid
             // false positives from tool output or user content.
-            let reason = if is_rate_limited_error(&final_result) {
+            //
+            // Check both the final result text and non-JSON output (stderr) for
+            // auth/rate-limit markers. When Claude Code is SIGKILL'd mid-turn, the
+            // final_result is a generic "did not emit terminal result" message, but
+            // stderr may contain the actual auth error from the Anthropic API.
+            let combined_for_detection = if non_json_output.is_empty() {
+                final_result.clone()
+            } else {
+                format!("{}\n{}", final_result, non_json_output.join("\n"))
+            };
+            let reason = if is_rate_limited_error(&combined_for_detection) {
                 TerminalReason::RateLimited
-            } else if is_auth_error(&final_result) {
+            } else if is_auth_error(&combined_for_detection) {
                 TerminalReason::AuthError
             } else {
                 TerminalReason::LlmError


### PR DESCRIPTION
## Summary

- **Skip `agent_finished` automations on transient failures**: When a turn ends with `AuthError`, `RateLimited`, or `CapacityLimited`, don't fire automations. This prevents the loop where the automation re-sends the same message on each auth failure (observed: 3 user_message + 3 failed assistant_message pairs in quick succession).
- **Check stderr for auth/rate-limit markers**: When classifying errors, also scan non-JSON output (stderr). When Claude Code is SIGKILL'd mid-turn, the final_result is a generic transport failure message, but stderr may contain the actual auth error.
- **Preemptive auth refresh on SIGKILL**: When Claude Code is SIGKILL'd mid-turn (common when auth tokens expire during API calls), proactively refresh OAuth credentials before the transport recovery retry.

## Context

Observed on production: an Anthropic OAuth token expiry caused mission `ea330a9a` to get 3x "Invalid authentication credentials" errors in quick succession (agent_finished automation kept re-queuing the same message), and mission `021d8368` to get SIGKILL'd mid-turn while spawning 3 subagent Tasks.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all` applied
- [x] All 149 mission_runner tests pass
- [ ] Deploy to dev and verify auth error recovery doesn't trigger automation loops
- [ ] Verify SIGKILL'd processes get preemptive credential refresh in logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission completion automation triggering and error classification/credential refresh paths; mistakes could suppress legitimate automations or cause extra retries/credential invalidation during failures.
> 
> **Overview**
> Prevents noisy retry loops by **skipping `agent_finished` automations** when a mission/turn ends in transient infrastructure failures (`AuthError`, `RateLimited`, `CapacityLimited`) in both the main and parallel mission runners (`control.rs`).
> 
> Hardens Claude Code failure handling in `mission_runner.rs` by **classifying auth/rate-limit errors using combined stdout + stderr** (to catch SIGKILL/incomplete-turn cases) and by **proactively invalidating per-mission credentials + forcing an OAuth refresh** when a turn appears SIGKILL’d before transport retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d59201ee194a3e37e16d6d7bfb81855e23e213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->