### PR TITLE
feat(settings/providers): video-game Resource HUD for AI usage

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -30,6 +30,8 @@ import {
 import { cn } from '@/lib/utils';
 import { AddProviderModal } from '@/components/ui/add-provider-modal';
 import { AsyncButton } from '@/components/ui/async-button';
+import { ProviderUsageHud } from '@/components/ui/provider-usage-hud';
+import type { UsageWindow } from '@/lib/api';
 
 const providerConfig: Record<string, { color: string; icon: string }> = {
   anthropic: { color: 'bg-orange-500/10 text-orange-400', icon: '🧠' },
@@ -313,6 +315,7 @@ export default function ProvidersPage() {
   const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
   const [usageData, setUsageData] = useState<Record<string, ProviderUsage>>({});
   const [usageLoading, setUsageLoading] = useState<Record<string, boolean>>({});
+  const [hudWindow, setHudWindow] = useState<UsageWindow>('7d');
   const [editForm, setEditForm] = useState<{
     name?: string;
     label?: string;
@@ -472,6 +475,10 @@ export default function ProvidersPage() {
           <p className="mt-1 text-sm text-white/50">
             Manage API keys and authentication
           </p>
+        </div>
+
+        <div className="mb-4">
+          <ProviderUsageHud window={hudWindow} onWindowChange={setHudWindow} />
         </div>
 
         <div className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5">

--- a/dashboard/src/components/ui/provider-usage-hud.tsx
+++ b/dashboard/src/components/ui/provider-usage-hud.tsx
@@ -1,0 +1,475 @@
+'use client';
+
+/**
+ * ProviderUsageHud — a video-game-inspired "resource HUD" for AI provider usage.
+ *
+ * Design vocabulary borrowed from RPG / shooter HUDs:
+ *  - "Energy Core" stat tiles (Cost / Requests / Tokens) with a soft glow.
+ *  - Segmented horizontal bars (like retro RPG mana bars) for cache-hit ratio
+ *    and provider mix.
+ *  - "Loadout" list for top models, where each row is an equipment card.
+ *  - Period selector tabs ("season" picker): 24h / 7d / 30d / All.
+ *
+ * Data source: `GET /api/ai/usage/summary?window=<window>` — see
+ * `dashboard/src/lib/api/providers.ts::getUsageSummary`.
+ */
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import {
+  getUsageSummary,
+  type ModelUsageSummary,
+  type UsageSummary,
+  type UsageWindow,
+} from '@/lib/api';
+import { cn, formatCents } from '@/lib/utils';
+import { Coins, Zap, ArrowDown, ArrowUp, Trophy, Shield } from 'lucide-react';
+
+const WINDOWS: { id: UsageWindow; label: string }[] = [
+  { id: '24h', label: '24h' },
+  { id: '7d', label: '7d' },
+  { id: '30d', label: '30d' },
+  { id: 'all', label: 'All' },
+];
+
+/** Provider visual identity — colors map to the existing providerConfig palette. */
+const PROVIDER_COLOR: Record<string, { fill: string; text: string; icon: string }> = {
+  anthropic: { fill: 'bg-orange-400', text: 'text-orange-300', icon: '🧠' },
+  openai: { fill: 'bg-emerald-400', text: 'text-emerald-300', icon: '🤖' },
+  google: { fill: 'bg-blue-400', text: 'text-blue-300', icon: '🔮' },
+  xai: { fill: 'bg-slate-300', text: 'text-slate-200', icon: '𝕏' },
+  zai: { fill: 'bg-cyan-400', text: 'text-cyan-300', icon: 'Z' },
+  minimax: { fill: 'bg-teal-400', text: 'text-teal-300', icon: 'M' },
+  mistral: { fill: 'bg-indigo-400', text: 'text-indigo-300', icon: '🌪️' },
+  groq: { fill: 'bg-pink-400', text: 'text-pink-300', icon: '⚡' },
+  'open-router': { fill: 'bg-purple-400', text: 'text-purple-300', icon: '🔀' },
+  cohere: { fill: 'bg-rose-400', text: 'text-rose-300', icon: '💬' },
+  perplexity: { fill: 'bg-cyan-400', text: 'text-cyan-300', icon: '🔍' },
+  'github-copilot': { fill: 'bg-gray-400', text: 'text-gray-300', icon: '🐙' },
+  unknown: { fill: 'bg-white/30', text: 'text-white/40', icon: '?' },
+};
+
+function providerSkin(id: string | null | undefined) {
+  return PROVIDER_COLOR[id || 'unknown'] || PROVIDER_COLOR.unknown;
+}
+
+/** Compact number formatting: 1.2k, 3.4M, 1.1B */
+function fmtCompact(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0';
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 1 : 0)}M`;
+  return `${(n / 1_000_000_000).toFixed(1)}B`;
+}
+
+/** Segmented bar (RPG mana-bar style). `pct` is 0..100. */
+function SegmentBar({
+  pct,
+  segments = 20,
+  className,
+  fillClass = 'bg-emerald-400',
+  trackClass = 'bg-white/[0.06]',
+}: {
+  pct: number;
+  segments?: number;
+  className?: string;
+  fillClass?: string;
+  trackClass?: string;
+}) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round((clamped / 100) * segments);
+  return (
+    <div
+      className={cn('flex items-center gap-[2px]', className)}
+      data-testid="hud-segment-bar"
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      {Array.from({ length: segments }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(
+            'h-2 flex-1 rounded-[1px] transition-colors',
+            i < filled ? fillClass : trackClass
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** A single stat tile — the "HUD pod". */
+function StatTile({
+  icon,
+  label,
+  value,
+  sub,
+  glow = 'shadow-[0_0_24px_-12px_rgba(99,102,241,0.4)]',
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: React.ReactNode;
+  glow?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'relative rounded-lg border border-white/[0.06] bg-gradient-to-b from-white/[0.04] to-white/[0.01] p-3',
+        glow
+      )}
+      data-testid="hud-stat-tile"
+    >
+      <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-white/40">
+        <span className="text-white/50">{icon}</span>
+        <span>{label}</span>
+      </div>
+      <div className="mt-1 font-mono text-lg font-semibold text-white tabular-nums">
+        {value}
+      </div>
+      {sub && <div className="mt-0.5 text-[10px] text-white/40">{sub}</div>}
+    </div>
+  );
+}
+
+/** Top models loadout list. */
+function ModelLoadout({ models, totalRequests }: { models: ModelUsageSummary[]; totalRequests: number }) {
+  // Top 5 by requests
+  const top = useMemo(
+    () =>
+      [...models]
+        .filter((m) => m.requests > 0)
+        .sort((a, b) => b.requests - a.requests)
+        .slice(0, 5),
+    [models]
+  );
+
+  if (top.length === 0) {
+    return (
+      <div className="rounded-lg border border-white/[0.06] bg-white/[0.01] p-4 text-center text-xs text-white/40">
+        No model usage recorded yet — run a mission to populate the leaderboard.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2" data-testid="hud-loadout">
+      {top.map((m, idx) => {
+        const skin = providerSkin(m.provider);
+        const pct = totalRequests > 0 ? (m.requests / totalRequests) * 100 : 0;
+        return (
+          <div
+            key={m.model + idx}
+            className="rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2"
+            data-testid="hud-loadout-row"
+          >
+            <div className="flex items-center gap-2">
+              <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-[10px] text-white/50">
+                {idx === 0 ? <Trophy className="h-3.5 w-3.5 text-amber-300" /> : `#${idx + 1}`}
+              </span>
+              <span className="text-base leading-none">{skin.icon}</span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-xs font-medium text-white/80">
+                  {m.model || 'unknown'}
+                </div>
+                <div className="text-[10px] text-white/35">
+                  {fmtCompact(m.requests)} req · in {fmtCompact(m.input_tokens)} · out{' '}
+                  {fmtCompact(m.output_tokens)}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="font-mono text-xs text-white/80 tabular-nums">
+                  {formatCents(m.cost_cents)}
+                </div>
+                <div className="text-[10px] text-white/35">{pct.toFixed(0)}% share</div>
+              </div>
+            </div>
+            <SegmentBar
+              pct={pct}
+              segments={24}
+              className="mt-2"
+              fillClass={skin.fill}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Stacked provider distribution bar. */
+function ProviderDistribution({ models }: { models: ModelUsageSummary[] }) {
+  // Aggregate cost by provider
+  const byProvider = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const m of models) {
+      const key = m.provider || 'unknown';
+      map.set(key, (map.get(key) || 0) + m.cost_cents);
+    }
+    const total = Array.from(map.values()).reduce((a, b) => a + b, 0);
+    return {
+      total,
+      entries: Array.from(map.entries())
+        .map(([provider, cost]) => ({ provider, cost }))
+        .sort((a, b) => b.cost - a.cost),
+    };
+  }, [models]);
+
+  if (byProvider.total === 0) {
+    // Fall back to request share so the bar shows something useful
+    const map = new Map<string, number>();
+    let total = 0;
+    for (const m of models) {
+      const key = m.provider || 'unknown';
+      map.set(key, (map.get(key) || 0) + m.requests);
+      total += m.requests;
+    }
+    if (total === 0) return null;
+    const entries = Array.from(map.entries())
+      .map(([provider, cost]) => ({ provider, cost }))
+      .sort((a, b) => b.cost - a.cost);
+    return <ProviderDistributionBar entries={entries} total={total} unit="req" />;
+  }
+
+  return (
+    <ProviderDistributionBar
+      entries={byProvider.entries}
+      total={byProvider.total}
+      unit="cost"
+    />
+  );
+}
+
+function ProviderDistributionBar({
+  entries,
+  total,
+  unit,
+}: {
+  entries: { provider: string; cost: number }[];
+  total: number;
+  unit: 'cost' | 'req';
+}) {
+  return (
+    <div data-testid="hud-distribution">
+      <div className="mb-1.5 flex items-center justify-between text-[10px] uppercase tracking-wider text-white/40">
+        <span>Provider Mix ({unit === 'cost' ? 'by spend' : 'by requests'})</span>
+        <span className="font-mono text-white/50 tabular-nums">
+          {unit === 'cost' ? formatCents(total) : `${fmtCompact(total)} req`}
+        </span>
+      </div>
+      <div className="flex h-2 overflow-hidden rounded-full bg-white/[0.04]">
+        {entries.map(({ provider, cost }) => {
+          const pct = (cost / total) * 100;
+          const skin = providerSkin(provider);
+          return (
+            <div
+              key={provider}
+              className={cn('h-full transition-all', skin.fill)}
+              style={{ width: `${pct}%` }}
+              title={`${provider}: ${pct.toFixed(1)}%`}
+            />
+          );
+        })}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+        {entries.map(({ provider, cost }) => {
+          const pct = (cost / total) * 100;
+          const skin = providerSkin(provider);
+          return (
+            <div key={provider} className="flex items-center gap-1.5 text-[10px]">
+              <span className={cn('h-1.5 w-1.5 rounded-full', skin.fill)} />
+              <span className="text-white/60">{provider}</span>
+              <span className="font-mono text-white/35 tabular-nums">{pct.toFixed(0)}%</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export interface ProviderUsageHudProps {
+  /** Initial window selection. */
+  window: UsageWindow;
+  /** Called when the user picks a new window tab. */
+  onWindowChange: (w: UsageWindow) => void;
+}
+
+export function ProviderUsageHud({ window, onWindowChange }: ProviderUsageHudProps) {
+  const { data, isLoading, error } = useSWR<UsageSummary>(
+    ['ai-usage-summary', window],
+    () => getUsageSummary(window),
+    { revalidateOnFocus: false }
+  );
+
+  const totals = data?.totals;
+  const cacheReadShare = useMemo(() => {
+    if (!totals) return 0;
+    const total = totals.input_tokens + totals.cache_read_tokens + totals.cache_creation_tokens;
+    if (total === 0) return 0;
+    return (totals.cache_read_tokens / total) * 100;
+  }, [totals]);
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-white/[0.06] bg-gradient-to-b from-indigo-500/[0.04] via-white/[0.02] to-white/[0.01] p-5',
+        // Soft "screen" glow at the edges to feel like a HUD overlay
+        'shadow-[inset_0_1px_0_0_rgba(255,255,255,0.04)]'
+      )}
+      data-testid="provider-usage-hud"
+    >
+      {/* Header: title + window picker */}
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-500/10 ring-1 ring-inset ring-indigo-400/20">
+            {/* hex-style energy core */}
+            <Zap className="h-5 w-5 text-indigo-300" />
+          </div>
+          <div>
+            <h2 className="text-sm font-medium text-white">Resource HUD</h2>
+            <p className="text-xs text-white/40">
+              Token economy across every mission you&apos;ve run
+            </p>
+          </div>
+        </div>
+        <div
+          className="flex items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.02] p-0.5"
+          role="tablist"
+          aria-label="Usage time window"
+        >
+          {WINDOWS.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => onWindowChange(w.id)}
+              role="tab"
+              aria-selected={window === w.id}
+              data-testid={`hud-window-${w.id}`}
+              className={cn(
+                'rounded-md px-2 py-1 text-[11px] font-medium transition-colors cursor-pointer',
+                window === w.id
+                  ? 'bg-indigo-500/20 text-indigo-200 ring-1 ring-inset ring-indigo-400/30'
+                  : 'text-white/40 hover:text-white/70'
+              )}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Error / empty / loading states */}
+      {error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/[0.04] p-3 text-xs text-red-300">
+          Failed to load usage summary.
+        </div>
+      ) : isLoading || !data ? (
+        <HudSkeleton />
+      ) : data.by_model.length === 0 ? (
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.01] p-6 text-center">
+          <div className="text-xs text-white/50">
+            No AI usage recorded in this window.
+          </div>
+          <div className="mt-1 text-[10px] text-white/30">
+            Start a mission to begin filling your stat sheet.
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Stat tiles */}
+          <div
+            className="grid grid-cols-2 gap-2 sm:grid-cols-4"
+            data-testid="hud-stat-tiles"
+          >
+            <StatTile
+              icon={<Coins className="h-3.5 w-3.5 text-amber-300" />}
+              label="Gold spent"
+              value={formatCents(totals!.cost_cents)}
+              sub={
+                <span className="font-mono tabular-nums">
+                  {fmtCompact(totals!.requests)} battles
+                </span>
+              }
+              glow="shadow-[0_0_24px_-12px_rgba(245,158,11,0.5)]"
+            />
+            <StatTile
+              icon={<ArrowDown className="h-3.5 w-3.5 text-sky-300" />}
+              label="Input tokens"
+              value={fmtCompact(totals!.input_tokens)}
+              sub={
+                <span className="text-white/40">
+                  + {fmtCompact(totals!.cache_read_tokens)} cached
+                </span>
+              }
+              glow="shadow-[0_0_24px_-12px_rgba(56,189,248,0.45)]"
+            />
+            <StatTile
+              icon={<ArrowUp className="h-3.5 w-3.5 text-emerald-300" />}
+              label="Output tokens"
+              value={fmtCompact(totals!.output_tokens)}
+              sub={
+                <span className="text-white/40 font-mono tabular-nums">
+                  {totals!.requests > 0
+                    ? `${Math.round(totals!.output_tokens / totals!.requests)} avg/req`
+                    : '—'}
+                </span>
+              }
+              glow="shadow-[0_0_24px_-12px_rgba(52,211,153,0.45)]"
+            />
+            <StatTile
+              icon={<Shield className="h-3.5 w-3.5 text-cyan-300" />}
+              label="Cache shield"
+              value={`${cacheReadShare.toFixed(0)}%`}
+              sub={
+                <span className="text-white/40">
+                  saved {fmtCompact(totals!.cache_read_tokens)} tok
+                </span>
+              }
+              glow="shadow-[0_0_24px_-12px_rgba(34,211,238,0.5)]"
+            />
+          </div>
+
+          {/* Provider distribution */}
+          <div className="mt-4">
+            <ProviderDistribution models={data.by_model} />
+          </div>
+
+          {/* Top models loadout */}
+          <div className="mt-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-[10px] uppercase tracking-wider text-white/40">
+                Top loadout
+              </span>
+              <span className="text-[10px] text-white/30">{data.by_model.length} models</span>
+            </div>
+            <ModelLoadout models={data.by_model} totalRequests={totals!.requests} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function HudSkeleton() {
+  return (
+    <div className="space-y-3" data-testid="hud-skeleton">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-[68px] rounded-lg border border-white/[0.06] bg-white/[0.02]"
+          />
+        ))}
+      </div>
+      <div className="h-2 rounded-full bg-white/[0.04]" />
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-[52px] rounded-lg border border-white/[0.05] bg-white/[0.015]" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -115,6 +115,10 @@ export {
   listBackendModelOptions,
   type ProviderUsage,
   getProviderUsage,
+  type UsageWindow,
+  type ModelUsageSummary,
+  type UsageSummary,
+  getUsageSummary,
 } from "./providers";
 
 // Model Routing

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -318,6 +318,45 @@ export async function getProviderUsage(id: string): Promise<ProviderUsage> {
   return apiGet(`/api/ai/providers/${id}/usage`, "Failed to get provider usage");
 }
 
+// ---------------------------------------------------------------------------
+// Aggregated usage summary (across all missions)
+// ---------------------------------------------------------------------------
+
+export type UsageWindow = "24h" | "7d" | "30d" | "all";
+
+export interface ModelUsageSummary {
+  model: string;
+  /** Inferred provider id ("anthropic", "openai", ...). Null if unknown. */
+  provider: string | null;
+  requests: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+}
+
+export interface UsageSummary {
+  window: UsageWindow;
+  since: string | null;
+  totals: {
+    requests: number;
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_tokens: number;
+    cache_read_tokens: number;
+    cost_cents: number;
+  };
+  by_model: ModelUsageSummary[];
+}
+
+export async function getUsageSummary(window: UsageWindow = "all"): Promise<UsageSummary> {
+  return apiGet(
+    `/api/ai/usage/summary?window=${encodeURIComponent(window)}`,
+    "Failed to get usage summary"
+  );
+}
+
 export async function listProviders(options?: { includeAll?: boolean }): Promise<ProvidersResponse> {
   const params = new URLSearchParams();
   if (options?.includeAll) {

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -135,6 +135,20 @@ pub struct StoredEvent {
     pub metadata: serde_json::Value,
 }
 
+/// Aggregated AI token/cost usage for a single (normalized) model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelUsageStats {
+    /// Canonical model identifier (e.g. "claude-3-5-sonnet", "gpt-4o").
+    /// Empty string when the model was not recorded for an event.
+    pub model: String,
+    pub requests: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cost_cents: u64,
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Automation Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1082,6 +1096,15 @@ pub trait MissionStore: Send + Sync {
     /// Get cost in cents grouped by source, for events on or after `since` (ISO-8601).
     async fn get_cost_by_source_since(&self, _since: &str) -> Result<(u64, u64, u64), String> {
         Ok((0, 0, 0))
+    }
+
+    /// Aggregate AI usage per (normalized) model across all assistant_message events.
+    /// Returns per-model totals (requests, tokens, cost). Time-window optional.
+    async fn get_usage_by_model(
+        &self,
+        _since: Option<&str>,
+    ) -> Result<Vec<ModelUsageStats>, String> {
+        Ok(Vec::new())
     }
 
     // === Automation methods (default no-op for backward compatibility) ===

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3,13 +3,13 @@
 use super::{
     now_string, sanitize_filename, Automation, AutomationExecution, CommandSource, ExecutionStatus,
     FreshSession, Mission, MissionHistoryEntry, MissionMode, MissionStatus, MissionStore,
-    RetryConfig, StopPolicy, StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
-    TelegramActionExecutionStatus, TelegramChannel, TelegramChatMission, TelegramConversation,
-    TelegramConversationMessage, TelegramConversationMessageDirection, TelegramScheduledMessage,
-    TelegramScheduledMessageStatus, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
-    TelegramStructuredMemoryScope, TelegramStructuredMemorySearchHit, TelegramWorkflow,
-    TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus, TriggerType,
-    WebhookConfig,
+    ModelUsageStats, RetryConfig, StopPolicy, StoredEvent, TelegramActionExecution,
+    TelegramActionExecutionKind, TelegramActionExecutionStatus, TelegramChannel,
+    TelegramChatMission, TelegramConversation, TelegramConversationMessage,
+    TelegramConversationMessageDirection, TelegramScheduledMessage, TelegramScheduledMessageStatus,
+    TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
+    TelegramStructuredMemorySearchHit, TelegramWorkflow, TelegramWorkflowEvent,
+    TelegramWorkflowKind, TelegramWorkflowStatus, TriggerType, WebhookConfig,
 };
 use crate::api::control::{AgentEvent, AgentTreeNode, DesktopSessionInfo};
 use async_trait::async_trait;
@@ -3865,6 +3865,102 @@ impl MissionStore for SqliteMissionStore {
             }
         }
         Ok((actual, estimated, unknown))
+    }
+
+    async fn get_usage_by_model(
+        &self,
+        since: Option<&str>,
+    ) -> Result<Vec<ModelUsageStats>, String> {
+        let conn = self.conn.lock().await;
+
+        // Aggregate by normalized model from assistant_message events. Falls back
+        // to the raw `model` string if `model_normalized` is missing. Token and
+        // cost fields tolerate the legacy flat shape (`cost_cents`) and missing
+        // values via COALESCE.
+        let base_query = r#"
+            SELECT
+                COALESCE(
+                    json_extract(metadata, '$.model_normalized'),
+                    json_extract(metadata, '$.model'),
+                    ''
+                ) AS model,
+                COUNT(*) AS requests,
+                COALESCE(SUM(CAST(json_extract(metadata, '$.usage.input_tokens') AS INTEGER)), 0) AS input_tokens,
+                COALESCE(SUM(CAST(json_extract(metadata, '$.usage.output_tokens') AS INTEGER)), 0) AS output_tokens,
+                COALESCE(SUM(CAST(json_extract(metadata, '$.usage.cache_creation_input_tokens') AS INTEGER)), 0) AS cache_creation_tokens,
+                COALESCE(SUM(CAST(json_extract(metadata, '$.usage.cache_read_input_tokens') AS INTEGER)), 0) AS cache_read_tokens,
+                COALESCE(SUM(
+                    CASE WHEN CAST(
+                        COALESCE(
+                            json_extract(metadata, '$.cost.amount_cents'),
+                            json_extract(metadata, '$.cost_cents'),
+                            0
+                        ) AS INTEGER
+                    ) > 0
+                    THEN CAST(
+                        COALESCE(
+                            json_extract(metadata, '$.cost.amount_cents'),
+                            json_extract(metadata, '$.cost_cents'),
+                            0
+                        ) AS INTEGER
+                    ) ELSE 0 END
+                ), 0) AS cost_cents
+            FROM mission_events
+            WHERE event_type = 'assistant_message'
+        "#;
+
+        let sql = match since {
+            Some(_) => format!(
+                "{base_query} AND timestamp >= ?1 GROUP BY model ORDER BY cost_cents DESC, requests DESC"
+            ),
+            None => format!(
+                "{base_query} GROUP BY model ORDER BY cost_cents DESC, requests DESC"
+            ),
+        };
+
+        let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+        let since_owned = since.map(|s| s.to_string());
+        let params: Vec<&dyn rusqlite::ToSql> = match since_owned.as_ref() {
+            Some(s) => vec![s],
+            None => vec![],
+        };
+        let rows = stmt
+            .query_map(params.as_slice(), |row| {
+                let model: String = row.get(0)?;
+                let requests: i64 = row.get(1)?;
+                let input_tokens: i64 = row.get(2)?;
+                let output_tokens: i64 = row.get(3)?;
+                let cache_creation_tokens: i64 = row.get(4)?;
+                let cache_read_tokens: i64 = row.get(5)?;
+                let cost_cents: i64 = row.get(6)?;
+                Ok(ModelUsageStats {
+                    model,
+                    requests: requests.max(0) as u64,
+                    input_tokens: input_tokens.max(0) as u64,
+                    output_tokens: output_tokens.max(0) as u64,
+                    cache_creation_tokens: cache_creation_tokens.max(0) as u64,
+                    cache_read_tokens: cache_read_tokens.max(0) as u64,
+                    cost_cents: cost_cents.max(0) as u64,
+                })
+            })
+            .map_err(|e| e.to_string())?;
+
+        let mut out: Vec<ModelUsageStats> = Vec::new();
+        for r in rows {
+            let row = r.map_err(|e| e.to_string())?;
+            // Skip empty-model rows that carry no usage signal at all
+            if row.model.is_empty()
+                && row.input_tokens == 0
+                && row.output_tokens == 0
+                && row.cache_creation_tokens == 0
+                && row.cache_read_tokens == 0
+                && row.cost_cents == 0
+            {
+                continue;
+            }
+            out.push(row);
+        }
+        Ok(out)
     }
 
     async fn create_automation(&self, automation: Automation) -> Result<Automation, String> {
@@ -7824,6 +7920,127 @@ mod tests {
         assert_eq!(estimated, 50);
         // Unknown (10) + legacy (5) both go into the unknown bucket
         assert_eq!(unknown, 15);
+    }
+
+    #[tokio::test]
+    async fn get_usage_by_model_aggregates_tokens_and_cost_per_model() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(
+                Some("Usage by model mission"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("mission");
+
+        let conn = store.conn.lock().await;
+        let query = r#"
+            INSERT INTO mission_events (
+                mission_id, sequence, event_type, timestamp, metadata
+            ) VALUES (?1, ?2, 'assistant_message', ?3, ?4)
+        "#;
+
+        // Two calls to claude-3-5-sonnet with usage + cost
+        conn.execute(
+            query,
+            params![
+                mission.id.to_string(),
+                1i64,
+                "2026-04-22T00:00:00Z",
+                json!({
+                    "model": "claude-3-5-sonnet-20241022",
+                    "model_normalized": "claude-3-5-sonnet",
+                    "usage": {
+                        "input_tokens": 1000,
+                        "output_tokens": 500,
+                        "cache_creation_input_tokens": 200,
+                        "cache_read_input_tokens": 300
+                    },
+                    "cost": { "amount_cents": 12, "source": "actual" }
+                })
+                .to_string()
+            ],
+        )
+        .expect("insert sonnet 1");
+        conn.execute(
+            query,
+            params![
+                mission.id.to_string(),
+                2i64,
+                "2026-04-22T00:01:00Z",
+                json!({
+                    "model": "claude-3-5-sonnet-20241022",
+                    "model_normalized": "claude-3-5-sonnet",
+                    "usage": {
+                        "input_tokens": 2000,
+                        "output_tokens": 800,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 100
+                    },
+                    "cost": { "amount_cents": 25, "source": "actual" }
+                })
+                .to_string()
+            ],
+        )
+        .expect("insert sonnet 2");
+
+        // One call to gpt-4o with usage + cost
+        conn.execute(
+            query,
+            params![
+                mission.id.to_string(),
+                3i64,
+                "2026-04-22T00:02:00Z",
+                json!({
+                    "model": "gpt-4o-2024-08-06",
+                    "model_normalized": "gpt-4o",
+                    "usage": {
+                        "input_tokens": 500,
+                        "output_tokens": 200
+                    },
+                    "cost": { "amount_cents": 4, "source": "estimated" }
+                })
+                .to_string()
+            ],
+        )
+        .expect("insert gpt-4o");
+
+        drop(conn);
+
+        let rows = store
+            .get_usage_by_model(None)
+            .await
+            .expect("aggregate by model");
+
+        // Ordered by cost_cents DESC: sonnet (37) before gpt-4o (4).
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].model, "claude-3-5-sonnet");
+        assert_eq!(rows[0].requests, 2);
+        assert_eq!(rows[0].input_tokens, 3000);
+        assert_eq!(rows[0].output_tokens, 1300);
+        assert_eq!(rows[0].cache_creation_tokens, 200);
+        assert_eq!(rows[0].cache_read_tokens, 400);
+        assert_eq!(rows[0].cost_cents, 37);
+
+        assert_eq!(rows[1].model, "gpt-4o");
+        assert_eq!(rows[1].requests, 1);
+        assert_eq!(rows[1].cost_cents, 4);
+
+        // since=… filter should drop the older entries.
+        let recent = store
+            .get_usage_by_model(Some("2026-04-22T00:01:30Z"))
+            .await
+            .expect("filtered aggregate");
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].model, "gpt-4o");
     }
 
     #[tokio::test]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -31,7 +31,7 @@ use axum::{
     Router,
 };
 use futures::stream::Stream;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use uuid::Uuid;
