### PR TITLE
perf(control): lazy-mount markdown via IntersectionObserver (P2 #13)

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback, memo, startTransition } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { toast } from "@/components/toast";
-import { MarkdownContent } from "@/components/markdown-content";
+import { MarkdownContent, LazyMarkdownContent } from "@/components/markdown-content";
 import { StreamingMarkdown } from "@/components/streaming-markdown";
 import {
   EnhancedInput,
@@ -3163,7 +3163,9 @@ const ChatItemRow = memo(function ChatItemRow({
             <span>•</span>
             <span className="text-white/30">{formatTime(item.timestamp)}</span>
           </div>
-          <MarkdownContent
+          {/* P2-#13: lazy markdown — bubbles render as raw text until they
+              scroll near the viewport, then upgrade to full markdown. */}
+          <LazyMarkdownContent
             content={item.content}
             basePath={basePath}
             workspaceId={workspaceId}

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo, memo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef, memo } from "react";
 import { createRoot } from "react-dom/client";
 import Markdown, { Components, defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -1058,3 +1058,69 @@ export const MarkdownContent = memo(function MarkdownContent({
     </div>
   );
 });
+
+/**
+ * P2-#13: lazy-mount wrapper around `MarkdownContent`.
+ *
+ * Renders the raw text inside a `<pre>` until the first IntersectionObserver
+ * hit, then upgrades to the full markdown pipeline. One-way upgrade: once
+ * a bubble has been seen we keep the rich renderer mounted so scroll-out
+ * doesn't unmount + remount the syntax-highlighted code blocks.
+ *
+ * Bubbles smaller than the threshold skip the lazy path entirely — the
+ * setup cost of an IO observer + the placeholder swap isn't worth it for
+ * a 100-char ack message.
+ */
+const LAZY_THRESHOLD_BYTES = 1_000;
+
+export function LazyMarkdownContent(props: MarkdownContentProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const small = props.content.length < LAZY_THRESHOLD_BYTES;
+  const [visible, setVisible] = useState(small);
+
+  useEffect(() => {
+    if (visible) return;
+    const node = ref.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === "undefined") {
+      // Older browser — just upgrade immediately. CSS content-visibility
+      // already provides the bulk of the win on the chat list.
+      setVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      // 200px rootMargin so the upgrade fires just before the bubble
+      // scrolls into view; users almost never see the placeholder.
+      { rootMargin: "200px" }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  if (visible) {
+    return <MarkdownContent {...props} />;
+  }
+
+  // Placeholder: raw text in a pre block. Reserves a similar vertical
+  // footprint to the rendered markdown so scroll position stays stable
+  // when the upgrade swaps the children.
+  return (
+    <div
+      ref={ref}
+      className={cn("prose-glass text-sm [&_p]:my-2", props.className)}
+    >
+      <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed text-white/80">
+        {props.content}
+      </pre>
+    </div>
+  );
+}


### PR DESCRIPTION
Assistant bubbles render as raw `<pre>` until they scroll near the viewport (200px rootMargin), then upgrade in-place to the full markdown pipeline. One-way upgrade so scroll-out doesn't re-allocate highlighted code blocks. Bubbles <1KB skip the lazy path. Falls back to immediate upgrade in browsers without IntersectionObserver.

Compounds with the P1-#10 50KB cap and the CSS content-visibility on chat rows.

## Test plan
- [x] tsc clean
- [ ] Manual: open a long mission, scroll fast — confirm placeholders briefly visible before upgrade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only perf optimization that defers markdown rendering; main risk is minor UX/layout differences during placeholder-to-markdown swap and IntersectionObserver edge cases.
> 
> **Overview**
> Improves control chat scrolling performance by lazily mounting markdown rendering for assistant bubbles.
> 
> Adds `LazyMarkdownContent`, which initially renders bubble text as a plain `<pre>` and upgrades to full `MarkdownContent` when near the viewport via `IntersectionObserver` (with a 1KB bypass and a no-IO fallback). The control client now uses this lazy renderer for chat bubble content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3595f38961820baa2824c662b60aa09cbd6182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->