### PR TITLE
docs(perf): STREAMING.md + PERF_OVERHAUL log (P5 #27)

### DIFF
--- a/backend/PERF_OVERHAUL.md
+++ b/backend/PERF_OVERHAUL.md
@@ -1,0 +1,140 @@
+# /control performance overhaul — final notes
+
+This is the engineering log for the 27-item perf overhaul tracked in
+issue / project plan from May 2026. It captures what shipped, what was
+deliberately deferred, and the before/after measurements on the
+verity fixture missions.
+
+## Status summary
+
+| Phase | Item | Status |
+| --- | --- | --- |
+| P0 | #1 `?debug=perf` overlay | ✅ shipped #437 |
+| P0 | #2 reducer timers | ✅ shipped #437 |
+| P0 | #3 server metrics endpoint | ✅ shipped #440 |
+| P1 | #4 server SSE filter | ✅ shipped #438 |
+| P1 | #5 SSE-fresh poll guard | ✅ shipped #438 |
+| P1 | #6 rAF coalescing | ✅ shipped #438 |
+| P1 | #7 NowTickProvider | ✅ shipped #439 |
+| P1 | #8 tolerant continuation | ✅ shipped #438 |
+| P1 | #9 navigation leak | ✅ shipped #438 |
+| P1 | #10 markdown size cap | ✅ shipped #438 |
+| P2 | #11 virtualize chat | ⏸ deferred — see below |
+| P2 | #12 virtualize thoughts sheet | ⏸ deferred — see below |
+| P2 | #13 lazy markdown | ✅ shipped #443 |
+| P2 | #14 memoize derived slices | ✅ shipped #442 |
+| P2 | #15 split ControlView | ⏸ deferred — see below |
+| P2 | #16 worker reducer | ⏸ deferred — see below |
+| P3 | #17 delta summarization | ⏸ deferred — backend, large |
+| P3 | #18 since_seq cursors | ⏸ deferred — backend, large |
+| P3 | #19 WS migration | ⏸ deferred — backend, large |
+| P3 | #20 per-mission channels | ⏸ deferred — backend, medium |
+| P3 | #21 backend text_delta backpressure | ⏸ deferred — backend, medium |
+| P4 | #22-24 content model | ⏸ deferred — cross-stack |
+| P5 | #25 health budget telemetry | ⏸ deferred — needs ingestion |
+| P5 | #26 Playwright perf CI | ⏸ deferred — flaky-risk in CI |
+| P5 | #27 STREAMING.md | ✅ shipped (this file's sibling) |
+
+## Before / after (verity mission `3a902278`, 1882 events)
+
+Measured via the `?debug=perf` overlay we landed in P0-#1.
+
+| Metric | Before (master, May 17) | After (P0+P1+P2 partial) | Delta |
+| --- | --- | --- | --- |
+| 10s longtask total | 23.4 s | 53 ms | -440× |
+| 10s longtask max | 5.3 s | 53 ms | -100× |
+| DOM nodes after 10s idle | 13–14k (growing) | 967 (stable) | -14× |
+| JS heap after 10s | 318 MB (growing) | 141 MB (stable) | -55% |
+| SSE drops/sec (cross-mission noise) | 9.9 | 0 (post-server-filter deploy) | -100% |
+| Markdown render time, 200 KB bubble | 5.0 s | <1 ms (capped) | bounded |
+
+The original symptom (74-second freezes on opening verity #1884)
+disappeared after P1-#4..#10 alone. Subsequent items are
+optimisations, not bug fixes.
+
+## Deferred items, with reasoning
+
+These are intentional decisions to stop work, not abandoned TODOs.
+
+### P2-#11/12: virtualize chat list + thoughts sheet
+
+The chat list already uses CSS `content-visibility: auto` +
+`contain-intrinsic-size: auto 140px` on every row, which gives the
+browser permission to skip layout and paint for off-screen rows
+without any JS-level virtualizer. Combined with P2-#13 (lazy
+markdown) and the P2-#14 memoization, the perf overlay no longer
+shows DOM-traversal cost in the longtask profile on a 1.8k-event
+mission. A `@tanstack/react-virtual` integration would add 30 KB to
+the bundle and a non-trivial scroll-anchor refactor; cost > benefit
+at current data sizes. Revisit if a mission with >5k visible items
+becomes routine.
+
+### P2-#15: split ControlView into subscribers
+
+The win here is preventing the entire 9k-line component from
+re-rendering on every state tick. Half the win has already been
+captured: `ChatItemRow` is `memo()`-wrapped, the derived views go
+through `useMemo`+`useDeferredValue`, the 1Hz timer is shared
+(P1-#7), and SSE bursts coalesce into one commit per frame (P1-#6).
+The remaining win comes from migrating to Zustand-or-similar so
+unrelated state slices stop triggering global re-renders. That's a
+multi-day refactor with high regression risk. Track separately;
+don't bundle it into the perf overhaul.
+
+### P2-#16: Web Worker for `eventsToItems`
+
+After P0+P1 landed the `replay:apply` reducer runs at most
+**65 ms** for a 5000-event replay on the verity fixture (measured
+via the `replay:apply` console.time + the metrics overlay's
+"Reducers (cum)" panel). Moving it to a worker requires extracting
+~250 lines of helpers, building a worker bundle in Next.js, and
+paying ~100ms of structured-clone cost on every call to ship a 5k
+ChatItem[] back across the boundary. Net: probably break-even at
+current sizes, regression on small-list call sites that fire
+hundreds of times per session. Deferred until a mission size emerges
+where the reducer alone exceeds 200ms.
+
+### P3-#17..#21: backend streaming changes
+
+All five require coordinated dashboard + iOS + backend changes and
+substantial test coverage. The current SSE + `/events` shape is
+stable across three clients; changing it has high blast radius. The
+per-mission broadcast channels (P3-#20) and the text_delta
+backpressure (P3-#21) are the cheapest wins remaining; track them as
+follow-up issues.
+
+### P4-#22..#24: content model changes
+
+CRDT-style deltas (P4-#22), canonical-bubble persistence (P4-#23),
+and tool-output truncation (P4-#24) all imply data-model migrations.
+The P1-#8 tolerant continuation heuristic absorbs most of the
+duplicate-token symptom that motivated #22. #23 needs a clear
+data-loss story before it's worth the risk. #24 should be done but
+also needs backend cooperation (the streaming download endpoint
+doesn't exist yet).
+
+### P5-#25: health budget telemetry
+
+Needs a telemetry ingestion endpoint that the dashboard can POST to.
+We don't currently run one. Cheap to add server-side; the
+client-side aggregation is ~20 lines using the same
+`PerformanceObserver` we set up in P0-#1. Deferred pending decision
+on where the telemetry should land.
+
+### P5-#26: Playwright perf CI
+
+`@playwright/test --grep perf` runs that load a fixture mission and
+assert heap/longtask/DOM budgets are flaky-prone — the Vercel
+preview deploy lifecycle alone introduces 30s+ of variance. Better
+done as a manual regression script that the perf overlay's
+`?debug=perf` already supports.
+
+## Operational
+
+- Dashboard perf overlay: append `?debug=perf` to any /control URL.
+- Server metrics: `GET /api/control/metrics` returns
+  `{ uptime_secs, sse: { chunks_total, bytes_total, chunk_size_p50,
+  chunk_size_p99 }, endpoints: { events_req_per_minute,
+  running_req_per_minute }, broadcast: { events_total,
+  mission_count_observed, events_avg_per_mission, top_missions } }`.
+- Streaming contract: `backend/STREAMING.md`.

--- a/backend/STREAMING.md
+++ b/backend/STREAMING.md
@@ -1,0 +1,166 @@
+# Streaming contract
+
+The control plane emits agent activity to dashboard and iOS clients via a
+single SSE stream (`GET /api/control/stream`) plus a database-backed
+event log (`GET /api/control/missions/:id/events`, `…/trace`,
+`…/transcript`). This document is the canonical contract for what each
+backend emits and what each client expects. It exists because two
+incidents (the iOS replay-text-delta bug, the verity duplicated-thoughts
+freeze) traced back to drift between these three implementations.
+
+## SSE channel
+
+`GET /api/control/stream?mission=<uuid>`
+
+| Param | Meaning |
+| --- | --- |
+| `mission` | When present, the server only emits events whose `mission_id` matches. `status` and `stream_lagged` (connection-scoped) always pass. Omit the param to receive every event the authenticated user can see (used by the mission list and the `?debug=perf` overlay). |
+
+Each line is one of:
+
+- `event: status\ndata: <json>\n\n` — connection-scoped run state +
+  queue length. The client uses this as a keepalive heartbeat.
+- `event: stream_lagged\ndata: {"dropped": N}\n\n` — the broadcast
+  cursor fell behind by `N` events. Client refetches via `?since_seq`
+  rather than treating this as fatal.
+- `event: <type>\ndata: <json>\n\n` — a single `AgentEvent`. See the
+  type list below.
+
+### Event types
+
+All events carry `mission_id` (optional for connection-scoped events).
+Listed with the backends that emit them.
+
+| Type | Emitted by | Payload sketch | Notes |
+| --- | --- | --- | --- |
+| `status` | server | `{state, queue_len, mission_id?}` | Connection-scoped; sent on connect + after every state change. |
+| `user_message` | server | `{id, mission_id, content, queued}` | Echoes the user message back after persisting. |
+| `assistant_message` | server | `{id, mission_id, content, success, cost_cents?, cost_source?, model?, shared_files?}` | One per completed agent turn. **Cumulative content** — the message is the final consolidated text. |
+| `text_delta` | grok, codex | `{mission_id, content, event_id?}` | **Cumulative buffer** — the `content` field contains the *entire* text so far, not the new tokens. Clients must consolidate by replacing, not appending. See "Continuation rule". |
+| `thinking` | grok, codex | `{mission_id, content, done, goal_role?, event_id?}` | Cumulative buffer. `done: true` finalises the current thought; subsequent non-prefix payloads start a new thought. |
+| `tool_call` | all | `{mission_id, tool_call_id, name, args}` | One per tool invocation. |
+| `tool_result` | all | `{mission_id, tool_call_id, name, result}` | Pairs with `tool_call` via `tool_call_id`. |
+| `error` | server | `{message, mission_id, resumable}` | Treated as fatal by clients (toast + system error row). |
+| `mission_status_changed` | server | `{mission_id, status}` | New status enum from `MissionStatus`. |
+| `agent_phase` | server | `{mission_id, phase, detail?, agent?}` | Coarse-grained phase pill ("Working", "Searching"). |
+| `agent_tree` | server | `{mission_id, tree}` | Subagent hierarchy; pushed on shape change. |
+| `progress` | server | `{mission_id, total_subtasks, completed_subtasks, current_subtask?, depth}` | For subtask progress chips. |
+| `session_id_update` | server | `{mission_id, session_id}` | Some backends rotate session ids mid-mission. |
+| `mission_activity` | server | `{mission_id, ...}` | Stale-watchdog signal. |
+| `mission_title_changed` | server | `{mission_id, title}` | Metadata change pushed live. |
+| `mission_metadata_updated` | server | `{mission_id, ...}` | Same shape as the persisted `mission_metadata_updated` event row. |
+| `mission_settings_updated` | server | `{mission_id, ...}` | Backend / agent / model override changes. |
+| `fido_sign_request` | server | `{...}` | Connection-scoped; not filtered by `mission` query param. |
+| `goal_iteration` | server | `{mission_id, iteration, objective}` | Emitted when a `/goal` loop bumps. |
+| `goal_status` | server | `{mission_id, status, ...}` | Terminal `/goal` outcome. |
+
+## Continuation rule (the "NoNo newNo new CI…" bug)
+
+Both `text_delta` and `thinking` are **cumulative** — every event
+re-sends the entire buffer. Consolidation rule:
+
+```
+isContinuation(prev, next) := prev == next
+                              || next.startsWith(prev)
+                              || prev.startsWith(next)
+                              || trimEnd(next).startsWith(trimEnd(prev))
+                              || trimEnd(prev).startsWith(trimEnd(next))
+                              || shorter == longer up to TAIL_TOLERANCE trailing chars
+```
+
+`trimEnd` strips `\s.,!?;:'")]}…—–-`. `TAIL_TOLERANCE` is 6.
+
+Without the tail tolerance, grok / codex sometimes emit the same buffer
+twice with one punctuation character of drift, and the strict prefix
+check classifies the second copy as a new thought. The chat then
+shows duplicated tokens that grow quadratically with stream length.
+
+The dashboard implements this in `dashboard/src/lib/stream-continuation.ts`.
+The iOS app must mirror the same rule (the
+`HistoricalTranscriptBuilder.isStreamContinuation` Swift port).
+
+## Database event log
+
+The persisted event log is a superset of the SSE stream — every
+broadcast event lands in the `mission_events` table (with a few
+exceptions noted below). Clients reading historical missions consume
+the log through three endpoints:
+
+- `GET /api/control/missions/:id/events?types=…&limit=N&before_seq=N`
+  — page through structured events.
+- `GET /api/control/missions/:id/trace?since_seq=N&limit=N` — same
+  shape, ordered by `(sequence, timestamp, id)`.
+- `GET /api/control/missions/:id/transcript` — flattened message list.
+
+The historical reducer (`eventsToItems` in dashboard, the Swift
+`HistoricalTranscriptBuilder`) walks events in `sequence` order and
+must:
+
+1. Apply the same continuation rule above when consolidating
+   `text_delta` and `thinking`.
+2. Pair `tool_result` with the most recent `tool_call` sharing the
+   same `tool_call_id`.
+3. Treat `event_id` as the deduplication key when present (it survives
+   reorder); fall back to `event-<id>` otherwise.
+4. Promote a finished `thinking` block marked `goal_role: deliverable`
+   into a synthetic `assistant_message` only when (a) the mission is
+   in goal mode and (b) no existing assistant message already carries
+   the same trimmed content.
+
+Events NOT persisted:
+
+- `status`, `stream_lagged`, `fido_sign_request` — connection-scoped.
+- `mission_activity` — diagnostic only, intentionally not stored.
+
+## Client expectations
+
+### Dashboard (`dashboard/src/app/control/control-client.tsx`)
+
+- Connects with `?mission=<id>` when viewing a specific mission.
+- Reconnects whenever the viewing mission changes.
+- Coalesces `text_delta` and `thinking` re-renders via
+  `requestAnimationFrame` — at most one React commit per frame.
+- Caps markdown rendering for messages >50 KB (`<pre>` + opt-in button).
+- Lazy-mounts the markdown pipeline for off-screen bubbles via
+  `IntersectionObserver`.
+- Skips the 15s `/events` refetch poll while SSE is fresh (<30s since
+  last event).
+
+### iOS (`ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift`)
+
+- Live SSE handler at `ControlStreamSession`.
+- Historical replay at `HistoricalTranscriptBuilder` — gated on
+  `mission.goalMode` for goal-role inference.
+- Preserves `goalRole` through finalize-thinking transitions.
+
+## Per-backend notes
+
+- **Grok Build**: emits `thinking` deltas one token at a time. Each
+  delta carries the *cumulative* content. Final thought ends with
+  `done: true`.
+- **Codex**: same shape; bursts can be sub-10ms tight. The rAF
+  coalescing on the dashboard depends on this — without it every
+  delta would be a React commit.
+- **Claude Code**: emits `assistant_message` only (no inline text
+  deltas via SSE). Tool calls flow normally.
+- **Gemini, OpenCode**: tool calls + assistant messages; no streaming
+  text deltas in the current build.
+
+## Adding a new backend
+
+1. Pick a `backend_id` and emit `AgentEvent::*` via the shared
+   `events_tx` channel.
+2. Always populate `mission_id` (the `?mission=<uuid>` filter drops
+   events without it).
+3. For streaming text, send cumulative buffers in `text_delta`. Don't
+   send incremental tokens — every client consumer assumes cumulative
+   semantics today.
+4. Update this file with the per-backend notes.
+
+## Where this document is enforced
+
+- `dashboard/src/lib/stream-continuation.ts` (+ unit tests) is the
+  reference implementation of the continuation rule.
+- `src/api/control_metrics.rs` records p50/p99 SSE chunk sizes so we
+  can spot regressions in the streaming contract.
+- `src/api/control.rs::stream()` is the server-side mission filter.


### PR DESCRIPTION
Closes out the 27-item perf overhaul.

- `backend/STREAMING.md` — canonical SSE emission contract per backend, the tolerant continuation rule, client expectations, and the 'adding a new backend' checklist.
- `backend/PERF_OVERHAUL.md` — engineering log: which items shipped (P0-#1..#3, P1-#4..#10, P2-#13,#14, P5-#27), which were deliberately deferred with reasoning, and the before/after measurements on verity fixture missions (74s freeze → 53ms longtask max, 318MB → 141MB heap, 13-14k → 967 DOM nodes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds documentation and does not change runtime behavior.
> 
> **Overview**
> Adds `backend/STREAMING.md` as the canonical contract for `/api/control/stream` SSE and the persisted event log, including the full event-type catalog, the *tolerant continuation* rule for cumulative `text_delta`/`thinking`, and explicit dashboard/iOS consumer expectations.
> 
> Adds `backend/PERF_OVERHAUL.md` to close out the May 2026 `/control` performance project with shipped vs deferred items, before/after perf measurements on fixture missions, and operational pointers (perf overlay + `GET /api/control/metrics`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15109f9b1ff1991d187c2fbc1b21514c6610aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->