### PR TITLE
fix(mission): repair broken DELETE query in delete_mission

### DIFF
--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2631,7 +2631,7 @@ impl MissionStore for SqliteMissionStore {
             let conn = conn.blocking_lock();
             let rows = conn
                 .execute(
-                    "DELETE, COALESCE(goal_mode, 0) as goal_mode, goal_objective FROM missions WHERE id = ?1",
+                    "DELETE FROM missions WHERE id = ?1",
                     params![id.to_string()],
                 )
                 .map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Problem

Deleting a mission from the dashboard fails with HTTP 500. The backend returns:

```
near ",": syntax error in DELETE, COALESCE(goal_mode, 0) as goal_mode, goal_objective FROM missions WHERE id = ?1 at offset 6
```

`src/api/mission_store/sqlite.rs:2634` (in `delete_mission`) has a malformed query — looks like a search-replace accident:

```rust
async fn delete_mission(&self, id: Uuid) -> Result<bool, String> {
    ...
    let rows = conn
        .execute(
            "DELETE, COALESCE(goal_mode, 0) as goal_mode, goal_objective FROM missions WHERE id = ?1",
            params![id.to_string()],
        )
        .map_err(|e| e.to_string())?;
    ...
}
```

That isn't valid SQL in any direction — the column list looks like leftovers from a `SELECT id, COALESCE(goal_mode, 0) ... FROM missions WHERE id = ?1` somewhere else, but the verb got changed to `DELETE,` and the columns weren't trimmed.

## Fix

Replace the query with the plain delete it was meant to be:

```rust
"DELETE FROM missions WHERE id = ?1"
```

(There's another `DELETE FROM missions WHERE id = ?1` already at line ~2675 in `delete_empty_untitled_missions_excluding`, doing exactly this — so the fix matches existing code style.)

## Verified

Reproduced on `master`:
```
$ curl -i -X DELETE .../api/control/missions/<uuid>
HTTP/1.1 500 Internal Server Error
near ",": syntax error in DELETE, COALESCE(goal_mode, 0) as goal_mode, goal_objective FROM missions WHERE id = ?1 at offset 6
```

After the patch, `docker compose build` succeeds and the dashboard's "Delete mission" action returns 200.

---

_Please review before merging._
