### PR TITLE
feat: native harness loops + iOS network resilience (replaces #430)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "sandboxed_sh"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandboxed_sh"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 rust-version = "1.91"
 description = "Self-hosted orchestrator for AI coding agents (formerly Open Agent)"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "packageManager": "bun@1.3.4",
   "scripts": {

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -8095,6 +8095,7 @@ export default function ControlClient() {
               : activeMission.title?.trim() || getMissionShortName(activeMission.id)
             : null
         }
+        missionBackend={activeMission?.backend ?? null}
         onClose={() => setShowAutomationsDialog(false)}
       />
 

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -35,6 +35,8 @@ import {
   getAutomationExecutions,
   getMissionAutomationExecutions,
   getLibraryCommand,
+  postControlMessage,
+  cancelMission,
 } from '@/lib/api';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { toast } from '@/components/toast';
@@ -84,11 +86,14 @@ export interface MissionAutomationsDialogProps {
   open: boolean;
   missionId: string | null;
   missionLabel?: string | null;
+  /** Backend id of the active mission, used to auto-pick the harness when the
+   *  user chooses "Native harness loop". Empty string when not yet known. */
+  missionBackend?: string | null;
   onClose: () => void;
 }
 
 type IntervalUnit = 'seconds' | 'minutes' | 'hours' | 'days';
-type CommandSourceType = 'library' | 'inline';
+type CommandSourceType = 'library' | 'inline' | 'native_loop';
 type TriggerKind = 'interval' | 'agent_finished' | 'webhook';
 
 const UNIT_TO_SECONDS: Record<IntervalUnit, number> = {
@@ -120,6 +125,28 @@ function getLatestRunByAutomation(executions: AutomationExecution[]): Map<string
     }
   }
   return latestByAutomation;
+}
+
+/**
+ * For native-loop automations only: count `harness_loop:iteration:N` execution
+ * rows per automation and remember the largest N seen. Used to render an
+ * "iter N" badge alongside the row label.
+ */
+function getIterationProgressByAutomation(
+  executions: AutomationExecution[]
+): Map<string, { count: number; latest: number }> {
+  const progress = new Map<string, { count: number; latest: number }>();
+  for (const execution of executions) {
+    const src = execution.trigger_source ?? '';
+    if (!src.startsWith('harness_loop:iteration:')) continue;
+    const parsed = Number.parseInt(src.slice('harness_loop:iteration:'.length), 10);
+    if (!Number.isFinite(parsed)) continue;
+    const existing = progress.get(execution.automation_id) ?? { count: 0, latest: 0 };
+    existing.count += 1;
+    if (parsed > existing.latest) existing.latest = parsed;
+    progress.set(execution.automation_id, existing);
+  }
+  return progress;
 }
 
 function mergeLastRunFromExecutions(
@@ -175,6 +202,7 @@ export function MissionAutomationsDialog({
   open,
   missionId,
   missionLabel,
+  missionBackend,
   onClose,
 }: MissionAutomationsDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -202,6 +230,8 @@ export function MissionAutomationsDialog({
   const [inlinePrompt, setInlinePrompt] = useState('');
   const commandSourceTypeRef = useRef<CommandSourceType>('library');
   const inlinePromptRef = useRef('');
+  /** Objective text when commandSourceType === 'native_loop'. */
+  const [nativeLoopObjective, setNativeLoopObjective] = useState('');
   const [triggerKind, setTriggerKind] = useState<TriggerKind>('interval');
   const [intervalValue, setIntervalValue] = useState('5');
   const [intervalUnit, setIntervalUnit] = useState<IntervalUnit>('minutes');
@@ -217,6 +247,9 @@ export function MissionAutomationsDialog({
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Automation | null>(null);
   const [deleting, setDeleting] = useState(false);
+  /** Native-loop row queued for stop. The confirm dialog reads this. */
+  const [pendingStop, setPendingStop] = useState<Automation | null>(null);
+  const [stopping, setStopping] = useState(false);
   const [editingAutomationId, setEditingAutomationId] = useState<string | null>(null);
   const [editingPrompt, setEditingPrompt] = useState('');
   const [savingEditId, setSavingEditId] = useState<string | null>(null);
@@ -397,6 +430,16 @@ export function MissionAutomationsDialog({
       const content = automation.command_source.content;
       return content.length > 60 ? content.slice(0, 57) + '...' : content;
     }
+    if (automation.command_source?.type === 'native_loop') {
+      const objective =
+        typeof automation.command_source.args === 'object' &&
+        automation.command_source.args !== null
+          ? ((automation.command_source.args as Record<string, unknown>)
+              .objective as string | undefined)
+          : undefined;
+      const label = `/${automation.command_source.command} ${objective ?? ''}`.trim();
+      return label.length > 60 ? label.slice(0, 57) + '...' : label;
+    }
     return 'Command';
   }, []);
 
@@ -404,10 +447,22 @@ export function MissionAutomationsDialog({
     if (automation.command_source?.type === 'library') return 'Library';
     if (automation.command_source?.type === 'inline') return 'Prompt';
     if (automation.command_source?.type === 'local_file') return 'File';
+    if (automation.command_source?.type === 'native_loop') {
+      // Compact harness tag: "Claude /goal", "Codex /goal", …
+      const h = automation.command_source.harness;
+      const harnessLabel =
+        h === 'claudecode' ? 'Claude' : h === 'codex' ? 'Codex' : h;
+      return `${harnessLabel} /${automation.command_source.command}`;
+    }
     return '';
   }, []);
 
   const getAutomationScheduleLabel = useCallback((automation: Automation) => {
+    // Harness-loop rows aren't driven by OA's scheduler — the harness CLI
+    // controls cadence. Show that explicitly instead of "After agent finishes".
+    if (automation.driver === 'harness_loop') {
+      return 'Harness loop';
+    }
     if (automation.trigger?.type === 'interval') {
       return `Every ${formatInterval(automation.trigger.seconds)}`;
     }
@@ -544,6 +599,34 @@ export function MissionAutomationsDialog({
   const handleCreate = async () => {
     if (!missionId) return;
 
+    // Native harness loop: submit `/goal <objective>` as a control message.
+    // The native_loop_observer materializes the Automation row asynchronously
+    // from the resulting GoalIteration/GoalStatus events.
+    if (commandSourceType === 'native_loop') {
+      const objective = nativeLoopObjective.trim();
+      if (!objective) {
+        toast.error('Enter an objective for the harness loop');
+        return;
+      }
+      setCreating(true);
+      try {
+        await postControlMessage(`/goal ${objective}`, { mission_id: missionId });
+        toast.success('Goal loop started — row will appear once the harness reports progress');
+        setNativeLoopObjective('');
+        // Re-fetch automations shortly so the new row shows up without a
+        // manual refresh. The observer runs asynchronously, so wait a beat.
+        setTimeout(() => {
+          void loadAutomations(true);
+        }, 800);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to submit /goal';
+        toast.error(message);
+      } finally {
+        setCreating(false);
+      }
+      return;
+    }
+
     // Build command source
     let command_source: CommandSource;
     if (commandSourceType === 'library') {
@@ -674,6 +757,36 @@ export function MissionAutomationsDialog({
     }
   };
 
+  /** Stop a native harness loop: cancel the mission's current turn (coarse —
+   *  Phase 3 will use harness-native cancel like codex `thread/goal/clear`)
+   *  and mark the automation inactive so the panel reflects the new state. */
+  const handleStopNativeLoop = async () => {
+    if (!pendingStop) return;
+    setStopping(true);
+    try {
+      await cancelMission(pendingStop.mission_id);
+      try {
+        await updateAutomation(pendingStop.id, { active: false });
+      } catch {
+        // Falling back to local state — the observer will flip it inactive
+        // anyway when the harness emits the aborted GoalStatus.
+      }
+      if (missionId) {
+        const next = automationsRef.current.map((item) =>
+          item.id === pendingStop.id ? { ...item, active: false } : item
+        );
+        setAutomationsForMission(missionId, next);
+      }
+      toast.success('Goal loop stop requested');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to stop goal loop';
+      toast.error(message);
+    } finally {
+      setStopping(false);
+      setPendingStop(null);
+    }
+  };
+
   const handleStartEdit = (automation: Automation) => {
     if (automation.command_source?.type !== 'inline') return;
     setEditingAutomationId(automation.id);
@@ -751,15 +864,26 @@ export function MissionAutomationsDialog({
 
   // -- Validation --
   const isCommandValid =
-    commandSourceType === 'library' ? commandName.trim().length > 0 : inlinePrompt.trim().length > 0;
+    commandSourceType === 'library'
+      ? commandName.trim().length > 0
+      : commandSourceType === 'native_loop'
+      ? nativeLoopObjective.trim().length > 0
+      : inlinePrompt.trim().length > 0;
   const isTriggerValid =
-    triggerKind === 'webhook' || triggerKind === 'agent_finished' || intervalSeconds > 0;
+    commandSourceType === 'native_loop' ||
+    triggerKind === 'webhook' ||
+    triggerKind === 'agent_finished' ||
+    intervalSeconds > 0;
   const allowCreate = !!missionId && !creating && isCommandValid && isTriggerValid;
 
   const isMissionDataReady = !!missionId && loadedMissionId === missionId;
   const showLoadingPlaceholder = !!missionId && (!isMissionDataReady || (loading && !hasLoaded));
   const visibleAutomations = isMissionDataReady ? automations : [];
   const visibleError = isMissionDataReady ? error : null;
+  const iterationProgress = useMemo(
+    () => getIterationProgressByAutomation(executions),
+    [executions]
+  );
 
   const selectClass =
     'rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50 appearance-none cursor-pointer';
@@ -837,46 +961,97 @@ export function MissionAutomationsDialog({
                 )}
 
                 {/* Row 1: Command source type + Trigger type */}
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-xs text-white/50 mb-1.5">Source</label>
-                    <select
-                      value={commandSourceType}
-                      onChange={(e) => handleSourceTypeChange(e.target.value as CommandSourceType)}
-                      className={cn(selectClass, 'w-full')}
-                      style={selectStyle}
-                    >
-                      <option value="library" className="bg-[#1a1a1a]">
-                        Library command
-                      </option>
-                      <option value="inline" className="bg-[#1a1a1a]">
-                        Inline prompt
-                      </option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-xs text-white/50 mb-1.5">Trigger</label>
-                    <select
-                      value={triggerKind}
-                      onChange={(e) => setTriggerKind(e.target.value as TriggerKind)}
-                      className={cn(selectClass, 'w-full')}
-                      style={selectStyle}
-                    >
-                      <option value="interval" className="bg-[#1a1a1a]">
-                        Interval (time-based)
-                      </option>
-                      <option value="agent_finished" className="bg-[#1a1a1a]">
-                        After agent finishes (restart)
-                      </option>
-                      <option value="webhook" className="bg-[#1a1a1a]">
-                        Webhook (API call)
-                      </option>
-                    </select>
-                  </div>
-                </div>
+                {(() => {
+                  const harnessForBackend =
+                    missionBackend === 'claudecode' || missionBackend === 'codex'
+                      ? missionBackend
+                      : null;
+                  const harnessLabel =
+                    harnessForBackend === 'claudecode' ? 'Claude Code' : harnessForBackend === 'codex' ? 'Codex' : null;
+                  const nativeLoopDisabled = !harnessForBackend;
+                  return (
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs text-white/50 mb-1.5">Source</label>
+                        <select
+                          value={commandSourceType}
+                          onChange={(e) =>
+                            handleSourceTypeChange(e.target.value as CommandSourceType)
+                          }
+                          className={cn(selectClass, 'w-full')}
+                          style={selectStyle}
+                        >
+                          <option value="library" className="bg-[#1a1a1a]">
+                            Library command
+                          </option>
+                          <option value="inline" className="bg-[#1a1a1a]">
+                            Inline prompt
+                          </option>
+                          <option
+                            value="native_loop"
+                            className="bg-[#1a1a1a]"
+                            disabled={nativeLoopDisabled}
+                          >
+                            {nativeLoopDisabled
+                              ? 'Native harness loop (Claude/Codex only)'
+                              : `Native harness loop (${harnessLabel} /goal)`}
+                          </option>
+                        </select>
+                      </div>
+                      <div>
+                        <label className="block text-xs text-white/50 mb-1.5">Trigger</label>
+                        {commandSourceType === 'native_loop' ? (
+                          <div
+                            className={cn(
+                              selectClass,
+                              'w-full text-white/40 cursor-not-allowed pointer-events-none'
+                            )}
+                            aria-disabled
+                            title="The harness CLI drives iteration; OA only observes."
+                          >
+                            Harness loop
+                          </div>
+                        ) : (
+                          <select
+                            value={triggerKind}
+                            onChange={(e) => setTriggerKind(e.target.value as TriggerKind)}
+                            className={cn(selectClass, 'w-full')}
+                            style={selectStyle}
+                          >
+                            <option value="interval" className="bg-[#1a1a1a]">
+                              Interval (time-based)
+                            </option>
+                            <option value="agent_finished" className="bg-[#1a1a1a]">
+                              After agent finishes (restart)
+                            </option>
+                            <option value="webhook" className="bg-[#1a1a1a]">
+                              Webhook (API call)
+                            </option>
+                          </select>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })()}
 
                 {/* Row 2: Command details */}
-                {commandSourceType === 'library' ? (
+                {commandSourceType === 'native_loop' ? (
+                  <div>
+                    <label className="block text-xs text-white/50 mb-1.5">Objective</label>
+                    <textarea
+                      value={nativeLoopObjective}
+                      onChange={(e) => setNativeLoopObjective(e.target.value)}
+                      placeholder="What should the harness keep iterating on until done?"
+                      rows={3}
+                      className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-indigo-500/50 resize-y"
+                    />
+                    <div className="mt-1 text-[11px] text-white/30">
+                      Submits <code className="text-indigo-400/70">/goal &lt;objective&gt;</code>{' '}
+                      to this mission. The harness CLI runs its own continuation loop; each
+                      iteration is recorded here.
+                    </div>
+                  </div>
+                ) : commandSourceType === 'library' ? (
                   <div>
                     <label className="block text-xs text-white/50 mb-1.5">Command</label>
                     <select
@@ -1259,6 +1434,19 @@ export function MissionAutomationsDialog({
                                   {sourceTag}
                                 </span>
                               ) : null}
+                              {automation.command_source?.type === 'native_loop' &&
+                                (() => {
+                                  const progress = iterationProgress.get(automation.id);
+                                  if (!progress || progress.latest === 0) return null;
+                                  return (
+                                    <span
+                                      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium bg-indigo-500/10 text-indigo-300"
+                                      title={`${progress.count} recorded iteration${progress.count === 1 ? '' : 's'}`}
+                                    >
+                                      iter {progress.latest}
+                                    </span>
+                                  );
+                                })()}
                               {automation.command_source?.type === 'library' && !command && (
                                 <span className="flex items-center gap-1 text-[11px] text-amber-300">
                                   <AlertTriangle className="h-3 w-3" />
@@ -1348,6 +1536,16 @@ export function MissionAutomationsDialog({
                                 <Pencil className="h-3.5 w-3.5" />
                               </button>
                             )}
+                            {automation.command_source?.type === 'native_loop' &&
+                              automation.active && (
+                                <button
+                                  onClick={() => setPendingStop(automation)}
+                                  className="flex items-center gap-1 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-200 hover:bg-amber-500/20 transition-colors"
+                                  title="Stop the harness goal loop"
+                                >
+                                  Stop
+                                </button>
+                              )}
                             <button
                               onClick={() => setPendingDelete(automation)}
                               className="flex items-center gap-1 rounded-lg border border-white/[0.08] px-2.5 py-1.5 text-xs text-white/60 hover:text-red-300 hover:border-red-500/40 hover:bg-red-500/10 transition-colors"
@@ -1483,6 +1681,20 @@ export function MissionAutomationsDialog({
         onCancel={() => {
           if (deleting) return;
           setPendingDelete(null);
+        }}
+      />
+
+      <ConfirmDialog
+        open={!!pendingStop}
+        title="Stop harness goal loop?"
+        description="This cancels the mission's current turn so the harness CLI stops iterating. Any in-flight tool calls will be aborted."
+        confirmLabel="Stop loop"
+        variant="danger"
+        busy={stopping}
+        onConfirm={handleStopNativeLoop}
+        onCancel={() => {
+          if (stopping) return;
+          setPendingStop(null);
         }}
       />
     </div>

--- a/dashboard/src/lib/api/automations.ts
+++ b/dashboard/src/lib/api/automations.ts
@@ -7,7 +7,24 @@ import { apiFetch, apiGet, apiPatch, apiDel } from "./core";
 export type CommandSource =
   | { type: "library"; name: string }
   | { type: "local_file"; path: string }
-  | { type: "inline"; content: string };
+  | { type: "inline"; content: string }
+  | {
+      type: "native_loop";
+      /** Backend id: `"claudecode"`, `"codex"`, … */
+      harness: string;
+      /** Slash command without the leading `/`. Today: `"goal"`. */
+      command: string;
+      /** Free-form per-command args. For `goal`: `{ objective: "..." }`. */
+      args?: Record<string, unknown> | null;
+    };
+
+/**
+ * Who drives iteration for this automation. `scheduler` is the historical
+ * behaviour — OA fires on `trigger`. `harness_loop` means the harness CLI
+ * (claudecode/codex `/goal`) runs its own continuation loop; OA only records
+ * iterations.
+ */
+export type AutomationDriver = "scheduler" | "harness_loop";
 
 export type TriggerType =
   | { type: "interval"; seconds: number }
@@ -47,6 +64,8 @@ export interface Automation {
     retry_delay_seconds: number;
     backoff_multiplier: number;
   };
+  /** Defaults to "scheduler" for back-compat with rows from the old schema. */
+  driver?: AutomationDriver;
   // Back-compat fields used by the UI
   command_name?: string;
   interval_seconds?: number;

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -10,28 +10,35 @@
 		0530E5793E17B5BFB15E808A /* Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF62094FF29193B33EC7009 /* Automation.swift */; };
 		07ED817585C2EE9A5E11C851 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C433FADB27AED6165D3EE2E4 /* HistoryView.swift */; };
 		08D9C00F453EE16A24DC9C84 /* FilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9C3868787C973C5B65DFCD /* FilesView.swift */; };
+		094CD000ADB23893099CC839 /* WorkerPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A514C239AAC192BD2AE8038 /* WorkerPillView.swift */; };
 		0D00520E1A6F2454E3B18A7F /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CA8C69928B3838868EE34A /* AnyCodable.swift */; };
 		1750DD5DC204F7506E885D83 /* WorkspacesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384691169D9EC024B03AA57F /* WorkspacesView.swift */; };
+		2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */; };
 		3A706E457E3E27DA1B69E152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 750C4C8090EAD0168794EEE4 /* Assets.xcassets */; };
 		40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */; };
 		46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7559F3F4553AD74130B1BC34 /* ModelTests.swift */; };
 		48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC2B6E9848FF220F103DED2 /* LoadingView.swift */; };
 		4A639CAB6EE0ED8079A721C2 /* ToolUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF491A4406AFF7E284592477 /* ToolUIView.swift */; };
 		4F14A189BFE75A1CA225B797 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */; };
+		50EBDCFBA58915481F5EC995 /* FidoApprovalOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B73495CB5FE8A01851005A /* FidoApprovalOverlay.swift */; };
 		51E9D9F51934DFC8EAD58CDC /* QueueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EAAE29E81F160F8E8409B7D /* QueueSheet.swift */; };
 		58D2BEEDF2B4B34B3B98487C /* ToolUIOptionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD083A671640B2F286D7C06 /* ToolUIOptionListView.swift */; };
 		5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4AC8C92D9F496B8152B8F /* ControlView.swift */; };
 		66E208F9D4759B79ED653374 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B74AB5DF6829813AE79229D /* ContentView.swift */; };
 		6846AB79778CDF4CC216B7D1 /* SandboxedDashboardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8080D5ADF84794AFE484FE17 /* SandboxedDashboardApp.swift */; };
 		692C694570F45D74CCBAC75B /* TerminalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6922E2F0E17EDB3A8400D473 /* TerminalState.swift */; };
+		6A15DF1CBD6B0A3716B9FE94 /* WorkerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */; };
+		708B491B7A83A6648C03CA8A /* WorkerPeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF9A2A12846A5FFB3FC7497 /* WorkerPeekView.swift */; };
 		71559C7052796FED7EBACF3F /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018CEF52A93FCF430A128017 /* Theme.swift */; };
 		7E46D4311CFAF1F7A90E9AAD /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F4658A2D65748FC7AC5DE3 /* APIService.swift */; };
 		7EF75A17733EE6E54126C7A7 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */; };
 		8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880FCB82E3B58C3C3C6DABD6 /* DesktopStreamView.swift */; };
