### PR TITLE
[codex] add user GitHub OAuth for bots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,18 @@ JWT_TTL_DAYS=30
 # SANDBOXED_PUBLIC_URL=https://agent.example.com
 
 # =============================================================================
+# Optional: GitHub OAuth for user-scoped git access
+# =============================================================================
+# Enables each dashboard user to connect a GitHub account from Settings > GitHub.
+# Mission runs and Telegram bots inherit that user's token for GitHub commits/pushes.
+# Create a GitHub OAuth App with callback URL:
+#   https://agent.example.com/api/auth/github/callback
+# GITHUB_OAUTH_CLIENT_ID=...
+# GITHUB_OAUTH_CLIENT_SECRET=...
+# GITHUB_OAUTH_REDIRECT_URI=https://agent.example.com/api/auth/github/callback
+# GITHUB_OAUTH_SCOPES=repo workflow read:user user:email
+
+# =============================================================================
 # Optional: Web Search (Tavily)
 # =============================================================================
 # If not set, falls back to DuckDuckGo HTML (may be blocked by CAPTCHA)

--- a/dashboard/src/app/settings/github/page.tsx
+++ b/dashboard/src/app/settings/github/page.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import useSWR from 'swr';
+import {
+  disconnectGithubOAuth,
+  getGithubOAuthStatus,
+  startGithubOAuth,
+} from '@/lib/api';
+import { toast } from '@/components/toast';
+import {
+  AlertCircle,
+  CheckCircle,
+  ExternalLink,
+  Github,
+  Loader,
+  RefreshCw,
+  Unlink,
+} from 'lucide-react';
+import { useState } from 'react';
+
+export default function GithubSettingsPage() {
+  const { data: status, isLoading, mutate } = useSWR(
+    'github-oauth-status',
+    getGithubOAuthStatus,
+    { revalidateOnFocus: true }
+  );
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    const authWindow = window.open('about:blank', '_blank');
+    if (authWindow) {
+      authWindow.opener = null;
+    }
+    try {
+      const response = await startGithubOAuth();
+      if (authWindow) {
+        authWindow.location.href = response.url;
+      } else {
+        window.location.href = response.url;
+      }
+      toast.success('GitHub authorization opened');
+      setTimeout(() => void mutate(), 2000);
+    } catch (error) {
+      authWindow?.close();
+      toast.error(error instanceof Error ? error.message : 'Failed to start GitHub OAuth');
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await disconnectGithubOAuth();
+      await mutate();
+      toast.success('GitHub account disconnected');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to disconnect GitHub');
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const blockedReason = status
+    ? !status.configured
+      ? 'Set GITHUB_OAUTH_CLIENT_ID and GITHUB_OAUTH_CLIENT_SECRET on the server.'
+      : !status.can_decrypt
+        ? 'Unlock the secrets store or set SANDBOXED_SECRET_PASSPHRASE.'
+        : status.message
+    : null;
+
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold text-white">GitHub</h1>
+          <p className="mt-1 text-sm text-white/50">
+            Connect the current sandbox user to GitHub for mission and Telegram bot git operations.
+          </p>
+        </div>
+
+        <section className="rounded-xl border border-white/[0.08] bg-white/[0.03] p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.06]">
+                <Github className="h-5 w-5 text-white/80" />
+              </div>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <h2 className="text-sm font-medium text-white">User OAuth Account</h2>
+                  {isLoading ? (
+                    <Loader className="h-4 w-4 animate-spin text-white/40" />
+                  ) : status?.connected ? (
+                    <CheckCircle className="h-4 w-4 text-emerald-400" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4 text-amber-400" />
+                  )}
+                </div>
+                <p className="mt-1 text-sm text-white/50">
+                  {status?.connected
+                    ? `Connected as @${status.login ?? 'github-user'}`
+                    : 'No GitHub account connected for this sandbox user.'}
+                </p>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => void mutate()}
+              className="inline-flex h-9 items-center gap-2 rounded-lg border border-white/[0.08] px-3 text-xs text-white/70 hover:bg-white/[0.06]"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Refresh
+            </button>
+          </div>
+
+          {status?.connected && (
+            <dl className="mt-5 grid gap-3 rounded-lg border border-white/[0.06] bg-black/20 p-4 text-sm sm:grid-cols-2">
+              <div>
+                <dt className="text-white/35">Account</dt>
+                <dd className="mt-1 truncate text-white">{status.login}</dd>
+              </div>
+              <div>
+                <dt className="text-white/35">Email</dt>
+                <dd className="mt-1 truncate text-white">
+                  {status.email ?? 'GitHub noreply fallback'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-white/35">Scopes</dt>
+                <dd className="mt-1 truncate text-white">
+                  {status.scopes ?? 'Default OAuth scopes'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-white/35">Connected</dt>
+                <dd className="mt-1 truncate text-white">
+                  {status.connected_at
+                    ? new Date(status.connected_at).toLocaleString()
+                    : 'Unknown'}
+                </dd>
+              </div>
+            </dl>
+          )}
+
+          {blockedReason && !status?.connected && (
+            <div className="mt-5 rounded-lg border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+              {blockedReason}
+            </div>
+          )}
+
+          <div className="mt-5 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleConnect}
+              disabled={connecting || !status?.configured || !status?.can_decrypt}
+              className="inline-flex items-center gap-2 rounded-lg bg-white px-4 py-2 text-sm font-medium text-black transition hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {connecting ? (
+                <Loader className="h-4 w-4 animate-spin" />
+              ) : (
+                <ExternalLink className="h-4 w-4" />
+              )}
+              {status?.connected ? 'Reconnect GitHub' : 'Connect GitHub'}
+            </button>
+
+            {status?.connected && (
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                disabled={disconnecting}
+                className="inline-flex items-center gap-2 rounded-lg border border-red-400/20 px-4 py-2 text-sm font-medium text-red-200 transition hover:bg-red-400/10 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {disconnecting ? (
+                  <Loader className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Unlink className="h-4 w-4" />
+                )}
+                Disconnect
+              </button>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -32,6 +32,7 @@ import {
   Sparkles,
   ListTodo,
   MessageCircle,
+  Github,
 } from 'lucide-react';
 
 type NavItem = {
@@ -78,6 +79,7 @@ const navigation: NavItem[] = [
       { name: 'Providers', href: '/settings/providers', icon: Key },
       { name: 'LLM', href: '/settings/llm', icon: Sparkles },
       { name: 'Telegram', href: '/settings/telegram', icon: MessageCircle },
+      { name: 'GitHub', href: '/settings/github', icon: Github },
       { name: 'Security', href: '/settings/secrets', icon: Lock },
       { name: 'Data', href: '/settings/data', icon: Archive },
     ],

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -149,6 +149,40 @@ export async function changePassword(
   return apiPost("/api/auth/change-password", request, "Failed to change password");
 }
 
+export interface GithubOAuthStatusResponse {
+  configured: boolean;
+  connected: boolean;
+  can_decrypt: boolean;
+  login: string | null;
+  github_user_id: string | null;
+  name: string | null;
+  email: string | null;
+  scopes: string | null;
+  connected_at: string | null;
+  expires_at: number | null;
+  is_expired: boolean;
+  message: string | null;
+}
+
+export interface GithubOAuthAuthorizeResponse {
+  url: string;
+  state: string;
+  redirect_uri: string;
+  scopes: string;
+}
+
+export async function getGithubOAuthStatus(): Promise<GithubOAuthStatusResponse> {
+  return apiGet("/api/auth/github/status", "Failed to fetch GitHub OAuth status");
+}
+
+export async function startGithubOAuth(): Promise<GithubOAuthAuthorizeResponse> {
+  return apiPost("/api/auth/github/authorize", undefined, "Failed to start GitHub OAuth");
+}
+
+export async function disconnectGithubOAuth(): Promise<void> {
+  return apiDel("/api/auth/github", "Failed to disconnect GitHub");
+}
+
 // Get statistics
 export async function getStats(since?: string): Promise<StatsResponse> {
   const qs = since ? `?since=${encodeURIComponent(since)}` : "";

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -52,6 +52,18 @@ Copy `.env.example` to `.env` and configure the values below. The full file cont
 | `MAX_ITERATIONS` | `50` | Max tool-call iterations per mission |
 | `MAX_PARALLEL_MISSIONS` | `1` | Number of missions that can run concurrently |
 
+#### GitHub OAuth
+
+Set these when users should connect their own GitHub accounts from Settings > GitHub. Mission runs and Telegram bots inherit the connected user's token for GitHub commits and pushes.
+
+| Variable | Default | Description |
+|---|---|---|
+| `GITHUB_OAUTH_CLIENT_ID` | _(unset)_ | GitHub OAuth App client ID |
+| `GITHUB_OAUTH_CLIENT_SECRET` | _(unset)_ | GitHub OAuth App client secret |
+| `GITHUB_OAUTH_REDIRECT_URI` | `$SANDBOXED_PUBLIC_URL/api/auth/github/callback` | Callback URL registered on the GitHub OAuth App |
+| `GITHUB_OAUTH_SCOPES` | `repo workflow read:user user:email` | OAuth scopes requested from GitHub |
+| `SANDBOXED_SECRET_PASSPHRASE` | _(unset)_ | Unlocks the encrypted secrets store used for GitHub tokens |
+
 ### Enabling container workspaces
 
 By default, workspaces run in host/fallback mode — processes execute directly inside the Docker container. To enable full **systemd-nspawn isolation** (each workspace gets its own lightweight container), edit `docker-compose.yml` and uncomment the privileged lines:

--- a/docs/install-native.md
+++ b/docs/install-native.md
@@ -1048,6 +1048,26 @@ Note: Multi-user mode provides separate login credentials but does **not**
 provide workspace or data isolation between users. All users see the same
 missions and workspaces.
 
+### 11.3 GitHub OAuth for User Git Access
+
+To let each sandbox user connect a GitHub account from Settings > GitHub, create
+a GitHub OAuth App and set these variables:
+
+```bash
+# In /etc/sandboxed_sh/sandboxed_sh.env:
+GITHUB_OAUTH_CLIENT_ID=<github-oauth-client-id>
+GITHUB_OAUTH_CLIENT_SECRET=<github-oauth-client-secret>
+GITHUB_OAUTH_REDIRECT_URI=https://agent.yourdomain.com/api/auth/github/callback
+GITHUB_OAUTH_SCOPES="repo workflow read:user user:email"
+
+# Required so encrypted GitHub tokens can be stored and read by mission runners.
+SANDBOXED_SECRET_PASSPHRASE=<strong-secret-passphrase>
+```
+
+Use the same callback URL in the GitHub OAuth App. When connected, mission runs
+and Telegram bots inherit the current sandbox user's GitHub token for commits
+and pushes.
+
 ---
 
 ## 12) Dashboard Configuration

--- a/docs/mobile-github-oauth.md
+++ b/docs/mobile-github-oauth.md
@@ -1,0 +1,58 @@
+# Mobile GitHub OAuth
+
+The mobile clients should expose GitHub as an account connection under Settings.
+Users should not paste GitHub tokens or set runtime environment variables in the
+app.
+
+## Flow
+
+1. Fetch status:
+   ```http
+   GET /api/auth/github/status
+   Authorization: Bearer <dashboard-jwt>
+   ```
+
+2. Start OAuth:
+   ```http
+   POST /api/auth/github/authorize
+   Authorization: Bearer <dashboard-jwt>
+   ```
+
+   The response contains a GitHub authorization `url`.
+
+3. Open `url` in the system browser:
+   - iOS: `openURL(url)`
+   - Android: Chrome Custom Tabs or `Intent.ACTION_VIEW`
+
+4. GitHub redirects back to the sandboxed.sh server callback. The server stores
+   the OAuth token in the encrypted secrets store for the current sandbox user.
+
+5. When the app becomes active again, refresh `GET /api/auth/github/status`.
+
+6. Disconnect:
+   ```http
+   DELETE /api/auth/github
+   Authorization: Bearer <dashboard-jwt>
+   ```
+
+## Android Sketch
+
+```kotlin
+suspend fun connectGithub(api: SandboxedApi, context: Context) {
+    val auth = api.startGithubOAuth()
+    CustomTabsIntent.Builder()
+        .build()
+        .launchUrl(context, Uri.parse(auth.url))
+}
+
+override fun onResume() {
+    super.onResume()
+    lifecycleScope.launch {
+        githubStatus = api.getGithubOAuthStatus()
+    }
+}
+```
+
+The server must be configured with `GITHUB_OAUTH_CLIENT_ID`,
+`GITHUB_OAUTH_CLIENT_SECRET`, and an unlocked secrets store. Mobile clients only
+display the resulting connection state and account metadata.

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -92,6 +92,20 @@ final class APIService {
         }
         return response.status == "ok"
     }
+
+    // MARK: - GitHub OAuth
+
+    func getGithubOAuthStatus() async throws -> GithubOAuthStatus {
+        try await get("/api/auth/github/status")
+    }
+
+    func startGithubOAuth() async throws -> GithubOAuthAuthorizeResponse {
+        try await post("/api/auth/github/authorize", body: EmptyBody())
+    }
+
+    func disconnectGithubOAuth() async throws {
+        let _: EmptyResponse = try await delete("/api/auth/github")
+    }
     
     // MARK: - Missions
     
@@ -707,6 +721,50 @@ final class APIService {
 struct MissionEventsResult {
     let events: [StoredEvent]
     let maxSequence: Int64?
+}
+
+struct GithubOAuthStatus: Decodable, Equatable {
+    let configured: Bool
+    let connected: Bool
+    let canDecrypt: Bool
+    let login: String?
+    let githubUserId: String?
+    let name: String?
+    let email: String?
+    let scopes: String?
+    let connectedAt: String?
+    let expiresAt: Int?
+    let isExpired: Bool
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case configured
+        case connected
+        case canDecrypt = "can_decrypt"
+        case login
+        case githubUserId = "github_user_id"
+        case name
+        case email
+        case scopes
+        case connectedAt = "connected_at"
+        case expiresAt = "expires_at"
+        case isExpired = "is_expired"
+        case message
+    }
+}
+
+struct GithubOAuthAuthorizeResponse: Decodable {
+    let url: String
+    let state: String
+    let redirectUri: String
+    let scopes: String
+
+    enum CodingKeys: String, CodingKey {
+        case url
+        case state
+        case redirectUri = "redirect_uri"
+        case scopes
+    }
 }
 
 enum APIError: LocalizedError {

--- a/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
@@ -9,11 +9,19 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var serverURL: String
     @State private var isTestingConnection = false
     @State private var connectionStatus: ConnectionStatus = .unknown
     @State private var showingSaveConfirmation = false
+    @State private var githubStatus: GithubOAuthStatus?
+    @State private var isLoadingGithubStatus = false
+    @State private var isConnectingGithub = false
+    @State private var isDisconnectingGithub = false
+    @State private var githubErrorMessage: String?
+    @State private var didLaunchGithubOAuth = false
     
     // Default agent settings
     @State private var backends: [Backend] = Backend.defaults
@@ -149,6 +157,8 @@ struct SettingsView: View {
                                 }
                             }
                         }
+
+                        githubSection
 
                         // Mission Preferences Section
                         VStack(alignment: .leading, spacing: 16) {
@@ -350,10 +360,203 @@ struct SettingsView: View {
         .presentationDragIndicator(.visible)
         .task {
             await loadAgents()
+            await loadGithubStatus()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active && didLaunchGithubOAuth {
+                didLaunchGithubOAuth = false
+                Task { await loadGithubStatus() }
+            }
         }
     }
     
     // MARK: - Default Agent Picker
+
+    private var githubSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("GitHub", systemImage: "link.circle")
+                .font(.headline)
+                .foregroundStyle(Theme.textPrimary)
+
+            GlassCard(padding: 20, cornerRadius: 20) {
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack(alignment: .top, spacing: 12) {
+                        ZStack {
+                            Circle()
+                                .fill(githubStatusColor.opacity(0.14))
+                                .frame(width: 40, height: 40)
+                            Image(systemName: githubStatusIcon)
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(githubStatusColor)
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("GitHub Account")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(Theme.textPrimary)
+                            Text(githubStatusMessage)
+                                .font(.caption)
+                                .foregroundStyle(Theme.textSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer()
+
+                        Button {
+                            Task { await loadGithubStatus() }
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(Theme.textMuted)
+                        }
+                        .disabled(isLoadingGithubStatus)
+                        .symbolEffect(.rotate, isActive: isLoadingGithubStatus)
+                    }
+
+                    if let githubStatus, githubStatus.connected {
+                        Divider()
+                            .background(Theme.border)
+
+                        VStack(spacing: 10) {
+                            githubInfoRow(label: "Account", value: githubStatus.login.map { "@\($0)" } ?? "Connected")
+                            githubInfoRow(label: "Email", value: githubStatus.email ?? "GitHub noreply fallback")
+                            githubInfoRow(label: "Scopes", value: githubStatus.scopes ?? "Default OAuth scopes")
+                            githubInfoRow(label: "Connected", value: formattedGithubDate(githubStatus.connectedAt))
+                        }
+                    }
+
+                    if let blockedReason = githubBlockedReason, githubStatus?.connected != true {
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 14))
+                                .foregroundStyle(Theme.warning)
+                            Text(blockedReason)
+                                .font(.caption)
+                                .foregroundStyle(Theme.warning)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(12)
+                        .background(Theme.warning.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+
+                    if let githubErrorMessage {
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 14))
+                                .foregroundStyle(Theme.error)
+                            Text(githubErrorMessage)
+                                .font(.caption)
+                                .foregroundStyle(Theme.error)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(12)
+                        .background(Theme.error.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+
+                    HStack(spacing: 10) {
+                        Button {
+                            Task { await connectGithub() }
+                        } label: {
+                            HStack {
+                                if isConnectingGithub {
+                                    ProgressView()
+                                        .progressViewStyle(.circular)
+                                        .tint(.white)
+                                        .scaleEffect(0.8)
+                                } else {
+                                    Image(systemName: "arrow.up.forward.app")
+                                }
+                                Text(githubStatus?.connected == true ? "Reconnect" : "Connect GitHub")
+                                    .fontWeight(.semibold)
+                            }
+                            .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(GlassProminentButtonStyle())
+                        .disabled(githubConnectDisabled)
+
+                        if githubStatus?.connected == true {
+                            Button {
+                                Task { await disconnectGithub() }
+                            } label: {
+                                HStack {
+                                    if isDisconnectingGithub {
+                                        ProgressView()
+                                            .progressViewStyle(.circular)
+                                            .scaleEffect(0.8)
+                                    } else {
+                                        Image(systemName: "link.badge.minus")
+                                    }
+                                    Text("Disconnect")
+                                }
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(Theme.error)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 12)
+                                .background(Theme.error.opacity(0.1))
+                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(isDisconnectingGithub)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func githubInfoRow(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+            Spacer()
+            Text(value)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private var githubStatusIcon: String {
+        if isLoadingGithubStatus { return "arrow.trianglehead.2.clockwise.rotate.90" }
+        if githubStatus?.connected == true { return "checkmark.circle.fill" }
+        return "link.badge.plus"
+    }
+
+    private var githubStatusColor: Color {
+        if githubStatus?.connected == true { return Theme.success }
+        if githubBlockedReason != nil { return Theme.warning }
+        return Theme.textSecondary
+    }
+
+    private var githubStatusMessage: String {
+        if isLoadingGithubStatus { return "Checking GitHub connection..." }
+        if githubStatus?.connected == true {
+            return "Connected as @\(githubStatus?.login ?? "github-user")"
+        }
+        return "No GitHub account connected for this sandbox user."
+    }
+
+    private var githubBlockedReason: String? {
+        guard let githubStatus else { return nil }
+        if !githubStatus.configured {
+            return "GitHub OAuth is not configured on the server."
+        }
+        if !githubStatus.canDecrypt {
+            return "The server secrets store is locked."
+        }
+        return githubStatus.message
+    }
+
+    private var githubConnectDisabled: Bool {
+        isConnectingGithub
+            || isLoadingGithubStatus
+            || githubStatus?.configured != true
+            || githubStatus?.canDecrypt != true
+    }
     
     private var defaultAgentPicker: some View {
         VStack(spacing: 8) {
@@ -474,6 +677,70 @@ struct SettingsView: View {
                 selectedDefaultAgent = ""
             }
         }
+    }
+
+    private func loadGithubStatus() async {
+        guard api.isConfigured else { return }
+        isLoadingGithubStatus = true
+        githubErrorMessage = nil
+        defer { isLoadingGithubStatus = false }
+
+        do {
+            githubStatus = try await api.getGithubOAuthStatus()
+        } catch {
+            githubErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func connectGithub() async {
+        isConnectingGithub = true
+        githubErrorMessage = nil
+        defer { isConnectingGithub = false }
+
+        do {
+            let response = try await api.startGithubOAuth()
+            guard let url = URL(string: response.url) else {
+                throw APIError.invalidURL
+            }
+            didLaunchGithubOAuth = true
+            openURL(url)
+            HapticService.lightTap()
+
+            try? await Task.sleep(for: .seconds(2))
+            await loadGithubStatus()
+        } catch {
+            didLaunchGithubOAuth = false
+            githubErrorMessage = error.localizedDescription
+            HapticService.error()
+        }
+    }
+
+    private func disconnectGithub() async {
+        isDisconnectingGithub = true
+        githubErrorMessage = nil
+        defer { isDisconnectingGithub = false }
+
+        do {
+            try await api.disconnectGithubOAuth()
+            await loadGithubStatus()
+            HapticService.success()
+        } catch {
+            githubErrorMessage = error.localizedDescription
+            HapticService.error()
+        }
+    }
+
+    private func formattedGithubDate(_ rawValue: String?) -> String {
+        guard let rawValue else { return "Unknown" }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: rawValue) ?? {
+            let fallback = ISO8601DateFormatter()
+            fallback.formatOptions = [.withInternetDateTime]
+            return fallback.date(from: rawValue)
+        }()
+        guard let date else { return rawValue }
+        return DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .short)
     }
 
     private func testConnection() async {

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -10,19 +10,33 @@
 
 use axum::{
     body::Body,
-    extract::State,
+    extract::{Query, State},
     http::{Request, StatusCode},
     middleware::Next,
-    response::{IntoResponse, Response},
+    response::{Html, IntoResponse, Response},
     Extension, Json,
 };
 use chrono::{Duration, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
 
 use super::routes::AppState;
 use super::types::{LoginRequest, LoginResponse};
 use crate::config::{AuthMode, Config, UserAccount};
+use crate::secrets::types::{SecretMetadata, SecretType};
+use crate::secrets::SecretsStore;
 use crate::util::internal_error;
+
+const GITHUB_OAUTH_REGISTRY: &str = "github-oauth";
+const GITHUB_ACCESS_TOKEN_SUFFIX: &str = "access-token";
+const GITHUB_REFRESH_TOKEN_SUFFIX: &str = "refresh-token";
+const GITHUB_AUTHORIZE_URL: &str = "https://github.com/login/oauth/authorize";
+const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const GITHUB_USER_URL: &str = "https://api.github.com/user";
+const GITHUB_USER_EMAILS_URL: &str = "https://api.github.com/user/emails";
+const GITHUB_DEFAULT_SCOPES: &str = "repo workflow read:user user:email";
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Claims {
@@ -41,6 +55,22 @@ struct Claims {
 pub struct AuthUser {
     pub id: String,
     pub username: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingGithubOAuth {
+    pub user: AuthUser,
+    pub redirect_uri: String,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GithubOAuthCredentials {
+    pub access_token: String,
+    pub login: Option<String>,
+    pub github_user_id: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
 }
 
 fn configured_single_tenant_user_id() -> Option<String> {
@@ -522,6 +552,605 @@ pub async fn change_password(
         "success": true,
         "password_changed_at": now
     })))
+}
+
+// ─── GitHub OAuth for user-scoped bot/mission git access ───────────────────
+
+fn github_oauth_client_id() -> Option<String> {
+    std::env::var("GITHUB_OAUTH_CLIENT_ID")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn github_oauth_client_secret() -> Option<String> {
+    std::env::var("GITHUB_OAUTH_CLIENT_SECRET")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn github_oauth_scopes() -> String {
+    std::env::var("GITHUB_OAUTH_SCOPES")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| GITHUB_DEFAULT_SCOPES.to_string())
+}
+
+fn trim_trailing_slash(value: &str) -> String {
+    value.trim_end_matches('/').to_string()
+}
+
+fn github_oauth_redirect_uri(config: &Config) -> String {
+    if let Ok(uri) = std::env::var("GITHUB_OAUTH_REDIRECT_URI") {
+        let trimmed = uri.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    if let Ok(public_url) = std::env::var("SANDBOXED_PUBLIC_URL") {
+        let trimmed = public_url.trim();
+        if !trimmed.is_empty() {
+            return format!("{}/api/auth/github/callback", trim_trailing_slash(trimmed));
+        }
+    }
+
+    format!(
+        "http://{}:{}/api/auth/github/callback",
+        config.host, config.port
+    )
+}
+
+fn github_secret_key(user_id: &str, suffix: &str) -> String {
+    format!(
+        "{}-{}",
+        crate::api::mission_store::sanitize_filename(user_id),
+        suffix
+    )
+}
+
+fn github_oauth_configured() -> bool {
+    github_oauth_client_id().is_some() && github_oauth_client_secret().is_some()
+}
+
+async fn ensure_secrets_ready(secrets: &SecretsStore) -> Result<(), String> {
+    if !secrets.is_initialized().await {
+        secrets
+            .initialize("default")
+            .await
+            .map_err(|e| format!("Failed to initialize secrets store: {}", e))?;
+    }
+    if !secrets.can_decrypt().await {
+        return Err(
+            "Secrets store is locked. Unlock it or set SANDBOXED_SECRET_PASSPHRASE before connecting GitHub."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct GithubOAuthStatusResponse {
+    pub configured: bool,
+    pub connected: bool,
+    pub can_decrypt: bool,
+    pub login: Option<String>,
+    pub github_user_id: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub scopes: Option<String>,
+    pub connected_at: Option<String>,
+    pub expires_at: Option<i64>,
+    pub is_expired: bool,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct GithubOAuthAuthorizeResponse {
+    pub url: String,
+    pub state: String,
+    pub redirect_uri: String,
+    pub scopes: String,
+}
+
+pub async fn github_oauth_status(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Json<GithubOAuthStatusResponse> {
+    let Some(secrets) = state.secrets.as_ref() else {
+        return Json(GithubOAuthStatusResponse {
+            configured: github_oauth_configured(),
+            connected: false,
+            can_decrypt: false,
+            login: None,
+            github_user_id: None,
+            name: None,
+            email: None,
+            scopes: None,
+            connected_at: None,
+            expires_at: None,
+            is_expired: false,
+            message: Some("Secrets store is not available".to_string()),
+        });
+    };
+
+    let can_decrypt = secrets.can_decrypt().await;
+    let key = github_secret_key(&user.id, GITHUB_ACCESS_TOKEN_SUFFIX);
+    let secret_info = secrets
+        .list_secrets(GITHUB_OAUTH_REGISTRY)
+        .await
+        .ok()
+        .and_then(|secrets| secrets.into_iter().find(|secret| secret.key == key));
+
+    let Some(secret_info) = secret_info else {
+        return Json(GithubOAuthStatusResponse {
+            configured: github_oauth_configured(),
+            connected: false,
+            can_decrypt,
+            login: None,
+            github_user_id: None,
+            name: None,
+            email: None,
+            scopes: None,
+            connected_at: None,
+            expires_at: None,
+            is_expired: false,
+            message: None,
+        });
+    };
+
+    let labels = secret_info.labels;
+    Json(GithubOAuthStatusResponse {
+        configured: github_oauth_configured(),
+        connected: !secret_info.is_expired,
+        can_decrypt,
+        login: labels.get("github_login").cloned(),
+        github_user_id: labels.get("github_user_id").cloned(),
+        name: labels.get("github_name").cloned(),
+        email: labels.get("github_email").cloned(),
+        scopes: labels.get("scopes").cloned(),
+        connected_at: labels.get("connected_at").cloned(),
+        expires_at: secret_info.expires_at,
+        is_expired: secret_info.is_expired,
+        message: secret_info
+            .is_expired
+            .then_some("GitHub OAuth token is expired; reconnect GitHub.".to_string()),
+    })
+}
+
+pub async fn github_oauth_authorize(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<Json<GithubOAuthAuthorizeResponse>, (StatusCode, String)> {
+    let client_id = github_oauth_client_id().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "GITHUB_OAUTH_CLIENT_ID is not configured".to_string(),
+        )
+    })?;
+    let _client_secret = github_oauth_client_secret().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "GITHUB_OAUTH_CLIENT_SECRET is not configured".to_string(),
+        )
+    })?;
+
+    let secrets = state.secrets.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Secrets store is not available".to_string(),
+        )
+    })?;
+    ensure_secrets_ready(secrets)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+
+    let state_token = Uuid::new_v4().to_string();
+    let redirect_uri = github_oauth_redirect_uri(&state.config);
+    let scopes = github_oauth_scopes();
+
+    {
+        let mut pending = state.pending_github_oauth.write().await;
+        let cutoff = Utc::now() - Duration::minutes(15);
+        pending.retain(|_, value| value.created_at >= cutoff);
+        pending.insert(
+            state_token.clone(),
+            PendingGithubOAuth {
+                user,
+                redirect_uri: redirect_uri.clone(),
+                created_at: Utc::now(),
+            },
+        );
+    }
+
+    let mut url = url::Url::parse(GITHUB_AUTHORIZE_URL).map_err(internal_error)?;
+    url.query_pairs_mut()
+        .append_pair("client_id", &client_id)
+        .append_pair("redirect_uri", &redirect_uri)
+        .append_pair("scope", &scopes)
+        .append_pair("state", &state_token)
+        .append_pair("allow_signup", "true");
+
+    Ok(Json(GithubOAuthAuthorizeResponse {
+        url: url.to_string(),
+        state: state_token,
+        redirect_uri,
+        scopes,
+    }))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GithubOAuthCallbackQuery {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GithubTokenResponse {
+    access_token: Option<String>,
+    token_type: Option<String>,
+    scope: Option<String>,
+    expires_in: Option<i64>,
+    refresh_token: Option<String>,
+    refresh_token_expires_in: Option<i64>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GithubUserResponse {
+    id: i64,
+    login: String,
+    name: Option<String>,
+    email: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GithubEmailResponse {
+    email: String,
+    primary: bool,
+    verified: bool,
+}
+
+pub async fn github_oauth_callback(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<GithubOAuthCallbackQuery>,
+) -> Result<Html<String>, (StatusCode, String)> {
+    if let Some(error) = query.error {
+        let description = query.error_description.unwrap_or_default();
+        return Ok(github_callback_html(
+            "GitHub connection cancelled",
+            &format!("{} {}", error, description).trim(),
+            false,
+        ));
+    }
+
+    let code = query
+        .code
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing OAuth code".to_string()))?;
+    let state_token = query
+        .state
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing OAuth state".to_string()))?;
+
+    let pending = state
+        .pending_github_oauth
+        .write()
+        .await
+        .remove(&state_token)
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "OAuth state is invalid or expired".to_string(),
+            )
+        })?;
+
+    let client_id = github_oauth_client_id().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "GITHUB_OAUTH_CLIENT_ID is not configured".to_string(),
+        )
+    })?;
+    let client_secret = github_oauth_client_secret().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "GITHUB_OAUTH_CLIENT_SECRET is not configured".to_string(),
+        )
+    })?;
+    let secrets = state.secrets.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Secrets store is not available".to_string(),
+        )
+    })?;
+    ensure_secrets_ready(secrets)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+
+    let token_response = state
+        .http_client
+        .post(GITHUB_TOKEN_URL)
+        .header("Accept", "application/json")
+        .header("User-Agent", "sandboxed.sh")
+        .form(&[
+            ("client_id", client_id.as_str()),
+            ("client_secret", client_secret.as_str()),
+            ("code", code.as_str()),
+            ("redirect_uri", pending.redirect_uri.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(internal_error)?;
+
+    if !token_response.status().is_success() {
+        let status = token_response.status();
+        let text = token_response.text().await.unwrap_or_default();
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!("GitHub token exchange failed ({}): {}", status, text),
+        ));
+    }
+
+    let token_data: GithubTokenResponse = token_response.json().await.map_err(internal_error)?;
+    if let Some(error) = token_data.error {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!(
+                "GitHub token exchange failed: {} {}",
+                error,
+                token_data.error_description.unwrap_or_default()
+            ),
+        ));
+    }
+    let access_token = token_data.access_token.ok_or_else(|| {
+        (
+            StatusCode::BAD_GATEWAY,
+            "GitHub did not return an access token".to_string(),
+        )
+    })?;
+
+    let github_user = fetch_github_user(&state.http_client, &access_token)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
+    let email = if github_user
+        .email
+        .as_deref()
+        .is_some_and(|v| !v.trim().is_empty())
+    {
+        github_user.email.clone()
+    } else {
+        fetch_github_primary_email(&state.http_client, &access_token)
+            .await
+            .ok()
+            .flatten()
+    };
+
+    store_github_oauth(
+        secrets,
+        &pending.user,
+        &access_token,
+        token_data.refresh_token.as_deref(),
+        token_data.expires_in,
+        token_data.refresh_token_expires_in,
+        token_data.scope.as_deref(),
+        token_data.token_type.as_deref(),
+        &github_user,
+        email.as_deref(),
+    )
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(github_callback_html(
+        "GitHub connected",
+        "You can close this window and return to sandboxed.sh.",
+        true,
+    ))
+}
+
+fn github_callback_html(title: &str, message: &str, success: bool) -> Html<String> {
+    let color = if success { "#34d399" } else { "#f87171" };
+    let title = escape_html(title);
+    let message = escape_html(message);
+    Html(format!(
+        r#"<!doctype html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{title}</title></head>
+<body style="margin:0;background:#121214;color:white;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:grid;min-height:100vh;place-items:center">
+  <main style="max-width:440px;padding:32px;text-align:center">
+    <div style="width:48px;height:48px;border-radius:999px;background:{color};margin:0 auto 20px"></div>
+    <h1 style="font-size:22px;margin:0 0 10px">{title}</h1>
+    <p style="color:rgba(255,255,255,.68);line-height:1.5">{message}</p>
+    <button onclick="window.close()" style="margin-top:18px;border:1px solid rgba(255,255,255,.14);background:rgba(255,255,255,.06);color:white;border-radius:8px;padding:10px 14px">Close</button>
+  </main>
+</body>
+</html>"#
+    ))
+}
+
+fn escape_html(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+async fn fetch_github_user(
+    client: &reqwest::Client,
+    access_token: &str,
+) -> Result<GithubUserResponse, String> {
+    let resp = client
+        .get(GITHUB_USER_URL)
+        .bearer_auth(access_token)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "sandboxed.sh")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch GitHub user: {}", e))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("GitHub user fetch failed ({}): {}", status, text));
+    }
+
+    resp.json()
+        .await
+        .map_err(|e| format!("Failed to parse GitHub user response: {}", e))
+}
+
+async fn fetch_github_primary_email(
+    client: &reqwest::Client,
+    access_token: &str,
+) -> Result<Option<String>, String> {
+    let resp = client
+        .get(GITHUB_USER_EMAILS_URL)
+        .bearer_auth(access_token)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "sandboxed.sh")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch GitHub emails: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+
+    let emails: Vec<GithubEmailResponse> = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse GitHub emails response: {}", e))?;
+    Ok(emails
+        .into_iter()
+        .find(|email| email.primary && email.verified)
+        .map(|email| email.email))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn store_github_oauth(
+    secrets: &SecretsStore,
+    user: &AuthUser,
+    access_token: &str,
+    refresh_token: Option<&str>,
+    expires_in: Option<i64>,
+    refresh_token_expires_in: Option<i64>,
+    scopes: Option<&str>,
+    token_type: Option<&str>,
+    github_user: &GithubUserResponse,
+    email: Option<&str>,
+) -> Result<(), String> {
+    let now = Utc::now();
+    let expires_at = expires_in.map(|seconds| (now + Duration::seconds(seconds)).timestamp());
+    let refresh_expires_at =
+        refresh_token_expires_in.map(|seconds| (now + Duration::seconds(seconds)).timestamp());
+    let connected_at = now.to_rfc3339();
+
+    let mut labels = HashMap::new();
+    labels.insert("provider".to_string(), "github".to_string());
+    labels.insert("user_id".to_string(), user.id.clone());
+    labels.insert("username".to_string(), user.username.clone());
+    labels.insert("github_login".to_string(), github_user.login.clone());
+    labels.insert("github_user_id".to_string(), github_user.id.to_string());
+    labels.insert("connected_at".to_string(), connected_at);
+    if let Some(name) = github_user.name.as_deref().filter(|v| !v.trim().is_empty()) {
+        labels.insert("github_name".to_string(), name.to_string());
+    }
+    if let Some(email) = email.filter(|v| !v.trim().is_empty()) {
+        labels.insert("github_email".to_string(), email.to_string());
+    }
+    if let Some(scopes) = scopes.filter(|v| !v.trim().is_empty()) {
+        labels.insert("scopes".to_string(), scopes.to_string());
+    }
+    if let Some(token_type) = token_type.filter(|v| !v.trim().is_empty()) {
+        labels.insert("token_type".to_string(), token_type.to_string());
+    }
+
+    secrets
+        .set_secret(
+            GITHUB_OAUTH_REGISTRY,
+            &github_secret_key(&user.id, GITHUB_ACCESS_TOKEN_SUFFIX),
+            access_token,
+            Some(SecretMetadata {
+                secret_type: Some(SecretType::OAuthAccessToken),
+                expires_at,
+                labels,
+            }),
+        )
+        .await
+        .map_err(|e| format!("Failed to store GitHub access token: {}", e))?;
+
+    if let Some(refresh_token) = refresh_token.filter(|v| !v.trim().is_empty()) {
+        let mut refresh_labels = HashMap::new();
+        refresh_labels.insert("provider".to_string(), "github".to_string());
+        refresh_labels.insert("user_id".to_string(), user.id.clone());
+        refresh_labels.insert("github_login".to_string(), github_user.login.clone());
+        secrets
+            .set_secret(
+                GITHUB_OAUTH_REGISTRY,
+                &github_secret_key(&user.id, GITHUB_REFRESH_TOKEN_SUFFIX),
+                refresh_token,
+                Some(SecretMetadata {
+                    secret_type: Some(SecretType::OAuthRefreshToken),
+                    expires_at: refresh_expires_at,
+                    labels: refresh_labels,
+                }),
+            )
+            .await
+            .map_err(|e| format!("Failed to store GitHub refresh token: {}", e))?;
+    }
+
+    Ok(())
+}
+
+pub async fn github_oauth_disconnect(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let secrets = state.secrets.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Secrets store is not available".to_string(),
+        )
+    })?;
+
+    for suffix in [GITHUB_ACCESS_TOKEN_SUFFIX, GITHUB_REFRESH_TOKEN_SUFFIX] {
+        let key = github_secret_key(&user.id, suffix);
+        if let Err(e) = secrets.delete_secret(GITHUB_OAUTH_REGISTRY, &key).await {
+            tracing::debug!("GitHub OAuth secret {} was not deleted: {}", key, e);
+        }
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn github_oauth_credentials_for_user(
+    secrets: Option<&Arc<SecretsStore>>,
+    user_id: &str,
+) -> Option<GithubOAuthCredentials> {
+    let secrets = secrets?;
+    let key = github_secret_key(user_id, GITHUB_ACCESS_TOKEN_SUFFIX);
+    let info = secrets
+        .list_secrets(GITHUB_OAUTH_REGISTRY)
+        .await
+        .ok()?
+        .into_iter()
+        .find(|secret| secret.key == key)?;
+    if info.is_expired {
+        return None;
+    }
+    let access_token = secrets.get_secret(GITHUB_OAUTH_REGISTRY, &key).await.ok()?;
+    let labels = info.labels;
+    Some(GithubOAuthCredentials {
+        access_token,
+        login: labels.get("github_login").cloned(),
+        github_user_id: labels.get("github_user_id").cloned(),
+        name: labels.get("github_name").cloned(),
+        email: labels.get("github_email").cloned(),
+    })
 }
 
 #[cfg(test)]

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3221,6 +3221,7 @@ impl ControlHub {
             mission_store,
             self.secrets.clone(),
             self.telegram_bridge.clone(),
+            user.id.clone(),
         );
         sessions.insert(user.id.clone(), state.clone());
 
@@ -4947,6 +4948,7 @@ fn spawn_control_session(
     mission_store: Arc<dyn MissionStore>,
     secrets: Option<Arc<SecretsStore>>,
     telegram_bridge: Option<super::telegram::SharedTelegramBridge>,
+    user_id: String,
 ) -> ControlState {
     let (cmd_tx, cmd_rx) = mpsc::channel::<ControlCommand>(256);
     let (events_tx, events_rx) = broadcast::channel::<AgentEvent>(1024);
@@ -5002,6 +5004,7 @@ fn spawn_control_session(
         progress,
         mission_store,
         secrets,
+        user_id,
     ));
 
     // Recover orphaned missions from previous run.
@@ -6617,6 +6620,7 @@ async fn control_actor_loop(
     progress: Arc<RwLock<ExecutionProgress>>,
     mission_store: Arc<dyn MissionStore>,
     secrets: Option<Arc<SecretsStore>>,
+    user_id: String,
 ) {
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
@@ -7020,6 +7024,7 @@ async fn control_actor_loop(
                                             mission_cmd_tx.clone(),
                                             Arc::new(RwLock::new(Some(tid))),
                                             secrets.clone(),
+                                            user_id.clone(),
                                         );
                                     }
                                     let _ = respond.send(was_running);
@@ -7121,6 +7126,7 @@ async fn control_actor_loop(
                                                 mission_cmd_tx.clone(),
                                                 Arc::new(RwLock::new(Some(tid))),
                                                 secrets.clone(),
+                                                user_id.clone(),
                                             );
                                             tracing::info!("Auto-started mission {} in parallel", tid);
                                             parallel_runners.insert(tid, runner);
@@ -7723,6 +7729,7 @@ async fn control_actor_loop(
                                 mission_cmd_tx.clone(),
                                 Arc::new(RwLock::new(Some(mission_id))), // Each runner tracks its own mission
                                 secrets.clone(),
+                                user_id.clone(),
                             );
 
                             if started {
@@ -8885,6 +8892,7 @@ async fn control_actor_loop(
                                     mission_cmd_tx.clone(),
                                     Arc::new(RwLock::new(Some(*mission_id))),
                                     secrets.clone(),
+                                    user_id.clone(),
                                 );
 
                                 // If no queued messages, update status and mark for cleanup

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1935,6 +1935,7 @@ impl MissionRunner {
         mission_cmd_tx: mpsc::Sender<crate::tools::mission::MissionControlCommand>,
         current_mission: Arc<RwLock<Option<Uuid>>>,
         secrets: Option<Arc<SecretsStore>>,
+        user_id: String,
     ) -> bool {
         // Don't start if already running
         if self.is_running() {
@@ -2015,6 +2016,7 @@ impl MissionRunner {
                 session_id,
                 config_profile,
                 working_directory,
+                Some(user_id),
             )
             .await;
             (msg_id, user_message, result)
@@ -2333,6 +2335,7 @@ async fn run_mission_turn(
     session_id: Option<String>,
     mission_config_profile: Option<String>,
     mission_working_directory: Option<String>,
+    user_id: Option<String>,
 ) -> AgentResult {
     let mut config = config;
     let effective_agent = agent_override.clone();
@@ -2505,6 +2508,15 @@ async fn run_mission_turn(
     } else {
         mission_work_dir
     };
+
+    apply_github_oauth_to_workspace_env(
+        &mut workspace,
+        &mission_work_dir,
+        user_id.as_deref(),
+        secrets.as_ref(),
+        mission_id,
+    )
+    .await;
 
     // For Telegram missions, append channel instructions and memory awareness
     // to CLAUDE.md so the backend LLM adopts the bot persona.
@@ -5492,6 +5504,120 @@ fn workspace_path_for_env(
         }
     }
     host_path.to_path_buf()
+}
+
+async fn apply_github_oauth_to_workspace_env(
+    workspace: &mut Workspace,
+    work_dir: &std::path::Path,
+    user_id: Option<&str>,
+    secrets: Option<&Arc<SecretsStore>>,
+    mission_id: Uuid,
+) {
+    let Some(user_id) = user_id else {
+        return;
+    };
+    let Some(creds) = super::auth::github_oauth_credentials_for_user(secrets, user_id).await else {
+        return;
+    };
+
+    let helper_dir = work_dir.join(".sandboxed-sh-bin");
+    if let Err(e) = std::fs::create_dir_all(&helper_dir) {
+        tracing::warn!(
+            mission_id = %mission_id,
+            error = %e,
+            "Failed to create GitHub OAuth helper directory"
+        );
+        return;
+    }
+
+    let helper_path = helper_dir.join("github-askpass.sh");
+    let helper = r#"#!/bin/sh
+case "$1" in
+  *Username*) printf '%s\n' "${GITHUB_USER:-x-access-token}" ;;
+  *Password*) printf '%s\n' "$GITHUB_TOKEN" ;;
+  *) printf '%s\n' "$GITHUB_TOKEN" ;;
+esac
+"#;
+    if let Err(e) = std::fs::write(&helper_path, helper) {
+        tracing::warn!(
+            mission_id = %mission_id,
+            error = %e,
+            "Failed to write GitHub OAuth askpass helper"
+        );
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            std::fs::set_permissions(&helper_path, std::fs::Permissions::from_mode(0o700))
+        {
+            tracing::warn!(
+                mission_id = %mission_id,
+                error = %e,
+                "Failed to chmod GitHub OAuth askpass helper"
+            );
+        }
+    }
+
+    let helper_env_path = workspace_path_for_env(workspace, &helper_path)
+        .to_string_lossy()
+        .to_string();
+    let env = &mut workspace.env_vars;
+    env.insert("GH_TOKEN".to_string(), creds.access_token.clone());
+    env.insert("GITHUB_TOKEN".to_string(), creds.access_token);
+    env.insert(
+        "GITHUB_USER".to_string(),
+        creds
+            .login
+            .clone()
+            .unwrap_or_else(|| "x-access-token".to_string()),
+    );
+    env.insert("GIT_ASKPASS".to_string(), helper_env_path);
+    env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
+
+    if let Some(name) = creds.name.as_deref().or(creds.login.as_deref()) {
+        env.entry("GIT_AUTHOR_NAME".to_string())
+            .or_insert_with(|| name.to_string());
+        env.entry("GIT_COMMITTER_NAME".to_string())
+            .or_insert_with(|| name.to_string());
+    }
+    let fallback_email = creds.login.as_ref().and_then(|login| {
+        creds
+            .github_user_id
+            .as_ref()
+            .map(|id| format!("{}+{}@users.noreply.github.com", id, login))
+    });
+    if let Some(email) = creds.email.as_deref().or(fallback_email.as_deref()) {
+        env.entry("GIT_AUTHOR_EMAIL".to_string())
+            .or_insert_with(|| email.to_string());
+        env.entry("GIT_COMMITTER_EMAIL".to_string())
+            .or_insert_with(|| email.to_string());
+    }
+
+    let base_count = env
+        .get("GIT_CONFIG_COUNT")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    let rewrites = [
+        ("url.https://github.com/.insteadOf", "git@github.com:"),
+        ("url.https://github.com/.insteadOf", "ssh://git@github.com/"),
+    ];
+    for (offset, (key, value)) in rewrites.iter().enumerate() {
+        let idx = base_count + offset;
+        env.insert(format!("GIT_CONFIG_KEY_{}", idx), (*key).to_string());
+        env.insert(format!("GIT_CONFIG_VALUE_{}", idx), (*value).to_string());
+    }
+    env.insert(
+        "GIT_CONFIG_COUNT".to_string(),
+        (base_count + rewrites.len()).to_string(),
+    );
+
+    tracing::info!(
+        mission_id = %mission_id,
+        github_login = ?creds.login,
+        "Injected user GitHub OAuth environment for mission"
+    );
 }
 
 fn strip_ansi_codes(input: &str) -> Cow<'_, str> {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -90,6 +90,8 @@ pub struct AppState {
     /// Pending OAuth state for provider authorization
     pub pending_oauth:
         Arc<RwLock<HashMap<crate::ai_providers::ProviderType, crate::ai_providers::PendingOAuth>>>,
