### PR TITLE
Fix prod shutdown stream drain

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4869,12 +4869,25 @@ pub async fn stream(
             }
         }
 
-        // Keepalive interval to prevent connection timeouts during long LLM calls
+        // Keepalive interval to prevent connection timeouts during long LLM calls.
         let mut keepalive_interval = tokio::time::interval(std::time::Duration::from_secs(15));
         keepalive_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut shutdown_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        shutdown_check_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             tokio::select! {
+                _ = shutdown_check_interval.tick() => {
+                    if super::routes::is_shutdown_initiated() {
+                        tracing::info!(
+                            stream_id = %stream_id,
+                            user_id = %user.id,
+                            username = %user.username,
+                            "Control SSE stream closing for graceful shutdown"
+                        );
+                        break;
+                    }
+                }
                 result = rx.recv() => {
                     match result {
                         Ok(ev) => {
@@ -9712,6 +9725,14 @@ async fn run_single_control_turn(
             .await;
 
             loop {
+                if cancel.is_cancelled() || super::routes::is_shutdown_initiated() {
+                    tracing::debug!(
+                        mission_id = %mid,
+                        "Skipping Claude transport recovery because execution is cancelling or shutting down"
+                    );
+                    break;
+                }
+
                 match super::mission_runner::claudecode_transport_recovery_strategy(
                     &result,
                     effective_session_id.is_some(),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2755,6 +2755,14 @@ async fn run_mission_turn(
             .await;
 
             loop {
+                if cancel.is_cancelled() || super::routes::is_shutdown_initiated() {
+                    tracing::debug!(
+                        mission_id = %mission_id,
+                        "Skipping Claude transport recovery because execution is cancelling or shutting down"
+                    );
+                    break;
+                }
+
                 match claudecode_transport_recovery_strategy(
                     &result,
                     effective_sid.is_some(),


### PR DESCRIPTION
## Summary
- close control SSE streams once graceful shutdown starts
- skip Claude transport-recovery retries after cancellation or shutdown begins

## Verification
- cargo fmt --all
- cargo check
- cargo test claudecode_transport_recovery_strategy_prefers_same_session_resume_for_incomplete_turn --lib
- cargo test maybe_finalize_terminal_mission_preserves_interrupted_status --lib
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission execution and control SSE streaming loops to change behavior during graceful shutdown, which could affect in-flight missions and client UX if the shutdown flag is mis-set or checked too aggressively.
> 
> **Overview**
> Improves graceful shutdown handling by actively closing `control` SSE streams once shutdown begins (periodically polling `is_shutdown_initiated()` and breaking the stream loop).
> 
> Prevents wasted work during shutdown/cancellation by skipping Claude Code transport-recovery retry loops when the cancel token is set or shutdown has been initiated (applied in both the control-path Claude execution and the main `mission_runner`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd428d4de42e07cbf8e1ba05d78cf32a4203f4c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->