### PR TITLE
fix: format workspace leader discovery

### DIFF
--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -548,7 +548,11 @@ impl WorkspaceExec {
             .lines()
             .next()
             .map(|s| s.trim().to_string())?;
-        if leader.is_empty() { None } else { Some(leader) }
+        if leader.is_empty() {
+            None
+        } else {
+            Some(leader)
+        }
     }
 
     fn leader_has_keepalive_marker(&self, leader: &str) -> bool {


### PR DESCRIPTION
## Summary

Fixes the rustfmt drift introduced by the nspawn leader-discovery change merged from #408.

## Validation

- `cargo fmt --all --check`
- `cargo check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a rustfmt-only change that rewrites a single conditional for `running_container_leader()` without altering behavior.
> 
> **Overview**
> Fixes a minor `rustfmt` drift in `WorkspaceExec::running_container_leader()` by expanding the final `if leader.is_empty()` return into a multi-line block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5206c0eaa87a8e19291fd1413ea8e7f0816fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->