### PR TITLE
feat(shutdown): distinguish server-shutdown from user cancel

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -7524,7 +7524,7 @@ export default function ControlClient() {
         }
 
         // If the mission is in a resumable state (failed/interrupted/blocked),
-        // resume it first to update the status before sending the message.
+        // Resume/sync it first before sending the message.
         // Use skipMessage to avoid the automatic resume message
         // since the user is about to send their own custom message.
         if (["failed", "interrupted", "blocked"].includes(mission.status)) {

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3684,10 +3684,10 @@ export default function ControlClient() {
    * (so a later "load older" page-replace can find the live tail) and
    * publishes the "more older messages exist" state to the UI.
    */
-  // `historyItemsLen` MUST count only items derived from server events
-  // (i.e. the result of `eventsToItems` / `missionHistoryToItems`), NOT
-  // the post-queue-merge length. `loadOlderHistoryEvents` later splices
-  // via `prev.slice(oldHistoricCount)`; if queued messages were counted
+  // `historyItemsLen` MUST count only the history-derived prefix
+  // (event replay plus any coarse mission-history fallback), NOT the
+  // post-queue-merge length. `loadOlderHistoryEvents` later splices via
+  // `prev.slice(oldHistoricCount)`; if queued messages were counted
   // here, they'd land before the splice point, get rebuilt by
   // `eventsToItems` (which doesn't see queued messages), and silently
   // disappear from the UI on the next page-back.
@@ -4452,6 +4452,35 @@ export default function ControlClient() {
     });
   }, []);
 
