### PR TITLE
fix(docker): bump rust to 1.91 so Docker build compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sandboxed_sh"
 version = "0.11.1"
 edition = "2021"
+rust-version = "1.91"
 description = "Self-hosted orchestrator for AI coding agents (formerly Open Agent)"
 authors = ["sandboxed.sh Contributors"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Rust builder
 # ---------------------------------------------------------------------------
-FROM rust:1.88-bookworm AS rust-builder
+FROM rust:1.91-bookworm AS rust-builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Problem

`docker compose build` fails on a fresh checkout with:

```
error[E0658]: use of unstable library feature `round_char_boundary`
    --> src/api/telegram.rs:1660:38
     |
1660 |             &clean_text[..clean_text.floor_char_boundary(100)]
     |                                      ^^^^^^^^^^^^^^^^^^^
```

The Dockerfile pins `rust:1.88-bookworm`, but `floor_char_boundary` (the `round_char_boundary` feature) was only stabilized in Rust 1.91 — see [rust-lang/rust#93743](https://github.com/rust-lang/rust/issues/93743). So a fresh build of v0.11.x is broken.

## Fix

- `Dockerfile`: `FROM rust:1.88-bookworm` → `FROM rust:1.91-bookworm` (specific minimum, not a floating tag, so reproducibility is preserved).
- `Cargo.toml`: add `rust-version = "1.91"` so cargo emits a clear error if anyone tries an older toolchain locally (instead of the cryptic E0658).

## Verified

Built successfully via `docker compose build` on Ubuntu 26.04 / Docker 29.4.

---

_Please review before merging._
