### PR TITLE
fix(mission_runner): classify OpenAI model-capacity errors as CapacityLimited

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -6053,12 +6053,18 @@ pub(crate) async fn refresh_claude_credentials_after_auth_error(
 }
 
 fn is_capacity_limited_error(message: &str) -> bool {
-    const CAPACITY_LIMIT_MARKERS: [&str; 5] = [
+    const CAPACITY_LIMIT_MARKERS: [&str; 8] = [
         "already have five missions running",
         "already have 5 missions running",
         "too many concurrent missions",
         "concurrent mission limit",
         "maximum concurrent missions",
+        // OpenAI's model-level capacity rejection, emitted by Codex CLI
+        // as a TurnFailed error when the selected model (e.g. GPT-5.5
+        // during its rollout window) is saturated.
+        "selected model is at capacity",
+        "model is at capacity",
+        "please try a different model",
     ];
 
     if CAPACITY_LIMIT_MARKERS
@@ -14558,6 +14564,23 @@ mod tests {
         ));
         assert!(!is_capacity_limited_error("Error: 429 Too Many Requests"));
         assert!(!is_capacity_limited_error("Model finished successfully"));
+    }
+
+    #[test]
+    fn is_capacity_limited_error_detects_openai_model_capacity_rejection() {
+        // Codex CLI surfaces this as a TurnFailed error when the
+        // selected OpenAI model (e.g. gpt-5.5 during its rollout
+        // window) is saturated. Previously misclassified as LlmError.
+        assert!(is_capacity_limited_error(
+            "Selected model is at capacity. Please try a different model."
+        ));
+        assert!(is_capacity_limited_error(
+            "Model is at capacity, please try a different model."
+        ));
+        // Case-insensitive and substring-safe.
+        assert!(is_capacity_limited_error(
+            "SOMETHING upstream: SELECTED MODEL IS AT CAPACITY. retry later."
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

GPT-5.5 was saturated on OpenAI's side today (saw it on mission a104148b). OpenAI's backend responded with \`Selected model is at capacity. Please try a different model.\` mid-stream. Codex CLI surfaced this as a TurnFailed error and our \`is_capacity_limited_error\` marker list didn't recognize it, so the terminal reason came back as \`LlmError\` instead of \`CapacityLimited\`. That hid the capacity-classification downstream rotation hooks and returned a generic "Model error" to the UI.

Adding the three literal markers we've seen in the wild to the existing list. Same case-insensitive/substring machinery, no behavior change for concurrency-limit markers.

Combined with the already-merged #392 (which preserves partial Codex output when the CLI exits 1 post-stream), any future mid-stream capacity rejection:

1. Has its pre-capacity content preserved as the assistant message (#392).
2. The turn is classified \`CapacityLimited\` (this PR), so \`mission_status_for_terminal_reason\` and the existing rotation paths handle it correctly.

## Test plan

- [x] New unit test \`is_capacity_limited_error_detects_openai_model_capacity_rejection\` — passes.
- [x] \`cargo fmt --all --check\` clean, \`cargo clippy --lib -- -D clippy::all\` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to string-matching in `is_capacity_limited_error` plus a unit test, but it can alter terminal error classification for some OpenAI/Codex failure messages.
> 
> **Overview**
> Improves capacity-limit detection in `mission_runner` by expanding `is_capacity_limited_error` to recognize OpenAI model-level capacity rejection messages (e.g., “Selected model is at capacity…”, “Please try a different model”).
> 
> Adds a focused unit test to ensure these new markers are matched (case-insensitive/substring-safe), so such failures are classified as `CapacityLimited` instead of generic LLM errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0937d98bc017b978eaec4b70d5340576ba698cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->