### PR TITLE
fix(dashboard): keep image blob URLs alive while still mounted

### DIFF
--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -30,35 +30,93 @@ interface MarkdownContentProps {
   missionId?: string;
 }
 
-// Global cache for fetched image URLs with automatic cleanup
-// Uses a simple LRU-style eviction: when cache exceeds limit, oldest entries are revoked
+// Global, refcounted cache of fetched image blob URLs.
+//
+// Why refcounted: the previous implementation revoked the oldest URL on
+// LRU eviction, but that URL was often still the `src=` of a mounted
+// `<img>` element somewhere on the page (the URL lives in component
+// state, not just in this map). Revoking it under the running DOM made
+// the browser show its broken-image icon — but a click-through to the
+// preview modal triggered a fresh fetch and worked, which matched the
+// reported "image fails until I click the broken icon" symptom exactly.
+//
+// New contract: every consumer that uses a URL from this cache must call
+// `acquireCachedImageUrl` (or `cacheAndAcquireImageUrl` if it just
+// fetched) and pair it with a later `releaseImageUrl`. The cache only
+// revokes a URL when its refcount reaches zero AND the entry has been
+// LRU-evicted, so a URL stuck in a mounted `<img>` keeps working until
+// that `<img>` unmounts.
 const IMAGE_CACHE_LIMIT = 50;
-const imageUrlCache = new Map<string, string>();
 
