### PR TITLE
fix: SSE lag UX, Needs You row icon, Claude Code in picker

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -7427,6 +7427,28 @@ export default function ControlClient() {
         }
       }
 
+      // `stream_lagged` is emitted by the server when this SSE
+      // subscriber's broadcast cursor falls behind the channel buffer
+      // (chatty mission outpaces the browser tab's event handler). The
+      // stream itself stays alive — we just missed a window of events.
+      // Silently catch up via the existing delta-resume path
+      // (`reloadMissionHistory` → `loadHistoryEvents(sinceSeq)`) so the
+      // user never sees a scary error toast for what is a transient
+      // back-pressure event.
+      if (event.type === "stream_lagged") {
+        const dropped = isRecord(data) && typeof data["dropped"] === "number"
+          ? (data["dropped"] as number)
+          : undefined;
+        streamLog("warn", "stream_lagged — refetching", { dropped });
+        const viewingId = viewingMissionIdRef.current;
+        if (viewingId) {
+          void reloadMissionHistory(viewingId).catch((err) => {
+            streamLog("warn", "stream_lagged refetch failed", { err: String(err) });
+          });
+        }
+        return;
+      }
+
       // Handle mission status changes
       if (event.type === "mission_status_changed" && isRecord(data)) {
         const newStatus = String(data["status"] ?? "");

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -418,12 +418,22 @@ private struct MissionRow: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            // Icon based on backend
-            Image(systemName: mission.canResume ? "play.circle" : backendIcon)
+            // Leading tile always identifies the backend (codex / claudecode
+            // / opencode / gemini / grok). Previously this slot painted a
+            // yellow `play.circle` when `mission.canResume == true` to flag
+            // resumability — but `canResume` now also covers `awaiting_user`
+            // and `acknowledged` (added with the Needs You refactor), so
+            // *every* Needs You row went yellow regardless of backend while
+            // sibling rows in other columns kept their cyan/indigo/green
+            // backend tile. The StatusBadge directly below the title
+            // already conveys the "Needs You" / "Interrupted" / "Blocked"
+            // state in the right color, so the leading-tile override was
+            // redundant and visually inconsistent across buckets.
+            Image(systemName: backendIcon)
                 .font(.title3)
-                .foregroundStyle(mission.canResume ? Theme.warning : backendColor)
+                .foregroundStyle(backendColor)
                 .frame(width: 40, height: 40)
-                .background((mission.canResume ? Theme.warning : backendColor).opacity(0.15))
+                .background(backendColor.opacity(0.15))
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
             // Content

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5248,26 +5248,41 @@ pub async fn stream(
                                 }
                             }
                         }
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                        Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                            // This receiver's cursor slipped behind the
+                            // broadcast buffer's tail by `dropped` events.
+                            // The stream itself is still alive — `recv()`
+                            // will keep yielding fresh events on the next
+                            // tick — so we deliberately don't emit an
+                            // `error` event here. The dashboard treats
+                            // `error` as fatal (red toast + system-error
+                            // row in the chat) and it caused a confusing
+                            // user-facing alert every time a chatty
+                            // mission (text_delta burst, big tool result)
+                            // outpaced the browser tab's event handler.
+                            //
+                            // Instead, emit a distinct `stream_lagged`
+                            // event with the dropped count. The dashboard
+                            // reacts by silently refetching the viewing
+                            // mission via the existing `since_seq` path
+                            // so any dropped events are recovered from
+                            // the database. No user toast, no chat
+                            // pollution.
                             tracing::warn!(
                                 stream_id = %stream_id,
-                                "Control SSE stream lagged; events dropped"
+                                dropped = dropped,
+                                "Control SSE stream lagged; signalling client refetch"
                             );
                             match Event::default()
