### PR TITLE
fix(ci): don't cancel push/schedule runs against each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,14 @@ on:
   schedule:
     - cron: '0 */6 * * *' # Every 6 hours
 
-# Cancel in-progress runs when new commits are pushed
+# Cancel in-progress runs only on PR pushes — pushes to master and the
+# 6-hour scheduled cron share the same `ref` group, so blanket
+# `cancel-in-progress: true` had the schedule killing the post-merge
+# push run (e.g. PR #400's master push CI was cancelled by the cron
+# that fired ~1 min later, leaving master with a non-green badge).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Pushes to master and the every-6-hours scheduled cron resolve to the
same concurrency group (\`CI-refs/heads/master\`). With
\`cancel-in-progress: true\` set unconditionally, the schedule cron was
able to kill the just-started post-merge push run — that is exactly
what happened to PR #400's merge commit (master push CI cancelled
by the cron that fired ~1 minute later, leaving the merge commit
badged as cancelled on the GitHub UI).

Restrict cancellation to \`pull_request\` events. PR pushes still cancel
their predecessors (the original intent of the concurrency block), but
push and schedule runs no longer kill each other.

## Test plan

- [x] Workflow file lints (YAML valid, expression valid)
- [ ] After merge, the post-merge master push CI completes without being
      cancelled by the next cron fire

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only changes GitHub Actions concurrency cancellation behavior to avoid scheduled runs cancelling post-merge push CI.
> 
> **Overview**
> Prevents `schedule`/`push` CI runs from cancelling each other by making `concurrency.cancel-in-progress` conditional on `pull_request` events.
> 
> Adds inline documentation explaining the shared concurrency group and the prior failure mode where the 6-hour cron could cancel a just-started post-merge `master` run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ce2e37aecf73d05a0dd9ae57cccc687af67968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->