-function cacheImageUrl(path: string, url: string): void {
-  // If already cached, revoke the duplicate URL and update access order
-  if (imageUrlCache.has(path)) {
-    // Revoke the incoming duplicate URL to prevent memory leak from concurrent fetches
+interface ImageCacheEntry {
+  url: string;
+  refCount: number;
+  /** Marked when LRU-evicted but kept alive because refCount > 0. The
+   *  next `releaseImageUrl` that drops refCount to 0 will revoke and
+   *  drop the entry instead of leaving it indefinitely. */
+  evicted: boolean;
+}
+
+const imageUrlCache = new Map<string, ImageCacheEntry>();
+
+/** Try to read a cached URL for `path` and acquire a reference. Returns
+ *  null when not cached. Callers must pair every successful return with
+ *  exactly one `releaseImageUrl(path)` on unmount. */
+function acquireCachedImageUrl(path: string): string | null {
+  const entry = imageUrlCache.get(path);
+  if (!entry) return null;
+  entry.refCount++;
+  return entry.url;
+}
+
+/** Insert a freshly-fetched blob URL and acquire one reference. Caller
+ *  owns the reference and must release it on unmount. Concurrent fetches
+ *  for the same path collapse onto the existing entry — the duplicate
+ *  URL is revoked here so the caller's later `releaseImageUrl` decrements
+ *  the canonical entry's refCount instead of leaking. */
+function cacheAndAcquireImageUrl(path: string, url: string): string {
+  const existing = imageUrlCache.get(path);
+  if (existing) {
     URL.revokeObjectURL(url);
-    const existingUrl = imageUrlCache.get(path)!;
-    imageUrlCache.delete(path);
-    imageUrlCache.set(path, existingUrl);
-    return;
+    existing.refCount++;
+    return existing.url;
   }
 
-  // Evict oldest entries if at limit
-  while (imageUrlCache.size >= IMAGE_CACHE_LIMIT) {
-    const oldestKey = imageUrlCache.keys().next().value;
-    if (oldestKey) {
-      const oldUrl = imageUrlCache.get(oldestKey);
-      if (oldUrl) {
-        URL.revokeObjectURL(oldUrl);
+  // LRU eviction: drop entries with refCount === 0 first (safe to revoke).
+  // For entries still in use, mark them `evicted` and let
+  // `releaseImageUrl` revoke them when the last consumer unmounts. If
+  // every entry is referenced we stop trying — better to leak the URL
+  // bookkeeping than break a live `<img>`.
+  let attempts = imageUrlCache.size;
+  while (imageUrlCache.size >= IMAGE_CACHE_LIMIT && attempts > 0) {
+    let dropped = false;
+    for (const [key, entry] of imageUrlCache) {
+      if (entry.refCount === 0) {
+        URL.revokeObjectURL(entry.url);
+        imageUrlCache.delete(key);
+        dropped = true;
+        break;
       }
-      imageUrlCache.delete(oldestKey);
+      entry.evicted = true;
     }
+    if (!dropped) break;
+    attempts--;
   }
 
-  imageUrlCache.set(path, url);
+  imageUrlCache.set(path, { url, refCount: 1, evicted: false });
+  return url;
+}
+
+/** Decrement the refcount for `path`. If it reaches zero AND the entry
+ *  was previously LRU-evicted, revoke the URL and drop it. */
+function releaseImageUrl(path: string): void {
+  const entry = imageUrlCache.get(path);
+  if (!entry) return;
+  entry.refCount = Math.max(0, entry.refCount - 1);
+  if (entry.refCount === 0 && entry.evicted) {
+    URL.revokeObjectURL(entry.url);
+    imageUrlCache.delete(path);
+  }
 }
 
 function isFilePath(str: string): boolean {
@@ -155,8 +213,13 @@ function FilePreviewModalContent({
   const FileIcon = getFileIcon(path);
   const fileName = path.split("/").pop() || "file";
 
-  const [imageUrl, setImageUrl] = useState<string | null>(imageUrlCache.get(resolvedPath) || null);
-  const [loading, setLoading] = useState(!imageUrl && isImage);
+  // imageUrl initial state is null on purpose — the effect below acquires
+  // (and refcounts) the cached URL on mount instead of reading the cache
+  // directly here. Reading cache without acquiring would let LRU eviction
+  // revoke the URL out from under this component's `<img src>`, which is
+  // the bug this refcount fix is closing.
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(isImage);
   const [error, setError] = useState<string | null>(null);
   const [fileSize, setFileSize] = useState<number | null>(null);
   const [downloading, setDownloading] = useState(false);
@@ -167,9 +230,22 @@ function FilePreviewModalContent({
 
   // Fetch image on mount
   useEffect(() => {
-    if (!isImage || imageUrl) return;
+    if (!isImage) return;
 
     let cancelled = false;
+    let acquired = false;
+
+    const cached = acquireCachedImageUrl(resolvedPath);
+    if (cached) {
+      setImageUrl(cached);
+      setLoading(false);
+      acquired = true;
+      return () => {
+        cancelled = true;
+        if (acquired) releaseImageUrl(resolvedPath);
+      };
+    }
+
     const fetchImage = async () => {
       const API_BASE = getRuntimeApiBase();
       const params = new URLSearchParams({ path: resolvedPath });
@@ -187,8 +263,15 @@ function FilePreviewModalContent({
         const blob = await res.blob();
         if (!cancelled) setFileSize(blob.size);
         const url = URL.createObjectURL(blob);
-        cacheImageUrl(resolvedPath, url);
-        if (!cancelled) setImageUrl(url);
+        if (cancelled) {
+          // Component unmounted before fetch landed — don't put this URL
+          // into the cache where it would leak; just revoke it directly.
+          URL.revokeObjectURL(url);
+          return;
+        }
+        const stored = cacheAndAcquireImageUrl(resolvedPath, url);
+        acquired = true;
+        setImageUrl(stored);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
       } finally {
@@ -197,8 +280,11 @@ function FilePreviewModalContent({
     };
 
     fetchImage();
-    return () => { cancelled = true; };
-  }, [isImage, imageUrl, resolvedPath]);
+    return () => {
+      cancelled = true;
+      if (acquired) releaseImageUrl(resolvedPath);
+    };
+  }, [isImage, resolvedPath, workspaceId, missionId]);
 
   // Fetch text preview on mount
   useEffect(() => {
@@ -546,13 +632,25 @@ function InlineImagePreview({
   missionId?: string;
 }) {
   const resolvedPath = resolvePath(path, basePath);
-  const [imageUrl, setImageUrl] = useState<string | null>(imageUrlCache.get(resolvedPath) || null);
-  const [loading, setLoading] = useState(!imageUrl);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (imageUrl) return;
     let cancelled = false;
+    let acquired = false;
+
+    const cached = acquireCachedImageUrl(resolvedPath);
+    if (cached) {
+      setImageUrl(cached);
+      setLoading(false);
+      acquired = true;
+      return () => {
+        cancelled = true;
+        if (acquired) releaseImageUrl(resolvedPath);
+      };
+    }
+
     const fetchImage = async () => {
       const API_BASE = getRuntimeApiBase();
       const params = new URLSearchParams({ path: resolvedPath });
@@ -569,8 +667,13 @@ function InlineImagePreview({
         }
         const blob = await res.blob();
         const url = URL.createObjectURL(blob);
-        cacheImageUrl(resolvedPath, url);
-        if (!cancelled) setImageUrl(url);
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        const stored = cacheAndAcquireImageUrl(resolvedPath, url);
+        acquired = true;
+        setImageUrl(stored);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
       } finally {
@@ -578,8 +681,11 @@ function InlineImagePreview({
       }
     };
     fetchImage();
-    return () => { cancelled = true; };
-  }, [imageUrl, resolvedPath, workspaceId, missionId]);
+    return () => {
+      cancelled = true;
+      if (acquired) releaseImageUrl(resolvedPath);
+    };
+  }, [resolvedPath, workspaceId, missionId]);
 
   if (error) {
     return (

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -66,6 +66,10 @@ function acquireCachedImageUrl(path: string): string | null {
   const entry = imageUrlCache.get(path);
   if (!entry) return null;
   entry.refCount++;
+  // Re-acquired by a new consumer, so the entry is back to useful —
+  // clear any stale eviction mark from a prior overflow that didn't
+  // actually need to revoke this URL after all.
+  entry.evicted = false;
   return entry.url;
 }
 
@@ -79,16 +83,26 @@ function cacheAndAcquireImageUrl(path: string, url: string): string {
   if (existing) {
     URL.revokeObjectURL(url);
     existing.refCount++;
+    // The entry is being acquired again, so it's clearly still useful —
+    // clear any prior eviction mark so a subsequent release doesn't
+    // revoke a URL we're actively re-using.
+    existing.evicted = false;
     return existing.url;
   }
 
-  // LRU eviction: drop entries with refCount === 0 first (safe to revoke).
-  // For entries still in use, mark them `evicted` and let
-  // `releaseImageUrl` revoke them when the last consumer unmounts. If
-  // every entry is referenced we stop trying — better to leak the URL
-  // bookkeeping than break a live `<img>`.
-  let attempts = imageUrlCache.size;
-  while (imageUrlCache.size >= IMAGE_CACHE_LIMIT && attempts > 0) {
+  // LRU eviction strategy:
+  //   1. Drop refCount=0 entries first — they're safe to revoke immediately.
+  //   2. If everything is referenced, mark only the OLDEST entry (first
+  //      in insertion order) as `evicted`, so its last consumer's
+  //      `releaseImageUrl` revokes it. We don't mark more than one —
+  //      that would needlessly destroy cache effectiveness for entries
+  //      that callers might still re-acquire. If the working set really
+  //      exceeds the cap, future inserts will mark additional entries
+  //      one-by-one as they overflow.
+  //   3. The cache may temporarily exceed `IMAGE_CACHE_LIMIT` when all
+  //      entries are referenced; that's fine and self-corrects as
+  //      consumers unmount.
+  while (imageUrlCache.size >= IMAGE_CACHE_LIMIT) {
     let dropped = false;
     for (const [key, entry] of imageUrlCache) {
       if (entry.refCount === 0) {
@@ -97,10 +111,19 @@ function cacheAndAcquireImageUrl(path: string, url: string): string {
         dropped = true;
         break;
       }
-      entry.evicted = true;
     }
-    if (!dropped) break;
-    attempts--;
+    if (dropped) continue;
+
+    // No droppable entries — every URL is live. Mark only the oldest
+    // for revoke-on-last-release and stop.
+    const oldestKey = imageUrlCache.keys().next().value;
+    if (oldestKey) {
+      const oldest = imageUrlCache.get(oldestKey);
+      if (oldest && !oldest.evicted) {
+        oldest.evicted = true;
+      }
+    }
+    break;
   }
 
   imageUrlCache.set(path, { url, refCount: 1, evicted: false });


### PR DESCRIPTION
## Summary

Rich-view images (\`<image path=\"...\" />\` in agent output) sometimes failed to render with the browser's broken-image icon, but clicking the icon to open the file preview modal showed the image correctly — because the modal triggered a fresh fetch from a separate \`URL.createObjectURL\`.

**Root cause**: \`imageUrlCache\` was a global LRU keyed on path with a 50-entry cap (\`dashboard/src/components/markdown-content.tsx:33-62\`). When the cache overflowed, \`cacheImageUrl\` called \`URL.revokeObjectURL(oldUrl)\` on the evicted entry. But that URL was typically still the \`src=\` of an \`<img>\` element currently mounted elsewhere on the page (the URL lives in component state, not just the cache). Revoking it under the running DOM produced the broken image. The preview modal worked because it re-fetched on open.

**Fix**: refcount the cache.

- \`imageUrlCache\` is now \`Map<string, { url, refCount, evicted }>\`.
- New \`acquireCachedImageUrl(path)\` returns a URL and increments refCount.
- New \`cacheAndAcquireImageUrl(path, url)\` for the post-fetch insert (collapses concurrent fetches by revoking duplicates).
- New \`releaseImageUrl(path)\` decrements; revokes the URL only when refCount reaches 0 AND the entry was previously LRU-evicted.
- LRU eviction drops \`refCount === 0\` entries first; entries still in use get marked \`evicted\` and revoked later by \`releaseImageUrl\`. If every entry is referenced the loop stops — better to leak cache bookkeeping than break a live \`<img>\`.
- \`InlineImagePreview\` and the modal's image-fetch effect now follow acquire/release semantics: read from cache via \`acquireCachedImageUrl\`, pair every fetch with \`cacheAndAcquireImageUrl\`, and release in the effect cleanup. Mid-fetch unmount revokes the just-created URL directly instead of caching it (no leak, no orphaned refcount).
- Initial state for \`imageUrl\` is \`null\`; the effect populates it. Reading from \`imageUrlCache\` directly during render (the previous pattern) didn't acquire a refcount, which is exactly how the bug slipped in.

## Test plan

- [x] \`bun run build\` clean
- [x] Pattern is symmetric: every code path that produces an \`acquired\` URL is matched by a release in the cleanup, including the unmount-during-fetch race
- [ ] Manual test: open a mission with many \`<image>\` tags; scroll past 50+ unique images; verify earlier ones still render after newer ones cause LRU pressure
- [ ] Manual test: open the file preview modal for a previously-viewed image; verify it still uses the cache (no duplicate fetch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes shared image caching/eviction and adds acquire/release lifecycles; mistakes could cause leaks or missing `release` calls impacting memory or rendering.
> 
> **Overview**
> Fixes intermittent broken inline images by replacing the global image blob URL cache from simple LRU eviction (which could `revokeObjectURL` while an `<img>` was still mounted) to a **refcounted** cache that only revokes URLs after the last consumer releases them.
> 
> Updates both the inline rich-image renderer and the file preview modal to use explicit `acquireCachedImageUrl`/`cacheAndAcquireImageUrl` + `releaseImageUrl` semantics (including unmount-during-fetch cleanup), and adjusts eviction to prefer dropping unreferenced entries while deferring revocation for still-referenced ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11eccb7b2343c59cbb17bc8e7e5a52cc05b6445f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->