### PR TITLE
fix: fall through to OAuth when CLI credentials are expired

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3520,16 +3520,39 @@ pub fn run_claudecode_turn<'a>(
                 }
             }
         }
-        let has_cli_creds = looks_like_claude_cli_credentials(&mission_creds_path);
+        let mut has_cli_creds = looks_like_claude_cli_credentials(&mission_creds_path);
         if let Some((expires_at, has_refresh)) = claude_cli_credentials_info(&mission_creds_path) {
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            let is_expired = expires_at < now_ms;
             tracing::info!(
                 mission_id = %mission_id,
                 path = %mission_creds_path.display(),
                 expires_at = expires_at,
                 has_refresh = has_refresh,
                 has_cli_creds = has_cli_creds,
+                is_expired = is_expired,
                 "Claude CLI credential status for mission"
             );
+            // If credentials are expired even after the copy/refresh attempt,
+            // don't trust them — fall through to OAuth injection instead.
+            if is_expired {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    expires_at = expires_at,
+                    now_ms = now_ms,
+                    "Mission CLI credentials are expired; removing stale file and falling through to OAuth refresh"
+                );
+                has_cli_creds = false;
+                // Remove the stale file so Claude Code doesn't pick it up
+                // and fail with "Invalid authentication credentials".
+                if let Err(e) = std::fs::remove_file(&mission_creds_path) {
+                    tracing::debug!(
+                        mission_id = %mission_id,
+                        error = %e,
+                        "Failed to remove expired credentials file (may not exist)"
+                    );
+                }
+            }
         } else {
             tracing::info!(
                 mission_id = %mission_id,


### PR DESCRIPTION
## Summary
- When a mission workspace has a `.credentials.json` from a previous run but the token has expired, the system would still trust it (`has_cli_creds=true`) and skip OAuth injection
- Claude Code would then use the expired token and fail with "Invalid authentication credentials"
- Now checks token expiry after the copy/refresh attempt; if expired, removes the stale file and falls through to the OAuth injection path

## Root cause
The `needs_copy` logic correctly detects expired tokens and tries to re-copy from host credentials. But when no host credentials exist (common when auth is managed via OAuth providers, not `claude login`), the copy is skipped and the stale expired token persists. The `has_cli_creds` flag remains `true` because the file exists, so the OAuth path is never tried.

## Test plan
- [x] Verified on prod server: mission `9b413dc4` had this exact failure pattern
- [x] Already deployed the earlier bun-symlink fix; this auth fix needs separate deploy
- [ ] Create a mission with an expired credentials file and verify it falls through to OAuth

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential-selection logic for missions and adds deletion of expired `.credentials.json`, which could affect authentication behavior if expiry detection is wrong or filesystem operations fail in edge cases.
> 
> **Overview**
> Prevents missions from trusting stale Claude CLI credentials: after any copy/refresh attempt, the runner now checks `expires_at` from the mission `.credentials.json`, logs an `is_expired` flag, and if expired forces `has_cli_creds=false`.
> 
> When expired credentials are detected, it removes the stale credentials file so Claude Code won’t pick it up, allowing the flow to fall through to the existing OAuth token injection/refresh path instead of failing with invalid credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9940c2994040e437806799e8cc3394f0782623e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->