### PR TITLE
fix(tasks): bound steps Vec, truncate log lines, validate env names

### DIFF
--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { cn } from "@/lib/utils";
 import { listTasks, stopTask, type Task, type TaskStep } from "@/lib/api/tasks";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { useDocumentVisible } from "@/hooks/use-visibility-polling";
 import {
   Clock,
   Loader,
@@ -251,10 +252,11 @@ function TaskRow({ task, onStop, stopping }: { task: Task; onStop: (id: string) 
 export default function TasksPage() {
   const [stoppingIds, setStoppingIds] = useState<Set<string>>(new Set());
 
+  const visible = useDocumentVisible();
   const { data: tasks = [], mutate } = useSWR<Task[]>(
     "tasks",
     listTasks,
-    { refreshInterval: 2000 }
+    { refreshInterval: visible ? 2000 : 0 }
   );
 
   const handleStop = async (id: string) => {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1325,8 +1325,32 @@ async fn stop_task(
 /// Maximum log entries per task. Prevents unbounded memory growth from verbose scripts.
 const LOG_MAX_ENTRIES: usize = 10_000;
 
+/// Maximum bytes per log line. A single oversized line is truncated rather than allowed
+/// to balloon memory (a script printing one 100MB line should not blow up the task store).
+const MAX_LOG_LINE_BYTES: usize = 16 * 1024;
+
+/// Maximum step annotations retained per task. Mirrors LOG_MAX_ENTRIES — without this
+/// a script can emit unlimited `{"step": ...}` lines and grow the steps Vec without bound.
+const MAX_TASK_STEPS: usize = 1_000;
+
 /// Maximum completed tasks to retain per user. Oldest are evicted first on completion.
 const MAX_COMPLETED_TASKS: usize = 500;
+
+/// Truncate `s` so the resulting string is at most `max_bytes` long while staying on a
+/// UTF-8 char boundary. Returns the original string when already within budget.
+fn truncate_utf8(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = String::with_capacity(end + 24);
+    out.push_str(&s[..end]);
+    out.push_str("…[truncated]");
+    out
+}
 
 /// Append a log entry to a task. Shared by agent-mode and command-mode paths.
 /// Silently drops entries beyond LOG_MAX_ENTRIES (with a sentinel at the cap).
@@ -1338,6 +1362,7 @@ async fn append_log(
     content: &str,
 ) {
     let timestamp = chrono::Utc::now().to_rfc3339();
+    let content = truncate_utf8(content, MAX_LOG_LINE_BYTES);
     let mut tasks = state.tasks.write().await;
     if let Some(user_tasks) = tasks.get_mut(user_id) {
         if let Some(task_state) = user_tasks.get_mut(&task_id) {
@@ -1346,7 +1371,7 @@ async fn append_log(
                 task_state.log.push(TaskLogEntry {
                     timestamp,
                     entry_type,
-                    content: content.to_string(),
+                    content,
                 });
             } else if len == LOG_MAX_ENTRIES {
                 task_state.log.push(TaskLogEntry {
@@ -1489,6 +1514,7 @@ async fn run_command_task(
         let state_clone = Arc::clone(&state);
         let user_id_clone = user_id.clone();
         Some(tokio::spawn(async move {
+            let mut steps_capped_logged = false;
             while let Ok(Some(line)) = lines.next_line().await {
                 // Try to parse JSON step annotations; emit readable summary and skip raw line.
                 if line.trim_start().starts_with('{') {
@@ -1512,13 +1538,29 @@ async fn run_command_task(
                                 duration_s: v.get("duration_s").and_then(|x| x.as_f64()),
                                 metadata: v.get("metadata").cloned(),
                             };
+                            let mut hit_cap = false;
                             {
                                 let mut tasks = state_clone.tasks.write().await;
                                 if let Some(ut) = tasks.get_mut(&user_id_clone) {
                                     if let Some(ts) = ut.get_mut(&task_id) {
-                                        ts.steps.push(step);
+                                        if ts.steps.len() < MAX_TASK_STEPS {
+                                            ts.steps.push(step);
+                                        } else {
+                                            hit_cap = true;
+                                        }
                                     }
                                 }
+                            }
+                            if hit_cap && !steps_capped_logged {
+                                steps_capped_logged = true;
+                                append_log(
+                                    &state_clone,
+                                    &user_id_clone,
+                                    task_id,
+                                    LogEntryType::Error,
+                                    "[steps truncated — 1000 step limit reached]",
+                                )
+                                .await;
                             }
                             // Emit a readable one-liner instead of the raw JSON blob
                             let label = format!(
@@ -1647,10 +1689,20 @@ async fn run_command_task(
         }
 
         // Evict oldest completed tasks if over the retention cap (single pass).
+        // Tasks without a completed_at (e.g., orphan-cleaned) sort to the END so they
+        // are not preferentially evicted over real timestamped finishes; an empty
+        // string would otherwise sort lexicographically before any ISO 8601 stamp.
         let mut completed: Vec<(Uuid, String)> = ut
             .iter()
             .filter(|(_, t)| !matches!(t.status, TaskStatus::Running | TaskStatus::Pending))
-            .map(|(id, t)| (*id, t.completed_at.clone().unwrap_or_default()))
+            .map(|(id, t)| {
+                (
+                    *id,
+                    t.completed_at
+                        .clone()
+                        .unwrap_or_else(|| "9999-12-31T23:59:59Z".to_string()),
+                )
+            })
             .collect();
         if completed.len() > MAX_COMPLETED_TASKS {
             // Sort oldest-first by completed_at (ISO 8601 sorts lexicographically).

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1336,19 +1336,32 @@ const MAX_TASK_STEPS: usize = 1_000;
 /// Maximum completed tasks to retain per user. Oldest are evicted first on completion.
 const MAX_COMPLETED_TASKS: usize = 500;
 
-/// Truncate `s` so the resulting string is at most `max_bytes` long while staying on a
-/// UTF-8 char boundary. Returns the original string when already within budget.
+/// Truncate `s` so the *output* string is at most `max_bytes` long while staying on a
+/// UTF-8 char boundary. The trailing `…[truncated]` marker is counted against the cap,
+/// so the returned string's length never exceeds `max_bytes`. Returns the original
+/// string when already within budget.
 fn truncate_utf8(s: &str, max_bytes: usize) -> String {
     if s.len() <= max_bytes {
         return s.to_string();
     }
-    let mut end = max_bytes;
+    const MARKER: &str = "…[truncated]";
+    // If the cap is so small the marker doesn't fit, fall back to a hard byte
+    // truncation on a char boundary — better than blowing past the limit.
+    if max_bytes <= MARKER.len() {
+        let mut end = max_bytes;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        return s[..end].to_string();
+    }
+    let budget = max_bytes - MARKER.len();
+    let mut end = budget;
     while end > 0 && !s.is_char_boundary(end) {
         end -= 1;
     }
-    let mut out = String::with_capacity(end + 24);
+    let mut out = String::with_capacity(max_bytes);
     out.push_str(&s[..end]);
-    out.push_str("…[truncated]");
+    out.push_str(MARKER);
     out
 }
 
@@ -2337,5 +2350,51 @@ async fn oauth_token_refresher_loop(
         );
 
         tokio::time::sleep(check_interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_utf8;
+
+    #[test]
+    fn truncate_utf8_passes_through_short_strings() {
+        assert_eq!(truncate_utf8("hello", 32), "hello");
+    }
+
+    #[test]
+    fn truncate_utf8_caps_total_output_length_at_max_bytes() {
+        // 100 bytes of input, cap of 32 — output must not exceed 32 bytes
+        // *including* the marker. Previous implementation kept 32 bytes of
+        // input and *appended* the marker, blowing past the cap.
+        let s = "x".repeat(100);
+        let out = truncate_utf8(&s, 32);
+        assert!(
+            out.len() <= 32,
+            "output {} bytes exceeded cap of 32",
+            out.len()
+        );
+        assert!(out.ends_with("…[truncated]"));
+    }
+
+    #[test]
+    fn truncate_utf8_keeps_char_boundary() {
+        // 4-byte char (U+1F600) repeated; truncating in the middle of a
+        // multi-byte sequence must back up to a boundary.
+        let s = "😀".repeat(20); // 80 bytes of content
+        let out = truncate_utf8(&s, 32);
+        assert!(out.len() <= 32);
+        // Just confirms valid UTF-8 — String is by construction valid here, so
+        // this test mainly guards the boundary backtrack logic from panicking.
+        assert!(out.ends_with("…[truncated]"));
+    }
+
+    #[test]
+    fn truncate_utf8_handles_cap_smaller_than_marker() {
+        // When the cap is smaller than the marker itself we still must not
+        // exceed the cap — fall back to a hard byte truncation.
+        let s = "abcdefghijklmnop".to_string();
+        let out = truncate_utf8(&s, 4);
+        assert!(out.len() <= 4);
     }
 }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -821,10 +821,23 @@ fn normalize_init_script(value: Option<String>) -> Option<String> {
 }
 
 fn sanitize_env_vars(env_vars: HashMap<String, String>) -> HashMap<String, String> {
+    // Drop entries whose key is not a valid POSIX env var name. nspawn passes
+    // `--setenv=KEY=VALUE` as one argv token, so a key containing `=`, whitespace,
+    // a leading `-`, or a control character would either confuse the parser or be
+    // silently mishandled. Values are passed through unchanged.
     env_vars
         .into_iter()
-        .filter(|(key, _)| !key.trim().is_empty())
+        .filter(|(key, value)| is_valid_env_name(key) && !value.contains('\0'))
         .collect()
+}
+
+fn is_valid_env_name(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// Escape a string for safe use in shell commands.


### PR DESCRIPTION
## Summary
Follow-ups to #372 (command-mode tasks). Addresses three resource-bound gaps and a small nspawn arg-validation hole found in post-merge review.

- **Unbounded `steps` Vec → OOM** (`src/api/routes.rs`): scripts can emit unlimited `{"step": ...}` JSON lines on stdout, each pushing onto `TaskState.steps`. There was a 10k cap on log entries but nothing equivalent for steps. Cap at 1000, mirror the log sentinel ("[steps truncated …]" once per task).
- **Unbounded log line size → malloc DoS** (`src/api/routes.rs`): `append_log` stored every line verbatim, so one 100 MB line was one 100 MB `String`. Truncate at 16 KiB on a UTF-8 char boundary with a `…[truncated]` marker.
- **Eviction misorders missing timestamps** (`src/api/routes.rs`): `unwrap_or_default()` mapped a missing `completed_at` to `""`, which sorts lexicographically *before* any ISO 8601 timestamp — so orphan-cleaned tasks were preferentially evicted. Use a far-future sentinel so they sort to the end.
- **`sanitize_env_vars` too permissive** (`src/api/workspaces.rs`): `nspawn` passes `--setenv=KEY=VALUE` as a single argv token. A key with `=`, whitespace, a leading `-`, or a non-ASCII character would either confuse the parser or produce a broken env. Require `^[A-Za-z_][A-Za-z0-9_]*$` and reject NULs in values.
- **Tasks page polled while hidden** (`dashboard/src/app/tasks/page.tsx`): the control page already uses `useVisibilityPolling`. The new tasks page polled `listTasks` every 2 s regardless of tab visibility. Gate `refreshInterval` on `useDocumentVisible()`.

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --no-run --lib` builds (full suite covered by CI)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `npx tsc --noEmit` clean in dashboard
- [ ] Manually emit > 1000 step lines from a command task and confirm `steps` is capped + sentinel appears once
- [ ] Manually print a 1 MB line on stdout and confirm it lands as `…[truncated]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 74b1f653f63a7d75bddb40e77e4371aae4ebe422. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->