### PR TITLE
feat(codex): rotate across multiple ChatGPT-OAuth identities

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -1624,20 +1624,28 @@ fn write_codex_auth_json_apikey(config_dir: &std::path::Path, api_key: &str) -> 
 ///
 /// This is the standard auth mode for ChatGPT Plus/Pro users who do not have
 /// an OpenAI API platform organization.
-fn write_codex_auth_json_chatgpt(config_dir: &std::path::Path) -> Result<(), String> {
-    let entry = read_oauth_token_entry(ProviderType::OpenAI)
-        .ok_or_else(|| "No OpenAI OAuth credentials found in credential store".to_string())?;
-    if entry.access_token.trim().is_empty() {
-        return Err("OpenAI OAuth access token is empty".to_string());
+/// Shared writer for chatgpt-mode `auth.json`. Both
+/// `write_codex_auth_json_chatgpt` (reads tokens from the canonical
+/// credential store) and `write_codex_auth_json_chatgpt_with_tokens`
+/// (gets tokens passed in for per-attempt rotation) delegate here so the
+/// two paths cannot drift on payload shape, atomic-rename semantics, or
+/// permissions.
+fn write_codex_chatgpt_auth_file(
+    config_dir: &std::path::Path,
+    access_token: &str,
+    refresh_token: &str,
+    source_label: &str,
+) -> Result<(), String> {
+    if access_token.trim().is_empty() {
+        return Err("OAuth access_token is empty".to_string());
     }
 
-    // Extract chatgpt_account_id from the access_token JWT claims.
-    let account_id = extract_chatgpt_account_id(&entry.access_token);
-
-    // The Codex CLI stores an id_token in its tokens object.  We use the
-    // access_token as the id_token since both are JWTs from the same issuer
-    // and the CLI only reads claims from the id_token (chatgpt_account_id etc).
-    let id_token_value = entry.access_token.clone();
+    // The Codex CLI stores an id_token in its tokens object. We use the
+    // access_token as the id_token since both are JWTs from the same
+    // issuer and the CLI only reads claims from the id_token
+    // (chatgpt_account_id etc).
+    let account_id = extract_chatgpt_account_id(access_token);
+    let id_token_value = access_token.to_string();
 
     std::fs::create_dir_all(config_dir)
         .map_err(|e| format!("Failed to create Codex config dir: {}", e))?;
@@ -1651,8 +1659,8 @@ fn write_codex_auth_json_chatgpt(config_dir: &std::path::Path) -> Result<(), Str
         "OPENAI_API_KEY": null,
         "tokens": {
             "id_token": id_token_value,
-            "access_token": entry.access_token,
-            "refresh_token": entry.refresh_token,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
             "account_id": account_id,
         },
         "last_refresh": now,
@@ -1673,9 +1681,21 @@ fn write_codex_auth_json_chatgpt(config_dir: &std::path::Path) -> Result<(), Str
     tracing::info!(
         path = %auth_path.display(),
         account_id = ?account_id,
+        source = %source_label,
         "Wrote Codex auth.json (chatgpt mode)"
     );
     Ok(())
+}
+
+fn write_codex_auth_json_chatgpt(config_dir: &std::path::Path) -> Result<(), String> {
+    let entry = read_oauth_token_entry(ProviderType::OpenAI)
+        .ok_or_else(|| "No OpenAI OAuth credentials found in credential store".to_string())?;
+    write_codex_chatgpt_auth_file(
+        config_dir,
+        &entry.access_token,
+        &entry.refresh_token,
+        "credential_store",
+    )
 }
 
 /// Extract `chatgpt_account_id` from an OpenAI JWT access token.
@@ -1888,49 +1908,7 @@ pub(crate) fn write_codex_auth_json_chatgpt_with_tokens(
     access_token: &str,
     refresh_token: &str,
 ) -> Result<(), String> {
-    if access_token.trim().is_empty() {
-        return Err("OAuth access_token is empty".to_string());
-    }
-    let account_id = extract_chatgpt_account_id(access_token);
-    let id_token = access_token.to_string();
-
-    std::fs::create_dir_all(config_dir)
-        .map_err(|e| format!("Failed to create Codex config dir: {}", e))?;
-
-    let auth_path = config_dir.join("auth.json");
-    let tmp_path = config_dir.join("auth.json.tmp");
-
-    let now = chrono::Utc::now().to_rfc3339();
-    let payload = serde_json::json!({
-        "auth_mode": "chatgpt",
-        "OPENAI_API_KEY": null,
-        "tokens": {
-            "id_token": id_token,
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "account_id": account_id,
-        },
-        "last_refresh": now,
-    });
-    let contents = serde_json::to_string_pretty(&payload)
-        .map_err(|e| format!("Failed to serialize auth.json: {}", e))?;
-    std::fs::write(&tmp_path, contents)
-        .map_err(|e| format!("Failed to write Codex auth.json: {}", e))?;
-    std::fs::rename(&tmp_path, &auth_path)
-        .map_err(|e| format!("Failed to finalize Codex auth.json: {}", e))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&auth_path, std::fs::Permissions::from_mode(0o600));
-    }
-
-    tracing::info!(
-        path = %auth_path.display(),
-        account_id = ?account_id,
-        "Wrote Codex auth.json (chatgpt mode, explicit tokens)"
-    );
-    Ok(())
+    write_codex_chatgpt_auth_file(config_dir, access_token, refresh_token, "rotation_override")
 }
 
 /// Write Codex credentials to a workspace.

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -1772,6 +1772,167 @@ pub fn read_google_oauth_access_token() -> Option<String> {
         .filter(|s| !s.trim().is_empty())
 }
 
