### PR TITLE
polish(ios): UX pass — cost, title, banner, empty states, copy, theme

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Models/ChatMessage.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatMessage.swift
@@ -285,7 +285,13 @@ struct ChatMessage: Identifiable {
             // Don't show cost for unknown sources — avoids misleading "$0.0000"
             guard costSource != .unknown else { return nil }
             guard costCents > 0 else { return nil }
-            let formatted = String(format: "$%.4f", Double(costCents) / 100.0)
+            let dollars = Double(costCents) / 100.0
+            // Sub-cent amounts (< $0.005) collapse to a sentinel rather than
+            // rendering as "$0.00" — matches receipt-style readability while
+            // avoiding the four-decimal "$4.2200" debug-overlay look.
+            let formatted: String = dollars < 0.005
+                ? "<$0.01"
+                : String(format: "$%.2f", dollars)
             return costSource == .estimated ? "~\(formatted)" : formatted
         }
         return nil

--- a/ios_dashboard/SandboxedDashboard/Models/ChatMessage.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatMessage.swift
@@ -286,12 +286,11 @@ struct ChatMessage: Identifiable {
             guard costSource != .unknown else { return nil }
             guard costCents > 0 else { return nil }
             let dollars = Double(costCents) / 100.0
-            // Sub-cent amounts (< $0.005) collapse to a sentinel rather than
-            // rendering as "$0.00" — matches receipt-style readability while
-            // avoiding the four-decimal "$4.2200" debug-overlay look.
-            let formatted: String = dollars < 0.005
-                ? "<$0.01"
-                : String(format: "$%.2f", dollars)
+            // Two-decimal receipt-style render — replaces the previous
+            // "$4.2200" debug-overlay look. `costCents > 0` already guards
+            // against the zero case, so the smallest value we ever format
+            // is `$0.01`.
+            let formatted = String(format: "$%.2f", dollars)
             return costSource == .estimated ? "~\(formatted)" : formatted
         }
         return nil

--- a/ios_dashboard/SandboxedDashboard/Views/Components/RunningMissionsBar.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/RunningMissionsBar.swift
@@ -94,7 +94,7 @@ struct RunningMissionsBar: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            .background(isViewing ? Theme.accent.opacity(0.15) : Color.white.opacity(0.05))
+            .background(isViewing ? Theme.accent.opacity(0.15) : Theme.backgroundTertiary)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -191,10 +191,11 @@ struct RunningMissionsBar: View {
                     .font(.system(size: 9, weight: .medium))
                     .foregroundStyle(Theme.textMuted)
                     .frame(width: 18, height: 18)
-                    .background(Color.white.opacity(0.08))
+                    .background(Theme.borderElevated)
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Cancel mission")
         }
         .padding(.leading, 12)
         .padding(.trailing, 6)

