### PR TITLE
chore(ios): correct CFBundleShortVersionString to 1.2.0

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Info.plist
+++ b/ios_dashboard/SandboxedDashboard/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.12.0</string>
+    <string>1.2.0</string>
     <key>CFBundleVersion</key>
     <string>2</string>
     <key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary

Previous bump (PR #400) targeted \`0.12.0\` but the actual next App
Store Connect version is \`1.2.0\` — App Store Connect already has the
1.1.x line published, so the next TestFlight build needs to be a strict
semver increase from there.

## Test plan

- [x] \`Info.plist\` \`CFBundleShortVersionString\` reads \`1.2.0\`
- [ ] Archive + upload to App Store Connect succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single `Info.plist` version-string update with no runtime behavior change; main risk is only around release/versioning workflows.
> 
> **Overview**
> Updates `ios_dashboard/SandboxedDashboard/Info.plist` to set `CFBundleShortVersionString` (marketing version) from `0.12.0` to `1.2.0` to align the next build with App Store Connect versioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b565deefffc3afaec49b398bb14c6d90cafa60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->