### PR TITLE
revert: PR #390 — codex flagged a MCP-desktop-tool regression

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6342,34 +6342,15 @@ export default function ControlClient() {
           }
         }
 
-        // When the mission leaves the running state, finalize any
-        // in-flight side-panel items so they don't stay stuck
-        // "thinking". For tool calls we only cancel when the turn
-        // ended unexpectedly (interrupted / failed / blocked /
-        // not_feasible) — a normal `completed` means an
-        // assistant_message was produced, so any truly-pending
-        // tool_result will arrive over SSE shortly and the
-        // tool_result handler will fill it in. Pre-cancelling on
-        // `completed` wrongly flips sub-agents (Task / orchestrator
-        // workers) to a cancelled state that then persists across
-        // subsequent user messages.
+        // When mission is no longer active, mark all pending tool calls as cancelled
         if (newStatus !== "active") {
           const now = Date.now();
-          const shouldCancelPendingTools =
-            newStatus === "interrupted" ||
-            newStatus === "failed" ||
-            newStatus === "blocked" ||
-            newStatus === "not_feasible";
           setItems((prev) =>
             prev.map((item) => {
               if ((item.kind === "thinking" || item.kind === "stream") && !item.done) {
                 return { ...item, done: true, endTime: now };
               }
-              if (
-                shouldCancelPendingTools &&
-                item.kind === "tool" &&
-                item.result === undefined
-              ) {
+              if (item.kind === "tool" && item.result === undefined) {
                 return {
                   ...item,
                   result: { status: "cancelled", reason: `Mission ${newStatus}` },


### PR DESCRIPTION
Reverts #390.

## Why

codex-connector flagged the #390 change as a P1 regression on the merged PR:

> Limiting \`shouldCancelPendingTools\` to only \`interrupted|failed|blocked|not_feasible\` leaves \`tool\` items with \`result === undefined\` permanently running when a mission ends as \`completed\`. In this file, the \`tool_call\` path explicitly handles tools that may never emit a \`tool_result\` (e.g. MCP desktop tools), so those rows now never get an \`endTime\`/terminal status and continue showing "Running for …" indefinitely after completion.

Re-analysing the original UX complaint ("workers that completed in a previous message get stopped when I send a new one") against the code:

- The old completion handler only overwrites items with \`result === undefined\`. Items that had a real \`tool_result\` (i.e. the Tasks that actually "completed in a previous message") are untouched.
- If a Task is still in-flight at completion time and the handler marks it \`{ status: "cancelled" }\`, the SSE \`tool_result\` handler at \`control-client.tsx:6250\` unconditionally overwrites \`result\` with the real payload when it arrives — self-correcting.
- MCP desktop tools and other fire-and-forget tools never emit \`tool_result\`; the old finalization was the only thing giving those rows a terminal state. #390 broke that.

Reverting is safer than the partial fix I pushed. If the original "worker appears stopped on new message" reproduces, we'll go after the specific visual path instead of touching the completion-finalization logic.

## Test plan

- [x] \`bun run test:unit\` — 137/137 pass after revert
- [x] \`bun run tsc --noEmit\` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission-finalization behavior for tool-call UI state; incorrect cancellation timing could misreport tool status or hide late-arriving `tool_result` events.
> 
> **Overview**
> Restores mission finalization to **always** mark any `tool` items with `result === undefined` as `cancelled` (and set `endTime`) whenever a mission transitions away from `active`, including `completed`.
> 
> This removes the prior gating that only cancelled pending tools for specific abnormal end states, preventing fire-and-forget tools (e.g., desktop/MCP) from remaining stuck in a running state after mission completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ba6bf162d80db987c3a0e99bef84ccc120ddd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->