@@ -604,6 +604,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
 
     let protected_routes = Router::new()
         .route("/api/stats", get(get_stats))
+        .route("/api/ai/usage/summary", get(get_ai_usage_summary))
         .route("/api/task", post(create_task))
         .route("/api/task/:id", get(get_task))
         .route("/api/task/:id/stop", post(stop_task))
@@ -1301,6 +1302,144 @@ async fn get_stats(
         estimated_cost_cents,
         unknown_cost_cents,
         success_rate,
+    })
+}
+
+/// Optional query parameters for the AI usage summary endpoint.
+#[derive(Debug, Deserialize)]
+pub struct UsageSummaryQuery {
+    /// Time window: "24h", "7d", "30d", or "all". Default "all".
+    window: Option<String>,
+}
+
+/// Per-model usage row in the API response.
+#[derive(Debug, Serialize)]
+pub struct ModelUsageResponse {
+    pub model: String,
+    /// Inferred provider type (e.g. "anthropic", "openai", "google", "xai") or
+    /// `null` when unknown.
+    pub provider: Option<String>,
+    pub requests: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cost_cents: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageSummaryTotals {
+    pub requests: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cost_cents: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageSummaryResponse {
+    pub window: String,
+    pub since: Option<String>,
+    pub totals: UsageSummaryTotals,
+    pub by_model: Vec<ModelUsageResponse>,
+}
+
+/// Map a normalized model identifier to a provider type id.
+fn infer_provider_for_model(model: &str) -> Option<String> {
+    let m = model.to_lowercase();
+    if m.contains("claude") {
+        Some("anthropic".to_string())
+    } else if m.contains("gpt") || m.starts_with("o3") || m.starts_with("o4") || m.contains("openai") {
+        Some("openai".to_string())
+    } else if m.contains("gemini") {
+        Some("google".to_string())
+    } else if m.contains("grok") {
+        Some("xai".to_string())
+    } else if m.contains("glm") || m.contains("z-ai") || m.contains("zai") {
+        Some("zai".to_string())
+    } else if m.contains("minimax") || m.contains("abab") {
+        Some("minimax".to_string())
+    } else if m.contains("mistral") || m.contains("codestral") {
+        Some("mistral".to_string())
+    } else if m.contains("llama") && m.contains("groq") {
+        Some("groq".to_string())
+    } else if m.contains("command") || m.contains("cohere") {
+        Some("cohere".to_string())
+    } else if m.contains("qwen") || m.contains("deepseek") {
+        // Common open-router / together-ai models; default to open-router
+        Some("open-router".to_string())
+    } else {
+        None
+    }
+}
+
+/// GET /api/ai/usage/summary — aggregated AI token/cost usage.
+///
+/// Query params:
+/// - `window`: "24h" | "7d" | "30d" | "all" (default "all").
+async fn get_ai_usage_summary(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Query(params): Query<UsageSummaryQuery>,
+) -> Json<UsageSummaryResponse> {
+    let window = params.window.as_deref().unwrap_or("all");
+    let since: Option<String> = match window {
+        "24h" => Some((chrono::Utc::now() - chrono::Duration::hours(24)).to_rfc3339()),
+        "7d" => Some((chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339()),
+        "30d" => Some((chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339()),
+        _ => None,
+    };
+
+    let control_state = state.control.get_or_spawn(&user).await;
+    let rows = control_state
+        .mission_store
+        .get_usage_by_model(since.as_deref())
+        .await
+        .unwrap_or_default();
+
+    let mut totals = UsageSummaryTotals {
+        requests: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        cost_cents: 0,
+    };
+    let mut by_model: Vec<ModelUsageResponse> = Vec::with_capacity(rows.len());
+    for r in rows {
+        totals.requests = totals.requests.saturating_add(r.requests);
+        totals.input_tokens = totals.input_tokens.saturating_add(r.input_tokens);
+        totals.output_tokens = totals.output_tokens.saturating_add(r.output_tokens);
+        totals.cache_creation_tokens = totals
+            .cache_creation_tokens
+            .saturating_add(r.cache_creation_tokens);
+        totals.cache_read_tokens = totals
+            .cache_read_tokens
+            .saturating_add(r.cache_read_tokens);
+        totals.cost_cents = totals.cost_cents.saturating_add(r.cost_cents);
+        let provider = if r.model.is_empty() {
+            None
+        } else {
+            infer_provider_for_model(&r.model)
+        };
+        by_model.push(ModelUsageResponse {
+            model: r.model,
+            provider,
+            requests: r.requests,
+            input_tokens: r.input_tokens,
+            output_tokens: r.output_tokens,
+            cache_creation_tokens: r.cache_creation_tokens,
+            cache_read_tokens: r.cache_read_tokens,
+            cost_cents: r.cost_cents,
+        });
+    }
+
+    Json(UsageSummaryResponse {
+        window: window.to_string(),
+        since,
+        totals,
+        by_model,
     })
 }
 


### PR DESCRIPTION
## Summary
- Adds a dense, one-card *Resource HUD* at the top of `/settings/providers` summarising **token economy across every mission**: total cost, input/output tokens, cache hit ratio, provider mix, and the top loadout of models.
- New backend endpoint `GET /api/ai/usage/summary?window=24h|7d|30d|all` aggregates `assistant_message` events from `mission_events` by normalized model (cost, requests, input/output/cache tokens).
- New `ProviderUsageHud` React component renders the data in an RPG/shooter-style HUD vocabulary — glowing stat pods, segmented retro-RPG bars, a top-loadout leaderboard, and a 24h/7d/30d/All window picker.

## Design — keeping it simple but useful
The brief was *"resource management in video games"*. I tried hard to keep the visualization a **single card** so it doesn't sprawl into a new page or tab. The vocabulary is:

| HUD element | Game metaphor | What it shows |
| --- | --- | --- |
| 4 glowing stat pods | RPG HUD pods (HP/MP/EXP/Shield) | Gold spent · Input tokens · Output tokens · Cache shield % |
| Stacked horizontal bar | Team-composition strip | Provider mix by spend, with a colored legend |
| Top Loadout list (top 5) | Equipment / weapon slots | Model ranked by requests, segmented bar in provider color, cost + share on the right |
| Window picker tabs | Season / episode selector | 24h · 7d · 30d · All |
| Empty state | Stat-sheet placeholder | "No usage in this window — Start a mission to begin filling your stat sheet." |

Provider color identity is shared with the existing provider chips on the same page so the HUD and the configured-providers list read as one cohesive screen.

## Backend
- `MissionStore::get_usage_by_model(since)` (default: empty) + SQLite implementation that aggregates by `COALESCE(model_normalized, model)`. Tolerates the legacy flat `cost_cents` shape; clamps malformed negative values to zero (matching `get_total_cost_cents`).
- `GET /api/ai/usage/summary` infers provider from the model id (`claude-*` → anthropic, `gpt-*`/`o3` → openai, `gemini-*` → google, `grok-*` → xai, `glm-*` → zai, etc.) — works even for providers without a rate-limit API.

## Frontend
- New `dashboard/src/components/ui/provider-usage-hud.tsx` (self-contained component, uses SWR keyed on window).
- New API client function `getUsageSummary(window)` and `UsageSummary`/`ModelUsageSummary` types.
- `/settings/providers` page wires the HUD in above the existing list.

## Test plan
- [x] `cargo test --lib get_usage_by_model_aggregates_tokens_and_cost_per_model` — covers multi-row aggregation, ordering, and the `since=` filter against a real sqlite store
- [x] `cargo check` clean
- [x] `bun run build` clean (dashboard production build)
- [x] `bun run lint` — no new lint findings from added files
- [x] Backend deployed to dev server, endpoint reachable at `https://agent-backend-dev.thomas.md/api/ai/usage/summary?window=all`
- [x] Playwright: navigated to `/settings/providers` with a fetch interceptor returning mocked aggregation responses for 24h/7d/30d/all. Verified:
  - HUD card renders with header "Resource HUD"
  - 4 `hud-stat-tile` pods populated with formatted values (`$187.42`, `313M`, `11M`, `44%`)
  - 5 `hud-loadout-row` rows rendered in request-count order; segmented bars present
  - Window picker tabs swap `aria-selected` correctly when clicked; SWR refetches under the new window key
  - Empty state renders cleanly when an aggregation returns 0 rows
  - Console clean (no HUD-related errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new protected backend API and SQLite aggregation query over `mission_events` JSON metadata; mistakes could misreport spend/usage or add query load on large datasets.
> 
> **Overview**
> Adds a new protected endpoint `GET /api/ai/usage/summary?window=24h|7d|30d|all` that aggregates `assistant_message` events by normalized model (requests, tokens, cache tokens, cost) via a new `MissionStore::get_usage_by_model` implementation in SQLite, including a unit test for aggregation + time filtering.
> 
> Updates the dashboard API client (`getUsageSummary` + types) and introduces a new `ProviderUsageHud` component (window picker, totals, provider mix, top models), wiring it into `/settings/providers` above the existing provider list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e584b3e04359ff6b4fc719d0271bda6d5ee6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->