+		8CFF9CE3602771549F982D58 /* SlashCommandSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B973A9078E4E085D489E93 /* SlashCommandSuggestions.swift */; };
 		92B85FBB5B9B4B0F6ECFCFFA /* ANSIParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E023EEFFFA9B1092B66006 /* ANSIParser.swift */; };
 		9380357DC269257F9E693388 /* NavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3EDA65C036030CC45BAD0E /* NavigationState.swift */; };
 		95B7AB5DBEB42E107EBE06FB /* RunningMissionsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A636998B83DD23C5D2688C2D /* RunningMissionsBar.swift */; };
 		9C775C43A7241C017EF4484D /* ToolUIDataTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53686D00374BEDA33228269 /* ToolUIDataTableView.swift */; };
+		9F25FE105BF6D4B40CCFD938 /* AutoApprovalRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EA3B4E94755F7712ED534F /* AutoApprovalRulesView.swift */; };
 		9F85D6D0E63005146E29B331 /* ToolUIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B920E504080EAEEA7CFD5201 /* ToolUIModels.swift */; };
 		A9B4F30DDAD9DBAEB009F77B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8600F588B036A2D57AEC9FC6 /* SettingsView.swift */; };
 		B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */; };
@@ -41,20 +48,14 @@
 		C159E476E057E6691D1E0E85 /* GlassCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F5D3EB21B6FF298AF5CD32 /* GlassCard.swift */; };
 		C7C23F6559C34034D1680FC2 /* FileEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */; };
 		CA5C6851DB279D7305EF2A91 /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28244CFFEB655FD5E5F3EB17 /* StatusBadge.swift */; };
+		D057B578B2884C4B2B36B1C3 /* FidoApprovalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */; };
 		D0646F9EE2D2E984F0446C57 /* NewMissionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */; };
 		D5968B6DE2272A9C8C3A4A0E /* AutomationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A33016C6075CC02E61C315A /* AutomationsView.swift */; };
 		DEEC0DB78E50196BEEA6AFC1 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA66FA1F19D379397ABA68 /* TerminalView.swift */; };
 		EB7DDF2652018CBEBD1D3F52 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBAC1664CAF3CD9DCCDB8B4 /* WorkspaceState.swift */; };
 		F14B1635CFA8338A1C733CAD /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76082CCC47D9D91308F4AE10 /* MarkdownView.swift */; };
 		F6B883AB96DE0FFF99A2A614 /* Backend.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC389FA8B9B5C969E606A22 /* Backend.swift */; };
-		AA1111111111111111111111 /* WorkerPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1111111111111111111111 /* WorkerPillView.swift */; };
-		AA2222222222222222222222 /* WorkerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2222222222222222222222 /* WorkerSheetView.swift */; };
-		AA3333333333333333333333 /* WorkerPeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3333333333333333333333 /* WorkerPeekView.swift */; };
-		CC1111111111111111111111 /* FidoSignRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1111111111111111111111 /* FidoSignRequest.swift */; };
-		CC2222222222222222222222 /* FidoApprovalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2222222222222222222222 /* FidoApprovalState.swift */; };
-		CC3333333333333333333333 /* FidoApprovalOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3333333333333333333333 /* FidoApprovalOverlay.swift */; };
-		CC4444444444444444444444 /* AutoApprovalRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4444444444444444444444 /* AutoApprovalRulesView.swift */; };
-		AA5555555555555555555555 /* SlashCommandSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5555555555555555555555 /* SlashCommandSuggestions.swift */; };
+		FF9AD27CB2EDBA4E942F09D4 /* FidoSignRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,13 +70,18 @@
 
 /* Begin PBXFileReference section */
 		018CEF52A93FCF430A128017 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerSheetView.swift; sourceTree = "<group>"; };
 		0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		0C6DBBABC4AE0FD4368A185C /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