-                                .event("error")
-                                .json_data(AgentEvent::Error {
-                                    message:
-                                        "event stream lagged; some events were dropped"
-                                            .to_string(),
-                                    mission_id: None,
-                                    resumable: false,
-                                }) {
+                                .event("stream_lagged")
+                                .json_data(serde_json::json!({ "dropped": dropped }))
+                            {
                                 Ok(sse) => yield Ok(sse),
                                 Err(e) => {
                                     tracing::error!(
                                         stream_id = %stream_id,
                                         error = %e,
-                                        "Failed to serialize SSE lag error event"
+                                        "Failed to serialize SSE stream_lagged event"
                                     );
                                 }
                             }
@@ -5304,7 +5319,13 @@ fn spawn_control_session(
     telegram_bridge: Option<super::telegram::SharedTelegramBridge>,
 ) -> ControlState {
     let (cmd_tx, cmd_rx) = mpsc::channel::<ControlCommand>(256);
-    let (events_tx, events_rx) = broadcast::channel::<AgentEvent>(1024);
+    // 8 192 slots ≈ ~8 s of headroom even for chatty missions (text_delta
+    // bursts during long completions push ~1 k events / sec). The previous
+    // 1 024 cap regularly overflowed for any tab whose JS event handler
+    // momentarily slowed (large React reducer work, tab backgrounded by
+    // Chrome). Per-receiver cursor + Arc<AgentEvent> internal layout keeps
+    // the memory cost bounded.
+    let (events_tx, events_rx) = broadcast::channel::<AgentEvent>(8192);
     let tool_hub = Arc::new(FrontendToolHub::new());
     let status = Arc::new(RwLock::new(ControlStatus {
         state: ControlRunState::Idle,

--- a/src/backend/claudecode/mod.rs
+++ b/src/backend/claudecode/mod.rs
@@ -96,16 +96,49 @@ impl Backend for ClaudeCodeBackend {
     }
 
     async fn check_auth_configured(&self, ctx: &crate::backend::AuthContext<'_>) -> Option<bool> {
-        // Claude Code keeps its api_key in the secrets store under the
-        // "claudecode" namespace. A non-expired entry means we have auth.
-        let Some(store) = ctx.secrets else {
-            return Some(false);
-        };
-        let has_key = match store.list_secrets("claudecode").await {
-            Ok(secrets) => secrets.iter().any(|s| s.key == "api_key" && !s.is_expired),
-            Err(_) => false,
-        };
-        Some(has_key)
+        // Two valid auth modes:
+        //   1. An API key stored in the secrets store under the
+        //      "claudecode" namespace (set via the providers UI).
+        //   2. OAuth credentials at `~/.claude/.credentials.json` (the
+        //      common case — written by `claude login` and used by every
+        //      mission via the workspace bootstrap). We previously only
+        //      checked (1), so any user authed via OAuth saw Claude Code
+        //      filtered out of the new-mission picker even though every
+        //      mission run worked correctly.
+        if let Some(store) = ctx.secrets {
+            if let Ok(secrets) = store.list_secrets("claudecode").await {
+                if secrets.iter().any(|s| s.key == "api_key" && !s.is_expired) {
+                    return Some(true);
+                }
+            }
+        }
+        // Probe the same on-disk locations the Claude CLI uses. See
+        // `crate::api::ai_providers::get_anthropic_auth_from_claude_cli_credentials`
+        // — duplicated here as a lightweight path-existence check so the
+        // backend module stays self-contained (no JSON parse needed, the
+        // file's mere presence is the install-completed signal).
+        let candidate_paths = [
+            std::path::PathBuf::from("/var/lib/opencode/.claude/.credentials.json"),
+            std::path::PathBuf::from("/root/.claude/.credentials.json"),
+        ];
+        for path in &candidate_paths {
+            if path.exists() {
+                return Some(true);
+            }
+        }
+        if let Ok(home) = std::env::var("HOME") {
+            let p = std::path::PathBuf::from(home).join(".claude/.credentials.json");
+            if p.exists() {
+                return Some(true);
+            }
+        }
+        // No secrets-store entry, no OAuth file on disk. Mirror Grok's
+        // "don't hide on uncertainty" by returning `None` rather than
+        // `Some(false)` — the CLI may still be authed via env vars
+        // (`ANTHROPIC_API_KEY`) we don't enumerate here, and worst case
+        // the user clicks the backend and gets a clear auth error
+        // instead of a hidden picker entry.
+        None
     }
 
     async fn list_agents(&self) -> Result<Vec<AgentInfo>, Error> {


### PR DESCRIPTION
Three independent regressions surfaced after v0.12.0.

## 1. \"event stream lagged; some events were dropped\" toast (#mission ca3677fc reported)
`/api/control/stream` broadcasts every event from every mission to every connected dashboard tab via `broadcast::channel(1024)`. When a tab's JS handler can't drain the stream fast enough (text_delta bursts during a long LLM completion, big tool results), TCP back-pressure stalls the read, the buffer fills, and the receiver gets \`Lagged(n)\`. The server emitted an \`event: error\` SSE event, which the dashboard rendered as fatal: red toast + system-error row in the chat. The stream itself was always still alive.

- Bump buffer **1024 → 8192** (≈8 s of headroom on a 1 k events/sec burst).
- Log the actual dropped count (was \`Lagged(_)\`).
- Replace \`event: error\` with \`event: stream_lagged\` carrying \`{dropped: n}\`.
- Dashboard routes \`stream_lagged\` through the existing \`reloadMissionHistory\` → \`loadHistoryEvents(sinceSeq)\` delta-resume path; missed events recover from the database silently.

## 2. Needs You rows all painted yellow (iOS)
\`MissionStatus.canResume\` now covers \`awaiting_user\`/\`acknowledged\` after the lifecycle refactor. \`MissionRow\` painted a yellow \`play.circle\` whenever \`canResume\` was true, so every Needs You row went yellow while sibling rows in other columns kept their cyan/indigo/green backend tile. The StatusBadge directly below already conveys Needs You in yellow, making the override redundant and inconsistent.

- Always render the backend icon in the backend colour.

## 3. Claude Code missing from the new-mission picker
\`isBackendAvailable\` hides any backend whose \`/api/backends/<id>/config\` returns \`auth_configured === false\`. Claude Code's \`check_auth_configured\` only checked the secrets store for \`claudecode/api_key\`, missing the much more common case: OAuth credentials at \`~/.claude/.credentials.json\` written by \`claude login\`. Result: a fully-working Claude Code install with OAuth credentials reported \`auth_configured: false\` and got filtered out of the picker.

- Probe standard CLI credential paths (\`/var/lib/opencode/.claude/.credentials.json\`, \`/root/.claude/.credentials.json\`, \`\$HOME/.claude/.credentials.json\`).
- When neither signal exists, return \`None\` (mirrors Grok's \"don't hide on uncertainty\" pattern) instead of \`Some(false)\`.

Verified on prod after redeploy: \`/api/backends/claudecode/config\` now returns \`auth_configured: true\` for the standard OAuth install.

## Test plan
- [x] Backend builds clean (\`cargo check\`, \`cargo fmt\`).
- [x] Dashboard builds clean (\`tsc --noEmit\`).
- [x] iOS builds clean (\`xcodebuild\` iPhone 17 Pro sim).
- [x] Prod + dev deployed; \`auth_configured: true\` confirmed for Claude Code.
- [ ] Manual: open a chatty mission in the dashboard, confirm no red toast/system-error row on text_delta bursts. \`stream_lagged\` events visible in browser devtools.
- [ ] Manual: open History → Needs You filter on iOS; rows now show backend-colored icons.
- [ ] Manual: open new-mission picker, Claude Code appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the control SSE streaming path and backend availability detection, which can affect realtime updates and backend selection if the new event type or auth probing behaves unexpectedly. Changes are otherwise targeted UX fixes with clear fallbacks.
> 
> **Overview**
> Prevents transient SSE backpressure from surfacing as a user-facing fatal error: the server now emits `stream_lagged` (with a dropped-event count) on broadcast lag and increases the broadcast buffer to `8192`, while the web dashboard handles `stream_lagged` by silently reloading mission history via the existing delta-resume path.
> 
> Fixes an iOS History UI regression by always rendering the backend icon/color in mission rows (instead of overriding to a yellow resume icon when `canResume`).
> 
> Fixes Claude Code being hidden from the new-mission picker by expanding `check_auth_configured` to also treat Claude CLI OAuth credentials (`~/.claude/.credentials.json` and standard locations) as configured, and returning `None` when uncertain rather than `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5a9c1455c85c5927dcbcc957dace0b5ad7e763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->