+    /// Pending GitHub OAuth states for dashboard/user GitHub account linking.
+    pub pending_github_oauth: Arc<RwLock<HashMap<String, auth::PendingGithubOAuth>>>,
     /// Secrets store for encrypted credentials
     pub secrets: Option<Arc<crate::secrets::SecretsStore>>,
     /// Console session pool for WebSocket reconnection
@@ -160,6 +162,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         crate::ai_providers::AIProviderStore::new(config.working_dir.join(AI_PROVIDERS_PATH)).await,
     );
     let pending_oauth = Arc::new(RwLock::new(HashMap::new()));
+    let pending_github_oauth = Arc::new(RwLock::new(HashMap::new()));
 
     // Initialize provider health tracker and model chain store
     let health_tracker = Arc::new(crate::provider_health::ProviderHealthTracker::new());
@@ -443,6 +446,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         opencode_agents_cache: RwLock::new(opencode_api::OpenCodeAgentsCache::default()),
         ai_providers,
         pending_oauth,
+        pending_github_oauth,
         secrets,
         console_pool,
         settings,
@@ -542,6 +546,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let public_routes = Router::new()
         .route("/api/health", get(health))
         .route("/api/auth/login", post(auth::login))
+        .route(
+            "/api/auth/github/callback",
+            get(auth::github_oauth_callback),
+        )
         // Webhook receiver endpoint (no auth required - uses webhook secret validation)
         .route(
             "/api/webhooks/:mission_id/:webhook_id",
@@ -931,6 +939,15 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         // Auth management endpoints
         .route("/api/auth/status", get(auth::auth_status))
         .route("/api/auth/change-password", post(auth::change_password))
+        .route("/api/auth/github/status", get(auth::github_oauth_status))
+        .route(
+            "/api/auth/github/authorize",
+            post(auth::github_oauth_authorize),
+        )
+        .route(
+            "/api/auth/github",
+            axum::routing::delete(auth::github_oauth_disconnect),
+        )
         // Backend management endpoints
         .route("/api/backends", get(backends_api::list_backends))
         .route("/api/backends/:id", get(backends_api::get_backend))


### PR DESCRIPTION
## Summary

Adds a user-scoped GitHub OAuth connection flow so a sandbox user can connect their GitHub account from Settings and have mission runs, including Telegram bot runs, inherit that account for git commits and pushes.

## Changes

- Adds backend GitHub OAuth status, authorize, callback, and disconnect endpoints.
- Stores GitHub OAuth tokens in the encrypted secrets store under the current sandbox user.
- Injects the connected user's GitHub credentials into mission execution via `GH_TOKEN`, `GITHUB_TOKEN`, git author/committer metadata, `GIT_ASKPASS`, and GitHub SSH-to-HTTPS rewrite config.
- Adds a web Settings > GitHub page with Connect/Reconnect, Refresh, and Disconnect.
- Adds the same Settings-based GitHub connection UI to the iOS dashboard.
- Documents server OAuth configuration and the mobile OAuth contract, including Android Custom Tabs guidance.

## Notes

The user-facing flow only connects GitHub through Settings. Users do not paste GitHub tokens or configure runtime environment variables in the web or mobile apps. Server operators still configure the GitHub OAuth app with `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, and an unlocked secrets store.

There is no Android app source tree in this repository, so Android support is documented as the API/client contract in `docs/mobile-github-oauth.md`.

## Validation

- `cargo fmt --all --check`
- `cargo check`
- `cargo test api::auth`
- `git diff --cached --check`
- `bun run lint -- src/app/settings/github/page.tsx`
- `xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj -scheme SandboxedDashboard -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build`

Full `bun run lint` now runs after installing Bun 1.3.4 and dashboard dependencies, but it still fails on pre-existing project-wide lint issues outside this change.
