### PR TITLE
feat(control): workers strip + declutter top toolbar

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -8715,7 +8715,7 @@ export default function ControlClient() {
     if (childMissions.length > 0 || hasInMissionSubagents) {
       setShowWorkerPanel(true);
     }
-  }, [activeMission?.id, childMissions.length, hasInMissionSubagents]);
+  }, [currentMission?.id, childMissions.length, hasInMissionSubagents]);
 
   // Determine if we should show the resume UI for interrupted/blocked/failed missions
   // Don't show resume UI if:

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1987,6 +1987,7 @@ function MissionWorkbenchPanel({
   role,
   isRunning,
   childMissions,
+  runtime,
   onClose,
   onResume,
   onCancel,
@@ -2002,6 +2003,16 @@ function MissionWorkbenchPanel({
   role: ReturnType<typeof inferMissionRole>;
   isRunning: boolean;
   childMissions: Mission[];
+  /**
+   * Optional runtime block (queue + subtask progress) surfaced inside the
+   * workbench so the toolbar can drop these chips. Caller passes only the
+   * values it has — the section renders only when at least one is active.
+   */
+  runtime?: {
+    queueLen: number;
+    subtaskCompleted?: number;
+    subtaskTotal?: number;
+  };
   onClose: () => void;
   onResume: () => void;
   onCancel: (missionId: string) => void;
@@ -2126,6 +2137,36 @@ function MissionWorkbenchPanel({
                 </p>
               )}
             </section>
+
+            {runtime && (runtime.queueLen > 0 || (runtime.subtaskTotal ?? 0) > 0) && (
+              <section className="space-y-2">
+                <p className="text-[10px] uppercase tracking-wide text-white/30">Runtime</p>
+                <div className="grid grid-cols-2 gap-2">
+                  {runtime.queueLen > 0 && (
+                    <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                      <p className="text-[10px] text-white/30">Queue</p>
+                      <p
+                        className={cn(
+                          "mt-1 text-xs font-medium tabular-nums",
+                          runtime.queueLen < 3 ? "text-amber-400" : "text-orange-400"
+                        )}
+                        title={`${runtime.queueLen} message${runtime.queueLen > 1 ? "s" : ""} waiting`}
+                      >
+                        {runtime.queueLen}
+                      </p>
+                    </div>
+                  )}
+                  {(runtime.subtaskTotal ?? 0) > 0 && (
+                    <div className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2">
+                      <p className="text-[10px] text-white/30">Subtask</p>
+                      <p className="mt-1 text-xs font-medium text-emerald-400 tabular-nums">
+                        {Math.min((runtime.subtaskCompleted ?? 0) + 1, runtime.subtaskTotal ?? 0)}/{runtime.subtaskTotal}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
 
             <section className="space-y-2">
               <p className="text-[10px] uppercase tracking-wide text-white/30">Actions</p>
@@ -9098,15 +9139,20 @@ export default function ControlClient() {
               </>
             )}
 
-            {/* Run state indicator with debug dropdown */}
+            {/* Run state indicator with debug dropdown — icon only.
+                The mission selector already shows the mission status dot and
+                the Workbench shows "Status: Running"; a "Running" label here
+                is redundant. Clicking the icon still opens the diagnostics
+                popover for the deep-debug case. */}
             <div className="relative">
               <button
                 onClick={() => setShowStreamDiagnostics((prev) => !prev)}
                 className={cn(
-                  "flex items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-white/[0.04]",
+                  "flex items-center justify-center rounded-md p-1 transition-colors hover:bg-white/[0.04]",
                   status.className
                 )}
-                title="Click for debug info"
+                title={`${status.label} — click for debug info`}
+                aria-label={`${status.label} — click for debug info`}
               >
                 <StatusIcon
                   className={cn(
@@ -9114,7 +9160,6 @@ export default function ControlClient() {
                     viewingRunState !== "idle" && "animate-spin"
                   )}
                 />
-                <span className="text-sm font-medium">{status.label}</span>
               </button>
 
               {showStreamDiagnostics && (
@@ -9287,24 +9332,29 @@ export default function ControlClient() {
               )}
             </div>
 
-            {/* Queue count */}
-            <div className="h-4 w-px bg-white/[0.08]" />
-            <div
-              className="flex items-center gap-1.5"
-              title={viewingQueueLen > 0 ? `${viewingQueueLen} message${viewingQueueLen > 1 ? 's' : ''} waiting to be processed` : 'No messages queued'}
-            >
-              <span className="text-[10px] uppercase tracking-wider text-white/40">
-                Queue
-              </span>
-              <span className={cn(
-                "text-sm font-medium tabular-nums",
-                viewingQueueLen === 0 && "text-white/70",
-                viewingQueueLen > 0 && viewingQueueLen < 3 && "text-amber-400",
-                viewingQueueLen >= 3 && "text-orange-400"
-              )}>
-                {viewingQueueLen}
-              </span>
-            </div>
+            {/* Queue count — only when something is queued.
+                Idle missions previously rendered a permanent "QUEUE 0" badge,
+                which added noise without information. The workbench mirrors
+                this count in its Runtime section when the user wants detail. */}
+            {viewingQueueLen > 0 && (
+              <>
+                <div className="h-4 w-px bg-white/[0.08]" />
+                <div
+                  className="flex items-center gap-1.5"
+                  title={`${viewingQueueLen} message${viewingQueueLen > 1 ? 's' : ''} waiting to be processed`}
+                >
+                  <span className="text-[10px] uppercase tracking-wider text-white/40">
+                    Queue
+                  </span>
+                  <span className={cn(
+                    "text-sm font-medium tabular-nums",
+                    viewingQueueLen < 3 ? "text-amber-400" : "text-orange-400"
+                  )}>
+                    {viewingQueueLen}
+                  </span>
+                </div>
+              </>
+            )}
 
             {/* Progress indicator */}
             {viewingProgress && viewingProgress.total > 0 && (
@@ -9879,6 +9929,11 @@ export default function ControlClient() {
                 role={activeMissionRole}
                 isRunning={viewingMissionIsRunning}
                 childMissions={childMissions}
+                runtime={{
+                  queueLen: viewingQueueLen,
+                  subtaskCompleted: viewingProgress?.completed,
+                  subtaskTotal: viewingProgress?.total,
+                }}
                 onClose={() => setShowWorkbenchPanel(false)}
                 onResume={handleResumeMission}
                 onCancel={handleCancelMission}

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -8668,11 +8668,12 @@ export default function ControlClient() {
     return null;
   }, [items]);
 
-  // Derive child (worker) missions for the active mission
+  // Derive child (worker) missions from the route's current mission, not the
+  // viewed worker, so the worker strip stays visible after selecting a chip.
   const childMissions = useMemo(() => {
-    if (!activeMission) return [];
-    return recentMissions.filter((m) => m.parent_mission_id === activeMission.id);
-  }, [activeMission, recentMissions]);
+    if (!currentMission) return [];
+    return recentMissions.filter((m) => m.parent_mission_id === currentMission.id);
+  }, [currentMission, recentMissions]);
   const activeMissionRole = activeMission ? inferMissionRole(activeMission) : null;
 
   // In-mission sub-agents: Claude Code's in-process `Task` /

--- a/dashboard/src/components/workers-strip.tsx
+++ b/dashboard/src/components/workers-strip.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { memo, useMemo } from 'react';
+import {
+  Loader2,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Clock,
+  Ban,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getMissionShortName } from '@/lib/mission-display';
+import type { Mission, RunningMissionInfo } from '@/lib/api';
+
+interface WorkersStripProps {
+  childMissions: Mission[];
+  runningMissions: RunningMissionInfo[];
+  viewingMissionId?: string | null;
+  onSelectWorker: (missionId: string) => void;
+  className?: string;
+}
+
+type ChipStatus = {
+  icon: React.ReactNode;
+  color: string;
+  bg: string;
+  activity: string | null;
+  isActive: boolean;
+};
+
+function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus {
+  if (info) {
+    if (info.state === 'running') {
+      return {
+        icon: <Loader2 className="h-3 w-3 animate-spin" />,
+        color: 'text-indigo-300',
+        bg: 'bg-indigo-500/10 border-indigo-500/25 hover:bg-indigo-500/15',
+        activity: info.current_activity || null,
+        isActive: true,
+      };
+    }
+    if (info.state === 'waiting_for_tool') {
+      return {
+        icon: <Clock className="h-3 w-3" />,
+        color: 'text-amber-300',
+        bg: 'bg-amber-500/10 border-amber-500/25 hover:bg-amber-500/15',
+        activity: info.current_activity || 'Waiting for tool',
+        isActive: true,
+      };
+    }
+    if (info.state === 'queued') {
+      return {
+        icon: <Clock className="h-3 w-3" />,
+        color: 'text-white/60',
+        bg: 'bg-white/[0.03] border-white/[0.08] hover:bg-white/[0.06]',
+        activity: 'Queued',
+        isActive: false,
+      };
+    }
+  }
+
+  switch (mission.status) {
+    case 'completed':
+      return {
+        icon: <CheckCircle className="h-3 w-3" />,
+        color: 'text-emerald-300',
+        bg: 'bg-emerald-500/10 border-emerald-500/20 hover:bg-emerald-500/15',
+        activity: null,
+        isActive: false,
+      };
+    case 'failed':
+      return {
+        icon: <XCircle className="h-3 w-3" />,
+        color: 'text-red-300',
+        bg: 'bg-red-500/10 border-red-500/20 hover:bg-red-500/15',
+        activity: null,
+        isActive: false,
+      };
+    case 'interrupted':
+      return {
+        icon: <AlertTriangle className="h-3 w-3" />,
+        color: 'text-amber-300',
+        bg: 'bg-amber-500/10 border-amber-500/20 hover:bg-amber-500/15',
+        activity: null,
+        isActive: false,
+      };
+    case 'not_feasible':
+      return {
+        icon: <Ban className="h-3 w-3" />,
+        color: 'text-rose-300',
+        bg: 'bg-rose-500/10 border-rose-500/20 hover:bg-rose-500/15',
+        activity: null,
+        isActive: false,
+      };
+    case 'active':
+      return {
+        icon: <Loader2 className="h-3 w-3 animate-spin" />,
+        color: 'text-indigo-300',
+        bg: 'bg-indigo-500/10 border-indigo-500/25 hover:bg-indigo-500/15',
+        activity: null,
+        isActive: true,
+      };
+    default:
+      return {
+        icon: <Clock className="h-3 w-3" />,
+        color: 'text-white/50',
+        bg: 'bg-white/[0.03] border-white/[0.08] hover:bg-white/[0.06]',
+        activity: null,
+        isActive: false,
+      };
+  }
+}
+
+/**
+ * Horizontal, sticky strip of worker chips. Sits at the top of the chat
+ * container so the boss can see active workers without opening the side
+ * panel. Click-to-switch into a worker. Self-hides when there are no
+ * children.
+ *
+ * Performance note: memoized; the sort + chip-info derivation is
+ * recomputed only when `childMissions` or `runningMissions` change. The
+ * chat scroll never re-renders this strip because it lives outside the
+ * scrolling region.
+ */
+export const WorkersStrip = memo(function WorkersStrip({
+  childMissions,
+  runningMissions,
+  viewingMissionId,
+  onSelectWorker,
+  className,
+}: WorkersStripProps) {
+  const chips = useMemo(() => {
+    if (childMissions.length === 0) return [];
+    const running = new Map<string, RunningMissionInfo>();
+    for (const rm of runningMissions) running.set(rm.mission_id, rm);
+
+    return [...childMissions]
+      .map((m) => ({ mission: m, info: running.get(m.id), status: chipStatusFor(m, running.get(m.id)) }))
+      .sort((a, b) => {
+        // Active first, then by updated_at desc.
+        if (a.status.isActive !== b.status.isActive) return a.status.isActive ? -1 : 1;
+        const at = a.mission.updated_at || a.mission.created_at || '';
+        const bt = b.mission.updated_at || b.mission.created_at || '';
+        return bt.localeCompare(at);
+      });
+  }, [childMissions, runningMissions]);
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 px-4 py-2 border-b border-white/[0.06] overflow-x-auto',
+        'scrollbar-thin scrollbar-thumb-white/10 scrollbar-track-transparent',
+        className
+      )}
+      aria-label="Active workers"
+    >
+      <span className="shrink-0 text-[10px] uppercase tracking-wider text-white/40 mr-1">
+        Workers
+      </span>
+      {chips.map(({ mission, status }) => {
+        const isViewing = mission.id === viewingMissionId;
+        const title = mission.title?.trim() || getMissionShortName(mission.id);
+        return (
+          <button
+            key={mission.id}
+            onClick={() => onSelectWorker(mission.id)}
+            className={cn(
+              'shrink-0 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors max-w-[280px]',
+              status.bg,
+              isViewing && 'ring-1 ring-indigo-400/60'
+            )}
+            title={status.activity ? `${title} — ${status.activity}` : title}
+          >
+            <span className={cn('shrink-0', status.color)}>{status.icon}</span>
+            <span className="truncate text-white/85">{title}</span>
+            {status.activity && (
+              <span className="hidden md:inline truncate text-white/40 max-w-[120px]">
+                · {status.activity}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary
- **Workers strip**: sticky horizontal row of worker chips above the chat for boss missions, so active workers are visible without opening the side panel and clicking through. Self-hides when there are no children.
- **Toolbar declutter**: the permanent "Running · QUEUE 0" pill becomes a single icon; queue/subtask chips render only when active. Mission status was already shown twice on screen (selector dot + Workbench), so the label was redundant.
- **Workbench Runtime section**: surfaces queue + subtask progress when active, so the moved detail stays one click away.
- **Tracks `workers-strip.tsx`**: a prior commit on master imported the component but left the file untracked; a fresh clone of master couldn't build. This PR adds the file.

## Before / After

| | Before | After |
|---|---|---|
| Toolbar (idle) | `[+New] [Workbench] [Thinking 1] [✦ Running \| QUEUE 0]` | `[+New] [Workbench] [Thinking 1] [✦]` |
| Active workers | Open Workers panel → scan cards → click | Sticky chips above the chat, click any |

## Perf

Tested with `?debug=perf` on a long streaming mission:
- DOM nodes: unchanged
- JS heap: unchanged (heap was lower on the sample with my changes)
- Longtask max: dropped vs master on same sample (126ms vs 482ms; high variance)
- `WorkersStrip` is `memo()` and only re-sorts when `childMissions` / `runningMissions` change — no new subscriptions, timers, or rapid-updating props.

## Test plan
- [ ] Open `/control` on a non-boss mission — strip hidden, toolbar shows icon-only run state.
- [ ] Open `/control` on a boss mission with active workers — strip renders above chat, click a chip to switch into that worker, current viewing worker has a ring outline.
- [ ] Queue a message — `Queue N` chip appears on toolbar; `Runtime → Queue` shows in Workbench.
- [ ] Click the run-state icon — diagnostics popover still opens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes, but alters how `childMissions` are derived (from `currentMission` instead of `activeMission`), which could affect worker visibility when switching missions.
> 
> **Overview**
> Adds a sticky `WorkersStrip` above the chat that shows child worker missions as clickable status chips (sorted with active workers first) so users can switch workers without opening the side panel.
> 
> Declutters the top toolbar by making the run-state indicator icon-only and hiding the queue badge when it’s zero; queue and subtask progress are instead surfaced in a new conditional *Runtime* section inside `MissionWorkbenchPanel` (fed via a new optional `runtime` prop).
> 
> Adjusts child-mission derivation to use the route’s `currentMission` (not the currently viewed worker mission) so worker UI remains visible after selecting a worker chip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0391144edf7eca738e173db510b0c0a7dc9e9cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->