### PR TITLE
perf(control): client health-budget telemetry (P5 #25)

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -17,6 +17,7 @@ import { PerfOverlay } from "@/components/perf-overlay";
 import { perfBus } from "@/lib/perf-bus";
 import { isStreamContinuation } from "@/lib/stream-continuation";
 import { NowTickProvider, useNow } from "@/lib/now-tick";
+import { startHealthBudgetWatcher } from "@/lib/health-budget";
 import { MissionDebugStats } from "./MissionDebugStats";
 import { LazyCodeBlock } from "@/components/lazy-code-block";
 import { LazyJsonHighlighter } from "@/components/lazy-json-highlighter";
@@ -5712,6 +5713,21 @@ export default function ControlClient() {
   }, []);
 
   useVisibilityPolling(refreshRunningMissions, { interval: 15_000 });
+
+  // P5-#25: client health-budget watcher. Posts to /telemetry/perf
+  // whenever the 5s longtask total breaches 2s. Cheap when healthy
+  // (no requests at all); refs avoid recreating the watcher on every
+  // mission/item change.
+  const itemsCountRef = useRef(0);
+  useEffect(() => {
+    itemsCountRef.current = items.length;
+  }, [items]);
+  useEffect(() => {
+    return startHealthBudgetWatcher(
+      () => viewingMissionIdRef.current,
+      () => itemsCountRef.current
+    );
+  }, []);
 
   const refreshRecentMissions = useCallback(async () => {
     try {

--- a/dashboard/src/lib/health-budget.ts
+++ b/dashboard/src/lib/health-budget.ts
@@ -1,0 +1,93 @@
+/**
+ * P5-#25: client-side health budget watcher.
+ *
+ * Sits on the same `PerformanceObserver({type:'longtask'})` the perf
+ * overlay (`perf-bus.ts`) installs. Every 5 seconds we compute the
+ * total longtask duration in the trailing window; if it exceeds 2s we
+ * POST a small JSON report to the server (`/api/control/telemetry/perf`).
+ * The server keeps the last 256 in memory and exposes them via
+ * `GET /api/control/metrics`.
+ *
+ * One report per 5s window max, even on sustained breaches, to keep
+ * the network and the in-memory ring under control. Reports include
+ * mission id (from the URL), heap, DOM size, and stored event count.
+ * No PII; no payload content.
+ */
+
+import { apiUrl } from "@/lib/api";
+import { authHeader } from "@/lib/auth";
+
+const WINDOW_MS = 5_000;
+const BUDGET_MS = 2_000;
+const REPORT_INTERVAL_MS = 5_000;
+
+type Longtask = { t: number; d: number };
+
+export function startHealthBudgetWatcher(getMissionId: () => string | null, getEventCount: () => number): () => void {
+  if (typeof window === "undefined") return () => {};
+  if (typeof PerformanceObserver === "undefined") return () => {};
+
+  const longtasks: Longtask[] = [];
+  let observer: PerformanceObserver | null = null;
+  try {
+    observer = new PerformanceObserver((list) => {
+      const now = performance.now();
+      for (const entry of list.getEntries()) {
+        longtasks.push({ t: entry.startTime, d: entry.duration });
+      }
+      // Prune outside the trailing window.
+      while (longtasks.length && longtasks[0].t < now - WINDOW_MS) {
+        longtasks.shift();
+      }
+    });
+    observer.observe({ type: "longtask", buffered: true });
+  } catch {
+    // longtask isn't supported on Safari / Firefox.
+    return () => {};
+  }
+
+  const interval = window.setInterval(() => {
+    const now = performance.now();
+    while (longtasks.length && longtasks[0].t < now - WINDOW_MS) {
+      longtasks.shift();
+    }
+    let total = 0;
+    let max = 0;
+    for (const l of longtasks) {
+      total += l.d;
+      if (l.d > max) max = l.d;
+    }
+    if (total < BUDGET_MS) return;
+
+    type MemoryInfo = { usedJSHeapSize: number };
+    const memory = (performance as unknown as { memory?: MemoryInfo }).memory;
+    const heapUsedMB = memory ? memory.usedJSHeapSize / 1024 / 1024 : 0;
+    const domNodes = document.getElementsByTagName("*").length;
+    const report = {
+      mission_id: getMissionId(),
+      longtask_total_ms: Math.round(total),
+      longtask_max_ms: Math.round(max),
+      event_count: getEventCount(),
+      heap_used_mb: Math.round(heapUsedMB * 10) / 10,
+      dom_nodes: domNodes,
+      at: Date.now(),
+    };
+    void fetch(apiUrl("/api/control/telemetry/perf"), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(),
+      },
+      body: JSON.stringify(report),
+      keepalive: true,
+    }).catch(() => {
+      // Best-effort — never surface failures to the user.
+    });
+  }, REPORT_INTERVAL_MS);
+
+  return () => {
+    window.clearInterval(interval);
+    observer?.disconnect();
+  };
+}

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4976,6 +4976,18 @@ pub async fn get_control_metrics(
     Json(state.control_metrics.snapshot())
 }
 
+/// P5-#25: client telemetry sink. Dashboard POSTs here when its 5-second
+/// longtask budget breaches the 2s threshold so we can correlate freezes
+/// with mission shape (event count, heap).
+pub async fn post_control_telemetry_perf(
+    State(state): State<Arc<AppState>>,
+    Extension(_user): Extension<AuthUser>,
+    Json(report): Json<super::control_metrics::HealthReport>,
+) -> StatusCode {
+    state.control_metrics.record_health_report(report);
+    StatusCode::ACCEPTED
+}
+
 /// Request body for starting a mission in parallel.
 #[derive(Debug, Deserialize)]
 pub struct StartParallelRequest {

--- a/src/api/control_metrics.rs
+++ b/src/api/control_metrics.rs
@@ -41,6 +41,23 @@ pub struct ControlMetrics {
 
     broadcast_events_total: AtomicU64,
     broadcast_events_by_mission: Mutex<HashMap<uuid::Uuid, u64>>,
+
+    /// P5-#25 health budget reports — bounded ring of recent client
+    /// telemetry pings. A client posts when its 5-second longtask total
+    /// exceeds 2s; we keep the last 256 to surface in /metrics.
+    health_reports: Mutex<Vec<HealthReport>>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct HealthReport {
+    pub mission_id: Option<uuid::Uuid>,
+    pub longtask_total_ms: u64,
+    pub longtask_max_ms: u64,
+    pub event_count: u64,
+    pub heap_used_mb: f64,
+    pub dom_nodes: u64,
+    /// Client wall-clock when the budget breach was observed (ms since epoch).
+    pub at: u64,
 }
 
 struct RingSamples {
@@ -103,6 +120,18 @@ impl ControlMetrics {
             running_endpoint_hits: Mutex::new(Vec::with_capacity(128)),
             broadcast_events_total: AtomicU64::new(0),
             broadcast_events_by_mission: Mutex::new(HashMap::new()),
+            health_reports: Mutex::new(Vec::with_capacity(256)),
+        }
+    }
+
+    /// Record a client-side health budget breach (P5-#25). Caps the
+    /// in-memory ring at 256 entries so a runaway client can't OOM us.
+    pub fn record_health_report(&self, report: HealthReport) {
+        if let Ok(mut buf) = self.health_reports.lock() {
+            if buf.len() >= 256 {
+                buf.remove(0);
+            }
+            buf.push(report);
         }
     }
 
@@ -200,8 +229,15 @@ impl ControlMetrics {
 
         let uptime_secs = now.saturating_duration_since(self.start).as_secs();
 
+        let health_reports = self
+            .health_reports
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default();
+
         MetricsSnapshot {
             uptime_secs,
+            health_reports,
             sse: SseStats {
                 chunks_total: self.sse_chunks_total.load(Ordering::Relaxed),
                 bytes_total: self.sse_bytes_total.load(Ordering::Relaxed),
@@ -229,6 +265,8 @@ pub struct MetricsSnapshot {
     pub sse: SseStats,
     pub endpoints: EndpointStats,
     pub broadcast: BroadcastStats,
+    /// Most recent client-side health budget breaches (P5-#25).
+    pub health_reports: Vec<HealthReport>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -873,6 +873,11 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         )
         // P0-#3: in-process metrics for perf validation.
         .route("/api/control/metrics", get(control::get_control_metrics))
+        // P5-#25: client health-budget telemetry sink.
+        .route(
+            "/api/control/telemetry/perf",
+            post(control::post_control_telemetry_perf),
+        )
         // Memory endpoints
         .route("/api/runs", get(list_runs))
         .route("/api/runs/:id", get(get_run))
@@ -1357,7 +1362,11 @@ fn infer_provider_for_model(model: &str) -> Option<String> {
     let m = model.to_lowercase();
     if m.contains("claude") {
         Some("anthropic".to_string())
-    } else if m.contains("gpt") || m.starts_with("o3") || m.starts_with("o4") || m.contains("openai") {
+    } else if m.contains("gpt")
+        || m.starts_with("o3")
+        || m.starts_with("o4")
+        || m.contains("openai")
+    {
         Some("openai".to_string())
     } else if m.contains("gemini") {
         Some("google".to_string())
@@ -1421,9 +1430,7 @@ async fn get_ai_usage_summary(
         totals.cache_creation_tokens = totals
             .cache_creation_tokens
             .saturating_add(r.cache_creation_tokens);
-        totals.cache_read_tokens = totals
-            .cache_read_tokens
-            .saturating_add(r.cache_read_tokens);
+        totals.cache_read_tokens = totals.cache_read_tokens.saturating_add(r.cache_read_tokens);
         totals.cost_cents = totals.cost_cents.saturating_add(r.cost_cents);
         let provider = if r.model.is_empty() {
             None


### PR DESCRIPTION
Adds longtask budget watcher + server telemetry sink. Dashboard POSTs when 5s longtask total breaches 2s; server stores last 256 reports in memory and surfaces via /api/control/metrics. No PII; bounded memory; safe to leave on in prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated telemetry POST path and in-memory storage for client reports; main risk is unintended request volume or lock contention during sustained UI freezes, though the client is rate-limited and server storage is capped.
> 
> **Overview**
> Adds a client-side *health budget watcher* that tracks `PerformanceObserver({type:'longtask'})` totals over a 5s window and, when the 2s budget is breached, POSTs a small report (mission id, event count, heap/DOM stats) to `/api/control/telemetry/perf`.
> 
> Introduces a new authenticated backend endpoint to accept these reports, stores the most recent 256 in-memory, and exposes them in the existing `/api/control/metrics` snapshot for correlation during perf investigations. Also includes minor formatting-only tweaks in `routes.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af249689455df6179d496336d7081d4467017a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->