### PR TITLE
perf(control): P1 quick wins — SSE filter, poll guard, rAF coalesce, leak fix, markdown cap

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -15,6 +15,7 @@ import {
 import { MissionAutomationsDialog } from "@/components/mission-automations-dialog";
 import { PerfOverlay } from "@/components/perf-overlay";
 import { perfBus } from "@/lib/perf-bus";
+import { isStreamContinuation } from "@/lib/stream-continuation";
 import { MissionDebugStats } from "./MissionDebugStats";
 import { LazyCodeBlock } from "@/components/lazy-code-block";
 import { LazyJsonHighlighter } from "@/components/lazy-json-highlighter";
@@ -4231,6 +4232,15 @@ export default function ControlClient() {
   const streamCleanupRef = useRef<null | (() => void)>(null);
   const enhancedInputRef = useRef<EnhancedInputHandle>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  /** Reconnect the SSE stream with the freshest mission filter. Set by the
+   * stream effect; called from the per-mission switcher effect. Ref-based so
+   * the SSE useEffect can keep its empty deps array. */
+  const reconnectStreamRef = useRef<(() => void) | null>(null);
+  /** Wall-clock timestamp (ms) of the last SSE event we received. The 15s
+   * "running mission" history reload (P1-#5) checks this and skips the
+   * refetch when the SSE stream is fresh — saves a 5000-row /events trip
+   * (and the longtask that comes with it) on every running mission. */
+  const lastSseEventAtRef = useRef<number>(0);
   const viewingMissionIdRef = useRef<string | null>(null);
   const runStateMissionIdRef = useRef<string | null>(null);
   const runningMissionsRef = useRef<RunningMissionInfo[]>([]);
@@ -4242,6 +4252,39 @@ export default function ControlClient() {
   // Keep refs in sync with state
   useEffect(() => {
     viewingMissionIdRef.current = viewingMissionId;
+    // Reconnect the SSE stream so the server-side ?mission=<uuid> filter
+    // (P1-#4) re-binds to the freshly-viewed mission. Skipped on the very
+    // first render — the stream effect makes the initial connection itself.
+    if (reconnectStreamRef.current) {
+      reconnectStreamRef.current();
+    }
+    // P1-#9 navigation leak guard. Every entry path eventually changes
+    // `viewingMissionId` — handleViewMission, the URL-driven effect, the
+    // mission switcher palette. Centralizing the cleanup here means a
+    // future path can't forget to clear refs. Bubble-buffer refs hold the
+    // *previous* mission's tail of streaming deltas; if we don't drop them
+    // here they get appended to the new mission's first bubble on the
+    // next flush, and the abandoned setTimeout keeps the previous closure
+    // alive (the main contributor to the ~150 MB-per-visit heap ratchet
+    // we measured).
+    if (thinkingFlushTimeoutRef.current) {
+      clearTimeout(thinkingFlushTimeoutRef.current);
+      thinkingFlushTimeoutRef.current = null;
+    }
+    if (thinkingFlushRafRef.current !== null) {
+      cancelAnimationFrame(thinkingFlushRafRef.current);
+      thinkingFlushRafRef.current = null;
+    }
+    if (streamFlushTimeoutRef.current) {
+      clearTimeout(streamFlushTimeoutRef.current);
+      streamFlushTimeoutRef.current = null;
+    }
+    if (streamFlushRafRef.current !== null) {
+      cancelAnimationFrame(streamFlushRafRef.current);
+      streamFlushRafRef.current = null;
+    }
+    pendingThinkingRef.current = null;
+    pendingStreamRef.current = null;
   }, [viewingMissionId]);
 
   useEffect(() => {
@@ -4935,11 +4978,10 @@ export default function ControlClient() {
           if (currentThinkingIdx !== null) {
             const existing = items[currentThinkingIdx] as Extract<ChatItem, { kind: "thinking" }>;
             const existingContent = existing.content || "";
-            const isContinuation =
-              !content ||
-              !existingContent ||
-              content.startsWith(existingContent) ||
-              existingContent.startsWith(content);
+            // P1-#8: tolerant continuation check — strips trailing
+            // whitespace/punct and allows a short tail wobble so the
+            // "NoNo newNo new CI…" double-emission pattern consolidates.
+            const isContinuation = isStreamContinuation(content, existingContent);
 
             if (!isContinuation) {
               // Treat as a new thought session: finalize previous and start a new item.
@@ -6637,6 +6679,7 @@ export default function ControlClient() {
     startTime: number;
   } | null>(null);
   const thinkingFlushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const thinkingFlushRafRef = useRef<number | null>(null);
   const thinkingIdCounterRef = useRef(0);
 
   const pendingStreamRef = useRef<{
@@ -6644,6 +6687,7 @@ export default function ControlClient() {
     startTime: number;
   } | null>(null);
   const streamFlushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const streamFlushRafRef = useRef<number | null>(null);
 
   // Auto-reconnecting stream with exponential backoff
   useEffect(() => {
@@ -6685,6 +6729,7 @@ export default function ControlClient() {
           : null;
       const currentMissionId = currentMissionRef.current?.id;
       perfBus.recordSseEvent("received");
+      lastSseEventAtRef.current = Date.now();
       streamLog("debug", "received", {
         type: event.type,
         eventMissionId,
@@ -6924,10 +6969,18 @@ export default function ControlClient() {
           clearTimeout(thinkingFlushTimeoutRef.current);
           thinkingFlushTimeoutRef.current = null;
         }
+        if (thinkingFlushRafRef.current !== null) {
+          cancelAnimationFrame(thinkingFlushRafRef.current);
+          thinkingFlushRafRef.current = null;
+        }
         pendingThinkingRef.current = null;
         if (streamFlushTimeoutRef.current) {
           clearTimeout(streamFlushTimeoutRef.current);
           streamFlushTimeoutRef.current = null;
+        }
+        if (streamFlushRafRef.current !== null) {
+          cancelAnimationFrame(streamFlushRafRef.current);
+          streamFlushRafRef.current = null;
         }
         pendingStreamRef.current = null;
 
@@ -7133,11 +7186,8 @@ export default function ControlClient() {
         // Get or create stable ID for current thinking session
         const existingPending = pendingThinkingRef.current;
         const existingContent = existingPending?.content ?? "";
-        const isContinuation =
-          !content ||
-          !existingContent ||
-          content.startsWith(existingContent) ||
-          existingContent.startsWith(content);
+        // P1-#8: tolerant continuation check (see stream-continuation.ts).
+        const isContinuation = isStreamContinuation(content, existingContent);
         const shouldStartNew = Boolean(existingPending && !isContinuation && existingContent.trim());
 
         if (shouldStartNew) {
@@ -7164,26 +7214,35 @@ export default function ControlClient() {
           startTime,
         };
 
-        // Clear any pending flush timeout
+        // Clear any pending flush handles
         if (thinkingFlushTimeoutRef.current) {
           clearTimeout(thinkingFlushTimeoutRef.current);
           thinkingFlushTimeoutRef.current = null;
+        }
+        if (thinkingFlushRafRef.current !== null) {
+          cancelAnimationFrame(thinkingFlushRafRef.current);
+          thinkingFlushRafRef.current = null;
         }
 
         // Flush immediately on:
         //  - `done: true` (finalization)
         //  - first delta of a brand-new thought (no pending content yet)
         //  - the existing thought session was just (re)started
-        // Otherwise debounce at 30 ms — codex's reasoning summary deltas
-        // arrive in tight ~10–20 ms bursts and the previous 100 ms
-        // debounce kept resetting until `done`, so the user only ever
-        // saw the final snapshot ("Thought for <1s") with no streaming.
+        // Otherwise coalesce on the next animation frame (P1-#6). The
+        // previous 30 ms setTimeout caused codex's tight 10-20 ms reasoning
+        // bursts to trigger a React commit per delta even though only one
+        // could ever be painted per frame. rAF guarantees ≤1 commit per
+        // frame regardless of arrival rate; pending content keeps
+        // accumulating in `pendingThinkingRef.current` so no delta is lost.
         const shouldFlushNow =
           done || shouldStartNew || !existingPending || !existingContent;
         if (shouldFlushNow) {
           flushThinking();
         } else {
-          thinkingFlushTimeoutRef.current = setTimeout(flushThinking, 30);
+          thinkingFlushRafRef.current = requestAnimationFrame(() => {
+            thinkingFlushRafRef.current = null;
+            flushThinking();
+          });
         }
         return;
       }
@@ -7212,11 +7271,8 @@ export default function ControlClient() {
                 { kind: "stream" }
               >;
               const existingContent = existing.content ?? "";
-              const isContinuation =
-                !pending.content ||
-                !existingContent ||
-                pending.content.startsWith(existingContent) ||
-                existingContent.startsWith(pending.content);
+              // P1-#8: tolerant continuation check (see stream-continuation.ts).
+              const isContinuation = isStreamContinuation(pending.content, existingContent);
               updated[existingIdx] = {
                 ...existing,
                 content: pending.content || existing.content,
@@ -7247,11 +7303,8 @@ export default function ControlClient() {
 
         const existingPending = pendingStreamRef.current;
         const existingContent = existingPending?.content ?? "";
-        const isContinuation =
-          !content ||
-          !existingContent ||
-          content.startsWith(existingContent) ||
-          existingContent.startsWith(content);
+        // P1-#8: tolerant continuation check (see stream-continuation.ts).
+        const isContinuation = isStreamContinuation(content, existingContent);
 
         pendingStreamRef.current = {
           content: content || existingPending?.content || "",
@@ -7262,7 +7315,18 @@ export default function ControlClient() {
           clearTimeout(streamFlushTimeoutRef.current);
           streamFlushTimeoutRef.current = null;
         }
-        streamFlushTimeoutRef.current = setTimeout(flushStream, 100);
+        if (streamFlushRafRef.current !== null) {
+          cancelAnimationFrame(streamFlushRafRef.current);
+          streamFlushRafRef.current = null;
+        }
+        // P1-#6: schedule the flush on the next animation frame. Multiple
+        // deltas arriving within the same frame collapse to a single React
+        // commit because pendingStreamRef accumulates content while the
+        // pending rAF callback hasn't fired yet.
+        streamFlushRafRef.current = requestAnimationFrame(() => {
+          streamFlushRafRef.current = null;
+          flushStream();
+        });
         return;
       }
 
@@ -7850,12 +7914,20 @@ export default function ControlClient() {
 
     const connect = () => {
       cleanup?.();
-      streamLog("info", "connecting stream");
-      cleanup = streamControl(handleEvent, handleStreamDiagnostics);
+      const missionFilter = viewingMissionIdRef.current ?? undefined;
+      streamLog("info", "connecting stream", { missionFilter });
+      cleanup = streamControl(handleEvent, handleStreamDiagnostics, {
+        missionId: missionFilter,
+      });
     };
 
     connect();
     streamCleanupRef.current = cleanup;
+    // Expose the reconnect hook so the per-mission switcher effect (below)
+    // can tear down the current SSE and open a new one filtered for the
+    // freshly-viewed mission. Reading from a ref keeps this effect's deps
+    // empty so we don't recycle the SSE on every unrelated render.
+    reconnectStreamRef.current = connect;
 
     return () => {
       mounted = false;
@@ -8388,13 +8460,23 @@ export default function ControlClient() {
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, [viewingMissionId, reloadMissionHistory]);
 
-  // Periodically sync history for running missions to catch missed SSE events
+  // Periodically sync history for running missions to catch missed SSE
+  // events. P1-#5: skip the refetch when the SSE stream is fresh (<30s
+  // since the last received event). The old unconditional refetch was the
+  // main /events traffic driver — on busy long-running missions it fired
+  // a 5000-row trip every 15s for every open tab, costing a 1-5s longtask
+  // in the dashboard reducer each time.
   useEffect(() => {
     if (!viewingMissionId || !viewingMissionIsRunning) return;
+    const SSE_FRESH_WINDOW_MS = 30_000;
     const interval = setInterval(() => {
-      if (document.visibilityState === "visible") {
-        reloadMissionHistory(viewingMissionId);
+      if (document.visibilityState !== "visible") return;
+      const since = Date.now() - lastSseEventAtRef.current;
+      if (lastSseEventAtRef.current > 0 && since < SSE_FRESH_WINDOW_MS) {
+        // SSE is healthy; trust the live stream rather than refetching.
+        return;
       }
+      reloadMissionHistory(viewingMissionId);
     }, 15_000);
     return () => clearInterval(interval);
   }, [viewingMissionId, viewingMissionIsRunning, reloadMissionHistory]);

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -874,6 +874,13 @@ function InlineFileCard({
   );
 }
 
+// P1-#10: messages larger than this render as plain <pre> with an opt-in
+// "Render markdown" button. The freeze trace on the verity missions
+// showed single assistant bubbles 200KB+ of repeated tokens that took
+// 5s+ to highlight + lay out. Past ~50KB the cost is no longer paying
+// for anything the user actually reads.
+const MARKDOWN_SIZE_CAP_BYTES = 50_000;
+
 // Memoized to prevent re-renders when parent re-renders with same props
 export const MarkdownContent = memo(function MarkdownContent({
   content,
@@ -882,8 +889,15 @@ export const MarkdownContent = memo(function MarkdownContent({
   workspaceId,
   missionId,
 }: MarkdownContentProps) {
+  const [forceMarkdown, setForceMarkdown] = useState(false);
+  const oversize = content.length > MARKDOWN_SIZE_CAP_BYTES;
+  const renderPlain = oversize && !forceMarkdown;
+
   // Pre-process content: transform <image> and <file> tags into markdown syntax
-  const processedContent = useMemo(() => transformRichTags(content), [content]);
+  const processedContent = useMemo(
+    () => (renderPlain ? "" : transformRichTags(content)),
+    [content, renderPlain]
+  );
 
   // Memoize components object to prevent react-markdown from re-creating DOM on every render
   const components: Components = useMemo(() => ({
@@ -1011,6 +1025,30 @@ export const MarkdownContent = memo(function MarkdownContent({
     }
     return defaultUrlTransform(url);
   }, []);
+
+  if (renderPlain) {
+    const sizeKb = (content.length / 1024).toFixed(0);
+    return (
+      <div className={cn("prose-glass text-sm [&_p]:my-2", className)}>
+        <div className="mb-2 flex items-center justify-between rounded border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          <span>
+            Large message ({sizeKb} KB). Markdown rendering skipped for
+            performance — code blocks, links, and images are not active.
+          </span>
+          <button
+            type="button"
+            onClick={() => setForceMarkdown(true)}
+            className="ml-3 shrink-0 rounded bg-amber-400/20 px-2 py-0.5 text-xs font-medium text-amber-100 hover:bg-amber-400/30"
+          >
+            Render markdown
+          </button>
+        </div>
+        <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded bg-white/5 p-3 text-xs leading-relaxed">
+          {content}
+        </pre>
+      </div>
+    );
+  }
 
   return (
     <div className={cn("prose-glass text-sm [&_p]:my-2", className)}>

--- a/dashboard/src/lib/__tests__/stream-continuation.test.ts
+++ b/dashboard/src/lib/__tests__/stream-continuation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { isStreamContinuation } from "../stream-continuation";
+
+describe("isStreamContinuation", () => {
+  it("treats empty strings as continuation", () => {
+    expect(isStreamContinuation("", "abc")).toBe(true);
+    expect(isStreamContinuation("abc", "")).toBe(true);
+    expect(isStreamContinuation("", "")).toBe(true);
+  });
+
+  it("accepts strict prefix in either direction", () => {
+    expect(isStreamContinuation("Hello", "Hello world")).toBe(true);
+    expect(isStreamContinuation("Hello world", "Hello")).toBe(true);
+  });
+
+  it("absorbs trailing punctuation drift", () => {
+    // grok thinking stream often re-emits the same buffer with a trailing
+    // period that the previous chunk didn't have.
+    expect(isStreamContinuation("Still active", "Still active.")).toBe(true);
+    expect(isStreamContinuation("Still active.", "Still active")).toBe(true);
+    expect(isStreamContinuation("No new CI", "No new CI…")).toBe(true);
+  });
+
+  it("absorbs trailing whitespace drift", () => {
+    expect(isStreamContinuation("Hello", "Hello ")).toBe(true);
+    expect(isStreamContinuation("Hello\n", "Hello")).toBe(true);
+  });
+
+  it("accepts short tail differences", () => {
+    // X → X. → X. — small tail wobble within the tolerance window.
+    expect(isStreamContinuation("Done", "Done!")).toBe(true);
+  });
+
+  it("rejects unrelated buffers", () => {
+    expect(isStreamContinuation("Hello world", "Goodbye world")).toBe(false);
+    expect(
+      isStreamContinuation("Reasoning about A", "Reasoning about B")
+    ).toBe(false);
+  });
+
+  it("rejects long divergent tails", () => {
+    // If the shorter side does not match the longer side up to the tail
+    // tolerance, this is a new bubble, not a continuation.
+    expect(
+      isStreamContinuation(
+        "The user wants to know about A",
+        "The user wants to know about A, then asks about B"
+      )
+    ).toBe(true); // strict prefix
+    expect(
+      isStreamContinuation(
+        "Reasoning about A",
+        "Reasoning about completely different topic"
+      )
+    ).toBe(false);
+  });
+});

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -498,15 +498,26 @@ export type StreamDiagnosticUpdate = {
   timestamp: number;
 };
 
+export type StreamControlOptions = {
+  /** Server-side filter — receive only events for this mission (and
+   * connection-scoped status / stream_lagged). Omit to receive every event
+   * the user can see. */
+  missionId?: string;
+};
+
 export function streamControl(
   onEvent: (event: { type: string; data: unknown }) => void,
-  onDiagnostics?: (update: StreamDiagnosticUpdate) => void
+  onDiagnostics?: (update: StreamDiagnosticUpdate) => void,
+  options?: StreamControlOptions
 ): () => void {
   const controller = new AbortController();
   const decoder = new TextDecoder();
   let buffer = "";
   let bytesRead = 0;
-  const streamUrl = apiUrl("/api/control/stream");
+  const baseUrl = apiUrl("/api/control/stream");
+  const streamUrl = options?.missionId
+    ? `${baseUrl}?mission=${encodeURIComponent(options.missionId)}`
+    : baseUrl;
 
   onDiagnostics?.({
     phase: "connecting",

--- a/dashboard/src/lib/stream-continuation.ts
+++ b/dashboard/src/lib/stream-continuation.ts
@@ -1,0 +1,56 @@
+/**
+ * Streaming-delta continuation detection.
+ *
+ * Backends (codex, grok, anthropic) emit incremental text/thinking deltas as
+ * the model produces tokens. We consolidate consecutive deltas of the same
+ * stream into one chat bubble. The naive rule — strict prefix equality —
+ * miscategorises plenty of real-world payloads as "new thoughts" because
+ * the backends occasionally re-emit a buffer with trailing whitespace
+ * trimmed, with a punctuation character added, or with one extra token
+ * appended. Each false-negative gets persisted as a fresh chat item and
+ * blows up DOM + memory (the "NoNo newNo new CI…" pattern visible on
+ * mission `3a902278`).
+ *
+ * Rules implemented here (all evaluated in `isStreamContinuation`):
+ *   1. If either side is empty, treat as a continuation.
+ *   2. Strict prefix in either direction → continuation.
+ *   3. Strip trailing whitespace + a fixed punctuation set, retest prefix.
+ *   4. Tail-tolerance: if the shorter side equals the longer side up to
+ *      `TAIL_TOLERANCE` trailing chars, treat as continuation (handles
+ *      "X" → "X." → "X. " drift).
+ *
+ * Pure + dependency-free so it can be unit-tested cheaply and shipped to
+ * the iOS app via the same logic on the Swift side (mirrored there in a
+ * follow-up commit).
+ */
+
+/** How many trailing characters of the *longer* side we ignore when the
+ * shorter side is otherwise a prefix. Tuned to absorb punctuation drift
+ * ("X" vs "X." vs "X.."), not real new content. */
+const TAIL_TOLERANCE = 6;
+
+const TRAILING_NOISE_RE = /[\s.,!?;:'")\]}…—–-]+$/u;
+
+function stripTrailingNoise(text: string): string {
+  return text.replace(TRAILING_NOISE_RE, "");
+}
+
+export function isStreamContinuation(a: string, b: string): boolean {
+  if (!a || !b) return true;
+  if (a === b) return true;
+
+  if (a.startsWith(b) || b.startsWith(a)) return true;
+
+  const aTrim = stripTrailingNoise(a);
+  const bTrim = stripTrailingNoise(b);
+  if (aTrim && bTrim && (aTrim.startsWith(bTrim) || bTrim.startsWith(aTrim))) {
+    return true;
+  }
+
+  // Tail-tolerant prefix: the shorter buffer matches the longer buffer up
+  // to a small trailing window. Lets `X` and `X. ` consolidate without
+  // collapsing genuinely different completions.
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  if (longer.length - shorter.length > TAIL_TOLERANCE) return false;
+  return longer.slice(0, shorter.length) === shorter;
+}

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -5142,17 +5142,31 @@ pub async fn cleanup_empty_missions(
 }
 
 /// Stream control session events via SSE.
+#[derive(Debug, Deserialize)]
+pub struct StreamQuery {
+    /// Optional mission filter. When set, the server only emits events whose
+    /// `mission_id` matches (plus the connection-scoped `status` /
+    /// `stream_lagged` events the dashboard relies on). Cuts cross-mission
+    /// noise to zero for a focused tab. Omit the param to receive every
+    /// event the user can see (used by the mission list / debug overlay).
+    #[serde(default)]
+    pub mission: Option<Uuid>,
+}
+
 pub async fn stream(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
+    axum::extract::Query(query): axum::extract::Query<StreamQuery>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     let mut rx = control.events_tx.subscribe();
     let stream_id = Uuid::new_v4();
+    let mission_filter = query.mission;
     tracing::info!(
         stream_id = %stream_id,
         user_id = %user.id,
         username = %user.username,
+        mission_filter = ?mission_filter,
         "Control SSE stream opened"
     );
 
@@ -5218,6 +5232,17 @@ pub async fn stream(
                     match result {
                         Ok(ev) => {
                             let mission_id = ev.mission_id();
+                            // Server-side mission filter (P1-#4). When the client
+                            // opened the stream with `?mission=<uuid>`, drop events
+                            // whose mission_id doesn't match. `Status` always passes
+                            // because it's the connection-keepalive and carries the
+                            // global running/queue state, not a per-mission update.
+                            if let Some(filter) = mission_filter {
+                                let is_status = matches!(&ev, AgentEvent::Status { .. });
+                                if !is_status && mission_id != Some(filter) {
+                                    continue;
+                                }
+                            }
                             match &ev {
                                 AgentEvent::Thinking { .. } => {
                                     tracing::trace!(


### PR DESCRIPTION
## Summary
Lands six of the P1 perf items in one slice. Validated end-to-end via Playwright on the previously-frozen verity mission `3a902278` — the one that produced a 74s single longtask before this PR.

| metric | before | after |
| --- | --- | --- |
| longtask 10s total | 23.4 s | 53 ms |
| longtask max | 5.3 s | 53 ms |
| DOM nodes | 13–14 k, growing | 967, stable |
| JS heap | 318 MB, growing | 141 MB, stable |
| SSE drops/sec (client filter) | 9.9 | 9.9* |

*Client-side filter still active because prod backend doesn't have the new mission filter yet; once merged + auto-deployed the drop column should fall to 0.

## What's in
- **P1-#4** — `GET /api/control/stream` accepts `?mission=<uuid>` and drops non-matching events server-side (status/stream_lagged still pass).
- **P1-#5** — 15 s `reloadMissionHistory` poll now skips when SSE is fresh (<30 s since last event).
- **P1-#6** — text_delta / thinking flushes moved from `setTimeout(30/100)` to `requestAnimationFrame` — at most one React commit per frame.
- **P1-#8** — new `lib/stream-continuation.ts` (+ 7 unit tests) replaces strict-prefix `isContinuation` at four call sites. Strips trailing whitespace+punct and allows a small tail-tolerance window so codex / grok payloads with punct drift consolidate correctly. Fixes the "NoNo newNo new CI…" duplication.
- **P1-#9** — centralised cleanup on `viewingMissionId` change: cancels both flush timers, both rAF handles, drops pending refs, reconnects SSE with the freshest mission filter. Stops the ~150 MB-per-visit heap ratchet.
- **P1-#10** — assistant_message > 50 KB renders as `<pre>` with "Render markdown" button. Stops the 5 s freeze on 200 KB+ token-stutter bubbles.

## Test plan
- [x] Playwright: open `/control?mission=3a902278…&debug=perf`, wait 20s, verify perf overlay shows <100 ms longtask total + <1 k DOM nodes.
- [x] `bunx vitest run src/lib/__tests__/stream-continuation.test.ts` — 7 tests pass.
- [x] `bunx tsc --noEmit` clean.
- [x] Backend `cargo check` clean.
- [ ] Manual: switch between two large missions twice; perf overlay heap should stay within ~50 MB of baseline.
- [ ] Manual: open a mission with a huge assistant bubble (e.g. verity); confirm "Render markdown" button appears and clicking it shows the full markdown.

## Still TODO
P0-#3 metrics endpoint, P1-#7 NowTickContext, P2/P3/P4/P5 in separate PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core control-stream event delivery and chat rendering/streaming consolidation; regressions could drop events or affect mission switching/stream UI, but changes are localized and mainly performance-oriented.
> 
> **Overview**
> **Performance-focused updates to the Control dashboard’s streaming path.** SSE can now be opened with an optional per-mission filter (`?mission=<uuid>`), wired end-to-end from `streamControl(...)` (dashboard) to the Axum handler (backend) to drop non-matching events while still emitting connection-scoped `status`.
> 
> **Cuts UI work during streaming and navigation.** Streaming `thinking`/`text_delta` flushes are coalesced via `requestAnimationFrame` (replacing `setTimeout` debounces), continuation detection is replaced with a new tolerant `isStreamContinuation` (with unit tests), and mission switches now reconnect the SSE stream and aggressively cancel pending flush timers/rAF + buffered refs to prevent cross-mission bleed and memory growth.
> 
> **Reduces heavy refetch/render costs.** The 15s running-mission history poll skips when SSE has been active recently, and very large assistant messages (>50KB) default to plain `<pre>` with an opt-in “Render markdown” button to avoid expensive markdown/highlight work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f34b507b1404a8e23e963860616d4926d794fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->