### PR TITLE
perf(dashboard): keep Workbench/Thinking toggle interactive

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback, memo, startTransition } from "react";
+import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback, memo, startTransition } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { toast } from "@/components/toast";
 import { MarkdownContent } from "@/components/markdown-content";
@@ -3498,6 +3498,9 @@ export default function ControlClient() {
 
   // Thinking panel state
   const [showThinkingPanel, setShowThinkingPanel] = useState(false);
+  // Deferred mirror used by the heavy chat-list regrouping memo so the toggle
+  // click stays interactive even on long missions.
+  const deferredShowThinkingPanel = useDeferredValue(showThinkingPanel);
   const [thinkingPanelManuallyHidden, setThinkingPanelManuallyHidden] = useState(false);
   const [showWorkbenchPanel, setShowWorkbenchPanel] = useState(
     () => searchParams.get("workbench") === "1"
@@ -3706,8 +3709,14 @@ export default function ControlClient() {
     hasActiveThinking,
     groupedItems,
   } = useMemo(
-    () => deriveItemViews(items, showThinkingPanel),
-    [items, showThinkingPanel]
+    // `showThinkingPanel` reroutes thinking items between the inline chat
+    // and the side panel, which flips the structure of `groupedItems` and
+    // forces React to reconcile every chat row. On long missions that can
+    // block the main thread for several seconds, so feed it through
+    // `useDeferredValue`: the toggle button + panel mount react instantly
+    // while the chat-list regrouping is treated as a non-urgent transition.
+    () => deriveItemViews(items, deferredShowThinkingPanel),
+    [items, deferredShowThinkingPanel]
   );
 
   // Auto-show thinking panel when thinking starts (only on transition to active)
@@ -8090,21 +8099,6 @@ export default function ControlClient() {
           )}
 
           <button
-            onClick={() => setShowAutomationsDialog(true)}
-            disabled={!activeMission}
-            className={cn(
-              "flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm transition-colors",
-              activeMission
-                ? "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
-                : "border-white/[0.04] bg-white/[0.01] text-white/30 cursor-not-allowed"
-            )}
-            title={activeMission ? "Manage mission automations" : "Select a mission to manage automations"}
-          >
-            <Clock className="h-4 w-4" />
-            <span className="hidden lg:inline">Automations</span>
-          </button>
-
-          <button
             onClick={() => setShowWorkbenchPanel((prev) => !prev)}
             className={cn(
               "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
@@ -9182,7 +9176,7 @@ export default function ControlClient() {
                 onOpenSwitcher={() => setShowMissionSwitcher(true)}
                 onViewMission={handleViewMission}
                 onSetStatus={handleSetStatus}
-                className={showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission) ? "flex-shrink-0 max-h-[40%]" : "flex-1"}
+                className="flex-1 min-h-0"
               />
             )}
 

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3279,6 +3279,36 @@ export default function ControlClient() {
   const lastQueueLenRef = useRef<number | null>(null);
   const syncingQueueRef = useRef(false);
 
+  // Backwards-pagination state. Long missions can have 20k+ history events
+  // and the initial load is capped at HISTORY_PAGE_SIZE for memory + render
+  // perf. These caches let the user click "Load older messages" to fetch
+  // the next page back without re-fetching the whole history.
+  //
+  // missionMinSeqRef            — lowest `sequence` currently loaded; used
+  //                               as the next `before_seq` cursor.
+  // missionHistoricEventsRef    — accumulated raw history events for the
+  //                               mission (initial + paginated older). Kept
+  //                               so we can replay `eventsToItems` over the
+  //                               full set when prepending older events,
+  //                               which preserves tool_call/result linkage
+  //                               and thinking-delta consolidation.
+  // historicItemsCountRef       — number of items in `items` that came
+  //                               from the current historic snapshot, so a
+  //                               paginate-older replace knows where the
+  //                               live SSE-appended tail starts.
+  // missionTotalHistoryRef      — server-reported total count (matching
+  //                               the type filter); compared against
+  //                               accumulated cache size to decide whether
+  //                               more older events exist.
+  const missionMinSeqRef = useRef<Map<string, number>>(new Map());
+  const missionHistoricEventsRef = useRef<Map<string, StoredEvent[]>>(new Map());
+  const historicItemsCountRef = useRef<Map<string, number>>(new Map());
+  const missionTotalHistoryRef = useRef<Map<string, number>>(new Map());
+  const [olderLoadState, setOlderLoadState] = useState<{
+    hasMore: boolean;
+    loading: boolean;
+  }>({ hasMore: false, loading: false });
+
   // Performance optimization: limit rendered items for large conversations
   const INITIAL_VISIBLE_ITEMS = 30;
   const LOAD_MORE_INCREMENT = 30;
@@ -3517,10 +3547,13 @@ export default function ControlClient() {
    */
   const missionMaxSeqRef = useRef<Map<string, number>>(new Map());
 
+  // Page size for both the initial history load and each backwards-
+  // paginate-older fetch. Tuned for memory headroom on long missions —
+  // see the `chatScrollContainerRef` comment block above.
+  const HISTORY_PAGE_SIZE = 5000;
+
   const loadHistoryEvents = useCallback(
     async (id: string, opts?: { sinceSeq?: number }) => {
-      const MAX_EVENTS = 5000;
-
       if (opts?.sinceSeq !== undefined) {
         // Delta load — used on reconnect/visibility/periodic sync.
         // The server returns events with sequence > sinceSeq already
@@ -3535,7 +3568,7 @@ export default function ControlClient() {
         const { events, meta } = await getMissionEventsWithMeta(id, {
           types: HISTORY_EVENT_TYPES,
           sinceSeq: opts.sinceSeq,
-          limit: MAX_EVENTS,
+          limit: HISTORY_PAGE_SIZE,
         });
         if (meta.maxSequence === undefined) {
           missionMaxSeqRef.current.delete(id);
@@ -3548,21 +3581,21 @@ export default function ControlClient() {
         const lastSeq =
           events.length > 0 ? events[events.length - 1].sequence : opts.sinceSeq;
         const cursor =
-          events.length >= MAX_EVENTS && lastSeq < meta.maxSequence
+          events.length >= HISTORY_PAGE_SIZE && lastSeq < meta.maxSequence
             ? lastSeq
             : meta.maxSequence;
         missionMaxSeqRef.current.set(id, cursor);
         return events;
       }
 
-      // Initial load — request the most recent MAX_EVENTS events.
+      // Initial load — request the most recent HISTORY_PAGE_SIZE events.
       // `latest=true` lets the server compute the tail offset in one
       // shot, so clients no longer need the binary-search probe loop
       // to handle 25k+ event missions.
       const { events, meta } = await getMissionEventsWithMeta(id, {
         types: HISTORY_EVENT_TYPES,
         latest: true,
-        limit: MAX_EVENTS,
+        limit: HISTORY_PAGE_SIZE,
       });
       // Only seed `missionMaxSeqRef` when the server has confirmed it
       // supports the resume protocol via `X-Max-Sequence`. Seeding from
@@ -3574,10 +3607,63 @@ export default function ControlClient() {
       }
       // Defensive: sort by sequence ASC in case upstream contract changes.
       const sorted = events.slice().sort((a, b) => a.sequence - b.sequence);
+      // Seed pagination caches: snapshot of historic events, lowest seq
+      // (cursor for next backwards page), and total filtered count from
+      // the server (so we know when the user has reached the start).
+      missionHistoricEventsRef.current.set(id, sorted);
+      if (sorted.length > 0) {
+        missionMinSeqRef.current.set(id, sorted[0].sequence);
+      } else {
+        missionMinSeqRef.current.delete(id);
+      }
+      if (meta.totalEvents !== undefined) {
+        missionTotalHistoryRef.current.set(id, meta.totalEvents);
+      } else {
+        missionTotalHistoryRef.current.delete(id);
+      }
       return sorted;
     },
     [HISTORY_EVENT_TYPES]
   );
+
+  /**
+   * Recompute "is there more older history to load" for a mission, by
+   * comparing the locally-cached event count against the server's total.
+   * `undefined` total (e.g. older backend without `X-Total-Events`) is
+   * treated as "unknown → assume yes" if we got a full page on the last
+   * fetch — gives the user the option to try, and the next fetch will
+   * surface emptiness.
+   */
+  const computeHasMoreOlder = useCallback((id: string): boolean => {
+    const accumulated = missionHistoricEventsRef.current.get(id)?.length ?? 0;
+    const total = missionTotalHistoryRef.current.get(id);
+    if (total === undefined) {
+      // Heuristic: a full page suggests there could be more. Empty/short
+      // page rules it out.
+      return accumulated >= HISTORY_PAGE_SIZE;
+    }
+    return accumulated < total;
+  }, []);
+
+  /**
+   * Bookkeeping after an initial history load completes and `setItems`
+   * has been called. Records how many items were derived from history
+   * (so a later "load older" page-replace can find the live tail) and
+   * publishes the "more older messages exist" state to the UI.
+   */
+  const seedPaginationStateAfterInitialLoad = useCallback(
+    (id: string, historyItemsLen: number) => {
+      historicItemsCountRef.current.set(id, historyItemsLen);
+      setOlderLoadState({
+        hasMore: computeHasMoreOlder(id),
+        loading: false,
+      });
+    },
+    [computeHasMoreOlder]
+  );
+
+  // `loadOlderHistoryEvents` is declared further down, after
+  // `eventsToItems` (TDZ). Search for its definition there.
 
   // Tool groups expansion state - tracks which groups are expanded by their first tool's id
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
@@ -4545,6 +4631,91 @@ export default function ControlClient() {
     return items;
   }, []);
 
+  /**
+   * Fetch the next page of older history events (events with `sequence`
+   * strictly less than the lowest currently loaded). Replays
+   * `eventsToItems` over the full accumulated event set so tool-call /
+   * tool-result linkage and thinking-delta consolidation stay coherent
+   * across the page boundary, then splices the new historic prefix in
+   * front of the SSE-appended live tail.
+   *
+   * Defined after `eventsToItems` so the callback's dependency array can
+   * reference it without hitting `const` TDZ at component init.
+   */
+  const loadOlderHistoryEvents = useCallback(
+    async (id: string) => {
+      const beforeSeq = missionMinSeqRef.current.get(id);
+      if (beforeSeq === undefined || beforeSeq <= 1) {
+        setOlderLoadState({ hasMore: false, loading: false });
+        return;
+      }
+      setOlderLoadState((prev) => ({ ...prev, loading: true }));
+      try {
+        const { events: olderEvents } = await getMissionEventsWithMeta(id, {
+          types: HISTORY_EVENT_TYPES,
+          beforeSeq,
+          limit: HISTORY_PAGE_SIZE,
+        });
+        if (olderEvents.length === 0) {
+          setOlderLoadState({ hasMore: false, loading: false });
+          return;
+        }
+
+        const sortedOlder = olderEvents
+          .slice()
+          .sort((a, b) => a.sequence - b.sequence);
+
+        missionMinSeqRef.current.set(id, sortedOlder[0].sequence);
+        const existing = missionHistoricEventsRef.current.get(id) ?? [];
+        const merged = [...sortedOlder, ...existing];
+        missionHistoricEventsRef.current.set(id, merged);
+
+        const mission =
+          currentMissionRef.current?.id === id
+            ? currentMissionRef.current
+            : viewingMission?.id === id
+              ? viewingMission
+              : null;
+        const newHistoricItems = eventsToItems(merged, mission);
+        const oldHistoricCount = historicItemsCountRef.current.get(id) ?? 0;
+        historicItemsCountRef.current.set(id, newHistoricItems.length);
+
+        // Capture scroll geometry so we can preserve the in-viewport
+        // message after React commits the longer list (otherwise the
+        // user's scroll position would jump to the now-distant top).
+        // `containerRef` is the messages-pane scroll container (see
+        // `useScrollToBottom` and the JSX below near `ref={containerRef}`).
+        const scrollEl = containerRef.current;
+        const oldScrollTop = scrollEl?.scrollTop ?? 0;
+        const oldScrollHeight = scrollEl?.scrollHeight ?? 0;
+
+        if (currentMissionRef.current?.id === id || viewingMission?.id === id) {
+          setItems((prev) => {
+            const liveTail = prev.slice(oldHistoricCount);
+            return [...newHistoricItems, ...liveTail];
+          });
+        }
+
+        requestAnimationFrame(() => {
+          if (!scrollEl) return;
+          const newScrollHeight = scrollEl.scrollHeight;
+          scrollEl.scrollTop =
+            newScrollHeight - oldScrollHeight + oldScrollTop;
+        });
+
+        setOlderLoadState({
+          hasMore: computeHasMoreOlder(id),
+          loading: false,
+        });
+      } catch (err) {
+        console.error("Failed to load older events:", err);
+        toast.error("Failed to load older messages");
+        setOlderLoadState((prev) => ({ ...prev, loading: false }));
+      }
+    },
+    [HISTORY_EVENT_TYPES, eventsToItems, computeHasMoreOlder, viewingMission]
+  );
+
   // Load mission from URL param on mount (and retry on auth success)
   const [authRetryTrigger, setAuthRetryTrigger] = useState(0);
 
@@ -4686,6 +4857,7 @@ export default function ControlClient() {
         }
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
+        seedPaginationStateAfterInitialLoad(id, historyItems.length);
         applyDesktopSessionState(mission);
         // Also check events for desktop sessions (in case mission.desktop_sessions isn't populated yet)
         if (events) {
@@ -4770,6 +4942,7 @@ export default function ControlClient() {
               }
               setItems(historyItems);
               adjustVisibleItemsLimit(historyItems);
+              seedPaginationStateAfterInitialLoad(mission.id, historyItems.length);
               // Also check events for desktop sessions
               applyDesktopSessionFromEvents(events);
             })
@@ -4802,6 +4975,7 @@ export default function ControlClient() {
     missionHistoryToItems,
     adjustVisibleItemsLimit,
     loadHistoryEvents,
+    seedPaginationStateAfterInitialLoad,
     applyDesktopSessionState,
     applyDesktopSessionFromEvents,
     authRetryTrigger,
@@ -5167,6 +5341,7 @@ export default function ControlClient() {
 
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
+        seedPaginationStateAfterInitialLoad(missionId, historyItems.length);
         // Check if mission has an active desktop session (stored metadata or fallback to history)
         applyDesktopSessionState(mission);
         // Also check events for desktop sessions
@@ -5221,6 +5396,7 @@ export default function ControlClient() {
       applyDesktopSessionState,
       adjustVisibleItemsLimit,
       loadHistoryEvents,
+      seedPaginationStateAfterInitialLoad,
       router,
     ]
   );
@@ -7489,6 +7665,7 @@ export default function ControlClient() {
 
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
+        seedPaginationStateAfterInitialLoad(missionId, historyItems.length);
         updateMissionItems(missionId, historyItems);
         if (events) {
           applyDesktopSessionFromEvents(events);
@@ -7502,6 +7679,7 @@ export default function ControlClient() {
       eventsToItems,
       missionHistoryToItems,
       adjustVisibleItemsLimit,
+      seedPaginationStateAfterInitialLoad,
       updateMissionItems,
       applyDesktopSessionFromEvents,
     ]
@@ -8328,6 +8506,28 @@ export default function ControlClient() {
         )}>
         {/* Messages */}
         <div ref={containerRef} className="flex-1 overflow-y-auto p-6">
+          {/* Backwards pagination — only when there's actually more older
+              history to fetch and the chat isn't empty. Click prepends the
+              previous page; scroll position is preserved so the message
+              currently in view stays put. */}
+          {items.length > 0 && olderLoadState.hasMore && viewingMissionId && (
+            <div className="flex justify-center mb-4">
+              <button
+                type="button"
+                disabled={olderLoadState.loading}
+                onClick={() => {
+                  void loadOlderHistoryEvents(viewingMissionId);
+                }}
+                className={cn(
+                  "px-4 py-1.5 text-xs rounded-full border transition-colors",
+                  "border-white/10 bg-white/[0.03] text-white/60 hover:bg-white/[0.06] hover:text-white/80",
+                  olderLoadState.loading && "opacity-60 cursor-wait"
+                )}
+              >
+                {olderLoadState.loading ? "Loading older messages…" : "Load older messages"}
+              </button>
+            </div>
+          )}
           {items.length === 0 ? (
             <div className="flex h-full items-center justify-center">
               <div className="text-center">

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3304,6 +3304,15 @@ export default function ControlClient() {
   const missionHistoricEventsRef = useRef<Map<string, StoredEvent[]>>(new Map());
   const historicItemsCountRef = useRef<Map<string, number>>(new Map());
   const missionTotalHistoryRef = useRef<Map<string, number>>(new Map());
+  // Captured scroll geometry from the moment of `setItems` during a
+  // paginate-back. Consumed by a `useLayoutEffect` watching `items` so the
+  // restoration runs synchronously after commit but BEFORE the browser
+  // paints — using `requestAnimationFrame` here would let the user see a
+  // one-frame jump against the longer DOM before the scroll adjusts.
+  const pendingScrollRestoreRef = useRef<{
+    oldScrollTop: number;
+    oldScrollHeight: number;
+  } | null>(null);
   const [olderLoadState, setOlderLoadState] = useState<{
     hasMore: boolean;
     loading: boolean;
@@ -3903,6 +3912,28 @@ export default function ControlClient() {
     if (items.length > 0 && isAtBottom) {
       scrollToBottomImmediate();
     }
+  }, [items]);
+
+  // Backwards-pagination scroll restore. `loadOlderHistoryEvents` snapshots
+  // `scrollTop` + `scrollHeight` BEFORE prepending items into this ref;
+  // after React commits the longer list, we adjust `scrollTop` to keep the
+  // previously-visible message in the viewport. This MUST run in a
+  // `useLayoutEffect` (synchronously after commit, before browser paint) —
+  // doing it in `requestAnimationFrame` produces a one-frame flash where
+  // the user sees the old `scrollTop` against the new (taller) DOM before
+  // the adjustment lands. Declared after the scroll-to-bottom effect on
+  // purpose so React runs it second; the bottom-scroll only fires when
+  // `isAtBottom`, which is never true during a paginate-back.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    const pending = pendingScrollRestoreRef.current;
+    if (!pending) return;
+    pendingScrollRestoreRef.current = null;
+    const scrollEl = containerRef.current;
+    if (!scrollEl) return;
+    const newScrollHeight = scrollEl.scrollHeight;
+    scrollEl.scrollTop =
+      newScrollHeight - pending.oldScrollHeight + pending.oldScrollTop;
   }, [items]);
 
   // Sync input to localStorage draft
@@ -4704,15 +4735,6 @@ export default function ControlClient() {
         const oldHistoricCount = historicItemsCountRef.current.get(id) ?? 0;
         historicItemsCountRef.current.set(id, newHistoricItems.length);
 
-        // Capture scroll geometry so we can preserve the in-viewport
-        // message after React commits the longer list (otherwise the
-        // user's scroll position would jump to the now-distant top).
-        // `containerRef` is the messages-pane scroll container (see
-        // `useScrollToBottom` and the JSX below near `ref={containerRef}`).
-        const scrollEl = containerRef.current;
-        const oldScrollTop = scrollEl?.scrollTop ?? 0;
-        const oldScrollHeight = scrollEl?.scrollHeight ?? 0;
-
         // The user may have switched missions during the await. Capture
         // the still-active gate once and use it for *every* state write
         // below — `setOlderLoadState` is single-shared (not per-mission),
@@ -4721,16 +4743,23 @@ export default function ControlClient() {
         const stillActiveForId = liveCurrent?.id === id || liveViewing?.id === id;
 
         if (stillActiveForId) {
+          // Snapshot scroll geometry FIRST, then setItems. The
+          // `useLayoutEffect` watching `items` reads
+          // `pendingScrollRestoreRef` synchronously after commit and
+          // BEFORE paint, so the user never sees the longer DOM with
+          // the old scrollTop. (Doing this in `requestAnimationFrame`
+          // would land one frame late and produce a visible jump.)
+          const scrollEl = containerRef.current;
+          if (scrollEl) {
+            pendingScrollRestoreRef.current = {
+              oldScrollTop: scrollEl.scrollTop,
+              oldScrollHeight: scrollEl.scrollHeight,
+            };
+          }
+
           setItems((prev) => {
             const liveTail = prev.slice(oldHistoricCount);
             return [...newHistoricItems, ...liveTail];
-          });
-
-          requestAnimationFrame(() => {
-            if (!scrollEl) return;
-            const newScrollHeight = scrollEl.scrollHeight;
-            scrollEl.scrollTop =
-              newScrollHeight - oldScrollHeight + oldScrollTop;
           });
 
           setOlderLoadState({

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -8090,6 +8090,21 @@ export default function ControlClient() {
           )}
 
           <button
+            onClick={() => setShowAutomationsDialog(true)}
+            disabled={!activeMission}
+            className={cn(
+              "flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm transition-colors",
+              activeMission
+                ? "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
+                : "border-white/[0.04] bg-white/[0.01] text-white/30 cursor-not-allowed"
+            )}
+            title={activeMission ? "Manage mission automations" : "Select a mission to manage automations"}
+          >
+            <Clock className="h-4 w-4" />
+            <span className="hidden lg:inline">Automations</span>
+          </button>
+
+          <button
             onClick={() => setShowWorkbenchPanel((prev) => !prev)}
             className={cn(
               "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
@@ -9167,7 +9182,7 @@ export default function ControlClient() {
                 onOpenSwitcher={() => setShowMissionSwitcher(true)}
                 onViewMission={handleViewMission}
                 onSetStatus={handleSetStatus}
-                className="flex-1 min-h-0"
+                className={showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission) ? "flex-shrink-0 max-h-[40%]" : "flex-1"}
               />
             )}
 

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3313,10 +3313,18 @@ export default function ControlClient() {
     oldScrollTop: number;
     oldScrollHeight: number;
   } | null>(null);
+  // Pagination UI state carries `missionId` so a stale-mission completion
+  // (or a stuck `loading: true` from a fetch the user navigated away
+  // from) can't surface on a different mission's button. The JSX reads
+  // through `activeOlderLoadState` below, which only honors the state
+  // when the recorded mission id matches what the user is currently
+  // viewing — otherwise it falls back to the safe defaults
+  // (`hasMore=false`, `loading=false`).
   const [olderLoadState, setOlderLoadState] = useState<{
+    missionId: string | null;
     hasMore: boolean;
     loading: boolean;
-  }>({ hasMore: false, loading: false });
+  }>({ missionId: null, hasMore: false, loading: false });
 
   // Performance optimization: limit rendered items for large conversations
   const INITIAL_VISIBLE_ITEMS = 30;
@@ -3671,6 +3679,7 @@ export default function ControlClient() {
     (id: string, historyItemsLen: number) => {
       historicItemsCountRef.current.set(id, historyItemsLen);
       setOlderLoadState({
+        missionId: id,
         hasMore: computeHasMoreOlder(id),
         loading: false,
       });
@@ -4684,10 +4693,21 @@ export default function ControlClient() {
     async (id: string) => {
       const beforeSeq = missionMinSeqRef.current.get(id);
       if (beforeSeq === undefined || beforeSeq <= 1) {
-        setOlderLoadState({ hasMore: false, loading: false });
+        setOlderLoadState({ missionId: id, hasMore: false, loading: false });
         return;
       }
-      setOlderLoadState((prev) => ({ ...prev, loading: true }));
+      // The button click that fired this is for the currently-viewing
+      // mission, so writing `missionId: id` here is correct. If the user
+      // switches missions during the in-flight fetch, the UI's
+      // `activeOlderLoadState` selector will discard this loading state
+      // (it filters on `missionId === viewingMissionId`), so a fetch
+      // that never gets to clear `loading: false` can't pin the new
+      // mission's button to a stuck "Loading…" state.
+      setOlderLoadState((prev) => ({
+        missionId: id,
+        hasMore: prev.missionId === id ? prev.hasMore : false,
+        loading: true,
+      }));
       try {
         const { events: olderEvents } = await getMissionEventsWithMeta(id, {
           types: HISTORY_EVENT_TYPES,
@@ -4703,7 +4723,7 @@ export default function ControlClient() {
             currentMissionRef.current?.id === id ||
             viewingMissionRef.current?.id === id
           ) {
-            setOlderLoadState({ hasMore: false, loading: false });
+            setOlderLoadState({ missionId: id, hasMore: false, loading: false });
           }
           return;
         }
@@ -4765,6 +4785,7 @@ export default function ControlClient() {
           });
 
           setOlderLoadState({
+            missionId: id,
             hasMore: computeHasMoreOlder(id),
             loading: false,
           });
@@ -4774,12 +4795,16 @@ export default function ControlClient() {
         toast.error("Failed to load older messages");
         // Only clear the loading flag if the active mission is still the
         // one we were paginating — otherwise we'd wipe state set for a
-        // newer, unrelated mission.
+        // newer, unrelated mission. (The missionId-tagged read selector
+        // also protects the UI here, but we keep this guard so we don't
+        // gratuitously rewrite state for a mission that isn't viewable.)
         const stillActive =
           currentMissionRef.current?.id === id ||
           viewingMissionRef.current?.id === id;
         if (stillActive) {
-          setOlderLoadState((prev) => ({ ...prev, loading: false }));
+          setOlderLoadState((prev) =>
+            prev.missionId === id ? { ...prev, loading: false } : prev
+          );
         }
       }
     },
@@ -8596,8 +8621,16 @@ export default function ControlClient() {
           {/* Backwards pagination — only when there's actually more older
               history to fetch and the chat isn't empty. Click prepends the
               previous page; scroll position is preserved so the message
-              currently in view stays put. */}
-          {items.length > 0 && olderLoadState.hasMore && viewingMissionId && (
+              currently in view stays put.
+              `olderLoadState` is single-shared but tagged with `missionId`,
+              so we ignore it unless it's for the mission the user is
+              actually viewing. Otherwise a stale completion (or a
+              still-in-flight fetch from a previously-viewed mission)
+              could pin this button to a wrong "Loading…" / hidden state. */}
+          {items.length > 0 &&
+            olderLoadState.missionId === viewingMissionId &&
+            olderLoadState.hasMore &&
+            viewingMissionId && (
             <div className="flex justify-center mb-4">
               <button
                 type="button"

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4664,7 +4664,16 @@ export default function ControlClient() {
           limit: HISTORY_PAGE_SIZE,
         });
         if (olderEvents.length === 0) {
-          setOlderLoadState({ hasMore: false, loading: false });
+          // Same per-mission gate as below — see comment on
+          // `stillActiveForId`. If the user switched missions while we
+          // were fetching, don't pin the new mission's UI to "no more
+          // older messages" based on the old mission's empty page.
+          if (
+            currentMissionRef.current?.id === id ||
+            viewingMissionRef.current?.id === id
+          ) {
+            setOlderLoadState({ hasMore: false, loading: false });
+          }
           return;
         }
 
@@ -4704,28 +4713,43 @@ export default function ControlClient() {
         const oldScrollTop = scrollEl?.scrollTop ?? 0;
         const oldScrollHeight = scrollEl?.scrollHeight ?? 0;
 
-        if (liveCurrent?.id === id || liveViewing?.id === id) {
+        // The user may have switched missions during the await. Capture
+        // the still-active gate once and use it for *every* state write
+        // below — `setOlderLoadState` is single-shared (not per-mission),
+        // so an old-mission completion would otherwise clobber the new
+        // mission's pagination UI state set by `seedPaginationStateAfterInitialLoad`.
+        const stillActiveForId = liveCurrent?.id === id || liveViewing?.id === id;
+
+        if (stillActiveForId) {
           setItems((prev) => {
             const liveTail = prev.slice(oldHistoricCount);
             return [...newHistoricItems, ...liveTail];
           });
+
+          requestAnimationFrame(() => {
+            if (!scrollEl) return;
+            const newScrollHeight = scrollEl.scrollHeight;
+            scrollEl.scrollTop =
+              newScrollHeight - oldScrollHeight + oldScrollTop;
+          });
+
+          setOlderLoadState({
+            hasMore: computeHasMoreOlder(id),
+            loading: false,
+          });
         }
-
-        requestAnimationFrame(() => {
-          if (!scrollEl) return;
-          const newScrollHeight = scrollEl.scrollHeight;
-          scrollEl.scrollTop =
-            newScrollHeight - oldScrollHeight + oldScrollTop;
-        });
-
-        setOlderLoadState({
-          hasMore: computeHasMoreOlder(id),
-          loading: false,
-        });
       } catch (err) {
         console.error("Failed to load older events:", err);
         toast.error("Failed to load older messages");
-        setOlderLoadState((prev) => ({ ...prev, loading: false }));
+        // Only clear the loading flag if the active mission is still the
+        // one we were paginating — otherwise we'd wipe state set for a
+        // newer, unrelated mission.
+        const stillActive =
+          currentMissionRef.current?.id === id ||
+          viewingMissionRef.current?.id === id;
+        if (stillActive) {
+          setOlderLoadState((prev) => ({ ...prev, loading: false }));
+        }
       }
     },
     // Note: `viewingMission` is intentionally NOT in deps — the body now

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4708,15 +4708,6 @@ export default function ControlClient() {
           return;
         }
 
-        const sortedOlder = olderEvents
-          .slice()
-          .sort((a, b) => a.sequence - b.sequence);
-
-        missionMinSeqRef.current.set(id, sortedOlder[0].sequence);
-        const existing = missionHistoricEventsRef.current.get(id) ?? [];
-        const merged = [...sortedOlder, ...existing];
-        missionHistoricEventsRef.current.set(id, merged);
-
         // After the await, the user may have switched missions. Read the
         // *currently-viewing* mission from refs (which the keep-in-sync
         // useEffects update synchronously from state), NOT from the
@@ -4725,24 +4716,35 @@ export default function ControlClient() {
         // mission's items.
         const liveCurrent = currentMissionRef.current;
         const liveViewing = viewingMissionRef.current;
-        const mission =
-          liveCurrent?.id === id
-            ? liveCurrent
-            : liveViewing?.id === id
-              ? liveViewing
-              : null;
-        const newHistoricItems = eventsToItems(merged, mission);
-        const oldHistoricCount = historicItemsCountRef.current.get(id) ?? 0;
-        historicItemsCountRef.current.set(id, newHistoricItems.length);
-
-        // The user may have switched missions during the await. Capture
-        // the still-active gate once and use it for *every* state write
-        // below — `setOlderLoadState` is single-shared (not per-mission),
-        // so an old-mission completion would otherwise clobber the new
-        // mission's pagination UI state set by `seedPaginationStateAfterInitialLoad`.
+        // Single shared gate. If false, this completion belongs to a
+        // mission the user has already navigated away from — every side
+        // effect below (cursor advance, cache merge, items splice,
+        // `olderLoadState` reset, scroll restore) MUST be skipped, or a
+        // stale-mission completion will corrupt refs that
+        // `loadHistoryEvents`/`reloadMissionHistory` may not reset on the
+        // user's eventual return path.
         const stillActiveForId = liveCurrent?.id === id || liveViewing?.id === id;
 
         if (stillActiveForId) {
+          const sortedOlder = olderEvents
+            .slice()
+            .sort((a, b) => a.sequence - b.sequence);
+
+          missionMinSeqRef.current.set(id, sortedOlder[0].sequence);
+          const existing = missionHistoricEventsRef.current.get(id) ?? [];
+          const merged = [...sortedOlder, ...existing];
+          missionHistoricEventsRef.current.set(id, merged);
+
+          const mission =
+            liveCurrent?.id === id
+              ? liveCurrent
+              : liveViewing?.id === id
+                ? liveViewing
+                : null;
+          const newHistoricItems = eventsToItems(merged, mission);
+          const oldHistoricCount = historicItemsCountRef.current.get(id) ?? 0;
+          historicItemsCountRef.current.set(id, newHistoricItems.length);
+
           // Snapshot scroll geometry FIRST, then setItems. The
           // `useLayoutEffect` watching `items` reads
           // `pendingScrollRestoreRef` synchronously after commit and

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3651,6 +3651,13 @@ export default function ControlClient() {
    * (so a later "load older" page-replace can find the live tail) and
    * publishes the "more older messages exist" state to the UI.
    */
+  // `historyItemsLen` MUST count only items derived from server events
+  // (i.e. the result of `eventsToItems` / `missionHistoryToItems`), NOT
+  // the post-queue-merge length. `loadOlderHistoryEvents` later splices
+  // via `prev.slice(oldHistoricCount)`; if queued messages were counted
+  // here, they'd land before the splice point, get rebuilt by
+  // `eventsToItems` (which doesn't see queued messages), and silently
+  // disappear from the UI on the next page-back.
   const seedPaginationStateAfterInitialLoad = useCallback(
     (id: string, historyItemsLen: number) => {
       historicItemsCountRef.current.set(id, historyItemsLen);
@@ -4670,11 +4677,19 @@ export default function ControlClient() {
         const merged = [...sortedOlder, ...existing];
         missionHistoricEventsRef.current.set(id, merged);
 
+        // After the await, the user may have switched missions. Read the
+        // *currently-viewing* mission from refs (which the keep-in-sync
+        // useEffects update synchronously from state), NOT from the
+        // closure-captured `viewingMission` — that's stale across renders
+        // and would happily prepend the old mission's events into the new
+        // mission's items.
+        const liveCurrent = currentMissionRef.current;
+        const liveViewing = viewingMissionRef.current;
         const mission =
-          currentMissionRef.current?.id === id
-            ? currentMissionRef.current
-            : viewingMission?.id === id
-              ? viewingMission
+          liveCurrent?.id === id
+            ? liveCurrent
+            : liveViewing?.id === id
+              ? liveViewing
               : null;
         const newHistoricItems = eventsToItems(merged, mission);
         const oldHistoricCount = historicItemsCountRef.current.get(id) ?? 0;
@@ -4689,7 +4704,7 @@ export default function ControlClient() {
         const oldScrollTop = scrollEl?.scrollTop ?? 0;
         const oldScrollHeight = scrollEl?.scrollHeight ?? 0;
 
-        if (currentMissionRef.current?.id === id || viewingMission?.id === id) {
+        if (liveCurrent?.id === id || liveViewing?.id === id) {
           setItems((prev) => {
             const liveTail = prev.slice(oldHistoricCount);
             return [...newHistoricItems, ...liveTail];
@@ -4713,7 +4728,11 @@ export default function ControlClient() {
         setOlderLoadState((prev) => ({ ...prev, loading: false }));
       }
     },
-    [HISTORY_EVENT_TYPES, eventsToItems, computeHasMoreOlder, viewingMission]
+    // Note: `viewingMission` is intentionally NOT in deps — the body now
+    // reads `viewingMissionRef.current` (synced from state by an effect
+    // above), so capturing the state value would re-introduce the stale
+    // closure that bugbot flagged.
+    [HISTORY_EVENT_TYPES, eventsToItems, computeHasMoreOlder]
   );
 
   // Load mission from URL param on mount (and retry on auth success)
@@ -4833,6 +4852,10 @@ export default function ControlClient() {
             historyItems = missionHistoryToItems(mission);
           }
         }
+        // Capture the events-derived count BEFORE the queue merge — this is
+        // what `loadOlderHistoryEvents` needs to find the live tail
+        // correctly (see `seedPaginationStateAfterInitialLoad`).
+        const historicEventsLen = historyItems.length;
         // Merge queued messages that belong to this mission
         const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === id);
         if (missionQueuedMessages.length > 0) {
@@ -4857,7 +4880,7 @@ export default function ControlClient() {
         }
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
-        seedPaginationStateAfterInitialLoad(id, historyItems.length);
+        seedPaginationStateAfterInitialLoad(id, historicEventsLen);
         applyDesktopSessionState(mission);
         // Also check events for desktop sessions (in case mission.desktop_sessions isn't populated yet)
         if (events) {
@@ -4920,6 +4943,9 @@ export default function ControlClient() {
                   historyItems = missionHistoryToItems(mission);
                 }
               }
+              // Capture pre-queue length so pagination doesn't clip
+              // queued items (see `seedPaginationStateAfterInitialLoad`).
+              const historicEventsLen = historyItems.length;
               // Merge queued messages that belong to this mission
               const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === mission.id);
               if (missionQueuedMessages.length > 0) {
@@ -4942,7 +4968,7 @@ export default function ControlClient() {
               }
               setItems(historyItems);
               adjustVisibleItemsLimit(historyItems);
-              seedPaginationStateAfterInitialLoad(mission.id, historyItems.length);
+              seedPaginationStateAfterInitialLoad(mission.id, historicEventsLen);
               // Also check events for desktop sessions
               applyDesktopSessionFromEvents(events);
             })
@@ -5318,6 +5344,9 @@ export default function ControlClient() {
           }
         }
 
+        // Capture pre-queue length so pagination doesn't clip queued items
+        // (see `seedPaginationStateAfterInitialLoad`).
+        const historicEventsLen = historyItems.length;
         // Merge queued messages that belong to this mission
         const missionQueuedMessages = queuedMessages.filter((qm) => qm.mission_id === missionId);
         if (missionQueuedMessages.length > 0) {
@@ -5341,7 +5370,7 @@ export default function ControlClient() {
 
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
-        seedPaginationStateAfterInitialLoad(missionId, historyItems.length);
+        seedPaginationStateAfterInitialLoad(missionId, historicEventsLen);
         // Check if mission has an active desktop session (stored metadata or fallback to history)
         applyDesktopSessionState(mission);
         // Also check events for desktop sessions
@@ -7639,6 +7668,9 @@ export default function ControlClient() {
           }
         }
 
+        // Pre-queue length: pagination uses this to find the live tail
+        // without clipping queued items (see `seedPaginationStateAfterInitialLoad`).
+        const historicEventsLen = historyItems.length;
         const missionQueuedMessages = queuedMessages.filter(
           (qm) => qm.mission_id === missionId
         );
@@ -7665,7 +7697,7 @@ export default function ControlClient() {
 
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
-        seedPaginationStateAfterInitialLoad(missionId, historyItems.length);
+        seedPaginationStateAfterInitialLoad(missionId, historicEventsLen);
         updateMissionItems(missionId, historyItems);
         if (events) {
           applyDesktopSessionFromEvents(events);

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4784,6 +4784,20 @@ export default function ControlClient() {
             return [...newHistoricItems, ...liveTail];
           });
 
+          // The render path uses `groupedItems.slice(-visibleItemsLimit)` —
+          // the LAST N items. Prepended older items land at the START of
+          // the array, so without expanding the limit they'd never
+          // actually render and the chat would visually be unchanged
+          // (and the scroll-restore would no-op against an unchanged
+          // DOM). Grow the limit by exactly the number of newly-added
+          // historic items so the visible window now also covers the
+          // older page. We don't shrink it past `prev` — other code
+          // may have already grown it for unrelated reasons.
+          const addedHistoricItems = newHistoricItems.length - oldHistoricCount;
+          if (addedHistoricItems > 0) {
+            setVisibleItemsLimit((prev) => prev + addedHistoricItems);
+          }
+
           setOlderLoadState({
             missionId: id,
             hasMore: computeHasMoreOlder(id),
@@ -8076,21 +8090,6 @@ export default function ControlClient() {
           )}
 
           <button
-            onClick={() => setShowAutomationsDialog(true)}
-            disabled={!activeMission}
-            className={cn(
-              "flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm transition-colors",
-              activeMission
-                ? "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]"
-                : "border-white/[0.04] bg-white/[0.01] text-white/30 cursor-not-allowed"
-            )}
-            title={activeMission ? "Manage mission automations" : "Select a mission to manage automations"}
-          >
-            <Clock className="h-4 w-4" />
-            <span className="hidden lg:inline">Automations</span>
-          </button>
-
-          <button
             onClick={() => setShowWorkbenchPanel((prev) => !prev)}
             className={cn(
               "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
@@ -9168,7 +9167,7 @@ export default function ControlClient() {
                 onOpenSwitcher={() => setShowMissionSwitcher(true)}
                 onViewMission={handleViewMission}
                 onSetStatus={handleSetStatus}
-                className={showThinkingPanel || showDesktopStream || (showWorkerPanel && isBossMission) ? "flex-shrink-0 max-h-[40%]" : "flex-1"}
+                className="flex-1 min-h-0"
               />
             )}
 

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -177,6 +177,10 @@ export async function getMissionEvents(
     /** When set, request only events with `sequence > sinceSeq`.
      * Takes precedence over `offset`/`latest` on the server. */
     sinceSeq?: number;
+    /** When set, request only events with `sequence < beforeSeq`,
+     * returned ASC. Takes precedence over `sinceSeq`/`offset`/`latest`.
+     * Used for backwards pagination. */
+    beforeSeq?: number;
   }
 ): Promise<StoredEvent[]> {
   const { events } = await getMissionEventsWithMeta(id, options);
@@ -208,6 +212,7 @@ export async function getMissionEventsWithMeta(
     offset?: number;
     latest?: boolean;
     sinceSeq?: number;
+    beforeSeq?: number;
   }
 ): Promise<{ events: StoredEvent[]; meta: MissionEventsMeta }> {
   const params = new URLSearchParams();
@@ -216,6 +221,7 @@ export async function getMissionEventsWithMeta(
   if (options?.offset) params.set("offset", String(options.offset));
   if (options?.latest) params.set("latest", "true");
   if (options?.sinceSeq !== undefined) params.set("since_seq", String(options.sinceSeq));
+  if (options?.beforeSeq !== undefined) params.set("before_seq", String(options.beforeSeq));
   const query = params.toString();
   const res = await apiFetch(
     `/api/control/missions/${id}/events${query ? `?${query}` : ""}`

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4480,6 +4480,13 @@ pub struct GetEventsQuery {
     /// Takes precedence over `offset`/`latest` when provided.
     #[serde(default)]
     pub since_seq: Option<i64>,
+    /// If set, return only events with `sequence < before_seq`, ordered
+    /// by sequence ASC (oldest first). Used by the client for backwards
+    /// pagination — pass the lowest sequence already seen to fetch the
+    /// next page of older events. Takes precedence over `since_seq` /
+    /// `offset` / `latest` when provided.
+    #[serde(default)]
+    pub before_seq: Option<i64>,
 }
 
 /// Get events for a mission (for debugging/replay).
@@ -4513,7 +4520,13 @@ pub async fn get_mission_events(
         .as_ref()
         .map(|s| s.split(',').map(|t| t.trim()).collect());
 
-    let events = if let Some(since_seq) = query.since_seq {
+    let events = if let Some(before_seq) = query.before_seq {
+        control
+            .mission_store
+            .get_events_before(mission_id, before_seq, types.as_deref(), query.limit)
+            .await
+            .map_err(internal_error)?
+    } else if let Some(since_seq) = query.since_seq {
         control
             .mission_store
             .get_events_since(mission_id, since_seq, types.as_deref(), query.limit)

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -936,6 +936,22 @@ pub trait MissionStore: Send + Sync {
         Ok(vec![])
     }
 
+    /// Get events with `sequence < before_seq`, ordered by sequence ASC.
+    /// Used by the client for backwards pagination — load the most
+    /// recent N events first (`latest=true`), then page older by
+    /// passing the lowest sequence already seen as `before_seq`.
+    /// Sequence-based so it's robust against concurrent inserts.
+    async fn get_events_before(
+        &self,
+        mission_id: Uuid,
+        before_seq: i64,
+        event_types: Option<&[&str]>,
+        limit: Option<usize>,
+    ) -> Result<Vec<StoredEvent>, String> {
+        let _ = (mission_id, before_seq, event_types, limit);
+        Ok(vec![])
+    }
+
     /// Count events for a mission, optionally filtered by type.
     async fn count_events(
         &self,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3323,6 +3323,99 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn get_events_before(
+        &self,
+        mission_id: Uuid,
+        before_seq: i64,
+        event_types: Option<&[&str]>,
+        limit: Option<usize>,
+    ) -> Result<Vec<StoredEvent>, String> {
+        let conn = self.conn.clone();
+        let mid = mission_id.to_string();
+        let types: Option<Vec<String>> =
+            event_types.map(|t| t.iter().map(|s| s.to_string()).collect());
+        let limit = limit.unwrap_or(50000) as i64;
+
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+
+            // We want the N events immediately preceding `before_seq`,
+            // but in chronological (ASC) order so the client can prepend
+            // them without re-sorting. SQLite has no `ORDER BY DESC LIMIT
+            // ... ORDER BY ASC` form, so do the DESC selection in a
+            // subquery and reverse it in the outer query.
+            let query = if types.is_some() {
+                "SELECT id, mission_id, sequence, event_type, timestamp, event_id, tool_call_id, tool_name, content, content_file, metadata
+                 FROM (
+                   SELECT id, mission_id, sequence, event_type, timestamp, event_id, tool_call_id, tool_name, content, content_file, metadata
+                   FROM mission_events
+                   WHERE mission_id = ?1 AND sequence < ?2 AND event_type IN (SELECT value FROM json_each(?3))
+                   ORDER BY sequence DESC
+                   LIMIT ?4
+                 )
+                 ORDER BY sequence ASC"
+            } else {
+                "SELECT id, mission_id, sequence, event_type, timestamp, event_id, tool_call_id, tool_name, content, content_file, metadata
+                 FROM (
+                   SELECT id, mission_id, sequence, event_type, timestamp, event_id, tool_call_id, tool_name, content, content_file, metadata
+                   FROM mission_events
+                   WHERE mission_id = ?1 AND sequence < ?2
+                   ORDER BY sequence DESC
+                   LIMIT ?3
+                 )
+                 ORDER BY sequence ASC"
+            };
+
+            fn parse_row(row: &rusqlite::Row<'_>) -> Result<StoredEvent, rusqlite::Error> {
+                let content: Option<String> = row.get(8)?;
+                let content_file: Option<String> = row.get(9)?;
+                let full_content = SqliteMissionStore::load_content(content.as_deref(), content_file.as_deref());
+                let metadata_str: String = row.get::<_, Option<String>>(10)?.unwrap_or_else(|| "{}".to_string());
+                let mid_str: String = row.get(1)?;
+
+                Ok(StoredEvent {
+                    id: row.get(0)?,
+                    mission_id: parse_uuid_or_nil(&mid_str),
+                    sequence: row.get(2)?,
+                    event_type: row.get(3)?,
+                    timestamp: row.get(4)?,
+                    event_id: row.get(5)?,
+                    tool_call_id: row.get(6)?,
+                    tool_name: row.get(7)?,
+                    content: full_content,
+                    metadata: serde_json::from_str(&metadata_str).unwrap_or(serde_json::json!({})),
+                })
+            }
+
+            let events: Vec<StoredEvent> = if let Some(types) = types {
+                let types_json = serde_json::to_string(&types).unwrap_or_else(|_| "[]".to_string());
+                let mut stmt = conn.prepare(query).map_err(|e| e.to_string())?;
+                let rows = stmt
+                    .query_map(params![&mid, before_seq, &types_json, limit], parse_row)
+                    .map_err(|e| e.to_string())?;
+                let mut result = Vec::new();
+                for row in rows {
+                    result.push(row.map_err(|e| e.to_string())?);
+                }
+                result
+            } else {
+                let mut stmt = conn.prepare(query).map_err(|e| e.to_string())?;
+                let rows = stmt
+                    .query_map(params![&mid, before_seq, limit], parse_row)
+                    .map_err(|e| e.to_string())?;
+                let mut result = Vec::new();
+                for row in rows {
+                    result.push(row.map_err(|e| e.to_string())?);
+                }
+                result
+            };
+
+            Ok(events)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn max_event_sequence(&self, mission_id: Uuid) -> Result<i64, String> {
         let conn = self.conn.clone();
         let mid = mission_id.to_string();
@@ -8039,6 +8132,111 @@ mod tests {
         for e in &assistants_only {
             assert_eq!(e.event_type, "assistant_message");
         }
+    }
+
+    #[tokio::test]
+    async fn get_events_before_returns_only_events_below_seq_in_ascending_order() {
+        use crate::api::control::AgentEvent;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("before test"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        for i in 0..5 {
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::UserMessage {
+                        id: Uuid::new_v4(),
+                        content: format!("msg {i}"),
+                        queued: false,
+                        mission_id: Some(mission.id),
+                    },
+                )
+                .await
+                .expect("log user message");
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::AssistantMessage {
+                        id: Uuid::new_v4(),
+                        content: format!("reply {i}"),
+                        success: true,
+                        cost_cents: 0,
+                        cost_source: CostSource::Unknown,
+                        usage: None,
+                        model: None,
+                        model_normalized: None,
+                        mission_id: Some(mission.id),
+                        shared_files: None,
+                        resumable: false,
+                    },
+                )
+                .await
+                .expect("log assistant");
+        }
+
+        // before_seq=11 returns all 10 events, ordered ASC.
+        let all = store
+            .get_events_before(mission.id, 11, None, None)
+            .await
+            .expect("get_events_before all");
+        assert_eq!(all.len(), 10);
+        let seqs: Vec<i64> = all.iter().map(|e| e.sequence).collect();
+        assert_eq!(seqs, (1..=10).collect::<Vec<_>>());
+
+        // before_seq=6 returns sequences 1..=5, ordered ASC.
+        let head = store
+            .get_events_before(mission.id, 6, None, None)
+            .await
+            .expect("get_events_before head");
+        assert_eq!(head.len(), 5);
+        assert_eq!(head.first().map(|e| e.sequence), Some(1));
+        assert_eq!(head.last().map(|e| e.sequence), Some(5));
+
+        // before_seq=1 returns empty (caller already at the start).
+        let empty = store
+            .get_events_before(mission.id, 1, None, None)
+            .await
+            .expect("get_events_before empty");
+        assert!(empty.is_empty());
+
+        // With limit=3 and before_seq=11 we want the 3 events IMMEDIATELY
+        // preceding seq=11 — i.e. seqs 8, 9, 10 — returned in ASC order.
+        // This is the contract that drives backwards pagination: each page
+        // must be the latest N below the cursor, then sorted oldest-first.
+        let last_three = store
+            .get_events_before(mission.id, 11, None, Some(3))
+            .await
+            .expect("get_events_before limited");
+        assert_eq!(last_three.len(), 3);
+        assert_eq!(
+            last_three.iter().map(|e| e.sequence).collect::<Vec<_>>(),
+            vec![8, 9, 10]
+        );
+
+        // event_types filter narrows further (asks for only the assistant
+        // events strictly before seq=11; sequences 2,4,6,8,10).
+        let assistants_only = store
+            .get_events_before(mission.id, 11, Some(&["assistant_message"]), None)
+            .await
+            .expect("get_events_before types");
+        assert_eq!(assistants_only.len(), 5);
+        for e in &assistants_only {
+            assert_eq!(e.event_type, "assistant_message");
+        }
+        assert_eq!(
+            assistants_only
+                .iter()
+                .map(|e| e.sequence)
+                .collect::<Vec<_>>(),
+            vec![2, 4, 6, 8, 10]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Toggling Thinking on a long mission blocked the main thread ~5.8s. Wrapped `showThinkingPanel` in `useDeferredValue` before feeding `deriveItemViews`, so the click + panel mount stay urgent (<100ms) while the chat-list regrouping runs as a concurrent transition.
- Workbench panel now uses `flex-1 min-h-0` so it fills the right column instead of being capped at `max-h-[40%]` when stacked with another panel.
- Removed the redundant Automations toolbar button — the Workbench panel exposes the same action under "Actions".

## Measurements (mission with hundreds of tool calls)
| Action | Before | After |
|---|---|---|
| TH toggle click → button reflects state | ~6s | 56–93ms |
| TH toggle click → panel mounts | ~6s | ~100ms |
| Background regrouping | 5.8s blocking | 5–8s, interruptible |
| CLS during toggles | 0 | 0 |

## Test plan
- [x] Type-check (`tsc --noEmit`) passes
- [x] Manual perf trace via Playwright on `/control?mission=...` — long task during click stayed under 100ms after fix
- [x] Visual: Workbench + Thinking layout fills the column without overflow
- [ ] Verify on iOS app (no equivalent toolbar/panel changes there)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new event-pagination query path (`before_seq`) across client+server and rewires chat history rendering/state to prepend pages while preserving scroll, which could surface subtle ordering/linkage bugs on long missions. Changes are localized to mission events fetching/rendering and include tests for the new store query.
> 
> **Overview**
> Enables **backwards pagination** in the Control chat: initial history loads are capped to `HISTORY_PAGE_SIZE`, with a new **“Load older messages”** button that fetches older events (`before_seq`), prepends them while preserving scroll position, and avoids clipping queued/SSE-appended tail items.
> 
> Adds `before_seq` support end-to-end (`getMissionEventsWithMeta` query param, `GetEventsQuery` handling, `MissionStore::get_events_before` + SQLite implementation) and covers it with a new unit test.
> 
> Improves perceived UI responsiveness by feeding `showThinkingPanel` through `useDeferredValue` for heavy `deriveItemViews` recomputation, adjusts Workbench panel sizing, and removes the redundant Automations toolbar button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6673ad923af22a4b19db5dfdcb3995a1fe3493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->