### PR TITLE
docs(perf): unify event endpoints around /events?since_seq (P3 #18)

### DIFF
--- a/backend/STREAMING.md
+++ b/backend/STREAMING.md
@@ -84,13 +84,28 @@ The iOS app must mirror the same rule (the
 The persisted event log is a superset of the SSE stream — every
 broadcast event lands in the `mission_events` table (with a few
 exceptions noted below). Clients reading historical missions consume
-the log through three endpoints:
+the log through the unified cursor endpoint:
 
-- `GET /api/control/missions/:id/events?types=…&limit=N&before_seq=N`
-  — page through structured events.
+- `GET /api/control/missions/:id/events` (P3-#18) is the canonical
+  cursor endpoint. Query params:
+  - `since_seq=N` — return events strictly after sequence N (forward
+    delta). Use this for SSE reconnect — keep the highest sequence
+    seen and pass it on resume.
+  - `before_seq=N` — page backwards (oldest-first within the page).
+    For "load older messages" UI.
+  - `types=user_message,assistant_message,…` — filter to a subset.
+    With the default set (the constant `HISTORY_EVENT_TYPES` on the
+    client) this returns the same shape as the legacy `/transcript`.
+  - `limit=N` — page size; default 5000.
+
+Legacy endpoints kept as thin aliases for iOS clients on older
+binaries:
+
 - `GET /api/control/missions/:id/trace?since_seq=N&limit=N` — same
-  shape, ordered by `(sequence, timestamp, id)`.
-- `GET /api/control/missions/:id/transcript` — flattened message list.
+  shape as `/events` but defaults to the activity-trace type set.
+- `GET /api/control/missions/:id/transcript` — flattened message
+  list. New clients should use `/events?types=user_message,…` with
+  a high `limit` instead.
 
 The historical reducer (`eventsToItems` in dashboard, the Swift
 `HistoricalTranscriptBuilder`) walks events in `sequence` order and

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4563,7 +4563,21 @@ pub async fn get_progress(
     Json(progress)
 }
 
-/// Query params for events endpoint.
+/// Query params for the unified mission events endpoint (P3-#18).
+///
+/// `GET /api/control/missions/:id/events` is the canonical cursor
+/// endpoint for fetching persisted events. With `since_seq=N` it
+/// returns events strictly after sequence N (forward delta — what
+/// SSE reconnect uses). With `before_seq=N` it pages backwards. With
+/// `types=tool_call,tool_result` it filters to a subset (replaces
+/// `/trace`). With `types=user_message,assistant_message,thinking,...`
+/// + a high `limit` it returns the full transcript shape.
+///
+/// `/trace` and `/transcript` remain as thin alias handlers for
+/// backward compatibility with iOS clients on older binaries — both
+/// forward to the same `mission_store.list_events` call. Document
+/// the migration: new clients should use `/events?since_seq=N`
+/// exclusively.
 #[derive(Debug, Clone, Deserialize)]
 pub struct GetEventsQuery {
     /// Comma-separated event types to filter (e.g., "tool_call,tool_result")


### PR DESCRIPTION
Documents /events as the canonical cursor endpoint; /trace + /transcript become legacy aliases. No API change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify API usage and migration; no behavioral or data-handling code changes.
> 
> **Overview**
> **Documents a migration to a single canonical historical-events endpoint.** Updates `backend/STREAMING.md` to describe `GET /api/control/missions/:id/events` as the unified cursor API (documenting `since_seq`, `before_seq`, `types`, and `limit`) and frames `/trace` and `/transcript` as legacy aliases for older iOS clients.
> 
> Adds matching clarifying rustdoc on `GetEventsQuery` in `src/api/control.rs`, explicitly stating that `/trace` and `/transcript` forward to the same underlying event listing and that new clients should standardize on `/events?since_seq=N`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7c7bc2a0d78b4119460edcf58bc4b9d389de14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->