### PR TITLE
fix: prevent recursive symlink ELOOP in Host workspaces

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3882,48 +3882,52 @@ pub async fn write_runtime_workspace_state(
     }
     let context_link = working_dir.join(context_dir_name);
     if let Some(target) = mission_context.as_ref() {
-        // Use symlink_metadata to avoid following symlinks (prevents ELOOP errors)
-        if tokio::fs::symlink_metadata(&context_link).await.is_ok()
-            && tokio::fs::remove_file(&context_link).await.is_err()
-        {
-            if let Err(e) = tokio::fs::remove_dir_all(&context_link).await {
-                tracing::warn!(
-                    workspace = %workspace.name,
-                    mission = ?mission_id,
-                    error = %e,
-                    "Failed to clear existing context link"
-                );
+        if context_link != context_root {
+            // Use symlink_metadata to avoid following symlinks (prevents ELOOP errors)
+            if tokio::fs::symlink_metadata(&context_link).await.is_ok()
+                && tokio::fs::remove_file(&context_link).await.is_err()
+            {
+                if let Err(e) = tokio::fs::remove_dir_all(&context_link).await {
+                    tracing::warn!(
+                        workspace = %workspace.name,
+                        mission = ?mission_id,
+                        error = %e,
+                        "Failed to clear existing context link"
+                    );
+                }
             }
-        }
-        #[cfg(unix)]
-        {
-            // For container workspaces, the symlink must point to the container path
-            // since /root/context is bind-mounted, not the host path
-            let symlink_target = if workspace.workspace_type == WorkspaceType::Container {
-                // mission_id is guaranteed Some here because we're inside
-                // `if let Some(target) = mission_context.as_ref()` and
-                // mission_context is derived from mission_id.map(...)
-                PathBuf::from("/root").join(context_dir_name).join(
-                    mission_id
-                        .expect("mission_id must be Some inside mission_context block")
-                        .to_string(),
-                )
-            } else {
-                target.clone()
-            };
-            if let Err(e) = std::os::unix::fs::symlink(&symlink_target, &context_link) {
-                tracing::warn!(
-                    workspace = %workspace.name,
-                    mission = ?mission_id,
-                    error = %e,
-                    "Failed to create context symlink; falling back to directory"
-                );
+            #[cfg(unix)]
+            {
+                // For container workspaces, the symlink must point to the container path
+                // since /root/context is bind-mounted, not the host path
+                let symlink_target = if workspace.workspace_type == WorkspaceType::Container {
+                    // mission_id is guaranteed Some here because we're inside
+                    // `if let Some(target) = mission_context.as_ref()` and
+                    // mission_context is derived from mission_id.map(...)
+                    PathBuf::from("/root").join(context_dir_name).join(
+                        mission_id
+                            .expect("mission_id must be Some inside mission_context block")
+                            .to_string(),
+                    )
+                } else {
+                    target.clone()
+                };
+                if let Err(e) = std::os::unix::fs::symlink(&symlink_target, &context_link) {
+                    tracing::warn!(
+                        workspace = %workspace.name,
+                        mission = ?mission_id,
+                        error = %e,
+                        "Failed to create context symlink; falling back to directory"
+                    );
+                    let _ = tokio::fs::create_dir_all(&context_link).await;
+                }
+            }
+            #[cfg(not(unix))]
+            {
                 let _ = tokio::fs::create_dir_all(&context_link).await;
             }
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = tokio::fs::create_dir_all(&context_link).await;
+        } else {
+            tracing::debug!("Skipping context symlink creation; workspace directory is root.");
         }
     }
 


### PR DESCRIPTION
This PR fixes the root cause of the recursive symlink issue (`Too many levels of symbolic links (os error 40)`) that was partially mitigated in #355 and #360. 

While the previous PRs successfully added garbage collection for ELOOP issues in `fs.rs` when executing `list()`, the underlying bug remained active in `src/workspace.rs` when starting an agent using the **Host Workspace** mode. 

### RCA (Root Cause Analysis)

When `WorkspaceType::Host` is used, the base `working_dir` is `/root`. 
Hence, `context_root` naturally resolves to `/root/context`.
1. The backend automatically creates `/root/context/<mission_id>` effectively creating the `/root/context` directory.
2. The legacy logic tried to create `context_link` (`/root/context`) by attempting to symlink it against `/root/context/<mission_id>`. 
3. Encountering an existing `/root/context` directory, it issued a `remove_dir_all` over it, completely obliterating the `mission_context` entirely.
4. Then it proceeded to recreate a recursive symlink `context` pointing into its own absent child, throwing the kernel into an infinite ELOOP on access.

### Fix
This PR implements a strict safety rail check `if context_link != context_root` around the symlink generation flow. In Host Workspaces, this creates an early exit. The agent continues functioning flawlessly dynamically referencing the workspace root, while averting the obliteration of the overarching structure.

## Testing done
- [x] Tested Host Workspace mission initiation.
- [x] Verified that `/root/context` retains its integrity as a standard directory holding active missions.
- [x] Validated that `WorkspaceType::Container` logic remains entirely unaffected as its `working_dir` properly encapsulates subdirectories (`/root/workspaces/mission-id`).