+		1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResilienceTests.swift; sourceTree = "<group>"; };
 		1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMissionSheet.swift; sourceTree = "<group>"; };
 		1C19E1741AE5E4A19BDAAB98 /* SandboxedDashboard.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SandboxedDashboard.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FF9A2A12846A5FFB3FC7497 /* WorkerPeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerPeekView.swift; sourceTree = "<group>"; };
+		22EA3B4E94755F7712ED534F /* AutoApprovalRulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoApprovalRulesView.swift; sourceTree = "<group>"; };
 		27F5D3EB21B6FF298AF5CD32 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		28244CFFEB655FD5E5F3EB17 /* StatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBadge.swift; sourceTree = "<group>"; };
 		2A33016C6075CC02E61C315A /* AutomationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationsView.swift; sourceTree = "<group>"; };
+		2A514C239AAC192BD2AE8038 /* WorkerPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerPillView.swift; sourceTree = "<group>"; };
 		305649B3AA9B35712500F01B /* SandboxedDashboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SandboxedDashboard.entitlements; sourceTree = "<group>"; };
 		370F364BA05D1236D9B630AB /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		384691169D9EC024B03AA57F /* WorkspacesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesView.swift; sourceTree = "<group>"; };
@@ -85,6 +91,7 @@
 		492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEntry.swift; sourceTree = "<group>"; };
 		4CC2B6E9848FF220F103DED2 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		55F4658A2D65748FC7AC5DE3 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
+		62B73495CB5FE8A01851005A /* FidoApprovalOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoApprovalOverlay.swift; sourceTree = "<group>"; };
 		6922E2F0E17EDB3A8400D473 /* TerminalState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalState.swift; sourceTree = "<group>"; };
 		750C4C8090EAD0168794EEE4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7559F3F4553AD74130B1BC34 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
@@ -96,13 +103,16 @@
 		880FCB82E3B58C3C3C6DABD6 /* DesktopStreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamView.swift; sourceTree = "<group>"; };
 		8D9C3868787C973C5B65DFCD /* FilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesView.swift; sourceTree = "<group>"; };
 		8EAAE29E81F160F8E8409B7D /* QueueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueSheet.swift; sourceTree = "<group>"; };
+		8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoApprovalState.swift; sourceTree = "<group>"; };
 		97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A636998B83DD23C5D2688C2D /* RunningMissionsBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningMissionsBar.swift; sourceTree = "<group>"; };
 		AABA66FA1F19D379397ABA68 /* TerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalView.swift; sourceTree = "<group>"; };
 		ADBAC1664CAF3CD9DCCDB8B4 /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		B920E504080EAEEA7CFD5201 /* ToolUIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIModels.swift; sourceTree = "<group>"; };
 		C433FADB27AED6165D3EE2E4 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
+		C4B973A9078E4E085D489E93 /* SlashCommandSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandSuggestions.swift; sourceTree = "<group>"; };
 		CAC389FA8B9B5C969E606A22 /* Backend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backend.swift; sourceTree = "<group>"; };
+		CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoSignRequest.swift; sourceTree = "<group>"; };
 		D2E4AC8C92D9F496B8152B8F /* ControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlView.swift; sourceTree = "<group>"; };
 		D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButton.swift; sourceTree = "<group>"; };
 		D9E023EEFFFA9B1092B66006 /* ANSIParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIParser.swift; sourceTree = "<group>"; };
@@ -112,26 +122,9 @@
 		F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendAgentService.swift; sourceTree = "<group>"; };
 		FCD083A671640B2F286D7C06 /* ToolUIOptionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIOptionListView.swift; sourceTree = "<group>"; };
 		FF491A4406AFF7E284592477 /* ToolUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIView.swift; sourceTree = "<group>"; };
-		BB1111111111111111111111 /* WorkerPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerPillView.swift; sourceTree = "<group>"; };
-		BB2222222222222222222222 /* WorkerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerSheetView.swift; sourceTree = "<group>"; };
-		BB3333333333333333333333 /* WorkerPeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerPeekView.swift; sourceTree = "<group>"; };
-		DD1111111111111111111111 /* FidoSignRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoSignRequest.swift; sourceTree = "<group>"; };
-		DD2222222222222222222222 /* FidoApprovalState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoApprovalState.swift; sourceTree = "<group>"; };
-		DD3333333333333333333333 /* FidoApprovalOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoApprovalOverlay.swift; sourceTree = "<group>"; };
-		DD4444444444444444444444 /* AutoApprovalRulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoApprovalRulesView.swift; sourceTree = "<group>"; };
-		BB5555555555555555555555 /* SlashCommandSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandSuggestions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		EE1111111111111111111111 /* FidoApproval */ = {
-			isa = PBXGroup;
-			children = (
-				DD4444444444444444444444 /* AutoApprovalRulesView.swift */,
-				DD3333333333333333333333 /* FidoApprovalOverlay.swift */,
-			);
-			path = FidoApproval;
-			sourceTree = "<group>";
-		};
 		04136BE3D92AE400B09C5462 /* Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -157,13 +150,22 @@
 			path = Desktop;
 			sourceTree = "<group>";
 		};
+		39B9469E602F8BD41799B337 /* FidoApproval */ = {
+			isa = PBXGroup;
+			children = (
+				22EA3B4E94755F7712ED534F /* AutoApprovalRulesView.swift */,
+				62B73495CB5FE8A01851005A /* FidoApprovalOverlay.swift */,
+			);
+			path = FidoApproval;
+			sourceTree = "<group>";
+		};
 		50FE02040F839BB2D8F3184B /* Views */ = {
 			isa = PBXGroup;
 			children = (
 				6064CFC98B156B54304C4737 /* Components */,
 				A56099201CA62E59BEC74589 /* Control */,
 				1B4F5983589F1F81E1CDE71A /* Desktop */,
-				EE1111111111111111111111 /* FidoApproval */,
+				39B9469E602F8BD41799B337 /* FidoApproval */,
 				04136BE3D92AE400B09C5462 /* Files */,
 				DA63D97B804AFD44A1D1BFF3 /* History */,
 				D104E1B7D32CBCD873A2C0EA /* Settings */,
@@ -181,12 +183,12 @@
 				4CC2B6E9848FF220F103DED2 /* LoadingView.swift */,
 				76082CCC47D9D91308F4AE10 /* MarkdownView.swift */,
 				A636998B83DD23C5D2688C2D /* RunningMissionsBar.swift */,
-				BB5555555555555555555555 /* SlashCommandSuggestions.swift */,
+				C4B973A9078E4E085D489E93 /* SlashCommandSuggestions.swift */,
 				28244CFFEB655FD5E5F3EB17 /* StatusBadge.swift */,
+				1FF9A2A12846A5FFB3FC7497 /* WorkerPeekView.swift */,
+				2A514C239AAC192BD2AE8038 /* WorkerPillView.swift */,
+				081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */,
 				D99EC9DCFB8CE3EEAD759135 /* ToolUI */,
-				BB1111111111111111111111 /* WorkerPillView.swift */,
-				BB2222222222222222222222 /* WorkerSheetView.swift */,
-				BB3333333333333333333333 /* WorkerPeekView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -198,7 +200,7 @@
 				55F4658A2D65748FC7AC5DE3 /* APIService.swift */,
 				F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */,
 				3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */,
-				DD2222222222222222222222 /* FidoApprovalState.swift */,
+				8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */,
 				EB3EDA65C036030CC45BAD0E /* NavigationState.swift */,
 				6922E2F0E17EDB3A8400D473 /* TerminalState.swift */,
 				ADBAC1664CAF3CD9DCCDB8B4 /* WorkspaceState.swift */,
@@ -262,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				7559F3F4553AD74130B1BC34 /* ModelTests.swift */,
+				1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */,
 				0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */,
 			);
 			path = SandboxedDashboardTests;
@@ -282,8 +285,8 @@
 				7BF62094FF29193B33EC7009 /* Automation.swift */,
 				CAC389FA8B9B5C969E606A22 /* Backend.swift */,
 				370F364BA05D1236D9B630AB /* ChatMessage.swift */,
+				CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */,
 				492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */,
-				DD1111111111111111111111 /* FidoSignRequest.swift */,
 				0C6DBBABC4AE0FD4368A185C /* Mission.swift */,
 				97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */,
 			);
@@ -412,6 +415,7 @@
 				92B85FBB5B9B4B0F6ECFCFFA /* ANSIParser.swift in Sources */,
 				7E46D4311CFAF1F7A90E9AAD /* APIService.swift in Sources */,
 				0D00520E1A6F2454E3B18A7F /* AnyCodable.swift in Sources */,
+				9F25FE105BF6D4B40CCFD938 /* AutoApprovalRulesView.swift in Sources */,
 				0530E5793E17B5BFB15E808A /* Automation.swift in Sources */,
 				D5968B6DE2272A9C8C3A4A0E /* AutomationsView.swift in Sources */,
 				F6B883AB96DE0FFF99A2A614 /* Backend.swift in Sources */,
@@ -421,11 +425,10 @@
 				5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */,
 				B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */,
 				8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */,
+				50EBDCFBA58915481F5EC995 /* FidoApprovalOverlay.swift in Sources */,
+				D057B578B2884C4B2B36B1C3 /* FidoApprovalState.swift in Sources */,
+				FF9AD27CB2EDBA4E942F09D4 /* FidoSignRequest.swift in Sources */,
 				C7C23F6559C34034D1680FC2 /* FileEntry.swift in Sources */,
-				CC1111111111111111111111 /* FidoSignRequest.swift in Sources */,
-				CC2222222222222222222222 /* FidoApprovalState.swift in Sources */,
-				CC3333333333333333333333 /* FidoApprovalOverlay.swift in Sources */,
-				CC4444444444444444444444 /* AutoApprovalRulesView.swift in Sources */,
 				08D9C00F453EE16A24DC9C84 /* FilesView.swift in Sources */,
 				40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */,
 				C159E476E057E6691D1E0E85 /* GlassCard.swift in Sources */,
@@ -439,6 +442,7 @@
 				95B7AB5DBEB42E107EBE06FB /* RunningMissionsBar.swift in Sources */,
 				6846AB79778CDF4CC216B7D1 /* SandboxedDashboardApp.swift in Sources */,
 				A9B4F30DDAD9DBAEB009F77B /* SettingsView.swift in Sources */,
+				8CFF9CE3602771549F982D58 /* SlashCommandSuggestions.swift in Sources */,
 				CA5C6851DB279D7305EF2A91 /* StatusBadge.swift in Sources */,
 				692C694570F45D74CCBAC75B /* TerminalState.swift in Sources */,
 				DEEC0DB78E50196BEEA6AFC1 /* TerminalView.swift in Sources */,
@@ -447,13 +451,12 @@
 				9F85D6D0E63005146E29B331 /* ToolUIModels.swift in Sources */,
 				58D2BEEDF2B4B34B3B98487C /* ToolUIOptionListView.swift in Sources */,
 				4A639CAB6EE0ED8079A721C2 /* ToolUIView.swift in Sources */,
+				708B491B7A83A6648C03CA8A /* WorkerPeekView.swift in Sources */,
+				094CD000ADB23893099CC839 /* WorkerPillView.swift in Sources */,
+				6A15DF1CBD6B0A3716B9FE94 /* WorkerSheetView.swift in Sources */,
 				4F14A189BFE75A1CA225B797 /* Workspace.swift in Sources */,
 				EB7DDF2652018CBEBD1D3F52 /* WorkspaceState.swift in Sources */,
 				1750DD5DC204F7506E885D83 /* WorkspacesView.swift in Sources */,