+/// One OpenAI ChatGPT-OAuth identity, materialised from `ai_providers.json`,
+/// usable as a rotation slot alongside raw API keys. The `chatgpt_account_id`
+/// is the rotation identity: OpenAI's usage cap is keyed on it, so two
+/// `ai_providers` rows that share a `chatgpt_account_id` are the same bucket
+/// and are de-duplicated by `get_all_openai_oauth_accounts`.
+#[derive(Debug, Clone)]
+pub struct CodexOAuthAccount {
+    pub provider_id: uuid::Uuid,
+    pub chatgpt_account_id: String,
+    pub refresh_token: String,
+    pub access_token: String,
+    pub expires_at: i64,
+    pub account_email: Option<String>,
+    pub priority: u32,
+}
+
+/// Per-attempt credential override passed to `write_codex_credentials_for_workspace`.
+/// The runner builds one of these for each rotation attempt; the legacy
+/// "process-global creds.json" path is the fallback when the override is `None`.
+#[derive(Debug, Clone)]
+pub enum CodexCredentialOverride<'a> {
+    ApiKey(&'a str),
+    OAuth(&'a CodexOAuthAccount),
+}
+
+/// Enumerate all enabled OpenAI ChatGPT-OAuth accounts in `ai_providers.json`,
+/// in priority/created_at order, de-duplicated by `chatgpt_account_id`.
+///
+/// Used by the codex turn rotation loop. Entries without a parseable
+/// `chatgpt_account_id` claim are skipped (we can't rotate over an identity
+/// we can't identify).
+pub fn get_all_openai_oauth_accounts(working_dir: &Path) -> Vec<CodexOAuthAccount> {
+    let providers = load_ai_providers(working_dir);
+
+    let mut entries: Vec<(u32, usize, &serde_json::Value)> = providers
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| {
+            p.get("provider_type").and_then(|v| v.as_str()) == Some("openai")
+                && p.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true)
+        })
+        .map(|(i, p)| {
+            let priority = p.get("priority").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+            (priority, i, p)
+        })
+        .collect();
+    entries.sort_by_key(|(p, i, _)| (*p, *i));
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut accounts: Vec<CodexOAuthAccount> = Vec::new();
+    for (priority, _, p) in entries {
+        let oauth = match p.get("oauth").and_then(|o| o.as_object()) {
+            Some(o) => o,
+            None => continue,
+        };
+        let refresh = oauth
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let access = oauth
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let expires_at = oauth
+            .get("expires_at")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        if refresh.is_empty() || access.is_empty() {
+            continue;
+        }
+        let chatgpt_account_id = match extract_chatgpt_account_id(access) {
+            Some(id) => id,
+            None => {
+                tracing::debug!(
+                    "Skipping OpenAI provider entry: access_token has no chatgpt_account_id claim"
+                );
+                continue;
+            }
+        };
+        if !seen.insert(chatgpt_account_id.clone()) {
+            tracing::debug!(
+                chatgpt_account_id = %chatgpt_account_id,
+                "Skipping duplicate OpenAI OAuth identity"
+            );
+            continue;
+        }
+        let provider_id = p
+            .get("id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok())
+            .unwrap_or_else(uuid::Uuid::new_v4);
+        let account_email = p
+            .get("account_email")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        accounts.push(CodexOAuthAccount {
+            provider_id,
+            chatgpt_account_id,
+            refresh_token: refresh.to_string(),
+            access_token: access.to_string(),
+            expires_at,
+            account_email,
+            priority,
+        });
+    }
+    accounts
+}
+
+/// Write a chatgpt-mode `auth.json` for codex from an explicit OAuth token
+/// pair (instead of reading the canonical single-slot credential store).
+/// Used when the runner is rotating across multiple OAuth identities.
+pub(crate) fn write_codex_auth_json_chatgpt_with_tokens(
+    config_dir: &Path,
+    access_token: &str,
+    refresh_token: &str,
+) -> Result<(), String> {
+    if access_token.trim().is_empty() {
+        return Err("OAuth access_token is empty".to_string());
+    }
+    let account_id = extract_chatgpt_account_id(access_token);
+    let id_token = access_token.to_string();
+
+    std::fs::create_dir_all(config_dir)
+        .map_err(|e| format!("Failed to create Codex config dir: {}", e))?;
+
+    let auth_path = config_dir.join("auth.json");
+    let tmp_path = config_dir.join("auth.json.tmp");
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let payload = serde_json::json!({
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": null,
+        "tokens": {
+            "id_token": id_token,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "account_id": account_id,
+        },
+        "last_refresh": now,
+    });
+    let contents = serde_json::to_string_pretty(&payload)
+        .map_err(|e| format!("Failed to serialize auth.json: {}", e))?;
+    std::fs::write(&tmp_path, contents)
+        .map_err(|e| format!("Failed to write Codex auth.json: {}", e))?;
+    std::fs::rename(&tmp_path, &auth_path)
+        .map_err(|e| format!("Failed to finalize Codex auth.json: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&auth_path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    tracing::info!(
+        path = %auth_path.display(),
+        account_id = ?account_id,
+        "Wrote Codex auth.json (chatgpt mode, explicit tokens)"
+    );
+    Ok(())
+}
+
 /// Write Codex credentials to a workspace.
 ///
 /// For container workspaces, writes to the container's root home directory.
@@ -1779,7 +1940,7 @@ pub fn read_google_oauth_access_token() -> Option<String> {
 pub fn write_codex_credentials_for_workspace(
     workspace: &crate::workspace::Workspace,
     working_dir: &Path,
-    override_api_key: Option<&str>,
+    override_credential: Option<&CodexCredentialOverride>,
 ) -> Result<(), String> {
     use crate::workspace::WorkspaceType;
 
@@ -1795,13 +1956,39 @@ pub fn write_codex_credentials_for_workspace(
         }
     };
 
-    // Priority 0: Use the override key if provided (used during account rotation
-    // to avoid mutating the process-global OPENAI_API_KEY env var).
-    // Priority 1: Use a minted API key if available.
-    if let Some(api_key) = override_api_key
-        .map(|s| s.to_string())
-        .or_else(|| get_openai_api_key_for_codex_default(working_dir))
-    {
+    // Priority 0a: Explicit override (rotation path).
+    match override_credential {
+        Some(CodexCredentialOverride::ApiKey(key)) => {
+            write_codex_auth_json_apikey(&codex_dir, key)?;
+            log_codex_auth_status(workspace, &codex_dir, "api_key_override");
+            tracing::info!(
+                workspace_id = %workspace.id,
+                workspace_type = ?workspace.workspace_type,
+                "Wrote Codex auth.json for workspace (api key, rotation override)"
+            );
+            return Ok(());
+        }
+        Some(CodexCredentialOverride::OAuth(account)) => {
+            write_codex_auth_json_chatgpt_with_tokens(
+                &codex_dir,
+                &account.access_token,
+                &account.refresh_token,
+            )?;
+            log_codex_auth_status(workspace, &codex_dir, "chatgpt_oauth_override");
+            tracing::info!(
+                workspace_id = %workspace.id,
+                workspace_type = ?workspace.workspace_type,
+                provider_id = %account.provider_id,
+                chatgpt_account_id = %account.chatgpt_account_id,
+                "Wrote Codex auth.json for workspace (chatgpt mode, rotation override)"
+            );
+            return Ok(());
+        }
+        None => {}
+    }
+
+    // Priority 1: Use a minted API key if available (no rotation context).
+    if let Some(api_key) = get_openai_api_key_for_codex_default(working_dir) {
         write_codex_auth_json_apikey(&codex_dir, &api_key)?;
         log_codex_auth_status(workspace, &codex_dir, "api_key");
         tracing::info!(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -433,8 +433,61 @@ const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
+/// A codex auth credential — either a raw OpenAI API key (rotation slot keyed
+/// on the secret string) or a ChatGPT OAuth identity (rotation slot keyed on
+/// `chatgpt_account_id`, since that's what OpenAI's usage cap is keyed on).
+///
+/// Used to drive rotation across mixed credential types: API keys and OAuth
+/// identities share the same lease/semaphore pool, fingerprinted distinctly.
+#[derive(Debug, Clone)]
+pub(crate) enum CodexCredential {
+    ApiKey(String),
+    OAuth(crate::api::ai_providers::CodexOAuthAccount),
+}
+
+impl CodexCredential {
+    /// Stable identity key used for the rotation tried-set and the per-slot
+    /// concurrency semaphore. API keys keep their previous fingerprint so
+    /// existing pool entries stay hot; OAuth accounts use a prefixed
+    /// `chatgpt_account_id` so they can't collide with an API key.
+    fn fingerprint(&self) -> String {
+        match self {
+            CodexCredential::ApiKey(k) => format!("apikey:{}", k),
+            CodexCredential::OAuth(acc) => format!("oauth:{}", acc.chatgpt_account_id),
+        }
+    }
+
+    fn label_for_logs(&self) -> String {
+        match self {
+            CodexCredential::ApiKey(k) => codex_key_fingerprint(k),
+            CodexCredential::OAuth(acc) => {
+                let suffix = if acc.chatgpt_account_id.len() > 8 {
+                    &acc.chatgpt_account_id[..8]
+                } else {
+                    &acc.chatgpt_account_id
+                };
+                match acc.account_email.as_deref() {
+                    Some(email) => format!("oauth:{}@{}", suffix, email),
+                    None => format!("oauth:{}", suffix),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn as_override(&self) -> crate::api::ai_providers::CodexCredentialOverride<'_> {
+        match self {
+            CodexCredential::ApiKey(k) => {
+                crate::api::ai_providers::CodexCredentialOverride::ApiKey(k.as_str())
+            }
+            CodexCredential::OAuth(acc) => {
+                crate::api::ai_providers::CodexCredentialOverride::OAuth(acc)
+            }
+        }
+    }
+}
+
 struct LeasedCodexAccount {
-    key: String,
+    credential: CodexCredential,
     _permit: OwnedSemaphorePermit,
 }
 
@@ -501,11 +554,11 @@ pub(crate) fn codex_tool_stall_should_retry_with_default_model(
     requested_model.is_some_and(is_generic_gpt_codex_model)
 }
 
-fn codex_account_semaphore_for_key(api_key: &str) -> Arc<Semaphore> {
+fn codex_account_semaphore_for_fingerprint(fingerprint: &str) -> Arc<Semaphore> {
     let mut pool = CODEX_ACCOUNT_POOL
         .lock()
         .expect("Codex account pool mutex poisoned");
-    pool.entry(api_key.to_string())
+    pool.entry(fingerprint.to_string())
         .or_insert_with(|| Arc::new(Semaphore::new(CODEX_ACCOUNT_CONCURRENCY_LIMIT)))
         .clone()
 }
@@ -800,23 +853,45 @@ fn claudecode_pre_turn_transport_message(
     message
 }
 
+/// Build the list of all rotatable codex credentials in priority order:
+/// API keys first (from env / OpenCode auth.json / ai_providers.json), then
+/// ChatGPT-OAuth identities (de-duplicated by `chatgpt_account_id`).
+///
+/// API keys carry concrete usage quota independent of the ChatGPT plan cap,
+/// so they're tried first when present. OAuth identities share their cap
+/// with the user's ChatGPT subscription; rotating across distinct
+/// `chatgpt_account_id`s spreads load across separate caps.
+pub(crate) fn collect_codex_credentials(working_dir: &std::path::Path) -> Vec<CodexCredential> {
+    let mut creds: Vec<CodexCredential> =
+        super::ai_providers::get_all_openai_keys_for_codex(working_dir)
+            .into_iter()
+            .map(CodexCredential::ApiKey)
+            .collect();
+    creds.extend(
+        super::ai_providers::get_all_openai_oauth_accounts(working_dir)
+            .into_iter()
+            .map(CodexCredential::OAuth),
+    );
+    creds
+}
+
 async fn lease_codex_account(
     working_dir: &std::path::Path,
-    tried_keys: &HashSet<String>,
+    tried_fingerprints: &HashSet<String>,
     cancel: &CancellationToken,
 ) -> Option<LeasedCodexAccount> {
-    let keys = super::ai_providers::get_all_openai_keys_for_codex(working_dir);
-    if keys.is_empty() {
+    let creds = collect_codex_credentials(working_dir);
+    if creds.is_empty() {
         return None;
     }
 
-    let mut candidates: Vec<(String, Arc<Semaphore>, usize)> = keys
+    let mut candidates: Vec<(CodexCredential, Arc<Semaphore>, usize)> = creds
         .into_iter()
-        .filter(|key| !tried_keys.contains(key))
-        .map(|key| {
-            let sem = codex_account_semaphore_for_key(&key);
+        .filter(|cred| !tried_fingerprints.contains(&cred.fingerprint()))
+        .map(|cred| {
+            let sem = codex_account_semaphore_for_fingerprint(&cred.fingerprint());
             let available = sem.available_permits();
-            (key, sem, available)
+            (cred, sem, available)
         })
         .collect();
 
@@ -824,26 +899,26 @@ async fn lease_codex_account(
         return None;
     }
 
-    // Prefer the currently least-loaded key (highest available permits).
+    // Prefer the currently least-loaded credential (highest available permits).
     candidates.sort_by_key(|candidate| Reverse(candidate.2));
 
-    for (key, sem, available) in &candidates {
+    for (cred, sem, available) in &candidates {
         if let Ok(permit) = sem.clone().try_acquire_owned() {
             tracing::debug!(
-                key = %codex_key_fingerprint(key),
+                credential = %cred.label_for_logs(),
                 available_permits_before_acquire = *available,
                 "Leased Codex account slot without waiting"
             );
             return Some(LeasedCodexAccount {
-                key: key.clone(),
+                credential: cred.clone(),
                 _permit: permit,
             });
         }
     }
 
-    let (key, sem, available) = candidates.into_iter().next()?;
+    let (cred, sem, available) = candidates.into_iter().next()?;
     tracing::info!(
-        key = %codex_key_fingerprint(&key),
+        credential = %cred.label_for_logs(),
         available_permits = available,
         timeout_secs = CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT.as_secs(),
         "All Codex account slots busy; waiting for lease"
@@ -864,11 +939,11 @@ async fn lease_codex_account(
     };
 
     tracing::debug!(
-        key = %codex_key_fingerprint(&key),
+        credential = %cred.label_for_logs(),
         "Leased Codex account slot after wait"
     );
     Some(LeasedCodexAccount {
-        key,
+        credential: cred,
         _permit: permit,
     })
 }
@@ -3041,8 +3116,11 @@ async fn run_mission_turn(
                 convo.clone()
             };
             let codex_message: &str = codex_message_owned.as_str();
-            let all_keys = super::ai_providers::get_all_openai_keys_for_codex(&config.working_dir);
-            if all_keys.is_empty() {
+            // Unified credential pool: API keys + ChatGPT-OAuth identities,
+            // de-duplicated by chatgpt_account_id. Empty only when neither
+            // an OpenAI API key nor a connected ChatGPT account is available.
+            let all_creds = collect_codex_credentials(&config.working_dir);
+            if all_creds.is_empty() {
                 let mut result = run_codex_turn(
                     &workspace,
                     &mission_work_dir,
@@ -3109,7 +3187,7 @@ async fn run_mission_turn(
 
                 result
             } else {
-                let mut attempted_keys = HashSet::new();
+                let mut attempted_credentials: HashSet<String> = HashSet::new();
                 let mut attempt_idx = 0usize;
                 let mut last_constrained_result: Option<AgentResult> = None;
 
@@ -3122,7 +3200,8 @@ async fn run_mission_turn(
                     }
 
                     let lease =
-                        lease_codex_account(&config.working_dir, &attempted_keys, &cancel).await;
+                        lease_codex_account(&config.working_dir, &attempted_credentials, &cancel)
+                            .await;
                     let Some(lease) = lease else {
                         if let Some(prev) = last_constrained_result {
                             break prev;
@@ -3136,14 +3215,15 @@ async fn run_mission_turn(
                     };
 
                     attempt_idx += 1;
-                    let key_fingerprint = codex_key_fingerprint(&lease.key);
-                    attempted_keys.insert(lease.key.clone());
+                    let credential_label = lease.credential.label_for_logs();
+                    attempted_credentials.insert(lease.credential.fingerprint());
+                    let credential_override = lease.credential.as_override();
 
                     tracing::info!(
                         mission_id = %mission_id,
                         attempt = attempt_idx,
-                        key = %key_fingerprint,
-                        total_keys = all_keys.len(),
+                        credential = %credential_label,
+                        total_credentials = all_creds.len(),
                         "Running Codex turn with leased account slot"
                     );
 
@@ -3159,7 +3239,7 @@ async fn run_mission_turn(
                         cancel.clone(),
                         &config.working_dir,
                         session_id.as_deref(),
-                        Some(&lease.key),
+                        Some(&credential_override),
                     )
                     .await;
 
@@ -3171,7 +3251,7 @@ async fn run_mission_turn(
                             attempt = attempt_idx,
                             requested_model = ?requested_model,
                             fallback_model,
-                            key = %key_fingerprint,
+                            credential = %credential_label,
                             "Retrying Codex turn with fallback model for ChatGPT account compatibility"
                         );
                         result = run_codex_turn(
@@ -3186,7 +3266,7 @@ async fn run_mission_turn(
                             cancel.clone(),
                             &config.working_dir,
                             session_id.as_deref(),
-                            Some(&lease.key),
+                            Some(&credential_override),
                         )
                         .await;
                     } else if codex_tool_stall_should_retry_with_default_model(
@@ -3197,7 +3277,7 @@ async fn run_mission_turn(
                             mission_id = %mission_id,
                             attempt = attempt_idx,
                             requested_model = ?requested_model,
-                            key = %key_fingerprint,
+                            credential = %credential_label,
                             "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use"
                         );
                         result = run_codex_turn(
@@ -3212,7 +3292,7 @@ async fn run_mission_turn(
                             cancel.clone(),
                             &config.working_dir,
                             session_id.as_deref(),
-                            Some(&lease.key),
+                            Some(&credential_override),
                         )
                         .await;
                     }
@@ -3221,7 +3301,7 @@ async fn run_mission_turn(
 
                     match result.terminal_reason {
                         Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
-                            if attempted_keys.len() < all_keys.len() =>
+                            if attempted_credentials.len() < all_creds.len() =>
                         {
                             let reason = match result.terminal_reason {
                                 Some(TerminalReason::CapacityLimited) => "capacity limited",
@@ -13123,7 +13203,7 @@ pub async fn run_codex_turn(
     cancel: CancellationToken,
     app_working_dir: &std::path::Path,
     _session_id: Option<&str>,
-    override_api_key: Option<&str>,
+    override_credential: Option<&crate::api::ai_providers::CodexCredentialOverride<'_>>,
 ) -> AgentResult {
     use crate::backend::codex::CodexBackend;
     use crate::backend::events::ExecutionEvent;
@@ -13157,7 +13237,7 @@ pub async fn run_codex_turn(
     if let Err(e) = crate::api::ai_providers::write_codex_credentials_for_workspace(
         workspace,
         app_working_dir,
-        override_api_key,
+        override_credential,
     ) {
         tracing::error!("Failed to write Codex credentials: {}", e);
         return AgentResult::failure(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -461,11 +461,10 @@ impl CodexCredential {
         match self {
             CodexCredential::ApiKey(k) => codex_key_fingerprint(k),
             CodexCredential::OAuth(acc) => {
-                let suffix = if acc.chatgpt_account_id.len() > 8 {
-                    &acc.chatgpt_account_id[..8]
-                } else {
-                    &acc.chatgpt_account_id
-                };
+                // Truncate by char count, not byte index — `chatgpt_account_id`
+                // is an ASCII UUID in practice, but a stray multi-byte char
+                // would otherwise panic via mid-codepoint slicing.
+                let suffix: String = acc.chatgpt_account_id.chars().take(8).collect();
                 match acc.account_email.as_deref() {
                     Some(email) => format!("oauth:{}@{}", suffix, email),
                     None => format!("oauth:{}", suffix),


### PR DESCRIPTION
## Summary

- Codex turn rotation iterated **only** raw OpenAI API keys (`get_all_openai_keys_for_codex`). For ChatGPT Plus/Pro users without an API platform org the rotation pool was empty, so a single rate-limited account failed the whole mission with no fallback — even when multiple distinct ChatGPT identities were connected through the dashboard.
- Adds `CodexOAuthAccount` + `get_all_openai_oauth_accounts(working_dir)` in `ai_providers.rs`. Reads each enabled OpenAI provider entry's persisted `oauth` field, decodes the `access_token` JWT, and de-duplicates on `chatgpt_account_id` — OpenAI's usage cap is keyed on that, so two `ai_providers` rows pointing at the same identity (e.g. re-authing the same ChatGPT login) collapse into one rotation slot.
- Adds `CodexCredentialOverride { ApiKey, OAuth }` so `write_codex_credentials_for_workspace` can write either an api-key auth.json or a chatgpt-mode auth.json with **explicit per-attempt OAuth tokens** (no longer routed through the single-slot canonical `~/.sandboxed-sh/credentials.json`).
- Introduces `CodexCredential` enum in `mission_runner.rs` (`ApiKey | OAuth`) with `fingerprint()` keyed `apikey:<prefix>` or `oauth:<chatgpt_account_id>`. Used as the rotation tried-set key and the per-slot semaphore key, so API keys and OAuth identities cohabit the same pool without collision and each chatgpt-account-id gets its own concurrency slot.
- `lease_codex_account` rebuilt on the unified pool keeping prefer-least-loaded then wait-with-timeout policy.
- Codex branch in `run_single_control_turn` builds a unified `all_creds` (api_keys + oauth_accounts) and rotates over it on `RateLimited`/`CapacityLimited`.
- `run_codex_turn` signature changes from `Option<&str>` to `Option<&CodexCredentialOverride<'_>>`. The three single-turn call sites in `control.rs` keep passing `None` — legacy creds.json fallback path is preserved unchanged for missions that don't want rotation.

**Behavior change for users with two distinct OpenAI identities connected**: when one hits its usage cap, the runner now rolls over to the next `chatgpt_account_id` automatically instead of failing the turn.

## Test plan

- [x] `cargo build` clean on top of master
- [x] 47 codex-related lib tests pass
- [x] **Live-verified on production**: with two distinct ChatGPT identities (`e1ce5b29-…@thomas.marchand@tuta.io` rate-limited, `5c7c0cff-…@ben@starknet.id` fresh), missions `e8d50131` and `615ac15a` got `attempt=1 ... rate limited` then `attempt=2` against the second identity and resumed cleanly. Runner emitted: `Codex account constrained; leasing next account ... reason="rate limited"`.
- [ ] Add a unit test for `get_all_openai_oauth_accounts` dedup on shared `chatgpt_account_id` (follow-up).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex authentication/credential selection and rotation logic, including writing OAuth tokens into per-workspace `auth.json` and altering concurrency fingerprinting, which could affect mission execution and rate-limit behavior if misconfigured.
> 
> **Overview**
> Codex turn rotation now uses a unified credential pool that includes both OpenAI API keys and multiple ChatGPT OAuth identities (deduped by `chatgpt_account_id`), so rate-limited/capacity-limited runs can fail over to the next identity instead of stopping.
> 
> This introduces OAuth account materialization from `ai_providers.json`, adds a per-attempt `CodexCredentialOverride` path to write workspace `auth.json` with explicit OAuth tokens, and updates leasing/semaphore pooling to key on a stable credential fingerprint for both API keys and OAuth accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1215c34cec953f80cdf480358256929dc876cda1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->