### PR TITLE
feat: add mission workbench and needs-you inbox

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -18,7 +18,7 @@ import { LazyJsonHighlighter } from "@/components/lazy-json-highlighter";
 import { cn } from "@/lib/utils";
 import { getMissionShortName } from "@/lib/mission-display";
 import { inferMissionRole } from "@/lib/mission-role";
-import { isFinishedStatus } from "@/lib/mission-status";
+import { getMissionDotColor, isFinishedStatus } from "@/lib/mission-status";
 import { getRuntimeApiBase } from "@/lib/settings";
 import { authHeader } from "@/lib/auth";
 import {
@@ -877,10 +877,14 @@ function statusLabel(state: ControlRunState): {
   }
 }
 
-function missionStatusLabel(status: MissionStatus): {
+function missionStatusLabel(status: MissionStatus, isRunning = false): {
   label: string;
   className: string;
 } {
+  if (isRunning) {
+    return { label: "Running", className: "bg-indigo-500/20 text-indigo-400" };
+  }
+
   switch (status) {
     case "active":
       return { label: "Active", className: "bg-indigo-500/20 text-indigo-400" };
@@ -900,23 +904,8 @@ function missionStatusLabel(status: MissionStatus): {
   }
 }
 
-function missionStatusDotClass(status: MissionStatus): string {
-  switch (status) {
-    case "active":
-      return "bg-emerald-400";
-    case "completed":
-      return "bg-emerald-400";
-    case "failed":
-      return "bg-red-400";
-    case "interrupted":
-      return "bg-amber-400";
-    case "blocked":
-      return "bg-orange-400";
-    case "not_feasible":
-      return "bg-red-400";
-    default:
-      return "bg-white/40";
-  }
+function missionStatusDotClass(status: MissionStatus, isRunning = false): string {
+  return getMissionDotColor(status, isRunning);
 }
 
 // Copy button component
@@ -1921,9 +1910,9 @@ function MissionWorkbenchPanel({
   onSetStatus: (status: MissionStatus) => void;
   className?: string;
 }) {
-  const status = mission ? missionStatusLabel(mission.status) : null;
   const title = mission?.title?.trim() || (mission ? getMissionShortName(mission.id) : "No mission selected");
   const isRunning = Boolean(runningInfo);
+  const status = mission ? missionStatusLabel(mission.status, isRunning) : null;
   const canResume =
     mission &&
     !isRunning &&
@@ -1977,9 +1966,9 @@ function MissionWorkbenchPanel({
                 <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
                   <p className="text-[10px] text-white/30">Status</p>
                   <div className="mt-1 flex items-center gap-1.5">
-                    <span className={cn("h-2 w-2 rounded-full", missionStatusDotClass(mission.status))} />
+                    <span className={cn("h-2 w-2 rounded-full", missionStatusDotClass(mission.status, isRunning))} />
                     <span className={cn("text-xs font-medium", status?.className)}>
-                      {isRunning ? "Running" : status?.label}
+                      {status?.label}
                     </span>
                   </div>
                 </div>
@@ -7587,7 +7576,7 @@ export default function ControlClient() {
   const activeWorkspaceLabel = activeMission?.workspace_name
     || (activeMission?.workspace_id ? workspaceNameById[activeMission.workspace_id] : undefined);
   const missionStatus = activeMission
-    ? missionStatusLabel(activeMission.status)
+    ? missionStatusLabel(activeMission.status, viewingMissionIsRunning)
     : null;
 
   // Update favicon with mission status dot
@@ -7737,7 +7726,7 @@ export default function ControlClient() {
                   <div
                     className={cn(
                       "h-2 w-2 rounded-full shrink-0",
-                      missionStatusDotClass(activeMission.status)
+                      missionStatusDotClass(activeMission.status, viewingMissionIsRunning)
                     )}
                     title={missionStatus?.label}
                   />

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -119,6 +119,8 @@ import {
   ExternalLink,
   MessageSquare,
   Users,
+  BriefcaseBusiness,
+  Inbox,
 } from "lucide-react";
 import { IMAGE_PATH_PATTERN } from "@/lib/file-extensions";
 import { insertTextAtSelection, type TextSelection } from "@/lib/text-selection";
@@ -203,6 +205,7 @@ import { NewMissionDialog } from "@/components/new-mission-dialog";
 import { MissionSwitcher, normalizeMetadataText } from "@/components/mission-switcher";
 import { WorkerPanel } from "@/components/worker-panel";
 import { SubagentsPanel, type SubagentEntry } from "@/components/subagents-panel";
+import { RelativeTime } from "@/components/ui/relative-time";
 
 import type { SharedFile } from "@/lib/api";
 
@@ -1889,6 +1892,209 @@ function ThinkingPanel({
   );
 }
 
+function MissionWorkbenchPanel({
+  mission,
+  workspaceLabel,
+  role,
+  runningInfo,
+  childMissions,
+  onClose,
+  onResume,
+  onCancel,
+  onOpenAutomations,
+  onOpenSwitcher,
+  onViewMission,
+  onSetStatus,
+  className,
+}: {
+  mission: Mission | null;
+  workspaceLabel?: string;
+  role: ReturnType<typeof inferMissionRole>;
+  runningInfo: RunningMissionInfo | null;
+  childMissions: Mission[];
+  onClose: () => void;
+  onResume: () => void;
+  onCancel: (missionId: string) => void;
+  onOpenAutomations: () => void;
+  onOpenSwitcher: () => void;
+  onViewMission: (missionId: string) => void;
+  onSetStatus: (status: MissionStatus) => void;
+  className?: string;
+}) {
+  const status = mission ? missionStatusLabel(mission.status) : null;
+  const title = mission?.title?.trim() || (mission ? getMissionShortName(mission.id) : "No mission selected");
+  const isRunning = Boolean(runningInfo);
+  const canResume =
+    mission &&
+    !isRunning &&
+    mission.resumable &&
+    (mission.status === "interrupted" || mission.status === "blocked" || mission.status === "failed");
+
+  return (
+    <aside
+      className={cn(
+        "w-full h-full flex flex-col rounded-2xl glass-panel border border-white/[0.06] overflow-hidden animate-slide-in-right",
+        className
+      )}
+      aria-label="Mission workbench"
+    >
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <BriefcaseBusiness className="h-4 w-4 shrink-0 text-indigo-400" />
+          <span className="truncate text-sm font-medium text-white">Workbench</span>
+        </div>
+        <button
+          onClick={onClose}
+          className="flex h-6 w-6 items-center justify-center rounded-lg text-white/40 hover:bg-white/[0.04] hover:text-white transition-colors"
+          title="Close workbench"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-4">
+        {!mission ? (
+          <div className="flex h-full flex-col items-center justify-center text-center">
+            <Inbox className="mb-3 h-8 w-8 text-white/20" />
+            <p className="text-sm text-white/40">Select a mission to inspect.</p>
+            <button
+              onClick={onOpenSwitcher}
+              className="mt-4 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white/70 hover:bg-white/[0.04]"
+            >
+              Open mission switcher
+            </button>
+          </div>
+        ) : (
+          <>
+            <section className="space-y-3">
+              <div>
+                <p className="mb-1 text-[10px] uppercase tracking-wide text-white/30">Mission</p>
+                <h2 className="line-clamp-3 text-sm font-medium leading-snug text-white/85" title={title}>
+                  {title}
+                </h2>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                  <p className="text-[10px] text-white/30">Status</p>
+                  <div className="mt-1 flex items-center gap-1.5">
+                    <span className={cn("h-2 w-2 rounded-full", missionStatusDotClass(mission.status))} />
+                    <span className={cn("text-xs font-medium", status?.className)}>
+                      {isRunning ? "Running" : status?.label}
+                    </span>
+                  </div>
+                </div>
+                <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                  <p className="text-[10px] text-white/30">Role</p>
+                  <p className="mt-1 truncate text-xs font-medium capitalize text-white/70">
+                    {role ?? "mission"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                  <p className="text-[10px] text-white/30">Workspace</p>
+                  <p className="mt-1 truncate text-xs font-medium text-white/70" title={workspaceLabel}>
+                    {workspaceLabel ?? "Unassigned"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                  <p className="text-[10px] text-white/30">Updated</p>
+                  <RelativeTime date={mission.updated_at} className="mt-1 text-xs font-medium text-white/70" />
+                </div>
+              </div>
+              {mission.short_description && (
+                <p className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2 text-xs leading-relaxed text-white/50">
+                  {mission.short_description}
+                </p>
+              )}
+            </section>
+
+            <section className="space-y-2">
+              <p className="text-[10px] uppercase tracking-wide text-white/30">Actions</p>
+              <div className="grid grid-cols-2 gap-2">
+                {canResume && (
+                  <button
+                    onClick={onResume}
+                    className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-xs font-medium text-emerald-300 hover:bg-emerald-500/15"
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Resume
+                  </button>
+                )}
+                {isRunning && (
+                  <button
+                    onClick={() => onCancel(mission.id)}
+                    className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs font-medium text-red-300 hover:bg-red-500/15"
+                  >
+                    <Square className="h-3.5 w-3.5" />
+                    Stop
+                  </button>
+                )}
+                <button
+                  onClick={onOpenAutomations}
+                  className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-xs font-medium text-white/70 hover:bg-white/[0.04]"
+                >
+                  <Clock className="h-3.5 w-3.5" />
+                  Automations
+                </button>
+                <button
+                  onClick={onOpenSwitcher}
+                  className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-xs font-medium text-white/70 hover:bg-white/[0.04]"
+                >
+                  <Layers className="h-3.5 w-3.5" />
+                  Switch
+                </button>
+              </div>
+            </section>
+
+            <section className="space-y-2">
+              <p className="text-[10px] uppercase tracking-wide text-white/30">Mark As</p>
+              <div className="flex flex-wrap gap-1.5">
+                {(["completed", "blocked", "failed"] as MissionStatus[]).map((nextStatus) => (
+                  <button
+                    key={nextStatus}
+                    onClick={() => onSetStatus(nextStatus)}
+                    disabled={mission.status === nextStatus}
+                    className="rounded-md border border-white/[0.06] bg-white/[0.02] px-2 py-1 text-[10px] capitalize text-white/55 transition-colors hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    {nextStatus.replace("_", " ")}
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            <section className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-[10px] uppercase tracking-wide text-white/30">Worker Missions</p>
+                <span className="text-[10px] tabular-nums text-white/30">{childMissions.length}</span>
+              </div>
+              {childMissions.length === 0 ? (
+                <div className="rounded-md border border-white/[0.04] bg-white/[0.01] px-3 py-4 text-center text-xs text-white/30">
+                  No workers attached to this mission.
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  {childMissions.slice(0, 6).map((child) => (
+                    <button
+                      key={child.id}
+                      onClick={() => onViewMission(child.id)}
+                      className="flex w-full items-center gap-2 rounded-md border border-white/[0.05] bg-white/[0.02] px-2.5 py-2 text-left hover:bg-white/[0.04]"
+                    >
+                      <span className={cn("h-2 w-2 rounded-full", missionStatusDotClass(child.status))} />
+                      <span className="min-w-0 flex-1 truncate text-xs text-white/70">
+                        {child.title?.trim() || getMissionShortName(child.id)}
+                      </span>
+                      <ChevronRight className="h-3 w-3 text-white/30" />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}
+
 // Get icon for tool based on its name
 function ToolIcon({ toolName, className }: { toolName: string; className?: string }) {
   const name = toolName.toLowerCase();
@@ -3258,6 +3464,9 @@ export default function ControlClient() {
   // Thinking panel state
   const [showThinkingPanel, setShowThinkingPanel] = useState(false);
   const [thinkingPanelManuallyHidden, setThinkingPanelManuallyHidden] = useState(false);
+  const [showWorkbenchPanel, setShowWorkbenchPanel] = useState(
+    () => searchParams.get("workbench") === "1"
+  );
   const handleToggleThinkingPanel = useCallback(() => {
     setShowThinkingPanel((prev) => {
       const next = !prev;
@@ -7603,6 +7812,20 @@ export default function ControlClient() {
             <span className="hidden lg:inline">Automations</span>
           </button>
 
+          <button
+            onClick={() => setShowWorkbenchPanel((prev) => !prev)}
+            className={cn(
+              "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
+              showWorkbenchPanel
+                ? "border-indigo-500/30 bg-indigo-500/10 text-indigo-400"
+                : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
+            )}
+            title={showWorkbenchPanel ? "Hide mission workbench" : "Show mission workbench"}
+          >
+            <BriefcaseBusiness className="h-4 w-4" />
+            <span className="hidden sm:inline">Workbench</span>
+          </button>
+
           {/* Thinking panel toggle */}
           <button
             onClick={handleToggleThinkingPanel}
@@ -8617,12 +8840,30 @@ export default function ControlClient() {
         </div>
       </div>
 
-        {/* Right column: Worker Panel, Thinking Panel, and Desktop Stream stacked */}
-        {(showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission)) && (
+        {/* Right column: Workbench, Thinking Panel and Desktop Stream stacked */}
+        {(showWorkbenchPanel || showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission)) && (
           <div className={cn(
             "min-h-0 flex flex-col gap-4 transition-all duration-300 animate-fade-in shrink-0",
             showDesktopStream ? "flex-1 max-w-md" : "w-80"
           )}>
+            {showWorkbenchPanel && (
+              <MissionWorkbenchPanel
+                mission={activeMission}
+                workspaceLabel={activeWorkspaceLabel}
+                role={activeMissionRole}
+                runningInfo={viewingRunningInfo}
+                childMissions={childMissions}
+                onClose={() => setShowWorkbenchPanel(false)}
+                onResume={handleResumeMission}
+                onCancel={handleCancelMission}
+                onOpenAutomations={() => setShowAutomationsDialog(true)}
+                onOpenSwitcher={() => setShowMissionSwitcher(true)}
+                onViewMission={handleViewMission}
+                onSetStatus={handleSetStatus}
+                className={showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission) ? "flex-shrink-0 max-h-[40%]" : "flex-1"}
+              />
+            )}
+
             {/* Worker Panel — real child missions (parent_mission_id) */}
             {showWorkerPanel && childMissions.length > 0 && (
               <WorkerPanel
@@ -8633,7 +8874,7 @@ export default function ControlClient() {
                 onSelectWorker={(missionId) => handleViewMission(missionId)}
                 onClose={() => setShowWorkerPanel(false)}
                 className={cn(
-                  showThinkingPanel || showDesktopStream || hasInMissionSubagents
+                  showWorkbenchPanel || showThinkingPanel || showDesktopStream || hasInMissionSubagents
                     ? "flex-shrink-0 max-h-[50%]"
                     : "flex-1"
                 )}
@@ -8647,7 +8888,7 @@ export default function ControlClient() {
                 onFocusItem={focusChatItem}
                 onClose={() => setShowWorkerPanel(false)}
                 className={cn(
-                  showThinkingPanel || showDesktopStream || childMissions.length > 0
+                  showWorkbenchPanel || showThinkingPanel || showDesktopStream || childMissions.length > 0
                     ? "flex-shrink-0 max-h-[50%]"
                     : "flex-1"
                 )}
@@ -8659,7 +8900,7 @@ export default function ControlClient() {
               <ThinkingPanel
                 items={thinkingItems}
                 onClose={handleCloseThinkingPanel}
-                className={showDesktopStream ? "flex-shrink-0 max-h-[40%]" : "flex-1"}
+                className={showWorkbenchPanel || showDesktopStream || (showWorkerPanel && isBossMission) ? "flex-shrink-0 max-h-[40%]" : "flex-1"}
                 basePath={missionWorkingDirectory}
                 missionId={viewingMissionId}
               />

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -175,7 +175,7 @@ function NeedsYouInbox({
   onResume: (id: string) => void;
   onDelete: (id: string) => void;
 }) {
-  const inboxMissions = useMemo(
+  const inboxCandidates = useMemo(
     () =>
       missions
         .filter(
@@ -186,10 +186,10 @@ function NeedsYouInbox({
         .sort(
           (a, b) =>
             new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-        )
-        .slice(0, 8),
+        ),
     [missions, runningMissionIds]
   );
+  const inboxMissions = useMemo(() => inboxCandidates.slice(0, 8), [inboxCandidates]);
 
   return (
     <section className="flex min-h-0 max-h-[46vh] flex-col border-b border-white/[0.06] pb-4">
@@ -199,7 +199,7 @@ function NeedsYouInbox({
           <h2 className="text-sm font-medium text-white/80">Needs You</h2>
         </div>
         <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] tabular-nums text-amber-300">
-          {inboxMissions.length}
+          {inboxCandidates.length}
         </span>
       </div>
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -33,6 +33,9 @@ import {
   Trash2,
   Hand,
   XCircle,
+  Ban,
+  Inbox,
+  ArrowRight,
 } from 'lucide-react';
 import { cn, formatCents } from '@/lib/utils';
 import { NewMissionDialog } from '@/components/new-mission-dialog';
@@ -43,7 +46,6 @@ import {
   type MissionCategory,
 } from '@/lib/mission-status';
 import { inferMissionRole } from '@/lib/mission-role';
-import { getStatusIcon } from '@/components/ui/status-icons';
 
 interface Column {
   id: MissionCategory;
@@ -56,6 +58,22 @@ const columns: Column[] = [
   { id: 'needs-you', label: 'Needs You', icon: Hand },
   { id: 'finished', label: 'Finished', icon: CheckCircle },
 ];
+
+function CompactStatusIcon({
+  status,
+  isRunning,
+  className,
+}: {
+  status: Mission['status'];
+  isRunning: boolean;
+  className?: string;
+}) {
+  if (isRunning || status === 'active') return <Loader className={className} />;
+  if (status === 'completed') return <CheckCircle className={className} />;
+  if (status === 'failed' || status === 'not_feasible') return <XCircle className={className} />;
+  if (status === 'interrupted' || status === 'blocked') return <Ban className={className} />;
+  return <Clock className={className} />;
+}
 
 function CompactMissionCard({
   mission,
@@ -74,7 +92,6 @@ function CompactMissionCard({
   onResume: (id: string) => void;
   onDelete: (id: string) => void;
 }) {
-  const Icon = isRunningForDisplay ? Loader : getStatusIcon(mission.status);
   const color = getMissionTextColor(mission.status, isRunningForDisplay);
   const title = getMissionTitle(mission);
   const isResumable = !isRunningForDisplay && mission.resumable &&
@@ -83,7 +100,9 @@ function CompactMissionCard({
   return (
     <div className="group rounded-md bg-white/[0.02] border border-white/[0.06] hover:border-white/[0.12] px-2.5 py-2 transition-colors">
       <div className="flex items-center gap-2 mb-1.5">
-        <Icon
+        <CompactStatusIcon
+          status={mission.status}
+          isRunning={isRunningForDisplay}
           className={cn('h-3.5 w-3.5 shrink-0', color, isRunningForDisplay && 'animate-spin')}
         />
         <Link href={`/control?mission=${mission.id}`} className="flex-1 min-w-0">
@@ -142,6 +161,119 @@ function CompactMissionCard({
         </div>
       </div>
     </div>
+  );
+}
+
+function NeedsYouInbox({
+  missions,
+  runningMissionIds,
+  onResume,
+  onDelete,
+}: {
+  missions: Mission[];
+  runningMissionIds: Set<string>;
+  onResume: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const inboxMissions = useMemo(
+    () =>
+      missions
+        .filter(
+          (mission) =>
+            !runningMissionIds.has(mission.id) &&
+            (mission.status === 'interrupted' || mission.status === 'blocked')
+        )
+        .sort(
+          (a, b) =>
+            new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+        )
+        .slice(0, 8),
+    [missions, runningMissionIds]
+  );
+
+  return (
+    <section className="flex min-h-0 max-h-[46vh] flex-col border-b border-white/[0.06] pb-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Inbox className="h-4 w-4 text-amber-400" />
+          <h2 className="text-sm font-medium text-white/80">Needs You</h2>
+        </div>
+        <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] tabular-nums text-amber-300">
+          {inboxMissions.length}
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
+        {inboxMissions.length === 0 ? (
+          <div className="flex min-h-24 items-center justify-center rounded-md border border-white/[0.04] bg-white/[0.01] px-4 text-center">
+            <p className="text-xs text-white/30">No missions are waiting on you.</p>
+          </div>
+        ) : (
+          inboxMissions.map((mission) => {
+            const title = getMissionTitle(mission, { maxLength: 72 });
+            const statusTone =
+              mission.status === 'blocked' ? 'text-orange-300' : 'text-amber-300';
+            return (
+              <div
+                key={mission.id}
+                className="group rounded-md border border-white/[0.06] bg-white/[0.02] p-3 transition-colors hover:border-amber-500/25"
+              >
+                <div className="flex items-start gap-2">
+                  <Hand className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', statusTone)} />
+                  <div className="min-w-0 flex-1">
+                    <Link
+                      href={`/control?mission=${mission.id}`}
+                      className="block truncate text-xs font-medium text-white/80 hover:text-white"
+                      title={title}
+                    >
+                      {title}
+                    </Link>
+                    <div className="mt-1 flex items-center gap-2 text-[10px] text-white/35">
+                      <span className={cn('capitalize', statusTone)}>
+                        {mission.status}
+                      </span>
+                      {mission.workspace_name && (
+                        <>
+                          <span>·</span>
+                          <span className="truncate">{mission.workspace_name}</span>
+                        </>
+                      )}
+                      <span>·</span>
+                      <RelativeTime date={mission.updated_at} />
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-2 flex items-center gap-1.5">
+                  {mission.resumable && (
+                    <button
+                      onClick={() => onResume(mission.id)}
+                      className="inline-flex items-center gap-1 rounded border border-emerald-500/20 bg-emerald-500/10 px-2 py-1 text-[10px] font-medium text-emerald-300 hover:bg-emerald-500/15"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      Resume
+                    </button>
+                  )}
+                  <Link
+                    href={`/control?mission=${mission.id}`}
+                    className="inline-flex items-center gap-1 rounded border border-white/[0.06] bg-white/[0.02] px-2 py-1 text-[10px] font-medium text-white/50 hover:text-white/75"
+                  >
+                    <ArrowRight className="h-3 w-3" />
+                    Open
+                  </Link>
+                  <button
+                    onClick={() => onDelete(mission.id)}
+                    className="ml-auto rounded p-1 text-white/25 transition-colors hover:bg-white/[0.06] hover:text-red-400"
+                    title="Delete"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -464,7 +596,13 @@ function OverviewPageContent() {
       </div>
 
       {/* Right sidebar - no glass panel wrapper, just border */}
-      <div className="w-80 h-screen border-l border-white/[0.06] p-4 flex flex-col overflow-hidden">
+      <div className="w-80 h-screen border-l border-white/[0.06] p-4 flex flex-col gap-4 overflow-hidden">
+        <NeedsYouInbox
+          missions={missions}
+          runningMissionIds={runningLikeMissionIds}
+          onResume={handleResume}
+          onDelete={handleDelete}
+        />
         <RecentTasks />
       </div>
     </div>

--- a/dashboard/tests/control.spec.ts
+++ b/dashboard/tests/control.spec.ts
@@ -1,4 +1,110 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+const RUNNING_INTERRUPTED_MISSION_ID = '55555555-5555-4555-8555-555555555555';
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockRunningInterruptedMission(page: Page) {
+  const now = new Date().toISOString();
+  const mission = {
+    id: RUNNING_INTERRUPTED_MISSION_ID,
+    title: 'Running interrupted mission',
+    status: 'interrupted',
+    workspace_id: '66666666-6666-4666-8666-666666666666',
+    workspace_name: 'dev-workspace',
+    backend: 'codex',
+    created_at: now,
+    updated_at: now,
+    history: [],
+    resumable: true,
+  };
+
+  await page.route('**/api/**', async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (route.request().method() === 'OPTIONS') {
+      await route.fulfill({
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+        },
+      });
+      return;
+    }
+
+    if (path === '/api/control/missions/current') {
+      await fulfillJson(route, mission);
+      return;
+    }
+    if (path === '/api/control/missions') {
+      await fulfillJson(route, [mission]);
+      return;
+    }
+    if (path === `/api/control/missions/${RUNNING_INTERRUPTED_MISSION_ID}`) {
+      await fulfillJson(route, mission);
+      return;
+    }
+    if (path === `/api/control/missions/${RUNNING_INTERRUPTED_MISSION_ID}/load`) {
+      await fulfillJson(route, mission);
+      return;
+    }
+    if (path === `/api/control/missions/${RUNNING_INTERRUPTED_MISSION_ID}/events`) {
+      await fulfillJson(route, { events: [], next_cursor: null, has_more: false });
+      return;
+    }
+    if (path === '/api/control/running') {
+      await fulfillJson(route, [{ mission_id: RUNNING_INTERRUPTED_MISSION_ID, state: 'running', queue_len: 0 }]);
+      return;
+    }
+    if (path === '/api/control/progress') {
+      await fulfillJson(route, { run_state: 'running', queue_len: 0, mission_id: RUNNING_INTERRUPTED_MISSION_ID });
+      return;
+    }
+    if (path === '/api/control/stream') {
+      await route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' });
+      return;
+    }
+    if (path === '/api/workspaces') {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (path === '/api/desktop/sessions') {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (path === '/api/backends' || path === '/api/providers' || path === '/api/providers/backend-models') {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (/^\/api\/backends\/[^/]+\/agents$/.test(path)) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (/^\/api\/backends\/[^/]+\/config$/.test(path)) {
+      await fulfillJson(route, { hidden_agents: [], default_agent: null });
+      return;
+    }
+    if (path.startsWith('/api/library/')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (path === '/api/health') {
+      await fulfillJson(route, { max_iterations: 50 });
+      return;
+    }
+
+    await fulfillJson(route, {});
+  });
+}
 
 test.describe('Control/Mission Page', () => {
   test('should load control page', async ({ page }) => {
@@ -29,11 +135,7 @@ test.describe('Control/Mission Page', () => {
     await page.goto('/control');
     await page.waitForTimeout(1500);
 
-    // Should have some status indicator (connection, mission state, etc.)
-    // Look for status elements or icons
-    const statusElements = page.locator('[class*="status"], [class*="connection"]');
-
-    // Or check for buttons that indicate state
+    // Check for buttons that indicate state
     const buttons = await page.getByRole('button').count();
     expect(buttons).toBeGreaterThan(0);
   });
@@ -76,5 +178,33 @@ test.describe('Control/Mission Page', () => {
     // Send button should be disabled or non-functional with empty input
     // This is behavioral - we just verify the input can be interacted with
     await expect(chatInput).toBeVisible();
+  });
+
+  test('workbench uses running colors for a resumed interrupted mission', async ({ page }) => {
+    await page.addInitScript(() => {
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = (input, init) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes('/api/control/stream')) {
+          return Promise.resolve(
+            new Response(new ReadableStream(), {
+              status: 200,
+              headers: { 'Content-Type': 'text/event-stream' },
+            })
+          );
+        }
+        return originalFetch(input, init);
+      };
+    });
+    await mockRunningInterruptedMission(page);
+    await page.goto(`/control?mission=${RUNNING_INTERRUPTED_MISSION_ID}&workbench=1`);
+
+    const workbench = page.getByLabel('Mission workbench');
+    await expect(workbench).toBeVisible();
+
+    const statusCard = workbench.getByText('Status').locator('xpath=ancestor::div[contains(@class, "rounded-md")]');
+    await expect(statusCard.getByText('Running')).toBeVisible();
+    await expect(statusCard.locator('.bg-indigo-400')).toBeVisible();
+    await expect(statusCard.locator('.text-indigo-400')).toBeVisible();
   });
 });

--- a/dashboard/tests/overview.spec.ts
+++ b/dashboard/tests/overview.spec.ts
@@ -36,16 +36,17 @@ test.describe('Overview Page', () => {
     await expect(page.getByRole('heading', { name: /Create New Mission/i })).toBeVisible();
 
     // Close dialog
-    await page.getByRole('button', { name: /Cancel/i }).click();
+    await page.locator('button').filter({ has: page.locator('svg') }).nth(1).click();
     await expect(page.getByRole('heading', { name: /Create New Mission/i })).not.toBeVisible();
   });
 
   test('should show radar visualization', async ({ page }) => {
     await page.goto('/');
 
-    // Should show the radar/visualization area
-    const visualizationArea = page.locator('.rounded-2xl').first();
-    await expect(visualizationArea).toBeVisible();
+    // Should show the compact mission board columns
+    await expect(page.getByText('Running').first()).toBeVisible();
+    await expect(page.getByText('Needs You').first()).toBeVisible();
+    await expect(page.getByText('Finished').first()).toBeVisible();
   });
 
   test('should show recent tasks sidebar', async ({ page }) => {
@@ -89,5 +90,120 @@ test.describe('Overview Page', () => {
 
     // Should either show LIVE or not - both are valid states
     expect(hasLive || !hasLive).toBeTruthy();
+  });
+
+  test('shows a needs you inbox for blocked and interrupted missions', async ({ page }) => {
+    const now = new Date().toISOString();
+    const blockedMission = {
+      id: '11111111-1111-4111-8111-111111111111',
+      title: 'Review deployment plan',
+      status: 'blocked',
+      workspace_name: 'dev-workspace',
+      history: [],
+      resumable: true,
+      created_at: now,
+      updated_at: now,
+    };
+    const interruptedMission = {
+      id: '22222222-2222-4222-8222-222222222222',
+      title: 'Answer product question',
+      status: 'interrupted',
+      workspace_name: 'app-workspace',
+      history: [],
+      resumable: false,
+      created_at: now,
+      updated_at: now,
+    };
+    const runningInterruptedMission = {
+      id: '33333333-3333-4333-8333-333333333333',
+      title: 'Running resumed mission',
+      status: 'interrupted',
+      history: [],
+      resumable: true,
+      created_at: now,
+      updated_at: now,
+    };
+
+    await page.route('**/api/**', async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      if (route.request().method() === 'OPTIONS') {
+        await route.fulfill({
+          status: 204,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': '*',
+            'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+          },
+        });
+        return;
+      }
+      const json = (body: unknown) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          body: JSON.stringify(body),
+        });
+
+      if (path === '/api/stats') {
+        await json({
+          total_tasks: 3,
+          active_tasks: 1,
+          completed_tasks: 0,
+          failed_tasks: 0,
+          total_cost_cents: 0,
+          actual_cost_cents: 0,
+          estimated_cost_cents: 0,
+          unknown_cost_cents: 0,
+          success_rate: 1,
+        });
+        return;
+      }
+      if (path === '/api/workspaces') {
+        await json([]);
+        return;
+      }
+      if (path === '/api/control/missions') {
+        await json([blockedMission, interruptedMission, runningInterruptedMission]);
+        return;
+      }
+      if (path === '/api/control/running') {
+        await json([{ mission_id: runningInterruptedMission.id, state: 'running', queue_len: 0 }]);
+        return;
+      }
+      if (path === '/api/control/automations') {
+        await json([]);
+        return;
+      }
+      if (path === '/api/backends') {
+        await json([]);
+        return;
+      }
+      if (path === '/api/providers' || path === '/api/providers/backend-models') {
+        await json([]);
+        return;
+      }
+      if (/^\/api\/backends\/[^/]+\/agents$/.test(path)) {
+        await json([]);
+        return;
+      }
+      if (/^\/api\/backends\/[^/]+\/config$/.test(path)) {
+        await json({ hidden_agents: [], default_agent: null });
+        return;
+      }
+      if (path.startsWith('/api/library/')) {
+        await json([]);
+        return;
+      }
+      await json({});
+    });
+
+    await page.goto('/');
+
+    const inbox = page.getByRole('heading', { name: 'Needs You' }).locator('xpath=ancestor::section');
+    await expect(inbox).toBeVisible();
+    await expect(inbox.getByText('Review deployment plan')).toBeVisible();
+    await expect(inbox.getByText('Answer product question')).toBeVisible();
+    await expect(inbox.getByText('Running resumed mission')).not.toBeVisible();
   });
 });

--- a/dashboard/tests/overview.spec.ts
+++ b/dashboard/tests/overview.spec.ts
@@ -123,6 +123,15 @@ test.describe('Overview Page', () => {
       created_at: now,
       updated_at: now,
     };
+    const extraBlockedMissions = Array.from({ length: 8 }, (_, index) => ({
+      id: `44444444-4444-4444-8444-44444444444${index}`,
+      title: `Waiting mission ${index + 1}`,
+      status: 'blocked',
+      history: [],
+      resumable: false,
+      created_at: now,
+      updated_at: now,
+    }));
 
     await page.route('**/api/**', async (route) => {
       const path = new URL(route.request().url()).pathname;
@@ -164,7 +173,12 @@ test.describe('Overview Page', () => {
         return;
       }
       if (path === '/api/control/missions') {
-        await json([blockedMission, interruptedMission, runningInterruptedMission]);
+        await json([
+          blockedMission,
+          interruptedMission,
+          ...extraBlockedMissions,
+          runningInterruptedMission,
+        ]);
         return;
       }
       if (path === '/api/control/running') {
@@ -202,6 +216,7 @@ test.describe('Overview Page', () => {
 
     const inbox = page.getByRole('heading', { name: 'Needs You' }).locator('xpath=ancestor::section');
     await expect(inbox).toBeVisible();
+    await expect(inbox.locator('.tabular-nums')).toHaveText('10');
     await expect(inbox.getByText('Review deployment plan')).toBeVisible();
     await expect(inbox.getByText('Answer product question')).toBeVisible();
     await expect(inbox.getByText('Running resumed mission')).not.toBeVisible();


### PR DESCRIPTION
## Summary
- add a Mission Workbench side panel on the control page with mission status, role, workspace, update time, quick actions, mark-as controls, and worker mission links
- add a Needs You inbox to the overview sidebar for blocked/interrupted missions that are not currently running
- add Playwright coverage for the Needs You inbox and update stale overview assertions for the compact board

## Verification
- `bun run build` (dashboard)
- `cargo check`
- `bun run test:unit -- src/lib/mission-status.test.ts`
- `bunx playwright test tests/overview.spec.ts:95 --reporter=line --workers=1`
- `mkdir -p test-results && bunx eslint src/app/page.tsx tests/overview.spec.ts tests/control.spec.ts` (passes with existing warnings only)

## Notes
- Full `bun run lint` is currently blocked by pre-existing repo-wide lint errors outside this change.
- Full dashboard `bunx tsc --noEmit` is currently blocked by pre-existing `mission-switcher.test.ts` `RunningMissionInfo.state` fixture typing errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new UI panels and updates status-color logic plus Playwright tests; risk is limited to potential UI regressions or incorrect mission state display.
> 
> **Overview**
> Adds a new **Mission Workbench** side panel on the `/control` page, showing selected mission details (status/role/workspace/updated time), quick actions (resume/stop, automations, switch), manual *mark-as* status buttons, and shortcuts to child/worker missions.
> 
> Updates mission status presentation to treat *actually running* missions as "Running" (including dot color via `getMissionDotColor`) even if their stored status is `interrupted`/etc., and exposes a `workbench=1` query param + toolbar toggle to show/hide the panel.
> 
> Enhances the overview (`/`) right sidebar with a **Needs You** inbox listing the most recently updated blocked/interrupted missions that are not currently running, and updates/extends Playwright coverage for the new inbox and workbench behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88617285d739cff1e8959a72da87b98ca31c15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->