### PR TITLE
fix(workspace): bootstrap baseline tooling into fresh container rootfs

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4466,6 +4466,21 @@ echo "[sandboxed] Harness bootstrap start"
 # Keep bun global bin dirs discoverable for command checks and installed CLIs.
 export PATH="/root/.bun/bin:/root/.cache/.bun/bin:$PATH"
 
+# --- Patched: bootstrap a minbase debootstrap rootfs into a usable state.
+#     Without these the rest of this script no-ops (no bun, no npm, no curl)
+#     and the workspace ends up unusable for missions.
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[sandboxed] baseline rootfs prereqs: installing curl/ca-certs/gnupg/git/jq/python3/build-essential"
+  apt-get update -qq || true
+  apt-get install -y -qq --no-install-recommends curl ca-certificates gnupg git jq python3 wget build-essential || true
+fi
+if ! command -v node >/dev/null 2>&1 && ! command -v bun >/dev/null 2>&1; then
+  echo "[sandboxed] baseline rootfs prereqs: installing Node.js 22 (NodeSource)"
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null 2>&1 || true
+  apt-get install -y -qq --no-install-recommends nodejs || true
+fi
+
 # Ensure bun is in PATH first (it's our preferred package manager)
 if [ -x /root/.bun/bin/bun ] && ! command -v bun >/dev/null 2>&1; then
   ln -sf /root/.bun/bin/bun /usr/local/bin/bun || true

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4501,9 +4501,19 @@ else
 fi
 
 if [ -n "$PKG_MGR" ]; then
+  # --- Patched: claude-code via npm to dodge bun ELF wrapping bug.
+  #     bun global-install of @anthropic-ai/claude-code points the
+  #     `claude` exec at the precompiled ELF inside the platform sub-package
+  #     and bun then tries to interpret it as JavaScript at runtime
+  #     (`error: Unexpected at .../claude:1:1`). npm wraps platform packages
+  #     correctly, so use npm for claude even when bun is preferred elsewhere.
+  CLAUDE_PKG_MGR="$PKG_MGR"
+  if [ "$PKG_MGR" = "bun" ] && command -v npm >/dev/null 2>&1; then
+    CLAUDE_PKG_MGR="npm"
+  fi
   if [ "{install_claudecode}" = "true" ] && ! command -v claude >/dev/null 2>&1; then
-    echo "[sandboxed] Installing Claude Code via $PKG_MGR..."
-    if ! $PKG_MGR install -g @anthropic-ai/claude-code@latest; then
+    echo "[sandboxed] Installing Claude Code via $CLAUDE_PKG_MGR..."
+    if ! $CLAUDE_PKG_MGR install -g @anthropic-ai/claude-code@latest; then
       echo "[sandboxed] Claude Code install failed"
     fi
   fi


### PR DESCRIPTION
## Problem

`bootstrap_workspace_harnesses()` (in `src/workspace.rs`) is supposed to install the AI CLIs (`claude`, `opencode`, `oh-my-opencode`) into a freshly-created container workspace. In practice, on a fresh debootstrap rootfs, **it silently no-ops**, and the workspace ends up unusable for missions.

Repro:

1. Create a new container workspace from the dashboard (workspace_type: `container`, distro: `ubuntu-noble`).
2. Trigger a mission against it (e.g. via a Telegram bot).
3. The mission's pre-flight network check fails with:
   ```
   No internet connectivity: Network check failed (code 127). Output: /bin/sh: 1: curl: not found
   ```
4. `which claude`, `which curl`, `which node` inside the rootfs all return nothing.

Cause: the rootfs is built with `debootstrap --variant=minbase ubuntu-noble`, which has neither curl, node, npm, nor bun. The bootstrap script then runs:

```sh
if command -v bun >/dev/null 2>&1; then
  PKG_MGR="bun"
elif command -v npm >/dev/null 2>&1; then
  PKG_MGR="npm"
else
  PKG_MGR=""
  echo "[sandboxed] No package manager (bun/npm) found; skipping harness install"
fi
```

…lands in the `else`, prints a warning, and returns success — the script "ran", so the workspace is marked `ready`, but nothing got installed.

## Fix

Prepend a baseline-install block to the bootstrap script: install `curl`, `ca-certificates`, `gnupg`, `git`, `jq`, `python3`, `build-essential` via `apt-get`, and Node.js 22 from NodeSource. The existing bun/npm-detection logic then sees `npm` and proceeds to install the AI CLIs as designed.

The new block is idempotent — guarded by `command -v curl` / `command -v node` / `command -v bun`. On a rootfs that already has these (e.g. a custom image), it's a no-op.

## Verified

End-to-end on Ubuntu 26.04 / Docker 29.4 (with `privileged: true` + `cgroup: host`):

- Created a fresh container workspace from the dashboard.
- Triggered a Telegram-bot mission against it.
- The mission's network check passes, claude spawns inside the rootfs, and the mission proceeds.

## Note

This PR depends on the nspawn fix in #408 (without `--register=no` the `execute_in_container` call inside `bootstrap_workspace_harnesses` itself fails on docker setups). On native (systemd-init) installs this PR is independently useful: it makes new container workspaces actually work without the user having to manually `apt install curl nodejs && npm install -g @anthropic-ai/claude-code` inside each rootfs.

---

_Please review before merging._
