### PR TITLE
fix(ios): unique ids for thinking/phase messages

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -3826,19 +3826,6 @@ private struct ThoughtsSheet: View {
                 } else {
                     ScrollView {
                         VStack(spacing: 14) {
-                            HStack(spacing: 10) {
-                                ThoughtSummaryCard(
-                                    title: "Active",
-                                    value: "\(activeThoughts.count)",
-                                    tint: hasActiveThinking ? Theme.accent : Theme.textMuted
-                                )
-                                ThoughtSummaryCard(
-                                    title: "Completed",
-                                    value: "\(completedThoughts.count)",
-                                    tint: Theme.success
-                                )
-                            }
-
                             if !activeThoughts.isEmpty {
                                 ThoughtSection(title: "Thinking Now", icon: "brain") {
                                     ForEach(activeThoughts) { msg in
@@ -3880,27 +3867,6 @@ private struct ThoughtsSheet: View {
                 }
             }
         }
-    }
-}
-
-private struct ThoughtSummaryCard: View {
-    let title: String
-    let value: String
-    let tint: Color
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(Theme.textMuted)
-            Text(value)
-                .font(.headline.monospacedDigit())
-                .foregroundStyle(tint)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(10)
-        .background(Theme.backgroundSecondary)
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 }
 
@@ -4870,25 +4836,71 @@ private struct MissionRow: View {
         }
     }
 
+    /// Whether the visible name above the title is just the 8-char short id.
+    /// In that case we suppress it: the title carries the meaning and the short
+    /// id can live in the trailing metadata as a caption.
+    private var displayLabelIsShortId: Bool {
+        let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed == nil || trimmed?.isEmpty == true
+    }
+
+    /// "<description> · <backend>" collapsed onto one line so we don't stack
+    /// four lineLimit-1 captions in a narrow row.
+    private var secondaryMetadataLine: String? {
+        var parts: [String] = []
+        if let shortDescription = shortDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !shortDescription.isEmpty {
+            parts.append(shortDescription)
+        }
+        if let backend = backend?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !backend.isEmpty {
+            parts.append(backend)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var trailingStatusPill: some View {
+        Group {
+            if isRunning, let state = runningState {
+                Text(state)
+                    .font(.caption2)
+                    .foregroundStyle(Theme.textMuted)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Theme.backgroundSecondary)
+                    .clipShape(Capsule())
+            } else {
+                Text(status.displayLabel)
+                    .font(.caption2)
+                    .foregroundStyle(statusColor)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(statusColor.opacity(0.1))
+                    .clipShape(Capsule())
+            }
+        }
+    }
+
     var body: some View {
         Button {
             onSelect()
             HapticService.selectionChanged()
         } label: {
             HStack(spacing: 12) {
-                // Status icon indicator
                 Image(systemName: statusIcon)
                     .font(.system(size: 18))
                     .foregroundStyle(statusColor)
                     .symbolEffect(.pulse, options: (isRunning && runningState == "running") ? .repeating : .nonRepeating)
                     .frame(width: 24, height: 24)
 
-                // Mission info
                 VStack(alignment: .leading, spacing: 2) {
+                    // Title (or short id when there is no title) is the primary
+                    // line. The viewing checkmark sits right next to it.
                     HStack(spacing: 6) {
-                        Text(missionDisplayLabel)
-                            .font(.subheadline.monospaced().weight(.medium))
+                        Text(title?.isEmpty == false ? title! : shortId)
+                            .font(.subheadline.weight(.medium))
                             .foregroundStyle(Theme.textPrimary)
+                            .lineLimit(1)
 
                         if isViewing {
                             Image(systemName: "checkmark.circle.fill")
@@ -4897,82 +4909,78 @@ private struct MissionRow: View {
                         }
                     }
 
-                    if let title = title, !title.isEmpty {
-                        Text(title)
-                            .font(.caption)
+                    // Secondary line: optional human display name when distinct
+                    // from the short id, plus collapsed description+backend.
+                    if !displayLabelIsShortId,
+                       let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                       !displayName.isEmpty,
+                       displayName != title {
+                        Text(displayName)
+                            .font(.caption.monospaced())
                             .foregroundStyle(Theme.textSecondary)
                             .lineLimit(1)
                     }
 
-                    if let shortDescription = shortDescription, !shortDescription.isEmpty {
-                        Text(shortDescription)
+                    if let secondaryMetadataLine {
+                        Text(secondaryMetadataLine)
                             .font(.caption2)
                             .foregroundStyle(Theme.textMuted)
                             .lineLimit(1)
-                    }
-
-                    if let backend = backend?.trimmingCharacters(in: .whitespacesAndNewlines), !backend.isEmpty {
-                        Text(backend)
-                            .font(.caption2.monospaced())
-                            .foregroundStyle(Theme.textMuted)
-                            .lineLimit(1)
+                            .truncationMode(.tail)
                     }
                 }
 
-                Spacer()
+                Spacer(minLength: 8)
 
-                // Running state or status
-                if isRunning, let state = runningState {
-                    Text(state)
-                        .font(.caption2)
-                        .foregroundStyle(Theme.textMuted)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Theme.backgroundSecondary)
-                        .clipShape(Capsule())
-                } else {
-                    Text(status.displayLabel)
-                        .font(.caption2)
-                        .foregroundStyle(statusColor)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(statusColor.opacity(0.1))
-                        .clipShape(Capsule())
-                }
-
-                if !quickActions.isEmpty, let onQuickAction {
-                    ForEach(quickActions, id: \.self) { action in
-                        Button {
-                            onQuickAction(action)
-                            HapticService.lightTap()
-                        } label: {
-                            Label(action.label, systemImage: action.icon)
-                                .font(.caption2.weight(.semibold))
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(Theme.accent.opacity(0.14))
-                                .foregroundStyle(Theme.accent)
-                                .clipShape(Capsule())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-
-                // Cancel button for running missions
-                if let onCancel = onCancel {
-                    Button {
-                        onCancel()
-                        HapticService.lightTap()
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(Theme.textMuted)
-                    }
-                    .buttonStyle(.plain)
-                }
+                trailingStatusPill
             }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            // Cancel ships first so it occupies the leftmost (closest)
+            // trailing slot when the user swipes — matches Mail's destructive
+            // affordance placement.
+            if let onCancel {
+                Button(role: .destructive) {
+                    onCancel()
+                    HapticService.lightTap()
+                } label: {
+                    Label("Cancel", systemImage: "xmark.circle.fill")
+                }
+            }
+            if let onQuickAction {
+                ForEach(quickActions, id: \.self) { action in
+                    Button {
+                        onQuickAction(action)
+                        HapticService.lightTap()
+                    } label: {
+                        Label(action.label, systemImage: action.icon)
+                    }
+                    .tint(Theme.accent)
+                }
+            }
+        }
+        .contextMenu {
+            // Long-press fallback: keeps every action discoverable for
+            // accessibility and for users who don't know about swipes.
+            if let onQuickAction {
+                ForEach(quickActions, id: \.self) { action in
+                    Button {
+                        onQuickAction(action)
+                    } label: {
+                        Label(action.label, systemImage: action.icon)
+                    }
+                }
+            }
+            if let onCancel {
+                Button(role: .destructive) {
+                    onCancel()
+                } label: {
+                    Label("Cancel Mission", systemImage: "xmark.circle.fill")
+                }
+            }
+        }
     }
 }
 

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -2567,17 +2567,20 @@ struct ControlView: View {
                 break
             }
 
-            // Remove phase items when thinking starts
-            messages.removeAll { $0.isPhase }
-
             // Skip if we've already seen this server-supplied event id —
             // delta resume can re-deliver completed thinking events we already
             // appended, and the active-message fast path won't catch them
-            // because the existing one is already `done: true`.
+            // because the existing one is already `done: true`. Run this
+            // *before* stripping phase messages, otherwise a duplicate-event
+            // break would silently clear a still-relevant `agent_phase`
+            // indicator without adding any new content.
             let eventId = data["id"] as? String
             if let eventId, messages.contains(where: { $0.id == eventId }) {
                 break
             }
+
+            // Remove phase items now that we know we're committing this event.
+            messages.removeAll { $0.isPhase }
 
             // Find existing active thinking message or create new
             if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -2396,9 +2396,12 @@ struct ControlView: View {
                 timestamp: existing.timestamp
             )
         } else {
+            // Append a UUID-suffixed id so concurrent fallback thoughts can't collide
+            // and crash the Thoughts sheet's `ForEach`. The "stream-thinking-" prefix
+            // is preserved because `isStreamingFallbackThought` still checks it.
             messages.append(
                 ChatMessage(
-                    id: "\(streamingThoughtPrefix)\(Date().timeIntervalSince1970)",
+                    id: "\(streamingThoughtPrefix)\(UUID().uuidString)",
                     type: .thinking(done: done, startTime: Date()),
                     content: content
                 )
@@ -2580,28 +2583,36 @@ struct ControlView: View {
                     timestamp: existing.timestamp
                 )
             } else {
-                // Create new thinking message - whether done or not
-                // This handles the case where we receive a completed thought without seeing it active first
-                // (e.g., when joining a mission mid-thought or reconnecting)
+                // Create new thinking message - whether done or not.
+                // Handles the case where we receive a completed thought without seeing it
+                // active first (joining mid-thought or reconnecting).
+                //
+                // Prefer the server-supplied event id when available; otherwise fall back
+                // to a UUID. A wall-clock-second id can collide during history replay
+                // (many thinking events landing in the same instant), which then crashes
+                // the Thoughts sheet's `ForEach` with a duplicate-id assertion.
+                let eventId = data["id"] as? String
+                let messageId = eventId ?? "thinking-\(UUID().uuidString)"
                 let message = ChatMessage(
-                    id: "thinking-\(Date().timeIntervalSince1970)",
+                    id: messageId,
                     type: .thinking(done: done, startTime: Date()),
                     content: content
                 )
                 messages.append(message)
             }
-            
+
         case "agent_phase":
             let phase = data["phase"] as? String ?? ""
             let detail = data["detail"] as? String
             let agent = data["agent"] as? String
-            
+
             // Remove existing phase messages
             messages.removeAll { $0.isPhase }
-            
-            // Add new phase message
+
+            // Add new phase message. UUID-suffixed id so back-to-back phase events in the
+            // same instant cannot collide and crash a `ForEach`.
             let message = ChatMessage(
-                id: "phase-\(Date().timeIntervalSince1970)",
+                id: "phase-\(UUID().uuidString)",
                 type: .phase(phase: phase, detail: detail, agent: agent),
                 content: ""
             )

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -2570,7 +2570,16 @@ struct ControlView: View {
             // Remove phase items when thinking starts
             messages.removeAll { $0.isPhase }
 
-            // Find existing thinking message or create new
+            // Skip if we've already seen this server-supplied event id —
+            // delta resume can re-deliver completed thinking events we already
+            // appended, and the active-message fast path won't catch them
+            // because the existing one is already `done: true`.
+            let eventId = data["id"] as? String
+            if let eventId, messages.contains(where: { $0.id == eventId }) {
+                break
+            }
+
+            // Find existing active thinking message or create new
             if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
                 let existing = messages[index]
                 let existingStartTime = existing.thinkingStartTime ?? existing.timestamp
@@ -2591,7 +2600,6 @@ struct ControlView: View {
                 // to a UUID. A wall-clock-second id can collide during history replay
                 // (many thinking events landing in the same instant), which then crashes
                 // the Thoughts sheet's `ForEach` with a duplicate-id assertion.
-                let eventId = data["id"] as? String
                 let messageId = eventId ?? "thinking-\(UUID().uuidString)"
                 let message = ChatMessage(
                     id: messageId,
@@ -4797,14 +4805,6 @@ private struct MissionRow: View {
         String(missionId.prefix(8))
     }
 
-    private var missionDisplayLabel: String {
-        let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let trimmed, !trimmed.isEmpty {
-            return trimmed
-        }
-        return shortId
-    }
-
     private var statusColor: Color {
         if isRunning {
             return Theme.success
@@ -4836,12 +4836,17 @@ private struct MissionRow: View {
         }
     }
 
-    /// Whether the visible name above the title is just the 8-char short id.
-    /// In that case we suppress it: the title carries the meaning and the short
-    /// id can live in the trailing metadata as a caption.
+    /// Whether the supplied `displayName` is just the uppercased short id.
+    /// `missionDisplayName(for:)` always returns at least the uppercased
+    /// 8-char short id (with an optional `"<workspace> · "` prefix), so we
+    /// can't detect the bare-id case by checking for nil/empty — we have to
+    /// compare against the actual short id. When it matches we suppress the
+    /// secondary line: the title above already carries the meaning.
     private var displayLabelIsShortId: Bool {
-        let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed == nil || trimmed?.isEmpty == true
+        guard let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return true }
+        return trimmed.caseInsensitiveCompare(shortId) == .orderedSame
     }
 
     /// "<description> · <backend>" collapsed onto one line so we don't stack


### PR DESCRIPTION
## Summary
Tapping the Thoughts tab on a long mission could crash the iOS app with a SwiftUI `ForEach` duplicate-id trap.

`ChatMessage` ids for new thinking and `agent_phase` messages were generated as `thinking-\(Date().timeIntervalSince1970)` (and similar). During history replay many events arrive in the same instant, so two messages can land with identical ids — `ForEach(thinkingMessages)` in `ThoughtsSheet` then aborts as soon as the sheet is presented.

## Fix
- For `case "thinking"` we now prefer the server-supplied `event_id` when present, otherwise fall back to `UUID().uuidString`.
- The streaming fallback thought keeps its `stream-thinking-` prefix (still checked by `isStreamingFallbackThought`) but uses a UUID suffix.
- `agent_phase` ids switch from a wall-clock-second suffix to a UUID for the same reason.

## Test plan
- [x] `xcodebuild` BUILD SUCCEEDED for iPhone 17 Pro Simulator
- [x] App relaunched on the simulator after install
- [ ] Tap Thoughts on the affected mission (`EVM Lean Yul Inte…`) — no crash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to SwiftUI message-id generation/dedup and mission-row presentation, with no backend/API contract changes. Main risk is subtle UI regressions in the Thoughts sheet or mission switcher row interactions.
> 
> **Overview**
> Prevents a SwiftUI `ForEach` duplicate-id crash in the Thoughts sheet by switching `thinking`, streaming fallback thinking, and `agent_phase` message ids from time-based strings to **server event ids when available** or **UUID-based** ids, and by skipping already-seen `thinking` events during delta resume.
> 
> Simplifies the Thoughts sheet UI by removing the active/completed summary cards.
> 
> Refactors `MissionRow` in the mission switcher to reduce cramped metadata (collapse description+backend into one line), adjust primary/secondary labeling, and adds swipe actions plus a context menu for quick actions and mission cancel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15607a75a0e40b2379e2b8625c08e75e743ce42f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->