### PR TITLE
fix: address Bugbot follow-ups on #428

### DIFF
--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -1372,12 +1372,21 @@ pub async fn download_from_url(
     // Validate URL to prevent SSRF attacks
     validate_url_for_ssrf(&req.url).map_err(|e| (StatusCode::BAD_REQUEST, e))?;
 
-    // Download to temp file
+    // Download to temp file. Follow up to 5 redirects, but re-validate each
+    // hop's URL with the same SSRF rules so a public redirect cannot bounce us
+    // to an internal host. Many file hosts (GitHub releases, CDNs) rely on
+    // redirects, so disabling them outright breaks common downloads.
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(300)) // 5 min timeout
-        // Do not follow redirects automatically. A redirected request to an
-        // internal host would already be an SSRF before post-response validation.
-        .redirect(reqwest::redirect::Policy::none())
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() >= 5 {
+                return attempt.error("too many redirects");
+            }
+            if let Err(e) = validate_url_for_ssrf(attempt.url().as_str()) {
+                return attempt.error(format!("redirect blocked: {}", e));
+            }
+            attempt.follow()
+        }))
         .build()
         .map_err(|e| {
             (

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -1379,7 +1379,10 @@ pub async fn download_from_url(
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(300)) // 5 min timeout
         .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            if attempt.previous().len() >= 5 {
+            // `previous()` lists hops already followed, so the Nth attempt has
+            // N-1 entries. Using `> 5` allows the 5 hops promised by the
+            // comment above; `>= 5` would cap at 4.
+            if attempt.previous().len() > 5 {
                 return attempt.error("too many redirects");
             }
             if let Err(e) = validate_url_for_ssrf(attempt.url().as_str()) {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9226,10 +9226,14 @@ async fn ensure_claudecode_cli_available(
 }
 
 fn desired_claudecode_version() -> String {
+    // 2.1.140 ships the bug-fixed native `/goal` slash command (added in
+    // 2.1.139, hardened against `disableAllHooks` / `allowManagedHooksOnly`
+    // in 2.1.140). Bumping the pin so the per-workspace install matches what
+    // `run_claudecode_native_goal` relies on.
     std::env::var("SANDBOXED_SH_CLAUDECODE_VERSION")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "2.1.139".to_string())
+        .unwrap_or_else(|| "2.1.140".to_string())
 }
 
 async fn claude_cli_matches_desired_version(
@@ -10648,24 +10652,30 @@ pub async fn run_opencode_turn(
     // Vanilla `opencode` is the default. oh-my-opencode wraps opencode with extra
     // features (todo enforcement, background tasks, opinionated agent profiles)
     // and is opt-in per workspace/profile via `enable_oh_my_opencode`.
-    // The `sisyphus` agent name is an oh-my-opencode-only identifier; if it is
-    // selected explicitly, fall back to plain opencode (the wrapper is not
-    // available) rather than failing.
     let oh_my_opencode_enabled = workspace
         .config
         .get("enable_oh_my_opencode")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let agent_needs_plain_opencode = agent
-        .map(|a| a.eq_ignore_ascii_case("sisyphus"))
-        .unwrap_or(false);
-    let use_plain_opencode = !oh_my_opencode_enabled || agent_needs_plain_opencode;
+    let use_plain_opencode = !oh_my_opencode_enabled;
+
+    // `sisyphus` only exists inside the oh-my-opencode wrapper. Warn loudly when
+    // it is requested without the wrapper so the failure mode is obvious.
+    if use_plain_opencode
+        && agent
+            .map(|a| a.eq_ignore_ascii_case("sisyphus"))
+            .unwrap_or(false)
+    {
+        tracing::warn!(
+            mission_id = %mission_id,
+            "Agent 'sisyphus' requires oh-my-opencode, but enable_oh_my_opencode is false; mission will likely fail"
+        );
+    }
 
     tracing::info!(
         mission_id = %mission_id,
         use_plain_opencode = use_plain_opencode,
         oh_my_opencode_enabled = oh_my_opencode_enabled,
-        agent_needs_plain_opencode = agent_needs_plain_opencode,
         "OpenCode mode selection"
     );
 

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2018,9 +2018,7 @@ fn stream_oh_my_opencode_uninstall() -> impl Stream<Item = Result<Event, std::co
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        extract_version_token, is_safe_repo_path, normalize_repo_path, select_repo_path,
-    };
+    use super::{extract_version_token, is_safe_repo_path, normalize_repo_path, select_repo_path};
 
     #[test]
     fn extract_version_token_basic_semver() {


### PR DESCRIPTION
## Summary
Two unresolved Bugbot findings from #428:

- **HIGH** — `src/api/fs.rs` `download_from_url`: `Policy::none()` + removing post-redirect SSRF validation broke any URL that 3xx-redirects (GitHub releases, CDNs, most file hosts). Restored redirect-following with a custom policy that re-runs `validate_url_for_ssrf` on every hop and caps at 5 redirects.
- **MEDIUM** — `src/api/mission_runner.rs`: when a user selected the `sisyphus` agent with `enable_oh_my_opencode=true`, the old `|| agent_needs_plain_opencode` clause still forced plain opencode, which doesn't ship sisyphus → mission fails. Dropped that override; now `use_plain_opencode` strictly mirrors the wrapper flag. Added a warning log for the obviously-broken combo (sisyphus + wrapper disabled).

## Test plan
- [ ] Download a GitHub Releases URL via the dashboard — confirm the redirect chain resolves and the file lands on disk.
- [ ] Download a URL that redirects to an internal/private IP — confirm SSRF block triggers on the redirect hop, not just the initial request.
- [ ] Create an OpenCode mission with `enable_oh_my_opencode=true` and agent=`sisyphus` — confirm it runs via the wrapper (look for `use_plain_opencode = false` in logs).
- [ ] Create an OpenCode mission without wrapper and agent=`sisyphus` — confirm the warning log fires.

Refs threads on #428.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF protection and HTTP redirect handling in `download_from_url`, where mistakes could reintroduce SSRF or break legitimate downloads. Also changes mission runner agent selection logic, which may affect how missions invoke OpenCode/oh-my-opencode.
> 
> **Overview**
> Re-enables following up to 5 HTTP redirects in `download_from_url` while **re-validating each redirect hop** with `validate_url_for_ssrf` to keep SSRF protections intact and avoid breaking common redirected file hosts.
> 
> Adjusts mission runner OpenCode mode selection so `use_plain_opencode` strictly mirrors `enable_oh_my_opencode`, preventing `sisyphus` from being forced onto plain `opencode`, and adds a warning when `sisyphus` is requested without the wrapper.
> 
> Minor formatting cleanup in `system.rs` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4e2ad5be1fc3b5d33200a2e24bed52a8f7a0a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->