### PR TITLE
fix(control): don't cancel pending tool calls on `completed` mission status

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6342,15 +6342,34 @@ export default function ControlClient() {
           }
         }
 
-        // When mission is no longer active, mark all pending tool calls as cancelled
+        // When the mission leaves the running state, finalize any
+        // in-flight side-panel items so they don't stay stuck
+        // "thinking". For tool calls we only cancel when the turn
+        // ended unexpectedly (interrupted / failed / blocked /
+        // not_feasible) — a normal `completed` means an
+        // assistant_message was produced, so any truly-pending
+        // tool_result will arrive over SSE shortly and the
+        // tool_result handler will fill it in. Pre-cancelling on
+        // `completed` wrongly flips sub-agents (Task / orchestrator
+        // workers) to a cancelled state that then persists across
+        // subsequent user messages.
         if (newStatus !== "active") {
           const now = Date.now();
+          const shouldCancelPendingTools =
+            newStatus === "interrupted" ||
+            newStatus === "failed" ||
+            newStatus === "blocked" ||
+            newStatus === "not_feasible";
           setItems((prev) =>
             prev.map((item) => {
               if ((item.kind === "thinking" || item.kind === "stream") && !item.done) {
                 return { ...item, done: true, endTime: now };
               }
-              if (item.kind === "tool" && item.result === undefined) {
+              if (
+                shouldCancelPendingTools &&
+                item.kind === "tool" &&
+                item.result === undefined
+              ) {
                 return {
                   ...item,
                   result: { status: "cancelled", reason: `Mission ${newStatus}` },


### PR DESCRIPTION
## Summary

On the control page, any `mission_status_changed` to a non-active status (completed, interrupted, failed, blocked, not_feasible) was marking every in-flight tool call as `{ status: "cancelled" }`. That's right for the "turn ended unexpectedly" statuses, but wrong for **completed** — a normal turn finish means an assistant_message was produced, so any outstanding `tool_result` will arrive over SSE shortly and the existing `tool_result` handler will fill it in correctly.

Pre-cancelling on `completed` had two user-visible consequences:

1. Task / orchestrator sub-agents could be flipped to the cancelled pill before their real result landed.
2. The cancelled state then persisted on those items across subsequent user messages, so **workers that had genuinely completed in a previous turn visually appeared stopped** after the user sent a new one — which is what prompted this fix.

Narrowed the cancellation to the four "turn ended unexpectedly" statuses. Side-panel `thinking` / `stream` items still get their `done` flag flipped on any non-active transition so the side panel doesn't hang.

## Test plan

- [x] `bun run test:unit` — 137/137 pass
- [x] `bun run tsc --noEmit` — clean
- [ ] Manually: on a mission with completed Task sub-agents, send a new user message; previously-completed sub-agents stay "completed" in the SubagentsPanel and the inline chat throughout the new turn and after it ends.
- [ ] Manually: interrupt a mission mid-Task and confirm the pending Task row still flips to "cancelled".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that only tweaks how pending tool calls are finalized on mission status transitions; main risk is incorrectly leaving tool items pending for unexpected statuses if the status set changes.
> 
> **Overview**
> Prevents the control side panel from pre-emptively marking in-flight tool calls as `cancelled` when a mission transitions to `completed`.
> 
> On `mission_status_changed`, non-active transitions still finalize `thinking`/`stream` items, but tool-call cancellation is now limited to unexpected terminal statuses (`interrupted`, `failed`, `blocked`, `not_feasible`) so late-arriving `tool_result` events can populate results normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde5e19ecf58390d238ebf71ebf01b04d79eaa6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->