### PR TITLE
fix(ios): land at conversation bottom on open + delta-resume on reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,7 @@ vllm-gb10-dgx-spark/
 
 # iOS build artifacts
 ios_dashboard/.build/
-ios_dashboard/SandboxedDashboard.xcodeproj/
+ios_dashboard/build/
+ios_dashboard/**/xcuserdata/
+ios_dashboard/SandboxedDashboard.xcodeproj/*
+!ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -167,6 +167,31 @@ final class APIService {
     }
 
     func getMissionEvents(id: String, types: [String]? = nil, limit: Int? = nil, offset: Int? = nil, latest: Bool = false) async throws -> [StoredEvent] {
+        try await getMissionEventsWithMeta(
+            id: id,
+            types: types,
+            limit: limit,
+            offset: offset,
+            latest: latest
+        ).events
+    }
+
+    /// Fetch mission events along with the response metadata.
+    ///
+    /// `maxSequence` is parsed from the `X-Max-Sequence` response header. Backends
+    /// that do not advertise this header return `nil` — callers should treat that
+    /// as "delta resume not supported" and not seed any high-water mark.
+    ///
+    /// `sinceSeq` requests only events with `sequence > sinceSeq` (delta path used
+    /// on SSE reconnect / scene-phase active). `latest` requests the tail page.
+    func getMissionEventsWithMeta(
+        id: String,
+        types: [String]? = nil,
+        limit: Int? = nil,
+        offset: Int? = nil,
+        latest: Bool = false,
+        sinceSeq: Int64? = nil
+    ) async throws -> MissionEventsResult {
         var queryItems: [URLQueryItem] = []
         if let types = types {
             queryItems.append(URLQueryItem(name: "types", value: types.joined(separator: ",")))
@@ -180,6 +205,9 @@ final class APIService {
         if latest {
             queryItems.append(URLQueryItem(name: "latest", value: "true"))
         }
+        if let sinceSeq = sinceSeq {
+            queryItems.append(URLQueryItem(name: "since_seq", value: String(sinceSeq)))
+        }
 
         var urlString = "/api/control/missions/\(id)/events"
         if !queryItems.isEmpty {
@@ -190,7 +218,10 @@ final class APIService {
             }
         }
 
-        return try await get(urlString)
+        let (events, response): ([StoredEvent], HTTPURLResponse) = try await getWithResponse(urlString)
+        let maxSequence = (response.value(forHTTPHeaderField: "X-Max-Sequence") ?? response.value(forHTTPHeaderField: "x-max-sequence"))
+            .flatMap { Int64($0) }
+        return MissionEventsResult(events: events, maxSequence: maxSequence)
     }
 
     /// Get child (worker) missions for a boss mission.
@@ -554,18 +585,27 @@ final class APIService {
     private struct EmptyResponse: Decodable {}
     
     private func get<T: Decodable>(_ path: String, authenticated: Bool = true) async throws -> T {
+        try await getWithResponse(path, authenticated: authenticated).0
+    }
+
+    /// GET that also returns the underlying `HTTPURLResponse` so callers can
+    /// inspect response headers (e.g. `X-Max-Sequence` for delta-event resume).
+    private func getWithResponse<T: Decodable>(
+        _ path: String,
+        authenticated: Bool = true
+    ) async throws -> (T, HTTPURLResponse) {
         guard let url = URL(string: "\(baseURL)\(path)") else {
             throw APIError.invalidURL
         }
-        
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        
+
         if authenticated, let token = jwtToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        
-        return try await execute(request)
+
+        return try await executeWithResponse(request)
     }
     
     private func post<T: Decodable, B: Encodable>(_ path: String, body: B, authenticated: Bool = true) async throws -> T {
@@ -620,31 +660,44 @@ final class APIService {
     }
     
     private func execute<T: Decodable>(_ request: URLRequest) async throws -> T {
+        try await executeWithResponse(request).0
+    }
+
+    private func executeWithResponse<T: Decodable>(_ request: URLRequest) async throws -> (T, HTTPURLResponse) {
         let (data, response) = try await URLSession.shared.data(for: request)
-        
+
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }
-        
+
         if httpResponse.statusCode == 401 {
             logout()
             throw APIError.unauthorized
         }
-        
+
         guard httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 else {
             throw APIError.httpError(httpResponse.statusCode, String(data: data, encoding: .utf8))
         }
-        
+
         // Handle empty responses
         if data.isEmpty || (T.self == EmptyResponse.self) {
             if let empty = EmptyResponse() as? T {
-                return empty
+                return (empty, httpResponse)
             }
         }
-        
+
         let decoder = JSONDecoder()
-        return try decoder.decode(T.self, from: data)
+        let value = try decoder.decode(T.self, from: data)
+        return (value, httpResponse)
     }
+}
+
+/// Result of a `/missions/:id/events` fetch. `maxSequence` is the response's
+/// `X-Max-Sequence` header — `nil` if the backend doesn't advertise it (older
+/// versions). Callers must treat `nil` as "delta resume unsupported".
+struct MissionEventsResult {
+    let events: [StoredEvent]
+    let maxSequence: Int64?
 }
 
 enum APIError: LocalizedError {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -23,7 +23,14 @@ struct ControlView: View {
     @State private var isLoading = true
     @State private var streamTask: Task<Void, Never>?
     @State private var showMissionMenu = false
-    @State private var shouldScrollToBottom = false
+    /// Monotonic counter — each increment is a request to scroll to the bottom.
+    /// Counter rather than a Bool because the conversation `ScrollView` is
+    /// conditionally mounted (only when `messages` is non-empty). A Bool flag
+    /// can get stuck `true` if it's set while the ScrollView is unmounted —
+    /// the resetter inside `.onChange` never runs, and subsequent re-arms to
+    /// `true` are no-ops because the value didn't change. A counter always
+    /// advances, so `.onChange` fires reliably on every request.
+    @State private var scrollToBottomTick = 0
     @State private var progress: ExecutionProgress?
     @State private var isAtBottom = true
     @State private var copiedMessageId: String?
@@ -686,10 +693,8 @@ struct ControlView: View {
                     scrollToBottom(proxy: proxy)
                 }
             }
-            .onChange(of: shouldScrollToBottom) { _, shouldScroll in
-                guard shouldScroll else { return }
+            .onChange(of: scrollToBottomTick) { _, _ in
                 let immediate = shouldScrollImmediately
-                shouldScrollToBottom = false
                 shouldScrollImmediately = false
                 // Used when the ScrollView is already mounted and the
                 // mission's content has been swapped wholesale (mission
@@ -1103,7 +1108,7 @@ struct ControlView: View {
 
         if scrollToBottom {
             shouldScrollImmediately = true
-            shouldScrollToBottom = true
+            scrollToBottomTick += 1
         }
         clearLoadingHistoryAfterRender()
     }
@@ -1163,7 +1168,7 @@ struct ControlView: View {
 
         if scrollToBottom {
             shouldScrollImmediately = true
-            shouldScrollToBottom = true
+            scrollToBottomTick += 1
         }
         clearLoadingHistoryAfterRender()
     }
@@ -1446,11 +1451,13 @@ struct ControlView: View {
             }
             applyDeltaEvents(result.events)
             // If the page was capped by the limit, advance the cursor to the
-            // last returned event's sequence so the next call resumes from
-            // that point — otherwise we'd skip rows between this page's tail
-            // and the true max.
-            let lastSeq = result.events.last?.sequence ?? knownSeq
-            let cursor = (result.events.count >= Self.deltaResumePageLimit && lastSeq < maxSeq) ? lastSeq : maxSeq
+            // largest sequence we actually saw so the next call resumes from
+            // there — otherwise we'd skip rows between this page and the
+            // true max. Use `max()` rather than `last`: the API contract is
+            // ASC-by-sequence but defensive callers shouldn't trust input
+            // ordering.
+            let pageMax = result.events.map { $0.sequence }.max() ?? knownSeq
+            let cursor = (result.events.count >= Self.deltaResumePageLimit && pageMax < maxSeq) ? pageMax : maxSeq
             missionMaxSeq[id] = cursor
             return .applied
         } catch {
@@ -1486,20 +1493,34 @@ struct ControlView: View {
                 }
             }
 
-            // Fallback / first-time path: fetch the recent tail.
+            // Fallback / first-time path: fetch the recent tail. Distinguish
+            // a *failed* fetch (network/server error) from a *successful but
+            // empty* response. On failure we keep the currently rendered
+            // conversation — silently downgrading to `applyViewingMission`
+            // (which uses the basic `mission.history` payload) would erase
+            // the event-rendered chat under flaky networks. On empty we
+            // clear the cache and fall back, since the mission really does
+            // have no events.
             let limit = hasMoreHistory ? Self.initialEventLimit : nil
             let latest = hasMoreHistory
-            if let result = try? await api.getMissionEventsWithMeta(id: id, types: historyEventTypes, limit: limit, latest: latest), !result.events.isEmpty {
+            do {
+                let result = try await api.getMissionEventsWithMeta(id: id, types: historyEventTypes, limit: limit, latest: latest)
                 guard viewingMissionId == id else { return }
-                applyViewingMissionWithEvents(mission, events: result.events, scrollToBottom: false)
-                if let maxSeq = result.maxSequence, maxSeq > 0 {
-                    missionMaxSeq[id] = maxSeq
+                if result.events.isEmpty {
+                    removeMissionFromCache(mission.id)
+                    applyViewingMission(mission, scrollToBottom: false)
+                } else {
+                    applyViewingMissionWithEvents(mission, events: result.events, scrollToBottom: false)
+                    if let maxSeq = result.maxSequence, maxSeq > 0 {
+                        missionMaxSeq[id] = maxSeq
+                    }
+                    cacheMissionWithEvents(mission, events: result.events)
                 }
-                cacheMissionWithEvents(mission, events: result.events)
-            } else {
-                guard viewingMissionId == id else { return }
-                removeMissionFromCache(mission.id)
-                applyViewingMission(mission, scrollToBottom: false)
+            } catch {
+                // Tail fetch failed — keep the existing rendered conversation.
+                // SSE will deliver any new events; next active/visible cycle
+                // will retry the fetch.
+                print("Tail reload fetch failed, keeping current view: \(error)")
             }
         } catch {
             print("Failed to reload mission from server: \(error)")
@@ -1885,7 +1906,7 @@ struct ControlView: View {
         let tempMessage = ChatMessage(id: tempId, type: .user, content: content)
         messages.append(tempMessage)
         recomputeGroupedItems()
-        shouldScrollToBottom = true
+        scrollToBottomTick += 1
 
         Task { @MainActor in
             do {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1105,10 +1105,7 @@ struct ControlView: View {
             shouldScrollImmediately = true
             shouldScrollToBottom = true
         }
-        // Cleared synchronously at the next runloop tick, alongside the
-        // explicit scroll, so the `messages.count` onChange and the bottom
-        // anchor land in the same render pass instead of racing a sleep.
-        isLoadingHistory = false
+        clearLoadingHistoryAfterRender()
     }
 
     private static let initialEventLimit = 50
@@ -1168,7 +1165,20 @@ struct ControlView: View {
             shouldScrollImmediately = true
             shouldScrollToBottom = true
         }
-        isLoadingHistory = false
+        clearLoadingHistoryAfterRender()
+    }
+
+    /// Clear `isLoadingHistory` on the next runloop tick. Setting it to `false`
+    /// in the same synchronous block where it was set to `true` would coalesce
+    /// into a single observed value, defeating the `messages.count` onChange
+    /// guard that is supposed to suppress an animated auto-scroll during
+    /// content replacement. Deferring lets the count-change handler observe
+    /// `isLoadingHistory == true`, after which the explicit scroll path wins.
+    private func clearLoadingHistoryAfterRender() {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 16_000_000)
+            isLoadingHistory = false
+        }
     }
 
     /// Append delta events to the existing conversation without clearing.
@@ -1176,9 +1186,12 @@ struct ControlView: View {
     /// Used by the SSE-reconnect / scene-phase-active resume path: the server
     /// returns only events with `sequence > knownMaxSeq`, so they must be
     /// appended (not replayed-from-empty). Each event is fed through
-    /// `handleStreamEvent` with `isHistoricalReplay: false` so the existing
-    /// upsert-by-id logic naturally dedupes anything that overlapped a live
-    /// SSE event we already saw.
+    /// `handleStreamEvent` as a historical replay — the request includes
+    /// `text_delta` events, so without the historical flag the live-only
+    /// `upsertStreamingFallbackThought` path would synthesize duplicate
+    /// thinking content from already-finalized text. Per-id dedup guards on
+    /// `user_message`, `assistant_message`, and `tool_call` further protect
+    /// against overlap with events we already rendered live.
     private func applyDeltaEvents(_ events: [StoredEvent]) {
         guard !events.isEmpty else { return }
 
@@ -1199,7 +1212,7 @@ struct ControlView: View {
             if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
             if let toolName = event.toolName { data["name"] = toolName }
 
-            handleStreamEvent(type: event.eventType, data: data)
+            handleStreamEvent(type: event.eventType, data: data, isHistoricalReplay: true)
         }
 
         loadedEventCount += orderedEvents.count
@@ -1397,6 +1410,53 @@ struct ControlView: View {
         }
     }
 
+    /// Hard cap on the number of events per delta page. Mirrors the web client.
+    private static let deltaResumePageLimit = 5000
+
+    /// Outcome of a `tryDeltaResume` attempt.
+    private enum DeltaResumeOutcome {
+        case applied      // backend supports resume, events applied, cursor advanced
+        case unsupported  // backend stripped `X-Max-Sequence` — cursor dropped
+        case noCursor     // no high-water mark recorded; nothing attempted
+        case failed       // network/server error; cursor untouched
+    }
+
+    /// Try to fetch and apply only the events that arrived after our recorded
+    /// high-water mark for this mission. Shared between `resumeMissionAfterReconnect`
+    /// (post SSE reconnect) and `reloadMissionFromServer` (post scene-phase active).
+    /// Caller is responsible for the fallback path when this returns anything
+    /// other than `.applied`.
+    private func tryDeltaResume(missionId id: String) async -> DeltaResumeOutcome {
+        guard let knownSeq = missionMaxSeq[id] else { return .noCursor }
+        do {
+            let result = try await api.getMissionEventsWithMeta(
+                id: id,
+                types: historyEventTypes,
+                limit: Self.deltaResumePageLimit,
+                sinceSeq: knownSeq
+            )
+            guard viewingMissionId == id else { return .applied }
+            guard let maxSeq = result.maxSequence else {
+                // Backend stripped `X-Max-Sequence` — drop the cursor so the
+                // delta path is disabled until the next header-bearing fetch.
+                missionMaxSeq.removeValue(forKey: id)
+                return .unsupported
+            }
+            applyDeltaEvents(result.events)
+            // If the page was capped by the limit, advance the cursor to the
+            // last returned event's sequence so the next call resumes from
+            // that point — otherwise we'd skip rows between this page's tail
+            // and the true max.
+            let lastSeq = result.events.last?.sequence ?? knownSeq
+            let cursor = (result.events.count >= Self.deltaResumePageLimit && lastSeq < maxSeq) ? lastSeq : maxSeq
+            missionMaxSeq[id] = cursor
+            return .applied
+        } catch {
+            print("Delta resume failed: \(error)")
+            return .failed
+        }
+    }
+
     // Reload mission from server without showing loading state or cache.
     // Called when the scene becomes active to catch missed SSE events (mirrors
     // the web's visibility-change handler). Prefers the `since_seq` delta path
@@ -1413,33 +1473,11 @@ struct ControlView: View {
                 currentMission = mission
             }
 
-            // Delta path: if we have a high-water mark, ask the backend for
-            // events arriving after it. Avoids re-downloading the entire
-            // history for what is usually a single missed message.
-            if let knownSeq = missionMaxSeq[id] {
-                do {
-                    let result = try await api.getMissionEventsWithMeta(
-                        id: id,
-                        types: historyEventTypes,
-                        limit: 5000,
-                        sinceSeq: knownSeq
-                    )
-                    guard viewingMissionId == id else { return }
-                    if let maxSeq = result.maxSequence {
-                        // Backend supports delta resume — apply and update cursor.
-                        applyDeltaEvents(result.events)
-                        let lastSeq = result.events.last?.sequence ?? knownSeq
-                        let cursor = (result.events.count >= 5000 && lastSeq < maxSeq) ? lastSeq : maxSeq
-                        missionMaxSeq[id] = cursor
-                        return
-                    }
-                    // Backend stripped X-Max-Sequence — drop the cursor and
-                    // fall through to the full-reload path below.
-                    missionMaxSeq.removeValue(forKey: id)
-                } catch {
-                    // Network/server error during delta — fall through to full reload.
-                    print("Delta resume failed, falling back to tail reload: \(error)")
-                }
+            switch await tryDeltaResume(missionId: id) {
+            case .applied:
+                return
+            case .noCursor, .unsupported, .failed:
+                break  // fall through to full tail reload below
             }
 
             // Fallback / first-time path: fetch the recent tail.
@@ -1468,31 +1506,9 @@ struct ControlView: View {
     /// reconnect catch-up fast even on missions with thousands of events.
     private func resumeMissionAfterReconnect(id: String) async {
         guard viewingMissionId == id else { return }
-
-        if let knownSeq = missionMaxSeq[id] {
-            do {
-                let result = try await api.getMissionEventsWithMeta(
-                    id: id,
-                    types: historyEventTypes,
-                    limit: 5000,
-                    sinceSeq: knownSeq
-                )
-                guard viewingMissionId == id else { return }
-                if let maxSeq = result.maxSequence {
-                    applyDeltaEvents(result.events)
-                    let lastSeq = result.events.last?.sequence ?? knownSeq
-                    let cursor = (result.events.count >= 5000 && lastSeq < maxSeq) ? lastSeq : maxSeq
-                    missionMaxSeq[id] = cursor
-                    return
-                }
-                missionMaxSeq.removeValue(forKey: id)
-            } catch {
-                print("Reconnect delta resume failed: \(error)")
-            }
-        }
-
-        // No cursor or backend doesn't advertise resume — fall back to the
-        // full reload, scoped to this mission.
+        if case .applied = await tryDeltaResume(missionId: id) { return }
+        // No cursor, backend doesn't advertise resume, or transient error —
+        // fall back to a scoped tail reload.
         await reloadMissionFromServer(id: id)
     }
 
@@ -2497,6 +2513,13 @@ struct ControlView: View {
             if let toolCallId = data["tool_call_id"] as? String,
                let name = data["name"] as? String,
                let args = data["args"] as? [String: Any] {
+                // Skip if already present — historical replay or delta resume
+                // can re-deliver a tool_call we already saw via SSE. The
+                // per-row id depends on the path (toolUI vs toolCall), so
+                // check both forms.
+                if messages.contains(where: { $0.id == toolCallId || $0.id == "tool-\(toolCallId)" }) {
+                    break
+                }
                 finalizeActiveThinkingMessages()
                 // Parse UI tool calls
                 if let toolUI = ToolUIContent.parse(name: name, args: args) {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -395,9 +395,6 @@ struct ControlView: View {
         .onChange(of: viewingMissionId) { _, newId in
             UserDefaults.standard.set(newId, forKey: Self.lastMissionIdKey)
         }
-        .onChange(of: showThoughts) { _, _ in
-            recomputeGroupedItems()
-        }
         .onChange(of: inputText) { _, newText in
             // Debounced save: persist draft after 1 second of inactivity
             draftSaveTask?.cancel()
@@ -739,15 +736,22 @@ struct ControlView: View {
     }
     
     private var hasActiveStreamingItem: Bool {
+        // Thinking messages don't render in the main content pane any more
+        // (they live exclusively in the thoughts sheet), so a live thinking
+        // event isn't a "visible streaming item". Without this exclusion the
+        // "Agent is working…" indicator would be suppressed while the agent
+        // is thinking, leaving the main pane silent.
         messages.contains { msg in
-            (msg.isThinking && !msg.thinkingDone) || msg.isPhase || (msg.isToolCall && msg.isActiveToolCall)
+            msg.isPhase || (msg.isToolCall && msg.isActiveToolCall)
         }
     }
 
     // MARK: - Message Grouping
 
-    /// Groups consecutive tool calls together for collapsed display (like dashboard)
-    private static func buildGroupedItems(from messages: [ChatMessage], showThoughts: Bool) -> [GroupedChatItem] {
+    /// Groups consecutive tool calls together for collapsed display (like dashboard).
+    /// Thinking messages are always elided here — they live in the thoughts sheet
+    /// only. Showing them inline duplicated the same content twice on screen.
+    private static func buildGroupedItems(from messages: [ChatMessage]) -> [GroupedChatItem] {
         var result: [GroupedChatItem] = []
         var currentToolGroup: [ChatMessage] = []
 
@@ -763,8 +767,8 @@ struct ControlView: View {
         }
 
         for message in messages {
-            // Skip thinking messages when thoughts panel is open (they're shown in the panel)
-            if message.isThinking && showThoughts {
+            // Thinking renders only in the thoughts sheet, never in the main pane.
+            if message.isThinking {
                 flushToolGroup()
                 continue
             }
@@ -785,7 +789,7 @@ struct ControlView: View {
     }
 
     private func recomputeGroupedItems() {
-        groupedItems = Self.buildGroupedItems(from: messages, showThoughts: showThoughts)
+        groupedItems = Self.buildGroupedItems(from: messages)
     }
 
     /// Check if the currently viewed mission is running (not just any mission)

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1463,8 +1463,10 @@ struct ControlView: View {
     // Called when the scene becomes active to catch missed SSE events (mirrors
     // the web's visibility-change handler). Prefers the `since_seq` delta path
     // when supported; falls back to a tail reload only when no high-water mark
-    // is recorded for this mission yet.
-    private func reloadMissionFromServer(id: String) async {
+    // is recorded for this mission yet. `skipDeltaAttempt=true` is used by
+    // callers that just tried delta and got `.failed` — no point hammering
+    // the same flaky network for the same answer twice.
+    private func reloadMissionFromServer(id: String, skipDeltaAttempt: Bool = false) async {
         guard viewingMissionId == id else { return }
 
         do {
@@ -1475,11 +1477,13 @@ struct ControlView: View {
                 currentMission = mission
             }
 
-            switch await tryDeltaResume(missionId: id) {
-            case .applied, .viewChanged:
-                return
-            case .noCursor, .unsupported, .failed:
-                break  // fall through to full tail reload below
+            if !skipDeltaAttempt {
+                switch await tryDeltaResume(missionId: id) {
+                case .applied, .viewChanged:
+                    return
+                case .noCursor, .unsupported, .failed:
+                    break  // fall through to full tail reload below
+                }
             }
 
             // Fallback / first-time path: fetch the recent tail.
@@ -1511,10 +1515,15 @@ struct ControlView: View {
         switch await tryDeltaResume(missionId: id) {
         case .applied, .viewChanged:
             return
-        case .noCursor, .unsupported, .failed:
-            // Fall back to a scoped tail reload — covers first-connect (no cursor),
-            // older backends (no `X-Max-Sequence`), and transient errors.
-            await reloadMissionFromServer(id: id)
+        case .noCursor, .unsupported:
+            // Cursor wasn't usable — fall back to a tail reload. Skip its
+            // delta retry since the cursor state is what just told us the
+            // delta path isn't available right now.
+            await reloadMissionFromServer(id: id, skipDeltaAttempt: true)
+        case .failed:
+            // Transient network/server error — same skip rationale, plus
+            // avoid hammering a flaky connection with the identical request.
+            await reloadMissionFromServer(id: id, skipDeltaAttempt: true)
         }
     }
 
@@ -2142,10 +2151,16 @@ struct ControlView: View {
             }
 
             // Fetch full event history to avoid partial history rendering.
-            if let events = try? await api.getMissionEvents(id: id, types: historyEventTypes), !events.isEmpty {
+            // Use the meta variant so the `X-Max-Sequence` header seeds the
+            // delta-resume cursor — otherwise missions loaded via the switcher
+            // would always fall back to a full tail reload on reconnect.
+            if let result = try? await api.getMissionEventsWithMeta(id: id, types: historyEventTypes), !result.events.isEmpty {
                 guard fetchingMissionId == id else { return }
-                applyViewingMissionWithEvents(mission, events: events)
-                cacheMissionWithEvents(mission, events: events)
+                applyViewingMissionWithEvents(mission, events: result.events)
+                if let maxSeq = result.maxSequence, maxSeq > 0 {
+                    missionMaxSeq[id] = maxSeq
+                }
+                cacheMissionWithEvents(mission, events: result.events)
             } else {
                 guard fetchingMissionId == id else { return }
                 removeMissionFromCache(mission.id)

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -36,6 +36,13 @@ struct ControlView: View {
     @State private var isLoadingEarlier = false
     @State private var loadedEventCount = 0  // How many events we've loaded so far
 
+    /// Per-mission high-water mark for `sequence`. When non-nil, reload paths
+    /// pass it as `since_seq` to `/events` so the server returns only the tail
+    /// that arrived while we were disconnected, not the whole history. Seeded
+    /// from the `X-Max-Sequence` response header — backends that don't set the
+    /// header leave this `nil` and callers fall back to full reload.
+    @State private var missionMaxSeq: [String: Int64] = [:]
+
     // Cached grouped items (recomputed only when messages change)
     @State private var groupedItems: [GroupedChatItem] = []
 
@@ -572,140 +579,160 @@ struct ControlView: View {
     
     private var messagesView: some View {
         ZStack(alignment: .bottom) {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 20) {
-                        // "Load earlier messages" button when history is truncated
-                        if hasMoreHistory {
-                            Button {
-                                Task { await loadEarlierMessages() }
-                            } label: {
-                                HStack(spacing: 6) {
-                                    if isLoadingEarlier {
-                                        ProgressView()
-                                            .controlSize(.small)
-                                            .tint(Theme.accent)
-                                    } else {
-                                        Image(systemName: "arrow.up.circle")
-                                    }
-                                    Text("Load earlier messages")
-                                }
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(Theme.accent)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 12)
-                                .background(Theme.accent.opacity(0.08))
-                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                            }
-                            .disabled(isLoadingEarlier)
-                        }
+            // Mount the ScrollView only once we have content. ScrollView's
+            // `.defaultScrollAnchor(.bottom)` only takes effect on initial
+            // layout — mounting it with empty content would make the anchor a
+            // no-op once messages stream in, and we'd have to chase the
+            // bottom with explicit scrollTo's. Holding the ScrollView until
+            // `messages` is non-empty means its very first layout already has
+            // the conversation in it, so the bottom anchor lands the user at
+            // the most recent message naturally with no animation, no race.
+            if messages.isEmpty {
+                if isLoading {
+                    LoadingView(message: "Loading conversation...")
+                } else if viewingMissionIsRunning {
+                    agentWorkingIndicator
+                } else {
+                    emptyStateView
+                }
+            } else {
+                conversationScrollView
+            }
+        }
+    }
 
-                        if messages.isEmpty && !isLoading {
-                            // Show working indicator when this specific mission is running but no messages yet
-                            if viewingMissionIsRunning {
-                                agentWorkingIndicator
-                            } else {
-                                emptyStateView
-                            }
-                        } else if isLoading {
-                            LoadingView(message: "Loading conversation...")
-                                .frame(height: 200)
-                        } else {
-                            ForEach(groupedItems) { item in
-                                switch item {
-                                case .single(let message):
-                                    MessageBubble(
-                                        message: message,
-                                        isCopied: copiedMessageId == message.id,
-                                        onCopy: { copyMessage(message) }
-                                    )
-                                    .id(message.id)
-                                case .toolGroup(let groupId, let tools):
-                                    ToolGroupView(
-                                        groupId: groupId,
-                                        tools: tools,
-                                        expandedGroups: $expandedToolGroups
-                                    )
-                                    .id(item.id)
-                                }
-                            }
-
-                            // Show working indicator after messages when this mission is running but no active streaming item
-                            if viewingMissionIsRunning && !hasActiveStreamingItem {
-                                agentWorkingIndicator
-                            }
-                        }
-                        
-                        // Bottom anchor for scrolling past last message
-                        Color.clear
-                            .frame(height: 1)
-                            .id(bottomAnchorId)
-                    }
-                    .padding()
-                    .background(
-                        GeometryReader { geo in
-                            Color.clear.preference(
-                                key: ScrollOffsetPreferenceKey.self,
-                                value: geo.frame(in: .named("scroll")).maxY
-                            )
-                        }
-                    )
-                }
-                .defaultScrollAnchor(.bottom)
-                .coordinateSpace(name: "scroll")
-                .onPreferenceChange(ScrollOffsetPreferenceKey.self) { maxY in
-                    // Check if we're at the bottom (within 200 points for less flicker)
-                    isAtBottom = maxY < UIScreen.main.bounds.height + 200
-                }
-                .onTapGesture {
-                    // Dismiss keyboard when tapping on messages area
-                    isInputFocused = false
-                }
-                .onChange(of: messages.count) { _, _ in
-                    if let pendingFocusedMessageId {
-                        scheduleMessageFocusRetry(proxy: proxy, targetId: pendingFocusedMessageId)
-                    }
-                    // Only auto-scroll on message count change if we're at bottom AND not loading historical messages
-                    // This prevents the jarring animated scroll when loading cached/historical conversations
-                    if isAtBottom && !isLoadingHistory {
-                        scrollToBottom(proxy: proxy)
-                    }
-                }
-                .onChange(of: shouldScrollToBottom) { _, shouldScroll in
-                    if shouldScroll {
-                        scrollToBottom(proxy: proxy, immediate: shouldScrollImmediately)
-                        shouldScrollToBottom = false
-                        shouldScrollImmediately = false
-                    }
-                }
-                .onChange(of: pendingFocusedMessageId) { _, targetId in
-                    guard let targetId else { return }
-                    scheduleMessageFocusRetry(proxy: proxy, targetId: targetId)
-                }
-                .overlay(alignment: .bottom) {
-                    // Scroll to bottom button
-                    if !isAtBottom && !messages.isEmpty {
+    private var conversationScrollView: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 20) {
+                    // "Load earlier messages" button when history is truncated
+                    if hasMoreHistory {
                         Button {
-                            withAnimation(.spring(duration: 0.3)) {
-                                proxy.scrollTo(bottomAnchorId, anchor: .bottom)
-                            }
-                            isAtBottom = true
+                            Task { await loadEarlierMessages() }
                         } label: {
-                            Image(systemName: "arrow.down")
-                                .font(.system(size: 14, weight: .semibold))
-                                .foregroundStyle(.white)
-                                .frame(width: 36, height: 36)
-                                .background(.ultraThinMaterial)
-                                .clipShape(Circle())
-                                .overlay(
-                                    Circle()
-                                        .stroke(Theme.border, lineWidth: 1)
-                                )
-                                .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                            HStack(spacing: 6) {
+                                if isLoadingEarlier {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .tint(Theme.accent)
+                                } else {
+                                    Image(systemName: "arrow.up.circle")
+                                }
+                                Text("Load earlier messages")
+                            }
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(Theme.accent)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(Theme.accent.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
-                        .padding(.bottom, 16)
-                        .transition(.scale.combined(with: .opacity))
+                        .disabled(isLoadingEarlier)
                     }
+
+                    ForEach(groupedItems) { item in
+                        switch item {
+                        case .single(let message):
+                            MessageBubble(
+                                message: message,
+                                isCopied: copiedMessageId == message.id,
+                                onCopy: { copyMessage(message) }
+                            )
+                            .id(message.id)
+                        case .toolGroup(let groupId, let tools):
+                            ToolGroupView(
+                                groupId: groupId,
+                                tools: tools,
+                                expandedGroups: $expandedToolGroups
+                            )
+                            .id(item.id)
+                        }
+                    }
+
+                    // Show working indicator after messages when this mission is running but no active streaming item
+                    if viewingMissionIsRunning && !hasActiveStreamingItem {
+                        agentWorkingIndicator
+                    }
+
+                    // Bottom anchor for scrolling past last message
+                    Color.clear
+                        .frame(height: 1)
+                        .id(bottomAnchorId)
+                }
+                .padding()
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(
+                            key: ScrollOffsetPreferenceKey.self,
+                            value: geo.frame(in: .named("scroll")).maxY
+                        )
+                    }
+                )
+            }
+            .defaultScrollAnchor(.bottom)
+            .coordinateSpace(name: "scroll")
+            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { maxY in
+                // Check if we're at the bottom (within 200 points for less flicker)
+                isAtBottom = maxY < UIScreen.main.bounds.height + 200
+            }
+            .onTapGesture {
+                // Dismiss keyboard when tapping on messages area
+                isInputFocused = false
+            }
+            .onChange(of: messages.count) { _, _ in
+                if let pendingFocusedMessageId {
+                    scheduleMessageFocusRetry(proxy: proxy, targetId: pendingFocusedMessageId)
+                }
+                // Only auto-scroll on message count change if we're at bottom AND not loading historical messages
+                // This prevents the jarring animated scroll when loading cached/historical conversations
+                if isAtBottom && !isLoadingHistory {
+                    scrollToBottom(proxy: proxy)
+                }
+            }
+            .onChange(of: shouldScrollToBottom) { _, shouldScroll in
+                guard shouldScroll else { return }
+                let immediate = shouldScrollImmediately
+                shouldScrollToBottom = false
+                shouldScrollImmediately = false
+                // Used when the ScrollView is already mounted and the
+                // mission's content has been swapped wholesale (mission
+                // switch from cache, "load earlier", etc.). The first
+                // mount-with-content case relies on `.defaultScrollAnchor`
+                // and skips this path entirely. We defer one frame so the
+                // LazyVStack has had a tick to lay out the new rows before
+                // measuring the anchor.
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 16_000_000)
+                    scrollToBottom(proxy: proxy, immediate: immediate)
+                }
+            }
+            .onChange(of: pendingFocusedMessageId) { _, targetId in
+                guard let targetId else { return }
+                scheduleMessageFocusRetry(proxy: proxy, targetId: targetId)
+            }
+            .overlay(alignment: .bottom) {
+                // Scroll to bottom button
+                if !isAtBottom && !messages.isEmpty {
+                    Button {
+                        withAnimation(.spring(duration: 0.3)) {
+                            proxy.scrollTo(bottomAnchorId, anchor: .bottom)
+                        }
+                        isAtBottom = true
+                    } label: {
+                        Image(systemName: "arrow.down")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 36, height: 36)
+                            .background(.ultraThinMaterial)
+                            .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .stroke(Theme.border, lineWidth: 1)
+                            )
+                            .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
+                    }
+                    .padding(.bottom, 16)
+                    .transition(.scale.combined(with: .opacity))
                 }
             }
         }
@@ -1055,7 +1082,7 @@ struct ControlView: View {
     }
 
     private func applyViewingMission(_ mission: Mission, scrollToBottom: Bool = true) {
-        isLoadingHistory = true  // Prevent animated scroll during history load
+        isLoadingHistory = true  // Suppress animated auto-scroll during history load
 
         viewingMission = mission
         viewingMissionId = mission.id
@@ -1074,18 +1101,16 @@ struct ControlView: View {
             shouldScrollImmediately = true
             shouldScrollToBottom = true
         }
-
-        // Reset flag after SwiftUI has processed the state change
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-            isLoadingHistory = false
-        }
+        // Cleared synchronously at the next runloop tick, alongside the
+        // explicit scroll, so the `messages.count` onChange and the bottom
+        // anchor land in the same render pass instead of racing a sleep.
+        isLoadingHistory = false
     }
 
     private static let initialEventLimit = 50
 
     private func applyViewingMissionWithEvents(_ mission: Mission, events: [StoredEvent], scrollToBottom: Bool = true) {
-        isLoadingHistory = true  // Prevent animated scroll during history load
+        isLoadingHistory = true  // Suppress animated auto-scroll during history load
 
         viewingMission = mission
         viewingMissionId = mission.id
@@ -1139,12 +1164,42 @@ struct ControlView: View {
             shouldScrollImmediately = true
             shouldScrollToBottom = true
         }
+        isLoadingHistory = false
+    }
 
-        // Reset flag after SwiftUI has processed the state change
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-            isLoadingHistory = false
+    /// Append delta events to the existing conversation without clearing.
+    ///
+    /// Used by the SSE-reconnect / scene-phase-active resume path: the server
+    /// returns only events with `sequence > knownMaxSeq`, so they must be
+    /// appended (not replayed-from-empty). Each event is fed through
+    /// `handleStreamEvent` with `isHistoricalReplay: false` so the existing
+    /// upsert-by-id logic naturally dedupes anything that overlapped a live
+    /// SSE event we already saw.
+    private func applyDeltaEvents(_ events: [StoredEvent]) {
+        guard !events.isEmpty else { return }
+
+        let orderedEvents = events.sorted { lhs, rhs in
+            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
+            return lhs.id < rhs.id
         }
+
+        for event in orderedEvents {
+            var data: [String: Any] = [:]
+            for (key, value) in event.metadata {
+                data[key] = value.value
+            }
+            data["mission_id"] = event.missionId
+            data["content"] = event.content
+            if let eventId = event.eventId { data["id"] = eventId }
+            if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
+            if let toolName = event.toolName { data["name"] = toolName }
+
+            handleStreamEvent(type: event.eventType, data: data)
+        }
+
+        loadedEventCount += orderedEvents.count
+        recomputeGroupedItems()
     }
 
     private func loadCurrentMission(updateViewing: Bool) async {
@@ -1174,7 +1229,8 @@ struct ControlView: View {
                 if updateViewing || viewingMissionId == nil || viewingMissionId == mission.id {
                     do {
                         let eventTypes = ["user_message", "assistant_message", "tool_call", "tool_result", "text_delta", "thinking"]
-                        let events = try await api.getMissionEvents(id: mission.id, types: eventTypes, limit: Self.initialEventLimit, latest: true)
+                        let result = try await api.getMissionEventsWithMeta(id: mission.id, types: eventTypes, limit: Self.initialEventLimit, latest: true)
+                        let events = result.events
 
                         if events.isEmpty {
                             // Clear stale cache when events are empty
@@ -1183,6 +1239,12 @@ struct ControlView: View {
                         } else {
                             hasMoreHistory = events.count >= Self.initialEventLimit
                             applyViewingMissionWithEvents(mission, events: events)
+                            // Seed delta cursor only when the backend advertises support
+                            // via X-Max-Sequence — otherwise a delta call would be
+                            // ignored and return offset=0 rows.
+                            if let maxSeq = result.maxSequence, maxSeq > 0 {
+                                missionMaxSeq[mission.id] = maxSeq
+                            }
                             // Update cache with fresh data
                             cacheMissionWithEvents(mission, events: events)
                         }
@@ -1244,7 +1306,8 @@ struct ControlView: View {
             // Try to fetch full event history (optional - fall back to basic history if it fails)
             do {
                 // Fetch all relevant event types including thinking events (matching web dashboard behavior)
-                let events = try await api.getMissionEvents(id: id, types: historyEventTypes, limit: Self.initialEventLimit, latest: true)
+                let result = try await api.getMissionEventsWithMeta(id: id, types: historyEventTypes, limit: Self.initialEventLimit, latest: true)
+                let events = result.events
 
                 // Race condition guard after the second await
                 guard fetchingMissionId == id else {
@@ -1258,6 +1321,9 @@ struct ControlView: View {
                 } else {
                     hasMoreHistory = events.count >= Self.initialEventLimit
                     applyViewingMissionWithEvents(mission, events: events)
+                    if let maxSeq = result.maxSequence, maxSeq > 0 {
+                        missionMaxSeq[id] = maxSeq
+                    }
                     // Cache the mission with events for next time
                     cacheMissionWithEvents(mission, events: events)
                 }
@@ -1327,42 +1393,103 @@ struct ControlView: View {
         }
     }
 
-    // Reload mission from server without showing loading state or cache
-    // Used when app becomes active to catch missed SSE events (like web's visibility change handler)
+    // Reload mission from server without showing loading state or cache.
+    // Called when the scene becomes active to catch missed SSE events (mirrors
+    // the web's visibility-change handler). Prefers the `since_seq` delta path
+    // when supported; falls back to a tail reload only when no high-water mark
+    // is recorded for this mission yet.
     private func reloadMissionFromServer(id: String) async {
-        // Guard against race conditions - only apply if user is still viewing this mission
         guard viewingMissionId == id else { return }
 
         do {
             let mission = try await api.getMission(id: id)
-
-            // Check again after async operation
             guard viewingMissionId == id else { return }
 
-            // Update current mission if it matches
             if currentMission?.id == mission.id {
                 currentMission = mission
             }
 
-            // Fetch events to get the updated history (use pagination if we haven't loaded full history)
+            // Delta path: if we have a high-water mark, ask the backend for
+            // events arriving after it. Avoids re-downloading the entire
+            // history for what is usually a single missed message.
+            if let knownSeq = missionMaxSeq[id] {
+                do {
+                    let result = try await api.getMissionEventsWithMeta(
+                        id: id,
+                        types: historyEventTypes,
+                        limit: 5000,
+                        sinceSeq: knownSeq
+                    )
+                    guard viewingMissionId == id else { return }
+                    if let maxSeq = result.maxSequence {
+                        // Backend supports delta resume — apply and update cursor.
+                        applyDeltaEvents(result.events)
+                        let lastSeq = result.events.last?.sequence ?? knownSeq
+                        let cursor = (result.events.count >= 5000 && lastSeq < maxSeq) ? lastSeq : maxSeq
+                        missionMaxSeq[id] = cursor
+                        return
+                    }
+                    // Backend stripped X-Max-Sequence — drop the cursor and
+                    // fall through to the full-reload path below.
+                    missionMaxSeq.removeValue(forKey: id)
+                } catch {
+                    // Network/server error during delta — fall through to full reload.
+                    print("Delta resume failed, falling back to tail reload: \(error)")
+                }
+            }
+
+            // Fallback / first-time path: fetch the recent tail.
             let limit = hasMoreHistory ? Self.initialEventLimit : nil
             let latest = hasMoreHistory
-            if let events = try? await api.getMissionEvents(id: id, types: historyEventTypes, limit: limit, latest: latest), !events.isEmpty {
-                // Final check before applying
+            if let result = try? await api.getMissionEventsWithMeta(id: id, types: historyEventTypes, limit: limit, latest: latest), !result.events.isEmpty {
                 guard viewingMissionId == id else { return }
-                applyViewingMissionWithEvents(mission, events: events, scrollToBottom: false)
-                // Update cache with fresh data
-                cacheMissionWithEvents(mission, events: events)
+                applyViewingMissionWithEvents(mission, events: result.events, scrollToBottom: false)
+                if let maxSeq = result.maxSequence, maxSeq > 0 {
+                    missionMaxSeq[id] = maxSeq
+                }
+                cacheMissionWithEvents(mission, events: result.events)
             } else {
-                // Final check before applying
                 guard viewingMissionId == id else { return }
-                // Clear stale cache when events are empty or fetch fails to prevent visual flashing
                 removeMissionFromCache(mission.id)
                 applyViewingMission(mission, scrollToBottom: false)
             }
         } catch {
             print("Failed to reload mission from server: \(error)")
         }
+    }
+
+    /// Resume a viewing mission after an SSE reconnect. Same delta-first logic
+    /// as `reloadMissionFromServer` but without the mission-metadata refetch
+    /// (the SSE stream itself will deliver any metadata changes). Keeps the
+    /// reconnect catch-up fast even on missions with thousands of events.
+    private func resumeMissionAfterReconnect(id: String) async {
+        guard viewingMissionId == id else { return }
+
+        if let knownSeq = missionMaxSeq[id] {
+            do {
+                let result = try await api.getMissionEventsWithMeta(
+                    id: id,
+                    types: historyEventTypes,
+                    limit: 5000,
+                    sinceSeq: knownSeq
+                )
+                guard viewingMissionId == id else { return }
+                if let maxSeq = result.maxSequence {
+                    applyDeltaEvents(result.events)
+                    let lastSeq = result.events.last?.sequence ?? knownSeq
+                    let cursor = (result.events.count >= 5000 && lastSeq < maxSeq) ? lastSeq : maxSeq
+                    missionMaxSeq[id] = cursor
+                    return
+                }
+                missionMaxSeq.removeValue(forKey: id)
+            } catch {
+                print("Reconnect delta resume failed: \(error)")
+            }
+        }
+
+        // No cursor or backend doesn't advertise resume — fall back to the
+        // full reload, scoped to this mission.
+        await reloadMissionFromServer(id: id)
     }
 
     private func createNewMission(options: NewMissionOptions? = nil) async {
@@ -1842,21 +1969,14 @@ struct ControlView: View {
                                 self.connectionState = .connected
                                 self.reconnectAttempt = 0
 
-                                // If we just reconnected, refresh the viewed mission's history to catch missed events
+                                // Just reconnected — catch up on events we missed while disconnected.
+                                // Prefer the delta path (since_seq) when the backend supports it
+                                // and we have a high-water mark for this mission. Falls back to a
+                                // full reload only if the backend doesn't advertise X-Max-Sequence
+                                // or we never recorded a cursor for this mission.
                                 if wasReconnecting, let viewingId = self.viewingMissionId {
                                     Task {
-                                        do {
-                                            let mission = try await self.api.getMission(id: viewingId)
-                                            let events = try await self.api.getMissionEvents(
-                                                id: viewingId,
-                                                types: self.historyEventTypes
-                                            )
-                                            await MainActor.run {
-                                                self.applyViewingMissionWithEvents(mission, events: events)
-                                            }
-                                        } catch {
-                                            // Ignore errors - we'll get updates via stream
-                                        }
+                                        await self.resumeMissionAfterReconnect(id: viewingId)
                                     }
                                 }
                             }
@@ -2229,6 +2349,9 @@ struct ControlView: View {
         case "assistant_message":
             if let content = data["content"] as? String,
                let id = data["id"] as? String {
+                // Skip if already present — historical replay or delta resume
+                // can re-deliver an assistant_message we already saw via SSE.
+                guard !messages.contains(where: { $0.id == id }) else { break }
                 let success = data["success"] as? Bool ?? true
                 let costObj = data["cost"] as? [String: Any]
                 let costCents = data["cost_cents"] as? Int

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1416,6 +1416,8 @@ struct ControlView: View {
     /// Outcome of a `tryDeltaResume` attempt.
     private enum DeltaResumeOutcome {
         case applied      // backend supports resume, events applied, cursor advanced
+        case viewChanged  // user navigated away mid-request; nothing applied, no
+                          // fallback should run (the new view will refetch on its own)
         case unsupported  // backend stripped `X-Max-Sequence` — cursor dropped
         case noCursor     // no high-water mark recorded; nothing attempted
         case failed       // network/server error; cursor untouched
@@ -1435,7 +1437,7 @@ struct ControlView: View {
                 limit: Self.deltaResumePageLimit,
                 sinceSeq: knownSeq
             )
-            guard viewingMissionId == id else { return .applied }
+            guard viewingMissionId == id else { return .viewChanged }
             guard let maxSeq = result.maxSequence else {
                 // Backend stripped `X-Max-Sequence` — drop the cursor so the
                 // delta path is disabled until the next header-bearing fetch.
@@ -1474,7 +1476,7 @@ struct ControlView: View {
             }
 
             switch await tryDeltaResume(missionId: id) {
-            case .applied:
+            case .applied, .viewChanged:
                 return
             case .noCursor, .unsupported, .failed:
                 break  // fall through to full tail reload below
@@ -1506,10 +1508,14 @@ struct ControlView: View {
     /// reconnect catch-up fast even on missions with thousands of events.
     private func resumeMissionAfterReconnect(id: String) async {
         guard viewingMissionId == id else { return }
-        if case .applied = await tryDeltaResume(missionId: id) { return }
-        // No cursor, backend doesn't advertise resume, or transient error —
-        // fall back to a scoped tail reload.
-        await reloadMissionFromServer(id: id)
+        switch await tryDeltaResume(missionId: id) {
+        case .applied, .viewChanged:
+            return
+        case .noCursor, .unsupported, .failed:
+            // Fall back to a scoped tail reload — covers first-connect (no cursor),
+            // older backends (no `X-Max-Sequence`), and transient errors.
+            await reloadMissionFromServer(id: id)
+        }
     }
 
     private func createNewMission(options: NewMissionOptions? = nil) async {


### PR DESCRIPTION
## Summary
Two perceived-perf fixes for the iOS app, both addressing user complaints about chat UX:

### 1. Open the conversation already at the bottom — no scroll dance

`ControlView` mounted the `ScrollView` *before* the conversation had been
loaded. SwiftUI's `.defaultScrollAnchor(.bottom)` only takes effect on the
ScrollView's first layout, so anchoring against an empty LazyVStack made it a
no-op once messages streamed in. The view then chased the bottom with
`proxy.scrollTo` calls that raced a 100ms `Task.sleep`-gated `isLoadingHistory`
flag, the GeometryReader preference, and the LazyVStack's lazy layout. Net
result: opening a mission would land the user near the top of the history.

Fix: hold the ScrollView until ``messages`` is non-empty (cached or fresh).
Loading and empty placeholders render outside it. When the ScrollView mounts,
its very first layout already contains the conversation, so
`.defaultScrollAnchor(.bottom)` correctly puts the most recent message in view
with no animation, no race, no extra scroll plumbing.

The 100ms ``Task.sleep`` race in ``applyViewingMission`` /
``applyViewingMissionWithEvents`` is gone — ``isLoadingHistory`` is cleared
synchronously alongside the message update.

### 2. Port the web client's `since_seq` + `X-Max-Sequence` resume protocol

iOS previously refetched the *full* event history on every SSE reconnect and
on every scene-phase transition to ``.active``. On long missions that's a
multi-second blocker on cellular. The web client landed this protocol in
``adefb0c8`` / ``95e5f5c8``; this PR brings it to iOS:

- ``APIService.getMissionEventsWithMeta(...)`` — same signature plus
  ``sinceSeq``, returns ``MissionEventsResult { events, maxSequence }`` parsed
  from the ``X-Max-Sequence`` response header.
- ``missionMaxSeq: [String: Int64]`` per-mission high-water mark, seeded only
  after a header-bearing response so we don't enable delta against older
  backends that silently ignore ``since_seq``.
- ``resumeMissionAfterReconnect(id:)`` runs after SSE reconnect; uses delta
  when the cursor is set, falls back to ``reloadMissionFromServer`` otherwise.
- ``reloadMissionFromServer(id:)`` (scene-phase active) prefers the delta path
  identically.
- New ``applyDeltaEvents(_:)`` feeds delta events through the existing
  ``handleStreamEvent`` upsert path so anything that overlapped a live SSE
  event we already saw is naturally deduped.

Also tightens ``assistant_message`` handling to dedup by id like
``user_message`` already did — exposed by the delta path, which can replay
messages already rendered from the live stream.

## Test plan
- [x] Swift compile clean against ``-sdk iphonesimulator``
- [ ] Cold-launch app: lands at most recent message with no visible scroll
- [ ] Foreground app from background mid-conversation: only the missed events
      arrive, full history is *not* refetched (network panel)
- [ ] Force SSE reconnect: same — delta-only network call
- [ ] Mission switch (cache hit): lands at bottom of switched-to mission
- [ ] Long mission (1k+ events): scrolling stays smooth, no jank during
      stream deltas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 806262d53f8d964c3877439379361ad38310f226. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->