### PR TITLE
dashboard: require Cmd+Enter to send messages

### DIFF
--- a/dashboard/src/components/enhanced-input.test.tsx
+++ b/dashboard/src/components/enhanced-input.test.tsx
@@ -89,6 +89,7 @@ describe("EnhancedInput composer behavior", () => {
       key: "Enter",
       code: "Enter",
       shiftKey: false,
+      metaKey: true,
     });
 
     expect(onSubmit).toHaveBeenCalledWith({ content: "draft message" });

--- a/dashboard/src/components/enhanced-input.tsx
+++ b/dashboard/src/components/enhanced-input.tsx
@@ -516,8 +516,8 @@ export const EnhancedInput = memo(forwardRef<EnhancedInputHandle, EnhancedInputP
       return;
     }
 
-    // Normal Enter to submit (without Shift)
-    if (e.key === 'Enter' && !e.shiftKey && !showAutocomplete) {
+    // Cmd+Enter (or Ctrl+Enter) to submit; plain Enter inserts a newline
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !showAutocomplete) {
       e.preventDefault();
       handleSubmit();
     }


### PR DESCRIPTION
Plain Enter now inserts a newline; Cmd+Enter (or Ctrl+Enter on non-Mac) submits the message. Previously a bare Enter sent the message and Shift+Enter inserted a newline.