### PR TITLE
chore(ios): bump CFBundleShortVersionString to 0.12.0

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Info.plist
+++ b/ios_dashboard/SandboxedDashboard/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.10.0</string>
+    <string>0.12.0</string>
     <key>CFBundleVersion</key>
     <string>2</string>
     <key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary

App Store Connect already has 0.11.0 published, but the working copy
was still 0.10.0 — TestFlight uploads would be rejected as either a
downgrade or a duplicate. Skip to 0.12.0 so the next build is strictly
newer than what's on App Store Connect.

## Test plan

- [x] `Info.plist` `CFBundleShortVersionString` reads `0.12.0`
- [ ] Archive + upload to App Store Connect succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the marketing version in `Info.plist`, with no runtime logic changes.
> 
> **Overview**
> Bumps the iOS app’s `CFBundleShortVersionString` in `SandboxedDashboard/Info.plist` from `0.10.0` to `0.12.0` to ensure the next build is treated as a newer version for App Store Connect/TestFlight uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67423bc773d59cc7b259e7f870e986e4e69c1b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->