### PR TITLE
fix: align workbench running state

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1885,7 +1885,7 @@ function MissionWorkbenchPanel({
   mission,
   workspaceLabel,
   role,
-  runningInfo,
+  isRunning,
   childMissions,
   onClose,
   onResume,
@@ -1899,7 +1899,7 @@ function MissionWorkbenchPanel({
   mission: Mission | null;
   workspaceLabel?: string;
   role: ReturnType<typeof inferMissionRole>;
-  runningInfo: RunningMissionInfo | null;
+  isRunning: boolean;
   childMissions: Mission[];
   onClose: () => void;
   onResume: () => void;
@@ -1911,7 +1911,6 @@ function MissionWorkbenchPanel({
   className?: string;
 }) {
   const title = mission?.title?.trim() || (mission ? getMissionShortName(mission.id) : "No mission selected");
-  const isRunning = Boolean(runningInfo);
   const status = mission ? missionStatusLabel(mission.status, isRunning) : null;
   const canResume =
     mission &&
@@ -8840,7 +8839,7 @@ export default function ControlClient() {
                 mission={activeMission}
                 workspaceLabel={activeWorkspaceLabel}
                 role={activeMissionRole}
-                runningInfo={viewingRunningInfo}
+                isRunning={viewingMissionIsRunning}
                 childMissions={childMissions}
                 onClose={() => setShowWorkbenchPanel(false)}
                 onResume={handleResumeMission}

--- a/dashboard/tests/control.spec.ts
+++ b/dashboard/tests/control.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page, type Route } from '@playwright/test';
 
 const RUNNING_INTERRUPTED_MISSION_ID = '55555555-5555-4555-8555-555555555555';
+type MockRunningState = 'queued' | 'running' | 'waiting_for_tool' | 'finished';
 
 async function fulfillJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
@@ -11,7 +12,7 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
   });
 }
 
-async function mockRunningInterruptedMission(page: Page) {
+async function mockInterruptedMission(page: Page, runningState: MockRunningState) {
   const now = new Date().toISOString();
   const mission = {
     id: RUNNING_INTERRUPTED_MISSION_ID,
@@ -62,11 +63,15 @@ async function mockRunningInterruptedMission(page: Page) {
       return;
     }
     if (path === '/api/control/running') {
-      await fulfillJson(route, [{ mission_id: RUNNING_INTERRUPTED_MISSION_ID, state: 'running', queue_len: 0 }]);
+      await fulfillJson(route, [{ mission_id: RUNNING_INTERRUPTED_MISSION_ID, state: runningState, queue_len: 0 }]);
       return;
     }
     if (path === '/api/control/progress') {
-      await fulfillJson(route, { run_state: 'running', queue_len: 0, mission_id: RUNNING_INTERRUPTED_MISSION_ID });
+      await fulfillJson(route, { run_state: runningState === 'finished' ? 'idle' : 'running', queue_len: 0, mission_id: RUNNING_INTERRUPTED_MISSION_ID });
+      return;
+    }
+    if (path === '/api/control/queue') {
+      await fulfillJson(route, []);
       return;
     }
     if (path === '/api/control/stream') {
@@ -103,6 +108,24 @@ async function mockRunningInterruptedMission(page: Page) {
     }
 
     await fulfillJson(route, {});
+  });
+}
+
+async function keepMockedControlStreamOpen(page: Page) {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/api/control/stream')) {
+        return Promise.resolve(
+          new Response(new ReadableStream(), {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          })
+        );
+      }
+      return originalFetch(input, init);
+    };
   });
 }
 
@@ -181,22 +204,8 @@ test.describe('Control/Mission Page', () => {
   });
 
   test('workbench uses running colors for a resumed interrupted mission', async ({ page }) => {
-    await page.addInitScript(() => {
-      const originalFetch = window.fetch.bind(window);
-      window.fetch = (input, init) => {
-        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-        if (url.includes('/api/control/stream')) {
-          return Promise.resolve(
-            new Response(new ReadableStream(), {
-              status: 200,
-              headers: { 'Content-Type': 'text/event-stream' },
-            })
-          );
-        }
-        return originalFetch(input, init);
-      };
-    });
-    await mockRunningInterruptedMission(page);
+    await keepMockedControlStreamOpen(page);
+    await mockInterruptedMission(page, 'running');
     await page.goto(`/control?mission=${RUNNING_INTERRUPTED_MISSION_ID}&workbench=1`);
 
     const workbench = page.getByLabel('Mission workbench');
@@ -206,5 +215,19 @@ test.describe('Control/Mission Page', () => {
     await expect(statusCard.getByText('Running')).toBeVisible();
     await expect(statusCard.locator('.bg-indigo-400')).toBeVisible();
     await expect(statusCard.locator('.text-indigo-400')).toBeVisible();
+  });
+
+  test('workbench ignores finished running records for status display', async ({ page }) => {
+    await keepMockedControlStreamOpen(page);
+    await mockInterruptedMission(page, 'finished');
+    await page.goto(`/control?mission=${RUNNING_INTERRUPTED_MISSION_ID}&workbench=1`);
+
+    const workbench = page.getByLabel('Mission workbench');
+    await expect(workbench).toBeVisible();
+
+    const statusCard = workbench.getByText('Status').locator('xpath=ancestor::div[contains(@class, "rounded-md")]');
+    await expect(statusCard.getByText('Interrupted')).toBeVisible();
+    await expect(statusCard.getByText('Running')).not.toBeVisible();
+    await expect(statusCard.locator('.bg-amber-400')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- align Mission Workbench running display with the canonical `viewingMissionIsRunning` state used by the header
- add Playwright coverage for both running interrupted missions and stale finished running records

## Verification
- `bunx eslint tests/control.spec.ts src/app/control/control-client.tsx src/app/page.tsx tests/overview.spec.ts` (passes with existing warnings only)
- `bunx playwright test tests/control.spec.ts --grep "workbench" --reporter=line --workers=1`
- `bunx playwright test tests/overview.spec.ts:95 --reporter=line --workers=1`
- `bun run build` (dashboard)
- `cargo check`

## Notes
- Follow-up for the final Bugbot finding left on merged PR #404.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only adjusts how the workbench determines “running” state, plus additional Playwright mocks/tests to prevent regressions.
> 
> **Overview**
> Aligns the Mission Workbench’s status display with the canonical `viewingMissionIsRunning` boolean (instead of inferring running from presence of `runningInfo`), preventing stale/terminal running records from forcing “Running” UI colors.
> 
> Expands Playwright coverage by parameterizing the mocked running state, keeping the control SSE stream open in tests, and adding a regression test ensuring `finished` running records don’t override an interrupted mission’s status styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412bd612d688f8df6678d6e666b36dc53ddad865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->