### PR TITLE
fix(docker): make container workspaces work without systemd-as-PID-1

### DIFF
--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -555,6 +555,9 @@ pub async fn execute_in_container(
     cmd.arg("--quiet");
     // Disable timezone bind-mount (minbase containers lack /usr/share/zoneinfo)
     cmd.arg("--timezone=off");
+    cmd.arg("--register=no");
+    cmd.arg("--keep-unit");
+    // Skip machined registration (no dbus inside docker entrypoint)
 
     match config.network_mode {
         NetworkMode::Host => {}
@@ -644,6 +647,8 @@ pub async fn execute_in_container_streaming(
     cmd.arg("-D").arg(path);
     cmd.arg("--quiet");
     cmd.arg("--timezone=off");
+    cmd.arg("--register=no");
+    cmd.arg("--keep-unit");
 
     match config.network_mode {
         NetworkMode::Host => {}

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -515,26 +515,40 @@ impl WorkspaceExec {
     }
 
     async fn running_container_leader(&self) -> Option<String> {
-        let name = self.machine_name()?;
-        let machinectl = if Path::new("/usr/bin/machinectl").exists() {
-            "/usr/bin/machinectl"
-        } else {
-            "machinectl"
-        };
-        let output = Command::new(machinectl)
-            .args(["show", &name, "-p", "Leader", "--value"])
+        // Patched: discover the leader via pgrep instead of machinectl.
+        // Inside the docker entrypoint (Caddy as PID 1) machinectl refuses
+        // to operate, and machined cannot create cgroup scopes without
+        // systemd as PID 1, so we run nspawn with --register=no and locate
+        // the leader by scanning for `systemd-nspawn -D <workspace path>`.
+        let path = self.workspace.path.to_string_lossy().into_owned();
+        let nspawn_pids = Command::new("pgrep")
+            .args(["-f", &format!("systemd-nspawn.*-D {}", path)])
             .output()
             .await
             .ok()?;
-        if !output.status.success() {
+        if !nspawn_pids.status.success() {
             return None;
         }
-        let leader = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if leader.is_empty() {
-            None
-        } else {
-            Some(leader)
+        let nspawn_pid = String::from_utf8_lossy(&nspawn_pids.stdout)
+            .lines()
+            .next()
+            .map(|s| s.trim().to_string())?;
+        if nspawn_pid.is_empty() {
+            return None;
         }
+        let child_pids = Command::new("pgrep")
+            .args(["-P", &nspawn_pid])
+            .output()
+            .await
+            .ok()?;
+        if !child_pids.status.success() {
+            return None;
+        }
+        let leader = String::from_utf8_lossy(&child_pids.stdout)
+            .lines()
+            .next()
+            .map(|s| s.trim().to_string())?;
+        if leader.is_empty() { None } else { Some(leader) }
     }
 
     fn leader_has_keepalive_marker(&self, leader: &str) -> bool {
@@ -560,6 +574,8 @@ impl WorkspaceExec {
         cmd.arg("--quiet");
         cmd.arg("--timezone=off");
         cmd.arg("--console=pipe");
+        cmd.arg("--register=no");
+        cmd.arg("--keep-unit");
 
         let context_dir_name = std::env::var("SANDBOXED_SH_CONTEXT_DIR_NAME")
             .ok()


### PR DESCRIPTION
## Problem

Following the official `docs/install-docker.md` — Docker + `privileged: true` + `cgroup: host` per the table — container workspaces fail to spawn missions on a fresh deployment. Symptoms:

- A new mission auto-creates from a Telegram bot or via the API.
- The runner forks `systemd-nspawn -D <rootfs> --machine=<name> ...` and it errors with:
  ```
  Failed to register machine: Launch helper exited with unknown return code 1
  ```
- `systemd-machined` can't create cgroup scopes (`machine-<name>.scope`) because `systemd` isn't PID 1 inside the container — the upstream Dockerfile entrypoint runs `caddy`. The launch helper just exits 1.
- Even forcing `--register=no` doesn't help: `running_container_leader()` uses `machinectl show <name> -p Leader --value` to discover the container's PID 1 to `nsenter` into, but with `--register=no` machinectl never sees the container, so the lookup returns empty.
- The mission_runner gets stuck — `start_persistent_container_leader()` thinks no leader exists and keeps re-launching nspawn, always failing the same way.

So the docker path as documented can't actually run container workspaces today.

## Fix

Three changes across `src/nspawn.rs` and `src/workspace_exec.rs`:

1. **Pass `--register=no --keep-unit` to all `systemd-nspawn` invocations.** Skips machined registration entirely. Containers still keep their `--machine=<name>` for log identification; they just don't show up in `machinectl list`.

2. **Replace `running_container_leader()`'s machinectl call with a pgrep-based lookup.** Locate the persistent `systemd-nspawn` for the workspace via `pgrep -f "systemd-nspawn.*-D <path>"`, then take its first child PID — that's the in-container PID 1 we want to `nsenter`. No dbus / machined dependency.

3. Same `--register=no --keep-unit` applied to both `execute_in_container` and `execute_in_container_streaming` in `nspawn.rs` (used for one-shot commands like `bootstrap_workspace_harnesses`).

## Verified end-to-end

Tested on Ubuntu 26.04 / Docker 29.4 with `privileged: true` + `cgroup: host`:

- mission_runner forks the persistent leader successfully.
- pgrep correctly identifies the leader PID inside the rootfs.
- `nsenter --target <leader>` enters the per-mission namespaces.
- `claude` (installed inside the rootfs via npm) runs and processes the user's prompt.
- Telegram bot → auto-create mission → claude responds. Real per-mission Linux namespace isolation works.

## Note on native installs

On native (`systemd` as PID 1) installs, this is a behavior change: containers no longer register with `systemd-machined`, so `machinectl shell`, `machinectl status`, `journalctl -M` etc. against these workspaces from *outside* sandboxed.sh stop working. The pgrep discovery itself works fine on native too (it's namespace-agnostic), so missions function normally.

If preserving the machined integration on native is important, the right fix is conditional based on `sd_booted()` (i.e. check `/proc/1/comm == "systemd"`) — happy to make that change if preferred. I went unconditional here for minimal-diff reviewability, and because it's the same code path on both deployment modes.

---

_Please review before merging._
