### PR TITLE
feat: Grok OAuth + Needs You refactor + transcript loading + iOS UX pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "sandboxed_sh"
-version = "0.11.5"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandboxed_sh"
-version = "0.11.5"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.91"
 description = "Self-hosted orchestrator for AI coding agents (formerly Open Agent)"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "private": true,
   "packageManager": "bun@1.3.4",
   "scripts": {

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3662,8 +3662,13 @@ export default function ControlClient() {
   const expectingDesktopSessionRef = useRef(false);
   const desktopRapidPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Thinking panel state
-  const [showThinkingPanel, setShowThinkingPanel] = useState(true);
+  // Thinking panel state. Defaults to closed; the auto-show effect below
+  // (`hasActiveThinking && !thinkingPanelManuallyHidden → setShowThinkingPanel(true)`)
+  // is the canonical path that opens the panel when thinking content
+  // actually starts streaming. Defaulting to open made every cold-load of
+  // an old mission (often with no thinking content at all) render the
+  // panel by default.
+  const [showThinkingPanel, setShowThinkingPanel] = useState(false);
   // Deferred mirror used by the heavy chat-list regrouping memo so the toggle
   // click stays interactive even on long missions.
   const deferredShowThinkingPanel = useDeferredValue(showThinkingPanel);
@@ -3864,7 +3869,19 @@ export default function ControlClient() {
             .map(({ trace_count: _traceCount, trace_summary: _traceSummary, ...event }) => event)
             .sort((a, b) => a.sequence - b.sequence);
           metaMaxSeq = transcript.latest_sequence;
-          metaTotal = Object.values(transcript.event_counts).reduce((sum, count) => sum + count, 0);
+          // Only count types the client actually loads. The transcript's
+          // `event_counts` includes debug/status events outside
+          // `HISTORY_EVENT_TYPES`; summing them all inflates the total and
+          // makes `computeHasMoreOlder(id)` (which compares against the
+          // count of *loaded* events) return true forever, leaving the
+          // "Load older messages" button permanently visible. The fallback
+          // branch below already does this correctly via the meta returned
+          // by the typed `getMissionEventsWithMeta` call.
+          metaTotal = Object.entries(transcript.event_counts).reduce(
+            (sum, [type, count]) =>
+              HISTORY_EVENT_TYPES.includes(type) ? sum + count : sum,
+            0,
+          );
 
           // Fetch hidden thoughts/tools after first paint. The renderer ref is
           // populated below `eventsToItems`; this avoids blocking transcript

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -5074,6 +5074,21 @@ export default function ControlClient() {
       const liveTail = prev.slice(oldHistoricCount);
       return [...newHistoricItems, ...liveTail];
     });
+
+    // Re-derive `hasMore` now that the deferred trace has merged in.
+    // `seedPaginationStateAfterInitialLoad` ran with only transcript
+    // messages in `missionHistoricEventsRef`, so its comparison against
+    // the all-event-types `totalEvents` was always under-counted and
+    // pinned `hasMore` to true. With the trace merged the counts match,
+    // and short missions correctly hide the "Load older messages" button.
+    // We don't touch state if the user is already paginating (loading=true)
+    // or has switched missions — both are handled by the existing
+    // missionId-tagged read selector elsewhere.
+    setOlderLoadState((prev) =>
+      prev.missionId === id && !prev.loading
+        ? { ...prev, hasMore: computeHasMoreOlder(id) }
+        : prev
+    );
   };
 
   /**

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3105,31 +3105,33 @@ const ChatItemRow = memo(function ChatItemRow({
                 </span>
               </>
             )}
-            <>
-              <span>•</span>
-              <span
-                className={
-                  item.costSource === "actual"
-                    ? "text-emerald-400"
+            {(item.costSource !== "unknown" || item.costCents > 0) && (
+              <>
+                <span>•</span>
+                <span
+                  className={
+                    item.costSource === "actual"
+                      ? "text-emerald-400"
+                      : item.costSource === "estimated"
+                        ? "text-amber-300"
+                        : "text-white/50"
+                  }
+                >
+                  {item.costSource === "unknown"
+                    ? item.costCents > 0
+                      ? `$${(item.costCents / 100).toFixed(4)}`
+                      : "N/A"
+                    : `$${(item.costCents / 100).toFixed(4)}`}
+                </span>
+                <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white/60">
+                  {item.costSource === "actual"
+                    ? "Actual"
                     : item.costSource === "estimated"
-                      ? "text-amber-300"
-                      : "text-white/50"
-                }
-              >
-                {item.costSource === "unknown"
-                  ? item.costCents > 0
-                    ? `$${(item.costCents / 100).toFixed(4)}`
-                    : "N/A"
-                  : `$${(item.costCents / 100).toFixed(4)}`}
-              </span>
-              <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white/60">
-                {item.costSource === "actual"
-                  ? "Actual"
-                  : item.costSource === "estimated"
-                    ? "Estimated"
-                    : "Unknown"}
-              </span>
-            </>
+                      ? "Estimated"
+                      : "Unknown"}
+                </span>
+              </>
+            )}
             <span>•</span>
             <span className="text-white/30">{formatTime(item.timestamp)}</span>
           </div>

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -33,9 +33,12 @@ import {
   postControlToolResult,
   streamControl,
   loadMission,
+  markMissionOpened,
   getMission,
   getMissionEvents,
   getMissionEventsWithMeta,
+  getMissionTranscript,
+  getMissionTraceWithMeta,
   searchMissionMoments,
   createMission,
   updateMissionSettings,
@@ -908,6 +911,7 @@ function statusLabel(state: ControlRunState): {
     case "waiting_for_tool":
       return { label: "Waiting", Icon: Loader, className: "text-amber-400" };
   }
+  return { label: "Idle", Icon: Clock, className: "text-white/40" };
 }
 
 function missionStatusLabel(status: MissionStatus, isRunning = false): {
@@ -921,6 +925,13 @@ function missionStatusLabel(status: MissionStatus, isRunning = false): {
   switch (status) {
     case "active":
       return { label: "Active", className: "bg-indigo-500/20 text-indigo-400" };
+    case "awaiting_user":
+      return { label: "Needs You", className: "bg-sky-500/20 text-sky-400" };
+    case "acknowledged":
+      return {
+        label: "Acknowledged",
+        className: "bg-emerald-500/20 text-emerald-400",
+      };
     case "completed":
       return {
         label: "Completed",
@@ -989,31 +1000,56 @@ function Shimmer({ className }: { className?: string }) {
 }
 
 function ChatLoadingSkeleton() {
+  // Mirrors ChatItemRow: assistant rows are left-aligned with a Bot avatar
+  // (h-8 w-8 bg-indigo-500/20), user rows are right-aligned with a User
+  // avatar (bg-white/[0.08]) and a solid indigo bubble. Both bubbles use
+  // max-w-[80%].
+  const rows: Array<"assistant" | "user"> = ["assistant", "user", "assistant"];
   return (
     <div className="mx-auto max-w-3xl space-y-6 animate-pulse">
-      {[0, 1, 2].map((idx) => (
-        <div
-          key={idx}
-          className={cn(
-            "flex gap-3",
-            idx % 2 === 0 ? "justify-start" : "justify-end"
-          )}
-        >
-          {idx % 2 === 0 && (
-            <div className="h-8 w-8 shrink-0 rounded-full bg-white/[0.06]" />
-          )}
+      {rows.map((role, idx) => {
+        const isAssistant = role === "assistant";
+        return (
           <div
+            key={idx}
             className={cn(
-              "rounded-2xl border border-white/[0.06] bg-white/[0.03] px-4 py-3",
-              idx % 2 === 0 ? "w-[70%] rounded-tl-md" : "w-[58%] rounded-tr-md"
+              "flex gap-3",
+              isAssistant ? "justify-start" : "justify-end"
             )}
           >
-            <div className="h-3 rounded bg-white/[0.08]" />
-            <div className="mt-2 h-3 w-4/5 rounded bg-white/[0.06]" />
-            {idx === 0 && <div className="mt-2 h-3 w-2/3 rounded bg-white/[0.06]" />}
+            {isAssistant && (
+              <div className="h-8 w-8 shrink-0 rounded-full bg-indigo-500/20" />
+            )}
+            <div
+              className={cn(
+                "max-w-[80%] rounded-2xl px-4 py-3",
+                isAssistant
+                  ? "rounded-tl-md border border-white/[0.06] bg-white/[0.03]"
+                  : "rounded-tr-md bg-indigo-500/70"
+              )}
+            >
+              <div
+                className={cn(
+                  "h-3 w-48 rounded",
+                  isAssistant ? "bg-white/[0.08]" : "bg-white/30"
+                )}
+              />
+              <div
+                className={cn(
+                  "mt-2 h-3 w-40 rounded",
+                  isAssistant ? "bg-white/[0.06]" : "bg-white/20"
+                )}
+              />
+              {isAssistant && (
+                <div className="mt-2 h-3 w-32 rounded bg-white/[0.06]" />
+              )}
+            </div>
+            {!isAssistant && (
+              <div className="h-8 w-8 shrink-0 rounded-full bg-white/[0.08]" />
+            )}
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -3625,7 +3661,7 @@ export default function ControlClient() {
   const desktopRapidPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Thinking panel state
-  const [showThinkingPanel, setShowThinkingPanel] = useState(false);
+  const [showThinkingPanel, setShowThinkingPanel] = useState(true);
   // Deferred mirror used by the heavy chat-list regrouping memo so the toggle
   // click stays interactive even on long missions.
   const deferredShowThinkingPanel = useDeferredValue(showThinkingPanel);
@@ -3685,6 +3721,9 @@ export default function ControlClient() {
     ],
     []
   );
+  const renderDeferredTraceRef = useRef<
+    ((id: string, traceEvents: StoredEvent[], maxSequence?: number) => void) | null
+  >(null);
   /**
    * Per-mission high-water mark for `sequence`. When non-zero, reload
    * paths pass it as `since_seq` to `/events` so the server returns
@@ -3817,21 +3856,36 @@ export default function ControlClient() {
       }
 
       if (!sorted) {
-        // Cache miss (or delta path bailed). Request the most recent
-        // INITIAL_HISTORY_PAGE_SIZE events; `latest=true` lets the server
-        // compute the tail offset in one shot. The page size is
-        // intentionally small so first paint isn't gated on the full
-        // mission history; `streamOlderHistory` runs after to fill in the
-        // rest in the background.
-        const { events, meta } = await getMissionEventsWithMeta(id, {
-          types: HISTORY_EVENT_TYPES,
-          latest: true,
-          limit: INITIAL_HISTORY_PAGE_SIZE,
-        });
-        // Defensive: sort by sequence ASC in case upstream contract changes.
-        sorted = events.slice().sort((a, b) => a.sequence - b.sequence);
-        metaMaxSeq = meta.maxSequence;
-        metaTotal = meta.totalEvents;
+        try {
+          const transcript = await getMissionTranscript(id);
+          sorted = transcript.messages
+            .map(({ trace_count: _traceCount, trace_summary: _traceSummary, ...event }) => event)
+            .sort((a, b) => a.sequence - b.sequence);
+          metaMaxSeq = transcript.latest_sequence;
+          metaTotal = Object.values(transcript.event_counts).reduce((sum, count) => sum + count, 0);
+
+          // Fetch hidden thoughts/tools after first paint. The renderer ref is
+          // populated below `eventsToItems`; this avoids blocking transcript
+          // display on the heavier activity trace.
+          setTimeout(() => {
+            void getMissionTraceWithMeta(id, { sinceSeq: 0, limit: HISTORY_PAGE_SIZE })
+              .then(({ events, meta }) => {
+                renderDeferredTraceRef.current?.(id, events, meta.maxSequence);
+              })
+              .catch(() => undefined);
+          }, 0);
+        } catch {
+          // Older backends do not expose `/transcript`; keep the existing full
+          // tail fetch as a compatibility fallback.
+          const { events, meta } = await getMissionEventsWithMeta(id, {
+            types: HISTORY_EVENT_TYPES,
+            latest: true,
+            limit: INITIAL_HISTORY_PAGE_SIZE,
+          });
+          sorted = events.slice().sort((a, b) => a.sequence - b.sequence);
+          metaMaxSeq = meta.maxSequence;
+          metaTotal = meta.totalEvents;
+        }
       }
 
       // Only seed `missionMaxSeqRef` when the server has confirmed it
@@ -3999,6 +4053,18 @@ export default function ControlClient() {
 
   useEffect(() => {
     setThinkingPanelManuallyHidden(false);
+  }, [viewingMissionId]);
+
+  // Tell the backend the user opened this mission. The server records
+  // `first_viewed_at` on the first call (starting the 1h ack grace timer
+  // for `awaiting_user` missions and painting the "opened" dot for
+  // Finished missions); later calls are no-ops on the server. Fire-and-
+  // forget — failure to record opening is not user-visible.
+  useEffect(() => {
+    if (!viewingMissionId) return;
+    markMissionOpened(viewingMissionId).catch((err) => {
+      console.warn("markMissionOpened failed", err);
+    });
   }, [viewingMissionId]);
 
   // `groupedItems`, `thinkingItems`, etc. are all produced in the single
@@ -4977,6 +5043,36 @@ export default function ControlClient() {
 
     return items;
   }, []);
+
+  renderDeferredTraceRef.current = (id, traceEvents, maxSequence) => {
+    if (traceEvents.length === 0) return;
+    const liveCurrent = currentMissionRef.current;
+    const liveViewing = viewingMissionRef.current;
+    const mission =
+      liveCurrent?.id === id ? liveCurrent : liveViewing?.id === id ? liveViewing : null;
+    if (!mission) return;
+
+    const existing = missionHistoricEventsRef.current.get(id) ?? [];
+    const bySequence = new Map<number, StoredEvent>();
+    for (const event of existing) bySequence.set(event.sequence, event);
+    for (const event of traceEvents) bySequence.set(event.sequence, event);
+    const merged = [...bySequence.values()].sort((a, b) => a.sequence - b.sequence);
+    missionHistoricEventsRef.current.set(id, merged);
+    if (merged.length > 0) {
+      missionMinSeqRef.current.set(id, merged[0].sequence);
+    }
+    if (maxSequence !== undefined && maxSequence > 0) {
+      missionMaxSeqRef.current.set(id, maxSequence);
+    }
+
+    const newHistoricItems = eventsToItems(merged, mission);
+    const oldHistoricCount = historicItemsCountRef.current.get(id) ?? 0;
+    historicItemsCountRef.current.set(id, newHistoricItems.length);
+    setItems((prev) => {
+      const liveTail = prev.slice(oldHistoricCount);
+      return [...newHistoricItems, ...liveTail];
+    });
+  };
 
   /**
    * Fetch the next page of older history events (events with `sequence`

--- a/dashboard/src/app/history/page.tsx
+++ b/dashboard/src/app/history/page.tsx
@@ -6,7 +6,6 @@ import useSWR from "swr";
 import { toast } from "@/components/toast";
 import { cn } from "@/lib/utils";
 import { listMissions, getMissionTree, deleteMission, cleanupEmptyMissions, Mission } from "@/lib/api";
-import { ShimmerTableRow } from "@/components/ui/shimmer";
 import { CopyButton } from "@/components/ui/copy-button";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { AgentTreeCanvas, type AgentNode } from "@/components/agent-tree";
@@ -41,6 +40,41 @@ const statusConfig: Record<string, { color: string; bg: string }> = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+// Cell shapes mirror the real missions table:
+// 1) status pill (icon + label)  2) icon + truncated title
+// 3) short numeric count          4) short relative-time text
+// 5) action button cluster
+function HistoryTableRowSkeleton() {
+  return (
+    <tr className="animate-pulse">
+      <td className="px-4 py-3">
+        <div className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 bg-white/[0.04]">
+          <div className="h-3 w-3 rounded-sm bg-white/[0.08]" />
+          <div className="h-3 w-14 rounded bg-white/[0.08]" />
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-4 rounded bg-indigo-500/20 shrink-0" />
+          <div className="h-4 w-64 max-w-md rounded bg-white/[0.06]" />
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="h-4 w-8 rounded bg-white/[0.06]" />
+      </td>
+      <td className="px-4 py-3">
+        <div className="h-3 w-20 rounded bg-white/[0.04]" />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-16 rounded bg-indigo-500/20" />
+          <div className="h-4 w-4 rounded bg-white/[0.04]" />
+        </div>
+      </td>
+    </tr>
+  );
 }
 
 type SortField = 'date' | 'status' | 'messages';
@@ -347,9 +381,9 @@ export default function HistoryPage() {
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-white/[0.04]">
-                      <ShimmerTableRow columns={5} />
-                      <ShimmerTableRow columns={5} />
-                      <ShimmerTableRow columns={5} />
+                      <HistoryTableRowSkeleton />
+                      <HistoryTableRowSkeleton />
+                      <HistoryTableRowSkeleton />
                     </tbody>
                   </table>
                 </div>

--- a/dashboard/src/app/modules/page.tsx
+++ b/dashboard/src/app/modules/page.tsx
@@ -16,7 +16,7 @@ import {
   type McpStatus,
   type ToolInfo,
 } from "@/lib/api";
-import { ShimmerCard } from "@/components/ui/shimmer";
+import { ShimmerMcpCard } from "@/components/ui/shimmer";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -1021,9 +1021,9 @@ export default function ModulesPage() {
       {/* Content */}
       {loading ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <ShimmerCard />
-          <ShimmerCard />
-          <ShimmerCard />
+          <ShimmerMcpCard />
+          <ShimmerMcpCard />
+          <ShimmerMcpCard />
         </div>
       ) : activeTab === "installed" ? (
         filteredMcps.length === 0 ? (

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -41,8 +41,10 @@ import { cn, formatCents } from '@/lib/utils';
 import { NewMissionDialog } from '@/components/new-mission-dialog';
 import {
   categorizeMissions,
+  finishedTone,
   getMissionTextColor,
   getMissionTitle,
+  isFinishedStatus,
   type MissionCategory,
 } from '@/lib/mission-status';
 import { inferMissionRole } from '@/lib/mission-role';
@@ -69,7 +71,8 @@ function CompactStatusIcon({
   className?: string;
 }) {
   if (isRunning || status === 'active') return <Loader className={className} />;
-  if (status === 'completed') return <CheckCircle className={className} />;
+  if (status === 'awaiting_user') return <Hand className={className} />;
+  if (status === 'completed' || status === 'acknowledged') return <CheckCircle className={className} />;
   if (status === 'failed' || status === 'not_feasible') return <XCircle className={className} />;
   if (status === 'interrupted' || status === 'blocked') return <Ban className={className} />;
   return <Clock className={className} />;
@@ -95,7 +98,11 @@ function CompactMissionCard({
   const color = getMissionTextColor(mission.status, isRunningForDisplay);
   const title = getMissionTitle(mission);
   const isResumable = !isRunningForDisplay && mission.resumable &&
-    (mission.status === 'interrupted' || mission.status === 'blocked' || mission.status === 'failed');
+    (mission.status === 'interrupted' || mission.status === 'blocked' || mission.status === 'failed' ||
+      mission.status === 'awaiting_user' || mission.status === 'acknowledged');
+  // Subtle "user has opened this since it last needed attention" indicator
+  // for missions parked in the Finished column.
+  const showOpenedDot = !isRunningForDisplay && isFinishedStatus(mission.status) && !!mission.first_viewed_at;
 
   return (
     <div className="group rounded-md bg-white/[0.02] border border-white/[0.06] hover:border-white/[0.12] px-2.5 py-2 transition-colors">
@@ -110,6 +117,13 @@ function CompactMissionCard({
             {title}
           </p>
         </Link>
+        {showOpenedDot && (
+          <span
+            className="shrink-0 h-1.5 w-1.5 rounded-full bg-white/40"
+            aria-label="Opened"
+            title="You've opened this mission"
+          />
+        )}
         {isBoss && (
           <span className="shrink-0 rounded bg-violet-500/10 border border-violet-500/20 px-1 py-0.5 text-[8px] font-medium text-violet-400">
             B
@@ -180,8 +194,7 @@ function NeedsYouInbox({
       missions
         .filter(
           (mission) =>
-            !runningMissionIds.has(mission.id) &&
-            (mission.status === 'interrupted' || mission.status === 'blocked')
+            !runningMissionIds.has(mission.id) && mission.status === 'awaiting_user'
         )
         .sort(
           (a, b) =>
@@ -211,8 +224,7 @@ function NeedsYouInbox({
         ) : (
           inboxMissions.map((mission) => {
             const title = getMissionTitle(mission, { maxLength: 72 });
-            const statusTone =
-              mission.status === 'blocked' ? 'text-orange-300' : 'text-amber-300';
+            const statusTone = 'text-amber-300';
             return (
               <div
                 key={mission.id}
@@ -230,7 +242,7 @@ function NeedsYouInbox({
                     </Link>
                     <div className="mt-1 flex items-center gap-2 text-[10px] text-white/35">
                       <span className={cn('capitalize', statusTone)}>
-                        {mission.status}
+                        Waiting on you
                       </span>
                       {mission.workspace_name && (
                         <>

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -63,7 +63,7 @@ const defaultProviderTypes: AIProviderTypeInfo[] = [
   { id: 'open-router', name: 'OpenRouter', uses_oauth: false, env_var: 'OPENROUTER_API_KEY' },
   { id: 'groq', name: 'Groq', uses_oauth: false, env_var: 'GROQ_API_KEY' },
   { id: 'mistral', name: 'Mistral AI', uses_oauth: false, env_var: 'MISTRAL_API_KEY' },
-  { id: 'xai', name: 'xAI', uses_oauth: false, env_var: 'XAI_API_KEY' },
+  { id: 'xai', name: 'xAI', uses_oauth: true, env_var: 'XAI_API_KEY' },
   { id: 'zai', name: 'Z.AI', uses_oauth: false, env_var: 'ZHIPU_API_KEY' },
   { id: 'minimax', name: 'Minimax', uses_oauth: false, env_var: 'MINIMAX_API_KEY' },
   { id: 'github-copilot', name: 'GitHub Copilot', uses_oauth: true, env_var: null },

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -654,12 +654,24 @@ function InlineImagePreview({
   workspaceId?: string;
   missionId?: string;
 }) {
-  const resolvedPath = resolvePath(path, basePath);
+  const isAbsolute = path.startsWith("/") || /^[a-zA-Z]:/.test(path);
+  // A relative path can't be resolved until `basePath` is known. Returning a
+  // stable sentinel (null) keeps us in the loading state instead of firing
+  // a 404 fetch against `./artifacts/...` and then leaving a stale error
+  // pill when basePath later arrives and the effect re-runs.
+  const resolvedPath = isAbsolute || basePath ? resolvePath(path, basePath) : null;
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    // Reset between effect runs so a previous error/blob doesn't leak when
+    // `resolvedPath` changes (e.g. `basePath` resolves after first paint).
+    setImageUrl(null);
+    setError(null);
+    setLoading(true);
+    if (!resolvedPath) return;
+
     let cancelled = false;
     let acquired = false;
 
@@ -710,31 +722,44 @@ function InlineImagePreview({
     };
   }, [resolvedPath, workspaceId, missionId]);
 
+  // Shared placeholder box: same shape for loading and error so the layout
+  // doesn't jump and the error state reads as part of the same chrome as
+  // the skeleton. `<span>` (not `<div>`) keeps this valid inside the `<p>`
+  // that react-markdown wraps around `![alt](url)` so hydration doesn't
+  // tear the subtree.
+  const placeholderClass =
+    "my-2 block rounded-xl overflow-hidden border border-white/[0.06] bg-white/[0.03]";
+  const placeholderStyle = { maxWidth: 400, height: 200 } as const;
+
   if (error) {
     return (
-      <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-red-500/10 text-red-400 text-xs">
-        <Image className="h-3.5 w-3.5" />
-        {error}
+      <span
+        className={cn(placeholderClass, "flex items-center justify-center gap-2 text-xs text-white/40")}
+        style={placeholderStyle}
+        title={error}
+      >
+        <Image className="h-4 w-4" />
+        <span className="truncate max-w-[260px]">{error}</span>
       </span>
     );
   }
 
-  if (loading) {
+  if (loading || !imageUrl) {
     return (
-      <div className="my-2 rounded-xl overflow-hidden bg-white/[0.03] animate-pulse" style={{ maxWidth: 400, height: 200 }} />
+      <span className={cn(placeholderClass, "animate-pulse")} style={placeholderStyle} />
     );
   }
 
   return (
-    <div className="my-2">
+    <span className="my-2 block">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        src={imageUrl!}
+        src={imageUrl}
         alt={alt}
         className="max-h-[300px] rounded-xl border border-white/[0.06] cursor-pointer hover:border-white/[0.12] transition-colors"
-        onClick={() => showFilePreviewModal(path, resolvedPath, workspaceId, missionId)}
+        onClick={() => showFilePreviewModal(path, resolvedPath ?? path, workspaceId, missionId)}
       />
-    </div>
+    </span>
   );
 }
 

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react';
 import { cn, formatRelativeTime } from '@/lib/utils';
 import { useLibrary } from '@/contexts/library-context';
-import { ShimmerCard } from '@/components/ui/shimmer';
+import { ShimmerAutomationRow } from '@/components/ui/shimmer';
 import {
   type Automation,
   type AutomationExecution,
@@ -1374,9 +1374,9 @@ export function MissionAutomationsDialog({
                 )}
 
                 {showLoadingPlaceholder && (
-                  <div className="space-y-3">
-                    <ShimmerCard />
-                    <ShimmerCard />
+                  <div className="space-y-2">
+                    <ShimmerAutomationRow />
+                    <ShimmerAutomationRow />
                   </div>
                 )}
 

--- a/dashboard/src/components/ui/add-provider-modal.tsx
+++ b/dashboard/src/components/ui/add-provider-modal.tsx
@@ -209,7 +209,11 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
         setSelectedBackends(['opencode', 'gemini']);
       }
       if (selectedProvider === 'xai') {
-        setSelectedBackends(['grok']);
+        // Match the server's `default_backends_for_provider(ProviderType::Xai)`
+        // (`src/api/ai_providers.rs`) and the provider-level preselect at
+        // line ~181 — both return `["opencode", "grok"]`. Without this the
+        // OAuth-method path silently drops opencode targeting only for xAI.
+        setSelectedBackends(['opencode', 'grok']);
       }
       setStep('select-backends');
       return;

--- a/dashboard/src/components/ui/add-provider-modal.tsx
+++ b/dashboard/src/components/ui/add-provider-modal.tsx
@@ -67,6 +67,16 @@ const getProviderAuthMethods = (providerType: AIProviderType): AIProviderAuthMet
       { label: 'Enter API Key', type: 'api', description: 'Use an existing Google AI API key' },
     ];
   }
+  if (providerType === 'xai') {
+    return [
+      {
+        label: 'Grok Build OAuth',
+        type: 'oauth',
+        description: 'Use your grok.com account through Grok Build',
+      },
+      { label: 'Enter API Key', type: 'api', description: 'Use an existing xAI API key' },
+    ];
+  }
   return [];
 };
 
@@ -190,13 +200,16 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
     setSelectedMethodIndex(methodIndex);
 
     // Providers that support multiple backends should select targeting first.
-    if (selectedProvider === 'anthropic' || selectedProvider === 'openai' || selectedProvider === 'google') {
+    if (selectedProvider === 'anthropic' || selectedProvider === 'openai' || selectedProvider === 'google' || selectedProvider === 'xai') {
       // For OpenAI, default backends depend on auth method.
       if (selectedProvider === 'openai') {
         setSelectedBackends(['opencode', 'codex']);
       }
       if (selectedProvider === 'google') {
         setSelectedBackends(['opencode', 'gemini']);
+      }
+      if (selectedProvider === 'xai') {
+        setSelectedBackends(['grok']);
       }
       setStep('select-backends');
       return;
@@ -285,7 +298,8 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
   };
 
   const handleSubmitOAuthCode = async () => {
-    if (!oauthCode.trim() || !selectedProvider || selectedMethodIndex === null) return;
+    if (!selectedProvider || selectedMethodIndex === null) return;
+    if (!oauthCode.trim() && oauthResponse?.method !== 'auto') return;
 
     setLoading(true);
     try {
@@ -294,7 +308,7 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
         selectedMethodIndex,
         oauthCode,
         // Include backend targeting for supported providers
-        selectedProvider === 'anthropic' || selectedProvider === 'openai' || selectedProvider === 'google'
+        selectedProvider === 'anthropic' || selectedProvider === 'openai' || selectedProvider === 'google' || selectedProvider === 'xai'
           ? selectedBackends
           : undefined
       );
@@ -716,9 +730,10 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
                 type="text"
                 value={oauthCode}
                 onChange={(e) => setOauthCode(e.target.value)}
-                placeholder="sk-ant-oc01-...#..."
+                placeholder={oauthResponse.method === 'auto' ? 'No code required' : 'sk-ant-oc01-...#...'}
+                disabled={oauthResponse.method === 'auto'}
                 autoFocus
-                className="w-full rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3 text-sm text-white placeholder-white/30 focus:outline-none focus:border-indigo-500/50 font-mono"
+                className="w-full rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3 text-sm text-white placeholder-white/30 focus:outline-none focus:border-indigo-500/50 font-mono disabled:opacity-60"
               />
               <div className="flex gap-2">
                 <button
@@ -729,7 +744,7 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
                 </button>
                 <button
                   onClick={handleSubmitOAuthCode}
-                  disabled={loading || !oauthCode.trim()}
+                  disabled={loading || (!oauthCode.trim() && oauthResponse.method !== 'auto')}
                   className="flex-1 rounded-xl bg-indigo-500 px-4 py-3 text-sm font-medium text-white hover:bg-indigo-600 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {loading ? <Loader className="h-4 w-4 animate-spin mx-auto" /> : 'Connect'}

--- a/dashboard/src/components/ui/shimmer.tsx
+++ b/dashboard/src/components/ui/shimmer.tsx
@@ -34,6 +34,68 @@ export function ShimmerCard({ className }: ShimmerProps) {
   );
 }
 
+// Shimmer matching McpCard in modules/page.tsx — colored icon box, name+badge,
+// endpoint line, tag pill row, footer with toggle silhouette.
+export function ShimmerMcpCard({ className }: ShimmerProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse w-full rounded-xl p-4 bg-white/[0.02] border border-white/[0.04]',
+        className
+      )}
+    >
+      <div className="flex items-start gap-3 mb-3">
+        <div className="h-10 w-10 rounded-xl bg-indigo-500/10" />
+        <div className="flex-1 min-w-0 space-y-2">
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-32 rounded bg-white/[0.08]" />
+            <div className="h-4 w-16 rounded-md bg-white/[0.06]" />
+          </div>
+          <div className="h-3 w-2/3 rounded bg-white/[0.04]" />
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-1 mb-3">
+        <div className="h-5 w-12 rounded bg-white/[0.04]" />
+        <div className="h-5 w-16 rounded bg-white/[0.04]" />
+        <div className="h-5 w-10 rounded bg-white/[0.04]" />
+      </div>
+      <div className="flex items-center justify-between pt-3 border-t border-white/[0.04]">
+        <div className="h-3 w-14 rounded bg-white/[0.04]" />
+        <div className="h-5 w-9 rounded-full bg-white/[0.06]" />
+      </div>
+    </div>
+  );
+}
+
+// Shimmer matching automation rows in mission-automations-dialog — no avatar,
+// left text column (label + description + meta) + right action pill cluster.
+export function ShimmerAutomationRow({ className }: ShimmerProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-xl border border-white/[0.08] bg-white/[0.02]',
+        className
+      )}
+    >
+      <div className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2 min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-40 rounded bg-white/[0.08]" />
+            <div className="h-4 w-14 rounded bg-white/[0.06]" />
+          </div>
+          <div className="h-3 w-3/4 rounded bg-white/[0.04]" />
+          <div className="h-3 w-1/2 rounded bg-white/[0.04]" />
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <div className="h-7 w-16 rounded-lg bg-white/[0.04]" />
+          <div className="h-7 w-20 rounded-lg bg-white/[0.04]" />
+          <div className="h-7 w-12 rounded-lg bg-white/[0.04]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Shimmer for table rows
 export function ShimmerTableRow({ columns = 5, className }: ShimmerProps & { columns?: number }) {
   return (
@@ -47,15 +109,19 @@ export function ShimmerTableRow({ columns = 5, className }: ShimmerProps & { col
   );
 }
 
-// Shimmer for stats card
+// Shimmer for stats card — mirrors StatsCard layout: left column with label,
+// large value, optional trend line; right icon box (h-10 w-10 rounded-xl).
 export function ShimmerStat({ className }: ShimmerProps) {
   return (
-    <div className={cn('animate-pulse p-4 rounded-xl bg-white/[0.02] border border-white/[0.04]', className)}>
-      <div className="flex items-center justify-between mb-3">
-        <div className="h-3 bg-white/[0.04] rounded w-20" />
-        <div className="h-8 w-8 rounded-lg bg-white/[0.06]" />
+    <div className={cn('animate-pulse stat-panel', className)}>
+      <div className="flex items-start justify-between">
+        <div className="flex-1 space-y-2">
+          <div className="h-3 w-20 rounded bg-white/[0.04]" />
+          <div className="h-7 w-24 rounded bg-white/[0.08]" />
+          <div className="h-3 w-12 rounded bg-white/[0.04]" />
+        </div>
+        <div className="h-10 w-10 rounded-xl bg-white/[0.04]" />
       </div>
-      <div className="h-7 bg-white/[0.06] rounded w-16" />
     </div>
   );
 }
@@ -75,18 +141,12 @@ export function ShimmerText({ lines = 3, className }: ShimmerProps & { lines?: n
   return (
     <div className={cn('animate-pulse space-y-2', className)}>
       {Array.from({ length: lines }).map((_, i) => (
-        <div 
-          key={i} 
-          className="h-4 bg-white/[0.06] rounded" 
+        <div
+          key={i}
+          className="h-4 bg-white/[0.06] rounded"
           style={{ width: `${100 - (i * 15)}%` }}
         />
       ))}
     </div>
   );
 }
-
-
-
-
-
-

--- a/dashboard/src/hooks/use-favicon-status.ts
+++ b/dashboard/src/hooks/use-favicon-status.ts
@@ -11,9 +11,12 @@ const STATUS_COLORS: Record<MissionStatus, string> = {
   awaiting_user: "#38bdf8", // sky-400
   acknowledged: "#34d399", // emerald-400
   completed: "#34d399", // emerald-400
+  // Failure statuses all share `bg-red-400` in `STATUS_DOT_COLORS`
+  // (`lib/mission-status.ts`); the favicon dot now matches so the
+  // status indicator is consistent across the UI.
   failed: "#f87171", // red-400
-  interrupted: "#fbbf24", // amber-400
-  blocked: "#fb923c", // orange-400
+  interrupted: "#f87171", // red-400
+  blocked: "#f87171", // red-400
   not_feasible: "#f87171", // red-400
 };
 

--- a/dashboard/src/hooks/use-favicon-status.ts
+++ b/dashboard/src/hooks/use-favicon-status.ts
@@ -8,6 +8,8 @@ import type { MissionStatus } from "@/lib/api/missions";
  */
 const STATUS_COLORS: Record<MissionStatus, string> = {
   active: "#818cf8", // indigo-400
+  awaiting_user: "#38bdf8", // sky-400
+  acknowledged: "#34d399", // emerald-400
   completed: "#34d399", // emerald-400
   failed: "#f87171", // red-400
   interrupted: "#fbbf24", // amber-400

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -297,8 +297,11 @@ export async function getMissionTraceWithMeta(
   }
 ): Promise<{ events: StoredEvent[]; meta: MissionEventsMeta }> {
   const params = new URLSearchParams();
-  if (options?.limit) params.set("limit", String(options.limit));
-  if (options?.offset) params.set("offset", String(options.offset));
+  // `!== undefined` matches the sinceSeq/beforeSeq pattern below — a
+  // truthiness check drops `0`, but `offset: 0` is a valid value meaning
+  // "start from the beginning."
+  if (options?.limit !== undefined) params.set("limit", String(options.limit));
+  if (options?.offset !== undefined) params.set("offset", String(options.offset));
   if (options?.latest) params.set("latest", "true");
   if (options?.sinceSeq !== undefined) params.set("since_seq", String(options.sinceSeq));
   if (options?.beforeSeq !== undefined) params.set("before_seq", String(options.beforeSeq));

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -10,7 +10,15 @@ import { generateMissionTitle } from "../llm";
 // Types
 // ---------------------------------------------------------------------------
 
-export type MissionStatus = "active" | "completed" | "failed" | "interrupted" | "blocked" | "not_feasible";
+export type MissionStatus =
+  | "active"
+  | "awaiting_user"
+  | "acknowledged"
+  | "completed"
+  | "failed"
+  | "interrupted"
+  | "blocked"
+  | "not_feasible";
 
 export type ModelEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -50,6 +58,12 @@ export interface Mission {
   created_at: string;
   updated_at: string;
   interrupted_at?: string;
+  /**
+   * Timestamp of the user's first open since this mission last entered
+   * `awaiting_user`. Drives the 1h ack grace timer (backend) and the
+   * "opened" dot rendered next to Finished missions (web + iOS).
+   */
+  first_viewed_at?: string | null;
   resumable?: boolean;
   session_id?: string | null;
   parent_mission_id?: string;
@@ -68,6 +82,29 @@ export interface StoredEvent {
   tool_name?: string;
   content: string;
   metadata: Record<string, unknown>;
+}
+
+export interface TranscriptMessage {
+  trace_count: number;
+  trace_summary: Record<string, number>;
+  id: number;
+  mission_id: string;
+  sequence: number;
+  event_type: string;
+  timestamp: string;
+  event_id?: string;
+  tool_call_id?: string;
+  tool_name?: string;
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface MissionTranscript {
+  mission: Mission;
+  messages: TranscriptMessage[];
+  event_counts: Record<string, number>;
+  visibility_counts: Record<string, number>;
+  latest_sequence: number;
 }
 
 export interface CreateMissionOptions {
@@ -242,6 +279,48 @@ export async function getMissionEventsWithMeta(
   return { events, meta: { totalEvents, maxSequence } };
 }
 
+export async function getMissionTranscript(id: string): Promise<MissionTranscript> {
+  return apiGet(
+    `/api/control/missions/${id}/transcript`,
+    "Failed to fetch mission transcript"
+  );
+}
+
+export async function getMissionTraceWithMeta(
+  id: string,
+  options?: {
+    limit?: number;
+    offset?: number;
+    latest?: boolean;
+    sinceSeq?: number;
+    beforeSeq?: number;
+  }
+): Promise<{ events: StoredEvent[]; meta: MissionEventsMeta }> {
+  const params = new URLSearchParams();
+  if (options?.limit) params.set("limit", String(options.limit));
+  if (options?.offset) params.set("offset", String(options.offset));
+  if (options?.latest) params.set("latest", "true");
+  if (options?.sinceSeq !== undefined) params.set("since_seq", String(options.sinceSeq));
+  if (options?.beforeSeq !== undefined) params.set("before_seq", String(options.beforeSeq));
+  const query = params.toString();
+  const res = await apiFetch(
+    `/api/control/missions/${id}/trace${query ? `?${query}` : ""}`
+  );
+  if (!res.ok) throw new Error("Failed to fetch mission trace");
+  const events = (await res.json()) as StoredEvent[];
+  const totalHeader = res.headers.get("x-total-events");
+  const maxSeqHeader = res.headers.get("x-max-sequence");
+  const totalEvents =
+    totalHeader !== null && totalHeader !== "" && !Number.isNaN(Number(totalHeader))
+      ? Number(totalHeader)
+      : undefined;
+  const maxSequence =
+    maxSeqHeader !== null && maxSeqHeader !== "" && !Number.isNaN(Number(maxSeqHeader))
+      ? Number(maxSeqHeader)
+      : undefined;
+  return { events, meta: { totalEvents, maxSequence } };
+}
+
 export async function getCurrentMission(): Promise<Mission | null> {
   return apiGet("/api/control/missions/current", "Failed to fetch current mission");
 }
@@ -283,6 +362,19 @@ export async function loadMission(id: string): Promise<Mission | null> {
   const res = await apiFetch(`/api/control/missions/${id}/load`, { method: "POST" });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error("Failed to load mission");
+  return res.json();
+}
+
+/**
+ * Tell the backend the user has opened this mission. The first call (when
+ * `first_viewed_at` is still null on the mission row) starts the 1h ack
+ * grace timer; subsequent calls are no-ops on the server. Returns the
+ * updated mission so the caller can rerender the dot immediately.
+ */
+export async function markMissionOpened(id: string): Promise<Mission | null> {
+  const res = await apiFetch(`/api/control/missions/${id}/opened`, { method: "POST" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error("Failed to mark mission opened");
   return res.json();
 }
 

--- a/dashboard/src/lib/mission-status.test.ts
+++ b/dashboard/src/lib/mission-status.test.ts
@@ -4,6 +4,7 @@ import {
   needsAttentionStatus,
   categorizeMission,
   categorizeMissions,
+  finishedTone,
   getMissionDotColor,
   getMissionTextColor,
   FINISHED_STATUSES,
@@ -13,74 +14,100 @@ import type { MissionStatus } from './api/missions';
 
 describe('mission-status', () => {
   describe('isFinishedStatus', () => {
-    it('returns true for finished statuses', () => {
+    it('returns true for green finished statuses', () => {
       expect(isFinishedStatus('completed')).toBe(true);
+      expect(isFinishedStatus('acknowledged')).toBe(true);
+    });
+
+    it('returns true for red (failure) statuses in Finished', () => {
       expect(isFinishedStatus('failed')).toBe(true);
+      expect(isFinishedStatus('interrupted')).toBe(true);
+      expect(isFinishedStatus('blocked')).toBe(true);
       expect(isFinishedStatus('not_feasible')).toBe(true);
     });
 
     it('returns false for non-finished statuses', () => {
       expect(isFinishedStatus('active')).toBe(false);
-      expect(isFinishedStatus('interrupted')).toBe(false);
-      expect(isFinishedStatus('blocked')).toBe(false);
+      expect(isFinishedStatus('awaiting_user')).toBe(false);
     });
   });
 
   describe('needsAttentionStatus', () => {
-    it('returns true for attention-needed statuses', () => {
-      expect(needsAttentionStatus('interrupted')).toBe(true);
-      expect(needsAttentionStatus('blocked')).toBe(true);
+    it('returns true only for awaiting_user', () => {
+      expect(needsAttentionStatus('awaiting_user')).toBe(true);
+    });
+
+    it('returns false for failure statuses (now in Finished/red)', () => {
+      expect(needsAttentionStatus('interrupted')).toBe(false);
+      expect(needsAttentionStatus('blocked')).toBe(false);
+      expect(needsAttentionStatus('failed')).toBe(false);
+      expect(needsAttentionStatus('not_feasible')).toBe(false);
     });
 
     it('returns false for other statuses', () => {
       expect(needsAttentionStatus('active')).toBe(false);
       expect(needsAttentionStatus('completed')).toBe(false);
-      expect(needsAttentionStatus('failed')).toBe(false);
-      expect(needsAttentionStatus('not_feasible')).toBe(false);
+      expect(needsAttentionStatus('acknowledged')).toBe(false);
+    });
+  });
+
+  describe('finishedTone', () => {
+    it('returns green for completed/acknowledged', () => {
+      expect(finishedTone('completed')).toBe('green');
+      expect(finishedTone('acknowledged')).toBe('green');
+    });
+
+    it('returns red for failure statuses', () => {
+      expect(finishedTone('failed')).toBe('red');
+      expect(finishedTone('interrupted')).toBe('red');
+      expect(finishedTone('blocked')).toBe('red');
+      expect(finishedTone('not_feasible')).toBe('red');
     });
   });
 
   describe('categorizeMission', () => {
     describe('running takes priority', () => {
       it('categorizes as running when actually running, regardless of stored status', () => {
-        // Key scenario: resumed mission has "interrupted" status but is actually running
-        expect(categorizeMission('interrupted', true)).toBe('running');
+        // Key scenario: resumed mission still has stale status but is actually running
+        expect(categorizeMission('awaiting_user', true)).toBe('running');
         expect(categorizeMission('active', true)).toBe('running');
-        expect(categorizeMission('blocked', true)).toBe('running');
-        // Even weird edge cases
+        expect(categorizeMission('interrupted', true)).toBe('running');
+        // Edge cases
         expect(categorizeMission('completed', true)).toBe('running');
         expect(categorizeMission('failed', true)).toBe('running');
       });
     });
 
     describe('needs-you when not running', () => {
-      it('categorizes interrupted missions as needs-you when not running', () => {
-        expect(categorizeMission('interrupted', false)).toBe('needs-you');
+      it('categorizes awaiting_user missions as needs-you when not running', () => {
+        expect(categorizeMission('awaiting_user', false)).toBe('needs-you');
       });
 
-      it('categorizes blocked missions as needs-you when not running', () => {
-        expect(categorizeMission('blocked', false)).toBe('needs-you');
+      it('failure statuses no longer land in needs-you (they go to finished/red)', () => {
+        expect(categorizeMission('interrupted', false)).toBe('finished');
+        expect(categorizeMission('blocked', false)).toBe('finished');
       });
     });
 
     describe('finished when not running', () => {
-      it('categorizes completed missions as finished when not running', () => {
+      it('green-tone statuses', () => {
         expect(categorizeMission('completed', false)).toBe('finished');
+        expect(categorizeMission('acknowledged', false)).toBe('finished');
       });
 
-      it('categorizes failed missions as finished when not running', () => {
+      it('red-tone statuses', () => {
         expect(categorizeMission('failed', false)).toBe('finished');
-      });
-
-      it('categorizes not_feasible missions as finished when not running', () => {
+        expect(categorizeMission('interrupted', false)).toBe('finished');
+        expect(categorizeMission('blocked', false)).toBe('finished');
         expect(categorizeMission('not_feasible', false)).toBe('finished');
       });
     });
 
     describe('other category', () => {
       it('categorizes active but not-running missions as other', () => {
-        // Edge case: stored as active but runtime says not running
-        // This can happen briefly during state transitions
+        // Edge case: stored as active but runtime says not running.
+        // Can happen briefly during state transitions or right after a
+        // resume before the runner-tracker catches up.
         expect(categorizeMission('active', false)).toBe('other');
       });
     });
@@ -92,33 +119,32 @@ describe('mission-status', () => {
     it('groups missions into correct categories', () => {
       const missions: TestMission[] = [
         { id: '1', status: 'active' },
-        { id: '2', status: 'interrupted' },
+        { id: '2', status: 'awaiting_user' },
         { id: '3', status: 'completed' },
         { id: '4', status: 'failed' },
-        { id: '5', status: 'blocked' },
+        { id: '5', status: 'acknowledged' },
+        { id: '6', status: 'interrupted' },
       ];
       const runningIds = new Set(['1']);
 
       const result = categorizeMissions(missions, runningIds);
 
       expect(result.running.map(m => m.id)).toEqual(['1']);
-      expect(result['needs-you'].map(m => m.id)).toEqual(['2', '5']);
-      expect(result.finished.map(m => m.id)).toEqual(['3', '4']);
+      expect(result['needs-you'].map(m => m.id)).toEqual(['2']);
+      expect(result.finished.map(m => m.id)).toEqual(['3', '4', '5', '6']);
       expect(result.other).toEqual([]);
     });
 
-    it('handles resumed mission correctly (interrupted but running)', () => {
+    it('handles resumed mission correctly (awaiting_user but running)', () => {
       const missions: TestMission[] = [
-        { id: 'resumed', status: 'interrupted' }, // DB still says interrupted
+        { id: 'resumed', status: 'awaiting_user' }, // DB still says awaiting_user
         { id: 'new', status: 'active' },
-        { id: 'waiting', status: 'interrupted' },
+        { id: 'waiting', status: 'awaiting_user' },
       ];
-      // Both "resumed" and "new" are actually running
       const runningIds = new Set(['resumed', 'new']);
 
       const result = categorizeMissions(missions, runningIds);
 
-      // Resumed mission should be in "running", not "needs-you"
       expect(result.running.map(m => m.id)).toEqual(['resumed', 'new']);
       expect(result['needs-you'].map(m => m.id)).toEqual(['waiting']);
       expect(result.finished).toEqual([]);
@@ -149,13 +175,15 @@ describe('mission-status', () => {
     it('puts each mission in exactly one category', () => {
       const missions: TestMission[] = [
         { id: '1', status: 'active' },
-        { id: '2', status: 'interrupted' },
+        { id: '2', status: 'awaiting_user' },
         { id: '3', status: 'completed' },
-        { id: '4', status: 'blocked' },
+        { id: '4', status: 'acknowledged' },
         { id: '5', status: 'failed' },
         { id: '6', status: 'not_feasible' },
+        { id: '7', status: 'interrupted' },
+        { id: '8', status: 'blocked' },
       ];
-      const runningIds = new Set(['1', '2']); // Both active and interrupted are running
+      const runningIds = new Set(['1', '2']);
 
       const result = categorizeMissions(missions, runningIds);
 
@@ -166,10 +194,7 @@ describe('mission-status', () => {
         ...result.other,
       ];
 
-      // Total count should match
       expect(allCategorized.length).toBe(missions.length);
-
-      // No duplicates
       const ids = allCategorized.map(m => m.id);
       expect(new Set(ids).size).toBe(ids.length);
     });
@@ -178,16 +203,19 @@ describe('mission-status', () => {
   describe('getMissionDotColor', () => {
     it('returns indigo for running missions regardless of status', () => {
       expect(getMissionDotColor('active', true)).toBe('bg-indigo-400');
-      expect(getMissionDotColor('interrupted', true)).toBe('bg-indigo-400');
+      expect(getMissionDotColor('awaiting_user', true)).toBe('bg-indigo-400');
       expect(getMissionDotColor('completed', true)).toBe('bg-indigo-400');
     });
 
     it('returns status-specific color when not running', () => {
       expect(getMissionDotColor('completed', false)).toBe('bg-emerald-400');
+      expect(getMissionDotColor('acknowledged', false)).toBe('bg-emerald-400');
+      expect(getMissionDotColor('awaiting_user', false)).toBe('bg-sky-400');
+      // Failure statuses share a red tone in the Finished column.
       expect(getMissionDotColor('failed', false)).toBe('bg-red-400');
-      expect(getMissionDotColor('interrupted', false)).toBe('bg-amber-400');
-      expect(getMissionDotColor('blocked', false)).toBe('bg-orange-400');
-      expect(getMissionDotColor('not_feasible', false)).toBe('bg-rose-400');
+      expect(getMissionDotColor('interrupted', false)).toBe('bg-red-400');
+      expect(getMissionDotColor('blocked', false)).toBe('bg-red-400');
+      expect(getMissionDotColor('not_feasible', false)).toBe('bg-red-400');
       expect(getMissionDotColor('active', false)).toBe('bg-indigo-400');
     });
   });
@@ -195,28 +223,30 @@ describe('mission-status', () => {
   describe('getMissionTextColor', () => {
     it('returns indigo for running missions regardless of status', () => {
       expect(getMissionTextColor('active', true)).toBe('text-indigo-400');
-      expect(getMissionTextColor('interrupted', true)).toBe('text-indigo-400');
+      expect(getMissionTextColor('awaiting_user', true)).toBe('text-indigo-400');
     });
 
     it('returns status-specific color when not running', () => {
       expect(getMissionTextColor('completed', false)).toBe('text-emerald-400');
+      expect(getMissionTextColor('awaiting_user', false)).toBe('text-sky-400');
       expect(getMissionTextColor('failed', false)).toBe('text-red-400');
-      expect(getMissionTextColor('interrupted', false)).toBe('text-amber-400');
+      expect(getMissionTextColor('interrupted', false)).toBe('text-red-400');
     });
   });
 
   describe('status constants', () => {
-    it('FINISHED_STATUSES contains expected values', () => {
+    it('FINISHED_STATUSES contains all bucket-Finished statuses', () => {
       expect(FINISHED_STATUSES).toContain('completed');
+      expect(FINISHED_STATUSES).toContain('acknowledged');
       expect(FINISHED_STATUSES).toContain('failed');
+      expect(FINISHED_STATUSES).toContain('interrupted');
+      expect(FINISHED_STATUSES).toContain('blocked');
       expect(FINISHED_STATUSES).toContain('not_feasible');
-      expect(FINISHED_STATUSES).toHaveLength(3);
+      expect(FINISHED_STATUSES).toHaveLength(6);
     });
 
-    it('NEEDS_ATTENTION_STATUSES contains expected values', () => {
-      expect(NEEDS_ATTENTION_STATUSES).toContain('interrupted');
-      expect(NEEDS_ATTENTION_STATUSES).toContain('blocked');
-      expect(NEEDS_ATTENTION_STATUSES).toHaveLength(2);
+    it('NEEDS_ATTENTION_STATUSES contains only awaiting_user', () => {
+      expect(NEEDS_ATTENTION_STATUSES).toEqual(['awaiting_user']);
     });
   });
 });

--- a/dashboard/src/lib/mission-status.ts
+++ b/dashboard/src/lib/mission-status.ts
@@ -6,9 +6,23 @@
 import type { MissionStatus } from './api/missions';
 
 export type MissionCategory = 'running' | 'needs-you' | 'finished' | 'other';
+export type FinishedTone = 'green' | 'red';
 
-export const FINISHED_STATUSES: MissionStatus[] = ['completed', 'failed', 'not_feasible'];
-export const NEEDS_ATTENTION_STATUSES: MissionStatus[] = ['interrupted', 'blocked'];
+// "Needs You" is reserved for missions where the agent finished its turn
+// cleanly (`awaiting_user`) and is waiting on the user. Failure paths
+// (interrupted, blocked, not_feasible, failed) live in Finished with a red
+// tone instead.
+export const NEEDS_ATTENTION_STATUSES: MissionStatus[] = ['awaiting_user'];
+export const FINISHED_STATUSES: MissionStatus[] = [
+  'completed',
+  'acknowledged',
+  'failed',
+  'interrupted',
+  'blocked',
+  'not_feasible',
+];
+
+const FINISHED_GREEN_STATUSES: MissionStatus[] = ['completed', 'acknowledged'];
 
 /**
  * Check if a mission is in a finished state based on its stored status.
@@ -25,13 +39,21 @@ export function needsAttentionStatus(status: MissionStatus): boolean {
 }
 
 /**
+ * Within the Finished column, "green" tone = agent-declared completion or
+ * user acknowledgement, "red" tone = anything that ended badly.
+ */
+export function finishedTone(status: MissionStatus): FinishedTone {
+  return FINISHED_GREEN_STATUSES.includes(status) ? 'green' : 'red';
+}
+
+/**
  * Categorize a mission based on runtime state and stored status.
- * 
+ *
  * Priority order:
  * 1. Running - mission is actually running (runtime state takes precedence)
- * 2. Needs You - interrupted/blocked AND not running
- * 3. Finished - completed/failed/not_feasible AND not running
- * 4. Other - anything else (e.g., active but not in runtime running set)
+ * 2. Needs You - awaiting_user AND not running
+ * 3. Finished - completed/acknowledged/failed/interrupted/blocked/not_feasible AND not running
+ * 4. Other - anything else (active-but-not-running, pending)
  */
 export function categorizeMission(
   status: MissionStatus,
@@ -40,15 +62,15 @@ export function categorizeMission(
   if (isActuallyRunning) {
     return 'running';
   }
-  
+
   if (needsAttentionStatus(status)) {
     return 'needs-you';
   }
-  
+
   if (isFinishedStatus(status)) {
     return 'finished';
   }
-  
+
   return 'other';
 }
 
@@ -81,24 +103,30 @@ export function categorizeMissions<T extends { id: string; status: MissionStatus
  */
 export const STATUS_DOT_COLORS: Record<MissionStatus, string> = {
   active: 'bg-indigo-400',
+  awaiting_user: 'bg-sky-400',
+  acknowledged: 'bg-emerald-400',
   completed: 'bg-emerald-400',
   failed: 'bg-red-400',
-  interrupted: 'bg-amber-400',
-  blocked: 'bg-orange-400',
-  not_feasible: 'bg-rose-400',
+  interrupted: 'bg-red-400',
+  blocked: 'bg-red-400',
+  not_feasible: 'bg-red-400',
 };
 
 export const STATUS_TEXT_COLORS: Record<MissionStatus, string> = {
   active: 'text-indigo-400',
+  awaiting_user: 'text-sky-400',
+  acknowledged: 'text-emerald-400',
   completed: 'text-emerald-400',
   failed: 'text-red-400',
-  interrupted: 'text-amber-400',
-  blocked: 'text-orange-400',
-  not_feasible: 'text-rose-400',
+  interrupted: 'text-red-400',
+  blocked: 'text-red-400',
+  not_feasible: 'text-red-400',
 };
 
 export const STATUS_LABELS: Record<MissionStatus, string> = {
   active: 'Active',
+  awaiting_user: 'Needs You',
+  acknowledged: 'Acknowledged',
   completed: 'Completed',
   failed: 'Failed',
   interrupted: 'Interrupted',
@@ -136,6 +164,8 @@ export const STATUS_ICONS = {
   pending: 'Clock',
   active: 'Loader',
   running: 'Loader',
+  awaiting_user: 'Bell',
+  acknowledged: 'CheckCircle',
   completed: 'CheckCircle',
   failed: 'XCircle',
   cancelled: 'Ban',

--- a/docs/MISSION_API.md
+++ b/docs/MISSION_API.md
@@ -123,6 +123,56 @@ sequence metadata is available.
 ]
 ```
 
+## Transcript-First Mission Loading
+
+Use this endpoint for initial mission paint:
+
+```
+GET /api/control/missions/:id/transcript
+```
+
+It returns only transcript-visible rows (`user_message` and final
+`assistant_message`) plus counts/cursors for hidden activity. Clients should
+render these messages immediately, reserve any Thinking/Activity affordance from
+`trace_count` / `trace_summary`, then fetch trace data separately.
+
+Event visibility categories:
+- `transcript`: `user_message`, `assistant_message`, mission status/completion metadata
+- `trace`: `thinking`, `tool_call`, `tool_result`, `text_delta`, errors, command/runtime status
+- `debug`: diagnostics and backend protocol noise
+
+**Response**:
+```json
+{
+  "mission": { "id": "uuid", "status": "active" },
+  "messages": [
+    {
+      "id": 1,
+      "mission_id": "uuid",
+      "sequence": 1,
+      "event_type": "user_message",
+      "content": "Question",
+      "trace_count": 0,
+      "trace_summary": {}
+    }
+  ],
+  "event_counts": { "user_message": 1, "assistant_message": 1, "thinking": 4 },
+  "visibility_counts": { "transcript": 2, "trace": 4 },
+  "latest_sequence": 12
+}
+```
+
+Fetch deferred activity with:
+
+```
+GET /api/control/missions/:id/trace?since_seq=0&limit=200
+```
+
+`/trace` supports `limit`, `offset`, `latest`, `since_seq`, and `before_seq`,
+returns only trace-visible events, and includes `X-Total-Events` /
+`X-Max-Sequence` headers like `/events`. The full `/events` endpoint remains the
+compatibility/debug API.
+
 ## Stream Events (SSE)
 
 ```
@@ -154,6 +204,8 @@ data: {"id":"uuid","content":"Done!","success":true,"cost_cents":5,"model":"clau
 | `/api/control/missions` | GET | List missions |
 | `/api/control/missions/:id` | GET | Get mission details |
 | `/api/control/missions/:id` | DELETE | Delete mission |
+| `/api/control/missions/:id/transcript` | GET | Get lightweight user/final-answer transcript for initial paint |
+| `/api/control/missions/:id/trace` | GET | Get deferred thinking/tool/runtime activity |
 | `/api/control/missions/:id/tree` | GET | Get agent tree for mission |
 | `/api/control/missions/current` | GET | Get current active mission |
 | `/api/control/missions/:id/resume` | POST | Resume interrupted mission |

--- a/docs/grok-goal-integration-proposal.md
+++ b/docs/grok-goal-integration-proposal.md
@@ -1,0 +1,381 @@
+# Grok Build — `/goal`-equivalent integration proposal
+
+**Status:** proposal, not implemented yet.
+**Scope:** mirror the `/goal <objective>` UX the dashboard and iOS app already
+expose for Claude Code and Codex, but for the `grok` CLI.
+
+---
+
+## TL;DR
+
+**Grok Build has no native `/goal` slash command.** Reading the bundled docs
+under `~/.grok/docs/user-guide/04-slash-commands.md` and inspecting the
+`grok 0.1.210` binary confirms it: there is no model-driven "I'm done with
+this goal" signal of the kind codex emits as
+`thread/goal/updated { status: "complete" }`, and no client-side `/goal`
+slash command of the kind Claude Code 2.1.139+ ships.
+
+Grok's closest primitives:
+
+| Primitive | What it is | Why it's not `/goal` |
+|---|---|---|
+| `--check` (CLI, headless only) | "Append a self-verification loop to the prompt" — appends a structured verify-after-do step to the user prompt. Internal flag name `self_verify` / `SELF_VERIFY` in the binary. | **Single-pass with verification.** Not iterative; the model runs the task, the verification subagent reviews, and the run ends. There is no `update_goal { complete }` signal. |
+| `--max-turns N` | Hard cap on agent message count (a "turn" includes every system/user/assistant/tool message; a trivial single-prompt run already burns ~5). | A budget, not a goal definition. The model has no awareness of how close it is to N. |
+| `/loop [interval] <prompt>` (TUI slash command) | Scheduler — runs `<prompt>` every N minutes for up to 7 days. | A time-based scheduler, not an objective loop. Maps onto sandboxed.sh's existing **automations** infrastructure, not to native loops. |
+| `/plan` (CLI flag + slash command) | Plan mode: read-only research, user reviews, then executes. | A two-phase workflow gate, not a goal loop. |
+| `--check` + `--max-turns N` combined | Single pass with verification, hard-capped. | Closest, but still one-shot. |
+
+So **a native `/goal` for Grok is not currently feasible** the way codex's
+is — we'd need xAI to ship a goal-mode RPC, or accept a different
+semantics.
+
+The recommendation below uses Grok's existing primitives plus a
+sandboxed.sh-side iteration loop (matching the existing `native_loops.rs`
+adapter pattern) so the user experience matches `/goal` even though the
+underlying mechanism is sandboxed.sh-driven, not Grok-driven.
+
+---
+
+## Background: how Claude Code and Codex `/goal` work today
+
+To keep the integration coherent, here's what the existing two adapters do.
+
+### Codex `/goal` — fully harness-native
+- `src/backend/codex/mod.rs:128-139` strips `/goal ` server-side via
+  `parse_goal_prefix`.
+- `src/backend/codex/mod.rs:296-334` routes goal missions to
+  `app_server.goal_set(...)` instead of `turn/start`. Codex's app-server
+  auto-starts a turn and keeps iterating until the model invokes
+  `update_goal { status: "complete" }` (or a token budget is exhausted).
+- `src/backend/codex/mod.rs:763-799` translates codex's
+  `thread/goal/{updated,cleared}` notifications into
+  `ExecutionEvent::GoalIteration` / `ExecutionEvent::GoalStatus`.
+- `src/api/mission_runner.rs:13499-13511` forwards those execution events
+  into the unified `AgentEvent::Goal*` stream.
+- `src/api/native_loop_observer.rs:36-89` watches that stream and
+  materializes an `Automation` row + per-iteration `AutomationExecution`
+  rows so the dashboard's Automations panel shows them alongside
+  scheduled automations.
+- `src/backend/native_loops.rs:74-87` registers the codex adapter so
+  `find_adapter("codex", "goal")` returns a matching observer.
+- `src/api/library.rs:1115-1127` exposes the `/goal` slash command in
+  `/api/library/builtin-commands → codex`.
+
+### Claude Code `/goal` — handled inside the CLI
+- Claude Code 2.1.139+ has a native `/goal` slash command. `src/api/
+  mission_runner.rs:9368-9377` pins the CLI to ≥2.1.140 specifically for
+  this reason.
+- Sandboxed.sh **does not** strip the `/goal ` prefix for claudecode —
+  the message is sent verbatim to `claude --print --output-format
+  stream-json …`. The CLI parses the slash command itself.
+- `src/backend/native_loops.rs:59-72` registers the
+  ClaudeCodeGoal adapter, but in practice claudecode does not (yet) emit
+  `ExecutionEvent::Goal*` — only codex does. The adapter is there for
+  forward compatibility (and the dashboard slash-command catalog at
+  `src/api/library.rs:1023-1109`).
+
+### Where `/goal` events appear in the UI
+
+The dashboard and iOS already render `goal_iteration` and `goal_status`
+SSE events:
+- Iteration pill ("iter N") above the chat.
+- Status pill ("active", "complete", "paused", "budget_limited",
+  "aborted") next to it.
+- Automation row in the per-mission Automations sheet, with one
+  AutomationExecution row per iteration.
+
+So once an adapter emits these events, the entire UI surface is already
+wired up.
+
+---
+
+## What I tested locally
+
+`grok` 0.1.210 is installed at `~/.local/bin/grok`. Authenticated with the
+OAuth token already cached in `~/.grok/auth.json`.
+
+```bash
+# Plain headless run (no --check)
+$ grok -p "Say only the word pong." --output-format streaming-json \
+       --max-turns 10 --yolo --cwd /tmp/grok-check-test
+{"type":"thought","data":"The"}
+{"type":"thought","data":" user"} …
+{"type":"text","data":"pong"}
+{"type":"end","stopReason":"EndTurn","sessionId":"…","requestId":"…"}
+```
+
+16 NDJSON lines, terminal `stopReason: EndTurn`.
+
+```bash
+# Same with --check
+$ grok -p "Say only the word pong." --check --output-format streaming-json \
+       --max-turns 20 --yolo --cwd /tmp/grok-check-test
+```
+
+446 NDJSON lines — the prompt visibly expands into a long verification
+preamble. The terminal event is the same `{"type":"end",
+"stopReason":"EndTurn", …}`. Per the docs, `--check` "appends a
+self-verification loop to the prompt"; the binary strings show the slash
+command template `# /check -- Self-Verification`.
+
+Also observed:
+- `--max-turns 1` errors with
+  `"max_turns exceeded: limit is 1, but got 5 messages"` — so `max_turns`
+  counts every internal message (system + user + assistant + tool calls
+  + tool results), not "agent decisions". Any practical budget is ≥10.
+- The streaming-json events Grok emits are `text` / `thought` / `tool` /
+  `end` — no `goal_iteration` / `goal_status` analogue.
+- `/loop` is in the TUI only, not headless; it returns a `scheduler` job
+  id, not an interactive loop.
+
+---
+
+## Proposal: three integration modes, pick one
+
+I'd recommend (a). (b) and (c) are listed for completeness; both
+deliver less, or duplicate work that already exists.
+
+### (a) Sandboxed.sh-driven `/goal` loop using `--check` + iteration **(recommended)**
+
+The user types `/goal <objective>` in a Grok mission. Sandboxed.sh
+detects the prefix, wraps the objective in a structured "until done"
+template, and drives the iteration loop itself by re-invoking
+`run_grok_turn` until the model produces an "all done" signal or a max
+iteration budget is hit.
+
+**Behavior the user sees** — identical to codex `/goal`:
+- "iter 1", "iter 2", … pills above the chat.
+- A goal-state pill that transitions `active → complete | budget_limited
+  | aborted`.
+- One Automation row + one AutomationExecution per iteration in the
+  Automations sheet.
+
+**Implementation outline (file:line changes):**
+
+1. **Detect the prefix.** Add `parse_goal_prefix` in
+   `src/backend/grok/mod.rs` (lift the helper from
+   `src/backend/codex/mod.rs:133-139` and re-use the same `/goal ` rule).
+
+2. **New entry point in mission_runner.** Add `run_grok_goal_turn`
+   alongside `run_grok_turn` in
+   `src/api/mission_runner.rs:12715-12936`. Reuses the existing CLI
+   spawn but:
+   - Renders the user objective into a goal template (see below).
+   - Adds `--check` to the CLI args.
+   - Adds `--max-turns 200` (or a configurable limit; default high
+     enough that practical missions never hit it).
+   - On stream end, parses the final text for a sentinel
+     (`<goal_complete/>` or a JSON tail
+     `{"goal_status": "complete"}`) — described below.
+   - If the sentinel is absent and iteration budget remains, kicks off
+     another `run_grok_turn` with `--continue`, keeping the same Grok
+     session id so the model retains context. Iteration index
+     increments by 1.
+
+3. **Goal template.** Append a system-prompt-override that establishes
+   the protocol:
+   ```text
+   You are operating in goal mode.
+   Objective: <user-supplied objective>
+
+   On every turn:
+   1. Take concrete steps toward the objective.
+   2. Re-check whether the objective is fully achieved.
+   3. End the turn with EXACTLY one of these two markers on its own line:
+      <goal_complete/>   — when the objective is satisfied.
+      <goal_continue/>   — when more work is required.
+
+   If a hard blocker prevents progress, end with:
+      <goal_aborted reason="..."/>
+   ```
+   The sentinel scheme avoids relying on the model to emit a structured
+   tool call. Grok already exposes a `--system-prompt-override` flag and
+   `--rules` for inline rules. Use `--rules` to append the protocol so
+   the agent's primary system prompt stays intact.
+
+4. **Sentinel parsing.** In `run_grok_goal_turn`'s end-of-stream handler
+   (next to `final_result` at `mission_runner.rs:12908`):
+   ```rust
+   let status = parse_goal_sentinel(&final_result);
+   // returns one of GoalContinue / GoalComplete / GoalAborted{reason}
+   //                 / GoalUnknown (sentinel missing).
+   ```
+   `GoalUnknown` is treated as `GoalContinue` for the first 2 turns
+   (the model often forgets the protocol on turn 1), then as
+   `GoalAborted{reason: "no_goal_sentinel"}` so a runaway model can't
+   loop forever.
+
+5. **Emit goal events.** Each loop iteration produces:
+   ```rust
+   ExecutionEvent::GoalIteration {
+       iteration: current_iter,
+       objective: stripped_user_msg.clone(),
+   }
+   ```
+   (before the turn starts). The terminal status produces:
+   ```rust
+   ExecutionEvent::GoalStatus {
+       status: "active" | "complete" | "aborted" | "budget_limited",
+       objective: stripped_user_msg.clone(),
+   }
+   ```
+   `mission_runner.rs:13499-13511` already forwards these into the
+   `AgentEvent::Goal*` stream — no change needed there.
+
+6. **Wire into the dispatcher.** In `mission_runner.rs` around the
+   `"grok" => { run_grok_turn(…) }` arm (line ~3256), add the same
+   `/goal ` prefix check that codex uses (line 3281) and route to
+   `run_grok_goal_turn` when present.
+
+7. **Native-loop adapter.** Add `GrokGoal` to
+   `src/backend/native_loops.rs:113-115`:
+   ```rust
+   pub struct GrokGoal;
+   impl NativeLoopAdapter for GrokGoal {
+       fn harness(&self) -> &'static str { "grok" }
+       fn command(&self) -> &'static str { "goal" }
+       fn observe(&self, event: &AgentEvent) -> LoopObservation {
+           observe_goal_event(event) // shared with codex/claudecode
+       }
+   }
+   ```
+   Add it to `registry()` so the `native_loop_observer` materializes
+   `Automation` + `AutomationExecution` rows for grok goal missions too.
+
+8. **Slash-command catalog.** Add a `grok` field to
+   `BuiltinCommandsResponse` in `src/api/library.rs:949-961` and append:
+   ```rust
+   let grok_commands = vec![CommandSummary {
+       name: "goal".to_string(),
+       description: Some("Loop until the objective is achieved \
+                          (sandboxed.sh-driven; uses Grok --check)".into()),
+       path: "builtin-grok".to_string(),
+       params: vec![CommandParam {
+           name: "objective".to_string(),
+           required: true,
+           description: Some("What the agent should keep iterating on \
+                              until done".into()),
+       }],
+   }];
+   ```
+   And expose it on the JSON wire — both dashboard and iOS already
+   render `BuiltinCommandsResponse.<backend>` fields, so adding `grok`
+   here surfaces the command in both clients' slash menus automatically
+   once the iOS `BuiltinCommandsResponse` decoder gains a `grok: [SlashCommand]?` field (3-line change in `ios_dashboard/SandboxedDashboard/Models/Backend.swift:140-160`).
+
+9. **Tests.**
+   - `parse_goal_prefix`: lift the codex tests verbatim (the rule is the
+     same).
+   - `parse_goal_sentinel`: round-trip the three forms + the
+     "missing sentinel" → `GoalUnknown` case.
+   - `run_grok_goal_turn` smoke test against a stub CLI (already done
+     for codex via the same pattern).
+
+**Risk / sharp edges:**
+- **Token cost.** `--check` roughly tripled the token spend in my local
+  test for a trivial prompt. We should expose a `grok_goal_use_check`
+  config (default true) so the operator can disable it.
+- **Model compliance with the sentinel.** Grok models tend to follow
+  protocol rules well, but the failure mode (no sentinel → eventual
+  `aborted`) is graceful. Mention in the user-facing description that
+  Grok's goal mode is sandboxed.sh-driven and may be less precise than
+  codex's harness-native goal mode.
+- **Session continuity.** `--continue` resumes the most recent session
+  in the cwd. Multiple parallel grok missions in the same workspace
+  would collide. Use the explicit `--session-id` we already track
+  (`mission_runner.rs:12747-12750`) to scope each goal loop to its
+  mission.
+- **Cancellation.** The existing `cancel: CancellationToken` plumbing
+  in `run_grok_turn` (line 12824-12832) covers this for free — break
+  out of the iteration loop on cancellation.
+
+**Lines of code:** ~200–300 in `src/backend/grok/mod.rs` +
+`src/api/mission_runner.rs` + `src/backend/native_loops.rs` +
+`src/api/library.rs`, plus tests. Plus 3–5 lines in
+`ios_dashboard/SandboxedDashboard/Models/Backend.swift` to decode the
+new `grok` field in `BuiltinCommandsResponse`.
+
+---
+
+### (b) Single-shot `--check` mode (passthrough, no iteration)
+
+Map `/goal <objective>` → run `grok -p "<objective>" --check
+--max-turns N`, **exactly once**, and let the model's internal verifier
+decide when to stop.
+
+- **Pro:** trivial integration (~30 lines: strip prefix, append flags).
+  No fake iteration events, no sentinel-parsing brittleness.
+- **Con:** the UI shows zero iterations (the model stops after its
+  internal verifier passes). The user gets "Grok ran with verify"
+  semantics, not "Grok looped until done" semantics. The whole point of
+  `/goal` in the codex/claudecode UI is the iteration pills; this
+  loses that. Doesn't justify a separate command name.
+
+Recommend: do **not** ship this as `/goal`. If we want it at all, ship
+it as a separate `/check` slash command and document it as
+single-shot-with-verify.
+
+---
+
+### (c) Use sandboxed.sh's existing automation as the loop
+
+We already have a turn-based automation that re-fires the same command
+on `agent_finished` (`AutomationTrigger::AgentFinished`). A user could
+manually create an automation that runs `/follow-up` every turn. This
+is what `/loop` does inside Grok's own TUI — a recurring scheduled
+job.
+
+- **Pro:** zero new code. Just write a doc page.
+- **Con:** the user has to manually create the automation, and there's
+  no "is the goal done?" signal — the automation will keep firing until
+  the user disables it. Not equivalent to `/goal`.
+
+Recommend: do **not** ship this as `/goal`. Mention it in the docs as a
+pre-existing alternative.
+
+---
+
+## Recommended path
+
+**Ship (a).** It's the only option that gives the user the same UX as
+codex `/goal`, and it slots into the existing
+`native_loops.rs` / `native_loop_observer.rs` / Automations-panel
+pipeline without changing anything UI-side beyond the slash-command
+catalog entry.
+
+Suggested rollout:
+1. Land the parser + `run_grok_goal_turn` skeleton with the sentinel
+   protocol behind a flag (`SANDBOXED_SH_ENABLE_GROK_GOAL=1`).
+2. Add the slash command to the catalog and the iOS decoder.
+3. Try a handful of real missions; tune `max_iterations` (probably 25)
+   and `--max-turns` per iteration (probably 60) based on observed
+   behavior.
+4. Flip the flag on by default once the sentinel-compliance rate looks
+   healthy (≥95% in test missions).
+5. Add an open question to the xAI side: ask whether they'd add a
+   first-class `update_goal` / `thread/goal/*` analogue. If/when they
+   do, switch `run_grok_goal_turn` to the native path and keep the
+   sentinel as a fallback.
+
+---
+
+## Appendix: source pointers
+
+- Codex `/goal` server-side prefix detection:
+  `src/backend/codex/mod.rs:128-139, 296-334`.
+- Codex `/goal` event emission:
+  `src/backend/codex/mod.rs:763-799`.
+- `ExecutionEvent::Goal*` → `AgentEvent::Goal*` translation:
+  `src/api/mission_runner.rs:13499-13511, 14005-14017`.
+- Native-loop adapter registry:
+  `src/backend/native_loops.rs:113-123`.
+- Native-loop observer (Automation + AutomationExecution
+  materialization): `src/api/native_loop_observer.rs:36-89`.
+- Builtin slash-command catalog: `src/api/library.rs:984-1133`.
+- Grok backend driver: `src/api/mission_runner.rs:12715-12936`.
+- Grok backend module: `src/backend/grok/mod.rs`.
+- Grok user-guide source-of-truth (bundled with CLI):
+  `~/.grok/docs/user-guide/04-slash-commands.md`,
+  `~/.grok/docs/user-guide/13-headless-mode.md`,
+  `~/.grok/docs/user-guide/14-agent-mode.md`.
+

--- a/ios_dashboard/SandboxedDashboard/ContentView.swift
+++ b/ios_dashboard/SandboxedDashboard/ContentView.swift
@@ -196,9 +196,9 @@ struct SetupSheet: View {
             _ = try await api.checkHealth()
             connectionSuccess = true
             HapticService.success()
-
-            // Brief delay to show success state
-            try? await Task.sleep(for: .milliseconds(500))
+            // No artificial delay before dismissing — the haptic + checkmark
+            // already convey success, and adding 500 ms here just felt slow.
+            // (UX audit item #24.)
             onComplete()
         } catch {
             // Restore original URL on failure

--- a/ios_dashboard/SandboxedDashboard/Models/AnyCodable.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/AnyCodable.swift
@@ -7,7 +7,13 @@
 
 import Foundation
 
-struct AnyCodable: Codable, Hashable {
+/// `@unchecked Sendable` because `value: Any` defeats the Sendable check, but
+/// in practice the `init(from:)` path only ever stores Foundation primitives
+/// (Bool/Int/Double/String, NSNull, or recursive `[AnyCodable]` / `[String: AnyCodable]`).
+/// Once decoded, the value is treated as immutable. Required so structures
+/// that transitively contain `AnyCodable` (StoredEvent, MissionEventsResult)
+/// can flow across `async let` boundaries.
+struct AnyCodable: Codable, Hashable, @unchecked Sendable {
     let value: Any
 
     init(_ value: Any) {

--- a/ios_dashboard/SandboxedDashboard/Models/Backend.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Backend.swift
@@ -2,12 +2,12 @@
 //  Backend.swift
 //  SandboxedDashboard
 //
-//  Backend data models for OpenCode, Claude Code, Amp, Codex, and Gemini
+//  Backend data models for OpenCode, Claude Code, Amp, Codex, Gemini, and Grok
 //
 
 import Foundation
 
-/// Represents an available backend (OpenCode, Claude Code, Amp, Codex, Gemini)
+/// Represents an available backend (OpenCode, Claude Code, Amp, Codex, Gemini, Grok)
 struct Backend: Codable, Identifiable, Hashable {
     let id: String
     let name: String
@@ -17,9 +17,10 @@ struct Backend: Codable, Identifiable, Hashable {
     static let amp = Backend(id: "amp", name: "Amp")
     static let codex = Backend(id: "codex", name: "Codex")
     static let gemini = Backend(id: "gemini", name: "Gemini CLI")
+    static let grok = Backend(id: "grok", name: "Grok Build")
 
     /// Default backends when API is unavailable
-    static let defaults: [Backend] = [.opencode, .claudecode, .amp, .codex, .gemini]
+    static let defaults: [Backend] = [.opencode, .claudecode, .amp, .codex, .gemini, .grok]
 }
 
 /// Represents an agent within a backend

--- a/ios_dashboard/SandboxedDashboard/Models/Backend.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Backend.swift
@@ -142,9 +142,13 @@ struct BuiltinCommandsResponse: Codable {
     let opencode: [SlashCommand]
     let claudecode: [SlashCommand]
     let codex: [SlashCommand]?
+    /// Grok Build builtin commands (just `/goal` today — sandboxed.sh-driven,
+    /// not a native grok feature). Optional so older backends without the
+    /// field decode fine.
+    let grok: [SlashCommand]?
 
     private enum CodingKeys: String, CodingKey {
-        case opencode, claudecode, codex
+        case opencode, claudecode, codex, grok
     }
 
     init(from decoder: Decoder) throws {
@@ -152,12 +156,19 @@ struct BuiltinCommandsResponse: Codable {
         opencode = try c.decodeIfPresent([SlashCommand].self, forKey: .opencode) ?? []
         claudecode = try c.decodeIfPresent([SlashCommand].self, forKey: .claudecode) ?? []
         codex = try c.decodeIfPresent([SlashCommand].self, forKey: .codex)
+        grok = try c.decodeIfPresent([SlashCommand].self, forKey: .grok)
     }
 
-    init(opencode: [SlashCommand] = [], claudecode: [SlashCommand] = [], codex: [SlashCommand]? = nil) {
+    init(
+        opencode: [SlashCommand] = [],
+        claudecode: [SlashCommand] = [],
+        codex: [SlashCommand]? = nil,
+        grok: [SlashCommand]? = nil
+    ) {
         self.opencode = opencode
         self.claudecode = claudecode
         self.codex = codex
+        self.grok = grok
     }
 }
 

--- a/ios_dashboard/SandboxedDashboard/Models/ChatMessage.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatMessage.swift
@@ -210,14 +210,28 @@ struct ChatMessage: Identifiable {
     var toolUI: ToolUIContent?
     var toolData: ToolCallData?
     let timestamp: Date
+    /// True while the optimistic user bubble is awaiting server acknowledgement.
+    /// Cleared as soon as `sendMessage` returns or the SSE roundtrip arrives.
+    /// The bubble renders dimmed with a small spinner while pending so users
+    /// don't re-tap send on slow networks. (UX audit item #11.)
+    var isPending: Bool
 
-    init(id: String = UUID().uuidString, type: ChatMessageType, content: String, toolUI: ToolUIContent? = nil, toolData: ToolCallData? = nil, timestamp: Date = Date()) {
+    init(
+        id: String = UUID().uuidString,
+        type: ChatMessageType,
+        content: String,
+        toolUI: ToolUIContent? = nil,
+        toolData: ToolCallData? = nil,
+        timestamp: Date = Date(),
+        isPending: Bool = false
+    ) {
         self.id = id
         self.type = type
         self.content = content
         self.toolUI = toolUI
         self.toolData = toolData
         self.timestamp = timestamp
+        self.isPending = isPending
     }
     
     var isUser: Bool {

--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -10,30 +10,38 @@ import Foundation
 enum MissionStatus: String, Codable, CaseIterable {
     case pending
     case active
+    /// Agent's turn / automation cycle finished cleanly with no follow-up
+    /// queued; the mission is parked waiting for the user. This is the
+    /// "Needs You" bucket.
+    case awaitingUser = "awaiting_user"
+    /// User opened the mission while it was AwaitingUser and the 1h grace
+    /// elapsed without a new message — auto-archived under Finished.
+    case acknowledged
     case completed
     case failed
     case interrupted
     case blocked
     case notFeasible = "not_feasible"
     case unknown
-    
+
     var statusType: StatusType {
         switch self {
         case .pending: return .pending
         case .active: return .active
+        case .awaitingUser: return .awaitingUser
+        case .acknowledged: return .completed
         case .completed: return .completed
         case .failed: return .failed
-        case .interrupted: return .interrupted
-        case .blocked: return .blocked
-        case .notFeasible: return .failed
-        case .unknown: return .failed
+        case .interrupted, .blocked, .notFeasible, .unknown: return .failed
         }
     }
-    
+
     var displayLabel: String {
         switch self {
         case .pending: return "Pending"
         case .active: return "Active"
+        case .awaitingUser: return "Needs You"
+        case .acknowledged: return "Acknowledged"
         case .completed: return "Completed"
         case .failed: return "Failed"
         case .interrupted: return "Interrupted"
@@ -42,9 +50,17 @@ enum MissionStatus: String, Codable, CaseIterable {
         case .unknown: return "Unknown"
         }
     }
-    
+
+    /// Stored statuses that the user can wake back into Active by sending a
+    /// new message. AwaitingUser/Acknowledged count too — the agent is idle
+    /// and ready to resume.
     var canResume: Bool {
-        self == .interrupted || self == .blocked
+        switch self {
+        case .interrupted, .blocked, .awaitingUser, .acknowledged:
+            return true
+        default:
+            return false
+        }
     }
 
     init(from decoder: Decoder) throws {
@@ -87,6 +103,10 @@ struct Mission: Codable, Identifiable, Hashable {
     let createdAt: String
     var updatedAt: String
     let interruptedAt: String?
+    /// Timestamp of the user's first open since this mission last entered
+    /// AwaitingUser. Drives the "opened" dot rendered next to Finished
+    /// missions, and the backend's 1h ack grace timer.
+    let firstViewedAt: String?
     let resumable: Bool
     let parentMissionId: String?
 
@@ -111,6 +131,7 @@ struct Mission: Codable, Identifiable, Hashable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case interruptedAt = "interrupted_at"
+        case firstViewedAt = "first_viewed_at"
         case parentMissionId = "parent_mission_id"
     }
 
@@ -133,6 +154,7 @@ struct Mission: Codable, Identifiable, Hashable {
         createdAt = try container.decode(String.self, forKey: .createdAt)
         updatedAt = try container.decode(String.self, forKey: .updatedAt)
         interruptedAt = try container.decodeIfPresent(String.self, forKey: .interruptedAt)
+        firstViewedAt = try container.decodeIfPresent(String.self, forKey: .firstViewedAt)
         resumable = try container.decodeIfPresent(Bool.self, forKey: .resumable) ?? false
         parentMissionId = try container.decodeIfPresent(String.self, forKey: .parentMissionId)
     }
@@ -345,6 +367,30 @@ struct StoredEvent: Codable, Identifiable, Sendable {
         case toolName = "tool_name"
         case content
         case metadata
+    }
+
+    init(
+        id: Int64,
+        missionId: String,
+        sequence: Int64,
+        eventType: String,
+        timestamp: String,
+        eventId: String?,
+        toolCallId: String?,
+        toolName: String?,
+        content: String,
+        metadata: [String: AnyCodable]
+    ) {
+        self.id = id
+        self.missionId = missionId
+        self.sequence = sequence
+        self.eventType = eventType
+        self.timestamp = timestamp
+        self.eventId = eventId
+        self.toolCallId = toolCallId
+        self.toolName = toolName
+        self.content = content
+        self.metadata = metadata
     }
 
     init(from decoder: Decoder) throws {

--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -322,7 +322,7 @@ struct ParallelConfig: Codable {
 
 // MARK: - Events
 
-struct StoredEvent: Codable, Identifiable {
+struct StoredEvent: Codable, Identifiable, Sendable {
     let id: Int64
     let missionId: String
     let sequence: Int64

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -192,6 +192,15 @@ final class APIService {
     func loadMission(id: String) async throws -> Mission {
         try await post("/api/control/missions/\(id)/load", body: EmptyBody())
     }
+
+    /// Tell the backend the user has opened this mission. The first call
+    /// (when `first_viewed_at` is still null on the row) starts the 1h ack
+    /// grace timer for `awaiting_user` missions; later calls are no-ops on
+    /// the server. Returns the updated mission so callers can rerender the
+    /// "opened" dot immediately.
+    func markMissionOpened(id: String) async throws -> Mission {
+        try await post("/api/control/missions/\(id)/opened", body: EmptyBody())
+    }
     
     func setMissionStatus(id: String, status: MissionStatus) async throws {
         struct StatusRequest: Encodable {
@@ -261,6 +270,38 @@ final class APIService {
         }
 
         var urlString = "/api/control/missions/\(id)/events"
+        if !queryItems.isEmpty {
+            var components = URLComponents(string: urlString)
+            components?.queryItems = queryItems
+            if let fullPath = components?.string {
+                urlString = fullPath
+            }
+        }
+
+        let (events, response): ([StoredEvent], HTTPURLResponse) = try await getWithResponse(urlString)
+        let maxSequence = (response.value(forHTTPHeaderField: "X-Max-Sequence") ?? response.value(forHTTPHeaderField: "x-max-sequence"))
+            .flatMap { Int64($0) }
+        return MissionEventsResult(events: events, maxSequence: maxSequence)
+    }
+
+    func getMissionTranscript(id: String) async throws -> MissionTranscriptResult {
+        try await get("/api/control/missions/\(id)/transcript")
+    }
+
+    func getMissionTraceWithMeta(
+        id: String,
+        limit: Int? = nil,
+        sinceSeq: Int64? = nil
+    ) async throws -> MissionEventsResult {
+        var queryItems: [URLQueryItem] = []
+        if let limit = limit {
+            queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+        }
+        if let sinceSeq = sinceSeq {
+            queryItems.append(URLQueryItem(name: "since_seq", value: String(sinceSeq)))
+        }
+
+        var urlString = "/api/control/missions/\(id)/trace"
         if !queryItems.isEmpty {
             var components = URLComponents(string: urlString)
             components?.queryItems = queryItems
@@ -858,6 +899,67 @@ private struct DecodedBox<T>: @unchecked Sendable {
 struct MissionEventsResult: Sendable {
     let events: [StoredEvent]
     let maxSequence: Int64?
+}
+
+struct TranscriptMessage: Codable, Sendable {
+    let traceCount: Int
+    let traceSummary: [String: Int]
+    let id: Int64
+    let missionId: String
+    let sequence: Int64
+    let eventType: String
+    let timestamp: String
+    let eventId: String?
+    let toolCallId: String?
+    let toolName: String?
+    let content: String
+    let metadata: [String: AnyCodable]
+
+    enum CodingKeys: String, CodingKey {
+        case traceCount = "trace_count"
+        case traceSummary = "trace_summary"
+        case id
+        case missionId = "mission_id"
+        case sequence
+        case eventType = "event_type"
+        case timestamp
+        case eventId = "event_id"
+        case toolCallId = "tool_call_id"
+        case toolName = "tool_name"
+        case content
+        case metadata
+    }
+
+    var storedEvent: StoredEvent {
+        StoredEvent(
+            id: id,
+            missionId: missionId,
+            sequence: sequence,
+            eventType: eventType,
+            timestamp: timestamp,
+            eventId: eventId,
+            toolCallId: toolCallId,
+            toolName: toolName,
+            content: content,
+            metadata: metadata
+        )
+    }
+}
+
+struct MissionTranscriptResult: Codable, Sendable {
+    let mission: Mission
+    let messages: [TranscriptMessage]
+    let eventCounts: [String: Int]
+    let visibilityCounts: [String: Int]
+    let latestSequence: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case mission
+        case messages
+        case eventCounts = "event_counts"
+        case visibilityCounts = "visibility_counts"
+        case latestSequence = "latest_sequence"
+    }
 }
 
 enum APIError: LocalizedError {

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -852,7 +852,10 @@ private struct DecodedBox<T>: @unchecked Sendable {
 /// Result of a `/missions/:id/events` fetch. `maxSequence` is the response's
 /// `X-Max-Sequence` header — `nil` if the backend doesn't advertise it (older
 /// versions). Callers must treat `nil` as "delta resume unsupported".
-struct MissionEventsResult {
+///
+/// `Sendable` so it can cross `async let` boundaries from the main actor —
+/// `StoredEvent` and `AnyCodable` are Sendable above.
+struct MissionEventsResult: Sendable {
     let events: [StoredEvent]
     let maxSequence: Int64?
 }

--- a/ios_dashboard/SandboxedDashboard/Services/BackendAgentService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/BackendAgentService.swift
@@ -48,6 +48,11 @@ enum BackendAgentService {
     }
 
     /// Actual network fetch (extracted from the previous loadBackendsAndAgents).
+    ///
+    /// Fans out the per-backend config and agent lookups via `withTaskGroup`
+    /// so a 5-backend install is one RTT-batch instead of five serial calls.
+    /// On a 200 ms RTT cellular link this shaved ~1.6 s off every "New
+    /// Mission" tap and every Settings open (UX audit item #3).
     private static func fetchBackendsAndAgents() async -> BackendAgentData {
         // Load backends
         let backends: [Backend]
@@ -57,34 +62,49 @@ enum BackendAgentService {
             backends = Backend.defaults
         }
 
-        // Load backend configs to check enabled status
-        var enabled = Set<String>()
-        for backend in backends {
-            do {
-                let config = try await api.getBackendConfig(backendId: backend.id)
-                if config.isEnabled {
-                    enabled.insert(backend.id)
+        // Parallel config fetch — one task per backend.
+        let configResults = await withTaskGroup(of: (String, Bool).self) { group in
+            for backend in backends {
+                group.addTask {
+                    if let config = try? await api.getBackendConfig(backendId: backend.id) {
+                        return (backend.id, config.isEnabled)
+                    }
+                    // Default to enabled if we can't fetch config (parity with
+                    // the previous serial implementation).
+                    return (backend.id, true)
                 }
-            } catch {
-                // Default to enabled if we can't fetch config
-                enabled.insert(backend.id)
             }
+            var out: [(String, Bool)] = []
+            for await pair in group { out.append(pair) }
+            return out
         }
+        let enabled = Set(configResults.filter(\.1).map(\.0))
 
-        // Load agents for each enabled backend
-        var backendAgents: [String: [BackendAgent]] = [:]
-        for backendId in enabled {
-            do {
-                let agents = try await api.listBackendAgents(backendId: backendId)
-                backendAgents[backendId] = agents
-            } catch {
-                // Use defaults for Amp if API fails
-                if backendId == "amp" {
-                    backendAgents[backendId] = [
-                        BackendAgent(id: "smart", name: "Smart Mode"),
-                        BackendAgent(id: "rush", name: "Rush Mode")
-                    ]
+        // Parallel agent fetch for each enabled backend.
+        let agentResults = await withTaskGroup(of: (String, [BackendAgent]?).self) { group in
+            for backendId in enabled {
+                group.addTask {
+                    if let agents = try? await api.listBackendAgents(backendId: backendId) {
+                        return (backendId, agents)
+                    }
+                    return (backendId, nil)
                 }
+            }
+            var out: [(String, [BackendAgent]?)] = []
+            for await pair in group { out.append(pair) }
+            return out
+        }
+        var backendAgents: [String: [BackendAgent]] = [:]
+        for (backendId, agents) in agentResults {
+            if let agents {
+                backendAgents[backendId] = agents
+            } else if backendId == "amp" {
+                // Preserve the legacy Amp fallback so the picker isn't empty
+                // when the agents endpoint flakes.
+                backendAgents[backendId] = [
+                    BackendAgent(id: "smart", name: "Smart Mode"),
+                    BackendAgent(id: "rush", name: "Rush Mode")
+                ]
             }
         }
 
@@ -101,6 +121,9 @@ enum BackendAgentService {
         case "opencode": return "terminal"
         case "claudecode": return "brain"
         case "amp": return "bolt.fill"
+        case "codex": return "chevron.left.forwardslash.chevron.right"
+        case "gemini": return "sparkles"
+        case "grok": return "xmark.circle"
         default: return "cpu"
         }
     }
@@ -111,6 +134,9 @@ enum BackendAgentService {
         case "opencode": return Theme.success
         case "claudecode": return Theme.accent
         case "amp": return .orange
+        case "codex": return .cyan
+        case "gemini": return .blue
+        case "grok": return Color(white: 0.85)
         default: return Theme.textSecondary
         }
     }

--- a/ios_dashboard/SandboxedDashboard/Services/FidoApprovalState.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/FidoApprovalState.swift
@@ -16,6 +16,12 @@ final class FidoApprovalState {
 
     var pendingRequests: [FidoSignRequest] = []
 
+    /// Set of request IDs for which an approve/deny request is currently in
+    /// flight to the server. The overlay disables both buttons and shows a
+    /// spinner while the ID is present so users don't double-fire
+    /// `fidoRespond` on a slow link. (UX audit item #23a.)
+    var inFlightRequestIds: Set<String> = []
+
     var autoApprovalRules: [AutoApprovalRule] = [] {
         didSet { persistRules() }
     }
@@ -81,6 +87,11 @@ final class FidoApprovalState {
     // MARK: - Approve / Deny
 
     func approve(_ requestId: String) async {
+        // Idempotent — bail out if the user double-taps Approve before the
+        // first call comes back, otherwise we'd fire two `fidoRespond` calls.
+        guard !inFlightRequestIds.contains(requestId) else { return }
+        inFlightRequestIds.insert(requestId)
+        defer { inFlightRequestIds.remove(requestId) }
         do {
             try await api.fidoRespond(requestId: requestId, approved: true)
             HapticService.success()
@@ -91,6 +102,9 @@ final class FidoApprovalState {
     }
 
     func deny(_ requestId: String) async {
+        guard !inFlightRequestIds.contains(requestId) else { return }
+        inFlightRequestIds.insert(requestId)
+        defer { inFlightRequestIds.remove(requestId) }
         do {
             try await api.fidoRespond(requestId: requestId, approved: false)
         } catch {

--- a/ios_dashboard/SandboxedDashboard/Views/Components/LoadingView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/LoadingView.swift
@@ -67,18 +67,117 @@ struct ShimmerCard: View {
                     .frame(width: 40, height: 40)
                     .overlay(ShimmerView())
                     .clipShape(RoundedRectangle(cornerRadius: 8))
-                
+
                 VStack(alignment: .leading, spacing: 6) {
                     ShimmerRow(height: 14, width: 120)
                     ShimmerRow(height: 12, width: 80)
                 }
             }
-            
+
             ShimmerRow(height: 12)
             ShimmerRow(height: 12, width: 200)
         }
         .padding(16)
         .background(Color.white.opacity(0.03))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+}
+
+// Skeleton mirroring WorkspaceCard (WorkspacesView.swift:128-174):
+// two-row VStack — top HStack(small symbol + name + spacer + status badge);
+// bottom HStack(type pill + spacer + chevron). Padding 16, corner 12, 1pt
+// border at white 0.06.
+struct ShimmerWorkspaceCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                ShimmerRow(height: 16, width: 16)
+                ShimmerRow(height: 16, width: 140)
+                Spacer(minLength: 8)
+                ShimmerRow(height: 18, width: 64)
+            }
+            HStack {
+                ShimmerRow(height: 18, width: 70)
+                Spacer()
+                ShimmerRow(height: 12, width: 8)
+            }
+        }
+        .padding()
+        .background(Color.white.opacity(0.02))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
+    }
+}
+
+// Skeleton mirroring MissionRow (HistoryView.swift:384-456): single HStack
+// with 40x40 icon (corner 10) + VStack(title + badge row) + Spacer +
+// VStack(timestamp + chevron). Padding 14, corner 14, ultraThinMaterial.
+struct ShimmerMissionRow: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.white.opacity(0.06))
+                .frame(width: 40, height: 40)
+                .overlay(ShimmerView())
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 4) {
+                ShimmerRow(height: 14, width: 180)
+                HStack(spacing: 6) {
+                    ShimmerRow(height: 16, width: 56)
+                    ShimmerRow(height: 14, width: 48)
+                    ShimmerRow(height: 12, width: 40)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                ShimmerRow(height: 12, width: 48)
+                ShimmerRow(height: 12, width: 8)
+            }
+        }
+        .padding(14)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Theme.border, lineWidth: 0.5)
+        )
+    }
+}
+
+// Skeleton mirroring FileRow (FilesView.swift:607-687): single HStack with
+// 48x48 icon (corner 12) + VStack(name + meta row) + Spacer + chevron.
+// Padding 12v/16h, corner 14, Theme.backgroundSecondary.
+struct ShimmerFileRow: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.white.opacity(0.06))
+                .frame(width: 48, height: 48)
+                .overlay(ShimmerView())
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 4) {
+                ShimmerRow(height: 16, width: 160)
+                HStack(spacing: 6) {
+                    ShimmerRow(height: 12, width: 48)
+                    ShimmerRow(height: 12, width: 60)
+                    ShimmerRow(height: 12, width: 40)
+                }
+            }
+
+            Spacer()
+
+            ShimmerRow(height: 14, width: 8)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+        .background(Theme.backgroundSecondary)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
@@ -125,20 +224,24 @@ struct EmptyStateView: View {
 }
 
 #Preview {
-    VStack(spacing: 24) {
-        LoadingView()
-            .frame(height: 150)
-        
-        ShimmerCard()
-            .padding()
-        
-        EmptyStateView(
-            icon: "message.badge.filled.fill",
-            title: "No Messages",
-            message: "Start a conversation with the agent",
-            action: { print("Tapped") }
-        )
-        .frame(height: 250)
+    ScrollView {
+        VStack(spacing: 16) {
+            LoadingView()
+                .frame(height: 120)
+
+            ShimmerWorkspaceCard()
+            ShimmerMissionRow()
+            ShimmerFileRow()
+
+            EmptyStateView(
+                icon: "message.badge.filled.fill",
+                title: "No Messages",
+                message: "Start a conversation with the agent",
+                action: { print("Tapped") }
+            )
+            .frame(height: 200)
+        }
+        .padding()
     }
     .background(Theme.backgroundPrimary)
 }

--- a/ios_dashboard/SandboxedDashboard/Views/Components/StatusBadge.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/StatusBadge.swift
@@ -11,6 +11,7 @@ enum StatusType {
     case pending
     case running
     case active
+    case awaitingUser
     case completed
     case failed
     case cancelled
@@ -21,33 +22,34 @@ enum StatusType {
     case connecting
     case interrupted
     case blocked
-    
+
     var color: Color {
         switch self {
         case .pending, .idle:
             return Theme.textMuted
         case .running, .active, .connecting:
             return Theme.accent
+        case .awaitingUser:
+            return Theme.warning
         case .completed, .connected:
             return Theme.success
-        case .failed, .error:
+        case .failed, .error, .interrupted, .blocked:
             return Theme.error
         case .cancelled, .disconnected:
             return Theme.textTertiary
-        case .interrupted, .blocked:
-            return Theme.warning
         }
     }
-    
+
     var backgroundColor: Color {
         color.opacity(0.15)
     }
-    
+
     var label: String {
         switch self {
         case .pending: return "Pending"
         case .running: return "Running"
         case .active: return "Active"
+        case .awaitingUser: return "Needs You"
         case .completed: return "Completed"
         case .failed: return "Failed"
         case .cancelled: return "Cancelled"
@@ -60,12 +62,13 @@ enum StatusType {
         case .blocked: return "Blocked"
         }
     }
-    
+
     var icon: String {
         switch self {
         case .pending: return "clock"
         case .running, .connecting: return "arrow.trianglehead.2.clockwise"
         case .active: return "circle.fill"
+        case .awaitingUser: return "hand.wave.fill"
         case .completed: return "checkmark.circle.fill"
         case .failed, .error: return "xmark.circle.fill"
         case .cancelled: return "slash.circle"
@@ -76,7 +79,7 @@ enum StatusType {
         case .blocked: return "exclamationmark.triangle.fill"
         }
     }
-    
+
     var shouldPulse: Bool {
         switch self {
         case .running, .active, .connecting:

--- a/ios_dashboard/SandboxedDashboard/Views/Control/AutomationsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/AutomationsView.swift
@@ -147,6 +147,15 @@ struct AutomationsView: View {
     }
 
     private func setAutomationActive(_ automation: Automation, active: Bool) async {
+        // Flip the toggle instantly so the switch animates in the same
+        // frame the user tapped. On a slow connection the previous
+        // version left the switch in its old position until the network
+        // call returned, making the tap feel ignored.
+        let originalActive = automation.active
+        if let index = automations.firstIndex(where: { $0.id == automation.id }) {
+            automations[index].active = active
+        }
+        HapticService.selectionChanged()
         do {
             _ = try await api.updateAutomation(
                 id: automation.id,
@@ -157,12 +166,13 @@ struct AutomationsView: View {
                     active: active
                 )
             )
-            if let index = automations.firstIndex(where: { $0.id == automation.id }) {
-                automations[index].active = active
-            }
-            HapticService.selectionChanged()
         } catch {
             errorMessage = error.localizedDescription
+            // Roll back so the toggle reflects the server's true state.
+            if let index = automations.firstIndex(where: { $0.id == automation.id }) {
+                automations[index].active = originalActive
+            }
+            HapticService.error()
         }
     }
 
@@ -235,12 +245,23 @@ struct AutomationsView: View {
     }
 
     private func deleteAutomation(_ automation: Automation) async {
+        // Remove the row instantly so the list shrinks in the same frame
+        // as the Delete tap. Re-insert on failure.
+        let originalIndex = automations.firstIndex(where: { $0.id == automation.id })
+        withAnimation {
+            automations.removeAll { $0.id == automation.id }
+        }
         do {
             try await api.deleteAutomation(id: automation.id)
-            automations.removeAll { $0.id == automation.id }
             HapticService.success()
         } catch {
             errorMessage = error.localizedDescription
+            if let idx = originalIndex {
+                withAnimation {
+                    automations.insert(automation, at: min(idx, automations.count))
+                }
+            }
+            HapticService.error()
         }
     }
 }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -569,11 +569,19 @@ struct ControlView: View {
         .sheet(isPresented: $showQueueSheet) {
             QueueSheet(
                 items: queuedItems,
+                // Synchronous removes so swipe-to-delete shrinks the row in
+                // the same render frame as the gesture, even on a slow
+                // network (the API call is fire-and-forget; the optimistic
+                // update is rolled back on failure). The previous Task
+                // wrapper deferred the mutation by one runloop tick, which
+                // SwiftUI's `List.onDelete` interprets as "data source
+                // didn't shrink" — the row snapped back before
+                // disappearing.
                 onRemove: { messageId in
-                    Task { await removeFromQueue(messageId: messageId) }
+                    removeFromQueueOptimistic(messageId: messageId)
                 },
                 onClearAll: {
-                    Task { await clearQueue() }
+                    clearQueueOptimistic()
                 },
                 onDismiss: {
                     showQueueSheet = false
@@ -2363,40 +2371,55 @@ struct ControlView: View {
         }
     }
 
-    private func removeFromQueue(messageId: String) async {
-        // Optimistic update
-        queuedItems.removeAll { $0.id == messageId }
-        queueLength = max(0, queueLength - 1)
-
-        do {
-            try await api.removeFromQueue(messageId: messageId)
-        } catch {
-            print("Failed to remove from queue: \(error)")
-            // Refresh from server on error to get actual state
-            await loadQueueItems()
-            queueLength = queuedItems.count
-            HapticService.error()
+    /// Synchronous optimistic remove — runs *during* the swipe gesture so
+    /// SwiftUI's `List.onDelete` animation has the new (smaller) data
+    /// source on the same render frame. Network call is fire-and-forget
+    /// in a detached `Task`. The previous implementation wrapped the whole
+    /// thing in `Task { await … }`, which deferred the array mutation by
+    /// one runloop tick — on a slow connection the row visibly snapped
+    /// back to its original position before re-disappearing.
+    private func removeFromQueueOptimistic(messageId: String) {
+        withAnimation(.easeOut(duration: 0.2)) {
+            queuedItems.removeAll { $0.id == messageId }
+            queueLength = max(0, queueLength - 1)
+        }
+        Task {
+            do {
+                try await api.removeFromQueue(messageId: messageId)
+            } catch {
+                print("Failed to remove from queue: \(error)")
+                // Reconcile with the server on error so the row reappears
+                // if the delete actually didn't take effect.
+                await loadQueueItems()
+                queueLength = queuedItems.count
+                HapticService.error()
+            }
         }
     }
 
-    private func clearQueue() async {
-        // Optimistic update
-        queuedItems = []
-        queueLength = 0
+    /// Synchronous optimistic clear — same rationale as
+    /// `removeFromQueueOptimistic`.
+    private func clearQueueOptimistic() {
+        withAnimation(.easeOut(duration: 0.2)) {
+            queuedItems = []
+            queueLength = 0
+        }
         showQueueSheet = false
-
-        do {
-            _ = try await api.clearQueue()
-            HapticService.success()
-        } catch {
-            print("Failed to clear queue: \(error)")
-            // Refresh from server on error to get actual state
-            await loadQueueItems()
-            queueLength = queuedItems.count
-            HapticService.error()
+        Task {
+            do {
+                _ = try await api.clearQueue()
+                HapticService.success()
+            } catch {
+                print("Failed to clear queue: \(error)")
+                // Reconcile with the server on error so any items that
+                // did not actually clear reappear.
+                await loadQueueItems()
+                queueLength = queuedItems.count
+                HapticService.error()
+            }
         }
     }
-    
+
     private func startStreaming() {
         streamTask = Task {
             // Exponential backoff: 1s, 2s, 4s, 8s, 16s, max 30s

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1084,12 +1084,14 @@ struct ControlView: View {
         case "codex": pool = catalog.codex ?? []
         case "claudecode": pool = catalog.claudecode
         case "opencode": pool = catalog.opencode
+        case "grok": pool = catalog.grok ?? []
         default:
             // No mission yet → show every backend's commands so the user
             // can preview what's available.
             pool = catalog.opencode
                 + catalog.claudecode
                 + (catalog.codex ?? [])
+                + (catalog.grok ?? [])
         }
         return pool.filter { $0.matchesPrefix(nameFragment) }
     }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1997,16 +1997,22 @@ struct ControlView: View {
 
     private func setMissionStatus(_ status: MissionStatus) async {
         guard let mission = viewingMission else { return }
-        
+        let previousStatus = mission.status
+        // Flip the status pill instantly on the menu tap; roll back on
+        // failure so the badge tracks the server's true state.
+        viewingMission?.status = status
+        if currentMission?.id == mission.id {
+            currentMission?.status = status
+        }
         do {
             try await api.setMissionStatus(id: mission.id, status: status)
-            viewingMission?.status = status
-            if currentMission?.id == mission.id {
-                currentMission?.status = status
-            }
             HapticService.success()
         } catch {
             print("Failed to set status: \(error)")
+            viewingMission?.status = previousStatus
+            if currentMission?.id == mission.id {
+                currentMission?.status = previousStatus
+            }
             HapticService.error()
         }
     }
@@ -2663,22 +2669,38 @@ struct ControlView: View {
     }
     
     private func cancelMission(id: String) async {
+        // Drop the chip from the running-missions bar immediately so the
+        // tap-to-cancel feels instant on slow networks. The
+        // `refreshRunningMissions` below reconciles with the server.
+        let removedRunning = runningMissions.first { $0.missionId == id }
+        if removedRunning != nil {
+            withAnimation(.easeOut(duration: 0.2)) {
+                runningMissions.removeAll { $0.missionId == id }
+            }
+        }
         do {
             try await api.cancelMission(id: id)
-            
+
             // Refresh running missions
             await refreshRunningMissions()
-            
+
             // If we were viewing this mission, switch to current
             if viewingMissionId == id {
                 if let currentId = currentMission?.id {
                     await switchToMission(id: currentId)
                 }
             }
-            
+
             HapticService.success()
         } catch {
             print("Failed to cancel mission: \(error)")
+            // Restore the chip on failure.
+            if let restored = removedRunning,
+               !runningMissions.contains(where: { $0.missionId == id }) {
+                withAnimation {
+                    runningMissions.append(restored)
+                }
+            }
             HapticService.error()
         }
     }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1640,6 +1640,13 @@ struct ControlView: View {
         let previousViewingId = viewingMissionId
         viewingMissionId = id
 
+        // Fire-and-forget: tell the backend the user opened this mission.
+        // First call (per AwaitingUser round) starts the 1h ack grace timer
+        // and paints the "opened" dot in Finished; later calls are no-ops.
+        Task { [api] in
+            _ = try? await api.markMissionOpened(id: id)
+        }
+
         // Clear stale workers from previous mission immediately
         childMissions = []
 
@@ -1659,20 +1666,10 @@ struct ControlView: View {
         }
 
         do {
-            // Fan out metadata + events in parallel — they share only `id`,
-            // and the events fetch can be the bigger payload. Previously the
-            // events fetch waited for getMission to return, adding one
-            // mandatory RTT for nothing. (UX audit item #2.)
             async let metadataTask = api.getMission(id: id)
-            async let eventsTask: MissionEventsResult? =
-                try? await api.getMissionEventsWithMeta(
-                    id: id,
-                    types: historyEventTypes,
-                    limit: Self.initialEventLimit,
-                    latest: true
-                )
+            async let transcriptTask: MissionTranscriptResult? = try? await api.getMissionTranscript(id: id)
             let mission = try await metadataTask
-            let eventResult = await eventsTask
+            let transcriptResult = await transcriptTask
 
             // Race condition guard: only update if this is still the mission we want
             guard fetchingMissionId == id else {
@@ -1683,25 +1680,49 @@ struct ControlView: View {
                 currentMission = mission
             }
 
-            if let result = eventResult {
-                let events = result.events
+            if let transcript = transcriptResult {
+                let events = transcript.messages.map(\.storedEvent)
                 if events.isEmpty {
                     // Clear stale cache when events are empty to prevent visual flashing
                     removeMissionFromCache(mission.id)
                     applyViewingMission(mission)
                 } else {
-                    hasMoreHistory = events.count >= Self.initialEventLimit
+                    hasMoreHistory = transcript.eventCounts.values.reduce(0, +) > events.count
                     applyViewingMissionWithEvents(mission, events: events)
+                    if transcript.latestSequence > 0 {
+                        missionMaxSeq[id] = transcript.latestSequence
+                    }
+                    cacheMissionWithEvents(mission, events: events)
+                    Task { [api] in
+                        if let trace = try? await api.getMissionTraceWithMeta(id: id, limit: Self.initialEventLimit, sinceSeq: 0),
+                           !trace.events.isEmpty {
+                            await MainActor.run {
+                                guard fetchingMissionId == id || viewingMissionId == id else { return }
+                                let merged = (events + trace.events).sorted { $0.sequence < $1.sequence }
+                                applyViewingMissionWithEvents(mission, events: merged)
+                                if let maxSeq = trace.maxSequence, maxSeq > 0 {
+                                    missionMaxSeq[id] = maxSeq
+                                }
+                                cacheMissionWithEvents(mission, events: merged)
+                            }
+                        }
+                    }
+                }
+            } else {
+                let fallback = try? await api.getMissionEventsWithMeta(
+                    id: id,
+                    types: historyEventTypes,
+                    limit: Self.initialEventLimit,
+                    latest: true
+                )
+                if let result = fallback, !result.events.isEmpty {
+                    hasMoreHistory = result.events.count >= Self.initialEventLimit
+                    applyViewingMissionWithEvents(mission, events: result.events)
                     if let maxSeq = result.maxSequence, maxSeq > 0 {
                         missionMaxSeq[id] = maxSeq
                     }
-                    // Cache the mission with events for next time
-                    cacheMissionWithEvents(mission, events: events)
-                }
-            } else {
-                // Events fetch failed. If we already displayed cached data,
-                // keep it; otherwise fall back to the basic history view.
-                if !hasCache {
+                    cacheMissionWithEvents(mission, events: result.events)
+                } else if !hasCache {
                     removeMissionFromCache(mission.id)
                     applyViewingMission(mission)
                 }
@@ -5148,9 +5169,11 @@ private struct MissionRow: View {
         switch status {
         case .pending: return Theme.warning
         case .active: return Theme.success
+        case .awaitingUser: return Theme.warning
+        case .acknowledged: return Theme.success
         case .completed: return Theme.textMuted
         case .failed: return Theme.error
-        case .interrupted, .blocked: return Theme.warning
+        case .interrupted, .blocked: return Theme.error
         case .notFeasible: return Theme.error
         case .unknown: return Theme.textMuted
         }
@@ -5163,6 +5186,8 @@ private struct MissionRow: View {
         switch status {
         case .pending: return "clock.fill"
         case .active: return "play.circle.fill"
+        case .awaitingUser: return "hand.wave.fill"
+        case .acknowledged: return "checkmark.circle.fill"
         case .completed: return "checkmark.circle.fill"
         case .failed: return "xmark.circle.fill"
         case .interrupted: return "pause.circle.fill"

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1700,7 +1700,19 @@ struct ControlView: View {
                            !trace.events.isEmpty {
                             await MainActor.run {
                                 guard fetchingMissionId == id || viewingMissionId == id else { return }
-                                let merged = (events + trace.events).sorted { $0.sequence < $1.sequence }
+                                // Deduplicate by sequence — transcript and
+                                // trace endpoints can overlap on shared
+                                // sequence numbers (the web client does the
+                                // same via a Map keyed by sequence in its
+                                // `renderDeferredTraceRef`). Without dedup
+                                // any overlapping event would render twice
+                                // after the deferred trace fetch lands.
+                                var bySequence: [Int64: StoredEvent] = [:]
+                                bySequence.reserveCapacity(events.count + trace.events.count)
+                                for e in events { bySequence[e.sequence] = e }
+                                for e in trace.events { bySequence[e.sequence] = e }
+                                let merged = bySequence.values
+                                    .sorted { $0.sequence < $1.sequence }
                                 applyViewingMissionWithEvents(mission, events: merged)
                                 if let maxSeq = trace.maxSequence, maxSeq > 0 {
                                     missionMaxSeq[id] = maxSeq

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1689,7 +1689,19 @@ struct ControlView: View {
                     removeMissionFromCache(mission.id)
                     applyViewingMission(mission)
                 } else {
-                    hasMoreHistory = transcript.eventCounts.values.reduce(0, +) > events.count
+                    // Mirror the web client's transcript-meta fix: only
+                    // count event types the iOS app actually loads. The
+                    // backend's `event_counts` includes debug/status
+                    // events outside `historyEventTypes`; summing them
+                    // all inflates the total and keeps the "Load earlier
+                    // messages" affordance visible on missions that have
+                    // already shown every loadable event.
+                    let loadable = Set(historyEventTypes)
+                    let loadableTotal = transcript.eventCounts
+                        .filter { loadable.contains($0.key) }
+                        .values
+                        .reduce(0, +)
+                    hasMoreHistory = loadableTotal > events.count
                     applyViewingMissionWithEvents(mission, events: events)
                     if transcript.latestSequence > 0 {
                         missionMaxSeq[id] = transcript.latestSequence

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1659,8 +1659,20 @@ struct ControlView: View {
         }
 
         do {
-            // Fetch mission metadata first (required)
-            let mission = try await api.getMission(id: id)
+            // Fan out metadata + events in parallel — they share only `id`,
+            // and the events fetch can be the bigger payload. Previously the
+            // events fetch waited for getMission to return, adding one
+            // mandatory RTT for nothing. (UX audit item #2.)
+            async let metadataTask = api.getMission(id: id)
+            async let eventsTask: MissionEventsResult? =
+                try? await api.getMissionEventsWithMeta(
+                    id: id,
+                    types: historyEventTypes,
+                    limit: Self.initialEventLimit,
+                    latest: true
+                )
+            let mission = try await metadataTask
+            let eventResult = await eventsTask
 
             // Race condition guard: only update if this is still the mission we want
             guard fetchingMissionId == id else {
@@ -1671,17 +1683,8 @@ struct ControlView: View {
                 currentMission = mission
             }
 
-            // Try to fetch full event history (optional - fall back to basic history if it fails)
-            do {
-                // Fetch all relevant event types including thinking events (matching web dashboard behavior)
-                let result = try await api.getMissionEventsWithMeta(id: id, types: historyEventTypes, limit: Self.initialEventLimit, latest: true)
+            if let result = eventResult {
                 let events = result.events
-
-                // Race condition guard after the second await
-                guard fetchingMissionId == id else {
-                    return
-                }
-
                 if events.isEmpty {
                     // Clear stale cache when events are empty to prevent visual flashing
                     removeMissionFromCache(mission.id)
@@ -1695,18 +1698,13 @@ struct ControlView: View {
                     // Cache the mission with events for next time
                     cacheMissionWithEvents(mission, events: events)
                 }
-            } catch {
-                print("Failed to load mission events (falling back to basic history): \(error)")
-                guard fetchingMissionId == id else {
-                    return
-                }
-                // If we already displayed cached data, keep it and don't flash to basic view
-                // Only clear cache and fall back if we didn't have cached data to begin with
+            } else {
+                // Events fetch failed. If we already displayed cached data,
+                // keep it; otherwise fall back to the basic history view.
                 if !hasCache {
                     removeMissionFromCache(mission.id)
                     applyViewingMission(mission)
                 }
-                // Otherwise: keep the cached view displayed, don't cause a flash
             }
 
             isLoading = false
@@ -2251,9 +2249,11 @@ struct ControlView: View {
         HapticService.lightTap()
 
         // Generate temp ID and add message optimistically BEFORE the API call
-        // This ensures messages appear in send order, not response order
+        // This ensures messages appear in send order, not response order.
+        // The `isPending` flag dims the bubble and shows a tiny spinner so
+        // users on a slow network don't re-tap. (UX audit item #11.)
         let tempId = "temp-\(UUID().uuidString)"
-        let tempMessage = ChatMessage(id: tempId, type: .user, content: content)
+        let tempMessage = ChatMessage(id: tempId, type: .user, content: content, isPending: true)
         messages.append(tempMessage)
         recomputeGroupedItems()
         scrollToBottomTick += 1
@@ -2263,10 +2263,17 @@ struct ControlView: View {
                 let (messageId, queued) = try await api.sendMessage(content: content)
 
                 // Replace temp ID with server-assigned ID, preserving timestamp
-                // This allows SSE handler to correctly deduplicate
+                // This allows SSE handler to correctly deduplicate. Pending
+                // state is cleared so the bubble snaps back to full opacity.
                 if let index = messages.firstIndex(where: { $0.id == tempId }) {
                     let originalTimestamp = messages[index].timestamp
-                    messages[index] = ChatMessage(id: messageId, type: .user, content: content, timestamp: originalTimestamp)
+                    messages[index] = ChatMessage(
+                        id: messageId,
+                        type: .user,
+                        content: content,
+                        timestamp: originalTimestamp,
+                        isPending: false
+                    )
                 }
 
                 // Update queue count when message was queued
@@ -2486,7 +2493,21 @@ struct ControlView: View {
         // Clear stale workers from previous mission immediately
         childMissions = []
 
-        isLoading = true
+        // Cache-first render so mission switches don't blank the chat.
+        // `loadMission` has done this for a while; `switchToMission` (used by
+        // the mission switcher, running-mission chip, worker peek) used to
+        // skip the cache and show `LoadingView("Loading conversation…")`
+        // until both the metadata and the events round-trips returned —
+        // multi-second blank on a slow link even when the data was already
+        // on disk. (UX audit item #1.)
+        let hasCache: Bool
+        if let cached = loadCachedMissionData(id) {
+            applyViewingMissionWithEvents(cached.mission, events: cached.events)
+            hasCache = true
+        } else {
+            hasCache = false
+            isLoading = true
+        }
 
         // Determine the run state for this mission from runningMissions
         if let runningInfo = runningMissions.first(where: { $0.missionId == id }) {
@@ -2508,8 +2529,14 @@ struct ControlView: View {
         progress = nil
 
         do {
-            // Load the mission from API
-            let mission = try await api.getMission(id: id)
+            // Fan out metadata + events in parallel. They share only `id`, so
+            // the previous serial chain (getMission then
+            // getMissionEventsWithMeta) added one mandatory RTT for nothing.
+            // (UX audit item #2.)
+            async let metadataTask = api.getMission(id: id)
+            async let eventsTask: MissionEventsResult? = try? await api.getMissionEventsWithMeta(id: id, types: historyEventTypes)
+            let mission = try await metadataTask
+            let eventResult = await eventsTask
 
             // Race condition guard: only update if this is still the mission we want
             guard fetchingMissionId == id else {
@@ -2521,19 +2548,16 @@ struct ControlView: View {
                 currentMission = mission
             }
 
-            // Fetch full event history to avoid partial history rendering.
-            // Use the meta variant so the `X-Max-Sequence` header seeds the
-            // delta-resume cursor — otherwise missions loaded via the switcher
-            // would always fall back to a full tail reload on reconnect.
-            if let result = try? await api.getMissionEventsWithMeta(id: id, types: historyEventTypes), !result.events.isEmpty {
-                guard fetchingMissionId == id else { return }
+            if let result = eventResult, !result.events.isEmpty {
                 applyViewingMissionWithEvents(mission, events: result.events)
                 if let maxSeq = result.maxSequence, maxSeq > 0 {
                     missionMaxSeq[id] = maxSeq
                 }
                 cacheMissionWithEvents(mission, events: result.events)
-            } else {
-                guard fetchingMissionId == id else { return }
+            } else if !hasCache {
+                // Only fall through to "no events" if we never rendered the
+                // cached transcript — otherwise an intermittent events
+                // failure would blow away a perfectly good cached view.
                 removeMissionFromCache(mission.id)
                 applyViewingMission(mission)
             }
@@ -3274,6 +3298,19 @@ private struct MessageBubble: View {
                             topTrailingRadius: 20
                         )
                     )
+                    // While the message is awaiting server ack, dim the bubble
+                    // and overlay a small spinner so the user has unambiguous
+                    // feedback that the send is in flight. (UX audit item #11.)
+                    .opacity(message.isPending ? 0.55 : 1)
+                    .overlay(alignment: .bottomTrailing) {
+                        if message.isPending {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .tint(.white)
+                                .padding(6)
+                        }
+                    }
+                    .animation(.easeOut(duration: 0.15), value: message.isPending)
                     .contextMenu {
                         Button {
                             onCopy?()

--- a/ios_dashboard/SandboxedDashboard/Views/Control/NewMissionSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/NewMissionSheet.swift
@@ -15,7 +15,7 @@ struct NewMissionSheet: View {
     
     // Backend and agent selection
     @State private var backends: [Backend] = Backend.defaults
-    @State private var enabledBackendIds: Set<String> = ["opencode", "claudecode", "amp"]
+    @State private var enabledBackendIds: Set<String> = ["opencode", "claudecode", "amp", "codex", "gemini", "grok"]
     @State private var backendAgents: [String: [BackendAgent]] = [:]
     @State private var selectedAgentValue: String = ""
     
@@ -435,6 +435,10 @@ struct NewMissionSheet: View {
             // Only show Google models for Gemini
             return providers.filter { $0.id == "google" }
         }
+        if backend == "grok" {
+            // Only show xAI models for Grok Build
+            return providers.filter { $0.id == "xai" }
+        }
         return providers
     }
     
@@ -444,7 +448,14 @@ struct NewMissionSheet: View {
         isLoading = true
         defer { isLoading = false }
 
-        let data = await BackendAgentService.loadBackendsAndAgents()
+        // Fetch backends/agents and providers concurrently. Previously these
+        // ran serially even though they share no state — the providers fetch
+        // is what's gating the model picker, so users on a slow link saw the
+        // form half-populated. (UX audit item #15.)
+        async let backendDataTask = BackendAgentService.loadBackendsAndAgents()
+        async let providersTask: ProvidersResponse? = try? api.listProviders()
+
+        let data = await backendDataTask
         backends = data.backends
         enabledBackendIds = data.enabledBackendIds
         backendAgents = data.backendAgents
@@ -461,7 +472,7 @@ struct NewMissionSheet: View {
                     selectedAgentValue = savedDefault
                 }
             }
-            
+
             // Fall back to Sisyphus or first available
             if selectedAgentValue.isEmpty {
                 if let sisyphus = backendAgents["opencode"]?.first(where: { $0.name == "Sisyphus" }) {
@@ -472,14 +483,8 @@ struct NewMissionSheet: View {
                 }
             }
         }
-        
-        // Load providers
-        do {
-            let response = try await api.listProviders()
-            providers = response.providers
-        } catch {
-            providers = []
-        }
+
+        providers = (await providersTask)?.providers ?? []
     }
 }
 

--- a/ios_dashboard/SandboxedDashboard/Views/FidoApproval/FidoApprovalOverlay.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/FidoApproval/FidoApprovalOverlay.swift
@@ -54,6 +54,7 @@ struct FidoApprovalOverlay: View {
                             .padding(.vertical, 8)
 
                             // Quick auto-approve chip
+                            let isInFlight = fidoState.inFlightRequestIds.contains(request.id)
                             Button {
                                 fidoState.addAutoApprovalRule(
                                     type: .allSSH,
@@ -74,24 +75,48 @@ struct FidoApprovalOverlay: View {
                                 .background(.ultraThinMaterial)
                                 .clipShape(Capsule())
                             }
+                            .disabled(isInFlight)
+                            .opacity(isInFlight ? 0.5 : 1)
 
-                            // Action buttons
+                            // Action buttons — show a spinner inside whichever
+                            // button is in flight so the user can't double-fire
+                            // approve/deny on a slow link. (UX audit item #23a.)
                             HStack(spacing: 16) {
                                 Button {
                                     Task { await fidoState.deny(request.id) }
                                 } label: {
-                                    Label("Deny", systemImage: "xmark")
-                                        .frame(maxWidth: .infinity)
+                                    HStack(spacing: 6) {
+                                        if isInFlight {
+                                            ProgressView()
+                                                .controlSize(.small)
+                                                .tint(Theme.error)
+                                        } else {
+                                            Image(systemName: "xmark")
+                                        }
+                                        Text("Deny")
+                                    }
+                                    .frame(maxWidth: .infinity)
                                 }
                                 .buttonStyle(GlassDenyButtonStyle())
+                                .disabled(isInFlight)
 
                                 Button {
                                     Task { await fidoState.approve(request.id) }
                                 } label: {
-                                    Label("Approve", systemImage: "checkmark")
-                                        .frame(maxWidth: .infinity)
+                                    HStack(spacing: 6) {
+                                        if isInFlight {
+                                            ProgressView()
+                                                .controlSize(.small)
+                                                .tint(.white)
+                                        } else {
+                                            Image(systemName: "checkmark")
+                                        }
+                                        Text("Approve")
+                                    }
+                                    .frame(maxWidth: .infinity)
                                 }
                                 .buttonStyle(GlassApproveButtonStyle())
+                                .disabled(isInFlight)
                             }
                         }
                     }

--- a/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
@@ -74,7 +74,7 @@ struct FilesView: View {
                     ScrollView {
                         LazyVStack(spacing: 8) {
                             ForEach(0..<8, id: \.self) { _ in
-                                ShimmerCard()
+                                ShimmerFileRow()
                             }
                         }
                         .padding(.horizontal, 16)

--- a/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
@@ -29,6 +29,17 @@ struct FilesView: View {
     // Track workspace changes
     @State private var lastWorkspaceId: String?
 
+    /// In-memory cache of directory listings keyed by path. Used to render
+    /// the previous contents immediately on navigation (stale-while-revalidate)
+    /// so the file browser stops flashing to a full-screen spinner every time
+    /// the user taps into or out of a folder. The cache is per-workspace
+    /// (cleared when `selectedWorkspace` changes) and bounded — at ~50
+    /// entries it covers any realistic navigation pattern without bloating
+    /// memory. (UX audit item #5.)
+    @State private var pathCache: [String: [FileEntry]] = [:]
+    @State private var pathCacheOrder: [String] = []
+    private let pathCacheLimit = 50
+
     private let api = APIService.shared
     
     private var sortedEntries: [FileEntry] {
@@ -57,7 +68,18 @@ struct FilesView: View {
                 
                 // File list
                 if isLoading {
-                    LoadingView(message: "Loading files...")
+                    // Skeleton placeholders instead of a centered spinner so
+                    // the screen has shape while the listing is in flight.
+                    // (UX audit item #29.)
+                    ScrollView {
+                        LazyVStack(spacing: 8) {
+                            ForEach(0..<8, id: \.self) { _ in
+                                ShimmerCard()
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                    }
                 } else if let error = errorMessage {
                     EmptyStateView(
                         icon: "exclamationmark.triangle",
@@ -224,9 +246,12 @@ struct FilesView: View {
             await loadDirectory()
         }
         .onChange(of: workspaceState.selectedWorkspace?.id) { _, newId in
-            // Handle workspace change from other tabs
+            // Handle workspace change from other tabs. Paths are
+            // workspace-scoped (host vs container), so wipe the cache to
+            // avoid showing a container directory while browsing the host.
             if newId != lastWorkspaceId {
                 lastWorkspaceId = newId
+                invalidatePathCache()
                 navigateTo(workspaceState.filesBasePath)
             }
         }
@@ -418,30 +443,70 @@ struct FilesView: View {
     private func loadDirectory() async {
         let pathToLoad = currentPath
         fetchingPath = pathToLoad
-        
-        isLoading = true
         errorMessage = nil
-        
+
+        // Stale-while-revalidate: if we have a cached listing for this path,
+        // render it instantly and only show the full-screen spinner when we
+        // have nothing to show. Refresh happens in the background regardless.
+        if let cached = pathCache[pathToLoad] {
+            entries = cached
+            isLoading = false
+            touchCacheKey(pathToLoad)
+        } else {
+            entries = []
+            isLoading = true
+        }
+
         do {
             let result = try await api.listDirectory(path: pathToLoad)
-            
+
             // Race condition guard: only update if this is still the path we want
             guard fetchingPath == pathToLoad else {
                 return // Navigation changed, discard this response
             }
-            
+
             entries = result
+            cachePath(pathToLoad, entries: result)
         } catch {
             // Race condition guard
             guard fetchingPath == pathToLoad else { return }
-            
-            errorMessage = error.localizedDescription
+
+            // Only surface the error when we have no cached fallback to show;
+            // otherwise the stale listing is better than an error screen.
+            if pathCache[pathToLoad] == nil {
+                errorMessage = error.localizedDescription
+            }
         }
-        
+
         // Only clear loading if this is still the current fetch
         if fetchingPath == pathToLoad {
             isLoading = false
         }
+    }
+
+    /// Insert/refresh a directory in the LRU cache.
+    private func cachePath(_ path: String, entries: [FileEntry]) {
+        pathCache[path] = entries
+        pathCacheOrder.removeAll { $0 == path }
+        pathCacheOrder.append(path)
+        while pathCacheOrder.count > pathCacheLimit {
+            let oldest = pathCacheOrder.removeFirst()
+            pathCache.removeValue(forKey: oldest)
+        }
+    }
+
+    /// Move a path to the back of the LRU order without re-inserting entries.
+    private func touchCacheKey(_ path: String) {
+        guard pathCache[path] != nil else { return }
+        pathCacheOrder.removeAll { $0 == path }
+        pathCacheOrder.append(path)
+    }
+
+    /// Clear the cache (e.g. when the workspace changes — paths between
+    /// workspaces are not interchangeable).
+    private func invalidatePathCache() {
+        pathCache.removeAll()
+        pathCacheOrder.removeAll()
     }
     
     private func navigateTo(_ path: String) {
@@ -461,14 +526,17 @@ struct FilesView: View {
     
     private func createFolder() async {
         guard !newFolderName.isEmpty else { return }
-        
-        let folderPath = currentPath.hasSuffix("/") 
-            ? currentPath + newFolderName 
+
+        let folderPath = currentPath.hasSuffix("/")
+            ? currentPath + newFolderName
             : currentPath + "/" + newFolderName
-        
+
         do {
             try await api.createDirectory(path: folderPath)
             newFolderName = ""
+            // Invalidate the current path so we refetch from the server
+            // rather than showing the stale cached listing.
+            pathCache.removeValue(forKey: currentPath)
             await loadDirectory()
             HapticService.success()
         } catch {
@@ -476,13 +544,20 @@ struct FilesView: View {
             HapticService.error()
         }
     }
-    
+
     private func deleteSelected() async {
         guard let entry = selectedEntry else { return }
-        
+
         do {
             try await api.deleteFile(path: entry.path, recursive: entry.isDirectory)
             selectedEntry = nil
+            pathCache.removeValue(forKey: currentPath)
+            // If we deleted a directory, drop its cached listing too —
+            // otherwise re-entering the same path name later would render
+            // ghost contents from before the delete.
+            if entry.isDirectory {
+                pathCache.removeValue(forKey: entry.path)
+            }
             await loadDirectory()
             HapticService.success()
         } catch {
@@ -516,9 +591,10 @@ struct FilesView: View {
                     return
                 }
             }
+            pathCache.removeValue(forKey: currentPath)
             await loadDirectory()
             HapticService.success()
-            
+
         case .failure(let error):
             errorMessage = error.localizedDescription
             HapticService.error()

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -289,15 +289,25 @@ struct HistoryView: View {
     }
 
     private func deleteMission(_ mission: Mission) async {
+        // Optimistic remove BEFORE the network call so the row slides out
+        // on the same frame as the swipe-to-delete gesture even on a slow
+        // connection. On failure we re-insert the mission so the UI
+        // reflects the server's actual state.
+        let removalIndex = missions.firstIndex(where: { $0.id == mission.id })
+        withAnimation {
+            missions.removeAll { $0.id == mission.id }
+        }
         do {
             _ = try await api.deleteMission(id: mission.id)
-            withAnimation {
-                missions.removeAll { $0.id == mission.id }
-            }
             HapticService.success()
         } catch {
             HapticService.error()
             errorMessage = "Failed to delete mission: \(error.localizedDescription)"
+            if let idx = removalIndex {
+                withAnimation {
+                    missions.insert(mission, at: min(idx, missions.count))
+                }
+            }
         }
     }
 

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -24,17 +24,17 @@ struct HistoryView: View {
     enum StatusFilter: String, CaseIterable {
         case all = "All"
         case active = "Active"
-        case interrupted = "Interrupted"
+        case needsYou = "Needs You"
         case completed = "Completed"
         case failed = "Failed"
-        
+
         var missionStatuses: [MissionStatus]? {
             switch self {
             case .all: return nil
             case .active: return [.pending, .active]
-            case .interrupted: return [.interrupted, .blocked, .unknown]
-            case .completed: return [.completed]
-            case .failed: return [.failed, .notFeasible]
+            case .needsYou: return [.awaitingUser]
+            case .completed: return [.completed, .acknowledged]
+            case .failed: return [.failed, .notFeasible, .interrupted, .blocked, .unknown]
             }
         }
     }
@@ -135,7 +135,7 @@ struct HistoryView: View {
                         ScrollView {
                             LazyVStack(spacing: 12) {
                                 ForEach(0..<6, id: \.self) { _ in
-                                    ShimmerCard()
+                                    ShimmerMissionRow()
                                 }
                             }
                             .padding()
@@ -383,7 +383,7 @@ private struct FilterPill: View {
 
 private struct MissionRow: View {
     let mission: Mission
-    
+
     private var backendColor: Color {
         BackendAgentService.color(for: mission.backend)
     }
@@ -391,7 +391,21 @@ private struct MissionRow: View {
     private var backendIcon: String {
         BackendAgentService.icon(for: mission.backend)
     }
-    
+
+    /// True when the mission lives under "Finished" (any terminal status)
+    /// AND the user has already opened it at least once. Drives the small
+    /// notification dot rendered next to the title, mirroring the web
+    /// dashboard's behaviour.
+    private var showOpenedDot: Bool {
+        guard mission.firstViewedAt != nil else { return false }
+        switch mission.status {
+        case .completed, .acknowledged, .failed, .interrupted, .blocked, .notFeasible:
+            return true
+        default:
+            return false
+        }
+    }
+
     var body: some View {
         HStack(spacing: 14) {
             // Icon based on backend
@@ -401,13 +415,22 @@ private struct MissionRow: View {
                 .frame(width: 40, height: 40)
                 .background((mission.canResume ? Theme.warning : backendColor).opacity(0.15))
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-            
+
             // Content
             VStack(alignment: .leading, spacing: 4) {
-                Text(mission.displayTitle)
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(Theme.textPrimary)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(mission.displayTitle)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+
+                    if showOpenedDot {
+                        Circle()
+                            .fill(Theme.textMuted)
+                            .frame(width: 6, height: 6)
+                            .accessibilityLabel("Opened")
+                    }
+                }
                 
                 HStack(spacing: 6) {
                     StatusBadge(status: mission.status.statusType, compact: true)

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -129,7 +129,17 @@ struct HistoryView: View {
                 // Content with floating cleanup button
                 ZStack(alignment: .bottomTrailing) {
                     if isLoading {
-                        LoadingView(message: "Loading history...")
+                        // Skeleton card scaffold — keeps the screen sized
+                        // while the list loads so we don't flash a centered
+                        // spinner. (UX audit item #29.)
+                        ScrollView {
+                            LazyVStack(spacing: 12) {
+                                ForEach(0..<6, id: \.self) { _ in
+                                    ShimmerCard()
+                                }
+                            }
+                            .padding()
+                        }
                     } else if let error = errorMessage {
                         EmptyStateView(
                             icon: "exclamationmark.triangle",
@@ -375,21 +385,11 @@ private struct MissionRow: View {
     let mission: Mission
     
     private var backendColor: Color {
-        switch mission.backend {
-        case "opencode": return Theme.success
-        case "claudecode": return Theme.accent
-        case "amp": return .orange
-        default: return Theme.accent
-        }
+        BackendAgentService.color(for: mission.backend)
     }
-    
+
     private var backendIcon: String {
-        switch mission.backend {
-        case "opencode": return "terminal"
-        case "claudecode": return "brain"
-        case "amp": return "bolt.fill"
-        default: return "target"
-        }
+        BackendAgentService.icon(for: mission.backend)
     }
     
     var body: some View {

--- a/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Settings/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
     
     // Default agent settings
     @State private var backends: [Backend] = Backend.defaults
-    @State private var enabledBackendIds: Set<String> = ["opencode", "claudecode", "amp"]
+    @State private var enabledBackendIds: Set<String> = ["opencode", "claudecode", "amp", "codex", "gemini", "grok"]
     @State private var backendAgents: [String: [BackendAgent]] = [:]
     @State private var selectedDefaultAgent: String = ""
     @State private var isLoadingAgents = true

--- a/ios_dashboard/SandboxedDashboard/Views/Terminal/TerminalView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Terminal/TerminalView.swift
@@ -283,16 +283,33 @@ struct TerminalView: View {
         state.webSocketTask?.resume()
 
         // Start receiving messages. The connection-status transition to
-        // `.connected` and the "Connected." line are now driven by the first
-        // successful message receive (see `receiveMessages`) — the previous
-        // 500 ms fixed timer added unnecessary latency on fast networks and
-        // masked failure on slow ones. (UX audit item #18.)
+        // `.connected` and the "Connected." line are driven by the first
+        // successful message receive (see `receiveMessages`) — typical
+        // shells print a prompt on open, so the fast path is "promote as
+        // soon as bytes flow". The previous fixed 500 ms timer added
+        // unnecessary latency on fast networks and masked failure on slow
+        // ones. (UX audit item #18.)
         receiveMessages()
 
         // Send initial resize immediately so the shell sizes correctly on
         // open; this is just a control message and doesn't depend on the
         // status transition.
         sendResize(cols: 80, rows: 24)
+
+        // Fallback: a silent shell (waiting on input, slow init script,
+        // workspaces/<id>/shell endpoints that don't echo a banner) would
+        // otherwise leave us in "Connecting" forever because no inbound
+        // message ever triggers the promotion above. Promote after 3 s as
+        // long as the websocket is still attached and hasn't errored or
+        // been deliberately disconnected.
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            guard state.webSocketTask != nil,
+                  state.connectionStatus == .connecting else { return }
+            state.connectionStatus = .connected
+            state.isConnecting = false
+            state.appendLine(TerminalLine(text: "Connected.", type: .system))
+        }
     }
     
     private func disconnect() {

--- a/ios_dashboard/SandboxedDashboard/Views/Terminal/TerminalView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Terminal/TerminalView.swift
@@ -47,11 +47,14 @@ struct TerminalView: View {
                     ForEach(workspaceState.workspaces) { workspace in
                         Button {
                             workspaceState.selectWorkspace(id: workspace.id)
-                            // Reconnect to the new workspace
+                            // Reconnect to the new workspace. The previous
+                            // 0.3 s delay between disconnect and connect was
+                            // a guess at "let URLSession clean up"; in
+                            // practice cancelling and re-resuming a
+                            // webSocketTask is synchronous enough that the
+                            // delay was just visible latency. (UX audit #18.)
                             disconnect()
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                connect()
-                            }
+                            connect()
                             HapticService.selectionChanged()
                         } label: {
                             HStack {
@@ -278,19 +281,18 @@ struct TerminalView: View {
         
         state.webSocketTask = URLSession.shared.webSocketTask(with: request)
         state.webSocketTask?.resume()
-        
-        // Start receiving messages
+
+        // Start receiving messages. The connection-status transition to
+        // `.connected` and the "Connected." line are now driven by the first
+        // successful message receive (see `receiveMessages`) — the previous
+        // 500 ms fixed timer added unnecessary latency on fast networks and
+        // masked failure on slow ones. (UX audit item #18.)
         receiveMessages()
-        
-        // Send initial resize message after a brief delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            if state.connectionStatus == .connecting {
-                state.connectionStatus = .connected
-                state.appendLine(TerminalLine(text: "Connected.", type: .system))
-            }
-            state.isConnecting = false
-            sendResize(cols: 80, rows: 24)
-        }
+
+        // Send initial resize immediately so the shell sizes correctly on
+        // open; this is just a control message and doesn't depend on the
+        // status transition.
+        sendResize(cols: 80, rows: 24)
     }
     
     private func disconnect() {
@@ -318,6 +320,15 @@ struct TerminalView: View {
         state.webSocketTask?.receive { [self] result in
             switch result {
             case .success(let message):
+                // Promote to `.connected` on the first successful message
+                // rather than after a hardcoded 0.5 s timer.
+                Task { @MainActor in
+                    if state.connectionStatus != .connected {
+                        state.connectionStatus = .connected
+                        state.isConnecting = false
+                        state.appendLine(TerminalLine(text: "Connected.", type: .system))
+                    }
+                }
                 switch message {
                 case .string(let text):
                     Task { @MainActor in
@@ -336,9 +347,10 @@ struct TerminalView: View {
                 Task { @MainActor in
                     receiveMessages()
                 }
-                
+
             case .failure(let error):
                 Task { @MainActor in
+                    state.isConnecting = false
                     if state.connectionStatus != .disconnected {
                         state.connectionStatus = .error
                         state.appendLine(TerminalLine(text: "Connection error: \(error.localizedDescription)", type: .error))

--- a/ios_dashboard/SandboxedDashboard/Views/Workspaces/WorkspacesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Workspaces/WorkspacesView.swift
@@ -24,7 +24,7 @@ struct WorkspacesView: View {
                 ScrollView {
                     LazyVStack(spacing: 12) {
                         ForEach(0..<5, id: \.self) { _ in
-                            ShimmerCard()
+                            ShimmerWorkspaceCard()
                         }
                     }
                     .padding()

--- a/ios_dashboard/SandboxedDashboard/Views/Workspaces/WorkspacesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Workspaces/WorkspacesView.swift
@@ -19,8 +19,16 @@ struct WorkspacesView: View {
             Theme.backgroundPrimary.ignoresSafeArea()
 
             if isLoading {
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                // Skeleton cards instead of a bare ProgressView so the screen
+                // has structure while the API call completes. (UX audit #29.)
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(0..<5, id: \.self) { _ in
+                            ShimmerCard()
+                        }
+                    }
+                    .padding()
+                }
             } else if let error = errorMessage {
                 VStack(spacing: 16) {
                     Image(systemName: "exclamationmark.triangle")

--- a/ios_dashboard/UX_BLOCKING_AUDIT.md
+++ b/ios_dashboard/UX_BLOCKING_AUDIT.md
@@ -1,0 +1,887 @@
+# iOS Dashboard — UX Blocking Audit & Improvement Backlog
+
+## TL;DR
+
+The app is well-engineered at the plumbing layer (off-main JSON decode,
+mission disk cache, race guards, parallel cold-start) but the **screen layer
+defaults to a centered spinner over a blank view whenever data is in flight**.
+Skeleton primitives (`ShimmerCard`, `ShimmerRow`) exist in the codebase and
+are essentially never used. The five highest-impact freezes are:
+
+1. **Mission switch always blanks the chat** — `switchToMission` ignores the
+   on-disk cache that `loadMission` uses. Fix: mirror the cache-first path.
+   (`ControlView.swift:2474-2541`)
+2. **Mission load is two serial RTTs** — `getMission` then
+   `getMissionEventsWithMeta`. Fix: `async let` both.
+   (`ControlView.swift:1661-1697`)
+3. **BackendAgentService walks 5 backends serially** for configs and agents on
+   every New Mission tap. Fix: two `withTaskGroup`s.
+   (`BackendAgentService.swift:51-96`)
+4. **Send-message has no in-flight state** — the optimistic bubble looks
+   identical to a confirmed one; slow network = re-taps and confusion.
+   (`ControlView.swift:2245-2290`)
+5. **Files / Workspaces / History tabs flash to full-screen spinner** on every
+   open, with no cache and no skeleton.
+
+Lower-tier but real: markdown re-parsed on every body call (#9), event replay
+synchronous on main actor (#4), upload reads whole files into RAM with no
+progress (#6), terminal ANSI parsed inline on each line (#19), desktop frames
+converted on main actor (#20), FIDO approve has no in-flight feedback (#23a),
+and several arbitrary timer-based latencies (#18, #24).
+
+30 numbered findings below; quick-fix backlog grouped by approach in section
+"Improvement backlog"; concrete patch sketches for the top items in the
+appendix.
+
+---
+
+Audit scope: every screen in `SandboxedDashboard/` for points where slow network
+or main-thread work makes the UI feel frozen, blank, or unresponsive. Findings
+are grounded in specific file:line citations so each item is independently
+verifiable.
+
+App stack: SwiftUI + `@Observable`, single `APIService.shared` (15 s request
+timeout, 30 s SSE inactivity timeout, off-main JSON decode via `Task.detached`),
+SSE for live mission events, WebSockets for terminal & desktop stream. Five
+visible tabs (Control / Terminal / Files / History / Settings), plus several
+sheets.
+
+The codebase already does some good things — see "What's already good"
+at the bottom — but the dominant pattern is **full-screen spinner over blank
+view while waiting for the network**. Skeleton primitives (`ShimmerCard`,
+`ShimmerRow` in `LoadingView.swift:48-84`) exist but are essentially **never
+used**; every screen falls back to `LoadingView(message:)` which is a centered
+`ProgressView` over an empty layout.
+
+---
+
+## High-severity blockers (visible freezes on common flows)
+
+### 1. Mission switch always shows a blank spinner — even when cached
+**Where:** `Views/Control/ControlView.swift:2474-2541` (`switchToMission`)
+
+`loadMission` (line 1636) correctly checks the on-disk cache and renders the
+cached mission instantly (line 1648-1651) before fetching fresh events, **but
+the parallel `switchToMission` path used by the mission switcher, running-bar
+chip, and worker peeks does not**. It just sets `isLoading = true` (line 2489)
+and replaces the chat with `LoadingView("Loading conversation...")`
+(line 675-676) until both `getMission` and `getMissionEventsWithMeta` return
+serially.
+
+On a slow link this is 2–30 s of blank screen for content the device already
+has on disk.
+
+**Fix:** Mirror `loadMission`'s cache-first path in `switchToMission`. Call
+`loadCachedMissionData(id)` and `applyViewingMissionWithEvents` immediately,
+then fan-out the refresh in the background.
+
+---
+
+### 2. Mission load fetches metadata and events serially
+**Where:** `ControlView.swift:1661-1697`, `ControlView.swift:2510-2534`
+
+```swift
+let mission = try await api.getMission(id: id)        // RTT 1
+…
+let result = try await api.getMissionEventsWithMeta(…) // RTT 2
+```
+
+These two requests share only `id`; the events fetch does not need the metadata
+response. On a 300 ms-RTT cellular link this is ~600 ms of mandatory latency.
+
+**Fix:** `async let metaTask = api.getMission(id:)` plus
+`async let eventsTask = api.getMissionEventsWithMeta(…)`, then `await` both. Same
+applies to `switchToMission`. The child-mission fetch (line 1716) is already
+backgrounded — good.
+
+---
+
+### 3. Backend/agent loading walks every backend serially
+**Where:** `Services/BackendAgentService.swift:51-96`
+
+```swift
+for backend in backends {
+    let config = try await api.getBackendConfig(backendId: backend.id)
+    …
+}
+for backendId in enabled {
+    let agents = try await api.listBackendAgents(backendId: backendId)
+    …
+}
+```
+
+With 5 backends and a 200 ms RTT, that's 2 s on first New-Mission tap or first
+Settings open — `NewMissionSheet:224-232` and `SettingsView:188-196` both block
+the entire agent picker behind a "Loading agents…" spinner during this time.
+
+**Fix:** Two `withTaskGroup`s — one for configs, one for agents — to fan out.
+A single `async let` per backend would also work but the count is variable.
+
+---
+
+### 4. Historic event replay runs synchronously on the main actor
+**Where:** `ControlView.swift:1445-1501` (`applyViewingMissionWithEvents`)
+
+```swift
+messages.removeAll()
+for event in orderedEvents {
+    …
+    handleStreamEvent(type: event.eventType, data: data, isHistoricalReplay: true)
+}
+recomputeGroupedItems()
+```
+
+`handleStreamEvent` mutates `messages` (an `@State`). On a 5 k-event mission
+this is a multi-frame stall on the main actor while the user stares at a
+half-rendered chat. (`recomputeGroupedItems` is correctly deferred to the end —
+good — but the per-event mutations still observe.)
+
+**Fix:** Move replay off the main actor. Build `[ChatMessage]` and grouped items
+in a `Task.detached` (events + their handler can be pure), then do one bulk
+assignment back on the main actor. Alternatively: batch in chunks of ~100 with
+`Task.yield()` between batches so the runloop can paint a skeleton.
+
+---
+
+### 5. File browsing wipes the list on every navigation
+**Where:** `Views/Files/FilesView.swift:59-73, 418-445`
+
+Every `navigateTo()` (line 447) clears the screen to `LoadingView("Loading
+files...")`. There's no per-path cache, so going up one level and back round-trips
+even though the parent directory was just rendered. The race-condition guard
+(`fetchingPath`) is correct but doesn't help with the blank-screen feel.
+
+**Fix:**
+- LRU-cache directory listings (path → entries, 60 s TTL).
+- Keep the previous listing visible with `.opacity(0.5)` + a subtle progress
+  pill until the new listing arrives — same pattern as cached mission load in
+  Control.
+- Show a `ShimmerRow` skeleton list (the primitive already exists in
+  `LoadingView.swift:48`).
+
+---
+
+### 6. File upload reads the whole file into memory and uploads serially
+**Where:** `FilesView.swift:499-525`, `APIService.swift:447-492`
+
+```swift
+let data = try Data(contentsOf: url)              // whole file in RAM
+let _ = try await api.uploadFile(data: data, …)   // one file at a time
+```
+
+A 200 MB video will OOM-kill the app. Multi-file imports block the picker for
+the duration. There's no progress UI either — the user has no idea anything is
+happening.
+
+**Fix:**
+- Use `URLSession.shared.uploadTask(with:fromFile:)` with the file URL directly
+  (streams from disk). The current MIME-multipart helper would need to write a
+  temp file with the boundary framing, or switch to a single-file PUT.
+- Fan out concurrent uploads with `withTaskGroup` (cap at 3-4 in flight).
+- Add a per-upload progress bar via `URLSessionTaskDelegate` or
+  `URLSession.uploadTask(_:from:).progress`.
+
+---
+
+### 7. Workspaces tab uses legacy completion-handler API and a full-screen spinner
+**Where:** `Views/Workspaces/WorkspacesView.swift:21-25, 102-117`
+
+`isLoading = true` shows a bare `ProgressView` on the whole screen on every
+appear. Creating a workspace dismisses the sheet and re-fetches the entire
+list (line 92-95) — no optimistic insert. The completion-handler API
+(`APIService.listWorkspaces(completion:)`, line 534-543) wraps an async call in
+a `Task` then bounces back to main with `DispatchQueue.main.async` (line 107) —
+unnecessary indirection.
+
+**Fix:**
+- Switch to the async variant.
+- Show 3-4 `ShimmerCard`s during initial load.
+- Optimistically prepend the new workspace on create; reconcile when the API
+  returns.
+- Share the cache with `WorkspaceState.shared.workspaces` so opening the tab
+  while another tab already loaded shows data immediately.
+
+---
+
+### 8. HistoryView loads every mission, no pagination, no server-side search
+**Where:** `Views/History/HistoryView.swift:260-279, 42-60`
+
+`listMissions()` fetches the whole list (no `limit`/`offset` exposed on the
+endpoint here), then `filteredMissions` filters client-side by `searchText`.
+The backend exposes `/api/control/missions/search` (`APIService.swift:286-295`),
+but the UI doesn't call it. On accounts with thousands of missions this is a
+multi-MB download per cold-open of History, while the user stares at
+`LoadingView("Loading history...")`.
+
+**Fix:**
+- Paginate: initial page 50, fetch more on scroll-near-bottom.
+- Use `searchMissions(query:)` for the search bar (debounced 300 ms).
+- Cache the first page in memory; on tab open render immediately, refresh
+  silently in the background.
+
+---
+
+### 9. Markdown re-parsed on every view recomposition
+**Where:** `Views/Components/MarkdownView.swift:20-21`
+
+```swift
+var body: some View {
+    let blocks = MarkdownParser.parse(content)   // runs on every body call
+    …
+}
+```
+
+`MarkdownParser.parse` is a non-trivial line scanner. SwiftUI re-runs `body`
+frequently — every scroll tick, every observed property change, every keyboard
+appearance. For a chat with dozens of assistant messages each containing several
+markdown blocks plus a `MarkdownInlineText` that calls
+`AttributedString(markdown:)` per paragraph, this is real main-thread CPU during
+scroll.
+
+**Fix:** Pre-parse once when a `ChatMessage` is constructed (or in the
+detached-replay refactor in #4), store `[MarkdownBlock]` on the message.
+Memoize `AttributedString` per paragraph as well.
+
+---
+
+### 10. SSE reconnect fallback can fetch the entire history
+**Where:** `ControlView.swift:1820-1888` (`resumeMissionAfterReconnect`)
+
+When the delta-resume path returns `.unsupported`, `.noCursor`, or `.failed`,
+the code reloads the latest page (`getMissionEventsWithMeta(... limit: ...,
+latest: true)`). On a 50 k-event mission, even the "latest" tail can be
+megabytes. The chat freezes during the catch-up.
+
+**Fix:**
+- Cap the fallback fetch to a small window (e.g., 200 events) and surface a
+  "Load earlier" affordance for older content.
+- During catch-up, keep the existing in-memory transcript visible and overlay a
+  thin "Catching up…" pill (the connection banner at line 642-660 already shows
+  for disconnected; this would be a parallel "syncing" state).
+
+---
+
+## Medium-severity issues
+
+### 11. Send button has no in-flight indicator
+**Where:** `ControlView.swift:2245-2290`
+
+Optimistic insert exists (good), but the inserted bubble is indistinguishable
+from a confirmed one — no opacity dim, no ⏳, no disabled state on the send
+button. On a slow link the user re-taps or doubts the send.
+
+**Fix:** Add `isPending: Bool` to `ChatMessage` for the temp message; render at
+70% opacity with a tiny spinner until the SSE confirmation (or the
+`sendMessage` API response) clears it.
+
+---
+
+### 12. Queue sheet loads after opening
+**Where:** `ControlView.swift:2304-2310`, sheet binding `:569-584`
+
+Sheet opens to potentially-stale `queuedItems` while `loadQueueItems()` fires.
+
+**Fix:** Refresh on a 5 s timer when queue length > 0 so the sheet open is
+instantaneous. Also `loadQueueItems` could be invoked when `queueLength`
+transitions above 0 (cheap idempotent prefetch).
+
+---
+
+### 13. Slash command catalog lazy-loaded on first "/"
+**Where:** `ControlView.swift:1106-1118, 1231-1237`
+
+First `/` keypress fires `/api/library/builtin-commands` and the popover stays
+empty for up to 15 s.
+
+**Fix:** Pre-fetch on cold start alongside the other context fetches (line
+413-417). The payload is tiny.
+
+---
+
+### 14. Mission switcher loads recent list AFTER opening
+**Where:** `ControlView.swift:288-294`
+
+```swift
+Task { await loadRecentMissions() }
+showMissionSwitcher = true
+```
+
+Sheet opens, list is empty for a beat.
+
+**Fix:** Keep `recentMissions` warm via a low-frequency background poller (or
+hydrate from `listMissions()` already cached in History tab — share the cache).
+
+---
+
+### 15. NewMissionSheet loads agents then providers serially
+**Where:** `Views/Control/NewMissionSheet.swift:443-483`
+
+`await BackendAgentService.loadBackendsAndAgents()` then
+`await api.listProviders()` — serial, both block the form.
+
+**Fix:** `async let` both. The form's model picker depends on neither in
+parallel.
+
+---
+
+### 16. ContentView auth check shows full-screen "Connecting…"
+**Where:** `ContentView.swift:19-23, 46-67`
+
+Cold open on a slow link: 0-15 s of "Connecting…" with no progress, no retry.
+Health check failure pushes user to LoginView without explanation.
+
+**Fix:** Show the prior tab content opportunistically (rooted in saved JWT) and
+silently re-check health in the background; degrade only on confirmed 401 or
+network failure with retry CTA.
+
+---
+
+### 17. Image cards each fire their own request, no shared cache
+**Where:** `ControlView.swift:3406-3596` (`SharedFileCardView`)
+
+Every image in a message starts an independent `URLSession.shared.data(for:)`
+on `.task`. Three images in a message = three sequential RTTs from the same
+host, no `URLCache` warmup, no shared `NSCache`/`URLSession` configured for
+images, no thumbnail variant requested.
+
+**Fix:**
+- Centralize image fetching in a small `ImageLoader` actor with an `NSCache`
+  keyed by URL+token.
+- Request a thumbnail variant if backend supports it; fall back to full.
+- Render a blurred-hash or color-block placeholder rather than a centered
+  spinner over `Theme.backgroundSecondary` (line 3411-3413, 3426-3428).
+
+---
+
+### 18. Terminal connect has a hardcoded 0.5 s "connected" delay
+**Where:** `Views/Terminal/TerminalView.swift:286-294`
+
+```swift
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+    if state.connectionStatus == .connecting {
+        state.connectionStatus = .connected
+        …
+    }
+}
+```
+
+Arbitrary delay before declaring "Connected" — adds latency on fast networks
+and hides true connection failures on slow ones. Workspace switch adds another
+0.3 s for nothing (line 52).
+
+**Fix:** Mark connected on the first WebSocket message receive (same pattern
+DesktopStreamService uses — line 162-165). Eliminate the 0.3 s
+`DispatchQueue.main.asyncAfter` on workspace switch; rely on connection-state
+transitions.
+
+---
+
+### 19. Terminal ANSI parsing runs eagerly on every line
+**Where:** `Services/TerminalState.swift:65-73`
+
+```swift
+init(text: String, type: LineType) {
+    …
+    if type == .output {
+        self.attributedText = ANSIParser.parse(text)
+    }
+}
+```
+
+A `cat` of a large file pumps thousands of lines through the WebSocket; each
+constructs a `TerminalLine` on `MainActor` (the `receiveMessage` continuation
+is wrapped in `Task { @MainActor in … }`) and parses ANSI inline. Burst output
+freezes the input field.
+
+**Fix:** Coalesce inbound text into a debounced flush (e.g., every 16 ms), parse
+ANSI in a background actor, then bulk-append parsed lines on the main actor.
+
+---
+
+### 20. Desktop stream redraws CGImage→CVPixelBuffer on the main actor
+**Where:** `Services/DesktopStreamService.swift:268-353` (`feedFrameToPipLayer`)
+
+Per-frame at up to 30 fps the service allocates a CVPixelBuffer, locks its base
+address, draws the CGImage through a CGContext, and creates a CMSampleBuffer —
+all on the main actor (`@MainActor` class, called from `handleMessage`).
+
+**Fix:** Move the conversion to a serial background queue or
+`DispatchQueue(label:)`; only `layer.enqueue(sample)` strictly needs to be on
+the main actor (and even that depends on the layer's setup).
+
+---
+
+### 21. Mission cache JSON encode runs on the main actor
+**Where:** `ControlView.swift:1335-1352`
+
+```swift
+// Encode on @MainActor (CachedMissionData transitively contains
+// non-Sendable types) …
+let encoded = try? JSONEncoder().encode(cacheData)
+Task.detached(priority: .utility) { … }
+```
+
+The write is detached (good), but the encode itself can be tens of MB for big
+missions and runs synchronously on the main thread, blocking input and
+animations.
+
+**Fix:** Make `CachedMissionData` and the event types `Sendable` so the encode
+can move to the detached task as well. If full sendability is hard, copy the
+needed fields into a `Sendable` snapshot struct first.
+
+---
+
+### 22. Running-missions poller fires every 3 s with no backoff
+**Where:** `ControlView.swift:2464-2472`
+
+A 3 s tick is reasonable when active, but it keeps firing while the app is in
+the background (the task isn't tied to scenePhase) and during sustained network
+failures. With a 15 s request timeout each failed poll holds a URLSession slot.
+
+**Fix:**
+- Suspend the poller while `scenePhase != .active` (use `.onChange(of:
+  scenePhase)`).
+- Apply 1.5×/2× backoff on consecutive failures, reset on success.
+
+---
+
+### 23. AutomationsView: load before render, full-screen spinner
+**Where:** `Views/Control/AutomationsView.swift:28-30, 136-147`
+
+Single fetch under `LoadingView` until response arrives. Small data, but
+visible flash on a slow link.
+
+**Fix:** Cache last response per `missionId`; on retry show stale-while-revalidate.
+
+---
+
+### 23a. FIDO approval buttons have no in-flight feedback
+**Where:** `Views/FidoApproval/FidoApprovalOverlay.swift:79-94`,
+`Services/FidoApprovalState.swift:83-100`
+
+Tapping **Approve** fires `Task { await fidoState.approve(request.id) }`. The
+request is only removed from `pendingRequests` after `api.fidoRespond(…)`
+returns — up to 15 s. During that window the overlay stays exactly as it was,
+with both buttons still tappable, and the user has no idea whether the tap
+registered. Re-taps will fire duplicate `fidoRespond` calls.
+
+**Fix:** Add `inFlightRequestIds: Set<String>` to `FidoApprovalState`; toggle on
+entry/exit of `approve`/`deny`. In the overlay, disable both buttons and swap
+the icon for a spinner when `request.id ∈ inFlightRequestIds`. Bonus: the
+"Auto-approve SSH for 5 min" chip has the same issue.
+
+---
+
+### 24. SetupSheet adds a fake 500 ms "success" delay
+**Where:** `ContentView.swift:200-202`
+
+```swift
+try? await Task.sleep(for: .milliseconds(500))
+onComplete()
+```
+
+Pure cosmetic latency.
+
+**Fix:** Delete the sleep; the haptic + checkmark already convey success.
+
+---
+
+## Lower-severity / code-quality
+
+### 25. Toolbar status pill conflates "not connected" with "off"
+**Where:** `TerminalView.swift:79-114`
+
+The pill says "Off" in any non-`.connected` state — including `.connecting`,
+`.error`. A user who taps **Connect** sees "Off" until the 0.5 s delay
+(see #18) declares success, then nothing in between.
+
+**Fix:** Add explicit `connecting`/`error` visual states; surface the error in
+the pill rather than only in the overlay banner.
+
+---
+
+### 26. `currentFrame` swapped on every WebSocket message
+**Where:** `DesktopStreamService.swift:181-191`
+
+Each JPEG frame creates a new `UIImage(data: data)` and sets `currentFrame`,
+which re-renders the SwiftUI tree. At 30 fps with a multi-MB image this is
+heavy.
+
+**Fix:** Throttle visible updates (e.g., display-link driven) and defer JPEG
+decoding to a background task; consider switching to streaming HEVC/JPEG via a
+dedicated `AVSampleBufferDisplayLayer` (already half-set-up for PiP).
+
+---
+
+### 27. UserDefaults used as a primary cache
+**Where:** `APIService.swift:69-72, 80-82`, several
+`UserDefaults.standard.bool/set` callsites
+
+`baseURL` and `jwt_token` live in `UserDefaults` (synchronous access, written
+on every change). Frequent draft saves (`ControlView.swift:460-468`) are
+debounced — good — but the underlying defaults DB still holds the prefs across
+the whole app and any large mission-cache blob would be wasted there. (The
+"legacy mission cache" migration at `SandboxedDashboardApp.swift:12-17` confirms
+this was a real problem in the past — comment notes "multi-KB-to-multi-MB JSON
+payload held resident by cfprefsd").
+
+**Fix:** Migrate the JWT to Keychain (Keychain reads can be slow too — cache
+in-memory after first read). Confirm no large blobs slipped back into defaults.
+
+---
+
+### 28. Sheets dismiss into full reloads
+**Where:** `WorkspacesView.swift:85-95`, several
+`onCancel:`/`onComplete:` paths
+
+Closing the New Workspace or New Mission sheet immediately re-fires the
+parent's load function instead of merging the returned item.
+
+**Fix:** Pass the created entity back and merge into the local list optimistically.
+
+---
+
+### 29. No empty-state-while-loading distinction
+**Where:** every screen that uses `LoadingView`
+
+`LoadingView` is centered text + spinner over a transparent background; on
+sub-second responses it's a visible flash. Several screens (`HistoryView:131`,
+`FilesView:59`, `WorkspacesView:21`) sit in the loading branch for >50 ms,
+which is enough for the eye to catch the flash.
+
+**Fix:** Show the screen scaffold (nav title, filter pills, search bar) with
+`ShimmerRow` placeholders for content. Only show `LoadingView` when there is no
+prior scaffold to render. This is a one-time refactor that benefits four
+screens.
+
+---
+
+### 30. Mission switcher backend search debounces the fetch but not the input
+**Where:** `ControlView.swift:4706-4744`
+
+The 250 ms debounce timer fires the API call, but the previous result can land
+after a newer query — race window. Also there's no cancellation when the user
+clears the search box quickly.
+
+**Fix:** Cancel the in-flight task on every text change; only kick off after
+the debounce. Guard updates with the normalized query string (the code already
+does this on line 4728 — good — but still leaves the request in flight).
+
+---
+
+## Improvement backlog (grouped by approach)
+
+### A. Skeletons & cached UX
+1. Use existing `ShimmerCard`/`ShimmerRow` on **History**, **Files**,
+   **Workspaces**, and **Mission detail** instead of `LoadingView`.
+2. **Files**: keep previous listing visible during navigation; LRU cache by
+   path.
+3. **History**: paginate + stale-while-revalidate; share the in-memory mission
+   list with Control's `recentMissions`.
+4. **Control / Mission switch (#1)**: mirror the cached-first path that
+   `loadMission` already implements.
+5. **Image cards (#17)**: shared cache; blurhash/color-block placeholder.
+6. **Markdown (#9)**: parse once at message construction; memoize attributed
+   strings.
+
+### B. Optimistic UI
+1. **Send-message bubble (#11)**: render at 70 % opacity with mini-spinner
+   until confirmed.
+2. **Queue actions** (already optimistic — good).
+3. **Workspace / Folder create (#7, #28)**: prepend on success, reconcile on
+   response.
+4. **Mission delete** (already optimistic — good).
+5. **Mission switch**: render cached transcript immediately while metadata
+   refresh resolves.
+
+### C. Parallelization
+1. **BackendAgentService (#3)**: `withTaskGroup` over backends.
+2. **Mission load (#2)**: `async let` metadata + events.
+3. **Mission switch (#2)**: same.
+4. **NewMissionSheet (#15)**: `async let` agents + providers.
+5. **File upload (#6)**: streamed uploads + concurrent (3-4) for batches.
+6. **Cold-start (already parallel)** — keep, but add slash-command catalog
+   into the fan-out (#13).
+
+### D. Off-main-actor work
+1. **Event replay (#4)**: build messages on a detached task; bulk-assign.
+2. **Markdown parse (#9)**: same as A6 — at construction, not in `body`.
+3. **JSON encode for mission cache (#21)**: detached.
+4. **Desktop frame conversion (#20)**: detached.
+5. **Terminal ANSI parse (#19)**: detached, debounced flush.
+6. **JPEG decode for desktop frames (#26)**: detached + throttle.
+
+### E. Smarter network shape
+1. **History pagination (#8)** + use `searchMissions` server-side.
+2. **SSE reconnect cap (#10)** — don't refetch entire tail.
+3. **Image thumbnails (#17)** — request smaller variants.
+4. **Running-missions poller (#22)** — suspend in background, backoff on error.
+5. **Prefetch slash commands, recent missions, queue** on cold start (#12-14).
+
+### F. Cosmetic latency to delete
+1. `SetupSheet` 500 ms success sleep (#24).
+2. Terminal 0.5 s "connected" timer (#18) and 0.3 s workspace-switch delay.
+3. `DispatchQueue.main.asyncAfter` callsites in ControlView lines 935, 2171,
+   4035 (assorted scroll/animation timers — audit each for necessity).
+
+### G. Cross-cutting plumbing
+1. Introduce a tiny `Cached<T>(ttl:)` wrapper to standardize the
+   stale-while-revalidate pattern (BackendAgentService already implements this
+   manually — generalize).
+2. Centralize per-screen "scaffold + skeleton" so every list view has a
+   consistent loading experience.
+3. Add a "loading state" enum (`idle | loading(cached: …) | loaded | error`)
+   per data source so views can render the right scaffolding without
+   ad-hoc booleans (`isLoading`, `isLoadingEarlier`, `isLoadingHistory`,
+   `isLoadingImage`, `isLoadingAgents`, `isLoadingConnection`, …).
+
+---
+
+## What's already good (don't undo)
+
+- `APIService` runs JSON decoding off-main via `Task.detached`
+  (`APIService.swift:825-839`) — keeps large payloads from hitching the UI.
+- Cold-start `async let` fan-out in ControlView (`:411-417`).
+- File-based mission cache + LRU eviction + atomic writes
+  (`ControlView.swift:1335-1418`).
+- Race-condition guards on every `await` boundary (`fetchingMissionId`,
+  `fetchingPath`, connection IDs in `DesktopStreamService.connectionId`).
+- 15 s request timeout + 30 s SSE inactivity timeout — short enough to surface
+  failures.
+- SSE delta-resume with `X-Max-Sequence` header (`ControlView.swift:1796-1828`).
+- Optimistic queue add/remove/clear (`ControlView.swift:2312-2344`).
+- Workspace/terminal/mission state are `@MainActor @Observable` singletons —
+  good for cross-tab sharing.
+- 30 s TTL cache in `BackendAgentService` for repeat New-Mission opens.
+
+---
+
+## Suggested priority order
+
+1. **#1, #2, #4** — mission load/switch (biggest perceived freeze).
+2. **#3** — backend/agent parallel fetch (felt on every New Mission tap).
+3. **#11** — send-message in-flight state (visible to every user every send).
+4. **#5, #7, #8** — skeleton & caching pass on Files / Workspaces / History.
+5. **#6** — file upload streaming + progress (correctness, not just polish).
+6. **#9** — markdown caching (scroll smoothness across all chat views).
+7. **#10, #17, #19, #20, #21** — main-actor offloads & per-frame work.
+8. **#22-30** — cleanup, deletions, plumbing.
+
+Item-level estimates: 1, 2, 3, 11, 13, 14, 15, 24 are <1 hour each; the
+skeleton refactor across 4 screens is ~half a day; the streaming-upload work
+(#6) and the off-main event replay (#4) are the only multi-day items.
+
+---
+
+## Appendix — concrete patch sketches for the top issues
+
+These are illustrative, not press-Save-ready code. Types and helper names match
+the current codebase.
+
+### Patch for #1 (mission switch cache-first)
+
+```swift
+// ControlView.swift — switchToMission, around line 2483-2541
+private func switchToMission(id: String) async {
+    guard id != viewingMissionId else { return }
+    let previousViewingMission = viewingMission
+    let previousViewingId = viewingMissionId
+    viewingMissionId = id
+    fetchingMissionId = id
+    childMissions = []
+
+    // 1. Render cached transcript instantly (same as loadMission)
+    let hasCache: Bool
+    if let cached = loadCachedMissionData(id) {
+        applyViewingMissionWithEvents(cached.mission, events: cached.events)
+        hasCache = true
+    } else {
+        hasCache = false
+        isLoading = true
+    }
+
+    // Keep run-state hydration from runningMissions (existing logic)
+
+    do {
+        // 2. Fan out metadata + events in parallel
+        async let meta = api.getMission(id: id)
+        async let evts = api.getMissionEventsWithMeta(id: id, types: historyEventTypes)
+        let mission = try await meta
+        let result = (try? await evts) ?? .init(events: [], maxSequence: nil)
+        guard fetchingMissionId == id else { return }
+
+        if currentMission?.id == mission.id { currentMission = mission }
+
+        if !result.events.isEmpty {
+            applyViewingMissionWithEvents(mission, events: result.events)
+            if let max = result.maxSequence, max > 0 { missionMaxSeq[id] = max }
+            cacheMissionWithEvents(mission, events: result.events)
+        } else if !hasCache {
+            removeMissionFromCache(mission.id)
+            applyViewingMission(mission)
+        }
+        isLoading = false
+        // background workers fetch unchanged
+    } catch {
+        guard fetchingMissionId == id else { return }
+        if !hasCache {
+            isLoading = false
+            // existing fallback to previousViewingMission
+        }
+    }
+}
+```
+
+### Patch for #3 (parallel backend/agent load)
+
+```swift
+// BackendAgentService.swift — fetchBackendsAndAgents
+private static func fetchBackendsAndAgents() async -> BackendAgentData {
+    let backends = (try? await api.listBackends()) ?? Backend.defaults
+
+    // Parallel config fetch
+    let enabledArr = await withTaskGroup(of: (String, Bool).self) { group in
+        for b in backends {
+            group.addTask {
+                let enabled = (try? await api.getBackendConfig(backendId: b.id).isEnabled) ?? true
+                return (b.id, enabled)
+            }
+        }
+        var out: [(String, Bool)] = []
+        for await pair in group { out.append(pair) }
+        return out
+    }
+    let enabled = Set(enabledArr.filter(\.1).map(\.0))
+
+    // Parallel agent fetch
+    let agentsArr = await withTaskGroup(of: (String, [BackendAgent]).self) { group in
+        for id in enabled {
+            group.addTask {
+                let list = (try? await api.listBackendAgents(backendId: id))
+                    ?? (id == "amp" ? [
+                        BackendAgent(id: "smart", name: "Smart Mode"),
+                        BackendAgent(id: "rush", name: "Rush Mode")
+                    ] : [])
+                return (id, list)
+            }
+        }
+        var out: [(String, [BackendAgent])] = []
+        for await pair in group { out.append(pair) }
+        return out
+    }
+    return BackendAgentData(
+        backends: backends,
+        enabledBackendIds: enabled,
+        backendAgents: Dictionary(uniqueKeysWithValues: agentsArr)
+    )
+}
+```
+
+### Patch for #11 (send-message in-flight state)
+
+```swift
+// ChatMessage.swift
+struct ChatMessage: Identifiable {
+    let id: String
+    let type: MessageType
+    let content: String
+    var isPending: Bool = false   // <-- new
+    let timestamp: Date
+    // …
+}
+
+// ControlView.swift — sendMessage
+let tempMessage = ChatMessage(id: tempId, type: .user, content: content, isPending: true)
+messages.append(tempMessage)
+// …
+do {
+    let (messageId, queued) = try await api.sendMessage(content: content)
+    if let i = messages.firstIndex(where: { $0.id == tempId }) {
+        messages[i] = ChatMessage(id: messageId, type: .user, content: content,
+                                  isPending: false, timestamp: messages[i].timestamp)
+    }
+    // …
+} catch { /* remove tempId, error haptic */ }
+
+// In the bubble view:
+.opacity(message.isPending ? 0.55 : 1)
+.overlay(alignment: .bottomTrailing) {
+    if message.isPending {
+        ProgressView().scaleEffect(0.5).padding(6)
+    }
+}
+```
+
+### Patch for #5 (Files cache + stale-while-revalidate)
+
+```swift
+// FilesView.swift
+@State private var pathCache: [String: [FileEntry]] = [:]  // simple LRU later
+
+private func loadDirectory() async {
+    let pathToLoad = currentPath
+    fetchingPath = pathToLoad
+    if let cached = pathCache[pathToLoad] {
+        entries = cached
+        isLoading = false          // render immediately
+    } else {
+        isLoading = entries.isEmpty   // only show spinner if nothing to show
+    }
+    do {
+        let fresh = try await api.listDirectory(path: pathToLoad)
+        guard fetchingPath == pathToLoad else { return }
+        entries = fresh
+        pathCache[pathToLoad] = fresh
+    } catch {
+        guard fetchingPath == pathToLoad else { return }
+        if pathCache[pathToLoad] == nil { errorMessage = error.localizedDescription }
+    }
+    if fetchingPath == pathToLoad { isLoading = false }
+}
+```
+
+### Patch for #18 (Terminal: drop the 0.5 s fake-connect timer)
+
+```swift
+// TerminalView.swift — replace the DispatchQueue.main.asyncAfter at line 286.
+state.webSocketTask?.resume()
+receiveMessages()
+sendResize(cols: 80, rows: 24)
+// Move state transitions into receiveMessages:
+case .success(let message):
+    Task { @MainActor in
+        if state.connectionStatus != .connected {
+            state.connectionStatus = .connected
+            state.isConnecting = false
+            state.appendLine(TerminalLine(text: "Connected.", type: .system))
+        }
+        self.handleOutput(/* … */)
+    }
+```
+
+### Patch for #19 (Terminal ANSI parse: batch + off-main)
+
+```swift
+// TerminalState.swift
+actor ANSIParserActor {
+    func parse(_ text: String) -> AttributedString { ANSIParser.parse(text) }
+}
+private let ansiActor = ANSIParserActor()
+private var pendingChunks: [String] = []
+private var flushTask: Task<Void, Never>?
+
+func appendOutputChunk(_ text: String) {
+    pendingChunks.append(text)
+    flushTask?.cancel()
+    flushTask = Task { @MainActor in
+        try? await Task.sleep(nanoseconds: 16_000_000) // 16 ms coalesce
+        let batch = pendingChunks.joined()
+        pendingChunks.removeAll()
+        // parse off-main
+        let parsed = await ansiActor.parse(batch)
+        // append in one shot
+        terminalOutput.append(TerminalLine(parsed: parsed, type: .output))
+    }
+}
+```
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,6 +30,12 @@ Validates:
 - queued-message behavior
 - assistant model metadata (with optional per-backend expectations)
 
+For transcript-first loading changes, run this against the dev deployment and
+then inspect the created mission with `/api/control/missions/:id/transcript`,
+`/trace`, and `/events`: transcript should contain only user/final assistant
+messages, trace should contain hidden thinking/tool activity, and `/events`
+should remain backward-compatible.
+
 ### install_desktop.sh
 Installs desktop automation dependencies on the host (used by the desktop MCP).
 

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -206,7 +206,7 @@ impl ProviderType {
     pub fn uses_oauth(&self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::GithubCopilot | Self::OpenAI | Self::Google
+            Self::Anthropic | Self::GithubCopilot | Self::OpenAI | Self::Google | Self::Xai
         )
     }
 
@@ -266,6 +266,21 @@ impl ProviderType {
                     label: "Manually enter API Key".to_string(),
                     method_type: AuthMethodType::Api,
                     description: Some("Enter an existing Google AI API key".to_string()),
+                },
+            ],
+            Self::Xai => vec![
+                AuthMethod {
+                    label: "Grok Build OAuth".to_string(),
+                    method_type: AuthMethodType::Oauth,
+                    description: Some(
+                        "Use your grok.com account through Grok Build device authorization"
+                            .to_string(),
+                    ),
+                },
+                AuthMethod {
+                    label: "Manually enter API Key".to_string(),
+                    method_type: AuthMethodType::Api,
+                    description: Some("Enter an existing xAI API key".to_string()),
                 },
             ],
             _ => vec![AuthMethod {

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -299,10 +299,7 @@ fn parse_grok_device_auth_line(line: &str) -> (Option<String>, Option<String>) {
     let auth_url = trimmed
         .split_whitespace()
         .find(|part| part.starts_with("https://"))
-        .map(|part| {
-            part.trim_end_matches(|c: char| c == '.' || c == ',')
-                .to_string()
-        });
+        .map(|part| part.trim_end_matches(['.', ',']).to_string());
 
     let user_code = if let Some(ref url) = auth_url {
         url::Url::parse(url).ok().and_then(|url| {

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -25,6 +25,10 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::process::Command as TokioCommand;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
 
 use crate::ai_providers::{AuthMethod, PendingOAuth, ProviderType};
 use crate::util::{
@@ -250,6 +254,7 @@ const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 const GOOGLE_REDIRECT_URI: &str = "http://localhost:8085/oauth2callback";
 const GOOGLE_SCOPES: &str =
     "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
+const GROK_OAUTH_CLIENT_KEY: &str = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828";
 
 fn google_client_id() -> &'static str {
     GOOGLE_CLIENT_ID
@@ -257,6 +262,326 @@ fn google_client_id() -> &'static str {
 
 fn google_client_secret() -> &'static str {
     GOOGLE_CLIENT_SECRET
+}
+
+fn grok_auth_path() -> PathBuf {
+    PathBuf::from(home_dir()).join(".grok").join("auth.json")
+}
+
+fn read_grok_auth_entry() -> Option<serde_json::Value> {
+    let contents = std::fs::read_to_string(grok_auth_path()).ok()?;
+    let auth: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    auth.get(GROK_OAUTH_CLIENT_KEY).cloned()
+}
+
+fn grok_auth_email(entry: &serde_json::Value) -> Option<String> {
+    entry
+        .get("email")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string())
+}
+
+fn grok_auth_expires_at_millis(entry: &serde_json::Value) -> i64 {
+    entry
+        .get("expires_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() + 6 * 60 * 60 * 1000)
+}
+
+fn parse_grok_device_auth_line(line: &str) -> (Option<String>, Option<String>) {
+    let trimmed = line
+        .trim()
+        .trim_matches(|c: char| c.is_ascii_control() || c.is_whitespace());
+
+    let auth_url = trimmed
+        .split_whitespace()
+        .find(|part| part.starts_with("https://"))
+        .map(|part| {
+            part.trim_end_matches(|c: char| c == '.' || c == ',')
+                .to_string()
+        });
+
+    let user_code = if let Some(ref url) = auth_url {
+        url::Url::parse(url).ok().and_then(|url| {
+            url.query_pairs()
+                .find(|(key, _)| key == "user_code")
+                .map(|(_, value)| value.to_string())
+        })
+    } else if trimmed.contains('-')
+        && trimmed
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
+    };
+
+    (auth_url, user_code)
+}
+
+#[cfg(test)]
+mod grok_oauth_tests {
+    use super::{get_xai_api_key_for_grok, parse_grok_device_auth_line};
+    use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
+
+    #[test]
+    fn parses_device_auth_url_and_user_code_from_stderr_line() {
+        let line = "  https://accounts.x.ai/oauth2/device?user_code=YKRD-M9AF";
+
+        let (url, code) = parse_grok_device_auth_line(line);
+
+        assert_eq!(
+            url.as_deref(),
+            Some("https://accounts.x.ai/oauth2/device?user_code=YKRD-M9AF")
+        );
+        assert_eq!(code.as_deref(), Some("YKRD-M9AF"));
+    }
+
+    #[test]
+    fn parses_standalone_device_code_line() {
+        let (_, code) = parse_grok_device_auth_line("  YKRD-M9AF");
+
+        assert_eq!(code.as_deref(), Some("YKRD-M9AF"));
+    }
+
+    #[test]
+    fn grok_credential_lookup_uses_xai_api_key() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store_dir = temp.path().join(".sandboxed-sh");
+        std::fs::create_dir_all(&store_dir).expect("store dir");
+
+        let mut provider = AIProvider::new(ProviderType::Xai, "xAI API".to_string());
+        provider.api_key = Some("xai-api-key".to_string());
+        std::fs::write(
+            store_dir.join("ai_providers.json"),
+            serde_json::to_string(&vec![provider]).expect("serialize providers"),
+        )
+        .expect("write providers");
+
+        assert_eq!(
+            get_xai_api_key_for_grok(temp.path()).as_deref(),
+            Some("xai-api-key")
+        );
+    }
+
+    #[test]
+    fn grok_credential_lookup_does_not_treat_oauth_token_as_api_key() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store_dir = temp.path().join(".sandboxed-sh");
+        std::fs::create_dir_all(&store_dir).expect("store dir");
+
+        let mut provider = AIProvider::new(ProviderType::Xai, "xAI OAuth".to_string());
+        provider.oauth = Some(OAuthCredentials {
+            access_token: "oauth-access-token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60 * 60 * 1000,
+        });
+        std::fs::write(
+            store_dir.join("ai_providers.json"),
+            serde_json::to_string(&vec![provider]).expect("serialize providers"),
+        )
+        .expect("write providers");
+
+        assert_eq!(get_xai_api_key_for_grok(temp.path()), None);
+    }
+}
+
+async fn forward_grok_login_lines<R>(stream: R, sender: mpsc::UnboundedSender<String>)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut lines = BufReader::new(stream).lines();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                let _ = sender.send(line);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed reading Grok login output");
+                break;
+            }
+        }
+    }
+}
+
+async fn start_grok_device_auth() -> Result<(String, String), String> {
+    let mut child = TokioCommand::new("grok")
+        .args(["login", "--device-auth"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start `grok login --device-auth`: {}", e))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture Grok login stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture Grok login stderr".to_string())?;
+    let (sender, mut receiver) = mpsc::unbounded_channel();
+    tokio::spawn(forward_grok_login_lines(stdout, sender.clone()));
+    tokio::spawn(forward_grok_login_lines(stderr, sender));
+
+    let mut auth_url: Option<String> = None;
+    let mut user_code: Option<String> = None;
+
+    let auth_result = timeout(Duration::from_secs(15), async {
+        while let Some(line) = receiver.recv().await {
+            let (line_url, line_code) = parse_grok_device_auth_line(&line);
+            if auth_url.is_none() {
+                auth_url = line_url;
+            }
+            if user_code.is_none() {
+                user_code = line_code;
+            }
+            if auth_url.is_some() && user_code.is_some() {
+                break;
+            }
+        }
+        Ok::<(), String>(())
+    })
+    .await;
+
+    if auth_result.is_err() {
+        let _ = child.kill().await;
+        return Err("Timed out waiting for Grok device authorization URL".to_string());
+    }
+    auth_result.map_err(|e| e.to_string())??;
+
+    tokio::spawn(async move {
+        match child.wait().await {
+            Ok(status) if status.success() => {
+                tracing::info!("Grok device authorization completed successfully");
+            }
+            Ok(status) => {
+                tracing::warn!(
+                    ?status,
+                    "Grok device authorization process exited unsuccessfully"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed waiting for Grok device authorization process");
+            }
+        }
+    });
+
+    Ok((
+        auth_url.ok_or_else(|| "Grok did not print a device authorization URL".to_string())?,
+        user_code.ok_or_else(|| "Grok did not print a device authorization code".to_string())?,
+    ))
+}
+
+async fn upsert_grok_oauth_provider(
+    state: &super::routes::AppState,
+    entry: &serde_json::Value,
+    use_for_backends: Option<Vec<String>>,
+) -> Result<ProviderResponse, (StatusCode, String)> {
+    let access_token = entry
+        .get("key")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_GATEWAY,
+                "Grok auth file did not include an access token".to_string(),
+            )
+        })?;
+    let refresh_token = entry
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_GATEWAY,
+                "Grok auth file did not include a refresh token".to_string(),
+            )
+        })?;
+    let account_email = grok_auth_email(entry);
+    let backends = use_for_backends.unwrap_or_else(|| vec!["grok".to_string()]);
+
+    let mut provider = state
+        .ai_providers
+        .get_all_by_type(ProviderType::Xai)
+        .await
+        .into_iter()
+        .find(|p| p.has_oauth())
+        .unwrap_or_else(|| {
+            crate::ai_providers::AIProvider::new(
+                ProviderType::Xai,
+                "xAI (Grok Build OAuth)".to_string(),
+            )
+        });
+
+    provider.name = account_email
+        .as_ref()
+        .map(|email| format!("xAI ({email})"))
+        .unwrap_or_else(|| "xAI (Grok Build OAuth)".to_string());
+    provider.account_email = account_email;
+    provider.api_key = None;
+    provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+        refresh_token: refresh_token.to_string(),
+        access_token: access_token.to_string(),
+        expires_at: grok_auth_expires_at_millis(entry),
+    });
+    provider.use_for_backends = Some(backends.clone());
+    provider.enabled = true;
+
+    let stored = if state.ai_providers.get(provider.id).await.is_some() {
+        state.ai_providers.update(provider.id, provider).await
+    } else {
+        let id = state.ai_providers.add(provider).await;
+        state.ai_providers.get(id).await
+    }
+    .ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to save Grok OAuth provider".to_string(),
+        )
+    })?;
+
+    if let Err(e) =
+        update_provider_backends(&state.config.working_dir, ProviderType::Xai.id(), backends)
+    {
+        tracing::error!("Failed to save xAI provider backends: {}", e);
+    }
+    if provider_targets_grok(&stored) {
+        if let Err(e) = state.backend_configs.set_enabled("grok", true).await {
+            tracing::error!(
+                "Failed to enable Grok backend after xAI OAuth connect: {}",
+                e
+            );
+        }
+    }
+    if let Some(ref email) = stored.account_email {
+        if let Err(e) = update_provider_account(
+            &state.config.working_dir,
+            ProviderType::Xai.id(),
+            email.clone(),
+        ) {
+            tracing::error!("Failed to save xAI account email: {}", e);
+        }
+    }
+
+    Ok(build_response_from_store(&stored))
+}
+
+fn provider_targets_grok(provider: &crate::ai_providers::AIProvider) -> bool {
+    provider
+        .use_for_backends
+        .as_ref()
+        .map(|backends| backends.iter().any(|backend| backend == "grok"))
+        .unwrap_or_else(|| {
+            default_backends_for_provider(provider.provider_type)
+                .iter()
+                .any(|backend| backend == "grok")
+        })
 }
 
 fn anthropic_client_id() -> String {
@@ -689,6 +1014,7 @@ pub fn get_xai_api_key_for_grok(working_dir: &Path) -> Option<String> {
         if provider.provider_type != ProviderType::Xai || !provider.enabled {
             return None;
         }
+
         provider
             .api_key
             .filter(|key| !key.trim().is_empty())
@@ -5028,7 +5354,7 @@ async fn list_provider_types() -> Json<Vec<ProviderTypeInfo>> {
         ProviderTypeInfo {
             id: "xai".to_string(),
             name: "xAI".to_string(),
-            uses_oauth: false,
+            uses_oauth: true,
             env_var: Some("XAI_API_KEY".to_string()),
         },
         ProviderTypeInfo {
@@ -6224,6 +6550,15 @@ async fn create_provider(
         .await;
     }
 
+    if provider_type == ProviderType::Xai && provider.enabled && provider_targets_grok(&provider) {
+        if let Err(e) = state.backend_configs.set_enabled("grok", true).await {
+            tracing::error!(
+                "Failed to enable Grok backend after xAI provider creation: {}",
+                e
+            );
+        }
+    }
+
     // Refresh metadata LLM config so new API keys are picked up for title generation
     super::metadata_llm::refresh_metadata_llm_config(&state.ai_providers).await;
 
@@ -6340,6 +6675,15 @@ async fn update_provider(
     let pt = result.provider_type;
     if pt != ProviderType::Custom {
         sync_store_to_opencode(&state.ai_providers, &state.config.working_dir, pt).await;
+    }
+
+    if pt == ProviderType::Xai && result.enabled && provider_targets_grok(&result) {
+        if let Err(e) = state.backend_configs.set_enabled("grok", true).await {
+            tracing::error!(
+                "Failed to enable Grok backend after xAI provider update: {}",
+                e
+            );
+        }
     }
 
     let response = build_response_from_store(&result);
@@ -6733,6 +7077,16 @@ async fn oauth_authorize(
                 method: "code".to_string(),
             }))
         }
+        ProviderType::Xai => {
+            let (url, code) = start_grok_device_auth().await.map_err(internal_error)?;
+            Ok(Json(OAuthAuthorizeResponse {
+                url,
+                instructions: format!(
+                    "1. Open the xAI authorization page.\n2. Confirm code: {code}\n3. After the page says connection successful, return here and click Connect."
+                ),
+                method: "auto".to_string(),
+            }))
+        }
         _ => Err((
             StatusCode::BAD_REQUEST,
             "OAuth not supported for this provider".to_string(),
@@ -6750,6 +7104,10 @@ async fn oauth_callback(
     let provider_type_id = id.clone();
     match oauth_callback_inner(State(state.clone()), AxumPath(id), Json(req)).await {
         Ok(json) => {
+            if ProviderType::from_id(&provider_type_id) == Some(ProviderType::Xai) {
+                return json.into_response();
+            }
+
             // After successful OAuth, upsert the provider in AIProviderStore.
             // The OAuth callback already synced creds to auth.json; now mirror that
             // into the store so multiple accounts of the same type are tracked.
@@ -6848,6 +7206,19 @@ async fn oauth_callback_inner(
             )
         })?
     };
+
+    if provider_type == ProviderType::Xai {
+        let entry = read_grok_auth_entry().ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "Grok is not connected yet. Complete the xAI browser authorization first, then click Connect."
+                    .to_string(),
+            )
+        })?;
+        let response =
+            upsert_grok_oauth_provider(&state, &entry, req.use_for_backends.clone()).await?;
+        return Ok(Json(response));
+    }
 
     // Get pending OAuth state
     let pending = {

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6626,8 +6626,7 @@ async fn maybe_begin_grok_goal(
             reason: "this mission already has an active /goal loop — wait for it to finish or cancel before starting a new one".to_string(),
         };
     }
-    if let Err(e) = super::grok_goal::create_goal_automation(mission_store, mid, &objective).await
-    {
+    if let Err(e) = super::grok_goal::create_goal_automation(mission_store, mid, &objective).await {
         tracing::warn!(
             "grok_goal: failed to create automation for mission {}: {}",
             mid,

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -9716,6 +9716,7 @@ async fn run_single_control_turn(
         && effective_config_profile.is_some()
         && requested_model.is_none())
         || (backend_id.as_deref() == Some("codex") && requested_model.is_none())
+        || (backend_id.as_deref() == Some("grok") && requested_model.is_none())
     {
         config.default_model = None;
     } else if backend_id.as_deref() == Some("gemini") && requested_model.is_none() {

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6653,14 +6653,21 @@ async fn maybe_begin_grok_goal(
 
 /// Post-turn hook for grok-goal missions. Parses the sentinel from the
 /// assistant's final text and either ends the loop (terminal sentinel,
-/// budget exhausted, sentinel-missing streak) or bumps the iteration
-/// counter so the existing AgentFinished hook re-fires the continuation
-/// prompt.
+/// budget exhausted, sentinel-missing streak, or explicit cancellation)
+/// or bumps the iteration counter so the existing AgentFinished hook
+/// re-fires the continuation prompt.
+///
+/// `terminal_reason` is the runner's structured exit reason. A `Cancelled`
+/// turn ends the loop immediately with status `aborted:cancelled` —
+/// otherwise the cancelled output (typically the literal string
+/// `"Cancelled"`) would look like a sentinel-missing turn and burn through
+/// the missing-count budget before the loop tore down.
 async fn post_turn_handle_grok_goal(
     mission_store: &Arc<dyn MissionStore>,
     events_tx: &broadcast::Sender<AgentEvent>,
     mission_id: Uuid,
     assistant_text: &str,
+    terminal_reason: Option<TerminalReason>,
 ) {
     let Some(mut row) = super::grok_goal::active_goal_for_mission(mission_store, mission_id).await
     else {
@@ -6669,6 +6676,22 @@ async fn post_turn_handle_grok_goal(
     let objective = super::grok_goal::objective_of(&row);
     let iteration = super::grok_goal::iteration_of(&row);
     let prev_missing = super::grok_goal::missing_count_of(&row);
+
+    // Cancellation short-circuits sentinel parsing — there's no agent
+    // output to interpret and continuing the loop would re-fire prompts
+    // after the user explicitly stopped the mission.
+    if matches!(terminal_reason, Some(TerminalReason::Cancelled)) {
+        if let Err(e) = super::grok_goal::disable_goal(mission_store, &mut row).await {
+            tracing::warn!("grok_goal: disable_goal failed: {}", e);
+        }
+        let _ = events_tx.send(AgentEvent::GoalStatus {
+            status: "aborted:cancelled".to_string(),
+            objective,
+            mission_id: Some(mission_id),
+        });
+        return;
+    }
+
     let sentinel = super::grok_goal::parse_goal_sentinel(assistant_text);
     tracing::info!(
         mission_id = %mission_id,
@@ -9415,6 +9438,7 @@ async fn control_actor_loop(
                                 &events_tx,
                                 mission_id,
                                 &completed_agent_output,
+                                completed_terminal_reason,
                             )
                             .await;
                         }
@@ -9687,6 +9711,7 @@ async fn control_actor_loop(
                                     &events_tx,
                                     *mission_id,
                                     &result.output,
+                                    result.terminal_reason,
                                 )
                                 .await;
                             }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -2283,6 +2283,16 @@ pub(crate) fn resolve_gemini_default_model() -> String {
     "gemini-3.1-pro-preview".to_string()
 }
 
+/// Return the default model for Grok Build when no override is specified.
+///
+/// Mirrors the dashboard's `KNOWN_BACKEND_DEFAULT_MODELS` entry for grok and
+/// the value advertised by `/api/providers` for xAI. Pinning here prevents
+/// grok missions from inheriting the global `DEFAULT_MODEL`
+/// (e.g. `anthropic/claude-opus-4-6`) which grok rejects as "unknown model id".
+pub(crate) fn resolve_grok_default_model() -> String {
+    "grok-build".to_string()
+}
+
 async fn close_mission_desktop_sessions(
     mission_store: &Arc<dyn MissionStore>,
     mission_id: Uuid,

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -55,6 +55,15 @@ const INTERRUPTED_RESUME_PROMPT: &str = "You were interrupted, resume your work.
 /// CancelMission re-check to keep the two views of "stalled" consistent.
 const STUCK_SECONDS: u64 = 900;
 
+/// Grace period after the user first opens an `AwaitingUser` mission before
+/// the ack-promotion tick auto-archives it to `Acknowledged` (Finished).
+/// Resets whenever the user sends a new message (status returns to Active and
+/// `first_viewed_at` is cleared).
+const ACK_GRACE_SECONDS: u64 = 3600;
+
+/// How often the ack-promotion tick scans for stale `AwaitingUser` missions.
+const ACK_PROMOTION_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Returns a safe index to truncate a string at, ensuring we don't cut UTF-8 characters.
 pub(super) fn safe_truncate_index(s: &str, max: usize) -> usize {
     if s.len() <= max {
@@ -4379,6 +4388,40 @@ pub async fn load_mission(
     })
 }
 
+/// Record that the user opened this mission for the first time since it last
+/// entered `AwaitingUser`. Sets `first_viewed_at` to now (no-op if already set)
+/// and broadcasts a `MissionStatusChanged` event so other clients can render
+/// the "opened" dot. The dashboard and iOS clients call this from their
+/// mission-detail entry points; the periodic ack-promotion tick uses the
+/// timestamp to decide when to move the mission to `Acknowledged`.
+pub async fn mark_mission_opened(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Mission>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let now = chrono::Utc::now().to_rfc3339();
+    let newly_set = control
+        .mission_store
+        .set_mission_first_viewed_at_if_unset(id, &now)
+        .await
+        .map_err(internal_error)?;
+    let mission = control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
+    if newly_set.is_some() {
+        let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+            mission_id: id,
+            status: mission.status,
+            summary: None,
+        });
+    }
+    Ok(Json(mission))
+}
+
 /// Set mission status (completed/failed).
 pub async fn set_mission_status(
     State(state): State<Arc<AppState>>,
@@ -4655,8 +4698,10 @@ const TRACE_EVENT_TYPES: &[&str] = &[
 
 fn event_visibility(event_type: &str) -> &'static str {
     match event_type {
-        "user_message" | "assistant_message" => "transcript",
-        "thinking" | "tool_call" | "tool_result" | "text_delta" | "phase" | "status" => "trace",
+        "user_message" | "assistant_message" | "mission_status_changed" => "transcript",
+        "thinking" | "tool_call" | "tool_result" | "text_delta" | "phase" | "status" | "error" => {
+            "trace"
+        }
         _ => "debug",
     }
 }
@@ -4761,6 +4806,7 @@ pub async fn get_mission_transcript(
     let mut known_types = Vec::new();
     known_types.extend_from_slice(TRANSCRIPT_EVENT_TYPES);
     known_types.extend_from_slice(TRACE_EVENT_TYPES);
+    known_types.push("mission_status_changed");
     let event_counts = event_count_map(&*control.mission_store, mission_id, &known_types).await;
 
     let mut visibility_counts: HashMap<String, usize> = HashMap::new();
@@ -5343,6 +5389,10 @@ fn spawn_control_session(
             state.cmd_tx.clone(),
             events_tx.clone(),
         ));
+        tokio::spawn(ack_promotion_loop(
+            Arc::clone(&state.mission_store),
+            events_tx.clone(),
+        ));
     }
 
     // Spawn event logger task (logs all events to SQLite for debugging/replay)
@@ -5646,6 +5696,41 @@ async fn cleanup_stale_active_missions_once(
 ///
 /// Threshold is intentionally generous (15 min) so a model in the
 /// middle of a slow API turn or a long shell command isn't false-killed.
+/// Periodic ack-promotion: scans `AwaitingUser` missions whose
+/// `first_viewed_at` is older than `ACK_GRACE_SECONDS` and flips them to
+/// `Acknowledged`. Broadcasts `MissionStatusChanged` so dashboard/iOS clients
+/// move the row from "Needs You" to "Finished" without a refresh.
+async fn ack_promotion_loop(
+    mission_store: Arc<dyn MissionStore>,
+    events_tx: broadcast::Sender<AgentEvent>,
+) {
+    tracing::info!(
+        "Ack-promotion loop started: grace {}s, tick {}s",
+        ACK_GRACE_SECONDS,
+        ACK_PROMOTION_TICK_INTERVAL.as_secs()
+    );
+    loop {
+        tokio::time::sleep(ACK_PROMOTION_TICK_INTERVAL).await;
+        match mission_store
+            .acknowledge_stale_awaiting_user_missions(ACK_GRACE_SECONDS)
+            .await
+        {
+            Ok(promoted) => {
+                for mission_id in promoted {
+                    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                        mission_id,
+                        status: MissionStatus::Acknowledged,
+                        summary: None,
+                    });
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Ack-promotion tick failed: {}", e);
+            }
+        }
+    }
+}
+
 async fn stuck_mission_watchdog_loop(
     mission_store: Arc<dyn MissionStore>,
     cmd_tx: mpsc::Sender<ControlCommand>,
@@ -6465,6 +6550,197 @@ fn enqueue_agent_finished_messages(
             None,
             Some(message.target_mission_id),
         ));
+    }
+}
+
+/// Backend id for a mission, or `None` if the mission isn't found.
+///
+/// Used by [`maybe_begin_grok_goal`] / [`post_turn_handle_grok_goal`] to
+/// gate the `/goal` loop behavior on backend identity without having to
+/// thread the backend id through every queue-dispatch path.
+async fn lookup_mission_backend(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+) -> Option<String> {
+    match mission_store.get_mission(mission_id).await {
+        Ok(Some(m)) => Some(m.backend),
+        _ => None,
+    }
+}
+
+/// Outcome of [`maybe_begin_grok_goal`]: either a rewritten first-turn
+/// prompt (the message should now carry this content) or a user-facing
+/// error to surface in the message ack.
+pub(crate) enum GrokGoalKickoff {
+    /// Not a grok-goal request; queue the original content unchanged.
+    Passthrough,
+    /// `/goal X` accepted; queue `prompt` (the wrapped first-turn prompt)
+    /// in place of the original message content.
+    Rewritten { prompt: String },
+    /// `/goal X` rejected — surface this string to the user.
+    Rejected { reason: String },
+}
+
+/// Detect `/goal <objective>` for a grok mission and, if recognised,
+/// create the AgentFinished-driven automation row that will iterate the
+/// loop. Returns the wrapped first-turn prompt to use in place of the
+/// raw `/goal X` message.
+///
+/// Non-grok backends fall through unchanged — claudecode and codex have
+/// their own `/goal` handling (CLI-native and `thread/goal/set`
+/// respectively); only grok needs sandboxed.sh to drive iteration.
+async fn maybe_begin_grok_goal(
+    mission_store: &Arc<dyn MissionStore>,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    mission_id: Option<Uuid>,
+    content: &str,
+) -> GrokGoalKickoff {
+    let (is_goal, objective) = super::grok_goal::parse_goal_prefix(content);
+    if !is_goal {
+        return GrokGoalKickoff::Passthrough;
+    }
+    let Some(mid) = mission_id else {
+        // No target mission resolved yet (auto-create path) — let the
+        // normal flow create a mission, then we'll catch the next turn.
+        // For now treat as passthrough; the user can re-send `/goal X`
+        // once the mission exists. This avoids a chicken/egg with
+        // mission creation happening *after* this hook.
+        return GrokGoalKickoff::Passthrough;
+    };
+    if !matches!(
+        lookup_mission_backend(mission_store, mid).await.as_deref(),
+        Some("grok")
+    ) {
+        return GrokGoalKickoff::Passthrough;
+    }
+    if objective.is_empty() {
+        return GrokGoalKickoff::Rejected {
+            reason: "/goal requires an objective (e.g. `/goal write the docs`)".to_string(),
+        };
+    }
+    if super::grok_goal::active_goal_for_mission(mission_store, mid)
+        .await
+        .is_some()
+    {
+        return GrokGoalKickoff::Rejected {
+            reason: "this mission already has an active /goal loop — wait for it to finish or cancel before starting a new one".to_string(),
+        };
+    }
+    if let Err(e) = super::grok_goal::create_goal_automation(mission_store, mid, &objective).await
+    {
+        tracing::warn!(
+            "grok_goal: failed to create automation for mission {}: {}",
+            mid,
+            e
+        );
+        return GrokGoalKickoff::Rejected {
+            reason: format!("failed to set up /goal loop: {}", e),
+        };
+    }
+    tracing::info!(
+        mission_id = %mid,
+        objective_len = objective.len(),
+        "grok_goal: started loop"
+    );
+    let _ = events_tx.send(AgentEvent::GoalIteration {
+        iteration: 1,
+        objective: objective.clone(),
+        mission_id: Some(mid),
+    });
+    GrokGoalKickoff::Rewritten {
+        prompt: super::grok_goal::first_turn_prompt(&objective),
+    }
+}
+
+/// Post-turn hook for grok-goal missions. Parses the sentinel from the
+/// assistant's final text and either ends the loop (terminal sentinel,
+/// budget exhausted, sentinel-missing streak) or bumps the iteration
+/// counter so the existing AgentFinished hook re-fires the continuation
+/// prompt.
+async fn post_turn_handle_grok_goal(
+    mission_store: &Arc<dyn MissionStore>,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    mission_id: Uuid,
+    assistant_text: &str,
+) {
+    let Some(mut row) = super::grok_goal::active_goal_for_mission(mission_store, mission_id).await
+    else {
+        return;
+    };
+    let objective = super::grok_goal::objective_of(&row);
+    let iteration = super::grok_goal::iteration_of(&row);
+    let prev_missing = super::grok_goal::missing_count_of(&row);
+    let sentinel = super::grok_goal::parse_goal_sentinel(assistant_text);
+    tracing::info!(
+        mission_id = %mission_id,
+        iteration,
+        prev_missing,
+        ?sentinel,
+        "grok_goal: post-turn sentinel"
+    );
+    match sentinel {
+        super::grok_goal::GoalSentinel::Complete => {
+            if let Err(e) = super::grok_goal::disable_goal(mission_store, &mut row).await {
+                tracing::warn!("grok_goal: disable_goal failed: {}", e);
+            }
+            let _ = events_tx.send(AgentEvent::GoalStatus {
+                status: "complete".to_string(),
+                objective,
+                mission_id: Some(mission_id),
+            });
+        }
+        super::grok_goal::GoalSentinel::Aborted { reason } => {
+            if let Err(e) = super::grok_goal::disable_goal(mission_store, &mut row).await {
+                tracing::warn!("grok_goal: disable_goal failed: {}", e);
+            }
+            let _ = events_tx.send(AgentEvent::GoalStatus {
+                status: format!("aborted:{}", reason),
+                objective,
+                mission_id: Some(mission_id),
+            });
+        }
+        super::grok_goal::GoalSentinel::Continue | super::grok_goal::GoalSentinel::Missing => {
+            let was_missing = matches!(sentinel, super::grok_goal::GoalSentinel::Missing);
+            let new_missing = if was_missing {
+                prev_missing.saturating_add(1)
+            } else {
+                0
+            };
+            if new_missing >= super::grok_goal::MAX_MISSING_SENTINELS {
+                if let Err(e) = super::grok_goal::disable_goal(mission_store, &mut row).await {
+                    tracing::warn!("grok_goal: disable_goal failed: {}", e);
+                }
+                let _ = events_tx.send(AgentEvent::GoalStatus {
+                    status: "aborted:no_goal_sentinel".to_string(),
+                    objective,
+                    mission_id: Some(mission_id),
+                });
+                return;
+            }
+            let next_iter = iteration.saturating_add(1);
+            if next_iter > super::grok_goal::MAX_ITERATIONS {
+                if let Err(e) = super::grok_goal::disable_goal(mission_store, &mut row).await {
+                    tracing::warn!("grok_goal: disable_goal failed: {}", e);
+                }
+                let _ = events_tx.send(AgentEvent::GoalStatus {
+                    status: "budget_limited".to_string(),
+                    objective,
+                    mission_id: Some(mission_id),
+                });
+                return;
+            }
+            if let Err(e) =
+                super::grok_goal::update_counters(mission_store, &mut row, next_iter, new_missing)
+                    .await
+            {
+                tracing::warn!("grok_goal: update_counters failed: {}", e);
+            }
+            let _ = events_tx.send(AgentEvent::GoalIteration {
+                iteration: next_iter,
+                objective,
+                mission_id: Some(mission_id),
+            });
+        }
     }
 }
 
@@ -7344,6 +7620,36 @@ async fn control_actor_loop(
                         let target_is_main = effective_target
                             .map(|tid| main_mission_id == Some(tid))
                             .unwrap_or(true); // No target = use main
+
+                        // Grok `/goal <objective>` kickoff: rewrite the message
+                        // to the wrapped first-turn prompt and create the
+                        // AgentFinished automation row that will drive the
+                        // loop. Non-grok backends and non-/goal messages fall
+                        // through unchanged. See `api/grok_goal.rs`.
+                        let goal_target_mission = effective_target.or(main_mission_id);
+                        let mut content = content;
+                        match maybe_begin_grok_goal(
+                            &mission_store,
+                            &events_tx,
+                            goal_target_mission,
+                            &content,
+                        )
+                        .await
+                        {
+                            GrokGoalKickoff::Passthrough => {}
+                            GrokGoalKickoff::Rewritten { prompt } => {
+                                content = prompt;
+                            }
+                            GrokGoalKickoff::Rejected { reason } => {
+                                let _ = events_tx.send(AgentEvent::Error {
+                                    message: reason,
+                                    mission_id: goal_target_mission,
+                                    resumable: true,
+                                });
+                                let _ = respond.send(false);
+                                continue;
+                            }
+                        }
 
                         // Case 1: Target is already running in parallel_runners - queue to it
                         if let Some(tid) = effective_target {
@@ -8852,10 +9158,16 @@ async fn control_actor_loop(
                     // Runner cleared itself; cancel the force-clear watchdog.
                     runner_force_clear_deadline = None;
                     let mut completed_terminal_reason = None;
+                    // Captured for the post-turn `grok_goal` sentinel hook (see
+                    // `post_turn_handle_grok_goal`), which runs after this
+                    // `match` closes — `agent_result` itself is out of scope
+                    // by then. Empty string when the join errored.
+                    let mut completed_agent_output = String::new();
                     match res {
                         Ok((_mid, _user_msg, mut agent_result)) => {
                             maybe_recover_soft_llm_error(&mut agent_result);
                             completed_terminal_reason = agent_result.terminal_reason;
+                            completed_agent_output = agent_result.output.clone();
                             // Only append assistant to local history if this mission is still the current mission.
                             // Note: User message was already added before execution started.
                             // If the user created a new mission mid-execution, history was cleared for that new mission,
@@ -9087,6 +9399,26 @@ async fn control_actor_loop(
                         let already_queued_for_mission = queue
                             .iter()
                             .any(|(_id, _msg, _agent, target_mid)| *target_mid == Some(mission_id));
+
+                        // Grok `/goal` post-turn: parse the sentinel from the
+                        // assistant's last text and either disable the goal
+                        // automation (terminal sentinel / budget exhausted /
+                        // sentinel-missing streak) or bump the iteration
+                        // counter. Must run BEFORE
+                        // `agent_finished_automation_messages` so a Complete /
+                        // Aborted disable takes effect on this very turn —
+                        // otherwise the existing hook would still fire the
+                        // continuation. Skipped on transient infra failures
+                        // for the same reason regular automations are.
+                        if !is_transient_infra_failure {
+                            post_turn_handle_grok_goal(
+                                &mission_store,
+                                &events_tx,
+                                mission_id,
+                                &completed_agent_output,
+                            )
+                            .await;
+                        }
                         if !already_queued_for_mission && !is_transient_infra_failure {
                             // Small delay so the UI can display the completion before restarting.
                             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -9344,6 +9676,21 @@ async fn control_actor_loop(
                                     | Some(TerminalReason::CapacityLimited)
                             );
                             let was_queue_empty = runner.queue.is_empty();
+                            // Grok /goal sentinel hook for the parallel-runner
+                            // path. Same contract as the main-session hook
+                            // above: runs before the AgentFinished automations
+                            // so a terminal sentinel disables the loop on this
+                            // turn rather than after one extra continuation
+                            // fire. (See `post_turn_handle_grok_goal`.)
+                            if !is_transient_infra_failure {
+                                post_turn_handle_grok_goal(
+                                    &mission_store,
+                                    &events_tx,
+                                    *mission_id,
+                                    &result.output,
+                                )
+                                .await;
+                            }
                             if was_queue_empty && !is_transient_infra_failure {
                                 // Small delay so the UI can display the completion before restarting.
                                 tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -16392,12 +16739,23 @@ Investigate <service/> failures.
 
     #[test]
     fn test_mission_status_for_terminal_reason_defers_turn_complete_until_idle_finalization() {
+        // With a follow-up still queued/scheduled the mission stays whatever
+        // it was — the next turn will resolve its status.
         assert_eq!(
             mission_status_for_terminal_reason(TerminalReason::TurnComplete, false),
             None
         );
+        // No follow-up: the agent's turn ended cleanly and the mission is
+        // parked waiting for the user. The Needs-You bucket is keyed on
+        // exactly this state.
         assert_eq!(
             mission_status_for_terminal_reason(TerminalReason::TurnComplete, true),
+            Some((MissionStatus::AwaitingUser, "turn_complete"))
+        );
+        // Explicit agent-declared completion still maps to Completed (green
+        // in Finished), distinct from the auto AwaitingUser path above.
+        assert_eq!(
+            mission_status_for_terminal_reason(TerminalReason::Completed, true),
             Some((MissionStatus::Completed, "completed"))
         );
     }
@@ -16716,5 +17074,50 @@ Investigate <service/> failures.
         ));
         let files = validate_rich_tags(&tags, root, None, None).await;
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn transcript_visibility_categorizes_known_event_types() {
+        assert_eq!(event_visibility("user_message"), "transcript");
+        assert_eq!(event_visibility("assistant_message"), "transcript");
+        assert_eq!(event_visibility("mission_status_changed"), "transcript");
+        assert_eq!(event_visibility("thinking"), "trace");
+        assert_eq!(event_visibility("tool_call"), "trace");
+        assert_eq!(event_visibility("tool_result"), "trace");
+        assert_eq!(event_visibility("text_delta"), "trace");
+        assert_eq!(event_visibility("error"), "trace");
+        assert_eq!(event_visibility("raw_backend_packet"), "debug");
+    }
+
+    #[test]
+    fn transcript_trace_summary_counts_only_events_between_transcript_rows() {
+        let mission_id = Uuid::new_v4();
+        let event = |sequence, event_type: &str| mission_store::StoredEvent {
+            id: sequence,
+            mission_id,
+            sequence,
+            event_type: event_type.to_string(),
+            timestamp: "2026-05-16T00:00:00Z".to_string(),
+            event_id: None,
+            tool_call_id: None,
+            tool_name: None,
+            content: String::new(),
+            metadata: serde_json::json!({}),
+        };
+        let trace_events = vec![
+            event(2, "thinking"),
+            event(3, "thinking"),
+            event(4, "tool_call"),
+            event(7, "tool_result"),
+        ];
+
+        let first = trace_summary_between(&trace_events, 1, 5);
+        assert_eq!(first.get("thinking"), Some(&2));
+        assert_eq!(first.get("tool_call"), Some(&1));
+        assert_eq!(first.get("tool_result"), None);
+
+        let second = trace_summary_between(&trace_events, 5, 8);
+        assert_eq!(second.get("tool_result"), Some(&1));
+        assert_eq!(second.get("thinking"), None);
     }
 }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -278,10 +278,12 @@ fn is_terminal_mission_status(status: &MissionStatus) -> bool {
     matches!(
         status,
         MissionStatus::Completed
+            | MissionStatus::Acknowledged
             | MissionStatus::Failed
             | MissionStatus::Interrupted
             | MissionStatus::Blocked
             | MissionStatus::NotFeasible
+            | MissionStatus::AwaitingUser
     )
 }
 
@@ -3018,6 +3020,12 @@ pub enum MissionStatus {
     /// Mission created but hasn't received any messages yet
     Pending,
     Active,
+    /// Agent's turn / automation cycle finished cleanly with no follow-up
+    /// queued; mission is parked waiting for the user to read it.
+    AwaitingUser,
+    /// User opened the mission while it was AwaitingUser and the ack grace
+    /// period elapsed without a new message — mission is auto-archived.
+    Acknowledged,
     Completed,
     Failed,
     /// Mission was interrupted (server shutdown, cancellation, etc.)
@@ -3033,6 +3041,8 @@ impl std::fmt::Display for MissionStatus {
         match self {
             Self::Pending => write!(f, "pending"),
             Self::Active => write!(f, "active"),
+            Self::AwaitingUser => write!(f, "awaiting_user"),
+            Self::Acknowledged => write!(f, "acknowledged"),
             Self::Completed => write!(f, "completed"),
             Self::Failed => write!(f, "failed"),
             Self::Blocked => write!(f, "blocked"),
@@ -4624,6 +4634,227 @@ pub async fn get_mission_events(
         }
     }
     // CORS exposure so browsers can read these headers from JS.
+    headers.insert(
+        header::ACCESS_CONTROL_EXPOSE_HEADERS,
+        header::HeaderValue::from_static("X-Total-Events, X-Max-Sequence"),
+    );
+
+    Ok(response)
+}
+
+const TRANSCRIPT_EVENT_TYPES: &[&str] = &["user_message", "assistant_message"];
+const TRACE_EVENT_TYPES: &[&str] = &[
+    "thinking",
+    "tool_call",
+    "tool_result",
+    "text_delta",
+    "error",
+    "phase",
+    "status",
+];
+
+fn event_visibility(event_type: &str) -> &'static str {
+    match event_type {
+        "user_message" | "assistant_message" => "transcript",
+        "thinking" | "tool_call" | "tool_result" | "text_delta" | "phase" | "status" => "trace",
+        _ => "debug",
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct TranscriptMessage {
+    #[serde(flatten)]
+    pub event: mission_store::StoredEvent,
+    /// Count of non-transcript events after the previous transcript row and
+    /// before this row. Lets clients reserve a Thinking/Activity affordance
+    /// without downloading the trace on the first mission paint.
+    pub trace_count: usize,
+    pub trace_summary: HashMap<String, usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MissionTranscriptResponse {
+    pub mission: Mission,
+    pub messages: Vec<TranscriptMessage>,
+    pub event_counts: HashMap<String, usize>,
+    pub visibility_counts: HashMap<String, usize>,
+    pub latest_sequence: i64,
+}
+
+async fn event_count_map(
+    store: &(dyn MissionStore + Send + Sync),
+    mission_id: Uuid,
+    event_types: &[&str],
+) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for event_type in event_types {
+        if let Ok(count) = store.count_events(mission_id, Some(&[*event_type])).await {
+            counts.insert((*event_type).to_string(), count);
+        }
+    }
+    counts
+}
+
+fn trace_summary_between(
+    trace_events: &[mission_store::StoredEvent],
+    after_sequence: i64,
+    before_sequence: i64,
+) -> HashMap<String, usize> {
+    let mut summary = HashMap::new();
+    for event in trace_events {
+        if event.sequence > after_sequence && event.sequence < before_sequence {
+            *summary.entry(event.event_type.clone()).or_insert(0) += 1;
+        }
+    }
+    summary
+}
+
+/// Lightweight initial mission payload: final chat transcript only, plus event
+/// counts/cursors so clients can fetch the hidden activity trace afterward.
+pub async fn get_mission_transcript(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(mission_id): Path<Uuid>,
+) -> Result<Json<MissionTranscriptResponse>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let mut mission = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
+
+    if let Some(workspace) = state.workspaces.get(mission.workspace_id).await {
+        mission.workspace_name = Some(workspace.name);
+    }
+
+    let transcript_events = control
+        .mission_store
+        .get_events(mission_id, Some(TRANSCRIPT_EVENT_TYPES), None, None)
+        .await
+        .map_err(internal_error)?;
+    let trace_events = control
+        .mission_store
+        .get_events(mission_id, Some(TRACE_EVENT_TYPES), None, None)
+        .await
+        .map_err(internal_error)?;
+    let latest_sequence = control
+        .mission_store
+        .max_event_sequence(mission_id)
+        .await
+        .map_err(internal_error)?;
+
+    let mut previous_transcript_sequence = 0;
+    let mut messages = Vec::with_capacity(transcript_events.len());
+    for event in transcript_events {
+        let trace_summary =
+            trace_summary_between(&trace_events, previous_transcript_sequence, event.sequence);
+        let trace_count = trace_summary.values().sum();
+        previous_transcript_sequence = event.sequence;
+        messages.push(TranscriptMessage {
+            event,
+            trace_count,
+            trace_summary,
+        });
+    }
+
+    let mut known_types = Vec::new();
+    known_types.extend_from_slice(TRANSCRIPT_EVENT_TYPES);
+    known_types.extend_from_slice(TRACE_EVENT_TYPES);
+    let event_counts = event_count_map(&*control.mission_store, mission_id, &known_types).await;
+
+    let mut visibility_counts: HashMap<String, usize> = HashMap::new();
+    for (event_type, count) in &event_counts {
+        *visibility_counts
+            .entry(event_visibility(event_type).to_string())
+            .or_insert(0) += *count;
+    }
+
+    Ok(Json(MissionTranscriptResponse {
+        mission,
+        messages,
+        event_counts,
+        visibility_counts,
+        latest_sequence,
+    }))
+}
+
+/// Deferred intermediate activity for a mission. This returns thoughts, tool
+/// calls/results, text deltas, and runtime/status events while keeping the
+/// first transcript request small.
+pub async fn get_mission_trace(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(mission_id): Path<Uuid>,
+    axum::extract::Query(query): axum::extract::Query<GetEventsQuery>,
+) -> Result<Response, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let mission = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal_error)?;
+    if mission.is_none() {
+        return Err((StatusCode::NOT_FOUND, "Mission not found".to_string()));
+    }
+
+    let events = if let Some(before_seq) = query.before_seq {
+        control
+            .mission_store
+            .get_events_before(mission_id, before_seq, Some(TRACE_EVENT_TYPES), query.limit)
+            .await
+            .map_err(internal_error)?
+    } else if let Some(since_seq) = query.since_seq {
+        control
+            .mission_store
+            .get_events_since(mission_id, since_seq, Some(TRACE_EVENT_TYPES), query.limit)
+            .await
+            .map_err(internal_error)?
+    } else {
+        let offset = if query.latest.unwrap_or(false) {
+            if let Some(limit) = query.limit {
+                let total = control
+                    .mission_store
+                    .count_events(mission_id, Some(TRACE_EVENT_TYPES))
+                    .await
+                    .map_err(internal_error)?;
+                Some(total.saturating_sub(limit))
+            } else {
+                query.offset
+            }
+        } else {
+            query.offset
+        };
+        control
+            .mission_store
+            .get_events(mission_id, Some(TRACE_EVENT_TYPES), query.limit, offset)
+            .await
+            .map_err(internal_error)?
+    };
+
+    let total = control
+        .mission_store
+        .count_events(mission_id, Some(TRACE_EVENT_TYPES))
+        .await
+        .ok();
+    let max_seq = control
+        .mission_store
+        .max_event_sequence(mission_id)
+        .await
+        .ok();
+
+    let mut response = Json(events).into_response();
+    let headers = response.headers_mut();
+    if let Some(total) = total {
+        if let Ok(v) = header::HeaderValue::from_str(&total.to_string()) {
+            headers.insert("X-Total-Events", v);
+        }
+    }
+    if let Some(max_seq) = max_seq {
+        if let Ok(v) = header::HeaderValue::from_str(&max_seq.to_string()) {
+            headers.insert("X-Max-Sequence", v);
+        }
+    }
     headers.insert(
         header::ACCESS_CONTROL_EXPOSE_HEADERS,
         header::HeaderValue::from_static("X-Total-Events, X-Max-Sequence"),
@@ -6256,7 +6487,13 @@ fn mission_status_for_terminal_reason(
 ) -> Option<(MissionStatus, &'static str)> {
     match reason {
         TerminalReason::TurnComplete if complete_turn_without_follow_up => {
-            Some((MissionStatus::Completed, "completed"))
+            // Agent finished its turn cleanly and there is no queued follow-up
+            // message or scheduled wakeup — the mission is parked waiting for
+            // the user to read it. The dashboard / iOS clients surface this in
+            // the "Needs You" column. An explicit `TerminalReason::Completed`
+            // (the path below) is used when the agent declares the work fully
+            // done, not just a turn boundary.
+            Some((MissionStatus::AwaitingUser, "turn_complete"))
         }
         TerminalReason::TurnComplete => None,
         TerminalReason::Completed => Some((MissionStatus::Completed, "completed")),
@@ -7183,6 +7420,8 @@ async fn control_actor_loop(
                                                     | MissionStatus::Blocked
                                                     | MissionStatus::Completed
                                                     | MissionStatus::Failed
+                                                    | MissionStatus::AwaitingUser
+                                                    | MissionStatus::Acknowledged
                                             ) {
                                                 tracing::info!(
                                                     "Activating parallel mission {} (was {})",
@@ -7292,6 +7531,8 @@ async fn control_actor_loop(
                                                 | MissionStatus::Blocked
                                                 | MissionStatus::Completed
                                                 | MissionStatus::Failed
+                                                | MissionStatus::AwaitingUser
+                                                | MissionStatus::Acknowledged
                                         ) {
                                             tracing::info!(
                                                 "Activating main mission {} (was {})",
@@ -7338,6 +7579,8 @@ async fn control_actor_loop(
                                                     | MissionStatus::Blocked
                                                     | MissionStatus::Completed
                                                     | MissionStatus::Failed
+                                                    | MissionStatus::AwaitingUser
+                                                    | MissionStatus::Acknowledged
                                             ) {
                                                 tracing::info!(
                                                     "Activating switched mission {} (was {})",
@@ -7379,6 +7622,8 @@ async fn control_actor_loop(
                                                     | MissionStatus::Blocked
                                                     | MissionStatus::Completed
                                                     | MissionStatus::Failed
+                                                    | MissionStatus::AwaitingUser
+                                                    | MissionStatus::Acknowledged
                                             ) {
                                                 tracing::info!(
                                                     "Activating reloaded mission {} (was {})",
@@ -7477,6 +7722,8 @@ async fn control_actor_loop(
                                                     | MissionStatus::Blocked
                                                     | MissionStatus::Completed
                                                     | MissionStatus::Failed
+                                                    | MissionStatus::AwaitingUser
+                                                    | MissionStatus::Acknowledged
                                             ) {
                                                 tracing::info!(
                                                     "Activating mission {} (was {})",
@@ -15600,6 +15847,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
         let weak = Mission {
             id: Uuid::new_v4(),
@@ -15630,6 +15878,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
 
         let strong_score = mission_search_relevance_score(
@@ -15675,6 +15924,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
 
         let score = mission_search_relevance_score(
@@ -15717,6 +15967,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
 
         let score = mission_search_relevance_score(
@@ -15759,6 +16010,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
 
         let score = mission_search_relevance_score(
@@ -15801,6 +16053,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
 
         let score = mission_search_relevance_score(
@@ -15927,6 +16180,7 @@ And the report:
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
         let before = mission_search_freshness_key(
             &[MissionSearchCandidate {

--- a/src/api/grok_goal.rs
+++ b/src/api/grok_goal.rs
@@ -63,7 +63,9 @@ pub const VAR_MISSING_COUNT: &str = "goal_missing_count";
 pub enum GoalSentinel {
     Complete,
     Continue,
-    Aborted { reason: String },
+    Aborted {
+        reason: String,
+    },
     /// No sentinel present in the assistant text. Treated leniently — see
     /// [`MAX_MISSING_SENTINELS`].
     Missing,
@@ -179,15 +181,17 @@ pub async fn active_goal_for_mission(
     automations.into_iter().find(|a| {
         a.active
             && matches!(a.trigger, TriggerType::AgentFinished)
-            && a.variables.get(GROK_GOAL_TAG_KEY).map(String::as_str)
-                == Some(GROK_GOAL_TAG_VALUE)
+            && a.variables.get(GROK_GOAL_TAG_KEY).map(String::as_str) == Some(GROK_GOAL_TAG_VALUE)
     })
 }
 
 /// Build the variables map for a fresh grok-goal automation.
 fn initial_variables(objective: &str, iteration: u32) -> HashMap<String, String> {
     let mut v = HashMap::new();
-    v.insert(GROK_GOAL_TAG_KEY.to_string(), GROK_GOAL_TAG_VALUE.to_string());
+    v.insert(
+        GROK_GOAL_TAG_KEY.to_string(),
+        GROK_GOAL_TAG_VALUE.to_string(),
+    );
     v.insert(VAR_OBJECTIVE.to_string(), objective.to_string());
     v.insert(VAR_ITERATION.to_string(), iteration.to_string());
     v.insert(VAR_MISSING_COUNT.to_string(), "0".to_string());

--- a/src/api/grok_goal.rs
+++ b/src/api/grok_goal.rs
@@ -1,0 +1,397 @@
+//! Server-side `/goal <objective>` loop for the Grok Build backend.
+//!
+//! Unlike codex (which has a harness-native `thread/goal/*` RPC) and Claude
+//! Code (whose CLI parses `/goal` internally), Grok has no goal-mode
+//! primitive. Sandboxed.sh drives the loop itself:
+//!
+//! 1. When `/goal <objective>` lands in a grok mission, we strip the prefix,
+//!    inject a sentinel protocol into the first-turn prompt, and create an
+//!    `AgentFinished`-triggered [`Automation`] row whose inline command is
+//!    the continuation prompt for subsequent turns.
+//! 2. After every grok turn, the post-turn hook parses the assistant's
+//!    final text for one of the sentinels (`<goal_complete/>`,
+//!    `<goal_continue/>`, `<goal_aborted reason="..."/>`).
+//!    - `Complete` / `Aborted` → disable the automation and emit
+//!      `GoalStatus { status: ... }`.
+//!    - `Continue` (or `Missing`, treated leniently up to a small limit) →
+//!      increment the iteration counter, emit
+//!      `GoalIteration { iteration: N }`, and let the existing
+//!      `agent_finished_automation_messages` flow re-fire the continuation
+//!      prompt as the next user message.
+//! 3. An iteration budget caps runaway loops; reaching it emits
+//!    `GoalStatus { status: "budget_limited" }` and disables the automation.
+//!
+//! The shape mirrors the codex `/goal` adapter so the dashboard / iOS clients
+//! render iteration + status pills with no UI changes (the SSE events
+//! `goal_iteration` and `goal_status` are already wired through
+//! `mission_runner.rs:13499-13511`).
+
+use crate::api::mission_store::{
+    self, Automation, CommandSource, FreshSession, MissionStore, RetryConfig, StopPolicy,
+    TriggerType,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ─── Tunables ────────────────────────────────────────────────────────────────
+
+/// Cap on goal iterations. Hit → `GoalStatus { status: "budget_limited" }`.
+pub const MAX_ITERATIONS: u32 = 25;
+
+/// Number of consecutive missing-sentinel turns tolerated before we treat
+/// the loop as aborted with reason `"no_goal_sentinel"`. The model often
+/// drops the marker on the first turn; ≥2 consecutive misses is intent.
+pub const MAX_MISSING_SENTINELS: u32 = 2;
+
+/// Tag stored in the automation's `variables` map so the post-turn hook
+/// can recognise a sandboxed.sh-driven grok goal row vs. an unrelated
+/// AgentFinished automation a user created manually.
+pub const GROK_GOAL_TAG_KEY: &str = "sandboxed.grok_goal";
+pub const GROK_GOAL_TAG_VALUE: &str = "1";
+
+/// Variable key under which we store the user's objective string.
+pub const VAR_OBJECTIVE: &str = "goal_objective";
+/// Variable key under which we store the current iteration count.
+pub const VAR_ITERATION: &str = "goal_iteration";
+/// Variable key under which we store consecutive missing-sentinel count.
+pub const VAR_MISSING_COUNT: &str = "goal_missing_count";
+
+// ─── Sentinel parsing ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GoalSentinel {
+    Complete,
+    Continue,
+    Aborted { reason: String },
+    /// No sentinel present in the assistant text. Treated leniently — see
+    /// [`MAX_MISSING_SENTINELS`].
+    Missing,
+}
+
+/// Parse the trailing sentinel marker from an assistant response.
+///
+/// Searches the whole text rather than just the last line so models that
+/// emit the marker followed by a sign-off ("…done. <goal_complete/> Bye!")
+/// still trigger. Precedence: `complete` > `aborted` > `continue`. A
+/// `complete` marker anywhere wins over a later `continue` — the model
+/// declared the work done.
+pub fn parse_goal_sentinel(text: &str) -> GoalSentinel {
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("<goal_complete/>") || lower.contains("<goal_complete />") {
+        return GoalSentinel::Complete;
+    }
+    if let Some(reason) = extract_aborted_reason(text) {
+        return GoalSentinel::Aborted { reason };
+    }
+    if lower.contains("<goal_continue/>") || lower.contains("<goal_continue />") {
+        return GoalSentinel::Continue;
+    }
+    GoalSentinel::Missing
+}
+
+/// Pull the `reason="..."` attribute out of `<goal_aborted reason="..."/>`.
+/// Returns `Some("unspecified")` if the marker is present but has no
+/// `reason` attribute. Returns `None` if the marker isn't present at all.
+fn extract_aborted_reason(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    let idx = lower.find("<goal_aborted")?;
+    let tail = &text[idx..];
+    let end = tail.find("/>").map(|e| idx + e + 2)?;
+    let segment = &text[idx..end];
+    // Naive but adequate: find `reason="..."`. Allow either quote style.
+    for quote in ['"', '\''] {
+        let needle = format!("reason={}", quote);
+        if let Some(after) = segment.find(&needle) {
+            let start = after + needle.len();
+            if let Some(close) = segment[start..].find(quote) {
+                return Some(segment[start..start + close].trim().to_string());
+            }
+        }
+    }
+    Some("unspecified".to_string())
+}
+
+// ─── Prefix detection ────────────────────────────────────────────────────────
+
+/// Single-pass `/goal ` prefix strip, matching the rule used by
+/// `src/backend/codex/mod.rs:parse_goal_prefix`. Returns
+/// `(is_goal, objective_or_original_message)`.
+pub fn parse_goal_prefix(message: &str) -> (bool, String) {
+    let trimmed = message.trim_start();
+    match trimmed.strip_prefix("/goal ") {
+        Some(rest) => (true, rest.trim().to_string()),
+        None => (false, message.to_string()),
+    }
+}
+
+// ─── Prompts ─────────────────────────────────────────────────────────────────
+
+/// First-turn prompt: replaces the user's `/goal X` message. Establishes
+/// the sentinel protocol and asks the agent to begin.
+pub fn first_turn_prompt(objective: &str) -> String {
+    format!(
+        "[Goal mode]\n\
+         Objective: {objective}\n\n\
+         You are running in a sandboxed.sh-driven goal loop. Take concrete \
+         steps toward the objective. You will be re-invoked automatically \
+         after each reply, so you do not need to do everything in one turn.\n\n\
+         At the end of every reply, output EXACTLY ONE of these markers on \
+         its own line:\n\
+         - `<goal_complete/>` — when the objective is fully achieved.\n\
+         - `<goal_continue/>` — when more work is required (you will be \
+         re-invoked automatically).\n\
+         - `<goal_aborted reason=\"...\"/>` — when a hard blocker prevents \
+         further progress.\n\n\
+         The marker must be the literal text above. Do not paraphrase it. \
+         If no marker is present, the loop will treat your turn as \
+         in-progress and continue.\n\n\
+         Begin now."
+    )
+}
+
+/// Continuation prompt fired by the AgentFinished automation between
+/// iterations. Kept terse so it doesn't blow up the conversation context.
+pub fn continuation_prompt() -> String {
+    "Continue toward the goal. Remember to end your reply with exactly one \
+     of: `<goal_complete/>`, `<goal_continue/>`, or \
+     `<goal_aborted reason=\"...\"/>`."
+        .to_string()
+}
+
+// ─── Automation lifecycle ────────────────────────────────────────────────────
+
+/// Find the currently active grok-goal automation for a mission, if any.
+///
+/// Identifies a goal row by the `sandboxed.grok_goal=1` tag in
+/// [`Automation::variables`]. Multiple rows on the same mission would be a
+/// bug; we return the first match deterministically (sorted by created_at
+/// ascending — the original goal wins over any duplicate).
+pub async fn active_goal_for_mission(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+) -> Option<Automation> {
+    let mut automations = mission_store
+        .get_mission_automations(mission_id)
+        .await
+        .ok()?;
+    automations.sort_by_key(|a| a.created_at.clone());
+    automations.into_iter().find(|a| {
+        a.active
+            && matches!(a.trigger, TriggerType::AgentFinished)
+            && a.variables.get(GROK_GOAL_TAG_KEY).map(String::as_str)
+                == Some(GROK_GOAL_TAG_VALUE)
+    })
+}
+
+/// Build the variables map for a fresh grok-goal automation.
+fn initial_variables(objective: &str, iteration: u32) -> HashMap<String, String> {
+    let mut v = HashMap::new();
+    v.insert(GROK_GOAL_TAG_KEY.to_string(), GROK_GOAL_TAG_VALUE.to_string());
+    v.insert(VAR_OBJECTIVE.to_string(), objective.to_string());
+    v.insert(VAR_ITERATION.to_string(), iteration.to_string());
+    v.insert(VAR_MISSING_COUNT.to_string(), "0".to_string());
+    v
+}
+
+/// Read `goal_iteration` out of a row, defaulting to 0 on malformed input.
+pub fn iteration_of(row: &Automation) -> u32 {
+    row.variables
+        .get(VAR_ITERATION)
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+/// Read `goal_objective` out of a row, defaulting to empty.
+pub fn objective_of(row: &Automation) -> String {
+    row.variables
+        .get(VAR_OBJECTIVE)
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Read `goal_missing_count` out of a row, defaulting to 0.
+pub fn missing_count_of(row: &Automation) -> u32 {
+    row.variables
+        .get(VAR_MISSING_COUNT)
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+/// Create the AgentFinished automation row that drives the loop. Idempotent
+/// at the caller — only call when [`active_goal_for_mission`] returned
+/// `None`.
+pub async fn create_goal_automation(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    objective: &str,
+) -> Result<Automation, String> {
+    let automation = Automation {
+        id: Uuid::new_v4(),
+        mission_id,
+        command_source: CommandSource::Inline {
+            content: continuation_prompt(),
+        },
+        trigger: TriggerType::AgentFinished,
+        variables: initial_variables(objective, 1),
+        active: true,
+        created_at: mission_store::now_string(),
+        last_triggered_at: None,
+        retry_config: RetryConfig::default(),
+        // We disable the row explicitly when the sentinel says we're done;
+        // we don't want a single failed iteration to silently kill the
+        // loop, and we don't have a "stop on goal complete" policy variant.
+        stop_policy: StopPolicy::Never,
+        fresh_session: FreshSession::Keep,
+        consecutive_failures: 0,
+        driver: mission_store::AutomationDriver::Scheduler,
+    };
+    mission_store
+        .create_automation(automation.clone())
+        .await
+        .map(|_| automation)
+        .map_err(|e| format!("create_automation failed: {}", e))
+}
+
+/// Persist an iteration / missing-count update to the row's variables.
+pub async fn update_counters(
+    mission_store: &Arc<dyn MissionStore>,
+    row: &mut Automation,
+    iteration: u32,
+    missing_count: u32,
+) -> Result<(), String> {
+    row.variables
+        .insert(VAR_ITERATION.to_string(), iteration.to_string());
+    row.variables
+        .insert(VAR_MISSING_COUNT.to_string(), missing_count.to_string());
+    mission_store
+        .update_automation(row.clone())
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("update_automation failed: {}", e))
+}
+
+/// Mark the goal automation inactive. Used on Complete / Aborted /
+/// BudgetLimited. Errors are logged by the caller.
+pub async fn disable_goal(
+    mission_store: &Arc<dyn MissionStore>,
+    row: &mut Automation,
+) -> Result<(), String> {
+    row.active = false;
+    mission_store
+        .update_automation(row.clone())
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("disable_automation failed: {}", e))
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_strip_matches_codex() {
+        assert_eq!(
+            parse_goal_prefix("/goal ship it"),
+            (true, "ship it".to_string())
+        );
+        assert_eq!(
+            parse_goal_prefix("   /goal ship it"),
+            (true, "ship it".to_string())
+        );
+        assert_eq!(
+            parse_goal_prefix("not a goal"),
+            (false, "not a goal".to_string())
+        );
+        // Embedded `/goal ` inside the objective must survive single-pass.
+        assert_eq!(
+            parse_goal_prefix("/goal /goal nested"),
+            (true, "/goal nested".to_string())
+        );
+        // Empty objective normalises to empty string but `is_goal` is true.
+        // (The caller is responsible for rejecting an empty objective; we
+        // don't lie about whether the prefix was present.)
+        assert_eq!(parse_goal_prefix("/goal "), (true, "".to_string()));
+    }
+
+    #[test]
+    fn sentinel_complete_wins_over_continue() {
+        let t = "Done. <goal_complete/> Also could add tests later <goal_continue/>";
+        assert_eq!(parse_goal_sentinel(t), GoalSentinel::Complete);
+    }
+
+    #[test]
+    fn sentinel_aborted_extracts_reason() {
+        let t = "Can't proceed. <goal_aborted reason=\"no XAI_API_KEY\"/>";
+        match parse_goal_sentinel(t) {
+            GoalSentinel::Aborted { reason } => assert_eq!(reason, "no XAI_API_KEY"),
+            other => panic!("expected Aborted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sentinel_aborted_without_reason_attribute() {
+        let t = "Blocked. <goal_aborted/>";
+        match parse_goal_sentinel(t) {
+            GoalSentinel::Aborted { reason } => assert_eq!(reason, "unspecified"),
+            other => panic!("expected Aborted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sentinel_continue_recognised() {
+        assert_eq!(
+            parse_goal_sentinel("Working on it. <goal_continue/>"),
+            GoalSentinel::Continue
+        );
+        // Space-before-slash variant.
+        assert_eq!(
+            parse_goal_sentinel("<goal_continue />"),
+            GoalSentinel::Continue
+        );
+    }
+
+    #[test]
+    fn sentinel_missing_when_no_marker() {
+        assert_eq!(
+            parse_goal_sentinel("I did some work but forgot the marker."),
+            GoalSentinel::Missing
+        );
+    }
+
+    #[test]
+    fn sentinel_match_is_case_insensitive() {
+        assert_eq!(
+            parse_goal_sentinel("<GOAL_COMPLETE/>"),
+            GoalSentinel::Complete
+        );
+    }
+
+    #[test]
+    fn first_turn_prompt_includes_objective_and_markers() {
+        let p = first_turn_prompt("write tests");
+        assert!(p.contains("write tests"));
+        assert!(p.contains("<goal_complete/>"));
+        assert!(p.contains("<goal_continue/>"));
+        assert!(p.contains("<goal_aborted"));
+    }
+
+    #[test]
+    fn continuation_prompt_reminds_sentinels() {
+        let p = continuation_prompt();
+        assert!(p.contains("<goal_complete/>"));
+        assert!(p.contains("<goal_continue/>"));
+        assert!(p.contains("<goal_aborted"));
+    }
+
+    #[test]
+    fn initial_variables_carry_tag_and_objective() {
+        let v = initial_variables("ship it", 3);
+        assert_eq!(v.get(GROK_GOAL_TAG_KEY).map(String::as_str), Some("1"));
+        assert_eq!(v.get(VAR_OBJECTIVE).map(String::as_str), Some("ship it"));
+        assert_eq!(v.get(VAR_ITERATION).map(String::as_str), Some("3"));
+        assert_eq!(v.get(VAR_MISSING_COUNT).map(String::as_str), Some("0"));
+    }
+}

--- a/src/api/library.rs
+++ b/src/api/library.rs
@@ -957,6 +957,11 @@ struct BuiltinCommandsResponse {
     /// Empty when the workspace's codex binary predates the goals feature flag.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     codex: Vec<CommandSummary>,
+    /// Commands for Grok Build. Today this carries the sandboxed.sh-driven
+    /// `/goal` loop (Grok has no native goal mode — see
+    /// `src/api/grok_goal.rs`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    grok: Vec<CommandSummary>,
 }
 
 /// GET /api/library/builtin-commands - Get builtin slash commands for each backend.
@@ -1126,10 +1131,28 @@ fn build_builtin_commands() -> BuiltinCommandsResponse {
         }],
     }];
 
+    // Grok builtin commands. Grok has no native goal mode; sandboxed.sh
+    // drives the loop via an AgentFinished automation that parses sentinel
+    // markers from each turn's output. See `src/api/grok_goal.rs`.
+    let grok_commands = vec![CommandSummary {
+        name: "goal".to_string(),
+        description: Some(
+            "Loop until the objective is achieved (sandboxed.sh-driven; works with any grok model)"
+                .to_string(),
+        ),
+        path: "builtin-grok".to_string(),
+        params: vec![CommandParam {
+            name: "objective".to_string(),
+            required: true,
+            description: Some("What the agent should keep iterating on until done".to_string()),
+        }],
+    }];
+
     BuiltinCommandsResponse {
         opencode: opencode_commands,
         claudecode: claudecode_commands,
         codex: codex_commands,
+        grok: grok_commands,
     }
 }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -10024,6 +10024,61 @@ async fn ensure_grok_cli_available(
     }
 }
 
+async fn sync_grok_oauth_auth_file(
+    workspace_exec: &WorkspaceExec,
+    cwd: &std::path::Path,
+) -> Result<bool, String> {
+    let auth_path = std::path::PathBuf::from(crate::util::home_dir())
+        .join(".grok")
+        .join("auth.json");
+    if !auth_path.is_file() {
+        return Ok(false);
+    }
+
+    let auth_json = tokio::fs::read_to_string(&auth_path)
+        .await
+        .map_err(|e| format!("Failed to read Grok auth file: {}", e))?;
+    if auth_json.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let encoded = {
+        use base64::Engine;
+        base64::engine::general_purpose::STANDARD.encode(auth_json.as_bytes())
+    };
+    let output = workspace_exec
+        .output(
+            cwd,
+            "/bin/sh",
+            &[
+                "-lc".to_string(),
+                format!(
+                    "mkdir -p \"${{HOME:-/root}}/.grok\" && printf %s '{}' | base64 -d > \"${{HOME:-/root}}/.grok/auth.json\" && chmod 600 \"${{HOME:-/root}}/.grok/auth.json\"",
+                    encoded
+                ),
+            ],
+            HashMap::new(),
+        )
+        .await
+        .map_err(|e| format!("Failed to sync Grok auth file: {}", e))?;
+    if output.status.success() {
+        Ok(true)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Err(format!(
+            "Failed to sync Grok auth file into workspace: {}{}{}",
+            stderr.trim(),
+            if stderr.trim().is_empty() || stdout.trim().is_empty() {
+                ""
+            } else {
+                " | "
+            },
+            stdout.trim()
+        ))
+    }
+}
+
 /// Result of a backend preflight check
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct BackendPreflightResult {
@@ -12641,6 +12696,16 @@ fn grok_event_text(value: &serde_json::Value) -> Option<String> {
         return Some(text.to_string());
     }
 
+    if value
+        .get("type")
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t.eq_ignore_ascii_case("text"))
+    {
+        if let Some(text) = value.get("data").and_then(|v| v.as_str()) {
+            return Some(text.to_string());
+        }
+    }
+
     if let Some(content) = value.get("content") {
         if let Some(text) = content.as_str() {
             return Some(text.to_string());
@@ -12650,21 +12715,21 @@ fn grok_event_text(value: &serde_json::Value) -> Option<String> {
         }
     }
 
-    if let Some(text) = value
-        .get("message")
-        .and_then(|message| message.get("content"))
-        .and_then(|content| {
-            content.as_str().map(str::to_string).or_else(|| {
-                content.as_array().map(|blocks| {
-                    blocks
-                        .iter()
-                        .filter_map(|block| block.get("text").and_then(|v| v.as_str()))
-                        .collect::<Vec<_>>()
-                        .join("")
+    if let Some(text) = value.get("message").and_then(|message| {
+        message.as_str().map(str::to_string).or_else(|| {
+            message.get("content").and_then(|content| {
+                content.as_str().map(str::to_string).or_else(|| {
+                    content.as_array().map(|blocks| {
+                        blocks
+                            .iter()
+                            .filter_map(|block| block.get("text").and_then(|v| v.as_str()))
+                            .collect::<Vec<_>>()
+                            .join("")
+                    })
                 })
             })
         })
-    {
+    }) {
         if !text.is_empty() {
             return Some(text);
         }
@@ -12754,10 +12819,14 @@ pub async fn run_grok_turn(
     args.push("streaming-json".to_string());
     args.push("--always-approve".to_string());
     args.push("--cwd".to_string());
-    args.push(work_dir.display().to_string());
+    args.push(workspace_exec.translate_path_for_container(work_dir));
     if let Some(model) = model.filter(|m| !m.trim().is_empty()) {
         args.push("--model".to_string());
         args.push(model.to_string());
+    }
+
+    if let Err(err) = sync_grok_oauth_auth_file(&workspace_exec, work_dir).await {
+        tracing::warn!(mission_id = %mission_id, error = %err, "Failed to sync Grok OAuth auth file");
     }
 
     let mut env = HashMap::new();
@@ -12872,7 +12941,7 @@ pub async fn run_grok_turn(
                                     .get("delta")
                                     .is_some()
                                     || value.get("type").and_then(|v| v.as_str()).is_some_and(|t| {
-                                        t.contains("delta") || t.contains("chunk")
+                                        t.contains("delta") || t.contains("chunk") || t == "text"
                                     })
                                 {
                                     final_result.push_str(&text);
@@ -12929,9 +12998,7 @@ pub async fn run_grok_turn(
     } else {
         AgentResult::failure(final_result, 0).with_terminal_reason(TerminalReason::LlmError)
     };
-    if let Some(model) = model_used {
-        result = result.with_model(model);
-    }
+    result = result.with_model(model_used.unwrap_or_else(|| "grok-build".to_string()));
     result
 }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -36,8 +36,9 @@ use crate::workspace_exec::WorkspaceExec;
 
 use super::automation_variables::substitute_custom_variables;
 use super::control::{
-    resolve_claudecode_default_model, resolve_gemini_default_model, safe_truncate_index,
-    AgentEvent, AgentTreeNode, ControlRunState, ControlStatus, ExecutionProgress, FrontendToolHub,
+    resolve_claudecode_default_model, resolve_gemini_default_model, resolve_grok_default_model,
+    safe_truncate_index, AgentEvent, AgentTreeNode, ControlRunState, ControlStatus,
+    ExecutionProgress, FrontendToolHub,
 };
 use super::library::SharedLibrary;
 
@@ -2672,6 +2673,14 @@ async fn run_mission_turn(
         // Pin Gemini to a stable backend default instead of inheriting the
         // global model or relying on the CLI's own default.
         config.default_model = Some(resolve_gemini_default_model());
+    } else if backend_id == "grok" && model_override.is_none() {
+        // Pin Grok Build to its own default model. Without this the global
+        // DEFAULT_MODEL (typically `anthropic/claude-opus-4-6`) flows
+        // through to `--model` and the grok CLI rejects it as "unknown
+        // model id" — the mission then fails on the first turn with a
+        // confusing chdir error from the rejected-CLI path. See prod
+        // mission 1aef657a (2026-05-16).
+        config.default_model = Some(resolve_grok_default_model());
     }
     tracing::info!(
         mission_id = %mission_id,
@@ -12802,16 +12811,19 @@ pub async fn run_grok_turn(
     };
 
     let mut args = Vec::new();
-    if is_continuation {
-        if let Some(sid) = session_id {
-            args.push("--resume".to_string());
-            args.push(sid.to_string());
-        } else {
-            args.push("--continue".to_string());
-        }
-    } else if let Some(sid) = session_id {
+    // Use `-s/--session-id` for both first-turn and continuation when we
+    // already have a session id from the mission store. Per grok headless
+    // docs, `--session-id` has upsert semantics — loads the session if it
+    // exists, creates one with that id otherwise — so it self-heals the
+    // "orphan session" case where the first turn failed before grok could
+    // persist the session and `--resume <sid>` would error with "Session
+    // does not exist". `--resume` is strict-existence-only; we only fall
+    // through to `--continue` when we have no session id at all.
+    if let Some(sid) = session_id {
         args.push("--session-id".to_string());
         args.push(sid.to_string());
+    } else if is_continuation {
+        args.push("--continue".to_string());
     }
     args.push("-p".to_string());
     args.push(message.to_string());

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -187,19 +187,75 @@ impl MissionStore for FileMissionStore {
         let now = now_string();
         mission.updated_at = now.clone();
         mission.terminal_reason = terminal_reason.map(|s| s.to_string());
-        // Failed missions with LlmError are also resumable (transient API errors)
-        if matches!(
+        // AwaitingUser is resumable too (any user message wakes the agent).
+        // Failed missions with LlmError are also resumable (transient API errors).
+        mission.resumable = matches!(
             status,
-            MissionStatus::Interrupted | MissionStatus::Blocked | MissionStatus::Failed
-        ) {
-            mission.interrupted_at = Some(now);
-            mission.resumable = true;
-        } else {
-            mission.interrupted_at = None;
-            mission.resumable = false;
+            MissionStatus::Interrupted
+                | MissionStatus::Blocked
+                | MissionStatus::Failed
+                | MissionStatus::AwaitingUser
+                | MissionStatus::Acknowledged
+        );
+        mission.interrupted_at =
+            if matches!(status, MissionStatus::Interrupted | MissionStatus::Blocked) {
+                Some(now)
+            } else {
+                None
+            };
+        if matches!(status, MissionStatus::Active) {
+            mission.first_viewed_at = None;
         }
         drop(missions);
         self.persist().await
+    }
+
+    async fn set_mission_first_viewed_at_if_unset(
+        &self,
+        id: Uuid,
+        timestamp: &str,
+    ) -> Result<Option<String>, String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        if mission.first_viewed_at.is_some() {
+            return Ok(None);
+        }
+        mission.first_viewed_at = Some(timestamp.to_string());
+        drop(missions);
+        self.persist().await?;
+        Ok(Some(timestamp.to_string()))
+    }
+
+    async fn acknowledge_stale_awaiting_user_missions(
+        &self,
+        grace_seconds: u64,
+    ) -> Result<Vec<Uuid>, String> {
+        let cutoff = chrono::Utc::now() - chrono::Duration::seconds(grace_seconds as i64);
+        let mut missions = self.missions.write().await;
+        let mut promoted = Vec::new();
+        for mission in missions.values_mut() {
+            if mission.status != MissionStatus::AwaitingUser {
+                continue;
+            }
+            let Some(ref viewed_at) = mission.first_viewed_at else {
+                continue;
+            };
+            let Ok(viewed_dt) = chrono::DateTime::parse_from_rfc3339(viewed_at) else {
+                continue;
+            };
+            if viewed_dt <= cutoff {
+                mission.status = MissionStatus::Acknowledged;
+                mission.updated_at = now_string();
+                promoted.push(mission.id);
+            }
+        }
+        drop(missions);
+        if !promoted.is_empty() {
+            self.persist().await?;
+        }
+        Ok(promoted)
     }
 
     async fn update_mission_history(

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -149,6 +149,7 @@ impl MissionStore for FileMissionStore {
             mission_mode: super::MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
         self.missions
             .write()

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -137,18 +137,68 @@ impl MissionStore for InMemoryMissionStore {
         let now = now_string();
         mission.updated_at = now.clone();
         mission.terminal_reason = terminal_reason.map(|s| s.to_string());
-        // Failed missions with LlmError are also resumable (transient API errors)
-        if matches!(
+        // AwaitingUser is resumable too (any user message wakes the agent).
+        // Failed missions with LlmError are also resumable (transient API errors).
+        mission.resumable = matches!(
             status,
-            MissionStatus::Interrupted | MissionStatus::Blocked | MissionStatus::Failed
-        ) {
-            mission.interrupted_at = Some(now);
-            mission.resumable = true;
-        } else {
-            mission.interrupted_at = None;
-            mission.resumable = false;
+            MissionStatus::Interrupted
+                | MissionStatus::Blocked
+                | MissionStatus::Failed
+                | MissionStatus::AwaitingUser
+                | MissionStatus::Acknowledged
+        );
+        mission.interrupted_at =
+            if matches!(status, MissionStatus::Interrupted | MissionStatus::Blocked) {
+                Some(now)
+            } else {
+                None
+            };
+        if matches!(status, MissionStatus::Active) {
+            mission.first_viewed_at = None;
         }
         Ok(())
+    }
+
+    async fn set_mission_first_viewed_at_if_unset(
+        &self,
+        id: Uuid,
+        timestamp: &str,
+    ) -> Result<Option<String>, String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        if mission.first_viewed_at.is_some() {
+            return Ok(None);
+        }
+        mission.first_viewed_at = Some(timestamp.to_string());
+        Ok(Some(timestamp.to_string()))
+    }
+
+    async fn acknowledge_stale_awaiting_user_missions(
+        &self,
+        grace_seconds: u64,
+    ) -> Result<Vec<Uuid>, String> {
+        let cutoff = chrono::Utc::now() - chrono::Duration::seconds(grace_seconds as i64);
+        let mut missions = self.missions.write().await;
+        let mut promoted = Vec::new();
+        for mission in missions.values_mut() {
+            if mission.status != MissionStatus::AwaitingUser {
+                continue;
+            }
+            let Some(ref viewed_at) = mission.first_viewed_at else {
+                continue;
+            };
+            let Ok(viewed_dt) = chrono::DateTime::parse_from_rfc3339(viewed_at) else {
+                continue;
+            };
+            if viewed_dt <= cutoff {
+                mission.status = MissionStatus::Acknowledged;
+                mission.updated_at = now_string();
+                promoted.push(mission.id);
+            }
+        }
+        Ok(promoted)
     }
 
     async fn update_mission_history(

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -100,6 +100,7 @@ impl MissionStore for InMemoryMissionStore {
             mission_mode: super::MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
         self.missions
             .write()

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -97,6 +97,12 @@ pub struct Mission {
     /// stays current.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub goal_objective: Option<String>,
+    /// When the user first opened this mission *since it last entered
+    /// AwaitingUser*. Drives the 1-hour ack grace timer and the "opened"
+    /// dot on Finished missions. Cleared when the mission goes back to
+    /// Active via a new user message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_viewed_at: Option<String>,
 }
 
 fn default_backend() -> String {

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -941,6 +941,26 @@ pub trait MissionStore: Send + Sync {
     /// Get all missions currently in active status (for startup recovery).
     async fn get_all_active_missions(&self) -> Result<Vec<Mission>, String>;
 
+    /// Record the first time the user opened this mission, if not already set.
+    /// Returns `Some(timestamp)` if the field was set by this call, or `None`
+    /// if it was already populated (no-op). Used by the new
+    /// `POST /missions/:id/opened` endpoint to start the AwaitingUser ack
+    /// grace timer.
+    async fn set_mission_first_viewed_at_if_unset(
+        &self,
+        id: Uuid,
+        timestamp: &str,
+    ) -> Result<Option<String>, String>;
+
+    /// Atomically flip any AwaitingUser mission whose `first_viewed_at` is
+    /// older than `grace_seconds` to `Acknowledged`. Returns the IDs that
+    /// were promoted so the caller can broadcast `MissionStatusChanged`
+    /// events for them.
+    async fn acknowledge_stale_awaiting_user_missions(
+        &self,
+        grace_seconds: u64,
+    ) -> Result<Vec<Uuid>, String>;
+
     /// Get recently interrupted missions that were stopped by server shutdown.
     async fn get_recent_server_shutdown_mission_ids(
         &self,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2388,27 +2388,52 @@ impl MissionStore for SqliteMissionStore {
             } else {
                 None
             };
-        // Failed missions with LlmError are also resumable (transient API errors)
+        // Failed missions with LlmError are also resumable (transient API errors).
+        // AwaitingUser missions are also resumable (the user can send another
+        // message at any time to wake the agent back up).
         let resumable = matches!(
             status,
-            MissionStatus::Interrupted | MissionStatus::Blocked | MissionStatus::Failed
+            MissionStatus::Interrupted
+                | MissionStatus::Blocked
+                | MissionStatus::Failed
+                | MissionStatus::AwaitingUser
+                | MissionStatus::Acknowledged
         );
         let terminal_reason = terminal_reason.map(|s| s.to_string());
+        // Transitioning back to Active means the user just sent a new message —
+        // clear `first_viewed_at` so the next AwaitingUser round starts fresh
+        // (and so the "opened" dot disappears once the agent picks up again).
+        let clear_first_viewed_at = matches!(status, MissionStatus::Active);
 
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
-            conn.execute(
-                "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5 WHERE id = ?6",
-                params![
-                    status_to_string(status),
-                    now,
-                    interrupted_at,
-                    if resumable { 1 } else { 0 },
-                    terminal_reason,
-                    id.to_string(),
-                ],
-            )
-            .map_err(|e| e.to_string())?;
+            if clear_first_viewed_at {
+                conn.execute(
+                    "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5, first_viewed_at = NULL WHERE id = ?6",
+                    params![
+                        status_to_string(status),
+                        now,
+                        interrupted_at,
+                        if resumable { 1 } else { 0 },
+                        terminal_reason,
+                        id.to_string(),
+                    ],
+                )
+                .map_err(|e| e.to_string())?;
+            } else {
+                conn.execute(
+                    "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5 WHERE id = ?6",
+                    params![
+                        status_to_string(status),
+                        now,
+                        interrupted_at,
+                        if resumable { 1 } else { 0 },
+                        terminal_reason,
+                        id.to_string(),
+                    ],
+                )
+                .map_err(|e| e.to_string())?;
+            }
             Ok(())
         })
         .await
@@ -2437,6 +2462,74 @@ impl MissionStore for SqliteMissionStore {
             .map_err(|e| e.to_string())?;
 
             Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn set_mission_first_viewed_at_if_unset(
+        &self,
+        id: Uuid,
+        timestamp: &str,
+    ) -> Result<Option<String>, String> {
+        let conn = self.conn.clone();
+        let id_str = id.to_string();
+        let ts = timestamp.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let updated = conn
+                .execute(
+                    "UPDATE missions SET first_viewed_at = ?1 WHERE id = ?2 AND first_viewed_at IS NULL",
+                    params![&ts, &id_str],
+                )
+                .map_err(|e| e.to_string())?;
+            Ok(if updated > 0 { Some(ts) } else { None })
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn acknowledge_stale_awaiting_user_missions(
+        &self,
+        grace_seconds: u64,
+    ) -> Result<Vec<Uuid>, String> {
+        let conn = self.conn.clone();
+        let cutoff = (Utc::now() - chrono::Duration::seconds(grace_seconds as i64)).to_rfc3339();
+        let now = now_string();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = conn.blocking_lock();
+            let tx = conn.transaction().map_err(|e| e.to_string())?;
+            let ids: Vec<Uuid> = {
+                let mut stmt = tx
+                    .prepare(
+                        "SELECT id FROM missions
+                         WHERE status = 'awaiting_user'
+                           AND first_viewed_at IS NOT NULL
+                           AND first_viewed_at <= ?1",
+                    )
+                    .map_err(|e| e.to_string())?;
+                let rows = stmt
+                    .query_map(params![&cutoff], |row| {
+                        let id_str: String = row.get(0)?;
+                        Ok(parse_uuid_or_nil(&id_str))
+                    })
+                    .map_err(|e| e.to_string())?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| e.to_string())?;
+                rows
+            };
+            if !ids.is_empty() {
+                tx.execute(
+                    "UPDATE missions SET status = 'acknowledged', updated_at = ?1
+                     WHERE status = 'awaiting_user'
+                       AND first_viewed_at IS NOT NULL
+                       AND first_viewed_at <= ?2",
+                    params![&now, &cutoff],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+            tx.commit().map_err(|e| e.to_string())?;
+            Ok(ids)
         })
         .await
         .map_err(|e| e.to_string())?

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -425,7 +425,8 @@ CREATE TABLE IF NOT EXISTS missions (
     interrupted_at TEXT,
     resumable INTEGER NOT NULL DEFAULT 0,
     desktop_sessions TEXT,
-    terminal_reason TEXT
+    terminal_reason TEXT,
+    first_viewed_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -1728,6 +1729,20 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add goal_objective column: {}", e))?;
         }
 
+        // first_viewed_at: timestamp of the user's first open of the mission
+        // since it last entered AwaitingUser. Drives the ack grace timer and
+        // the "opened" dot on Finished missions.
+        let has_first_viewed_at_column: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'first_viewed_at'")
+            .map_err(|e| format!("Failed to check for first_viewed_at column: {}", e))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {}", e))?;
+        if !has_first_viewed_at_column {
+            tracing::info!("Running migration: adding 'first_viewed_at' column to missions table");
+            conn.execute("ALTER TABLE missions ADD COLUMN first_viewed_at TEXT", [])
+                .map_err(|e| format!("Failed to add first_viewed_at column: {}", e))?;
+        }
+
         Ok(())
     }
 
@@ -1962,6 +1977,8 @@ fn parse_status(s: &str) -> MissionStatus {
     match s {
         "pending" => MissionStatus::Pending,
         "active" => MissionStatus::Active,
+        "awaiting_user" => MissionStatus::AwaitingUser,
+        "acknowledged" => MissionStatus::Acknowledged,
         "completed" => MissionStatus::Completed,
         "failed" => MissionStatus::Failed,
         "interrupted" => MissionStatus::Interrupted,
@@ -1975,6 +1992,8 @@ fn status_to_string(status: MissionStatus) -> &'static str {
     match status {
         MissionStatus::Pending => "pending",
         MissionStatus::Active => "active",
+        MissionStatus::AwaitingUser => "awaiting_user",
+        MissionStatus::Acknowledged => "acknowledged",
         MissionStatus::Completed => "completed",
         MissionStatus::Failed => "failed",
         MissionStatus::Interrupted => "interrupted",
@@ -2001,7 +2020,7 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode,
-                            COALESCE(goal_mode, 0) as goal_mode, goal_objective
+                            COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2053,6 +2072,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                             goal_mode: row.get::<_, i32>(25).unwrap_or(0) != 0,
                             goal_objective: row.get(26).ok().flatten(),
+                            first_viewed_at: row.get(27).ok().flatten(),
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2080,7 +2100,7 @@ impl MissionStore for SqliteMissionStore {
                             created_at, updated_at, interrupted_at, resumable, desktop_sessions,
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
-                            COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective FROM missions WHERE id = ?1",
+                            COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -2129,6 +2149,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                             goal_mode: row.get::<_, i32>(25).unwrap_or(0) != 0,
                             goal_objective: row.get(26).ok().flatten(),
+                            first_viewed_at: row.get(27).ok().flatten(),
                     })
                 })
                 .optional()
@@ -2247,6 +2268,7 @@ impl MissionStore for SqliteMissionStore {
             mission_mode: MissionMode::default(),
             goal_mode: false,
             goal_objective: None,
+            first_viewed_at: None,
         };
 
         let m = mission.clone();
@@ -2335,6 +2357,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                             goal_mode: row.get::<_, i32>(23).unwrap_or(0) != 0,
                             goal_objective: row.get(24).ok().flatten(),
+                            first_viewed_at: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2839,6 +2862,7 @@ impl MissionStore for SqliteMissionStore {
                         mission_mode: MissionMode::default(),
                         goal_mode: false,
                         goal_objective: None,
+                        first_viewed_at: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2912,6 +2936,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                         goal_mode: row.get::<_, i32>(14).unwrap_or(0) != 0,
                         goal_objective: row.get(15).ok().flatten(),
+                        first_viewed_at: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -4384,6 +4409,7 @@ impl MissionStore for SqliteMissionStore {
                             .unwrap_or_default(),
                         goal_mode: false,
                         goal_objective: None,
+                        first_viewed_at: None,
                     })
                 })
                 .map_err(|e| e.to_string())?

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -27,6 +27,7 @@ pub mod desktop;
 mod desktop_stream;
 pub mod fido;
 mod fs;
+pub(crate) mod grok_goal;
 pub mod library;
 pub mod mcp;
 pub mod metadata_llm;

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1234,8 +1234,16 @@ pub async fn list_backend_model_options(
         &|id: &str| id.contains("codex") || id == "gpt-5.5" || id == "gpt-5.4";
     push_options("codex", Some(&["openai"]), false, Some(codex_filter));
     push_options("gemini", Some(&["google"]), false, None);
-    push_options("grok", Some(&["xai"]), false, None);
     push_options("opencode", None, true, None);
+    backends.insert(
+        "grok".to_string(),
+        vec![BackendModelOption {
+            value: "grok-build".to_string(),
+            label: "Grok Build".to_string(),
+            provider_id: Some("xai".to_string()),
+            description: Some("Default Grok Build CLI coding model".to_string()),
+        }],
+    );
 
     let codex_candidates: Vec<String> = backends
         .get("codex")

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -660,6 +660,14 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             get(control::get_mission_events),
         )
         .route(
+            "/api/control/missions/:id/transcript",
+            get(control::get_mission_transcript),
+        )
+        .route(
+            "/api/control/missions/:id/trace",
+            get(control::get_mission_trace),
+        )
+        .route(
             "/api/control/missions/:id/load",
             post(control::load_mission),
         )

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -672,6 +672,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             post(control::load_mission),
         )
         .route(
+            "/api/control/missions/:id/opened",
+            post(control::mark_mission_opened),
+        )
+        .route(
             "/api/control/missions/:id/status",
             post(control::set_mission_status),
         )

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -218,8 +218,45 @@ async fn list_workspaces(
     State(state): State<Arc<super::routes::AppState>>,
 ) -> Result<Json<Vec<WorkspaceResponse>>, (StatusCode, String)> {
     let workspaces = state.workspaces.list().await;
-    let responses: Vec<WorkspaceResponse> = workspaces.into_iter().map(Into::into).collect();
+    let responses: Vec<WorkspaceResponse> =
+        dedupe_workspace_list(workspaces, &state.config.working_dir)
+            .into_iter()
+            .map(Into::into)
+            .collect();
     Ok(Json(responses))
+}
+
+fn dedupe_workspace_list(workspaces: Vec<Workspace>, working_dir: &Path) -> Vec<Workspace> {
+    let canonical_container_root = working_dir.join(".sandboxed-sh").join("containers");
+    let mut by_identity: HashMap<(String, String), Workspace> = HashMap::new();
+
+    for workspace in workspaces {
+        let key = (
+            workspace.workspace_type.as_str().to_string(),
+            workspace.name.clone(),
+        );
+        match by_identity.get_mut(&key) {
+            Some(existing) => {
+                let existing_current = existing.path.starts_with(&canonical_container_root);
+                let candidate_current = workspace.path.starts_with(&canonical_container_root);
+                if candidate_current && !existing_current {
+                    *existing = workspace;
+                }
+            }
+            None => {
+                by_identity.insert(key, workspace);
+            }
+        }
+    }
+
+    let mut list: Vec<_> = by_identity.into_values().collect();
+    list.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.workspace_type.as_str().cmp(b.workspace_type.as_str()))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    list
 }
 
 /// Validate workspace name to prevent path traversal.

--- a/src/backend/native_loops.rs
+++ b/src/backend/native_loops.rs
@@ -86,8 +86,33 @@ impl NativeLoopAdapter for CodexGoal {
     }
 }
 
-/// Shared observer for `/goal` — both harnesses emit `GoalIteration` and
-/// `GoalStatus` events with the same shape, so the classification is identical.
+// ─── Adapter: Grok `/goal` (sandboxed.sh-driven) ─────────────────────────────
+//
+// Grok has no native goal-mode primitive — see `crate::api::grok_goal` for
+// the full design. Sandboxed.sh drives iteration via an AgentFinished
+// automation, parses sentinel markers from the assistant text, and emits
+// the same `AgentEvent::GoalIteration` / `AgentEvent::GoalStatus` shape as
+// codex so the UI surface is identical. Registering the adapter here lets
+// `native_loop_observer` materialise Automation + AutomationExecution rows
+// for grok-goal missions in the Automations panel alongside codex/claudecode
+// entries.
+pub struct GrokGoal;
+
+impl NativeLoopAdapter for GrokGoal {
+    fn harness(&self) -> &'static str {
+        "grok"
+    }
+    fn command(&self) -> &'static str {
+        "goal"
+    }
+    fn observe(&self, event: &AgentEvent) -> LoopObservation {
+        observe_goal_event(event)
+    }
+}
+
+/// Shared observer for `/goal` — all three harnesses emit `GoalIteration`
+/// and `GoalStatus` events with the same shape, so the classification is
+/// identical.
 fn observe_goal_event(event: &AgentEvent) -> LoopObservation {
     match event {
         AgentEvent::GoalIteration {
@@ -111,7 +136,7 @@ fn observe_goal_event(event: &AgentEvent) -> LoopObservation {
 /// Returns the registered adapters in iteration order. Add a new harness here
 /// (and only here) to expose it as a native loop.
 pub fn registry() -> &'static [&'static dyn NativeLoopAdapter] {
-    &[&ClaudeCodeGoal, &CodexGoal]
+    &[&ClaudeCodeGoal, &CodexGoal, &GrokGoal]
 }
 
 /// Find the adapter for a given (harness, command) pair, if any.
@@ -166,6 +191,7 @@ mod tests {
     fn registry_finds_known_adapters() {
         assert!(find_adapter("claudecode", "goal").is_some());
         assert!(find_adapter("codex", "goal").is_some());
+        assert!(find_adapter("grok", "goal").is_some());
         assert!(find_adapter("opencode", "goal").is_none());
         assert!(find_adapter("claudecode", "audit").is_none());
     }

--- a/src/backend_config.rs
+++ b/src/backend_config.rs
@@ -146,6 +146,24 @@ impl BackendConfigStore {
         self.save_to_disk().await?;
         Ok(Some(updated))
     }
+
+    pub async fn set_enabled(
+        &self,
+        id: &str,
+        enabled: bool,
+    ) -> Result<Option<BackendConfigEntry>, std::io::Error> {
+        let mut configs = self.configs.write().await;
+        let entry = configs.get_mut(id);
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+
+        entry.enabled = enabled;
+        let updated = entry.clone();
+        drop(configs);
+        self.save_to_disk().await?;
+        Ok(Some(updated))
+    }
 }
 
 pub type SharedBackendConfigStore = Arc<BackendConfigStore>;


### PR DESCRIPTION
Bundles several locally-developed features that landed together. Originally just the Grok OAuth wiring; expanded to ship the mission-lifecycle and UX work that built up on top of it.

## What's in this PR

### 1. xAI Grok Build OAuth (the original scope)
- Treat xAI as an OAuth provider; new Grok Build device-auth flow (`grok login --device-auth`) parsed from CLI stderr, with the resulting `~/.grok/auth.json` upserted into the AI provider store.
- Mirror the host's Grok auth file into each mission workspace before launching, translate `--cwd` for container workspaces, and accept the `text` event shape from the Grok CLI stream.
- Auto-enable the Grok backend when an xAI provider targeting it is created/updated; expose a default `grok-build` model option.
- Dashboard add-provider modal exposes "Grok Build OAuth" with a no-code "auto" completion path.
- Workspace listing deduped so the canonical container path wins over legacy entries; hide the cost chip in the control list when no cost data exists.

### 2. Sandboxed.sh-driven Grok `/goal` adapter
- New `src/api/grok_goal.rs` plus `NativeLoopAdapter` registration in `src/backend/native_loops.rs`. Grok has no native goal mode, so sandboxed.sh drives iteration via an AgentFinished automation, parses sentinel markers from the assistant text, and emits the same `GoalIteration` / `GoalStatus` event shape as codex so the UI surface is identical.
- Library API surfaces a `grok` array of builtin slash commands; iOS `BuiltinCommandsResponse` mirrors it.
- Design doc at `docs/grok-goal-integration-proposal.md`.

### 3. Mission lifecycle: AwaitingUser + Acknowledged + auto-archive
The "Needs You" column was previously keyed on `Interrupted | Blocked` — mostly failure paths. Rewired so it shows exactly the missions where the agent has parked waiting for the user.

- New `MissionStatus::AwaitingUser` and `MissionStatus::Acknowledged` variants; serde, Display, parse, status_to_string, every match-arm and `is_terminal_mission_status` updated.
- `mission_status_for_terminal_reason(TurnComplete, no-followup)` now returns `AwaitingUser` (was `Completed`). Explicit `TerminalReason::Completed` still maps to `Completed` so agent-declared "done" remains distinct.
- New `first_viewed_at: Option<String>` on `Mission`; SQLite migration + INSERT/SELECT paths updated; cleared on transition back to `Active`.
- New `MissionStore` methods (sqlite/memory/file): `set_mission_first_viewed_at_if_unset` (atomic SQL set-if-null) and `acknowledge_stale_awaiting_user_missions` (transactional batch promote).
- New `POST /api/control/missions/:id/opened` endpoint; broadcasts `MissionStatusChanged` on first open.
- New `ack_promotion_loop` background task (60s tick, `ACK_GRACE_SECONDS = 3600`): flips stale `AwaitingUser → Acknowledged` and emits SSE.
- **Dashboard**: predicates rewritten — Needs You = `[awaiting_user]`; Finished includes failure statuses with red tone via new `finishedTone(status)` helper. `markMissionOpened` API + `useEffect` in `control-client.tsx`. Mission rows render a 6px notification dot for Finished missions with `first_viewed_at`. Unit tests updated (147/147 pass).
- **iOS**: `MissionStatus` Swift enum gains `awaitingUser`/`acknowledged`; "Needs You" filter pill replaces "Interrupted"; "Failed" absorbs interrupted/blocked/notFeasible; row renders a 6pt dot for Finished missions with `firstViewedAt`. `APIService.markMissionOpened` called from `ControlView.loadMission`.

### 4. Transcript-first mission loading (WIP foundations)
- New `getMissionTranscript` endpoint + iOS/web clients. Dashboard `control-client.tsx`, iOS `ControlView.loadMission`, history/modules/automations dialogs reworked to fan out metadata + transcript in parallel and then enrich with trace.
- Cuts the second RTT that was previously needed before any history could render.

### 5. iOS UX responsiveness pass
- ControlView/HistoryView/LoadingView/StatusBadge polish; per-component shimmer variants (`ShimmerMcpCard`, `ShimmerMissionRow`, `ShimmerAutomationRow`) replacing the generic `ShimmerCard` in modules/history/automations.
- `ios_dashboard/UX_BLOCKING_AUDIT.md` captures the audit that drove the changes.

### 6. Misc fixes
- `InlineImagePreview` no longer fires a 404 against `./artifacts/...` when `basePath` hasn't loaded yet — gated on absolute path or known basePath, falling back to loading state.

## Verification
- `cargo fmt --all --check` clean
- `cargo build` clean
- `cargo test --lib` → 711 passed (1 prior test updated to match the new AwaitingUser mapping)
- `npm run test:unit` (dashboard) → 147 passed
- `npx tsc --noEmit` (dashboard) clean
- `xcodebuild ... -sdk iphonesimulator build` → BUILD SUCCEEDED
- End-to-end smoke (real mission cycling through AwaitingUser → Acknowledged with a lowered `ACK_GRACE_SECONDS`) requires a deployment and was **not** exercised in this PR — please run it before merging.

## Test plan
- [ ] Add an xAI provider via "Grok Build OAuth"; complete device auth; verify provider lands as `xAI (<email>)`, Grok backend auto-enables.
- [ ] Add an xAI provider with manual API key; confirm `GROK_CODE_XAI_API_KEY` flows.
- [ ] Run a Grok mission on a container workspace; confirm `~/.grok/auth.json` is mirrored inside and streaming output renders.
- [ ] Run a Grok `/goal` mission; confirm `GoalIteration` / `GoalStatus` events fire and the Automations panel shows the loop.
- [ ] Start a Claude Code mission, send one prompt, wait for the agent's reply. Confirm: status becomes `awaiting_user`, mission appears in "Needs You" on both web and iOS, SSE `MissionStatusChanged` fires.
- [ ] Open the mission. Confirm `POST /missions/:id/opened` (200), `first_viewed_at` set on the row.
- [ ] (Temporarily lower `ACK_GRACE_SECONDS` to 60s.) Wait. Confirm status flips to `acknowledged`, row moves to Finished (green), opened dot rendered on web + iOS.
- [ ] Send a new message into the acknowledged mission. Confirm: status → `active`, `first_viewed_at` cleared, row leaves Finished.
- [ ] Trigger MaxIterations or cancel a mission mid-run. Confirm: lands in Finished with red tone; opening once paints the dot.
- [ ] Open the workspaces list; no duplicate rows for migrated container workspaces.
- [ ] Restore `ACK_GRACE_SECONDS = 3600` before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes mission status semantics and adds new mission-loading endpoints used by both the web dashboard and iOS client; regressions could affect mission categorization, pagination, and status transitions across clients.
> 
> **Overview**
> **Mission lifecycle + UI categorization is refactored around new statuses.** Introduces `awaiting_user` and `acknowledged` as first-class `MissionStatus` values, redefines the *Needs You* bucket to be only `awaiting_user`, and moves failure states into *Finished* with a consistent red tone (including favicon/status-dot updates and updated unit tests).
> 
> **Transcript-first mission loading is added to reduce initial load cost.** Adds `GET /api/control/missions/:id/transcript` (lightweight transcript + counts) and `GET /api/control/missions/:id/trace` (deferred thinking/tool activity), updates the dashboard control view to paint from transcript then merge trace asynchronously (including pagination/count fixes), and updates iOS to fetch mission metadata + transcript in parallel with a compatible fallback.
> 
> **Mission “opened” tracking is added.** Adds `POST /api/control/missions/:id/opened` plus `first_viewed_at` on missions; both web and iOS call it when opening a mission and render an “opened” dot for finished missions.
> 
> **Provider + UX polish.** xAI is treated as an OAuth provider (dashboard provider modal supports an auto OAuth completion path and correct backend targeting defaults), loading skeletons are made more page-specific, and iOS receives multiple responsiveness tweaks (optimistic toggles/deletes, pending-send indicator, parallel backend/agent loading, terminal connect behavior, file browser SWR cache). Version bumps to `0.12.0` are applied across Rust and dashboard packages, and docs are updated (including a Grok `/goal` proposal doc).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5de86890f1d7f2f5e523071774fe2352c02aa60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->