+  const mergeEventItemsWithMissionHistoryFallback = useCallback(
+    (eventItems: ChatItem[], mission: Mission): ChatItem[] => {
+      if (eventItems.some((item) => item.kind === "assistant")) {
+        return eventItems;
+      }
+
+      const historyHasAssistant = mission.history.some((entry) => entry.role === "assistant");
+      if (!historyHasAssistant) {
+        return eventItems;
+      }
+
+      const basicItems = missionHistoryToItems(mission);
+      if (eventItems.length === 0) {
+        return basicItems;
+      }
+
+      // Long Codex `/goal` missions can spend thousands of events in
+      // tool/thinking/status loops without a fresh assistant_message.
+      // The latest event page is still valuable: it contains the
+      // completed thought history and tool rows. Keep that replay and
+      // prepend coarse mission history so the chat still has prior
+      // user/assistant context.
+      const basicIds = new Set(basicItems.map((item) => item.id));
+      const eventOnlyItems = eventItems.filter((item) => !basicIds.has(item.id));
+      return [...basicItems, ...eventOnlyItems];
+    },
+    [missionHistoryToItems]
+  );
+
   // Convert stored events (from SQLite) to ChatItems for display
   // This enables full history replay including tool calls on page refresh
   const eventsToItems = useCallback((events: StoredEvent[], mission?: Mission | null): ChatItem[] => {
@@ -4965,15 +4994,9 @@ export default function ControlClient() {
           }
         }
         // Use events if available, otherwise fall back to basic history
-        let historyItems = events ? eventsToItems(events, mission) : missionHistoryToItems(mission);
-        if (events && !historyItems.some((item) => item.kind === "assistant")) {
-          const historyHasAssistant = mission.history.some(
-            (entry) => entry.role === "assistant"
-          );
-          if (historyHasAssistant) {
-            historyItems = missionHistoryToItems(mission);
-          }
-        }
+        let historyItems = events
+          ? mergeEventItemsWithMissionHistoryFallback(eventsToItems(events, mission), mission)
+          : missionHistoryToItems(mission);
         // Capture the events-derived count BEFORE the queue merge — this is
         // what `loadOlderHistoryEvents` needs to find the live tail
         // correctly (see `seedPaginationStateAfterInitialLoad`).
@@ -5056,15 +5079,10 @@ export default function ControlClient() {
           Promise.all([loadHistoryEvents(mission.id), getQueue().catch(() => [])])
             .then(([events, queuedMessages]) => {
               if (cancelled) return;
-              let historyItems = eventsToItems(events, mission);
-              if (!historyItems.some((item) => item.kind === "assistant")) {
-                const historyHasAssistant = mission.history.some(
-                  (entry) => entry.role === "assistant"
-                );
-                if (historyHasAssistant) {
-                  historyItems = missionHistoryToItems(mission);
-                }
-              }
+              let historyItems = mergeEventItemsWithMissionHistoryFallback(
+                eventsToItems(events, mission),
+                mission
+              );
               // Capture pre-queue length so pagination doesn't clip
               // queued items (see `seedPaginationStateAfterInitialLoad`).
               const historicEventsLen = historyItems.length;
@@ -5121,6 +5139,8 @@ export default function ControlClient() {
     searchParams,
     router,
     missionHistoryToItems,
+    mergeEventItemsWithMissionHistoryFallback,
+    eventsToItems,
     adjustVisibleItemsLimit,
     loadHistoryEvents,
     seedPaginationStateAfterInitialLoad,
@@ -5456,15 +5476,9 @@ export default function ControlClient() {
         }
 
         // Use events if available, otherwise fall back to basic history
-        let historyItems = events ? eventsToItems(events, mission) : missionHistoryToItems(mission);
-        if (events && !historyItems.some((item) => item.kind === "assistant")) {
-          const historyHasAssistant = mission.history.some(
-            (entry) => entry.role === "assistant"
-          );
-          if (historyHasAssistant) {
-            historyItems = missionHistoryToItems(mission);
-          }
-        }
+        let historyItems = events
+          ? mergeEventItemsWithMissionHistoryFallback(eventsToItems(events, mission), mission)
+          : missionHistoryToItems(mission);
 
         // Capture pre-queue length so pagination doesn't clip queued items
         // (see `seedPaginationStateAfterInitialLoad`).
@@ -5543,11 +5557,14 @@ export default function ControlClient() {
     [
       missionItems,
       missionHistoryToItems,
+      mergeEventItemsWithMissionHistoryFallback,
       eventsToItems,
       applyDesktopSessionState,
+      applyDesktopSessionFromEvents,
       adjustVisibleItemsLimit,
       loadHistoryEvents,
       seedPaginationStateAfterInitialLoad,
+      updateMissionItems,
       router,
     ]
   );
@@ -5956,15 +5973,10 @@ export default function ControlClient() {
       // Load full events in background (including tool calls)
       loadHistoryEvents(resumed.id)
         .then((events) => {
-          let fullItems = eventsToItems(events, resumed);
-          if (!fullItems.some((item) => item.kind === "assistant")) {
-            const historyHasAssistant = resumed.history.some(
-              (entry) => entry.role === "assistant"
-            );
-            if (historyHasAssistant) {
-              fullItems = missionHistoryToItems(resumed);
-            }
-          }
+          const fullItems = mergeEventItemsWithMissionHistoryFallback(
+            eventsToItems(events, resumed),
+            resumed
+          );
           setItems(fullItems);
           adjustVisibleItemsLimit(fullItems);
           updateMissionItems(resumed.id, fullItems);
@@ -7779,16 +7791,8 @@ export default function ControlClient() {
         if (viewingMissionIdRef.current !== missionId) return;
 
         let historyItems = events
-          ? eventsToItems(events, mission)
+          ? mergeEventItemsWithMissionHistoryFallback(eventsToItems(events, mission), mission)
           : missionHistoryToItems(mission);
-        if (events && !historyItems.some((item) => item.kind === "assistant")) {
-          const historyHasAssistant = mission.history.some(
-            (entry) => entry.role === "assistant"
-          );
-          if (historyHasAssistant) {
-            historyItems = missionHistoryToItems(mission);
-          }
-        }
 
         // Pre-queue length: pagination uses this to find the live tail
         // without clipping queued items (see `seedPaginationStateAfterInitialLoad`).
@@ -7832,6 +7836,7 @@ export default function ControlClient() {
       loadHistoryEvents,
       eventsToItems,
       missionHistoryToItems,
+      mergeEventItemsWithMissionHistoryFallback,
       adjustVisibleItemsLimit,
       seedPaginationStateAfterInitialLoad,
       updateMissionItems,

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -7525,7 +7525,7 @@ export default function ControlClient() {
 
         // If the mission is in a resumable state (failed/interrupted/blocked),
         // resume it first to update the status before sending the message.
-        // Use skipMessage to avoid the auto-generated "MISSION RESUMED" message
+        // Use skipMessage to avoid the automatic resume message
         // since the user is about to send their own custom message.
         if (["failed", "interrupted", "blocked"].includes(mission.status)) {
           mission = await resumeMission(mission.id, { skipMessage: true });

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type React from "react";
 import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback, memo, startTransition } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { toast } from "@/components/toast";
@@ -1894,6 +1895,7 @@ function MissionWorkbenchPanel({
   onOpenSwitcher,
   onViewMission,
   onSetStatus,
+  runSettingsSlot,
   className,
 }: {
   mission: Mission | null;
@@ -1908,6 +1910,12 @@ function MissionWorkbenchPanel({
   onOpenSwitcher: () => void;
   onViewMission: (missionId: string) => void;
   onSetStatus: (status: MissionStatus) => void;
+  /**
+   * Optional slot for the mission's run-settings editor (the
+   * `<NewMissionDialog mode="edit">` trigger). Rendered next to Resume/Stop
+   * so it's accessible without a separate toolbar button.
+   */
+  runSettingsSlot?: React.ReactNode;
   className?: string;
 }) {
   const title = mission?.title?.trim() || (mission ? getMissionShortName(mission.id) : "No mission selected");
@@ -2030,6 +2038,11 @@ function MissionWorkbenchPanel({
                   <Layers className="h-3.5 w-3.5" />
                   Switch
                 </button>
+                {runSettingsSlot && (
+                  <div className="col-span-2 [&>div]:w-full [&>div>button]:w-full [&>div>button]:justify-center">
+                    {runSettingsSlot}
+                  </div>
+                )}
               </div>
             </section>
 
@@ -4079,7 +4092,13 @@ export default function ControlClient() {
       }
     } catch (error) {
       console.error("Upload failed:", error);
-      toast.error(`Failed to upload ${displayName}`);
+      const detail = error instanceof Error
+        ? error.message.replace(/^Upload failed:\s*/, "").trim()
+        : "";
+      const suffix = detail
+        ? `: ${detail.slice(0, 180)}${detail.length > 180 ? "..." : ""}`
+        : "";
+      toast.error(`Failed to upload ${displayName}${suffix}`);
     } finally {
       setUploadQueue((prev) => prev.filter((name) => name !== displayName));
       setUploadProgress(null);
@@ -8080,25 +8099,8 @@ export default function ControlClient() {
             } : undefined}
           />
 
-          {activeMission && !viewingMissionIsRunning && (
-            <NewMissionDialog
-              workspaces={workspaces}
-              disabled={missionLoading}
-              onCreate={handleUpdateMissionSettings}
-              mode="edit"
-              lockWorkspace
-              initialValues={{
-                workspaceId: activeMission.workspace_id,
-                agent: activeMission.agent || undefined,
-                backend: activeMission.backend,
-                modelOverride: activeMission.model_override || undefined,
-                modelEffort: activeMission.model_effort || undefined,
-                configProfile: activeMission.config_profile,
-              }}
-            />
-          )}
-
           <button
+            type="button"
             onClick={() => setShowWorkbenchPanel((prev) => !prev)}
             className={cn(
               "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
@@ -9176,6 +9178,25 @@ export default function ControlClient() {
                 onOpenSwitcher={() => setShowMissionSwitcher(true)}
                 onViewMission={handleViewMission}
                 onSetStatus={handleSetStatus}
+                runSettingsSlot={
+                  activeMission && !viewingMissionIsRunning ? (
+                    <NewMissionDialog
+                      workspaces={workspaces}
+                      disabled={missionLoading}
+                      onCreate={handleUpdateMissionSettings}
+                      mode="edit"
+                      lockWorkspace
+                      initialValues={{
+                        workspaceId: activeMission.workspace_id,
+                        agent: activeMission.agent || undefined,
+                        backend: activeMission.backend,
+                        modelOverride: activeMission.model_override || undefined,
+                        modelEffort: activeMission.model_effort || undefined,
+                        configProfile: activeMission.config_profile,
+                      }}
+                    />
+                  ) : undefined
+                }
                 className="flex-1 min-h-0"
               />
             )}

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -315,8 +315,11 @@ export const EnhancedInput = memo(forwardRef<EnhancedInputHandle, EnhancedInputP
     const cursorPos = textarea.selectionStart;
     const textBeforeCursor = displayValue.substring(0, cursorPos);
 
-    // Check for / command trigger at start of line or after whitespace
-    const commandMatch = textBeforeCursor.match(/(?:^|\s)(\/[\w-]*)$/);
+    // Check for / command trigger — only at the very start of the input.
+    // A `/` mid-message (e.g. inside a URL like `https://...`) shouldn't pop
+    // the autocomplete; users only ever invoke a slash command as the first
+    // token of the message.
+    const commandMatch = textBeforeCursor.match(/^(\/[\w-]*)$/);
     if (commandMatch) {
       const searchTerm = commandMatch[1].substring(1).toLowerCase();
       const filtered = commands.filter(cmd =>
@@ -329,7 +332,7 @@ export const EnhancedInput = memo(forwardRef<EnhancedInputHandle, EnhancedInputP
         source: cmd.path === 'builtin' ? 'oh-my-opencode' : cmd.path === 'builtin-claude' ? 'claude-code' : 'library',
         params: cmd.params,
       })));
-      setTriggerPosition(cursorPos - commandMatch[1].length);
+      setTriggerPosition(0);
       setShowAutocomplete(filtered.length > 0);
       setSelectedIndex(0);
 

--- a/dashboard/src/components/new-mission-dialog.test.tsx
+++ b/dashboard/src/components/new-mission-dialog.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NewMissionDialog } from './new-mission-dialog';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  getVisibleAgents: vi.fn().mockResolvedValue([]),
+  getOpenAgentConfig: vi.fn().mockResolvedValue({ hidden_agents: [] }),
+  listBackends: vi.fn().mockResolvedValue([{ id: 'codex', name: 'Codex' }]),
+  listBackendAgents: vi.fn().mockResolvedValue([{ id: 'default', name: 'Default' }]),
+  getBackendConfig: vi.fn().mockResolvedValue({ enabled: true, cli_available: true }),
+  getClaudeCodeConfig: vi.fn().mockResolvedValue({ hidden_agents: [] }),
+  getLibraryOpenCodeSettingsForProfile: vi.fn().mockResolvedValue({ agents: [] }),
+  listBackendModelOptions: vi.fn().mockResolvedValue({ backends: {} }),
+  listProviders: vi.fn().mockResolvedValue({ providers: [] }),
+}));
+
+function renderDialog(onCreate: Parameters<typeof NewMissionDialog>[0]['onCreate']) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <NewMissionDialog workspaces={[]} onCreate={onCreate} />
+    </SWRConfig>
+  );
+}
+
+describe('NewMissionDialog', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('reserves a new tab synchronously before async mission creation finishes', async () => {
+    let resolveCreate: (mission: { id: string }) => void = () => {};
+    const createPromise = new Promise<{ id: string }>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const onCreate = vi.fn(() => createPromise);
+    const reservedTab = {
+      opener: {},
+      location: { href: 'about:blank' },
+      closed: false,
+      close: vi.fn(),
+    };
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(reservedTab as unknown as Window);
+
+    renderDialog(onCreate);
+
+    fireEvent.click(screen.getByRole('button', { name: /new mission/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /new tab/i }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(reservedTab.location.href).toBe('about:blank');
+
+    resolveCreate({ id: 'mission-1' });
+
+    await waitFor(() => {
+      expect(reservedTab.location.href).toBe('/control?mission=mission-1');
+    });
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, useMemo, useCallback } from 'react';
+import type { CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import { Plus, X, ExternalLink, RefreshCw, SlidersHorizontal } from 'lucide-react';
 import useSWR from 'swr';
@@ -120,8 +122,15 @@ export function NewMissionDialog({
   const [submitting, setSubmitting] = useState(false);
   const [defaultSet, setDefaultSet] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+  const [popoverStyle, setPopoverStyle] = useState<CSSProperties | null>(null);
   const prevBackendRef = useRef<string | null>(null);
   const isEditMode = mode === 'edit';
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // SWR: fetch backends
   const { data: backends } = useSWR<Backend[]>('backends', listBackends, {
@@ -392,12 +401,41 @@ export function NewMissionDialog({
   const formatWorkspaceType = (type: Workspace['workspace_type']) =>
     type === 'host' ? 'host' : 'isolated';
 
+  const updatePopoverPosition = useCallback(() => {
+    const trigger = dialogRef.current;
+    if (!trigger || typeof window === 'undefined') return;
+
+    const rect = trigger.getBoundingClientRect();
+    const margin = 12;
+    const width = Math.min(384, window.innerWidth - margin * 2);
+    const left = Math.min(
+      Math.max(margin, rect.right - width),
+      Math.max(margin, window.innerWidth - width - margin)
+    );
+    const estimatedHeight = popoverRef.current?.offsetHeight ?? 620;
+    const spaceBelow = window.innerHeight - rect.bottom - margin;
+    const top = spaceBelow >= Math.min(estimatedHeight, 420)
+      ? rect.bottom + 4
+      : Math.max(margin, rect.top - estimatedHeight - 4);
+
+    setPopoverStyle({
+      position: 'fixed',
+      top,
+      left,
+      width,
+      zIndex: 1000,
+    });
+  }, []);
+
   // Click outside and Escape key handler
   useEffect(() => {
     if (!open) return;
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (dialogRef.current && !dialogRef.current.contains(event.target as Node)) {
+      const target = event.target as Node;
+      const clickedTrigger = dialogRef.current?.contains(target);
+      const clickedPopover = popoverRef.current?.contains(target);
+      if (!clickedTrigger && !clickedPopover) {
         setOpen(false);
         setDefaultSet(false);
         onClose?.();
@@ -419,6 +457,17 @@ export function NewMissionDialog({
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [open, onClose]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePopoverPosition();
+    window.addEventListener('resize', updatePopoverPosition);
+    window.addEventListener('scroll', updatePopoverPosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePopoverPosition);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+    };
+  }, [open, updatePopoverPosition]);
 
   // Revalidate backend model options when dialog opens to pick up chain configuration changes
   useEffect(() => {
@@ -638,8 +687,12 @@ export function NewMissionDialog({
         {isEditMode ? <SlidersHorizontal className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
         <span className="hidden lg:inline">{isEditMode ? 'Run Settings' : 'New Mission'}</span>
       </button>
-      {open && (
-        <div className="absolute right-0 top-full mt-1 w-96 rounded-lg border border-white/[0.06] bg-[#1a1a1a] p-4 shadow-xl z-50">
+      {open && mounted && popoverStyle && createPortal(
+        <div
+          ref={popoverRef}
+          style={popoverStyle}
+          className="max-h-[calc(100vh-1.5rem)] overflow-y-auto rounded-lg border border-white/[0.06] bg-[#1a1a1a] p-4 shadow-xl"
+        >
           {/* Header with refresh and close buttons */}
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-sm font-medium text-white">
@@ -770,7 +823,6 @@ export function NewMissionDialog({
                 </option>
                 {(() => {
                   // Group options by provider
-                  const providers = (providersResponse?.providers || []) as Provider[];
                   const groupedOptions = new Map<string, Array<{ value: string; label: string; description?: string; provider_id?: string }>>();
 
                   for (const option of modelOptions) {
@@ -870,7 +922,8 @@ export function NewMissionDialog({
               )}
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -641,6 +641,10 @@ export function NewMissionDialog({
 
   const handleCreate = async (openInNewTab: boolean) => {
     if (disabled || submitting) return;
+    const pendingTab = openInNewTab ? window.open('about:blank', '_blank') : null;
+    if (pendingTab) {
+      pendingTab.opener = null;
+    }
     setSubmitting(true);
     try {
       const options = getCreateOptions();
@@ -653,7 +657,18 @@ export function NewMissionDialog({
       const url = `${controlPath}?mission=${mission.id}`;
 
       if (openInNewTab) {
-        window.open(url, '_blank');
+        let opened = false;
+        if (pendingTab && !pendingTab.closed) {
+          try {
+            pendingTab.location.href = url;
+            opened = true;
+          } catch {
+            opened = false;
+          }
+        }
+        if (!opened && !window.open(url, '_blank')) {
+          router.push(url);
+        }
         setOpen(false);
         resetForm();
         onClose?.();
@@ -666,6 +681,11 @@ export function NewMissionDialog({
         resetForm();
         router.push(url);
       }
+    } catch (err) {
+      if (pendingTab && !pendingTab.closed) {
+        pendingTab.close();
+      }
+      throw err;
     } finally {
       setSubmitting(false);
     }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -4009,7 +4009,7 @@ private struct ThoughtsSheet: View {
                         LazyVStack(spacing: 14) {
                             if !activeThoughts.isEmpty {
                                 ThoughtSection(title: "Thinking Now", icon: "brain") {
-                                    ForEach(Array(activeThoughts.enumerated()), id: \.offset) { _, msg in
+                                    ForEach(activeThoughts) { msg in
                                         ThoughtTimelineRow(message: msg, emphasize: true)
                                     }
                                 }
@@ -4017,7 +4017,7 @@ private struct ThoughtsSheet: View {
 
                             if !completedThoughts.isEmpty {
                                 ThoughtSection(title: "Recent Thoughts", icon: "clock.arrow.circlepath") {
-                                    ForEach(Array(completedThoughts.reversed().enumerated()), id: \.offset) { _, msg in
+                                    ForEach(completedThoughts.reversed()) { msg in
                                         ThoughtTimelineRow(message: msg, emphasize: false)
                                     }
                                 }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -4006,10 +4006,10 @@ private struct ThoughtsSheet: View {
                     )
                 } else {
                     ScrollView {
-                        VStack(spacing: 14) {
+                        LazyVStack(spacing: 14) {
                             if !activeThoughts.isEmpty {
                                 ThoughtSection(title: "Thinking Now", icon: "brain") {
-                                    ForEach(activeThoughts) { msg in
+                                    ForEach(Array(activeThoughts.enumerated()), id: \.offset) { _, msg in
                                         ThoughtTimelineRow(message: msg, emphasize: true)
                                     }
                                 }
@@ -4017,7 +4017,7 @@ private struct ThoughtsSheet: View {
 
                             if !completedThoughts.isEmpty {
                                 ThoughtSection(title: "Recent Thoughts", icon: "clock.arrow.circlepath") {
-                                    ForEach(Array(completedThoughts.reversed())) { msg in
+                                    ForEach(Array(completedThoughts.reversed().enumerated()), id: \.offset) { _, msg in
                                         ThoughtTimelineRow(message: msg, emphasize: false)
                                     }
                                 }
@@ -4067,7 +4067,7 @@ private struct ThoughtSection<Content: View>: View {
                     .foregroundStyle(Theme.textSecondary)
             }
 
-            VStack(spacing: 10) {
+            LazyVStack(spacing: 10) {
                 content()
             }
         }
@@ -4078,9 +4078,15 @@ private struct ThoughtSection<Content: View>: View {
 private struct ThoughtTimelineRow: View {
     let message: ChatMessage
     let emphasize: Bool
-    @State private var isExpanded = true
+    @State private var isExpanded: Bool
     @State private var elapsedSeconds: Int = 0
     @State private var timerTask: Task<Void, Never>?
+
+    init(message: ChatMessage, emphasize: Bool) {
+        self.message = message
+        self.emphasize = emphasize
+        _isExpanded = State(initialValue: emphasize)
+    }
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {

--- a/src/agents/types.rs
+++ b/src/agents/types.rs
@@ -166,6 +166,11 @@ pub enum TerminalReason {
     Completed,
     /// Task was cancelled by user
     Cancelled,
+    /// Mission was interrupted because the server is shutting down
+    /// (SIGTERM, deploy, package upgrade). Distinct from `Cancelled`
+    /// so the UI can show a "paused, click Resume" affordance instead
+    /// of the user-initiated cancel wording.
+    ServerShutdown,
     /// LLM/OpenCode API error
     LlmError,
     /// Agent stalled (no progress)

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -1095,12 +1095,37 @@ fn get_anthropic_auth_from_ai_providers(working_dir: &Path) -> Option<ClaudeCode
 }
 
 /// Load the ai_providers.json array, returning an empty vec on any failure.
+///
+/// Read/parse failures previously vanished silently which made post-mortem
+/// debugging of credential-rotation incidents impossible. We now emit a warn
+/// so the journal records exactly why the credential pool ended up empty.
 fn load_ai_providers(working_dir: &Path) -> Vec<serde_json::Value> {
     let path = working_dir.join(AI_PROVIDERS_PATH);
-    std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-        .unwrap_or_default()
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            // ENOENT is the common case before the user has connected any
+            // provider, so only escalate other errors to warn level.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                tracing::debug!(path = %path.display(), "ai_providers.json not present");
+            } else {
+                tracing::warn!(path = %path.display(), error = %e, "Failed to read ai_providers.json");
+            }
+            return Vec::new();
+        }
+    };
+    match serde_json::from_str::<Vec<serde_json::Value>>(&contents) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                bytes = contents.len(),
+                "Failed to parse ai_providers.json as JSON array; treating as empty",
+            );
+            Vec::new()
+        }
+    }
 }
 
 /// Get all Anthropic credentials from ai_providers.json, sorted by priority.

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -47,6 +47,7 @@ use super::mission_store::{
 use super::routes::AppState;
 
 const SERVER_SHUTDOWN_AUTO_RESUME_MAX_AGE_HOURS: u64 = 48;
+const INTERRUPTED_RESUME_PROMPT: &str = "You were interrupted, resume your work.";
 
 /// Returns a safe index to truncate a string at, ensuring we don't cut UTF-8 characters.
 pub(super) fn safe_truncate_index(s: &str, max: usize) -> usize {
@@ -2945,7 +2946,7 @@ pub enum ControlCommand {
         mission_id: Uuid,
         /// If true, clean the mission's work directory before resuming
         clean_workspace: bool,
-        /// If true, only update status without sending the "MISSION RESUMED" message
+        /// If true, only update status without sending the automatic resume message
         skip_message: bool,
         respond: oneshot::Sender<Result<Mission, String>>,
     },
@@ -4701,7 +4702,7 @@ pub struct ResumeMissionRequest {
     /// If true, clean the mission's work directory before resuming
     #[serde(default)]
     pub clean_workspace: bool,
-    /// If true, only update the mission status without sending the "MISSION RESUMED" message.
+    /// If true, only update the mission status without sending the automatic resume message.
     /// Useful when the user is about to send their own custom message.
     #[serde(default)]
     pub skip_message: bool,
@@ -6216,40 +6217,6 @@ fn parse_goal_objective(message: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn stored_goal_objective(mission: &Mission) -> Option<String> {
-    mission
-        .goal_objective
-        .as_deref()
-        .map(str::trim)
-        .filter(|objective| !objective.is_empty())
-        .map(ToString::to_string)
-        .or_else(|| {
-            mission
-                .history
-                .iter()
-                .find(|entry| entry.role == "user")
-                .and_then(|entry| parse_goal_objective(&entry.content))
-        })
-}
-
-fn resume_prompt_for_mission(mission: &Mission, resume_prompt: String) -> String {
-    if mission.goal_mode
-        || mission
-            .history
-            .iter()
-            .any(|entry| entry.role == "user" && parse_goal_objective(&entry.content).is_some())
-    {
-        if let Some(objective) = stored_goal_objective(mission) {
-            return format!(
-                "/goal {}\n\nThe server restarted while this goal was active. Continue the same goal using the recovery context below. Do not restart from scratch.\n\n{}",
-                objective, resume_prompt
-            );
-        }
-    }
-
-    resume_prompt
-}
-
 /// If the turn ended with `LlmError` or `AuthError` but the agent produced
 /// substantive output, downgrade the reason to `TurnComplete` so the mission
 /// stays active and can be picked up by the next automation cycle or user
@@ -6929,11 +6896,10 @@ async fn control_actor_loop(
             .await
     }
 
-    // Helper to build resume context for an interrupted or blocked mission
+    // Helper to validate and prepare an interrupted or blocked mission for resume.
     async fn resume_mission_impl(
         mission_store: &Arc<dyn MissionStore>,
         config: &Config,
-        workspaces: &workspace::SharedWorkspaceStore,
         mission_id: Uuid,
         clean_workspace: bool,
     ) -> Result<(Mission, String), String> {
@@ -6950,9 +6916,6 @@ async fn control_actor_loop(
                 mission_id, mission.status
             ));
         }
-
-        let workspace_root =
-            workspace::resolve_workspace_root(workspaces, config, Some(mission.workspace_id)).await;
 
         // Clean mission context if requested.
         // Missions share the workspace directory, so we avoid deleting project files.
@@ -6976,133 +6939,7 @@ async fn control_actor_loop(
             let _ = std::fs::remove_file(runtime_file);
         }
 
-        // Build resume context
-        let mut resume_parts = Vec::new();
-
-        // Add resumption notice based on status
-        let resume_reason = match mission.status {
-            MissionStatus::Blocked => "reached its iteration limit",
-            MissionStatus::Failed => "failed due to an error (retrying)",
-            _ => "was interrupted",
-        };
-
-        let workspace_note = if clean_workspace {
-            " (context cleaned)"
-        } else {
-            ""
-        };
-
-        if let Some(interrupted_at) = &mission.interrupted_at {
-            resume_parts.push(format!(
-                "**MISSION RESUMED**{}\nThis mission {} at {} and is now being continued.",
-                workspace_note, resume_reason, interrupted_at
-            ));
-        } else {
-            resume_parts.push(format!(
-                "**MISSION RESUMED**{}\nThis mission {} and is now being continued.",
-                workspace_note, resume_reason
-            ));
-        }
-
-        // Add history summary
-        if !mission.history.is_empty() {
-            resume_parts.push("\n## Previous Conversation Summary".to_string());
-
-            // Include the original user request
-            if let Some(first_user) = mission.history.iter().find(|h| h.role == "user") {
-                resume_parts.push(format!("\n**Original Request:**\n{}", first_user.content));
-            }
-
-            // Include last assistant response (what was being worked on)
-            if let Some(last_assistant) =
-                mission.history.iter().rev().find(|h| h.role == "assistant")
-            {
-                let truncated = if last_assistant.content.len() > 2000 {
-                    let end = safe_truncate_index(&last_assistant.content, 2000);
-                    format!("{}...", &last_assistant.content[..end])
-                } else {
-                    last_assistant.content.clone()
-                };
-                resume_parts.push(format!("\n**Last Progress:**\n{}", truncated));
-            }
-        }
-
-        // Scan work directory for a compact top-level overview (not full file listing)
-        if workspace_root.exists() {
-            resume_parts.push("\n## Workspace Layout".to_string());
-
-            let mut top_level_dirs = Vec::new();
-            let mut top_level_files = Vec::new();
-            const SKIP_DIRS: &[&str] = &[
-                "venv",
-                ".venv",
-                ".sandboxed_sh",
-                ".sandboxed-sh",
-                ".git",
-                ".claude",
-                ".cargo",
-                ".rustup",
-                "node_modules",
-                "target",
-                "__pycache__",
-                ".next",
-                ".cache",
-                "temp",
-                ".local",
-                ".config",
-            ];
-
-            if let Ok(entries) = std::fs::read_dir(&workspace_root) {
-                for entry in entries.filter_map(|e| e.ok()) {
-                    let name = entry.file_name().to_string_lossy().to_string();
-                    let path = entry.path();
-                    if path.is_dir() {
-                        if SKIP_DIRS.contains(&name.as_str()) {
-                            continue;
-                        }
-                        top_level_dirs.push(format!("{}/ ", name));
-                    } else if path.is_file() {
-                        top_level_files.push(name);
-                    }
-                }
-            }
-
-            top_level_dirs.sort();
-            top_level_files.sort();
-
-            if top_level_dirs.is_empty() && top_level_files.is_empty() {
-                resume_parts.push("Empty workspace.".to_string());
-            } else {
-                let mut listing = Vec::new();
-                for d in &top_level_dirs {
-                    listing.push(format!("- {}", d));
-                }
-                // Cap files at 20 to avoid token bloat
-                let file_cap = 20;
-                for f in top_level_files.iter().take(file_cap) {
-                    listing.push(format!("- {}", f));
-                }
-                if top_level_files.len() > file_cap {
-                    listing.push(format!(
-                        "- ... and {} more files",
-                        top_level_files.len() - file_cap
-                    ));
-                }
-                resume_parts.push(listing.join("\n"));
-            }
-        }
-
-        // Add instructions
-        resume_parts.push("\n## Instructions".to_string());
-        resume_parts.push(
-            "Please continue from where you left off. Review the previous progress and work directory contents, \
-            then continue working towards completing the original request. Do not repeat work that was already done."
-                .to_string()
-        );
-
-        let resume_prompt = resume_prompt_for_mission(&mission, resume_parts.join("\n"));
-
-        Ok((mission, resume_prompt))
+        Ok((mission, INTERRUPTED_RESUME_PROMPT.to_string()))
     }
 
     loop {
@@ -8093,7 +7930,6 @@ async fn control_actor_loop(
                         match resume_mission_impl(
                             &mission_store,
                             &config,
-                            &workspaces,
                             mission_id,
                             clean_workspace,
                         )

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -46,6 +46,8 @@ use super::mission_store::{
 };
 use super::routes::AppState;
 
+const SERVER_SHUTDOWN_AUTO_RESUME_MAX_AGE_HOURS: u64 = 48;
+
 /// Returns a safe index to truncate a string at, ensuring we don't cut UTF-8 characters.
 pub(super) fn safe_truncate_index(s: &str, max: usize) -> usize {
     if s.len() <= max {
@@ -5017,63 +5019,15 @@ fn spawn_control_session(
         secrets,
     ));
 
-    // Recover orphaned missions from previous run.
-    // Any mission still marked "active" in the DB cannot be running because
-    // we just started — mark them as interrupted.
+    // Recover missions stopped by the previous backend process. Graceful
+    // shutdown marks live runners as `interrupted/server_shutdown`; a hard
+    // stop can leave task-mode missions as `active`.
     if state.mission_store.is_persistent() {
         let store = Arc::clone(&state.mission_store);
         let tx = events_tx.clone();
+        let cmd = state.cmd_tx.clone();
         tokio::spawn(async move {
-            match store.get_all_active_missions().await {
-                Ok(orphans) if !orphans.is_empty() => {
-                    tracing::info!(
-                        "Startup recovery: marking {} orphaned active missions as interrupted",
-                        orphans.len()
-                    );
-                    for mission in orphans {
-                        tracing::info!(
-                            "  → {} '{}' (last update: {})",
-                            mission.id,
-                            mission.title.as_deref().unwrap_or("Untitled"),
-                            mission.updated_at
-                        );
-                        if let Err(e) = store
-                            .update_mission_status(mission.id, MissionStatus::Interrupted)
-                            .await
-                        {
-                            tracing::warn!(
-                                "Failed to mark orphaned mission {} as interrupted: {}",
-                                mission.id,
-                                e
-                            );
-                        } else {
-                            maybe_schedule_mission_metadata_refresh_for_status(
-                                &store,
-                                &tx,
-                                mission.id,
-                                MissionStatus::Interrupted,
-                            );
-                            let _ = tx.send(AgentEvent::MissionStatusChanged {
-                                mission_id: mission.id,
-                                status: MissionStatus::Interrupted,
-                                summary: Some(
-                                    "Interrupted: server restarted while mission was active"
-                                        .to_string(),
-                                ),
-                            });
-                        }
-                    }
-                }
-                Ok(_) => {
-                    tracing::debug!("Startup recovery: no orphaned active missions found");
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Startup recovery: failed to check for orphaned missions: {}",
-                        e
-                    );
-                }
-            }
+            recover_server_shutdown_missions(store, tx, cmd).await;
         });
     }
 
@@ -5162,6 +5116,147 @@ fn spawn_control_session(
     }
 
     state
+}
+
+async fn recover_server_shutdown_missions(
+    mission_store: Arc<dyn MissionStore>,
+    events_tx: broadcast::Sender<AgentEvent>,
+    cmd_tx: mpsc::Sender<ControlCommand>,
+) {
+    let mut to_resume = Vec::new();
+    let mut seen = HashSet::new();
+
+    match mission_store.get_all_active_missions().await {
+        Ok(active_missions) => {
+            for mission in active_missions {
+                if mission.mission_mode == super::mission_store::MissionMode::Assistant {
+                    tracing::debug!(
+                        mission_id = %mission.id,
+                        "Startup recovery: leaving assistant-mode active mission idle"
+                    );
+                    continue;
+                }
+
+                tracing::warn!(
+                    mission_id = %mission.id,
+                    title = %mission.title.as_deref().unwrap_or("Untitled"),
+                    updated_at = %mission.updated_at,
+                    "Startup recovery: active task mission survived restart; marking server_shutdown and auto-resuming"
+                );
+                if let Err(e) = mission_store
+                    .update_mission_status_with_reason(
+                        mission.id,
+                        MissionStatus::Interrupted,
+                        Some("server_shutdown"),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        mission_id = %mission.id,
+                        "Startup recovery: failed to mark active mission interrupted: {}",
+                        e
+                    );
+                    continue;
+                }
+
+                maybe_schedule_mission_metadata_refresh_for_status(
+                    &mission_store,
+                    &events_tx,
+                    mission.id,
+                    MissionStatus::Interrupted,
+                );
+                let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    mission_id: mission.id,
+                    status: MissionStatus::Interrupted,
+                    summary: Some(
+                        "Interrupted: server restarted while mission was active".to_string(),
+                    ),
+                });
+
+                if seen.insert(mission.id) {
+                    to_resume.push(mission.id);
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Startup recovery: failed to check for active missions: {}",
+                e
+            );
+        }
+    }
+
+    match mission_store
+        .get_recent_server_shutdown_mission_ids(SERVER_SHUTDOWN_AUTO_RESUME_MAX_AGE_HOURS)
+        .await
+    {
+        Ok(mission_ids) => {
+            for mission_id in mission_ids {
+                if seen.insert(mission_id) {
+                    to_resume.push(mission_id);
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Startup recovery: failed to check for server-shutdown missions: {}",
+                e
+            );
+        }
+    }
+
+    if to_resume.is_empty() {
+        tracing::debug!("Startup recovery: no server-shutdown missions to auto-resume");
+        return;
+    }
+
+    tracing::warn!(
+        count = to_resume.len(),
+        "Startup recovery: auto-resuming server-shutdown mission(s)"
+    );
+
+    for mission_id in to_resume {
+        let (tx, rx) = oneshot::channel();
+        if let Err(e) = cmd_tx
+            .send(ControlCommand::ResumeMission {
+                mission_id,
+                clean_workspace: false,
+                skip_message: false,
+                respond: tx,
+            })
+            .await
+        {
+            tracing::warn!(
+                mission_id = %mission_id,
+                "Startup recovery: failed to enqueue auto-resume: {}",
+                e
+            );
+            continue;
+        }
+
+        match rx.await {
+            Ok(Ok(_)) => {
+                tracing::info!(
+                    mission_id = %mission_id,
+                    "Startup recovery: auto-resume queued"
+                );
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    "Startup recovery: auto-resume failed: {}",
+                    e
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    "Startup recovery: auto-resume response dropped: {}",
+                    e
+                );
+            }
+        }
+    }
 }
 
 /// Apply the stale-mission safety net once.
@@ -6112,6 +6207,49 @@ fn mission_status_summary_for_terminal_reason(reason: TerminalReason) -> Option<
     }
 }
 
+fn parse_goal_objective(message: &str) -> Option<String> {
+    message
+        .trim_start()
+        .strip_prefix("/goal ")
+        .map(str::trim)
+        .filter(|objective| !objective.is_empty())
+        .map(ToString::to_string)
+}
+
+fn stored_goal_objective(mission: &Mission) -> Option<String> {
+    mission
+        .goal_objective
+        .as_deref()
+        .map(str::trim)
+        .filter(|objective| !objective.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            mission
+                .history
+                .iter()
+                .find(|entry| entry.role == "user")
+                .and_then(|entry| parse_goal_objective(&entry.content))
+        })
+}
+
+fn resume_prompt_for_mission(mission: &Mission, resume_prompt: String) -> String {
+    if mission.goal_mode
+        || mission
+            .history
+            .iter()
+            .any(|entry| entry.role == "user" && parse_goal_objective(&entry.content).is_some())
+    {
+        if let Some(objective) = stored_goal_objective(mission) {
+            return format!(
+                "/goal {}\n\nThe server restarted while this goal was active. Continue the same goal using the recovery context below. Do not restart from scratch.\n\n{}",
+                objective, resume_prompt
+            );
+        }
+    }
+
+    resume_prompt
+}
+
 /// If the turn ended with `LlmError` or `AuthError` but the agent produced
 /// substantive output, downgrade the reason to `TurnComplete` so the mission
 /// stays active and can be picked up by the next automation cycle or user
@@ -6962,7 +7100,7 @@ async fn control_actor_loop(
                 .to_string()
         );
 
-        let resume_prompt = resume_parts.join("\n");
+        let resume_prompt = resume_prompt_for_mission(&mission, resume_parts.join("\n"));
 
         Ok((mission, resume_prompt))
     }
@@ -7961,6 +8099,113 @@ async fn control_actor_loop(
                         )
                         .await {
                             Ok((mission, resume_prompt)) => {
+                                let already_running_main =
+                                    running.is_some() && running_mission_id == Some(mission_id);
+                                let already_running_parallel = parallel_runners
+                                    .get(&mission_id)
+                                    .is_some_and(|runner| runner.is_running());
+                                if already_running_main || already_running_parallel {
+                                    let _ = respond.send(Err(format!(
+                                        "Mission {} is already running",
+                                        mission_id
+                                    )));
+                                    continue;
+                                }
+
+                                // If another main mission is running, resume this one in a
+                                // parallel runner so its history stays isolated. This is
+                                // important for startup recovery when several missions were
+                                // interrupted by the same service restart.
+                                if running.is_some() {
+                                    let parallel_running = parallel_runners
+                                        .values()
+                                        .filter(|runner| runner.is_running())
+                                        .count();
+                                    let total_running = parallel_running + 1;
+                                    let max_parallel =
+                                        crate::settings::max_parallel_missions_cached_or(
+                                            config.max_parallel_missions,
+                                        );
+
+                                    if total_running >= max_parallel {
+                                        let _ = respond.send(Err(format!(
+                                            "Maximum parallel missions ({}) reached. {} running.",
+                                            max_parallel, total_running
+                                        )));
+                                        continue;
+                                    }
+
+                                    let mut runner = super::mission_runner::MissionRunner::new(
+                                        mission_id,
+                                        mission.workspace_id,
+                                        mission.agent.clone(),
+                                        Some(mission.backend.clone()),
+                                        mission.session_id.clone(),
+                                        mission.config_profile.clone(),
+                                        mission.model_override.clone(),
+                                        mission.model_effort.clone(),
+                                    );
+                                    runner.working_directory = mission.working_directory.clone();
+                                    for entry in &mission.history {
+                                        runner
+                                            .history
+                                            .push((entry.role.clone(), entry.content.clone()));
+                                    }
+                                    runner.queue_message(Uuid::new_v4(), resume_prompt, None);
+
+                                    let started = runner.start_next(
+                                        config.clone(),
+                                        Arc::clone(&root_agent),
+                                        Arc::clone(&mcp),
+                                        Arc::clone(&workspaces),
+                                        library.clone(),
+                                        events_tx.clone(),
+                                        Arc::clone(&tool_hub),
+                                        Arc::clone(&status),
+                                        mission_cmd_tx.clone(),
+                                        Arc::new(RwLock::new(Some(mission_id))),
+                                        secrets.clone(),
+                                    );
+
+                                    if !started {
+                                        let _ = respond.send(Err(
+                                            "Failed to start mission execution".to_string(),
+                                        ));
+                                        continue;
+                                    }
+
+                                    if let Err(e) = mission_store
+                                        .update_mission_status(mission_id, MissionStatus::Active)
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "Failed to resume parallel mission {}: {}",
+                                            mission_id,
+                                            e
+                                        );
+                                    } else {
+                                        maybe_schedule_mission_metadata_refresh_for_status(
+                                            &mission_store,
+                                            &events_tx,
+                                            mission_id,
+                                            MissionStatus::Active,
+                                        );
+                                        let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                            mission_id,
+                                            status: MissionStatus::Active,
+                                            summary: None,
+                                        });
+                                    }
+
+                                    parallel_runners.insert(mission_id, runner);
+                                    let mut updated_mission = mission;
+                                    updated_mission.status = MissionStatus::Active;
+                                    updated_mission.resumable = false;
+                                    updated_mission.interrupted_at = None;
+                                    let _ = respond.send(Ok(updated_mission));
+                                    continue;
+                                }
+
                                 // First persist current mission history (if any)
                                 persist_mission_history(
                                     &mission_store,
@@ -9030,6 +9275,8 @@ async fn control_actor_loop(
                         AgentEvent::Progress { mission_id, .. } => *mission_id,
                         AgentEvent::MissionActivity { mission_id, .. } => *mission_id,
                         AgentEvent::SessionIdUpdate { mission_id, .. } => Some(*mission_id),
+                        AgentEvent::GoalIteration { mission_id, .. } => *mission_id,
+                        AgentEvent::GoalStatus { mission_id, .. } => *mission_id,
                         _ => None,
                     };
                     // Update last_activity for matching runner (main or parallel)
@@ -9355,6 +9602,49 @@ async fn control_actor_loop(
                         // next turn picks up the new value instead of the stale one.
                         if let Some(runner) = parallel_runners.get_mut(mission_id) {
                             runner.session_id = Some(session_id.clone());
+                        }
+                    }
+
+                    // Persist `/goal` metadata so refreshes and restart recovery
+                    // can continue through codex goal mode instead of a plain turn.
+                    if let AgentEvent::UserMessage {
+                        content,
+                        mission_id: Some(mid),
+                        ..
+                    } = &event
+                    {
+                        if let Some(objective) = parse_goal_objective(content) {
+                            if let Err(err) = mission_store
+                                .update_mission_goal(*mid, true, Some(&objective))
+                                .await
+                            {
+                                tracing::warn!(
+                                    mission_id = %mid,
+                                    "Failed to persist goal metadata from user message: {}",
+                                    err
+                                );
+                            }
+                        }
+                    }
+
+                    if let AgentEvent::GoalStatus {
+                        status,
+                        objective,
+                        mission_id: Some(mid),
+                    } = &event
+                    {
+                        let goal_mode = status != "cleared";
+                        let objective = goal_mode.then_some(objective.as_str());
+                        if let Err(err) = mission_store
+                            .update_mission_goal(*mid, goal_mode, objective)
+                            .await
+                        {
+                            tracing::warn!(
+                                mission_id = %mid,
+                                status = %status,
+                                "Failed to persist goal metadata from goal status: {}",
+                                err
+                            );
                         }
                     }
                 }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -7953,6 +7953,43 @@ async fn control_actor_loop(
                                 // important for startup recovery when several missions were
                                 // interrupted by the same service restart.
                                 if running.is_some() {
+                                    if skip_message {
+                                        if let Err(e) = mission_store
+                                            .update_mission_status(
+                                                mission_id,
+                                                MissionStatus::Active,
+                                            )
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                "Failed to resume mission {}: {}",
+                                                mission_id,
+                                                e
+                                            );
+                                        } else {
+                                            maybe_schedule_mission_metadata_refresh_for_status(
+                                                &mission_store,
+                                                &events_tx,
+                                                mission_id,
+                                                MissionStatus::Active,
+                                            );
+                                            let _ = events_tx.send(
+                                                AgentEvent::MissionStatusChanged {
+                                                    mission_id,
+                                                    status: MissionStatus::Active,
+                                                    summary: None,
+                                                },
+                                            );
+                                        }
+
+                                        let mut updated_mission = mission;
+                                        updated_mission.status = MissionStatus::Active;
+                                        updated_mission.resumable = false;
+                                        updated_mission.interrupted_at = None;
+                                        let _ = respond.send(Ok(updated_mission));
+                                        continue;
+                                    }
+
                                     let parallel_running = parallel_runners
                                         .values()
                                         .filter(|runner| runner.is_running())

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6084,6 +6084,7 @@ fn mission_status_for_terminal_reason(
         TerminalReason::TurnComplete => None,
         TerminalReason::Completed => Some((MissionStatus::Completed, "completed")),
         TerminalReason::Cancelled => Some((MissionStatus::Interrupted, "cancelled")),
+        TerminalReason::ServerShutdown => Some((MissionStatus::Interrupted, "server_shutdown")),
         TerminalReason::MaxIterations => Some((MissionStatus::Blocked, "max_iterations")),
         TerminalReason::LlmError => Some((MissionStatus::Failed, "llm_error")),
         TerminalReason::Stalled => Some((MissionStatus::Failed, "stalled")),
@@ -6099,6 +6100,9 @@ fn mission_status_summary_for_terminal_reason(reason: TerminalReason) -> Option<
         TerminalReason::TurnComplete | TerminalReason::Completed => None,
         TerminalReason::MaxIterations => Some("Reached iteration limit".to_string()),
         TerminalReason::Cancelled => Some("Cancelled by user".to_string()),
+        TerminalReason::ServerShutdown => {
+            Some("Paused for server restart — click Resume to continue".to_string())
+        }
         TerminalReason::Stalled => Some("No progress detected".to_string()),
         TerminalReason::InfiniteLoop => Some("Detected repetitive behavior".to_string()),
         TerminalReason::LlmError => Some("Model error".to_string()),
@@ -8116,7 +8120,11 @@ async fn control_actor_loop(
                                 // belongs to current_mission, not running_mission_id
 
                                 if mission_store
-                                    .update_mission_status(mission_id, MissionStatus::Interrupted)
+                                    .update_mission_status_with_reason(
+                                        mission_id,
+                                        MissionStatus::Interrupted,
+                                        Some("server_shutdown"),
+                                    )
                                     .await
                                     .is_ok()
                                 {
@@ -8156,7 +8164,11 @@ async fn control_actor_loop(
                             )
                             .await;
                             if mission_store
-                                .update_mission_status(*mission_id, MissionStatus::Interrupted)
+                                .update_mission_status_with_reason(
+                                    *mission_id,
+                                    MissionStatus::Interrupted,
+                                    Some("server_shutdown"),
+                                )
                                 .await
                                 .is_ok()
                             {

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4702,7 +4702,7 @@ pub struct ResumeMissionRequest {
     /// If true, clean the mission's work directory before resuming
     #[serde(default)]
     pub clean_workspace: bool,
-    /// If true, only update the mission status without sending the automatic resume message.
+    /// If true, do not send the automatic resume message.
     /// Useful when the user is about to send their own custom message.
     #[serde(default)]
     pub skip_message: bool,
@@ -7954,39 +7954,11 @@ async fn control_actor_loop(
                                 // interrupted by the same service restart.
                                 if running.is_some() {
                                     if skip_message {
-                                        if let Err(e) = mission_store
-                                            .update_mission_status(
-                                                mission_id,
-                                                MissionStatus::Active,
-                                            )
-                                            .await
-                                        {
-                                            tracing::warn!(
-                                                "Failed to resume mission {}: {}",
-                                                mission_id,
-                                                e
-                                            );
-                                        } else {
-                                            maybe_schedule_mission_metadata_refresh_for_status(
-                                                &mission_store,
-                                                &events_tx,
-                                                mission_id,
-                                                MissionStatus::Active,
-                                            );
-                                            let _ = events_tx.send(
-                                                AgentEvent::MissionStatusChanged {
-                                                    mission_id,
-                                                    status: MissionStatus::Active,
-                                                    summary: None,
-                                                },
-                                            );
-                                        }
-
-                                        let mut updated_mission = mission;
-                                        updated_mission.status = MissionStatus::Active;
-                                        updated_mission.resumable = false;
-                                        updated_mission.interrupted_at = None;
-                                        let _ = respond.send(Ok(updated_mission));
+                                        tracing::info!(
+                                            mission_id = %mission_id,
+                                            "Deferring parallel resume until the caller sends a custom message"
+                                        );
+                                        let _ = respond.send(Ok(mission));
                                         continue;
                                     }
 

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -209,13 +209,66 @@ fn is_context_upload_path(path: &str) -> bool {
 }
 
 fn is_context_upload_path_for_dir(path: &str, context_dir_name: &str) -> bool {
-    let normalized = path.trim().trim_start_matches("./");
-    normalized == context_dir_name
-        || normalized.starts_with(&format!("{}/", context_dir_name))
-        || normalized == format!("root/{}", context_dir_name)
-        || normalized.starts_with(&format!("root/{}/", context_dir_name))
-        || path == format!("/root/{}", context_dir_name)
-        || path.starts_with(&format!("/root/{}/", context_dir_name))
+    context_upload_suffix_for_dir(path, context_dir_name).is_some()
+}
+
+fn context_upload_suffix_for_dir<'a>(path: &'a str, context_dir_name: &str) -> Option<&'a str> {
+    let trimmed = path.trim();
+    let normalized = trimmed.strip_prefix("./").unwrap_or(trimmed);
+
+    if normalized == context_dir_name {
+        return Some("");
+    }
+    if let Some(suffix) = normalized.strip_prefix(context_dir_name) {
+        if let Some(rest) = suffix.strip_prefix('/') {
+            return Some(rest);
+        }
+    }
+
+    let workspace_root_prefix = format!("root/{}", context_dir_name);
+    if normalized == workspace_root_prefix {
+        return Some("");
+    }
+    if let Some(suffix) = normalized.strip_prefix(&workspace_root_prefix) {
+        if let Some(rest) = suffix.strip_prefix('/') {
+            return Some(rest);
+        }
+    }
+
+    let container_root_prefix = format!("/root/{}", context_dir_name);
+    if trimmed == container_root_prefix {
+        return Some("");
+    }
+    if let Some(suffix) = trimmed.strip_prefix(&container_root_prefix) {
+        if let Some(rest) = suffix.strip_prefix('/') {
+            return Some(rest);
+        }
+    }
+
+    None
+}
+
+fn api_context_root_for_config(config: &crate::config::Config) -> PathBuf {
+    let root = config
+        .context
+        .context_dir(&config.working_dir.to_string_lossy());
+    let root = PathBuf::from(root);
+
+    if root.is_absolute() {
+        root
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(root)
+    } else {
+        root
+    }
+}
+
+fn api_context_root(state: &AppState) -> PathBuf {
+    api_context_root_for_config(&state.config)
+}
+
+fn canonicalize_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn configured_context_root(config_working_dir: &Path) -> PathBuf {
@@ -372,39 +425,20 @@ pub async fn resolve_path_for_workspace(
         } else {
             input.to_path_buf()
         }
-    } else if path.starts_with("./context") || path.starts_with("context") {
+    } else if let Some(suffix) =
+        context_upload_suffix_for_dir(path, &state.config.context.context_dir_name)
+    {
         // For "context" paths, use the mission-specific context directory if mission_id provided
-        let suffix = path
-            .trim_start_matches("./")
-            .trim_start_matches("context/")
-            .trim_start_matches("context");
-
         // If mission_id is provided, use mission-specific context directory
         // This ensures uploaded files go to the right place for the agent to find them
         let context_path = if let Some(mid) = mission_id {
-            if workspace.workspace_type == WorkspaceType::Container {
-                // For container workspaces, write to the HOST context root
-                // (config.working_dir/context/<mid>/).  This directory is
-                // bind-mounted into the container at /root/context, so the
-                // agent sees the files.  Writing to the container rootfs does
-                // NOT work because the bind-mount shadows the rootfs path.
-                let context_dir_name = std::env::var("SANDBOXED_SH_CONTEXT_DIR_NAME")
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
-                    .unwrap_or_else(|| "context".to_string());
-                let global_context_root = std::env::var("SANDBOXED_SH_CONTEXT_ROOT")
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
-                    .map(PathBuf::from)
-                    .unwrap_or_else(|| state.config.working_dir.join(&context_dir_name));
-                global_context_root.join(mid.to_string())
-            } else {
-                // For host workspaces, use the global context root
-                let context_root = state.config.working_dir.join("context");
-                context_root.join(mid.to_string())
-            }
+            // Mission context uploads must use the HTTP server's configured
+            // context root. The process env variant can be rewritten by
+            // workspace/tool execution and may point at a specific mission or
+            // container path while the API server continues handling requests.
+            api_context_root(state).join(mid.to_string())
         } else {
-            workspace_root.join("context")
+            workspace_root.join(&state.config.context.context_dir_name)
         };
 
         if suffix.is_empty() {
@@ -434,7 +468,7 @@ pub async fn resolve_path_for_workspace(
                     .map(|m| m.is_symlink())
                     .unwrap_or(false)
                 {
-                    let context_root_check = state.config.working_dir.join("context");
+                    let context_root_check = api_context_root(state);
                     let in_bounds = resolved.starts_with(&workspace_root)
                         || (mission_id.is_some() && resolved.starts_with(&context_root_check));
                     if in_bounds {
@@ -481,12 +515,14 @@ pub async fn resolve_path_for_workspace(
         if !parent.exists() {
             // For context paths, create the directory tree automatically
             // (the mission context directory may not exist yet on the first upload)
-            let is_context_path = path.starts_with("./context") || path.starts_with("context");
+            let is_context_path =
+                context_upload_suffix_for_dir(path, &state.config.context.context_dir_name)
+                    .is_some();
             if is_context_path && mission_id.is_some() {
                 // The context root (e.g. /root/context) may be a stale symlink
                 // from a previous mission's workspace prep. Remove it so
                 // create_dir_all can create the real directory tree.
-                let context_root = state.config.working_dir.join("context");
+                let context_root = api_context_root(state);
                 if context_root.is_symlink() {
                     let _ = tokio::fs::remove_file(&context_root).await;
                 }
@@ -519,7 +555,7 @@ pub async fn resolve_path_for_workspace(
 
     // Validate that the resolved path is within an allowed location
     // This can be either the workspace root or the global context directory for missions
-    let context_root = state.config.working_dir.join("context");
+    let context_root = canonicalize_or_original(&api_context_root(state));
     let in_workspace = canonical.starts_with(&workspace_root);
     let in_context = mission_id.is_some() && canonical.starts_with(&context_root);
 
@@ -1347,7 +1383,11 @@ pub async fn download_from_url(
 
 #[cfg(test)]
 mod tests {
-    use super::{context_mirror_suffix, is_context_upload_path_for_dir};
+    use super::{
+        api_context_root_for_config, context_mirror_suffix, context_upload_suffix_for_dir,
+        is_context_upload_path_for_dir,
+    };
+    use crate::config::Config;
     use std::path::{Path, PathBuf};
     use uuid::Uuid;
 
@@ -1374,6 +1414,41 @@ mod tests {
             "/root/context/file.pdf",
             "ctx"
         ));
+    }
+
+    #[test]
+    fn context_upload_suffix_respects_context_boundaries() {
+        assert_eq!(
+            context_upload_suffix_for_dir("./context/paper.pdf", "context"),
+            Some("paper.pdf")
+        );
+        assert_eq!(
+            context_upload_suffix_for_dir("context/nested/paper.pdf", "context"),
+            Some("nested/paper.pdf")
+        );
+        assert_eq!(
+            context_upload_suffix_for_dir("/root/context/paper.pdf", "context"),
+            Some("paper.pdf")
+        );
+        assert_eq!(
+            context_upload_suffix_for_dir("contextual/paper.pdf", "context"),
+            None
+        );
+    }
+
+    #[test]
+    fn api_context_root_ignores_runtime_context_env() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = Config::new(temp.path().to_path_buf());
+
+        std::env::set_var(
+            "SANDBOXED_SH_CONTEXT_ROOT",
+            "/tmp/mission-specific-context-root",
+        );
+        let root = api_context_root_for_config(&config);
+        std::env::remove_var("SANDBOXED_SH_CONTEXT_ROOT");
+
+        assert_eq!(root, temp.path().join("context"));
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -6207,6 +6207,58 @@ fn is_capacity_limited_error(message: &str) -> bool {
     has_concurrent && has_mission && has_limit
 }
 
+const CODEX_PENDING_TOOLS_ERROR_PREFIX: &str = "Codex stopped while tool calls were still pending";
+
+fn is_codex_generic_exit_wrapper(message: &str) -> bool {
+    message.contains("Codex CLI exited before completing the turn")
+}
+
+fn codex_pending_tools_error_message(
+    message: &str,
+    pending_tools: &HashMap<String, String>,
+) -> String {
+    let mut pending_tool_names: Vec<&str> = pending_tools.values().map(String::as_str).collect();
+    pending_tool_names.sort_unstable();
+    pending_tool_names.dedup();
+
+    if pending_tool_names.is_empty() {
+        format!("{CODEX_PENDING_TOOLS_ERROR_PREFIX}: {message}")
+    } else {
+        format!(
+            "{CODEX_PENDING_TOOLS_ERROR_PREFIX} ({}): {message}",
+            pending_tool_names.join(", ")
+        )
+    }
+}
+
+fn codex_error_message_to_surface(
+    assistant_message: &str,
+    pending_tools: &HashMap<String, String>,
+    message: &str,
+) -> Option<String> {
+    if assistant_message.trim().is_empty() {
+        Some(message.to_string())
+    } else if !pending_tools.is_empty() {
+        Some(codex_pending_tools_error_message(message, pending_tools))
+    } else {
+        None
+    }
+}
+
+fn record_codex_error_message(error_message: &mut Option<String>, message: String) -> bool {
+    let new_is_generic_exit_wrapper = is_codex_generic_exit_wrapper(&message);
+    let already_have_specific = error_message
+        .as_deref()
+        .is_some_and(|existing| !is_codex_generic_exit_wrapper(existing));
+
+    if new_is_generic_exit_wrapper && already_have_specific {
+        false
+    } else {
+        *error_message = Some(message);
+        true
+    }
+}
+
 fn strip_opencode_banner_lines(output: &str) -> Cow<'_, str> {
     let no_ansi = strip_ansi_codes(output);
     let source = no_ansi.as_ref();
@@ -13453,11 +13505,13 @@ pub async fn run_codex_turn(
                         //      consequence of the in-stream disconnect we
                         //      already decided to swallow.
                         //
-                        // Rule: if we have assistant output, ignore the error.
-                        // The empty-output branch still surfaces startup /
-                        // auth / config failures (which produce no text at
-                        // all) and mid-turn disconnects that happened before
-                        // any real content streamed.
+                        // Rule: if we have assistant output and no pending
+                        // tools, ignore the error. The empty-output branch
+                        // still surfaces startup / auth / config failures
+                        // (which produce no text at all). If a tool call is
+                        // still pending, the assistant's text is only a
+                        // progress update; swallowing a provider error would
+                        // mark unfinished work as completed.
                         //
                         // When we do surface an error, prefer the *first*
                         // meaningful message we saw — Codex CLI usually emits
@@ -13471,26 +13525,29 @@ pub async fn run_codex_turn(
                         // forces the user (and our `is_*_error` classifiers)
                         // to debug from log lines instead of the surfaced
                         // assistant_message.
-                        if assistant_message.trim().is_empty() {
-                            let new_is_generic_exit_wrapper = message.contains(
-                                "Codex CLI exited before completing the turn",
+                        if let Some(surfaced_message) =
+                            codex_error_message_to_surface(&assistant_message, &pending_tools, &message)
+                        {
+                            let recorded = record_codex_error_message(
+                                &mut error_message,
+                                surfaced_message.clone(),
                             );
-                            let already_have_specific = error_message
-                                .as_deref()
-                                .is_some_and(|existing| {
-                                    !existing.contains(
-                                        "Codex CLI exited before completing the turn",
-                                    )
-                                });
-                            if new_is_generic_exit_wrapper && already_have_specific {
+                            if recorded {
+                                if pending_tools.is_empty() {
+                                    tracing::error!("Codex error: {}", surfaced_message);
+                                } else {
+                                    tracing::warn!(
+                                        pending_tool_count = pending_tools.len(),
+                                        "Treating post-response Codex error as fatal because tool calls are still pending: {}",
+                                        surfaced_message
+                                    );
+                                }
+                            } else {
                                 tracing::warn!(
                                     "Keeping prior specific Codex error over generic exit wrapper: existing={}, ignored={}",
                                     error_message.as_deref().unwrap_or(""),
                                     message
                                 );
-                            } else {
-                                error_message = Some(message.clone());
-                                tracing::error!("Codex error: {}", message);
                             }
                         } else {
                             tracing::warn!(
@@ -13560,6 +13617,8 @@ pub async fn run_codex_turn(
     let stopped_on_progress_update = success
         && tool_activity_required
         && codex_final_message_looks_like_progress_update(&final_message);
+    let stopped_with_pending_tool_error =
+        !success && final_message.starts_with(CODEX_PENDING_TOOLS_ERROR_PREFIX);
     if stopped_before_required_tools || stopped_on_progress_update {
         tracing::warn!(
             mission_id = %mission_id,
@@ -13612,6 +13671,8 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
             TerminalReason::CapacityLimited
         } else if is_rate_limited_error(&final_message) {
             TerminalReason::RateLimited
+        } else if stopped_with_pending_tool_error {
+            TerminalReason::Stalled
         } else {
             TerminalReason::LlmError
         };
@@ -14378,22 +14439,23 @@ mod tests {
         claudecode_resume_current_session_message, claudecode_transport_failure_data,
         claudecode_transport_failure_stage, claudecode_transport_failure_stage_for_incomplete_turn,
         claudecode_transport_recovery_strategy, codex_chatgpt_fallback_for_result,
-        codex_chatgpt_fallback_model, codex_final_message_looks_like_progress_update,
-        codex_key_fingerprint, codex_tool_stall_should_retry_with_default_model,
-        codex_turn_requires_tool_activity, extract_model_from_message, extract_opencode_session_id,
-        extract_part_text, extract_str, extract_thought_line, is_capacity_limited_error,
-        is_codex_chatgpt_account_model_blocked, is_codex_node_wrapper, is_provider_payload_error,
-        is_rate_limited_error, is_session_corruption_error, is_success_path_auth_error,
+        codex_chatgpt_fallback_model, codex_error_message_to_surface,
+        codex_final_message_looks_like_progress_update, codex_key_fingerprint,
+        codex_tool_stall_should_retry_with_default_model, codex_turn_requires_tool_activity,
+        extract_model_from_message, extract_opencode_session_id, extract_part_text, extract_str,
+        extract_thought_line, is_capacity_limited_error, is_codex_chatgpt_account_model_blocked,
+        is_codex_node_wrapper, is_provider_payload_error, is_rate_limited_error,
+        is_session_corruption_error, is_success_path_auth_error,
         is_success_path_provider_payload_error, is_success_path_rate_limited_error,
         is_tool_call_only_output, opencode_idle_timeout_result_message,
         opencode_output_needs_fallback, opencode_session_token_from_line,
         parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
-        preferred_model_for_cost, resolve_cost_cents_and_source, running_health,
-        sanitized_opencode_stdout, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
-        strip_think_tags, summarize_recent_opencode_stderr, sync_opencode_agent_config,
-        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
-        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
-        OpencodeSseState, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        preferred_model_for_cost, record_codex_error_message, resolve_cost_cents_and_source,
+        running_health, sanitized_opencode_stdout, stall_severity, strip_ansi_codes,
+        strip_opencode_banner_lines, strip_think_tags, summarize_recent_opencode_stderr,
+        sync_opencode_agent_config, ClaudeIncompleteTurnContext, ClaudeTransportFailureStage,
+        ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState, MissionHealth, MissionRunState,
+        MissionStallSeverity, OpencodeSseState, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, inject_telegram_identity_into_claude_md,
@@ -14793,6 +14855,57 @@ mod tests {
         assert!(is_capacity_limited_error(
             "SOMETHING upstream: SELECTED MODEL IS AT CAPACITY. retry later."
         ));
+    }
+
+    #[test]
+    fn codex_post_response_error_with_pending_tool_is_surfaceable() {
+        let mut pending_tools = std::collections::HashMap::new();
+        pending_tools.insert("call_1".to_string(), "bash".to_string());
+
+        let surfaced = codex_error_message_to_surface(
+            "The caller-side destructuring is updated. I’m rebuilding now.",
+            &pending_tools,
+            "Selected model is at capacity. Please try a different model.",
+        )
+        .expect("pending tool error should be surfaced");
+
+        assert!(surfaced.contains("tool calls were still pending (bash)"));
+        assert!(is_capacity_limited_error(&surfaced));
+
+        let mut error_message = None;
+        assert!(record_codex_error_message(
+            &mut error_message,
+            surfaced.clone()
+        ));
+        assert_eq!(error_message.as_deref(), Some(surfaced.as_str()));
+    }
+
+    #[test]
+    fn codex_post_response_error_without_pending_tools_stays_ignored() {
+        let pending_tools = std::collections::HashMap::new();
+
+        assert!(codex_error_message_to_surface(
+            "I completed the requested work.",
+            &pending_tools,
+            "Failed to shutdown rollout recorder",
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn codex_error_recording_keeps_specific_error_over_exit_wrapper() {
+        let mut error_message =
+            Some("Selected model is at capacity. Please try a different model.".to_string());
+
+        assert!(!record_codex_error_message(
+            &mut error_message,
+            "Codex CLI exited before completing the turn (exit_status: exit status: 1)."
+                .to_string(),
+        ));
+        assert_eq!(
+            error_message.as_deref(),
+            Some("Selected model is at capacity. Please try a different model.")
+        );
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -900,16 +900,24 @@ fn claudecode_pre_turn_transport_message(
 /// with the user's ChatGPT subscription; rotating across distinct
 /// `chatgpt_account_id`s spreads load across separate caps.
 pub(crate) fn collect_codex_credentials(working_dir: &std::path::Path) -> Vec<CodexCredential> {
-    let mut creds: Vec<CodexCredential> =
-        super::ai_providers::get_all_openai_keys_for_codex(working_dir)
-            .into_iter()
-            .map(CodexCredential::ApiKey)
-            .collect();
-    creds.extend(
-        super::ai_providers::get_all_openai_oauth_accounts(working_dir)
-            .into_iter()
-            .map(CodexCredential::OAuth),
+    let api_keys: Vec<CodexCredential> = super::ai_providers::get_all_openai_keys_for_codex(working_dir)
+        .into_iter()
+        .map(CodexCredential::ApiKey)
+        .collect();
+    let oauths: Vec<CodexCredential> = super::ai_providers::get_all_openai_oauth_accounts(working_dir)
+        .into_iter()
+        .map(CodexCredential::OAuth)
+        .collect();
+    // Emit at debug so we can correlate rotation behaviour with the pool
+    // state for any given mission. Counts only; never the credentials.
+    tracing::debug!(
+        working_dir = %working_dir.display(),
+        api_keys = api_keys.len(),
+        oauth_accounts = oauths.len(),
+        "collect_codex_credentials"
     );
+    let mut creds = api_keys;
+    creds.extend(oauths);
     creds
 }
 
@@ -3157,7 +3165,16 @@ async fn run_mission_turn(
             // Unified credential pool: API keys + ChatGPT-OAuth identities,
             // de-duplicated by chatgpt_account_id. Empty only when neither
             // an OpenAI API key nor a connected ChatGPT account is available.
-            let all_creds = collect_codex_credentials(&config.working_dir);
+            //
+            // Defensive: if the pool was empty and the turn hits a rate
+            // limit, re-query once and rerun via rotation if credentials are
+            // now visible. The May 2026 incident showed the empty branch can
+            // be taken transiently even when accounts exist on disk, leaving
+            // the user with no rotation. The recheck guards against that
+            // without changing the happy-path behaviour.
+            'codex_arm: {
+            let mut all_creds = collect_codex_credentials(&config.working_dir);
+            let mut prior_empty_result: Option<AgentResult> = None;
             if all_creds.is_empty() {
                 let mut result = run_codex_turn(
                     &workspace,
@@ -3223,11 +3240,35 @@ async fn run_mission_turn(
                     .await;
                 }
 
-                result
-            } else {
+                // Defensive re-query: if this turn was rate/capacity limited
+                // and a fresh enumeration now returns accounts, fall through
+                // to the rotation loop instead of surfacing the failure.
+                let constrained = matches!(
+                    result.terminal_reason,
+                    Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
+                );
+                if constrained {
+                    let recheck = collect_codex_credentials(&config.working_dir);
+                    if !recheck.is_empty() {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            recovered_credentials = recheck.len(),
+                            "Codex credential pool was empty on first attempt but re-query found accounts after a rate-limited turn; retrying with rotation"
+                        );
+                        all_creds = recheck;
+                        prior_empty_result = Some(result);
+                        // fall through to rotation loop below
+                    } else {
+                        break 'codex_arm result;
+                    }
+                } else {
+                    break 'codex_arm result;
+                }
+            }
+            {
                 let mut attempted_credentials: HashSet<String> = HashSet::new();
                 let mut attempt_idx = 0usize;
-                let mut last_constrained_result: Option<AgentResult> = None;
+                let mut last_constrained_result: Option<AgentResult> = prior_empty_result;
 
                 loop {
                     if cancel.is_cancelled() {
@@ -3353,6 +3394,7 @@ async fn run_mission_turn(
                         _ => break result,
                     }
                 }
+            }
             }
         }
         "gemini" => {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -817,6 +817,27 @@ fn claudecode_incomplete_turn_message(
     message
 }
 
+fn apply_terminal_result_text(final_result: &mut String, terminal_result: Option<String>) {
+    if let Some(result) = terminal_result {
+        if !result.trim().is_empty() || final_result.trim().is_empty() {
+            *final_result = result;
+        }
+    }
+}
+
+fn use_thinking_only_fallback(
+    final_result: &mut String,
+    thinking_fallback: &str,
+    pending_tools_empty: bool,
+) -> bool {
+    if final_result.trim().is_empty() && !thinking_fallback.trim().is_empty() && pending_tools_empty
+    {
+        *final_result = thinking_fallback.to_string();
+        return true;
+    }
+    false
+}
+
 fn claudecode_malformed_startup_message(
     diagnostics: &[String],
     use_resume: bool,
@@ -5018,6 +5039,7 @@ pub fn run_claudecode_turn<'a>(
                                         total_cache_read_tokens +=
                                             usage.cache_read_input_tokens.unwrap_or(0);
                                     }
+                                    let mut assistant_thinking_fallback = String::new();
                                     for (content_idx, block) in evt.message.content.into_iter().enumerate() {
                                         let content_idx = content_idx as u32;
                                         match block {
@@ -5164,6 +5186,10 @@ pub fn run_claudecode_turn<'a>(
                                                     && !finalized_thinking_indices
                                                         .contains(&content_idx) =>
                                             {
+                                                if !assistant_thinking_fallback.is_empty() {
+                                                    assistant_thinking_fallback.push('\n');
+                                                }
+                                                assistant_thinking_fallback.push_str(&thinking);
                                                 // Only send done:true for the last active thinking block.
                                                 // Earlier blocks were already finalized during streaming
                                                 // (via the block-transition mechanism) and re-sending them
@@ -5199,6 +5225,17 @@ pub fn run_claudecode_turn<'a>(
                                         tracing::info!(
                                             mission_id = %mission_id,
                                             "Using thinking buffer as final result ({} chars, no text content in this turn)",
+                                            final_result.len()
+                                        );
+                                    }
+                                    if use_thinking_only_fallback(
+                                        &mut final_result,
+                                        &assistant_thinking_fallback,
+                                        pending_tools.is_empty(),
+                                    ) {
+                                        tracing::info!(
+                                            mission_id = %mission_id,
+                                            "Using assistant thinking-only block as final result ({} chars, no text content in this turn)",
                                             final_result.len()
                                         );
                                     }
@@ -5275,8 +5312,8 @@ pub fn run_claudecode_turn<'a>(
                                         // with success=false which the UI displays as a failure message.
                                         // Sending Error here would cause duplicate messages.
                                         final_result = error_msg;
-                                    } else if let Some(result) = res.result {
-                                        final_result = result;
+                                    } else {
+                                        apply_terminal_result_text(&mut final_result, res.result);
                                     }
                                     tracing::info!(
                                         mission_id = %mission_id,
@@ -12757,8 +12794,8 @@ pub async fn run_amp_turn(
                                     // with success=false which the UI displays as a failure message.
                                     // Sending Error here would cause duplicate messages.
                                     final_result = err_msg;
-                                } else if let Some(result) = res.result {
-                                    final_result = result;
+                                } else {
+                                    apply_terminal_result_text(&mut final_result, res.result);
                                 }
 
                                 tracing::debug!(
@@ -14433,7 +14470,7 @@ fn cleanup_old_debug_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        actual_cost_cents_from_total_cost_usd, bind_command_params,
+        actual_cost_cents_from_total_cost_usd, apply_terminal_result_text, bind_command_params,
         claudecode_idle_timeout_for_state, claudecode_incomplete_turn_message,
         claudecode_malformed_startup_message, claudecode_pre_turn_transport_message,
         claudecode_resume_current_session_message, claudecode_transport_failure_data,
@@ -14453,9 +14490,10 @@ mod tests {
         preferred_model_for_cost, record_codex_error_message, resolve_cost_cents_and_source,
         running_health, sanitized_opencode_stdout, stall_severity, strip_ansi_codes,
         strip_opencode_banner_lines, strip_think_tags, summarize_recent_opencode_stderr,
-        sync_opencode_agent_config, ClaudeIncompleteTurnContext, ClaudeTransportFailureStage,
-        ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState, MissionHealth, MissionRunState,
-        MissionStallSeverity, OpencodeSseState, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        sync_opencode_agent_config, use_thinking_only_fallback, ClaudeIncompleteTurnContext,
+        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
+        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState, STALL_SEVERE_SECS,
+        STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, inject_telegram_identity_into_claude_md,
@@ -15978,6 +16016,51 @@ mod tests {
         let message = claudecode_resume_current_session_message();
         assert!(message.contains("Continue from the current session state"));
         assert!(message.contains("without restarting completed tool calls"));
+    }
+
+    #[test]
+    fn terminal_result_empty_text_does_not_erase_captured_assistant_output() {
+        let mut final_result = "Captured assistant output from stream".to_string();
+
+        apply_terminal_result_text(&mut final_result, Some(String::new()));
+
+        assert_eq!(final_result, "Captured assistant output from stream");
+    }
+
+    #[test]
+    fn terminal_result_non_empty_text_replaces_stream_fallback() {
+        let mut final_result = "stream fallback".to_string();
+
+        apply_terminal_result_text(&mut final_result, Some("terminal result".to_string()));
+
+        assert_eq!(final_result, "terminal result");
+    }
+
+    #[test]
+    fn thinking_only_fallback_can_supply_final_result_when_no_tools_pending() {
+        let mut final_result = String::new();
+
+        let used = use_thinking_only_fallback(
+            &mut final_result,
+            "Final answer emitted as a thinking-only assistant block.",
+            true,
+        );
+
+        assert!(used);
+        assert_eq!(
+            final_result,
+            "Final answer emitted as a thinking-only assistant block."
+        );
+    }
+
+    #[test]
+    fn thinking_only_fallback_waits_when_tools_are_pending() {
+        let mut final_result = String::new();
+
+        let used = use_thinking_only_fallback(&mut final_result, "Need tool output first.", false);
+
+        assert!(!used);
+        assert!(final_result.is_empty());
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -41,6 +41,24 @@ use super::control::{
 };
 use super::library::SharedLibrary;
 
+/// Build the synthetic `AgentResult::failure` produced when a turn is
+/// cancelled. If the process has begun a graceful shutdown, return a
+/// friendlier "paused for restart" message and a `ServerShutdown` reason
+/// so the dashboard can render a Resume affordance instead of a
+/// user-cancel banner; otherwise behave as before.
+fn cancel_or_shutdown_failure() -> AgentResult {
+    if super::routes::is_shutdown_initiated() {
+        AgentResult::failure(
+            "Server restart — paused. Click Resume to continue.".to_string(),
+            0,
+        )
+        .with_terminal_reason(TerminalReason::ServerShutdown)
+    } else {
+        AgentResult::failure("Mission cancelled".to_string(), 0)
+            .with_terminal_reason(TerminalReason::Cancelled)
+    }
+}
+
 #[derive(Debug, Default)]
 struct OpencodeSseState {
     message_roles: HashMap<String, String>,
@@ -3192,10 +3210,7 @@ async fn run_mission_turn(
 
                 loop {
                     if cancel.is_cancelled() {
-                        break last_constrained_result.unwrap_or_else(|| {
-                            AgentResult::failure("Mission cancelled".to_string(), 0)
-                                .with_terminal_reason(TerminalReason::Cancelled)
-                        });
+                        break last_constrained_result.unwrap_or_else(cancel_or_shutdown_failure);
                     }
 
                     let lease =
@@ -13340,8 +13355,7 @@ pub async fn run_codex_turn(
             _ = cancel.cancelled() => {
                 tracing::info!("Codex turn cancelled for mission {}", mission_id);
                 // Note: Codex process will be cleaned up automatically when the event stream task ends
-                return AgentResult::failure("Mission cancelled".to_string(), 0)
-                    .with_terminal_reason(TerminalReason::Cancelled);
+                return cancel_or_shutdown_failure();
             }
             Some(event) = event_rx.recv() => {
                 match event {
@@ -13837,8 +13851,7 @@ pub async fn run_gemini_turn(
                 backend.kill().await;
                 // Abort the event-conversion task
                 handle.abort();
-                return AgentResult::failure("Mission cancelled".to_string(), 0)
-                    .with_terminal_reason(TerminalReason::Cancelled);
+                return cancel_or_shutdown_failure();
             }
             Some(event) = event_rx.recv() => {
                 match event {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -900,14 +900,16 @@ fn claudecode_pre_turn_transport_message(
 /// with the user's ChatGPT subscription; rotating across distinct
 /// `chatgpt_account_id`s spreads load across separate caps.
 pub(crate) fn collect_codex_credentials(working_dir: &std::path::Path) -> Vec<CodexCredential> {
-    let api_keys: Vec<CodexCredential> = super::ai_providers::get_all_openai_keys_for_codex(working_dir)
-        .into_iter()
-        .map(CodexCredential::ApiKey)
-        .collect();
-    let oauths: Vec<CodexCredential> = super::ai_providers::get_all_openai_oauth_accounts(working_dir)
-        .into_iter()
-        .map(CodexCredential::OAuth)
-        .collect();
+    let api_keys: Vec<CodexCredential> =
+        super::ai_providers::get_all_openai_keys_for_codex(working_dir)
+            .into_iter()
+            .map(CodexCredential::ApiKey)
+            .collect();
+    let oauths: Vec<CodexCredential> =
+        super::ai_providers::get_all_openai_oauth_accounts(working_dir)
+            .into_iter()
+            .map(CodexCredential::OAuth)
+            .collect();
     // Emit at debug so we can correlate rotation behaviour with the pool
     // state for any given mission. Counts only; never the credentials.
     tracing::debug!(
@@ -3173,136 +3175,9 @@ async fn run_mission_turn(
             // the user with no rotation. The recheck guards against that
             // without changing the happy-path behaviour.
             'codex_arm: {
-            let mut all_creds = collect_codex_credentials(&config.working_dir);
-            let mut prior_empty_result: Option<AgentResult> = None;
-            if all_creds.is_empty() {
-                let mut result = run_codex_turn(
-                    &workspace,
-                    &mission_work_dir,
-                    codex_message,
-                    requested_model,
-                    model_effort.as_deref(),
-                    effective_agent.as_deref(),
-                    mission_id,
-                    events_tx.clone(),
-                    cancel.clone(),
-                    &config.working_dir,
-                    session_id.as_deref(),
-                    None,
-                )
-                .await;
-
-                if let Some(fallback_model) =
-                    codex_chatgpt_fallback_for_result(requested_model, &result)
-                {
-                    tracing::warn!(
-                        mission_id = %mission_id,
-                        requested_model = ?requested_model,
-                        fallback_model,
-                        "Retrying Codex turn with fallback model for ChatGPT account compatibility"
-                    );
-                    result = run_codex_turn(
-                        &workspace,
-                        &mission_work_dir,
-                        codex_message,
-                        Some(fallback_model),
-                        model_effort.as_deref(),
-                        effective_agent.as_deref(),
-                        mission_id,
-                        events_tx.clone(),
-                        cancel.clone(),
-                        &config.working_dir,
-                        session_id.as_deref(),
-                        None,
-                    )
-                    .await;
-                } else if codex_tool_stall_should_retry_with_default_model(requested_model, &result)
-                {
-                    tracing::warn!(
-                        mission_id = %mission_id,
-                        requested_model = ?requested_model,
-                        "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use"
-                    );
-                    result = run_codex_turn(
-                        &workspace,
-                        &mission_work_dir,
-                        codex_message,
-                        None,
-                        model_effort.as_deref(),
-                        effective_agent.as_deref(),
-                        mission_id,
-                        events_tx.clone(),
-                        cancel.clone(),
-                        &config.working_dir,
-                        session_id.as_deref(),
-                        None,
-                    )
-                    .await;
-                }
-
-                // Defensive re-query: if this turn was rate/capacity limited
-                // and a fresh enumeration now returns accounts, fall through
-                // to the rotation loop instead of surfacing the failure.
-                let constrained = matches!(
-                    result.terminal_reason,
-                    Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
-                );
-                if constrained {
-                    let recheck = collect_codex_credentials(&config.working_dir);
-                    if !recheck.is_empty() {
-                        tracing::warn!(
-                            mission_id = %mission_id,
-                            recovered_credentials = recheck.len(),
-                            "Codex credential pool was empty on first attempt but re-query found accounts after a rate-limited turn; retrying with rotation"
-                        );
-                        all_creds = recheck;
-                        prior_empty_result = Some(result);
-                        // fall through to rotation loop below
-                    } else {
-                        break 'codex_arm result;
-                    }
-                } else {
-                    break 'codex_arm result;
-                }
-            }
-            {
-                let mut attempted_credentials: HashSet<String> = HashSet::new();
-                let mut attempt_idx = 0usize;
-                let mut last_constrained_result: Option<AgentResult> = prior_empty_result;
-
-                loop {
-                    if cancel.is_cancelled() {
-                        break last_constrained_result.unwrap_or_else(cancel_or_shutdown_failure);
-                    }
-
-                    let lease =
-                        lease_codex_account(&config.working_dir, &attempted_credentials, &cancel)
-                            .await;
-                    let Some(lease) = lease else {
-                        if let Some(prev) = last_constrained_result {
-                            break prev;
-                        }
-                        break AgentResult::failure(
-                            "All configured Codex accounts are currently at capacity. Try again shortly."
-                                .to_string(),
-                            0,
-                        )
-                        .with_terminal_reason(TerminalReason::CapacityLimited);
-                    };
-
-                    attempt_idx += 1;
-                    let credential_label = lease.credential.label_for_logs();
-                    attempted_credentials.insert(lease.credential.fingerprint());
-                    let credential_override = lease.credential.as_override();
-
-                    tracing::info!(
-                        mission_id = %mission_id,
-                        attempt = attempt_idx,
-                        credential = %credential_label,
-                        total_credentials = all_creds.len(),
-                        "Running Codex turn with leased account slot"
-                    );
-
+                let mut all_creds = collect_codex_credentials(&config.working_dir);
+                let mut prior_empty_result: Option<AgentResult> = None;
+                if all_creds.is_empty() {
                     let mut result = run_codex_turn(
                         &workspace,
                         &mission_work_dir,
@@ -3315,7 +3190,7 @@ async fn run_mission_turn(
                         cancel.clone(),
                         &config.working_dir,
                         session_id.as_deref(),
-                        Some(&credential_override),
+                        None,
                     )
                     .await;
 
@@ -3324,10 +3199,8 @@ async fn run_mission_turn(
                     {
                         tracing::warn!(
                             mission_id = %mission_id,
-                            attempt = attempt_idx,
                             requested_model = ?requested_model,
                             fallback_model,
-                            credential = %credential_label,
                             "Retrying Codex turn with fallback model for ChatGPT account compatibility"
                         );
                         result = run_codex_turn(
@@ -3342,7 +3215,7 @@ async fn run_mission_turn(
                             cancel.clone(),
                             &config.working_dir,
                             session_id.as_deref(),
-                            Some(&credential_override),
+                            None,
                         )
                         .await;
                     } else if codex_tool_stall_should_retry_with_default_model(
@@ -3351,9 +3224,7 @@ async fn run_mission_turn(
                     ) {
                         tracing::warn!(
                             mission_id = %mission_id,
-                            attempt = attempt_idx,
                             requested_model = ?requested_model,
-                            credential = %credential_label,
                             "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use"
                         );
                         result = run_codex_turn(
@@ -3368,33 +3239,170 @@ async fn run_mission_turn(
                             cancel.clone(),
                             &config.working_dir,
                             session_id.as_deref(),
-                            Some(&credential_override),
+                            None,
                         )
                         .await;
                     }
 
-                    drop(lease);
-
-                    match result.terminal_reason {
+                    // Defensive re-query: if this turn was rate/capacity limited
+                    // and a fresh enumeration now returns accounts, fall through
+                    // to the rotation loop instead of surfacing the failure.
+                    let constrained = matches!(
+                        result.terminal_reason,
                         Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
-                            if attempted_credentials.len() < all_creds.len() =>
-                        {
-                            let reason = match result.terminal_reason {
-                                Some(TerminalReason::CapacityLimited) => "capacity limited",
-                                _ => "rate limited",
-                            };
-                            tracing::info!(
+                    );
+                    if constrained {
+                        let recheck = collect_codex_credentials(&config.working_dir);
+                        if !recheck.is_empty() {
+                            tracing::warn!(
                                 mission_id = %mission_id,
-                                attempt = attempt_idx,
-                                reason,
-                                "Codex account constrained; leasing next account"
+                                recovered_credentials = recheck.len(),
+                                "Codex credential pool was empty on first attempt but re-query found accounts after a rate-limited turn; retrying with rotation"
                             );
-                            last_constrained_result = Some(result);
+                            all_creds = recheck;
+                            prior_empty_result = Some(result);
+                            // fall through to rotation loop below
+                        } else {
+                            break 'codex_arm result;
                         }
-                        _ => break result,
+                    } else {
+                        break 'codex_arm result;
                     }
                 }
-            }
+                {
+                    let mut attempted_credentials: HashSet<String> = HashSet::new();
+                    let mut attempt_idx = 0usize;
+                    let mut last_constrained_result: Option<AgentResult> = prior_empty_result;
+
+                    loop {
+                        if cancel.is_cancelled() {
+                            break last_constrained_result
+                                .unwrap_or_else(cancel_or_shutdown_failure);
+                        }
+
+                        let lease = lease_codex_account(
+                            &config.working_dir,
+                            &attempted_credentials,
+                            &cancel,
+                        )
+                        .await;
+                        let Some(lease) = lease else {
+                            if let Some(prev) = last_constrained_result {
+                                break prev;
+                            }
+                            break AgentResult::failure(
+                            "All configured Codex accounts are currently at capacity. Try again shortly."
+                                .to_string(),
+                            0,
+                        )
+                        .with_terminal_reason(TerminalReason::CapacityLimited);
+                        };
+
+                        attempt_idx += 1;
+                        let credential_label = lease.credential.label_for_logs();
+                        attempted_credentials.insert(lease.credential.fingerprint());
+                        let credential_override = lease.credential.as_override();
+
+                        tracing::info!(
+                            mission_id = %mission_id,
+                            attempt = attempt_idx,
+                            credential = %credential_label,
+                            total_credentials = all_creds.len(),
+                            "Running Codex turn with leased account slot"
+                        );
+
+                        let mut result = run_codex_turn(
+                            &workspace,
+                            &mission_work_dir,
+                            codex_message,
+                            requested_model,
+                            model_effort.as_deref(),
+                            effective_agent.as_deref(),
+                            mission_id,
+                            events_tx.clone(),
+                            cancel.clone(),
+                            &config.working_dir,
+                            session_id.as_deref(),
+                            Some(&credential_override),
+                        )
+                        .await;
+
+                        if let Some(fallback_model) =
+                            codex_chatgpt_fallback_for_result(requested_model, &result)
+                        {
+                            tracing::warn!(
+                                mission_id = %mission_id,
+                                attempt = attempt_idx,
+                                requested_model = ?requested_model,
+                                fallback_model,
+                                credential = %credential_label,
+                                "Retrying Codex turn with fallback model for ChatGPT account compatibility"
+                            );
+                            result = run_codex_turn(
+                                &workspace,
+                                &mission_work_dir,
+                                codex_message,
+                                Some(fallback_model),
+                                model_effort.as_deref(),
+                                effective_agent.as_deref(),
+                                mission_id,
+                                events_tx.clone(),
+                                cancel.clone(),
+                                &config.working_dir,
+                                session_id.as_deref(),
+                                Some(&credential_override),
+                            )
+                            .await;
+                        } else if codex_tool_stall_should_retry_with_default_model(
+                            requested_model,
+                            &result,
+                        ) {
+                            tracing::warn!(
+                                mission_id = %mission_id,
+                                attempt = attempt_idx,
+                                requested_model = ?requested_model,
+                                credential = %credential_label,
+                                "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use"
+                            );
+                            result = run_codex_turn(
+                                &workspace,
+                                &mission_work_dir,
+                                codex_message,
+                                None,
+                                model_effort.as_deref(),
+                                effective_agent.as_deref(),
+                                mission_id,
+                                events_tx.clone(),
+                                cancel.clone(),
+                                &config.working_dir,
+                                session_id.as_deref(),
+                                Some(&credential_override),
+                            )
+                            .await;
+                        }
+
+                        drop(lease);
+
+                        match result.terminal_reason {
+                            Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
+                                if attempted_credentials.len() < all_creds.len() =>
+                            {
+                                let reason = match result.terminal_reason {
+                                    Some(TerminalReason::CapacityLimited) => "capacity limited",
+                                    _ => "rate limited",
+                                };
+                                tracing::info!(
+                                    mission_id = %mission_id,
+                                    attempt = attempt_idx,
+                                    reason,
+                                    "Codex account constrained; leasing next account"
+                                );
+                                last_constrained_result = Some(result);
+                            }
+                            _ => break result,
+                        }
+                    }
+                }
             }
         }
         "gemini" => {
@@ -13461,9 +13469,16 @@ pub async fn run_codex_turn(
     {
         Ok(result) => result,
         Err(e) => {
+            let message = format!("Codex execution failed: {}", e);
             tracing::error!("Failed to send message to Codex: {}", e);
-            return AgentResult::failure(format!("Codex execution failed: {}", e), 0)
-                .with_terminal_reason(TerminalReason::LlmError);
+            let reason = if is_capacity_limited_error(&message) {
+                TerminalReason::CapacityLimited
+            } else if is_rate_limited_error(&message) {
+                TerminalReason::RateLimited
+            } else {
+                TerminalReason::LlmError
+            };
+            return AgentResult::failure(message, 0).with_terminal_reason(reason);
         }
     };
 

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -231,6 +231,23 @@ impl MissionStore for FileMissionStore {
         self.persist().await
     }
 
+    async fn update_mission_goal(
+        &self,
+        id: Uuid,
+        goal_mode: bool,
+        goal_objective: Option<&str>,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        mission.goal_mode = goal_mode;
+        mission.goal_objective = goal_objective.map(|s| s.to_string());
+        mission.updated_at = now_string();
+        drop(missions);
+        self.persist().await
+    }
+
     async fn update_mission_title(&self, id: Uuid, title: &str) -> Result<(), String> {
         let mut missions = self.missions.write().await;
         let mission = missions

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -178,6 +178,22 @@ impl MissionStore for InMemoryMissionStore {
         Ok(())
     }
 
+    async fn update_mission_goal(
+        &self,
+        id: Uuid,
+        goal_mode: bool,
+        goal_objective: Option<&str>,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        mission.goal_mode = goal_mode;
+        mission.goal_objective = goal_objective.map(|s| s.to_string());
+        mission.updated_at = now_string();
+        Ok(())
+    }
+
     async fn update_mission_title(&self, id: Uuid, title: &str) -> Result<(), String> {
         let mut missions = self.missions.write().await;
         let mission = missions

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -913,6 +913,7 @@ pub trait MissionStore: Send + Sync {
                 m.status == MissionStatus::Interrupted
                     && m.resumable
                     && m.terminal_reason.as_deref() == Some("server_shutdown")
+                    && m.mission_mode != MissionMode::Assistant
                     && m.interrupted_at
                         .as_deref()
                         .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -865,6 +865,14 @@ pub trait MissionStore: Send + Sync {
     /// Update mission session ID (for backends like Amp that generate their own IDs).
     async fn update_mission_session_id(&self, id: Uuid, session_id: &str) -> Result<(), String>;
 
+    /// Update cached goal-mode metadata for missions started with `/goal`.
+    async fn update_mission_goal(
+        &self,
+        id: Uuid,
+        goal_mode: bool,
+        goal_objective: Option<&str>,
+    ) -> Result<(), String>;
+
     /// Update mission agent tree.
     async fn update_mission_tree(&self, id: Uuid, tree: &AgentTreeNode) -> Result<(), String>;
 
@@ -891,6 +899,29 @@ pub trait MissionStore: Send + Sync {
 
     /// Get all missions currently in active status (for startup recovery).
     async fn get_all_active_missions(&self) -> Result<Vec<Mission>, String>;
+
+    /// Get recently interrupted missions that were stopped by server shutdown.
+    async fn get_recent_server_shutdown_mission_ids(
+        &self,
+        max_age_hours: u64,
+    ) -> Result<Vec<Uuid>, String> {
+        let cutoff = Utc::now() - chrono::Duration::hours(max_age_hours as i64);
+        let missions = self.list_missions(1000, 0).await?;
+        Ok(missions
+            .into_iter()
+            .filter(|m| {
+                m.status == MissionStatus::Interrupted
+                    && m.resumable
+                    && m.terminal_reason.as_deref() == Some("server_shutdown")
+                    && m.interrupted_at
+                        .as_deref()
+                        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                        .map(|value| value.with_timezone(&Utc) >= cutoff)
+                        .unwrap_or(false)
+            })
+            .map(|m| m.id)
+            .collect())
+    }
 
     /// Insert a mission summary (for historical lookup).
     async fn insert_mission_summary(

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -1960,7 +1960,8 @@ impl MissionStore for SqliteMissionStore {
                             created_at, updated_at, interrupted_at, resumable, desktop_sessions,
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
-                            COALESCE(mission_mode, 'task') as mission_mode
+                            COALESCE(mission_mode, 'task') as mission_mode,
+                            COALESCE(goal_mode, 0) as goal_mode, goal_objective
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2580,6 +2581,34 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn update_mission_goal(
+        &self,
+        id: Uuid,
+        goal_mode: bool,
+        goal_objective: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let now = now_string();
+        let goal_objective = goal_objective.map(|s| s.to_string());
+
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET goal_mode = ?1, goal_objective = ?2, updated_at = ?3 WHERE id = ?4",
+                params![
+                    if goal_mode { 1i64 } else { 0i64 },
+                    goal_objective,
+                    now,
+                    id.to_string()
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn update_mission_tree(&self, id: Uuid, tree: &AgentTreeNode) -> Result<(), String> {
         let conn = self.conn.clone();
         let now = now_string();
@@ -2791,7 +2820,10 @@ impl MissionStore for SqliteMissionStore {
                 .prepare(
                     "SELECT id, status, title, workspace_id, workspace_name, agent, model_override,
                             created_at, updated_at, interrupted_at, resumable, desktop_sessions,
-                            COALESCE(backend, 'opencode') as backend
+                            COALESCE(backend, 'opencode') as backend,
+                            COALESCE(mission_mode, 'task') as mission_mode,
+                            COALESCE(goal_mode, 0) as goal_mode,
+                            goal_objective
                      FROM missions
                      WHERE status = 'active'",
                 )
@@ -2833,10 +2865,13 @@ impl MissionStore for SqliteMissionStore {
                         session_id: None,
                         terminal_reason: None,
                         parent_mission_id: None,
-                        mission_mode: MissionMode::default(),
                         working_directory: None,
-                        goal_mode: false,
-                        goal_objective: None,
+                        mission_mode: row
+                            .get::<_, Option<String>>(13)?
+                            .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
+                            .unwrap_or_default(),
+                        goal_mode: row.get::<_, i32>(14).unwrap_or(0) != 0,
+                        goal_objective: row.get(15).ok().flatten(),
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2844,6 +2879,44 @@ impl MissionStore for SqliteMissionStore {
                 .map_err(|e| e.to_string())?;
 
             Ok(missions)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn get_recent_server_shutdown_mission_ids(
+        &self,
+        max_age_hours: u64,
+    ) -> Result<Vec<Uuid>, String> {
+        let conn = self.conn.clone();
+        let cutoff = Utc::now() - chrono::Duration::hours(max_age_hours as i64);
+        let cutoff_str = cutoff.to_rfc3339();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id
+                     FROM missions
+                     WHERE status = 'interrupted'
+                       AND resumable = 1
+                       AND terminal_reason = 'server_shutdown'
+                       AND interrupted_at IS NOT NULL
+                       AND interrupted_at >= ?1
+                     ORDER BY interrupted_at ASC",
+                )
+                .map_err(|e| e.to_string())?;
+
+            let mission_ids = stmt
+                .query_map(params![cutoff_str], |row| {
+                    let id_str: String = row.get(0)?;
+                    Ok(parse_uuid_or_nil(&id_str))
+                })
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+
+            Ok(mission_ids)
         })
         .await
         .map_err(|e| e.to_string())?

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2901,6 +2901,7 @@ impl MissionStore for SqliteMissionStore {
                      WHERE status = 'interrupted'
                        AND resumable = 1
                        AND terminal_reason = 'server_shutdown'
+                       AND COALESCE(mission_mode, 'task') != 'assistant'
                        AND interrupted_at IS NOT NULL
                        AND interrupted_at >= ?1
                      ORDER BY interrupted_at ASC",
@@ -6776,10 +6777,11 @@ mod tests {
     use super::{assistant_message_metadata, AssistantMessageMetadataInput, SqliteMissionStore};
     use crate::agents::CostSource;
     use crate::api::mission_store::{
-        MissionStore, TelegramChannel, TelegramConversation, TelegramConversationMessage,
-        TelegramConversationMessageDirection, TelegramStructuredMemoryEntry,
-        TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramTriggerMode,
-        TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus,
+        MissionMode, MissionStatus, MissionStore, TelegramChannel, TelegramConversation,
+        TelegramConversationMessage, TelegramConversationMessageDirection,
+        TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
+        TelegramTriggerMode, TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind,
+        TelegramWorkflowStatus,
     };
     use crate::cost::TokenUsage;
     use rusqlite::params;
@@ -8424,6 +8426,52 @@ mod tests {
             stale.iter().any(|m| m.id == mission.id),
             "mission with no recent events and old updated_at must still be flagged"
         );
+    }
+
+    #[tokio::test]
+    async fn recent_server_shutdown_query_skips_assistant_missions() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+
+        let task_mission = store
+            .create_mission(Some("task"), None, None, None, None, None, None)
+            .await
+            .expect("task mission");
+        store
+            .update_mission_status_with_reason(
+                task_mission.id,
+                MissionStatus::Interrupted,
+                Some("server_shutdown"),
+            )
+            .await
+            .expect("mark task interrupted");
+
+        let assistant_mission = store
+            .create_mission(Some("assistant"), None, None, None, None, None, None)
+            .await
+            .expect("assistant mission");
+        store
+            .update_mission_mode(assistant_mission.id, MissionMode::Assistant)
+            .await
+            .expect("set assistant mode");
+        store
+            .update_mission_status_with_reason(
+                assistant_mission.id,
+                MissionStatus::Interrupted,
+                Some("server_shutdown"),
+            )
+            .await
+            .expect("mark assistant interrupted");
+
+        let mission_ids = store
+            .get_recent_server_shutdown_mission_ids(48)
+            .await
+            .expect("recent server-shutdown missions");
+
+        assert!(mission_ids.contains(&task_mission.id));
+        assert!(!mission_ids.contains(&assistant_mission.id));
     }
 
     #[tokio::test]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2,7 +2,21 @@
 
 use std::cmp::Reverse;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+/// Process-wide flag set when the server has begun a graceful shutdown.
+/// Cancel-aware code paths (e.g. mission runners that observe a cancel
+/// token) read this to distinguish a server-initiated interruption from
+/// a user-initiated cancel, so they can emit a friendlier resume message
+/// and a `server_shutdown` terminal reason instead of `cancelled`.
+static SHUTDOWN_INITIATED: AtomicBool = AtomicBool::new(false);
+
+/// Returns `true` if `handle_shutdown_signal` has begun draining missions
+/// for a graceful shutdown.
+pub fn is_shutdown_initiated() -> bool {
+    SHUTDOWN_INITIATED.load(Ordering::Acquire)
+}
 use tokio::sync::RwLock;
 
 use axum::middleware;
@@ -1005,6 +1019,12 @@ async fn shutdown_signal(state: Arc<AppState>) {
         .map(|path| path.display().to_string())
         .unwrap_or_else(|| "<unknown>".to_string());
     let invocation_id = std::env::var("INVOCATION_ID").ok();
+    // Flip the global shutdown flag *before* we cancel any mission runners
+    // so the cancel-aware return paths can pick the friendlier
+    // `server_shutdown` terminal reason instead of treating this like a
+    // user-initiated cancel.
+    SHUTDOWN_INITIATED.store(true, Ordering::Release);
+
     tracing::warn!(
         signal,
         pid = std::process::id(),

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -248,9 +248,12 @@ async fn send_message_streaming_app_server(
     // through the codex backend config would silently get codex's built-in
     // default in app-server mode.
     let resolved_model = resolve_model(session.model.as_deref(), cfg.default_model.as_deref());
+    let thread_cwd = workspace_exec
+        .map(|exec| exec.translate_path_for_container(std::path::Path::new(&session.directory)))
+        .unwrap_or_else(|| session.directory.clone());
     let thread_start_params = ThreadStartParams {
         model: resolved_model,
-        cwd: Some(session.directory.clone()),
+        cwd: Some(thread_cwd),
         reasoning_effort: cfg.model_effort.clone(),
         ephemeral: None,
         // Match exec-mode's `--dangerously-bypass-approvals-and-sandbox`.


### PR DESCRIPTION
## Summary
When SIGTERM (deploy / `unattended-upgrades` / manual restart) ended a mission mid-turn, the runner used to write the same `Mission cancelled` synthetic assistant message and `terminal_reason="cancelled"` as a user-initiated cancel. The dashboard then surfaced it as if the user had clicked Cancel, even though the mission is `resumable=1` and just needs a Resume click.

This was diagnosed live on mission `e8d50131-45ef-402c-a9ac-eb4e53694298` after `apt.systemd.daily` restarted the prod service.

## Changes
- New `TerminalReason::ServerShutdown` mapped to `(MissionStatus::Interrupted, "server_shutdown")` and to a friendlier status summary ("Paused for server restart — click Resume to continue").
- `routes::handle_shutdown_signal` flips a process-wide `SHUTDOWN_INITIATED` atomic *before* draining sessions, exposed via `routes::is_shutdown_initiated()`.
- `mission_runner` cancel-aware return points (Codex turn, Gemini turn, OpenCode lease/retry loop) now route through a new `cancel_or_shutdown_failure()` helper that picks the friendlier message + `ServerShutdown` reason when the flag is set, and falls back to the old `Mission cancelled` / `Cancelled` behaviour otherwise.
- `control.rs::GracefulShutdown` writes `terminal_reason="server_shutdown"` directly via `update_mission_status_with_reason` so the row is unambiguous even if the runner result lands later. (The existing finalizer bails when status is already `Interrupted`, so this doesn't get overwritten.)

## Operational change (already applied on prod)
Bumped `TimeoutStopSec=300` on `/etc/systemd/system/sandboxed-sh-prod.service` so the graceful shutdown actually has time to drain. The previous default 90 s was too short for a 16 GB-resident process and caused a SIGKILL mid-shutdown.

## User-facing effect
Chat history now shows "Server restart — paused. Click Resume to continue." instead of "Mission cancelled" when the service is restarted, and the persisted `terminal_reason="server_shutdown"` lets the dashboard render a Resume affordance distinct from a user cancel.

## Test plan
- [x] `cargo build` clean locally and on server (`/opt/sandboxed-sh-prod`)
- [x] Deployed to prod; health check 200 OK at `agent-backend.thomas.md/api/health`
- [x] `strings sandboxed-sh-prod | grep -E 'Server restart|server_shutdown|ServerShutdown'` confirms the new strings are baked in
- [x] Resumed mission `e8d50131-45ef-402c-a9ac-eb4e53694298` post-deploy; status `active`, `state=running`, `health=healthy`
- [ ] Trigger a manual `systemctl restart sandboxed-sh-prod` while a mission is running and verify the synthetic message reads "Server restart — paused. Click Resume to continue." and the row has `terminal_reason="server_shutdown"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission lifecycle and startup recovery logic (status/terminal_reason, auto-resume, parallel runners) plus filesystem upload path validation, so mistakes could mis-label missions or resume unexpectedly.
> 
> **Overview**
> Missions interrupted by backend shutdown are now classified separately via `TerminalReason::ServerShutdown` and a process-wide shutdown flag, producing a *resume-friendly* message/summary instead of a user-cancelled one.
> 
> On startup, the control layer recovers `server_shutdown` task missions (including those left `active` after hard stops) and auto-enqueues resumes, using parallel runners when another mission is already running; mission storage is extended to persist `/goal` metadata and to query recently shutdown missions.
> 
> Dashboard improvements move the *Run Settings* editor into the mission workbench via a slot, harden history replay by merging event replay with coarse mission history when event pages lack assistant messages, improve upload error toasts, and refine slash-command autocomplete to only trigger at the start of input; `NewMissionDialog` is refactored to a portal-based positioned popover and pre-opens a blank tab to avoid popup blocking (with a new test). Also refines API context upload path handling and adds logging for `ai_providers.json` read/parse failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ddaccb998aec444df349352ab6549bdc104cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->