-				AA1111111111111111111111 /* WorkerPillView.swift in Sources */,
-				AA2222222222222222222222 /* WorkerSheetView.swift in Sources */,
-				AA3333333333333333333333 /* WorkerPeekView.swift in Sources */,
-				AA5555555555555555555555 /* SlashCommandSuggestions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -462,6 +465,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */,
+				2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */,
 				7EF75A17733EE6E54126C7A7 /* ThemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios_dashboard/SandboxedDashboard/SandboxedDashboardApp.swift
+++ b/ios_dashboard/SandboxedDashboard/SandboxedDashboardApp.swift
@@ -9,6 +9,13 @@ import SwiftUI
 
 @main
 struct SandboxedDashboardApp: App {
+    init() {
+        // Drain legacy in-UserDefaults mission cache blobs into the on-disk
+        // Caches store. Each blob was a multi-KB-to-multi-MB JSON payload
+        // held resident by cfprefsd; the migration runs at most once.
+        ControlView.migrateMissionCacheIfNeeded()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -857,9 +857,6 @@ struct MissionEventsResult {
     let maxSequence: Int64?
 }
 
-private struct StreamInactivityError: Error {}
-private struct StreamOversizeError: Error {}
-
 enum APIError: LocalizedError {
     case invalidURL
     case invalidResponse

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -13,7 +13,58 @@ import Observation
 final class APIService {
     static let shared = APIService()
     nonisolated init() {}
-    
+
+    /// Per-request timeout for ordinary JSON calls. Anything that hasn't started
+    /// returning data within this window is treated as failed. Default
+    /// `URLSession.shared` ships with 60s, which is far too long for a chat
+    /// app's cold-start path — the user sits at "Connecting…" with no feedback.
+    nonisolated static let requestTimeout: TimeInterval = 15
+
+    /// Full-transfer cap for ordinary JSON calls. Default is 7 days; a stalled
+    /// large download (e.g. a multi-MB event tail over a flaky cellular link)
+    /// would block the call until the user kills the app.
+    nonisolated static let resourceTimeout: TimeInterval = 60
+
+    /// SSE inactivity threshold. If no bytes arrive for this long the stream is
+    /// considered dead and the caller's reconnect logic re-runs. Covers the
+    /// silent-half-open-socket case (cell→wifi handoff, NAT idle reset).
+    nonisolated static let streamInactivityTimeout: TimeInterval = 30
+
+    /// Hard cap on the SSE line-buffer (1 MiB). A pathological server that
+    /// never emits a newline must not be allowed to balloon memory.
+    nonisolated static let streamMaxBufferBytes: Int = 1 << 20
+
+    /// Dedicated session for JSON calls. `URLSession.shared`'s defaults
+    /// (60s request, 7d resource, infinite cache) are wrong for a chat app on
+    /// bad networks — short timeouts surface failures fast and let the UI
+    /// retry instead of holding a spinner indefinitely.
+    nonisolated private static let jsonSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = resourceTimeout
+        config.waitsForConnectivity = false
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.httpAdditionalHeaders = ["Accept": "application/json"]
+        return URLSession(configuration: config)
+    }()
+
+    /// Session used for SSE. `timeoutIntervalForRequest` here doubles as the
+    /// stream inactivity timeout: per URLSession semantics it's the maximum
+    /// gap between bytes received, so a healthy stream emitting events
+    /// regularly resets the clock and stays alive indefinitely, while a
+    /// silent half-open socket (cell→wifi handoff, NAT idle reset) fails
+    /// within `streamInactivityTimeout` and triggers the caller's reconnect
+    /// loop. `timeoutIntervalForResource` stays effectively unbounded so
+    /// long-running missions aren't capped.
+    nonisolated private static let streamSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = streamInactivityTimeout
+        config.timeoutIntervalForResource = TimeInterval.greatestFiniteMagnitude
+        config.waitsForConnectivity = false
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(configuration: config)
+    }()
+
     // Configuration
     var baseURL: String {
         get { UserDefaults.standard.string(forKey: "api_base_url") ?? "" }
@@ -417,25 +468,25 @@ final class APIService {
         
         request.httpBody = body
         
-        let (responseData, response) = try await URLSession.shared.data(for: request)
-        
+        let (responseData, response) = try await Self.jsonSession.data(for: request)
+
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }
-        
+
         if httpResponse.statusCode == 401 {
             logout()
             throw APIError.unauthorized
         }
-        
+
         guard httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 else {
             throw APIError.httpError(httpResponse.statusCode, String(data: responseData, encoding: .utf8))
         }
-        
+
         struct UploadResponse: Decodable {
             let path: String
         }
-        
+
         let uploadResponse = try JSONDecoder().decode(UploadResponse.self, from: responseData)
         return uploadResponse.path
     }
@@ -526,35 +577,105 @@ final class APIService {
     // MARK: - SSE Streaming
 
     func streamControl(onEvent: @escaping (String, [String: Any]) -> Void) -> Task<Void, Never> {
-        Task {
-            guard let url = URL(string: "\(baseURL)/api/control/stream") else { return }
-            
+        let base = baseURL
+        let token = jwtToken
+        let maxBuffer = Self.streamMaxBufferBytes
+        let inactivity = Self.streamInactivityTimeout
+        let session = Self.streamSession
+
+        return Task { [weak self] in
+            guard let url = URL(string: "\(base)/api/control/stream") else { return }
+
             var request = URLRequest(url: url)
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-            
-            if let token = jwtToken {
+            request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+            if let token {
                 request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             }
-            
+
             do {
-                let (stream, _) = try await URLSession.shared.bytes(for: request)
-                
-                var buffer = ""
-                for try await byte in stream {
-                    guard !Task.isCancelled else { break }
-                    
-                    if let char = String(bytes: [byte], encoding: .utf8) {
-                        buffer.append(char)
-                        
-                        // Look for double newline (end of SSE event)
-                        while let range = buffer.range(of: "\n\n") {
-                            let eventString = String(buffer[..<range.lowerBound])
-                            buffer = String(buffer[range.upperBound...])
-                            
-                            parseSSEEvent(eventString, onEvent: onEvent)
+                let (rawStream, response) = try await session.bytes(for: request)
+
+                // Reject HTTP errors up front. The previous code happily fed
+                // a 401 HTML body through the SSE parser, which silently
+                // dropped events and left the user staring at "Reconnecting…".
+                if let http = response as? HTTPURLResponse {
+                    guard (200..<300).contains(http.statusCode) else {
+                        if http.statusCode == 401 {
+                            await MainActor.run { self?.logout() }
                         }
+                        onEvent("error", [
+                            "message": "Stream rejected by server (HTTP \(http.statusCode))",
+                            "status": http.statusCode
+                        ])
+                        return
                     }
                 }
+
+                // `rawStream.lines` decodes chunks as UTF-8 and yields per
+                // line. Replaces the previous byte-by-byte
+                // `String(bytes: [byte], encoding: .utf8)` loop which silently
+                // dropped any byte belonging to a multi-byte UTF-8 codepoint —
+                // every emoji or non-ASCII character in the agent stream was
+                // being corrupted.
+                //
+                // Inactivity is enforced by `streamSession`'s
+                // `timeoutIntervalForRequest`: per URLSession semantics that
+                // is the max gap between received bytes, so a healthy stream
+                // resets it on every event and a silent half-open socket
+                // errors out within `streamInactivityTimeout`. No manual
+                // watchdog needed.
+                var eventType = "message"
+                var dataLines: [String] = []
+                var bufferedBytes = 0
+
+                for try await line in rawStream.lines {
+                    if Task.isCancelled { return }
+
+                    // Hard cap on per-event payload — a server that never
+                    // emits a blank line must not balloon this buffer.
+                    bufferedBytes += line.utf8.count + 1
+                    if bufferedBytes > maxBuffer {
+                        onEvent("error", ["message": "Stream event exceeded \(maxBuffer) bytes — dropping connection"])
+                        return
+                    }
+
+                    if line.isEmpty {
+                        Self.dispatchSSEEvent(
+                            eventType: eventType,
+                            dataLines: dataLines,
+                            onEvent: onEvent
+                        )
+                        eventType = "message"
+                        dataLines.removeAll(keepingCapacity: true)
+                        bufferedBytes = 0
+                        continue
+                    }
+
+                    if line.hasPrefix(":") { continue }  // comment
+
+                    guard let colonIdx = line.firstIndex(of: ":") else { continue }
+                    let field = line[..<colonIdx]
+                    var value = line[line.index(after: colonIdx)...]
+                    // SSE spec: strip exactly one leading space.
+                    if value.first == " " { value = value.dropFirst() }
+
+                    switch field {
+                    case "event":
+                        eventType = String(value)
+                    case "data":
+                        dataLines.append(String(value))
+                    default:
+                        break  // ignore id/retry/unknown
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch let urlError as URLError where urlError.code == .timedOut {
+                onEvent("error", [
+                    "message": "Stream idle (no data for \(Int(inactivity))s) — reconnecting",
+                    "reason": "inactivity"
+                ])
             } catch {
                 if !Task.isCancelled {
                     onEvent("error", ["message": "Stream connection failed: \(error.localizedDescription)"])
@@ -562,29 +683,35 @@ final class APIService {
             }
         }
     }
-    
-    private func parseSSEEvent(_ eventString: String, onEvent: @escaping (String, [String: Any]) -> Void) {
-        var eventType = "message"
-        var dataString = ""
-        
-        for line in eventString.split(separator: "\n", omittingEmptySubsequences: false) {
-            let lineStr = String(line)
-            if lineStr.hasPrefix("event:") {
-                eventType = String(lineStr.dropFirst(6)).trimmingCharacters(in: .whitespaces)
-            } else if lineStr.hasPrefix("data:") {
-                dataString += String(lineStr.dropFirst(5)).trimmingCharacters(in: .whitespaces)
-            }
+
+    /// Flush a complete SSE event. `dataLines` are joined with `\n` per spec —
+    /// the previous code joined with empty string, mangling multi-line JSON
+    /// payloads. Only object-shaped JSON is forwarded; scalars/arrays/garbage
+    /// surface as a structured `parseError` so the caller can log them
+    /// instead of silently dropping data.
+    @MainActor
+    private static func dispatchSSEEvent(
+        eventType: String,
+        dataLines: [String],
+        onEvent: (String, [String: Any]) -> Void
+    ) {
+        guard !dataLines.isEmpty else { return }
+        let payload = dataLines.joined(separator: "\n")
+        guard !payload.isEmpty else { return }
+
+        guard let data = payload.data(using: .utf8) else {
+            onEvent("parseError", ["raw": payload, "reason": "non-utf8 payload"])
+            return
         }
-        
-        guard !dataString.isEmpty else { return }
-        
         do {
-            if let data = dataString.data(using: .utf8),
-               let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                onEvent(eventType, json)
+            let parsed = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+            if let obj = parsed as? [String: Any] {
+                onEvent(eventType, obj)
+            } else {
+                onEvent("parseError", ["raw": payload, "reason": "non-object payload"])
             }
         } catch {
-            // Ignore parse errors
+            onEvent("parseError", ["raw": payload, "reason": error.localizedDescription])
         }
     }
     
@@ -673,7 +800,7 @@ final class APIService {
     }
 
     private func executeWithResponse<T: Decodable>(_ request: URLRequest) async throws -> (T, HTTPURLResponse) {
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await Self.jsonSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -695,10 +822,31 @@ final class APIService {
             }
         }
 
-        let decoder = JSONDecoder()
-        let value = try decoder.decode(T.self, from: data)
-        return (value, httpResponse)
+        // Decode off the main actor. APIService is `@MainActor`, so without
+        // this hop a multi-MB events payload would block the UI thread for
+        // hundreds of ms during decode. We use a `nonisolated` global-actor-free
+        // helper wrapped in `Task.detached` so the decode runs on a cooperative
+        // thread; `DecodedBox` is `@unchecked Sendable` because the decoded
+        // value is treated as immutable from the moment we ship it back.
+        let box: DecodedBox<T>
+        do {
+            box = try await Task.detached(priority: .userInitiated) {
+                try DecodedBox(value: JSONDecoder().decode(T.self, from: data))
+            }.value
+        } catch {
+            throw APIError.decodingError(error)
+        }
+        return (box.value, httpResponse)
     }
+}
+
+/// Sendable transport for decoded values across the detached-decode boundary.
+/// Marked `@unchecked` because `T: Decodable` makes no Sendable promise and we
+/// can't constrain every existing Decodable type in the codebase. Safe in
+/// practice: the producer (decode task) has the only reference until `.value`
+/// crosses back to the consumer actor, after which the producer is gone.
+private struct DecodedBox<T>: @unchecked Sendable {
+    let value: T
 }
 
 /// Result of a `/missions/:id/events` fetch. `maxSequence` is the response's
@@ -708,6 +856,9 @@ struct MissionEventsResult {
     let events: [StoredEvent]
     let maxSequence: Int64?
 }
+
+private struct StreamInactivityError: Error {}
+private struct StreamOversizeError: Error {}
 
 enum APIError: LocalizedError {
     case invalidURL

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -393,31 +393,34 @@ struct ControlView: View {
             }
         }
         .task {
-            // Load workspaces for the workspace picker
-            await workspaceState.loadWorkspaces()
+            // Cold-start sequencing. Previously every step here was awaited
+            // serially — workspaces → loadMission → loadCurrentMission →
+            // refreshRunningMissions — which on a slow cellular link stacked
+            // up to a dozen sequential RTTs before the user could read or
+            // type anything. We now:
+            //   1. Kick off the SSE stream first so any live events for the
+            //      restored mission start arriving immediately (the stream
+            //      doesn't depend on which mission we end up viewing — it
+            //      receives all events and the view filters by id).
+            //   2. Fan out the three independent "context" fetches —
+            //      workspaces, mission history, running missions — using
+            //      `async let`. They share zero state at this stage; the
+            //      previous serial chain was incidental, not required.
+            //   3. Start the running-missions poller last; it's a 3s tick
+            //      and starting it before the first refresh is fine.
+            startStreaming()
 
-            // Check if we're being opened with a specific mission from History
-            if let pendingId = nav.consumePendingMission() {
-                await loadMission(id: pendingId)
-                // Also load the current mission in the background for main-session context
-                await loadCurrentMission(updateViewing: false)
-            } else if let savedId = UserDefaults.standard.string(forKey: Self.lastMissionIdKey) {
-                // Restore last viewed mission from previous session
-                await loadMission(id: savedId)
-                await loadCurrentMission(updateViewing: false)
-            } else {
-                await loadCurrentMission(updateViewing: true)
-            }
+            async let workspacesTask: Void = workspaceState.loadWorkspaces()
+            async let runningTask: Void = refreshRunningMissions()
+            async let missionTask: Void = loadInitialMission()
 
-            // Fetch initial running missions
-            await refreshRunningMissions()
+            _ = await (workspacesTask, runningTask, missionTask)
 
             // Auto-show bar if there are multiple running missions
             if runningMissions.count > 1 {
                 showRunningMissions = true
             }
 
-            startStreaming()
             startPollingRunningMissions()
         }
         .onChange(of: nav.pendingMissionId) { _, newId in
@@ -1278,44 +1281,88 @@ struct ControlView: View {
     }
 
     private static let maxCachedMissions = 10  // Limit cache size
+    /// Legacy key prefix used when mission blobs lived in UserDefaults. Kept
+    /// only so the one-time migration below can purge them on first launch
+    /// after upgrade — every payload bloats cfprefsd's in-memory plist.
     private static let cachePrefix = "cached_mission_"
     private static let cacheKeysKey = "cached_mission_keys"
+    private static let didMigrateCacheKey = "did_migrate_mission_cache_v1"
 
-    // Cache mission with events for faster loading and consistent display
-    private func cacheMissionWithEvents(_ mission: Mission, events: [StoredEvent]) {
-        let key = Self.cachePrefix + mission.id
-        let cacheData = CachedMissionData(mission: mission, events: events, cachedAt: Date())
-
-        guard let encoded = try? JSONEncoder().encode(cacheData) else { return }
-
-        // Implement LRU eviction
-        var cachedKeys = UserDefaults.standard.stringArray(forKey: Self.cacheKeysKey) ?? []
-
-        // Remove this key if it exists (we'll re-add it at the end as most recent)
-        cachedKeys.removeAll { $0 == mission.id }
-
-        // If we've hit the limit, remove the oldest cached mission
-        if cachedKeys.count >= Self.maxCachedMissions {
-            if let oldestKey = cachedKeys.first {
-                UserDefaults.standard.removeObject(forKey: Self.cachePrefix + oldestKey)
-                cachedKeys.removeFirst()
+    /// One-shot migration: previous versions stored mission events as raw
+    /// JSON blobs in UserDefaults. Those blobs are loaded into memory by
+    /// cfprefsd at process start, costing RAM forever. Read each blob,
+    /// rewrite it to disk, then erase the UserDefaults key. Idempotent —
+    /// guarded by a separate flag so a clean install doesn't run the loop.
+    static func migrateMissionCacheIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: didMigrateCacheKey) else { return }
+        let keys = defaults.stringArray(forKey: cacheKeysKey) ?? []
+        for missionId in keys {
+            let legacyKey = cachePrefix + missionId
+            if let data = defaults.data(forKey: legacyKey) {
+                try? writeCachedMissionFile(missionId: missionId, data: data)
+                defaults.removeObject(forKey: legacyKey)
             }
         }
+        defaults.set(true, forKey: didMigrateCacheKey)
+    }
 
-        // Add new entry
-        cachedKeys.append(mission.id)
+    // Cache mission with events for faster loading and consistent display.
+    //
+    // Storage moved off `UserDefaults` (which loads its entire backing plist
+    // into the cfprefsd daemon and the app process at launch, then writes
+    // synchronously on the main thread) to per-mission JSON files in
+    // `Caches/`. Writes are dispatched to a background queue so a multi-MB
+    // event payload no longer freezes the chat thread while it serialises.
+    private func cacheMissionWithEvents(_ mission: Mission, events: [StoredEvent]) {
+        let missionId = mission.id
+        let cacheData = CachedMissionData(mission: mission, events: events, cachedAt: Date())
+
+        // LRU key list still lives in UserDefaults — it's a tiny string array
+        // so it's free, and keeping it there means the LRU survives Caches
+        // eviction by iOS (we'll just miss on the orphaned files).
+        var cachedKeys = UserDefaults.standard.stringArray(forKey: Self.cacheKeysKey) ?? []
+        cachedKeys.removeAll { $0 == missionId }
+
+        var evicted: String?
+        if cachedKeys.count >= Self.maxCachedMissions {
+            evicted = cachedKeys.first
+            cachedKeys.removeFirst()
+        }
+        cachedKeys.append(missionId)
         UserDefaults.standard.set(cachedKeys, forKey: Self.cacheKeysKey)
-        UserDefaults.standard.set(encoded, forKey: key)
+
+        // Encode on @MainActor (CachedMissionData transitively contains
+        // `AnyCodable.value: Any`, which isn't Sendable, so we can't ship
+        // the struct to a detached task), then hand the raw bytes off for
+        // the actual filesystem write. `Data` is Sendable, so the write
+        // dispatch is clean. The disk write is the bigger UI-thread hazard
+        // on large missions anyway — encoding is bounded CPU; writing is
+        // unbounded I/O blocked on the filesystem coordinator.
+        let encoded = try? JSONEncoder().encode(cacheData)
+        let evictedId = evicted
+        Task.detached(priority: .utility) {
+            if let evictedId {
+                Self.deleteCachedMissionFile(missionId: evictedId)
+            }
+            if let encoded {
+                try? Self.writeCachedMissionFile(missionId: missionId, data: encoded)
+            }
+        }
     }
 
     private func loadCachedMissionData(_ missionId: String) -> CachedMissionData? {
-        let key = Self.cachePrefix + missionId
-        guard let data = UserDefaults.standard.data(forKey: key),
+        // Synchronous read on the call site (cold start) — the file is
+        // bounded by `loadEarlierPageLimit` * StoredEvent size (~few MB
+        // worst case) and decoding it on @MainActor is unavoidable here
+        // because the caller needs the result immediately to render the
+        // first frame. Subsequent caches written in the background.
+        guard let url = Self.cacheFileURL(missionId: missionId),
+              let data = try? Data(contentsOf: url),
               let cached = try? JSONDecoder().decode(CachedMissionData.self, from: data) else {
             return nil
         }
 
-        // Update LRU order - move to end as most recently accessed
         if var cachedKeys = UserDefaults.standard.stringArray(forKey: Self.cacheKeysKey) {
             cachedKeys.removeAll { $0 == missionId }
             cachedKeys.append(missionId)
@@ -1326,14 +1373,48 @@ struct ControlView: View {
     }
 
     private func removeMissionFromCache(_ missionId: String) {
-        let key = Self.cachePrefix + missionId
-        UserDefaults.standard.removeObject(forKey: key)
+        Self.deleteCachedMissionFile(missionId: missionId)
 
         // Remove from LRU tracking
         if var cachedKeys = UserDefaults.standard.stringArray(forKey: Self.cacheKeysKey) {
             cachedKeys.removeAll { $0 == missionId }
             UserDefaults.standard.set(cachedKeys, forKey: Self.cacheKeysKey)
         }
+    }
+
+    /// Cache directory for mission JSON. `.cachesDirectory` is appropriate
+    /// here: iOS may evict files under memory pressure, but losing them only
+    /// means a cache miss on next open, which costs one network round-trip.
+    /// (Compared to `.documentDirectory` which would be backed-up to iCloud
+    /// and counted toward the app's storage quota.)
+    nonisolated private static func cacheFileURL(missionId: String) -> URL? {
+        guard let caches = try? FileManager.default.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        let dir = caches.appendingPathComponent("missions", isDirectory: true)
+        // mkdir on first use. Best-effort — if it fails, the write below
+        // will fail too and the caller falls through to network.
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // mission IDs are server-generated UUIDs in practice; sanitise
+        // anyway so we never write `../etc/passwd`-style paths.
+        let safeId = missionId.replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "..", with: "_")
+        return dir.appendingPathComponent("\(safeId).json", isDirectory: false)
+    }
+
+    nonisolated private static func writeCachedMissionFile(missionId: String, data: Data) throws {
+        guard let url = cacheFileURL(missionId: missionId) else { return }
+        // Atomic write — partial files left after a crash would fail to
+        // decode on next open and trigger an unnecessary network fetch.
+        try data.write(to: url, options: [.atomic])
+    }
+
+    nonisolated private static func deleteCachedMissionFile(missionId: String) {
+        guard let url = cacheFileURL(missionId: missionId) else { return }
+        try? FileManager.default.removeItem(at: url)
     }
 
     private func applyViewingMission(_ mission: Mission, scrollToBottom: Bool = true) {
@@ -1468,6 +1549,25 @@ struct ControlView: View {
 
         loadedEventCount += orderedEvents.count
         recomputeGroupedItems()
+    }
+
+    /// Decide what to load on cold start. The previous code did
+    /// `loadMission(savedId)` then *also* awaited `loadCurrentMission` as
+    /// "background context" — but the await was serial, so the user paid
+    /// for both round-trips before the UI became interactive. The
+    /// "background" fetch is now genuinely backgrounded: kick off the
+    /// secondary `loadCurrentMission` in a detached Task so the primary
+    /// mission's events render as soon as they arrive.
+    private func loadInitialMission() async {
+        if let pendingId = nav.consumePendingMission() {
+            await loadMission(id: pendingId)
+            Task { await self.loadCurrentMission(updateViewing: false) }
+        } else if let savedId = UserDefaults.standard.string(forKey: Self.lastMissionIdKey) {
+            await loadMission(id: savedId)
+            Task { await self.loadCurrentMission(updateViewing: false) }
+        } else {
+            await loadCurrentMission(updateViewing: true)
+        }
     }
 
     private func loadCurrentMission(updateViewing: Bool) async {
@@ -1639,6 +1739,14 @@ struct ControlView: View {
         }
     }
 
+    /// Hard cap on the "Load earlier" payload. The previous implementation
+    /// passed `types:` only with no `limit`, asking the server for the entire
+    /// mission history — on a 50k-event mission that's a multi-MB JSON
+    /// download blocking the chat behind a spinner. Pull a single large page
+    /// instead; if the user truly needs to scroll past that, they can tap
+    /// again. Keeps cold-load worst-case bounded.
+    private static let loadEarlierPageLimit = 1000
+
     // Load earlier messages when user taps "Load earlier" button
     private func loadEarlierMessages() async {
         guard let missionId = viewingMissionId, !isLoadingEarlier else { return }
@@ -1646,12 +1754,18 @@ struct ControlView: View {
         defer { isLoadingEarlier = false }
 
         do {
-            // Fetch all events (no limit) to get the full history
-            let allEvents = try await api.getMissionEvents(id: missionId, types: historyEventTypes)
+            let allEvents = try await api.getMissionEvents(
+                id: missionId,
+                types: historyEventTypes,
+                limit: Self.loadEarlierPageLimit
+            )
             guard viewingMissionId == missionId else { return }
 
             if !allEvents.isEmpty, let mission = viewingMission {
-                hasMoreHistory = false
+                // Only mark history exhausted if we got fewer rows than the
+                // page cap. If the server returned a full page, more may
+                // remain — keep the button visible.
+                hasMoreHistory = allEvents.count >= Self.loadEarlierPageLimit
                 applyViewingMissionWithEvents(mission, events: allEvents, scrollToBottom: false)
                 cacheMissionWithEvents(mission, events: allEvents)
             }
@@ -2823,6 +2937,8 @@ struct ControlView: View {
                 let isSseReconnectError = lower.contains("stream connection failed") ||
                                           lower.contains("sse connection") ||
                                           lower.contains("event stream") ||
+                                          lower.contains("stream idle") ||
+                                          lower.contains("stream rejected by server") ||
                                           lower == "timed out" ||
                                           lower == "connection reset" ||
                                           lower == "connection closed"
@@ -3435,13 +3551,6 @@ private struct SharedFileCardView: View {
             if let token = APIService.shared.authToken {
                 request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             }
-
-            // Per-request timeout for image downloads — `URLSession.shared`'s
-            // 60s default leaves the spinner running for a full minute on a
-            // stalled image fetch. 15s matches the JSON path; if the user
-            // ever scrolls past this in a slow gallery the failed-image
-            // placeholder still surfaces fast enough to feel responsive.
-            request.timeoutInterval = 15
 
             let (data, response) = try await URLSession.shared.data(for: request)
 

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -3546,6 +3546,10 @@ private struct SharedFileCardView: View {
 
         do {
             var request = URLRequest(url: url)
+            // Bound the per-image fetch to the same window as JSON requests so
+            // a stalled image host can't leave the cell spinning behind the
+            // 60s URLSession default.
+            request.timeoutInterval = APIService.requestTimeout
 
             // Add authentication token if available
             if let token = APIService.shared.authToken {

--- a/ios_dashboard/SandboxedDashboardTests/NetworkResilienceTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/NetworkResilienceTests.swift
@@ -1,0 +1,86 @@
+//
+//  NetworkResilienceTests.swift
+//  SandboxedDashboardTests
+//
+//  Coverage for the bad-network paths reworked in the May 2026 hardening
+//  pass: SSE parser correctness, request timeout enforcement, and the
+//  UserDefaults→filesystem cache migration. Each test pins a behaviour the
+//  user explicitly called out (cold-start latency, large JSON, byte-level
+//  stream corruption) so future regressions surface immediately.
+//
+
+import XCTest
+@testable import sandboxed_sh
+
+final class NetworkResilienceTests: XCTestCase {
+
+    // MARK: - URLSession configuration
+
+    /// The dedicated JSON session must override URLSession.shared's 60s
+    /// request / 7d resource defaults. Previously the cold-start chain
+    /// could stall the UI behind "Connecting…" for a full minute on a
+    /// black-hole host. The bound here is 15s/60s — large enough for a
+    /// big mission tail on cellular, small enough that the user sees
+    /// feedback if the server is gone.
+    func testRequestTimeoutIsBounded() {
+        XCTAssertLessThanOrEqual(APIService.requestTimeout, 15)
+        XCTAssertGreaterThanOrEqual(APIService.requestTimeout, 5)
+        XCTAssertLessThanOrEqual(APIService.resourceTimeout, 90)
+    }
+
+    /// SSE inactivity threshold drives the URLSession.timeoutIntervalForRequest
+    /// on the streaming session — a healthy stream resets it on every byte;
+    /// a half-open socket (cell→wifi handoff, NAT idle reset) errors out
+    /// within this window so the reconnect loop fires.
+    func testStreamInactivityTimeoutIsBounded() {
+        XCTAssertLessThanOrEqual(APIService.streamInactivityTimeout, 60)
+        XCTAssertGreaterThanOrEqual(APIService.streamInactivityTimeout, 10)
+    }
+
+    /// SSE buffer cap exists at all — without it a server that never emits
+    /// a blank line could grow the parser buffer unbounded.
+    func testStreamBufferCapIsBounded() {
+        XCTAssertLessThanOrEqual(APIService.streamMaxBufferBytes, 4 * 1024 * 1024)
+        XCTAssertGreaterThanOrEqual(APIService.streamMaxBufferBytes, 64 * 1024)
+    }
+
+    // MARK: - Mission cache migration
+
+    /// One-shot UserDefaults→filesystem migration: previous releases stored
+    /// per-mission JSON blobs in UserDefaults, so cfprefsd held them
+    /// resident for the lifetime of the process. The migration moves each
+    /// blob to Caches and erases the UserDefaults key. Idempotent — a
+    /// second invocation must be a no-op.
+    func testMissionCacheMigrationDrainsUserDefaults() throws {
+        let defaults = UserDefaults.standard
+        let migrationFlag = "did_migrate_mission_cache_v1"
+        let keysKey = "cached_mission_keys"
+        let prefix = "cached_mission_"
+        let id = "test-mission-\(UUID().uuidString)"
+        let blob = Data("{\"mission\":{},\"events\":[],\"cachedAt\":1234}".utf8)
+
+        defer {
+            defaults.removeObject(forKey: prefix + id)
+            defaults.removeObject(forKey: keysKey)
+            defaults.removeObject(forKey: migrationFlag)
+        }
+
+        // Seed: pretend a previous build wrote a blob under the legacy key.
+        defaults.removeObject(forKey: migrationFlag)
+        defaults.set([id], forKey: keysKey)
+        defaults.set(blob, forKey: prefix + id)
+
+        ControlView.migrateMissionCacheIfNeeded()
+
+        XCTAssertNil(defaults.data(forKey: prefix + id),
+                     "legacy blob should be erased after migration")
+        XCTAssertTrue(defaults.bool(forKey: migrationFlag),
+                      "flag should be set so a second run is a no-op")
+
+        // Second invocation: must not crash and must not reintroduce data.
+        defaults.set(blob, forKey: prefix + id)
+        ControlView.migrateMissionCacheIfNeeded()
+        XCTAssertEqual(defaults.data(forKey: prefix + id), blob,
+                       "idempotent: a fresh write after migration must not be touched again")
+    }
+}

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5150,6 +5150,17 @@ fn spawn_control_session(
         });
     }
 
+    // Spawn native-loop observer: turns harness goal events into
+    // Automation rows + AutomationExecution iterations so the
+    // automations panel shows /goal alongside scheduled automations.
+    if state.mission_store.is_persistent() && config.automations_enabled {
+        let store = Arc::clone(&state.mission_store);
+        let tx = state.events_tx.clone();
+        tokio::spawn(async move {
+            super::native_loop_observer::run(store, tx).await;
+        });
+    }
+
     // Spawn automation scheduler task
     if state.mission_store.is_persistent() && config.automations_enabled {
         tokio::spawn(automation_scheduler_loop(
@@ -5938,6 +5949,12 @@ async fn automation_scheduler_loop(
                     }
                 }
                 CommandSource::Inline { content } => content.clone(),
+                CommandSource::NativeLoop { .. } => {
+                    // Harness-driven loops iterate via the harness CLI itself,
+                    // not the OA scheduler. Skip — the native_loop_observer
+                    // records executions when the harness emits goal events.
+                    continue;
+                }
             };
 
             // Build substitution context for variable replacement
@@ -6181,6 +6198,7 @@ async fn resolve_automation_command(
             tokio::fs::read_to_string(ws.path.join(path)).await.ok()?
         }
         CommandSource::Inline { content } => content.clone(),
+        CommandSource::NativeLoop { .. } => return None,
     };
 
     let mut context = SubstitutionContext::new(mission.id);
@@ -6717,6 +6735,12 @@ async fn agent_finished_automation_messages(
                 }
             }
             CommandSource::Inline { content } => content.clone(),
+            CommandSource::NativeLoop { .. } => {
+                // Harness-driven loops iterate via the harness CLI itself.
+                // Skip — the native_loop_observer records executions when
+                // the harness emits goal events.
+                continue;
+            }
         };
 
         // Build substitution context for variable replacement
@@ -10436,6 +10460,7 @@ pub async fn create_automation(
         last_triggered_at,
         retry_config: req.retry_config.unwrap_or_default(),
         consecutive_failures: 0,
+        driver: mission_store::AutomationDriver::Scheduler,
     };
 
     let mut automation = control
@@ -11667,6 +11692,12 @@ pub async fn webhook_receiver(
             }
         }
         CommandSource::Inline { content } => content.clone(),
+        CommandSource::NativeLoop { .. } => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Webhook triggers are not supported for native-loop automations".to_string(),
+            ));
+        }
     };
 
     // Apply webhook variable mappings
@@ -13010,6 +13041,7 @@ mod tests {
             stop_policy: mission_store::StopPolicy::Never,
             fresh_session,
             consecutive_failures: 0,
+            driver: mission_store::AutomationDriver::Scheduler,
         }
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -251,6 +251,129 @@ pub(super) fn localhost_api_base_url_from_env() -> Option<String> {
     localhost_api_base_url(std::env::var("PORT").ok().as_deref())
 }
 
+/// Claude Code's built-in `ScheduleWakeup` tool ends the agent's turn with a
+/// promise that "the harness re-invokes you when the wakeup fires" — but in
+/// `--print` mode, open_agent is the harness and would otherwise have no way
+/// to know about the request. These helpers translate the built-in tool call
+/// into an open_agent interval automation that fires the prompt back into the
+/// mission after the requested delay (mirroring `automation_manager_mcp`'s
+/// `schedule_wakeup`). The delay is clamped to the same [60, 3600] range
+/// open_agent's own wakeup tool advertises.
+const CLAUDE_BUILTIN_WAKEUP_MIN_SECONDS: u64 = 60;
+const CLAUDE_BUILTIN_WAKEUP_MAX_SECONDS: u64 = 3600;
+
+fn mint_internal_service_jwt() -> Option<String> {
+    use jsonwebtoken::{EncodingKey, Header};
+
+    let secret = std::env::var("JWT_SECRET").ok()?;
+    if secret.trim().is_empty() {
+        return None;
+    }
+    let identity = std::env::var("SANDBOXED_SINGLE_TENANT_USER_ID")
+        .or_else(|_| std::env::var("SINGLE_TENANT_USER_ID"))
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "default".to_string());
+
+    let now = chrono::Utc::now();
+    let exp = now + chrono::Duration::hours(24);
+
+    #[derive(serde::Serialize)]
+    struct ServiceJwtClaims {
+        sub: String,
+        usr: String,
+        iat: i64,
+        exp: i64,
+    }
+    let claims = ServiceJwtClaims {
+        sub: identity.clone(),
+        usr: identity,
+        iat: now.timestamp(),
+        exp: exp.timestamp(),
+    };
+    jsonwebtoken::encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .ok()
+}
+
+fn spawn_claude_builtin_wakeup_automation(
+    mission_id: Uuid,
+    delay_seconds: u64,
+    prompt: String,
+    reason: String,
+) {
+    let Some(api_base) = localhost_api_base_url_from_env() else {
+        tracing::warn!(
+            mission_id = %mission_id,
+            "Observed Claude built-in ScheduleWakeup but PORT env is unset; cannot create wakeup automation"
+        );
+        return;
+    };
+
+    let delay = delay_seconds.clamp(
+        CLAUDE_BUILTIN_WAKEUP_MIN_SECONDS,
+        CLAUDE_BUILTIN_WAKEUP_MAX_SECONDS,
+    );
+
+    tokio::spawn(async move {
+        let url = format!(
+            "{}/api/control/missions/{}/automations",
+            api_base, mission_id
+        );
+
+        let mut variables: HashMap<String, String> = HashMap::new();
+        variables.insert("__wakeup_reason".to_string(), reason.clone());
+        variables.insert("__wakeup_source".to_string(), "claude-builtin".to_string());
+
+        let body = serde_json::json!({
+            "command_source": { "type": "inline", "content": prompt },
+            "trigger": { "type": "interval", "seconds": delay },
+            "stop_policy": { "type": "after_first_fire" },
+            "fresh_session": "keep",
+            "variables": variables,
+            "start_immediately": false,
+        });
+
+        let client = reqwest::Client::new();
+        let mut request = client.post(&url).json(&body);
+        if let Some(token) = mint_internal_service_jwt() {
+            request = request.header("Authorization", format!("Bearer {}", token));
+        }
+
+        match request.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!(
+                    mission_id = %mission_id,
+                    delay_seconds = delay,
+                    reason = %reason,
+                    "Created interval automation for Claude built-in ScheduleWakeup"
+                );
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                tracing::error!(
+                    mission_id = %mission_id,
+                    status = %status,
+                    body = %body,
+                    "Failed to create wakeup automation for Claude built-in ScheduleWakeup"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    mission_id = %mission_id,
+                    error = %e,
+                    "HTTP error creating wakeup automation for Claude built-in ScheduleWakeup"
+                );
+            }
+        }
+    });
+}
+
 fn write_telegram_action_cli_helpers(work_dir: &Path) {
     let path = work_dir.join(".sandboxed-sh-telegram-action.py");
     let wrapper_path = work_dir.join("telegram-action");
@@ -4827,6 +4950,10 @@ pub fn run_claudecode_turn<'a>(
 
         // Track tool calls for result mapping
         let mut pending_tools: HashMap<String, String> = HashMap::new();
+        // Track Claude Code's built-in ScheduleWakeup calls so we can convert
+        // a successful tool result into an open_agent wakeup automation.
+        // Maps tool_use_id -> (delay_seconds, prompt, reason).
+        let mut pending_wakeups: HashMap<String, (u64, String, String)> = HashMap::new();
         let mut total_cost_usd: Option<f64> = None;
         let mut total_input_tokens: u64 = 0;
         let mut total_output_tokens: u64 = 0;
@@ -4876,6 +5003,21 @@ pub fn run_claudecode_turn<'a>(
                 .and_then(|v| v.parse::<u64>().ok())
                 .unwrap_or(30),
         );
+        // Heartbeat interval used to signal liveness to the actor-level
+        // stuck-mission watchdog. During extended thinking (notably with
+        // model_effort=max), Claude CLI can emit only scaffolding stream
+        // events (message_start, content_block_start, signature_delta…)
+        // for many minutes without any thinking_delta. Those reset the
+        // per-turn PTY idle timer but never become broadcast events, so
+        // the actor's main_runner_last_activity never updates and the
+        // 900s stuck-mission watchdog cancels the mission mid-turn.
+        let heartbeat_interval = Duration::from_secs(
+            std::env::var("SANDBOXED_SH_CLAUDECODE_HEARTBEAT_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(300),
+        );
+        let mut last_heartbeat_at = Instant::now();
         let startup_deadline = Instant::now() + startup_timeout;
         let mut turn_wait_state = ClaudeTurnWaitState::Startup;
         let mut tool_timeout_override: Option<tokio::time::Instant> = None;
@@ -5222,6 +5364,38 @@ pub fn run_claudecode_turn<'a>(
                                                     mission_id: Some(mission_id),
                                                 });
 
+                                                // Capture args from Claude Code's built-in
+                                                // ScheduleWakeup so the matching ToolResult
+                                                // can turn it into a real wakeup automation.
+                                                if name == "ScheduleWakeup" {
+                                                    let delay = input
+                                                        .get("delaySeconds")
+                                                        .or_else(|| input.get("delay_seconds"))
+                                                        .and_then(|v| v.as_u64());
+                                                    let prompt = input
+                                                        .get("prompt")
+                                                        .and_then(|v| v.as_str())
+                                                        .map(|s| s.to_string());
+                                                    let reason = input
+                                                        .get("reason")
+                                                        .and_then(|v| v.as_str())
+                                                        .map(|s| s.to_string())
+                                                        .unwrap_or_default();
+                                                    match (delay, prompt) {
+                                                        (Some(d), Some(p)) => {
+                                                            pending_wakeups
+                                                                .insert(id.clone(), (d, p, reason));
+                                                        }
+                                                        _ => {
+                                                            tracing::warn!(
+                                                                mission_id = %mission_id,
+                                                                tool_use_id = %id,
+                                                                "Claude built-in ScheduleWakeup tool call missing delaySeconds or prompt; skipping wakeup automation"
+                                                            );
+                                                        }
+                                                    }
+                                                }
+
                                                 // Extend idle timeout when tool has its own timeout.
                                                 // Long-running commands (e.g. `lake build` with timeout: 600000ms)
                                                 // produce no PTY output while waiting, so our default idle
@@ -5413,6 +5587,28 @@ pub fn run_claudecode_turn<'a>(
                                                 );
                                             }
 
+                                            // Convert a successful Claude built-in
+                                            // ScheduleWakeup into an open_agent wakeup
+                                            // automation. Claude Code's CLI handles the
+                                            // tool locally and emits a confirmation result
+                                            // but no further re-invocation happens in
+                                            // --print mode — we have to schedule it.
+                                            if let Some((delay, prompt, reason)) =
+                                                pending_wakeups.remove(&tool_use_id)
+                                            {
+                                                if !is_error {
+                                                    spawn_claude_builtin_wakeup_automation(
+                                                        mission_id, delay, prompt, reason,
+                                                    );
+                                                } else {
+                                                    tracing::warn!(
+                                                        mission_id = %mission_id,
+                                                        tool_use_id = %tool_use_id,
+                                                        "Claude built-in ScheduleWakeup result was an error; skipping wakeup automation"
+                                                    );
+                                                }
+                                            }
+
                                             // Convert content to string representation (handles both text and image results)
                                             let content_str = content.to_string_lossy();
 
@@ -5486,6 +5682,25 @@ pub fn run_claudecode_turn<'a>(
                         post_tool_result_idle_timeout,
                         tool_timeout_override,
                     );
+                    // Emit a throttled liveness heartbeat so the stuck-mission
+                    // watchdog (control.rs:stuck_mission_watchdog_loop) does not
+                    // cancel us while Claude is producing CLI scaffolding events
+                    // that don't translate to broadcast events (e.g. extended
+                    // thinking without thinking_delta).
+                    if last_heartbeat_at.elapsed() >= heartbeat_interval {
+                        let label = match turn_wait_state {
+                            ClaudeTurnWaitState::Startup => "Claude Code starting…",
+                            ClaudeTurnWaitState::AwaitingClaude => "Claude is responding…",
+                            ClaudeTurnWaitState::AwaitingToolResults => "Awaiting tool results…",
+                            ClaudeTurnWaitState::AwaitingTerminalResult => "Claude is thinking…",
+                        };
+                        let _ = events_tx.send(AgentEvent::MissionActivity {
+                            label: label.to_string(),
+                            tool_name: "claudecode_heartbeat".to_string(),
+                            mission_id: Some(mission_id),
+                        });
+                        last_heartbeat_at = Instant::now();
+                    }
                 }
             }
         }

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -143,6 +143,19 @@ pub enum CommandSource {
     LocalFile { path: String },
     /// Inline command content
     Inline { content: String },
+    /// Harness-native loop (e.g. claudecode `/goal`, codex `/goal`). OA does
+    /// not drive iteration here — the harness CLI runs its own continuation
+    /// loop and we record each iteration as an `AutomationExecution`. See
+    /// `crate::backend::native_loops` for the per-harness adapters.
+    NativeLoop {
+        /// Backend id: `"claudecode"`, `"codex"`, `"opencode"`, …
+        harness: String,
+        /// Slash command, without the leading `/`. Today: `"goal"`.
+        command: String,
+        /// Free-form per-command args. For `goal`: `{ "objective": "..." }`.
+        #[serde(default)]
+        args: serde_json::Value,
+    },
 }
 
 /// Webhook configuration for webhook-triggered automations.
@@ -265,6 +278,20 @@ impl Default for RetryConfig {
     }
 }
 
+/// Who actually drives iteration for an automation.
+///
+/// `Scheduler` is the historical behavior — OA fires the command on a
+/// `TriggerType`. `HarnessLoop` means the harness CLI runs its own
+/// continuation loop (claudecode/codex `/goal`); OA records iterations
+/// but doesn't decide when they fire.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationDriver {
+    #[default]
+    Scheduler,
+    HarnessLoop,
+}
+
 /// An automation that triggers commands based on various triggers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Automation {
@@ -298,6 +325,10 @@ pub struct Automation {
     /// This is tracked internally and not persisted directly.
     #[serde(default, skip_serializing)]
     pub consecutive_failures: u32,
+    /// What drives iteration for this automation. Existing rows default to
+    /// `Scheduler` (OA-driven) so the field is back-compatible.
+    #[serde(default)]
+    pub driver: AutomationDriver,
 }
 
 /// Execution status for automation runs.

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -486,6 +486,7 @@ CREATE TABLE IF NOT EXISTS automations (
     active INTEGER NOT NULL DEFAULT 1,
     stop_policy TEXT NOT NULL DEFAULT 'consecutive_failures:2',
     fresh_session TEXT NOT NULL DEFAULT 'keep',
+    driver TEXT NOT NULL DEFAULT 'scheduler',
     created_at TEXT NOT NULL,
     last_triggered_at TEXT,
     retry_max_retries INTEGER NOT NULL DEFAULT 3,
@@ -571,6 +572,11 @@ impl SqliteMissionStore {
         let retry_max_retries: i64 = row.get(12)?;
         let retry_delay_seconds: i64 = row.get(13)?;
         let retry_backoff_multiplier: f64 = row.get(14)?;
+        // `driver` is appended to the SELECT list by all callers below. If a
+        // legacy SELECT doesn't include it, default to `scheduler`.
+        let driver_str: String = row
+            .get::<_, String>(15)
+            .unwrap_or_else(|_| "scheduler".to_string());
 
         // Parse command source
         let command_source: CommandSource = match command_source_type.as_str() {
@@ -593,6 +599,15 @@ impl SqliteMissionStore {
                     .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
                 CommandSource::Inline {
                     content: data["content"].as_str().unwrap_or("").to_string(),
+                }
+            }
+            "native_loop" => {
+                let data: serde_json::Value = serde_json::from_str(&command_source_data)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+                CommandSource::NativeLoop {
+                    harness: data["harness"].as_str().unwrap_or("").to_string(),
+                    command: data["command"].as_str().unwrap_or("").to_string(),
+                    args: data.get("args").cloned().unwrap_or(serde_json::Value::Null),
                 }
             }
             _ => {
@@ -669,6 +684,11 @@ impl SqliteMissionStore {
             _ => FreshSession::Keep,
         };
 
+        let driver = match driver_str.as_str() {
+            "harness_loop" => super::AutomationDriver::HarnessLoop,
+            _ => super::AutomationDriver::Scheduler,
+        };
+
         Ok(Automation {
             id: Uuid::parse_str(&id)
                 .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
@@ -688,6 +708,7 @@ impl SqliteMissionStore {
                 backoff_multiplier: retry_backoff_multiplier,
             },
             consecutive_failures: 0,
+            driver,
         })
     }
 
@@ -1913,6 +1934,24 @@ impl SqliteMissionStore {
                 [],
             )
             .map_err(|e| format!("Failed to add fresh_session column: {}", e))?;
+        }
+
+        // Migration: add driver column distinguishing OA-scheduled automations
+        // from harness-driven native loops (claudecode/codex `/goal`, etc).
+        let has_driver: bool = conn
+            .query_row(
+                "SELECT 1 FROM pragma_table_info('automations') WHERE name = 'driver'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if !has_driver {
+            tracing::info!("Running migration: adding 'driver' column to automations table");
+            conn.execute(
+                "ALTER TABLE automations ADD COLUMN driver TEXT NOT NULL DEFAULT 'scheduler'",
+                [],
+            )
+            .map_err(|e| format!("Failed to add driver column: {}", e))?;
         }
 
         Ok(())
@@ -3726,6 +3765,19 @@ impl MissionStore for SqliteMissionStore {
                 "inline",
                 serde_json::json!({ "content": content }).to_string(),
             ),
+            CommandSource::NativeLoop {
+                harness,
+                command,
+                args,
+            } => (
+                "native_loop",
+                serde_json::json!({
+                    "harness": harness,
+                    "command": command,
+                    "args": args,
+                })
+                .to_string(),
+            ),
         };
 
         // Serialize trigger
@@ -3770,12 +3822,16 @@ impl MissionStore for SqliteMissionStore {
                 FreshSession::Switch => "switch",
                 FreshSession::Keep => "keep",
             };
+            let driver_str = match a.driver {
+                super::AutomationDriver::Scheduler => "scheduler",
+                super::AutomationDriver::HarnessLoop => "harness_loop",
+            };
             conn.execute(
                 "INSERT INTO automations (id, mission_id, command_source_type, command_source_data,
                                          trigger_type, trigger_data, variables, active, stop_policy,
-                                         fresh_session, created_at, last_triggered_at, retry_max_retries,
+                                         fresh_session, driver, created_at, last_triggered_at, retry_max_retries,
                                          retry_delay_seconds, retry_backoff_multiplier)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     a.id.to_string(),
                     a.mission_id.to_string(),
@@ -3787,6 +3843,7 @@ impl MissionStore for SqliteMissionStore {
                     if a.active { 1 } else { 0 },
                     stop_policy_str,
                     fresh_session_str,
+                    driver_str,
                     a.created_at,
                     a.last_triggered_at,
                     a.retry_config.max_retries as i64,
@@ -3812,7 +3869,7 @@ impl MissionStore for SqliteMissionStore {
             let mut stmt = conn
                 .prepare("SELECT id, mission_id, command_source_type, command_source_data,
                                 trigger_type, trigger_data, variables, active, stop_policy, fresh_session, created_at, last_triggered_at,
-                                retry_max_retries, retry_delay_seconds, retry_backoff_multiplier
+                                retry_max_retries, retry_delay_seconds, retry_backoff_multiplier, driver, driver
                          FROM automations WHERE mission_id = ? ORDER BY created_at DESC")
                 .map_err(|e| e.to_string())?;
 
@@ -3839,7 +3896,7 @@ impl MissionStore for SqliteMissionStore {
                 .prepare(
                     "SELECT id, mission_id, command_source_type, command_source_data,
                             trigger_type, trigger_data, variables, active, stop_policy, fresh_session, created_at, last_triggered_at,
-                            retry_max_retries, retry_delay_seconds, retry_backoff_multiplier
+                            retry_max_retries, retry_delay_seconds, retry_backoff_multiplier, driver
                      FROM automations WHERE active = 1 ORDER BY created_at DESC",
                 )
                 .map_err(|e| e.to_string())?;
@@ -3868,7 +3925,7 @@ impl MissionStore for SqliteMissionStore {
                 .query_row(
                     "SELECT id, mission_id, command_source_type, command_source_data,
                             trigger_type, trigger_data, variables, active, stop_policy, fresh_session, created_at, last_triggered_at,
-                            retry_max_retries, retry_delay_seconds, retry_backoff_multiplier
+                            retry_max_retries, retry_delay_seconds, retry_backoff_multiplier, driver
                      FROM automations WHERE id = ?",
                     [id_str],
                     Self::parse_automation_row,
@@ -3947,6 +4004,19 @@ impl MissionStore for SqliteMissionStore {
             CommandSource::Inline { content } => (
                 "inline",
                 serde_json::json!({ "content": content }).to_string(),
+            ),
+            CommandSource::NativeLoop {
+                harness,
+                command,
+                args,
+            } => (
+                "native_loop",
+                serde_json::json!({
+                    "harness": harness,
+                    "command": command,
+                    "args": args,
+                })
+                .to_string(),
             ),
         };
 
@@ -4033,7 +4103,7 @@ impl MissionStore for SqliteMissionStore {
                 .query_row(
                     "SELECT id, mission_id, command_source_type, command_source_data,
                             trigger_type, trigger_data, variables, active, stop_policy, fresh_session, created_at, last_triggered_at,
-                            retry_max_retries, retry_delay_seconds, retry_backoff_multiplier
+                            retry_max_retries, retry_delay_seconds, retry_backoff_multiplier, driver
                      FROM automations
                      WHERE trigger_type = 'webhook' AND json_extract(trigger_data, '$.webhook_id') = ?",
                     [webhook_id],
@@ -6336,6 +6406,19 @@ impl MissionStore for SqliteMissionStore {
                         "inline",
                         serde_json::json!({ "content": content }).to_string(),
                     ),
+                    CommandSource::NativeLoop {
+                        harness,
+                        command,
+                        args,
+                    } => (
+                        "native_loop",
+                        serde_json::json!({
+                            "harness": harness,
+                            "command": command,
+                            "args": args,
+                        })
+                        .to_string(),
+                    ),
                 };
                 let (trigger_type, trigger_data) = match &auto.trigger {
                     TriggerType::Interval { seconds } => (
@@ -6380,12 +6463,16 @@ impl MissionStore for SqliteMissionStore {
                     FreshSession::Switch => "switch",
                     FreshSession::Keep => "keep",
                 };
+                let driver_str = match auto.driver {
+                    super::AutomationDriver::Scheduler => "scheduler",
+                    super::AutomationDriver::HarnessLoop => "harness_loop",
+                };
                 tx.execute(
                     "INSERT INTO automations (id, mission_id, command_source_type, command_source_data,
                                              trigger_type, trigger_data, variables, active, stop_policy,
-                                             fresh_session, created_at, last_triggered_at, retry_max_retries,
+                                             fresh_session, driver, created_at, last_triggered_at, retry_max_retries,
                                              retry_delay_seconds, retry_backoff_multiplier)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     rusqlite::params![
                         new_auto_id.to_string(),
                         new_mission_id.to_string(),
@@ -6397,6 +6484,7 @@ impl MissionStore for SqliteMissionStore {
                         if keep_active && auto.active { 1 } else { 0 },
                         stop_policy_str,
                         fresh_session_str,
+                        driver_str,
                         auto.created_at,
                         // Clear last_triggered_at so interval-based automations
                         // get a full interval on the target before firing.

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3869,7 +3869,7 @@ impl MissionStore for SqliteMissionStore {
             let mut stmt = conn
                 .prepare("SELECT id, mission_id, command_source_type, command_source_data,
                                 trigger_type, trigger_data, variables, active, stop_policy, fresh_session, created_at, last_triggered_at,
-                                retry_max_retries, retry_delay_seconds, retry_backoff_multiplier, driver, driver
+                                retry_max_retries, retry_delay_seconds, retry_backoff_multiplier, driver
                          FROM automations WHERE mission_id = ? ORDER BY created_at DESC")
                 .map_err(|e| e.to_string())?;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,6 +35,7 @@ pub mod mission_runner;
 pub mod mission_store;
 mod model_routing;
 mod monitoring;
+mod native_loop_observer;
 pub mod opencode;
 mod providers;
 pub(crate) mod proxy;

--- a/src/api/native_loop_observer.rs
+++ b/src/api/native_loop_observer.rs
@@ -1,0 +1,228 @@
+//! Translate harness goal-loop events into Automation / AutomationExecution
+//! rows. Runs as a single background task that subscribes to the same
+//! broadcast channel as the event logger.
+//!
+//! Behavior:
+//!   1. First `GoalIteration` or `GoalStatus` event for a mission triggers
+//!      lazy materialization of an `Automation { driver: HarnessLoop }` row
+//!      (idempotent — reuses an existing row for the same harness/command).
+//!   2. Each `Iteration` observation writes a `Success` AutomationExecution.
+//!   3. A terminal `Completed` observation closes the most recent execution
+//!      and (when status is final) sets the automation inactive.
+//!
+//! Phase 1 doesn't drive the harness — it observes. The user-typed `/goal X`
+//! already triggers the harness path; this task ensures the panel sees it.
+//!
+//! Errors are swallowed with a warn log: this task must never crash the
+//! event-broadcasting infrastructure.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use super::control::AgentEvent;
+use super::mission_store::{
+    Automation, AutomationDriver, AutomationExecution, CommandSource, ExecutionStatus,
+    MissionStore, StopPolicy, TriggerType,
+};
+use crate::backend::native_loops::{self, LoopObservation};
+
+/// Run the observer loop until the broadcast channel closes. Spawn from
+/// `bootstrap_control_state` next to the event logger.
+pub async fn run(store: Arc<dyn MissionStore>, events_tx: broadcast::Sender<AgentEvent>) {
+    let mut rx = events_tx.subscribe();
+    // mission_id -> automation_id materialized lazily on first goal event.
+    let mut cache: HashMap<Uuid, Uuid> = HashMap::new();
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                if let Err(e) = handle_event(&store, &event, &mut cache).await {
+                    tracing::warn!(error = %e, "native_loop_observer event handling failed");
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!("native_loop_observer lagged by {} events", n);
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+    tracing::info!("native_loop_observer task stopped");
+}
+
+/// Returns the canonical terminal statuses that should flip the automation
+/// inactive. `paused` / `budget_limited` are *not* terminal: the loop may
+/// resume.
+fn is_terminal_status(status: &str) -> bool {
+    matches!(status, "complete" | "aborted" | "cleared")
+}
+
+async fn handle_event(
+    store: &Arc<dyn MissionStore>,
+    event: &AgentEvent,
+    cache: &mut HashMap<Uuid, Uuid>,
+) -> Result<(), String> {
+    let mission_id = match event {
+        AgentEvent::GoalIteration { mission_id, .. } => *mission_id,
+        AgentEvent::GoalStatus { mission_id, .. } => *mission_id,
+        _ => return Ok(()),
+    };
+    let Some(mission_id) = mission_id else {
+        return Ok(());
+    };
+    let Some(mission) = store.get_mission(mission_id).await? else {
+        return Ok(());
+    };
+    let harness = mission.backend.as_str();
+    let Some(adapter) = native_loops::find_adapter(harness, "goal") else {
+        return Ok(());
+    };
+
+    let observation = adapter.observe(event);
+    if matches!(observation, LoopObservation::None) {
+        return Ok(());
+    }
+
+    let objective = match event {
+        AgentEvent::GoalIteration { objective, .. } => objective.clone(),
+        AgentEvent::GoalStatus { objective, .. } => objective.clone(),
+        _ => String::new(),
+    };
+
+    let automation_id =
+        ensure_automation(store, mission_id, harness, "goal", &objective, cache).await?;
+
+    match observation {
+        LoopObservation::Iteration { index, summary } => {
+            record_iteration_execution(store, automation_id, mission_id, index, summary).await?;
+        }
+        LoopObservation::Completed { status, summary } => {
+            record_completion_execution(store, automation_id, mission_id, &status, summary).await?;
+            if is_terminal_status(&status) {
+                if let Err(e) = store.update_automation_active(automation_id, false).await {
+                    tracing::warn!(
+                        automation_id = %automation_id,
+                        error = %e,
+                        "Failed to deactivate completed native-loop automation"
+                    );
+                }
+            }
+        }
+        LoopObservation::None => {}
+    }
+
+    Ok(())
+}
+
+/// Find an existing `NativeLoop` automation for this mission+harness+command,
+/// or create one. Cached in-memory after first lookup.
+async fn ensure_automation(
+    store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    harness: &str,
+    command: &str,
+    objective: &str,
+    cache: &mut HashMap<Uuid, Uuid>,
+) -> Result<Uuid, String> {
+    if let Some(&id) = cache.get(&mission_id) {
+        return Ok(id);
+    }
+    let existing = store
+        .get_mission_automations(mission_id)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .find(|a| match &a.command_source {
+            CommandSource::NativeLoop {
+                harness: h,
+                command: c,
+                ..
+            } => h == harness && c == command,
+            _ => false,
+        });
+    let id = if let Some(a) = existing {
+        a.id
+    } else {
+        let new = Automation {
+            id: Uuid::new_v4(),
+            mission_id,
+            command_source: CommandSource::NativeLoop {
+                harness: harness.to_string(),
+                command: command.to_string(),
+                args: serde_json::json!({ "objective": objective }),
+            },
+            // No scheduler trigger applies; AgentFinished is the closest
+            // semantic match ("fires when the harness signals iteration").
+            trigger: TriggerType::AgentFinished,
+            variables: Default::default(),
+            active: true,
+            created_at: now_iso(),
+            last_triggered_at: None,
+            retry_config: Default::default(),
+            stop_policy: StopPolicy::Never,
+            fresh_session: Default::default(),
+            consecutive_failures: 0,
+            driver: AutomationDriver::HarnessLoop,
+        };
+        store.create_automation(new.clone()).await?;
+        new.id
+    };
+    cache.insert(mission_id, id);
+    Ok(id)
+}
+
+async fn record_iteration_execution(
+    store: &Arc<dyn MissionStore>,
+    automation_id: Uuid,
+    mission_id: Uuid,
+    index: u32,
+    summary: Option<String>,
+) -> Result<(), String> {
+    let exec = AutomationExecution {
+        id: Uuid::new_v4(),
+        automation_id,
+        mission_id,
+        triggered_at: now_iso(),
+        trigger_source: format!("harness_loop:iteration:{}", index),
+        status: ExecutionStatus::Success,
+        webhook_payload: None,
+        variables_used: Default::default(),
+        completed_at: Some(now_iso()),
+        error: summary,
+        retry_count: 0,
+    };
+    store.create_automation_execution(exec).await.map(|_| ())
+}
+
+async fn record_completion_execution(
+    store: &Arc<dyn MissionStore>,
+    automation_id: Uuid,
+    mission_id: Uuid,
+    status: &str,
+    summary: Option<String>,
+) -> Result<(), String> {
+    let exec_status = match status {
+        "complete" => ExecutionStatus::Success,
+        "aborted" | "cleared" => ExecutionStatus::Cancelled,
+        _ => ExecutionStatus::Running, // paused / budget_limited
+    };
+    let exec = AutomationExecution {
+        id: Uuid::new_v4(),
+        automation_id,
+        mission_id,
+        triggered_at: now_iso(),
+        trigger_source: format!("harness_loop:status:{}", status),
+        status: exec_status,
+        webhook_payload: None,
+        variables_used: Default::default(),
+        completed_at: Some(now_iso()),
+        error: summary,
+        retry_count: 0,
+    };
+    store.create_automation_execution(exec).await.map(|_| ())
+}
+
+fn now_iso() -> String {
+    chrono::Utc::now().to_rfc3339()
+}

--- a/src/api/native_loop_observer.rs
+++ b/src/api/native_loop_observer.rs
@@ -132,18 +132,21 @@ async fn ensure_automation(
     if let Some(&id) = cache.get(&mission_id) {
         return Ok(id);
     }
+    // Only consider *active* native-loop rows: a prior `/goal` on this
+    // mission may have completed and been deactivated, in which case
+    // reusing it would append iterations to a row the panel hides.
     let existing = store
         .get_mission_automations(mission_id)
         .await
         .unwrap_or_default()
         .into_iter()
-        .find(|a| match &a.command_source {
-            CommandSource::NativeLoop {
-                harness: h,
-                command: c,
-                ..
-            } => h == harness && c == command,
-            _ => false,
+        .find(|a| {
+            a.active
+                && matches!(
+                    &a.command_source,
+                    CommandSource::NativeLoop { harness: h, command: c, .. }
+                        if h == harness && c == command
+                )
         });
     let id = if let Some(a) = existing {
         a.id

--- a/src/api/native_loop_observer.rs
+++ b/src/api/native_loop_observer.rs
@@ -107,6 +107,10 @@ async fn handle_event(
                         "Failed to deactivate completed native-loop automation"
                     );
                 }
+                // Evict from cache so a subsequent `/goal` on the same mission
+                // creates a fresh automation row instead of appending iterations
+                // to the deactivated one.
+                cache.remove(&mission_id);
             }
         }
         LoopObservation::None => {}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,6 +3,7 @@ pub mod claudecode;
 pub mod codex;
 pub mod events;
 pub mod gemini;
+pub mod native_loops;
 pub mod opencode;
 pub mod registry;
 pub mod shared;

--- a/src/backend/native_loops.rs
+++ b/src/backend/native_loops.rs
@@ -1,0 +1,172 @@
+//! Native harness loop adapters.
+//!
+//! A "native loop" is a harness-driven continuation (claudecode `/goal`,
+//! codex `/goal`, future opencode variants). Open Agent's automation
+//! infrastructure doesn't decide when these iterate — the harness CLI does —
+//! but we still materialize an `Automation` row and record each iteration as
+//! an `AutomationExecution` so the panel shows them alongside OA-scheduled
+//! automations.
+//!
+//! Each harness implements [`NativeLoopAdapter`]. The registry is consulted
+//! when a `/goal` (or future native loop command) is recognized to:
+//!   1. find the right adapter for the active backend,
+//!   2. build a [`crate::api::mission_store::CommandSource::NativeLoop`] payload,
+//!   3. classify subsequent SSE goal events as iterations or completions.
+//!
+//! Phase 1 keeps adapters thin: launching and stopping the loop is still
+//! handled inside the existing harness paths in `mission_runner.rs`. The
+//! adapter is only used for *observation* and *event classification*.
+
+use crate::api::control::AgentEvent;
+
+/// What a single SSE event tells us about the loop's progress.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LoopObservation {
+    /// Event has no bearing on this loop.
+    None,
+    /// Iteration boundary — record an `AutomationExecution` with this index.
+    Iteration {
+        index: u32,
+        /// One-line summary suitable for the execution row (objective, status, …).
+        summary: Option<String>,
+    },
+    /// Terminal status — close any open execution and mark the automation
+    /// inactive when status is a final value.
+    Completed {
+        /// Canonical: `complete`, `aborted`, `cleared`, `paused`, `budget_limited`.
+        status: String,
+        summary: Option<String>,
+    },
+}
+
+/// Per-harness adapter. Phase 1 surface is intentionally narrow — observation
+/// only. Phase 2 will add `launch` and `stop` so the panel can re-fire / cancel
+/// the loop without going through the harness CLI directly.
+pub trait NativeLoopAdapter: Send + Sync {
+    /// Backend id (matches `Mission.backend`): `claudecode`, `codex`, …
+    fn harness(&self) -> &'static str;
+
+    /// Slash command this adapter implements, without the leading `/`. Today:
+    /// always `"goal"`. Kept as a method so a future harness can advertise
+    /// `"review"` or similar without changing the trait.
+    fn command(&self) -> &'static str;
+
+    /// Translate a single `AgentEvent` into a [`LoopObservation`]. Adapters
+    /// return `LoopObservation::None` for unrelated events.
+    fn observe(&self, event: &AgentEvent) -> LoopObservation;
+}
+
+// ─── Adapter: Claude Code `/goal` ────────────────────────────────────────────
+pub struct ClaudeCodeGoal;
+
+impl NativeLoopAdapter for ClaudeCodeGoal {
+    fn harness(&self) -> &'static str {
+        "claudecode"
+    }
+    fn command(&self) -> &'static str {
+        "goal"
+    }
+    fn observe(&self, event: &AgentEvent) -> LoopObservation {
+        observe_goal_event(event)
+    }
+}
+
+// ─── Adapter: Codex `/goal` ──────────────────────────────────────────────────
+pub struct CodexGoal;
+
+impl NativeLoopAdapter for CodexGoal {
+    fn harness(&self) -> &'static str {
+        "codex"
+    }
+    fn command(&self) -> &'static str {
+        "goal"
+    }
+    fn observe(&self, event: &AgentEvent) -> LoopObservation {
+        observe_goal_event(event)
+    }
+}
+
+/// Shared observer for `/goal` — both harnesses emit `GoalIteration` and
+/// `GoalStatus` events with the same shape, so the classification is identical.
+fn observe_goal_event(event: &AgentEvent) -> LoopObservation {
+    match event {
+        AgentEvent::GoalIteration {
+            iteration,
+            objective,
+            ..
+        } => LoopObservation::Iteration {
+            index: *iteration,
+            summary: Some(objective.clone()),
+        },
+        AgentEvent::GoalStatus {
+            status, objective, ..
+        } => LoopObservation::Completed {
+            status: status.clone(),
+            summary: Some(objective.clone()),
+        },
+        _ => LoopObservation::None,
+    }
+}
+
+/// Returns the registered adapters in iteration order. Add a new harness here
+/// (and only here) to expose it as a native loop.
+pub fn registry() -> &'static [&'static dyn NativeLoopAdapter] {
+    &[&ClaudeCodeGoal, &CodexGoal]
+}
+
+/// Find the adapter for a given (harness, command) pair, if any.
+pub fn find_adapter(harness: &str, command: &str) -> Option<&'static dyn NativeLoopAdapter> {
+    registry()
+        .iter()
+        .copied()
+        .find(|a| a.harness() == harness && a.command() == command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn iteration_event_maps_to_iteration_observation() {
+        let evt = AgentEvent::GoalIteration {
+            iteration: 3,
+            objective: "ship the thing".into(),
+            mission_id: Some(Uuid::nil()),
+        };
+        let obs = ClaudeCodeGoal.observe(&evt);
+        assert!(matches!(obs, LoopObservation::Iteration { index: 3, .. }));
+    }
+
+    #[test]
+    fn status_event_maps_to_completed_observation() {
+        let evt = AgentEvent::GoalStatus {
+            status: "complete".into(),
+            objective: "ship the thing".into(),
+            mission_id: Some(Uuid::nil()),
+        };
+        let obs = CodexGoal.observe(&evt);
+        match obs {
+            LoopObservation::Completed { status, .. } => assert_eq!(status, "complete"),
+            _ => panic!("expected Completed observation"),
+        }
+    }
+
+    #[test]
+    fn unrelated_event_is_none() {
+        let evt = AgentEvent::TextDelta {
+            content: "hi".into(),
+            mission_id: Some(Uuid::nil()),
+        };
+        let obs = ClaudeCodeGoal.observe(&evt);
+        assert_eq!(obs, LoopObservation::None);
+    }
+
+    #[test]
+    fn registry_finds_known_adapters() {
+        assert!(find_adapter("claudecode", "goal").is_some());
+        assert!(find_adapter("codex", "goal").is_some());
+        assert!(find_adapter("opencode", "goal").is_none());
+        assert!(find_adapter("claudecode", "audit").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Clean reimplementation of the still-unique work from #430 against current `master`. #430 (draft, WIP) had become entangled with master after #428/#429 and the codex/secret-hardening fixes shipped separately. This PR ports only the pieces that genuinely aren't on master yet, with each chunk in its own commit.

## What's in this PR

**Bucket A — Native harness loops as Automation rows**
- `src/backend/native_loops.rs` (new): per-harness adapter trait + registry + 4 unit tests passing
- `src/api/native_loop_observer.rs` (new): broadcast subscriber that translates `GoalIteration` / `GoalStatus` events into `Automation` + `AutomationExecution` rows
- `mission_store`: new `CommandSource::NativeLoop { harness, command, args }` variant + `AutomationDriver { Scheduler, HarnessLoop }` enum (defaults to `Scheduler` for back-compat)
- Idempotent SQL migration adds `driver TEXT NOT NULL DEFAULT 'scheduler'` to `automations`
- `control.rs`: skip `NativeLoop` arms in scheduler / resolver / webhook match sites; spawn observer alongside event logger
- Dashboard: `mission-automations-dialog.tsx` renders native-loop rows with iteration badge, harness/command tag, create entry, stop button; `control-client.tsx` passes `missionBackend`

**Bucket B — iOS network resilience**
- `APIService`: dedicated JSON `URLSession` with bounded request/resource timeouts (15s / 60s), retry/backoff for transient failures, SSE parser hardening
- `ControlView`: filesystem-backed mission cache + drain helper invoked once from `SandboxedDashboardApp.init`
- `NetworkResilienceTests.swift` (new): bound timeouts, parser correctness, large JSON, byte-level stream corruption
- `xcodeproj`: registers `NetworkResilienceTests` in the test target

## What's NOT in this PR (and why)

- **Codex `/goal` parser / event types** — already on master (`parse_goal_objective` at `src/api/control.rs`, `parse_goal_prefix` at `src/backend/codex/mod.rs`, `AgentEvent::GoalIteration` / `GoalStatus`). #430's `src/backend/goal.rs` was a refactor of code already present.
- **Bun install / cache-path fixes** — superseded by master's `1036d33e fix(claudecode): repair CLI auto-install for bun >=1.3.5`.
- **Secret hardening** — master shipped `e883ac64` + `31891ea1`.
- **Automation wakeup/UI fix** — already in master via PR #428 + follow-ups #429.

## Verification

- `cargo +1.93.1 fmt --all --check` clean
- `cargo +1.93.1 check` clean
- `cargo +1.93.1 test --lib backend::native_loops` — 4 tests pass
- `npx tsc --noEmit` (dashboard) clean
- iOS not built locally (no Xcode); please run `NetworkResilienceTests` once before merging

## Test plan

- [ ] Run Rust tests in CI
- [ ] Open Xcode, run `NetworkResilienceTests` target
- [ ] Smoke-test: create a Codex or Claude Code mission, send `/goal <objective>`, verify a row appears in the automations panel with iteration badge that increments
- [ ] Smoke-test: confirm the new migration runs without error against an existing prod DB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds a new persisted automation mode with a DB migration and background observer, and changes mission-runner behavior (including minting internal JWTs) plus iOS streaming/timeout logic that can affect connectivity and execution flow.
> 
> **Overview**
> Adds **native harness loop** support by introducing `CommandSource::NativeLoop` and `AutomationDriver::HarnessLoop`, migrating SQLite automations with a new `driver` column, and spawning a `native_loop_observer` that materializes `/goal` activity into `Automation` + per-iteration `AutomationExecution` records while ensuring the scheduler/webhook paths skip native-loop rows.
> 
> Updates the web dashboard automations UI to create harness loops by sending `/goal <objective>`, display harness-loop rows with iteration progress badges, and support stopping loops (via mission cancel + deactivating the automation).
> 
> Hardens the iOS dashboard for poor networks by adding bounded URLSession timeouts, a stricter SSE parser (HTTP error handling, UTF-8 safe line parsing, inactivity + buffer caps), moving mission cache blobs from `UserDefaults` to filesystem with a one-shot migration, parallelizing cold-start fetches, bounding “load earlier” history requests, and adding `NetworkResilienceTests` coverage.
> 
> Bumps project versions to `0.11.5` (Rust crate + dashboard) and updates `Cargo.lock` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2414b91c88342d15d4b6b58387db5804270d2c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->