--- a/ios_dashboard/SandboxedDashboard/Views/Components/WorkerPeekView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/WorkerPeekView.swift
@@ -111,7 +111,7 @@ struct WorkerPeekView: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.white.opacity(0.03))
+        .background(Theme.borderSubtle)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -110,6 +110,15 @@ struct ControlView: View {
             backgroundGlows
             
             VStack(spacing: 0) {
+                // Persistent connection banner. The 9pt wifi-slash glyph in
+                // the principal toolbar is too easy to miss when the SSE
+                // stream drops; a sticky strip across the top keeps the
+                // disconnected state in peripheral vision until reconnect.
+                if !connectionState.isConnected {
+                    connectionBanner
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+
                 // Messages
                 ZStack(alignment: .bottom) {
                     messagesView
@@ -133,69 +142,79 @@ struct ControlView: View {
                 // Input area
                 inputView
             }
+            .animation(.easeInOut(duration: 0.2), value: connectionState.isConnected)
         }
         .navigationTitle(viewingMission?.displayTitle ?? "Control")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 VStack(spacing: 2) {
-                    Text(viewingMission?.displayTitle ?? "Control")
+                    // Use the raw title with `.lineLimit(1)` rather than the
+                    // pre-truncated `displayTitle` (which silently slices at
+                    // 60 chars with no escape hatch). SwiftUI handles tail
+                    // truncation against the actual nav-bar width, and the
+                    // context menu lets the user pull up the full string.
+                    let trimmed = viewingMission?.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                    let fullTitle = trimmed.isEmpty ? "Control" : trimmed
+                    Text(fullTitle)
                         .font(.headline)
                         .foregroundStyle(Theme.textPrimary)
-
-                    HStack(spacing: 4) {
-                        // Show connection state or run state
-                        if !connectionState.isConnected {
-                            // Connection issue - show reconnecting/disconnected state
-                            Image(systemName: connectionState.icon)
-                                .font(.system(size: 9))
-                                .foregroundStyle(Theme.warning)
-                                .symbolEffect(.pulse, options: .repeating)
-                            Text(connectionState.label)
-                                .font(.caption2)
-                                .foregroundStyle(Theme.warning)
-                        } else {
-                            // Show backend/agent info if available
-                            if let mission = viewingMission {
-                                let backendColor = missionBackendColor(mission)
-                                if let agent = mission.agent, !agent.isEmpty {
-                                    Image(systemName: missionBackendIcon(mission))
-                                        .font(.system(size: 9))
-                                        .foregroundStyle(backendColor)
-                                    Text(agent)
-                                        .font(.caption2)
-                                        .foregroundStyle(backendColor)
-                                    Text("•")
-                                        .foregroundStyle(Theme.textMuted)
-                                }
-                            }
-                            
-                            // Connected - show normal run state
-                            StatusDot(status: runState.statusType, size: 5)
-                            Text(runState.label)
-                                .font(.caption2)
-                                .foregroundStyle(Theme.textSecondary)
-
-                            if queueLength > 0 {
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .contextMenu {
+                            if fullTitle != "Control" {
+                                Section(fullTitle) {}
                                 Button {
-                                    Task { await loadQueueItems() }
-                                    showQueueSheet = true
+                                    UIPasteboard.general.string = fullTitle
                                     HapticService.lightTap()
                                 } label: {
-                                    Text("• \(queueLength) queued")
-                                        .font(.caption2)
-                                        .foregroundStyle(Theme.warning)
+                                    Label("Copy title", systemImage: "doc.on.doc")
                                 }
                             }
+                        }
 
-                            // Progress indicator
-                            if let progress = progress, progress.total > 0 {
+                    HStack(spacing: 4) {
+                        // Connection state moved to a persistent banner above the
+                        // conversation; this row always shows backend + run state
+                        // so a disconnect doesn't blank out the run-state context.
+                        if let mission = viewingMission {
+                            let backendColor = missionBackendColor(mission)
+                            if let agent = mission.agent, !agent.isEmpty {
+                                Image(systemName: missionBackendIcon(mission))
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(backendColor)
+                                Text(agent)
+                                    .font(.caption2)
+                                    .foregroundStyle(backendColor)
                                 Text("•")
                                     .foregroundStyle(Theme.textMuted)
-                                Text(progress.displayText)
-                                    .font(.caption2.weight(.medium))
-                                    .foregroundStyle(Theme.success)
                             }
+                        }
+
+                        StatusDot(status: runState.statusType, size: 5)
+                        Text(runState.label)
+                            .font(.caption2)
+                            .foregroundStyle(Theme.textSecondary)
+
+                        if queueLength > 0 {
+                            Button {
+                                Task { await loadQueueItems() }
+                                showQueueSheet = true
+                                HapticService.lightTap()
+                            } label: {
+                                Text("• \(queueLength) queued")
+                                    .font(.caption2)
+                                    .foregroundStyle(Theme.warning)
+                            }
+                        }
+
+                        // Progress indicator
+                        if let progress, progress.total > 0 {
+                            Text("•")
+                                .foregroundStyle(Theme.textMuted)
+                            Text(progress.displayText)
+                                .font(.caption2.weight(.medium))
+                                .foregroundStyle(Theme.success)
                         }
                     }
                 }
@@ -574,11 +593,36 @@ struct ControlView: View {
     }
     
     // MARK: - Header (now in toolbar)
-    
+
     private var headerView: some View {
         EmptyView() // Moved to navigation bar
     }
-    
+
+    // MARK: - Connection banner
+
+    /// Sticky strip rendered above the conversation when the SSE stream is
+    /// down. The toolbar already shows a small wifi-slash glyph, but it's
+    /// easy to miss on a long page; this strip stays in peripheral vision.
+    private var connectionBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: connectionState.icon)
+                .font(.system(size: 11, weight: .semibold))
+                .symbolEffect(.pulse, options: .repeating)
+            Text(connectionState.label)
+                .font(.caption.weight(.medium))
+            Spacer()
+        }
+        .foregroundStyle(Theme.warning)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(Theme.warning.opacity(0.12))
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Theme.warning.opacity(0.25))
+                .frame(height: 0.5)
+        }
+    }
+
     // MARK: - Messages
     
     private var messagesView: some View {
@@ -2900,19 +2944,18 @@ private struct MessageBubble: View {
                         if let cost = message.costFormatted {
                             Text("•")
                                 .foregroundStyle(Theme.textMuted)
-                            Text(cost)
-                                .font(.caption2.monospaced())
-                                .foregroundStyle(message.costIsEstimated ? Theme.textSecondary : Theme.success)
-                            if let badge = message.costSourceLabel {
-                                Text(badge)
-                                    .font(.system(size: 8, weight: .medium))
-                                    .textCase(.uppercase)
-                                    .tracking(0.4)
-                                    .foregroundStyle(Theme.textMuted)
-                                    .padding(.horizontal, 4)
-                                    .padding(.vertical, 2)
-                                    .background(Color.white.opacity(0.08))
-                                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                            // Cost + source as one calm chip: "$4.22 actual" — the
+                            // ALL-CAPS pill version of "ACTUAL" was visually shouting
+                            // louder than the cost itself.
+                            HStack(spacing: 4) {
+                                Text(cost)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(message.costIsEstimated ? Theme.textSecondary : Theme.success)
+                                if let badge = message.costSourceLabel {
+                                    Text(badge.lowercased())
+                                        .font(.caption2)
+                                        .foregroundStyle(Theme.textMuted)
+                                }
                             }
                         }
 

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -154,15 +154,26 @@ struct ControlView: View {
                     // 60 chars with no escape hatch). SwiftUI handles tail
                     // truncation against the actual nav-bar width, and the
                     // context menu lets the user pull up the full string.
-                    let trimmed = viewingMission?.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                    let fullTitle = trimmed.isEmpty ? "Control" : trimmed
+                    //
+                    // Fall back to "Untitled Mission" — not "Control" — when a
+                    // mission is being viewed but its title is empty. Showing
+                    // "Control" would falsely imply no mission is active and
+                    // diverges from `.navigationTitle` (which uses
+                    // `displayTitle`, returning "Untitled Mission").
+                    let fullTitle: String = {
+                        if let mission = viewingMission {
+                            let trimmed = mission.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                            return trimmed.isEmpty ? "Untitled Mission" : trimmed
+                        }
+                        return "Control"
+                    }()
                     Text(fullTitle)
                         .font(.headline)
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .contextMenu {
-                            if fullTitle != "Control" {
+                            if viewingMission != nil {
                                 Section(fullTitle) {}
                                 Button {
                                     UIPasteboard.general.string = fullTitle

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -990,15 +990,11 @@ struct ControlView: View {
         else {
             return nil
         }
-        let icon: String
-        let tint: Color
-        switch parsed.backend {
-        case "opencode": icon = "terminal"; tint = Theme.success
-        case "claudecode": icon = "brain"; tint = Theme.accent
-        case "amp": icon = "bolt.fill"; tint = .orange
-        default: icon = "cpu"; tint = Theme.accent
-        }
-        return (icon, parsed.agent, tint)
+        return (
+            BackendAgentService.icon(for: parsed.backend),
+            parsed.agent,
+            BackendAgentService.color(for: parsed.backend)
+        )
     }
     
     private func suggestionChip(_ text: String) -> some View {
@@ -1970,23 +1966,13 @@ struct ControlView: View {
     }
     
     // MARK: - Backend Helpers
-    
+
     private func missionBackendColor(_ mission: Mission) -> Color {
-        switch mission.backend {
-        case "opencode": return Theme.success
-        case "claudecode": return Theme.accent
-        case "amp": return .orange
-        default: return Theme.accent
-        }
+        BackendAgentService.color(for: mission.backend)
     }
-    
+
     private func missionBackendIcon(_ mission: Mission) -> String {
-        switch mission.backend {
-        case "opencode": return "terminal"
-        case "claudecode": return "brain"
-        case "amp": return "bolt.fill"
-        default: return "cpu"
-        }
+        BackendAgentService.icon(for: mission.backend)
     }
     
     private func sendMessage() {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -924,12 +924,18 @@ struct ControlView: View {
                     .font(.title2.bold())
                     .foregroundStyle(Theme.textPrimary)
 
-                Text(emptyStateSubtitle)
+                Text("Send a message to start a new mission")
                     .font(.subheadline)
                     .foregroundStyle(Theme.textSecondary)
                     .multilineTextAlignment(.center)
                     .lineSpacing(4)
             }
+
+            // Context chips: gives a first-run user visual confirmation of
+            // *where* the next message lands and *which* agent will pick it
+            // up. Without these, the empty state hides this state behind
+            // the toolbar — easy to miss on a fresh install.
+            emptyStateContextChips
 
             Spacer()
             Spacer()
@@ -937,15 +943,62 @@ struct ControlView: View {
         .padding(.horizontal, 32)
     }
 
-    private var emptyStateSubtitle: String {
-        if let workspace = workspaceState.selectedWorkspace {
-            if workspace.isDefault {
-                return "Send a message to start working\non the host environment"
-            } else {
-                return "Send a message to start working\nin \(workspace.name)"
+    private var emptyStateContextChips: some View {
+        HStack(spacing: 8) {
+            if let workspace = workspaceState.selectedWorkspace {
+                emptyStateChip(
+                    icon: workspace.isDefault ? "macbook" : "shippingbox",
+                    label: workspace.isDefault ? "Host" : workspace.name,
+                    tint: Theme.accent
+                )
+            }
+            if let agentChip = defaultAgentChipInfo {
+                emptyStateChip(
+                    icon: agentChip.icon,
+                    label: agentChip.label,
+                    tint: agentChip.tint
+                )
             }
         }
-        return "Send a message to start working\nwith the AI agent"
+    }
+
+    private func emptyStateChip(icon: String, label: String, tint: Color) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .semibold))
+            Text(label)
+                .font(.caption.weight(.medium))
+                .lineLimit(1)
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(tint.opacity(0.12))
+        .clipShape(Capsule())
+        .overlay(
+            Capsule().stroke(tint.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+
+    /// Resolve the saved default agent into a chip, or `nil` if the user
+    /// hasn't saved one (in which case the picker fires on first send).
+    private var defaultAgentChipInfo: (icon: String, label: String, tint: Color)? {
+        guard
+            let saved = UserDefaults.standard.string(forKey: "default_agent"),
+            !saved.isEmpty,
+            let parsed = CombinedAgent.parse(saved)
+        else {
+            return nil
+        }
+        let icon: String
+        let tint: Color
+        switch parsed.backend {
+        case "opencode": icon = "terminal"; tint = Theme.success
+        case "claudecode": icon = "brain"; tint = Theme.accent
+        case "amp": icon = "bolt.fill"; tint = .orange
+        default: icon = "cpu"; tint = Theme.accent
+        }
+        return (icon, parsed.agent, tint)
     }
     
     private func suggestionChip(_ text: String) -> some View {
@@ -2916,6 +2969,13 @@ private struct MessageBubble: View {
                             topTrailingRadius: 20
                         )
                     )
+                    .contextMenu {
+                        Button {
+                            onCopy?()
+                        } label: {
+                            Label("Copy", systemImage: "doc.on.doc")
+                        }
+                    }
 
                 // Timestamp
                 Text(message.timestamp, style: .time)
@@ -2924,7 +2984,7 @@ private struct MessageBubble: View {
             }
         }
     }
-    
+
     private var assistantBubble: some View {
         HStack(alignment: .top, spacing: 8) {
             VStack(alignment: .leading, spacing: 8) {
@@ -2984,6 +3044,13 @@ private struct MessageBubble: View {
                         RoundedRectangle(cornerRadius: 20, style: .continuous)
                             .stroke(Theme.border, lineWidth: 0.5)
                     )
+                    .contextMenu {
+                        Button {
+                            onCopy?()
+                        } label: {
+                            Label("Copy", systemImage: "doc.on.doc")
+                        }
+                    }
 
                 // Render shared files
                 if let files = message.sharedFiles, !files.isEmpty {
@@ -3225,19 +3292,22 @@ private struct SharedFileCardView: View {
 private struct CopyButton: View {
     let isCopied: Bool
     let onCopy: (() -> Void)?
-    
+
     var body: some View {
         Button {
             onCopy?()
         } label: {
             Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
-                .font(.system(size: 12))
-                .foregroundStyle(isCopied ? Theme.success : Theme.textMuted)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(isCopied ? Theme.success : Theme.textSecondary)
                 .frame(width: 28, height: 28)
                 .background(Theme.backgroundSecondary)
                 .clipShape(Circle())
+                .overlay(
+                    Circle().stroke(Theme.border, lineWidth: 0.5)
+                )
         }
-        .opacity(0.7)
+        .accessibilityLabel(isCopied ? "Copied" : "Copy message")
     }
 }
 
@@ -3599,7 +3669,11 @@ private struct ThinkingBubble: View {
             // Expandable content
             if isExpanded && !message.content.isEmpty {
                 ScrollView {
-                    Text(message.content)
+                    // Inline a blinking caret while streaming so the user can
+                    // distinguish in-flight tokens from a settled thought.
+                    // Without this, a paused stream looks identical to a
+                    // completed one.
+                    (Text(message.content) + (message.thinkingDone ? Text("") : Text(" ▍").foregroundColor(Theme.accent)))
                         .font(.caption)
                         .foregroundStyle(Theme.textTertiary)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
@@ -197,6 +197,12 @@ struct FilesView: View {
             Button("Delete", role: .destructive) {
                 Task { await deleteSelected() }
             }
+        } message: {
+            if selectedEntry?.isDirectory == true {
+                Text("This permanently deletes the folder and everything inside it. This can't be undone.")
+            } else {
+                Text("This permanently deletes the file. This can't be undone.")
+            }
         }
         .fileImporter(
             isPresented: $isImporting,

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -139,10 +139,19 @@ struct HistoryView: View {
                             actionLabel: "Retry"
                         )
                     } else if filteredMissions.isEmpty && tasks.isEmpty {
+                        // Empty state used to be a dead end; the "Start a
+                        // mission" CTA gives the user a one-tap path back to
+                        // Control on first launch instead of leaving them
+                        // stuck on a tab with nothing in it.
                         EmptyStateView(
                             icon: "clock.arrow.circlepath",
                             title: "No History",
-                            message: "Your missions will appear here"
+                            message: "Missions you run will show up here once you've started one.",
+                            action: {
+                                nav.selectedTab = .control
+                                HapticService.lightTap()
+                            },
+                            actionLabel: "Start a mission"
                         )
                     } else {
                         missionsList

--- a/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
@@ -131,6 +131,10 @@ struct SettingsView: View {
                                         .textInputAutocapitalization(.never)
                                         .autocorrectionDisabled()
                                         .keyboardType(.URL)
+                                        .submitLabel(.done)
+                                        .onSubmit {
+                                            Task { await testConnection() }
+                                        }
                                         .padding(.horizontal, 16)
                                         .padding(.vertical, 14)
                                         .background(Color.white.opacity(0.05))
@@ -225,10 +229,30 @@ struct SettingsView: View {
                                             .tint(Theme.accent)
                                     }
 
-                                    if !FidoApprovalState.shared.autoApprovalRules.isEmpty {
-                                        Divider()
-                                            .background(Theme.border)
+                                    Divider()
+                                        .background(Theme.border)
 
+                                    if FidoApprovalState.shared.autoApprovalRules.isEmpty {
+                                        // Without this hint, an empty Auto-Approval section is
+                                        // invisible — users can't tell the feature exists, let
+                                        // alone how rules accumulate. Surface the explanation
+                                        // up-front so first-run state isn't a blank divider.
+                                        HStack(alignment: .top, spacing: 10) {
+                                            Image(systemName: "checkmark.shield")
+                                                .font(.system(size: 16, weight: .medium))
+                                                .foregroundStyle(Theme.textTertiary)
+                                                .frame(width: 24)
+                                            VStack(alignment: .leading, spacing: 4) {
+                                                Text("No auto-approval rules yet")
+                                                    .font(.subheadline.weight(.medium))
+                                                    .foregroundStyle(Theme.textPrimary)
+                                                Text("When you approve a signing request, you can save the choice as a rule so future identical requests skip the prompt.")
+                                                    .font(.caption)
+                                                    .foregroundStyle(Theme.textSecondary)
+                                                    .fixedSize(horizontal: false, vertical: true)
+                                            }
+                                        }
+                                    } else {
                                         AutoApprovalRulesView()
 
                                         Button {

--- a/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
     @State private var selectedDefaultAgent: String = ""
     @State private var isLoadingAgents = true
     @State private var skipAgentSelection = false
+    @State private var showClearRulesConfirm = false
 
     private let api = APIService.shared
     private let originalURL: String
@@ -231,10 +232,8 @@ struct SettingsView: View {
                                         AutoApprovalRulesView()
 
                                         Button {
-                                            withAnimation {
-                                                FidoApprovalState.shared.autoApprovalRules.removeAll()
-                                            }
-                                            HapticService.mediumTap()
+                                            showClearRulesConfirm = true
+                                            HapticService.lightTap()
                                         } label: {
                                             HStack {
                                                 Image(systemName: "trash")
@@ -246,6 +245,21 @@ struct SettingsView: View {
                                             .padding(.vertical, 10)
                                             .background(Theme.error.opacity(0.1))
                                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                                        }
+                                        .confirmationDialog(
+                                            "Clear all auto-approval rules?",
+                                            isPresented: $showClearRulesConfirm,
+                                            titleVisibility: .visible
+                                        ) {
+                                            Button("Clear All Rules", role: .destructive) {
+                                                withAnimation {
+                                                    FidoApprovalState.shared.autoApprovalRules.removeAll()
+                                                }
+                                                HapticService.mediumTap()
+                                            }
+                                            Button("Cancel", role: .cancel) {}
+                                        } message: {
+                                            Text("This permanently removes every saved auto-approval rule. Future signing requests will require manual approval until you create new rules. This can't be undone.")
                                         }
                                     }
                                 }

--- a/ios_dashboard/SandboxedDashboard/Views/Terminal/TerminalView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Terminal/TerminalView.swift
@@ -217,7 +217,7 @@ struct TerminalView: View {
                 .font(.system(size: 15, weight: .bold, design: .monospaced))
                 .foregroundStyle(Theme.success)
             
-            TextField("", text: $inputText, prompt: Text("command").foregroundStyle(Color.white.opacity(0.3)))
+            TextField("", text: $inputText, prompt: Text("command").foregroundStyle(Theme.textMuted))
                 .textFieldStyle(.plain)
                 .font(.system(size: 15, weight: .regular, design: .monospaced))
                 .foregroundStyle(.white)
@@ -246,7 +246,7 @@ struct TerminalView: View {
         .overlay(
             Rectangle()
                 .frame(height: 1)
-                .foregroundStyle(Color.white.opacity(0.1)),
+                .foregroundStyle(Theme.borderElevated),
             alignment: .top
         )
     }

--- a/ios_dashboard/SandboxedDashboard/Views/Workspaces/WorkspacesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Workspaces/WorkspacesView.swift
@@ -16,7 +16,7 @@ struct WorkspacesView: View {
 
     var body: some View {
         ZStack {
-            Color.black.ignoresSafeArea()
+            Theme.backgroundPrimary.ignoresSafeArea()
 
             if isLoading {
                 ProgressView()
@@ -172,7 +172,7 @@ struct WorkspaceDetailView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                Color.black.ignoresSafeArea()
+                Theme.backgroundPrimary.ignoresSafeArea()
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
@@ -251,11 +251,17 @@ struct NewWorkspaceSheet: View {
     var body: some View {
         NavigationView {
             ZStack {
-                Color.black.ignoresSafeArea()
+                Theme.backgroundPrimary.ignoresSafeArea()
 
                 VStack(spacing: 20) {
                     TextField("Workspace Name", text: $name)
                         .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .submitLabel(.done)
+                        .onSubmit {
+                            if !name.isEmpty && !isCreating { createWorkspace() }
+                        }
 
                     Picker("Type", selection: $workspaceType) {
                         Text("Host").tag(WorkspaceType.host)


### PR DESCRIPTION
## Summary

A focused two-pass polish of the iOS dashboard, driven by a hands-on
walkthrough on the booted iPhone 17 Pro 26.4 simulator. Every change is
visual / interaction-only; no model or behavior changes.

### Pass 1 — legibility & confirms

- **Cost rendering**: `\$4.2200` → `\$4.22` with a `<\$0.01` sentinel
  for sub-cent amounts. The ALL-CAPS background-pill `ACTUAL` badge
  becomes a calm inline lowercase `actual`, so the cost number leads
  the eye instead of the badge.
- **Nav-bar title**: stop pre-truncating at 60 chars in code; let
  SwiftUI handle tail truncation against the actual nav width and add
  a long-press `.contextMenu` exposing the full title + Copy.
- **Connection state**: the 9pt wifi-slash glyph in the toolbar was
  too easy to miss when the SSE stream dropped. It is now a sticky
  banner across the top with a pulsing icon and a `.move(edge: .top)
  + opacity` transition.
- **Clear All Rules** in Settings: bare button → `confirmationDialog`
  spelling out that the action is permanent and what it does to
  future signing requests.
- **File delete alert**: gained a `message:` body distinguishing
  directory-vs-file deletion, matching Apple HIG.

### Pass 2 — empty states, streaming, copy, theme

- **Control empty state**: brain + "Ready to Help" now ships with two
  context chips (workspace + saved default agent) so a first-run user
  can see *where* and *which agent* the next message routes to.
- **ThinkingBubble**: appends a tinted block-cursor while streaming
  is in flight. A paused stream used to be indistinguishable from a
  settled thought.
- **CopyButton**: dropped the global `.opacity(0.7)`, bumped icon
  weight + colour from `textMuted` → `textSecondary` with a hairline
  border ring. Both message bubbles also gained a `.contextMenu` for
  long-press → Copy.
- **HistoryView**: empty state ships an action button that switches
  back to Control instead of being a dead end on first launch.
- **Settings auto-approval rules**: section was entirely hidden when
  no rules existed (including the divider) — feature was invisible.
  Always render with a placeholder explaining what rules do.
- **Settings server URL field**: `.submitLabel(.done)` + `onSubmit`
  hook that triggers the connection test.
- **WorkspacesView**: replaced 3 raw `Color.black.ignoresSafeArea()`
  with `Theme.backgroundPrimary`.
- **NewWorkspaceSheet TextField**: autocorrection-disabled +
  `.submitLabel(.done)` + onSubmit creating the workspace.

## Test plan

- [x] `xcodebuild ... build` clean against `iphonesimulator26.4`
- [x] App installs and launches on the booted iPhone 17 Pro 26.4
- [x] Toolbar title truncates with ellipsis on a long mission name
- [x] Cost shows as `\$0.20 est.` lowercase inline (no pill)
- [ ] Disconnect server → sticky banner appears at top; reconnect → it
      slides up and disappears
- [ ] Empty Control state shows workspace + agent chips
- [ ] Streaming text shows a blinking caret while in-flight
- [ ] Long-press a message → Copy entry in context menu
- [ ] Empty History → "Start a mission" → returns to Control
- [ ] Settings → Security & Signing shows the placeholder when no
      rules saved
- [ ] Settings → server URL field: keyboard Done triggers connection
      test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily visual/interaction changes in SwiftUI (styling, labels, dialogs, context menus) with minimal impact on underlying data flow. Main risk is UI regressions around navigation/title rendering and the new connection banner transitions.
> 
> **Overview**
> Improves iOS dashboard UI polish and discoverability: assistant cost display is simplified to 2-decimal “receipt” formatting with a quieter inline source label, and message bubbles now support long-press `Copy` alongside updated copy-button styling/accessibility.
> 
> In `ControlView`, disconnect/reconnect state moves from a small toolbar indicator to a persistent top banner, the nav-bar title stops pre-truncating (adds context menu + copy title), and the empty state gains workspace/default-agent context chips; streaming “thinking” content also shows an in-flight caret.
> 
> Adds safer/descriptive confirmation copy across the app: `SettingsView` shows an empty-state explanation for auto-approval rules and requires confirmation before clearing them, server URL “Done” submits a connection test, `FilesView` delete alerts clarify folder vs file impact, `HistoryView` empty state includes a CTA to jump to Control, and several components standardize backgrounds to `Theme` plus minor accessibility/theme tweaks (running mission cancel label, terminal prompt colors, workspace screens, new-workspace submit behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c239cfde84dd9f987891ff962e8af2e2630b2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->