### PR TITLE
fix(mission_runner): preserve Codex output on mid-stream backend error + exit 1

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -13284,13 +13284,27 @@ pub async fn run_codex_turn(
                         total_output_tokens = total_output_tokens.saturating_add(output_tokens);
                     }
                     ExecutionEvent::Error { message } => {
-                        // Codex CLI sometimes emits non-fatal internal errors (e.g.
-                        // "Failed to shutdown rollout recorder") after the agent has
-                        // already produced a valid response. Ignore these if we
-                        // already have assistant output.
-                        let fatal_process_exit =
-                            message.contains("Codex CLI exited before completing the turn");
-                        if assistant_message.trim().is_empty() || fatal_process_exit {
+                        // Codex CLI emits two kinds of post-response errors we
+                        // want to treat as non-fatal:
+                        //   1. Internal hiccups like "Failed to shutdown rollout
+                        //      recorder" that fire after a clean turn.
+                        //   2. OpenAI backend returning a 500 mid-stream after
+                        //      real content has already been produced; Codex
+                        //      retries 5× and then exits with status 1. Our
+                        //      client wraps that in "Codex CLI exited before
+                        //      completing the turn (exit_status: exit status:
+                        //      1). Stderr: <empty> | Stdout: <empty>". The
+                        //      earlier assistant_message already captured the
+                        //      real response, so the exit error is a downstream
+                        //      consequence of the in-stream disconnect we
+                        //      already decided to swallow.
+                        //
+                        // Rule: if we have assistant output, ignore the error.
+                        // The empty-output branch still surfaces startup /
+                        // auth / config failures (which produce no text at
+                        // all) and mid-turn disconnects that happened before
+                        // any real content streamed.
+                        if assistant_message.trim().is_empty() {
                             error_message = Some(message.clone());
                             tracing::error!("Codex error: {}", message);
                         } else {


### PR DESCRIPTION
## Summary

Fixes a harness bug that surfaced on mission \`a104148b\` today: Codex CLI was streaming a response, OpenAI's backend returned a generic 500-class error mid-stream (request id included), Codex retried 5× and exited with status 1. The harness had already captured 327 bytes of real assistant output and logged \`Ignoring post-response Codex error (have 327B assistant output): ...\` for each of the 5 retries — but a \`fatal_process_exit\` carve-out then overrode everything with \"Codex CLI exited before completing the turn (exit_status: exit status: 1). Stderr: <empty> | Stdout: <empty>\" as the assistant message, and the mission ended showing the error instead of the real response.

The carve-out was added to ensure startup / auth / config failures (which exit 1 with no output) still surface as errors. That case is already handled by the \`assistant_message.trim().is_empty()\` check in the same if-block, so the carve-out is redundant. Removed.

With the fix, downstream \`maybe_recover_soft_llm_error\` sees the real 327B assistant message (not the blacklisted \"Codex CLI exited\" prefix) and upgrades the turn from \`LlmError\` to \`TurnComplete\`. The mission ends clean.

## Reference

Journal signal (mission a104148b, 2026-04-24T20:12 UTC):

\`\`\`
WARN Ignoring post-response Codex error (have 327B assistant output): stream disconnected before completion: ...
WARN Ignoring post-response Codex error (have 327B assistant output): stream disconnected before completion: ...
...5 retries total...
WARN Codex CLI exited with status: exit status: 1
ERROR Codex error: Codex CLI exited before completing the turn (exit_status: exit status: 1). Stderr: <empty> | Stdout: <empty>
\`\`\`

## Test plan

- [x] \`cargo check --lib\`
- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --lib -- -D clippy::all\`
- [ ] After deploy: mission a104148b has been set back to \`interrupted/resumable\` — sending it another message will hit this path on retry; the next turn's partial output (if OpenAI flakes again) should land as the assistant message, not the exit error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts error-handling logic in the mission runner, which could change when Codex failures are surfaced vs. ignored; risk is limited to turn completion/error reporting behavior.
> 
> **Overview**
> Ensures `mission_runner` no longer treats `ExecutionEvent::Error` as fatal when any assistant output has already been streamed, even if the error text indicates the Codex CLI exited before completing the turn.
> 
> This removes the special-case that could override a valid partial/full response with an exit-status error, while still surfacing startup/auth/config failures that produce no assistant output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7912c8d766330e50e0ab5aee459b76170c247472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->