### PR TITLE
feat(telegram): add Paloma ops controls

### DIFF
--- a/docs/PALOMA_TELEGRAM_ROADMAP.md
+++ b/docs/PALOMA_TELEGRAM_ROADMAP.md
@@ -1,0 +1,675 @@
+# Paloma Telegram Roadmap
+
+Long-term roadmap for making Paloma a quiet Telegram operations aide for
+Sandboxed.sh.
+
+The goal is not to build a second dashboard in chat. Telegram should be the
+smallest useful surface for awareness, steering, and timely answers while the
+dashboard remains the full control plane.
+
+## Product North Star
+
+Paloma should feel like a trusted operations aide:
+
+- She tells Thomas what changed since he last checked.
+- She alerts Thomas only when something matters.
+- She lets Thomas steer long-running agents from Telegram.
+- She can answer or help Benjamin in shared chats, but never expose secrets or
+  grant mission control to anyone except Thomas.
+- She learns notification preferences from direct feedback.
+- She handles useful media without turning Telegram into a noisy file dump.
+
+## User Model
+
+### Thomas
+
+Owner. Full control from DM only.
+
+Thomas can:
+
+- Check status across missions.
+- See what changed since his last Telegram or dashboard session.
+- Steer existing missions.
+- Start small worker missions.
+- Answer agent questions from Telegram.
+- Receive proactive alerts.
+- Teach Paloma alert preferences.
+
+### Benjamin
+
+Trusted friend/helper. Limited interaction in shared chats.
+
+Benjamin can:
+
+- Ask high-level questions in allowed shared chats.
+- Receive safe summaries when Paloma decides it is useful.
+- Trigger helpful context from Paloma when the answer saves Thomas time.
+
+Benjamin cannot:
+
+- DM Paloma to control Thomas's missions.
+- Start, stop, steer, or inspect private missions.
+- Access secrets, raw logs, private prompts, file paths, credentials, or
+  sensitive workspace details.
+
+### Everyone Else
+
+Ignored by default unless explicitly allowed.
+
+## Minimal Command Set
+
+Keep the command surface intentionally small:
+
+| Command | Purpose |
+| --- | --- |
+| `/status` | Delta summary since Thomas last checked. |
+| `/missions` | Compact list of active/interested missions. |
+| `/summary` | Succinct summary of one mission or the current situation. |
+| `/send` | Send a steering message to a mission or selected agent. |
+| `/approve` | Answer agent questions/options from Telegram. |
+
+Natural replies to Paloma alerts should work whenever possible, so commands are
+fallbacks rather than the main UX.
+
+## Core Concepts
+
+### Last-Seen Cursors
+
+Paloma needs per-user cursors, not just message history.
+
+Track:
+
+- Last Telegram `/status`.
+- Last Telegram alert acknowledged.
+- Last dashboard session activity.
+- Last dashboard mission viewed.
+- Last mission event summarized to Thomas.
+- Last digest sent.
+
+This lets `/status` answer the real question: "What changed since I last paid
+attention?"
+
+### Mission Interest
+
+Not every mission deserves alerts.
+
+Track interest signals:
+
+- Thomas explicitly subscribed.
+- Thomas recently viewed or messaged the mission.
+- Mission is long-running.
+- Mission is a parent goal mission.
+- Mission asks for input.
+- Mission has failed, completed, or become blocked/unblocked.
+
+Interest should decay over time unless refreshed by user activity.
+
+### Alert Preferences
+
+Paloma should store explicit notification rules learned from feedback.
+
+Examples:
+
+- "Do not alert me about routine worker completions."
+- "Tell me when a proof mission becomes unblocked."
+- "Send fewer updates about this mission."
+- "Tell me more about deployment failures."
+- "Never share raw logs in group chats."
+
+Preference updates should be auditable and editable later.
+
+### Friend-Safe Output
+
+Shared-chat answers must pass a safety filter before sending.
+
+Default deny:
+
+- Secrets and tokens.
+- Raw logs.
+- Private prompts or instructions.
+- File paths.
+- Credentials.
+- Full mission transcripts.
+- Sensitive personal data.
+- Unreviewed external links or generated files.
+
+Default allow:
+
+- High-level project status.
+- Publicly safe summaries.
+- Non-sensitive calendar availability if Thomas explicitly enables it.
+- Helpful answers that save Thomas time.
+
+## Architecture
+
+Current Telegram architecture:
+
+```text
+Telegram webhook
+  -> /api/telegram/webhook/:channel_id
+  -> TelegramBridge
+  -> ControlCommand::UserMessage
+  -> mission runner
+  -> AgentEvent stream
+  -> Telegram send/edit/media delivery
+```
+
+Paloma should extend this with a notification and preference layer:
+
+```text
+Mission events + dashboard activity + Telegram messages
+  -> Paloma classifier
+  -> interest and preference store
+  -> alert/digest planner
+  -> Telegram delivery
+  -> feedback parser
+  -> preference updates
+```
+
+Do not rebuild an OpenClaw-style gateway. Sandboxed.sh is mission-first. Paloma
+should make missions usable from Telegram.
+
+## Data Model
+
+Proposed tables:
+
+### `telegram_users`
+
+- `id`
+- `telegram_user_id`
+- `username`
+- `display_name`
+- `role`: `owner`, `trusted_friend`, `observer`, `blocked`
+- `created_at`
+- `updated_at`
+
+### `telegram_user_cursors`
+
+- `id`
+- `telegram_user_id`
+- `last_status_at`
+- `last_dashboard_seen_at`
+- `last_alert_ack_at`
+- `last_digest_at`
+- `last_seen_event_sequence_by_mission_json`
+- `created_at`
+- `updated_at`
+
+### `telegram_mission_subscriptions`
+
+- `id`
+- `telegram_user_id`
+- `mission_id`
+- `interest_level`: `muted`, `normal`, `high`
+- `reason`
+- `expires_at`
+- `created_at`
+- `updated_at`
+
+### `telegram_alert_preferences`
+
+- `id`
+- `telegram_user_id`
+- `scope`: `global`, `mission`, `chat`, `event_kind`
+- `scope_value`
+- `rule_text`
+- `enabled`
+- `created_from_message_id`
+- `created_at`
+- `updated_at`
+
+### `telegram_alerts`
+
+- `id`
+- `telegram_user_id`
+- `mission_id`
+- `event_kind`
+- `importance`
+- `title`
+- `body`
+- `status`: `pending`, `sent`, `muted`, `failed`, `acknowledged`
+- `telegram_message_id`
+- `last_error`
+- `created_at`
+- `sent_at`
+- `acknowledged_at`
+
+### `telegram_agent_questions`
+
+- `id`
+- `mission_id`
+- `telegram_user_id`
+- `question`
+- `options_json`
+- `status`: `pending`, `answered`, `expired`
+- `telegram_message_id`
+- `answer_text`
+- `created_at`
+- `answered_at`
+
+## Delivery Rules
+
+### Owner DM
+
+Allowed:
+
+- Full mission control.
+- Status summaries.
+- Steering.
+- Agent questions.
+- Worker creation.
+- Media and files.
+
+Still protected:
+
+- Secrets should be redacted by default.
+- Dangerous actions can be gated later, but the first version should focus on
+  answering agent questions rather than broad approval workflows.
+
+### Shared Chats
+
+Allowed only when:
+
+- Thomas or Benjamin is in the chat.
+- The chat is allowlisted.
+- The message is directly relevant.
+- The answer is safe after redaction.
+- Paloma's intervention is likely to save time.
+
+Paloma should usually stay silent.
+
+## Alert Policy
+
+Start with simple rules:
+
+Alert Thomas when:
+
+- A mission asks for user input.
+- A long-running mission completes.
+- A long-running mission fails.
+- A mission becomes stuck or repeatedly errors.
+- A subscribed mission has meaningful progress.
+- A deployment completes or fails.
+- A generated media/report artifact is ready.
+
+Do not alert Thomas for:
+
+- Routine worker completions unless subscribed.
+- Noisy low-level tool events.
+- Every text delta.
+- Repeated failures with the same cause after the first alert.
+
+Cadence:
+
+- Immediate for input-needed, failed, completed, or explicitly high-interest
+  events.
+- Digest after a few hours of quiet.
+- Exponential backoff until daily summaries.
+- Reset cadence when Thomas replies, views the dashboard, or marks a mission as
+  high-interest.
+
+## Status UX
+
+`/status` should return a delta summary.
+
+Example:
+
+```text
+3 meaningful changes since you last checked.
+
+1. Verity proof mission unblocked after the worker found the missing invariant.
+2. PR #1914 is waiting for your answer about scope.
+3. Keel UI worker failed screenshot validation twice; likely CSS overflow.
+```
+
+If there are many missions, send a compact text summary first and optionally a
+status card image second.
+
+## Missions UX
+
+`/missions` should be compact.
+
+Example:
+
+```text
+Active missions
+
+High interest
+- Verity proof layer: running, last progress 18m ago
+- Keel OS MVP: awaiting user
+
+Other
+- 4 workers running
+- 2 completed since last status
+```
+
+## Summary UX
+
+`/summary` should choose a sensible target:
+
+- If replying to an alert, summarize that mission.
+- If a mission is selected in the owner DM, summarize that mission.
+- Otherwise summarize high-interest active missions.
+
+Default length should be terse.
+
+## Steering UX
+
+`/send` should support:
+
+```text
+/send <mission selector> <message>
+/send latest focus on tests and report only blockers
+/send verity spawn a small worker to inspect docs
+```
+
+Natural replies to alerts should be preferred:
+
+```text
+Focus it on tests first.
+Ask a small worker to check docs.
+Stop this mission.
+```
+
+Paloma should confirm the target before sending if ambiguous.
+
+## Approval/Input UX
+
+`/approve` is primarily for answering agent questions.
+
+When a mission waits for input, Paloma should DM:
+
+```text
+Verity proof mission needs your input:
+Should it pin the merged Verity commit or keep tracking main?
+
+Reply:
+1. Pin merged commit
+2. Track main
+3. Ask agent to decide
+```
+
+Thomas can reply with a number or plain text. Paloma forwards the answer into
+the mission.
+
+## Media Roadmap
+
+### Phase 1
+
+- Forward mission `shared_files` to Telegram.
+- Send images as photos when safe.
+- Send reports and non-image files as documents.
+- Include captions with origin mission and short context.
+
+### Phase 2
+
+- Treat inbound Telegram files as mission attachments, not just temp paths.
+- Persist attachment metadata.
+- Show attachments in dashboard mission history.
+- Add OCR for images and screenshots.
+- Add transcription for voice notes.
+
+### Phase 3
+
+- Generate compact status cards as images.
+- Send graph/image summaries for complex mission states.
+- Support media bundles when a mission produces multiple artifacts.
+
+Voice is lowest priority.
+
+## Preference Learning
+
+Paloma should parse feedback messages such as:
+
+- "Don't tell me about this again."
+- "Tell me more about this kind of thing."
+- "Only alert me if this fails."
+- "Summarize this daily."
+- "Benjamin can see this level of detail."
+
+Implementation should create explicit preference records, then confirm tersely:
+
+```text
+Noted. I will mute routine updates for this mission unless it fails or asks for input.
+```
+
+Avoid opaque memory. Preference changes should be visible in Settings later.
+
+## Safety Rules
+
+Hard requirements:
+
+- Only Thomas can control missions.
+- Benjamin can interact only in allowlisted shared chats.
+- No one except Thomas can DM-control Paloma.
+- Redact secrets before Telegram delivery.
+- Do not send raw logs to shared chats.
+- Do not expose private prompts, internal instructions, or file paths to
+  friends.
+- Treat generated files as private unless explicitly shared.
+
+Future approval gates can cover deploy, push, merge, external messages, spending
+money, and sharing files. The first version should not overbuild approvals.
+
+## Implementation Phases
+
+### Phase 0: Confirm Current Baseline
+
+- Verify active production bot registration.
+- Verify webhook secret validation.
+- Verify `scripts/telegram_user_smoke.py` works from Thomas's Telegram account.
+- Verify current inbound text, media download, outbound text, and shared-file
+  delivery.
+- Document the production DB path clearly. Current production has been observed
+  using `missions-dev.db`; either rename it or document why this is intentional.
+
+### Phase 1: Owner Identity and `/status`
+
+- Add Telegram user role storage.
+- Mark Thomas as owner.
+- Track last-seen cursors.
+- Add `/status` command.
+- Generate delta summaries from mission events since last cursor.
+- Update cursor after successful status delivery.
+- Test with Telethon from Thomas's account.
+
+Acceptance:
+
+- `/status` returns only changes since the previous `/status`.
+- Dashboard activity can advance or influence the cursor.
+- Non-owner DMs cannot access mission status.
+
+### Phase 2: Mission Interest and `/missions`
+
+- Add mission subscriptions and interest scoring.
+- Add `/missions` command.
+- Rank long-running, recently viewed, parent, awaiting-user, failed, and
+  subscribed missions first.
+- Support muting and high-interest marking from Telegram replies.
+
+Acceptance:
+
+- `/missions` shows a compact list.
+- Muted missions disappear from proactive alerts.
+- High-interest missions surface first.
+
+### Phase 3: Proactive Alerts
+
+- Add alert classifier for mission events.
+- Add `telegram_alerts` store.
+- Add alert deduplication and cooldowns.
+- Add exponential digest cadence.
+- Deliver input-needed, completed, failed, stuck, and important-progress alerts.
+- Parse feedback to update alert preferences.
+
+Acceptance:
+
+- A completed interested mission sends one concise DM alert.
+- Repeated identical failures do not spam.
+- "Don't tell me about this again" creates a persistent mute rule.
+- "Tell me more about this" raises interest/preference.
+
+### Phase 4: Agent Questions and `/approve`
+
+- Detect missions awaiting user input.
+- Send question alerts to Thomas.
+- Support numbered options and free-text replies.
+- Route answer back into the correct mission.
+- Add `/approve` fallback command.
+
+Acceptance:
+
+- A mission question appears in Telegram.
+- Thomas answers in Telegram.
+- The answer reaches the mission.
+- The question is marked answered and not re-alerted.
+
+### Phase 5: Steering and Small Workers
+
+- Add `/send`.
+- Add natural reply routing for alert threads.
+- Support selecting latest/high-interest mission.
+- Support creating small worker missions from Telegram when Thomas asks.
+- Require confirmation only when the target is ambiguous.
+
+Acceptance:
+
+- Thomas can steer an existing long-running mission from Telegram.
+- Thomas can start a small worker from Telegram.
+- Benjamin cannot start or steer missions.
+
+### Phase 6: Shared Chat Intelligence
+
+- Add trusted friend role for Benjamin.
+- Add allowlisted shared chat behavior.
+- Add friend-safe redaction and summary policy.
+- Let Paloma answer when directly useful, but stay silent by default.
+
+Acceptance:
+
+- Benjamin can ask a safe high-level question in the shared chat.
+- Paloma answers without secrets or control access.
+- Random users cannot control or query private state.
+
+### Phase 7: Media
+
+- Persist inbound Telegram attachment metadata.
+- Show Telegram attachments in mission history.
+- Improve outbound shared-file captions.
+- Add status card image generation for complex status.
+- Add OCR for images and transcription for voice notes if still useful.
+
+Acceptance:
+
+- Thomas can send an image/file and the mission receives a durable attachment.
+- Mission-generated images/files can be sent back to Telegram.
+- `/status` can optionally include a compact image card.
+
+### Phase 8: Dashboard Settings
+
+- Add UI for:
+  - Telegram users and roles.
+  - Allowed chats.
+  - Alert preferences.
+  - Mission subscriptions.
+  - Last delivered alerts.
+  - Test-send button.
+
+Acceptance:
+
+- Thomas can inspect and edit Paloma's learned preferences.
+- Thomas can see why an alert was sent or muted.
+
+## Testing Strategy
+
+Use three test layers.
+
+### Unit Tests
+
+Cover:
+
+- Command parsing.
+- Role checks.
+- Redaction.
+- Alert classification.
+- Preference feedback parsing.
+- Delta summary cursor logic.
+- Mission interest ranking.
+
+### Local/Backend Integration Tests
+
+Cover:
+
+- SQLite migrations.
+- Alert store deduplication.
+- Cursor updates.
+- Mission event to alert flow.
+- Webhook update dedup.
+- Agent question routing.
+
+### Live Telegram Smoke Tests
+
+Use `scripts/telegram_user_smoke.py` with a real Telegram user session.
+
+Required environment:
+
+```bash
+export TELEGRAM_API_ID=...
+export TELEGRAM_API_HASH=...
+export TELEGRAM_PHONE=...
+export TELEGRAM_CHAT=...
+export TELEGRAM_FROM_USER=ana_lfgbot
+```
+
+Example:
+
+```bash
+python3 scripts/telegram_user_smoke.py \
+  --chat "$TELEGRAM_CHAT" \
+  --send "/status" \
+  --watch-seconds 60 \
+  --print-history
+```
+
+The production bot token is stored server-side and should not be needed for
+Telethon client-side smoke tests. If bot-token API checks are needed, retrieve
+only masked metadata or use server-side authenticated control APIs; do not print
+tokens in logs.
+
+Each feature phase should include a live smoke:
+
+- Send command from Thomas account.
+- Verify Paloma response appears.
+- Verify DB state changed correctly.
+- Verify non-owner behavior is denied.
+- Verify no secrets appear in Telegram output.
+
+## Open Questions
+
+- Should dashboard views update the same cursor as Telegram `/status`, or should
+  dashboard and Telegram have separate "briefed" cursors?
+- Should Paloma DM Thomas before answering Benjamin in a shared chat when the
+  answer depends on private context?
+- How should "small worker" defaults be chosen: same workspace as parent,
+  current dashboard mission, or Paloma's own control workspace?
+- Should status card images be generated by backend code or by an agent tool?
+
+## Suggested First Slice
+
+Build Phase 1 and part of Phase 3:
+
+- Owner role.
+- `/status` delta summary.
+- Last-seen cursor.
+- Input-needed proactive alert.
+- Telethon smoke test.
+
+This is the smallest version that changes the daily workflow.
+
+## Simple Goal Prompt
+
+Use this with an agent:
+
+```text
+/goal Implement the Paloma Telegram roadmap in docs/PALOMA_TELEGRAM_ROADMAP.md, starting with the smallest useful slice and continuing phase by phase. Keep the UX simple: one bot, Thomas-only mission control, concise /status deltas, proactive important alerts, and safe limited shared-chat behavior for Benjamin. For every completed feature, add focused tests and run live Telegram smoke tests with scripts/telegram_user_smoke.py from my Telegram account when credentials are available. Do not print bot tokens or secrets. Before stopping, audit the roadmap checklist against code, tests, production config, and Telegram smoke results; keep going until each implemented phase is genuinely verified or clearly marked blocked with the exact missing credential/config.
+```

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -488,6 +488,102 @@ pub struct TelegramChannel {
     pub updated_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelegramUser {
+    pub id: Uuid,
+    pub telegram_user_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub role: TelegramUserRole,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TelegramUserRole {
+    Owner,
+    TrustedFriend,
+    Observer,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelegramUserCursor {
+    pub id: Uuid,
+    pub telegram_user_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_status_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_dashboard_seen_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_alert_ack_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_digest_at: Option<String>,
+    pub last_seen_event_sequence_by_mission_json: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelegramMissionSubscription {
+    pub id: Uuid,
+    pub telegram_user_id: i64,
+    pub mission_id: Uuid,
+    pub interest_level: TelegramMissionInterestLevel,
+    pub reason: Option<String>,
+    pub expires_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TelegramMissionInterestLevel {
+    Muted,
+    Normal,
+    High,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelegramAlertPreference {
+    pub id: Uuid,
+    pub telegram_user_id: i64,
+    pub scope: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_value: Option<String>,
+    pub rule_text: String,
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_from_message_id: Option<i64>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelegramAlert {
+    pub id: Uuid,
+    pub telegram_user_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mission_id: Option<Uuid>,
+    pub event_kind: String,
+    pub importance: String,
+    pub title: String,
+    pub body: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telegram_message_id: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sent_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acknowledged_at: Option<String>,
+}
+
 /// A mapping from a Telegram chat to an auto-created mission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelegramChatMission {
@@ -1390,6 +1486,108 @@ pub trait MissionStore: Send + Sync {
     /// List all Telegram channels (both legacy and auto-create).
     async fn list_all_telegram_channels(&self) -> Result<Vec<TelegramChannel>, String> {
         Ok(vec![])
+    }
+
+    /// Upsert a Telegram user identity and role.
+    async fn upsert_telegram_user(&self, user: TelegramUser) -> Result<TelegramUser, String> {
+        let _ = user;
+        Err("Not supported".to_string())
+    }
+
+    /// Get a Telegram user by Telegram user id.
+    async fn get_telegram_user(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<Option<TelegramUser>, String> {
+        let _ = telegram_user_id;
+        Ok(None)
+    }
+
+    /// Get or create a per-user Telegram cursor row.
+    async fn get_or_create_telegram_user_cursor(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<TelegramUserCursor, String> {
+        let _ = telegram_user_id;
+        Err("Not supported".to_string())
+    }
+
+    /// Update the /status cursor after successful delivery.
+    async fn update_telegram_user_last_status_at(
+        &self,
+        telegram_user_id: i64,
+        last_status_at: &str,
+        last_seen_event_sequence_by_mission_json: &str,
+    ) -> Result<(), String> {
+        let _ = (
+            telegram_user_id,
+            last_status_at,
+            last_seen_event_sequence_by_mission_json,
+        );
+        Err("Not supported".to_string())
+    }
+
+    /// Upsert a mission subscription/interest row.
+    async fn upsert_telegram_mission_subscription(
+        &self,
+        subscription: TelegramMissionSubscription,
+    ) -> Result<TelegramMissionSubscription, String> {
+        let _ = subscription;
+        Err("Not supported".to_string())
+    }
+
+    /// List mission subscriptions for a Telegram user.
+    async fn list_telegram_mission_subscriptions(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<Vec<TelegramMissionSubscription>, String> {
+        let _ = telegram_user_id;
+        Ok(vec![])
+    }
+
+    /// Store an explicit Telegram alert preference learned from feedback.
+    async fn create_telegram_alert_preference(
+        &self,
+        preference: TelegramAlertPreference,
+    ) -> Result<TelegramAlertPreference, String> {
+        let _ = preference;
+        Err("Not supported".to_string())
+    }
+
+    /// Insert an alert unless an equivalent alert already exists.
+    async fn create_telegram_alert_if_absent(
+        &self,
+        alert: TelegramAlert,
+    ) -> Result<Option<TelegramAlert>, String> {
+        let _ = alert;
+        Ok(None)
+    }
+
+    /// List pending Telegram alerts for a user.
+    async fn list_pending_telegram_alerts(
+        &self,
+        telegram_user_id: i64,
+        limit: usize,
+    ) -> Result<Vec<TelegramAlert>, String> {
+        let _ = (telegram_user_id, limit);
+        Ok(vec![])
+    }
+
+    /// Mark an alert as sent.
+    async fn mark_telegram_alert_sent(
+        &self,
+        id: Uuid,
+        telegram_message_id: Option<i64>,
+        sent_at: &str,
+    ) -> Result<(), String> {
+        let _ = (id, telegram_message_id, sent_at);
+        Err("Not supported".to_string())
+    }
+
+    /// Mark an alert as failed.
+    async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
+        let _ = (id, error);
+        Err("Not supported".to_string())
     }
 
     // === Telegram Chat-Mission mapping methods ===

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -5,10 +5,12 @@ use super::{
     ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode,
     MissionStatus, MissionStore, ModelUsageStats, RetryConfig, StopPolicy, StoredEvent,
     TelegramActionExecution, TelegramActionExecutionKind, TelegramActionExecutionStatus,
-    TelegramChannel, TelegramChatMission, TelegramConversation, TelegramConversationMessage,
-    TelegramConversationMessageDirection, TelegramScheduledMessage, TelegramScheduledMessageStatus,
-    TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
-    TelegramStructuredMemorySearchHit, TelegramWorkflow, TelegramWorkflowEvent,
+    TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramChatMission,
+    TelegramConversation, TelegramConversationMessage, TelegramConversationMessageDirection,
+    TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramScheduledMessage,
+    TelegramScheduledMessageStatus, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
+    TelegramStructuredMemoryScope, TelegramStructuredMemorySearchHit, TelegramUser,
+    TelegramUserCursor, TelegramUserRole, TelegramWorkflow, TelegramWorkflowEvent,
     TelegramWorkflowKind, TelegramWorkflowStatus, TriggerType, WebhookConfig,
 };
 use crate::api::control::{AgentEvent, AgentTreeNode, DesktopSessionInfo, TextOp};
@@ -1443,6 +1445,83 @@ impl SqliteMissionStore {
                 e
             );
         }
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS telegram_users (
+                id TEXT PRIMARY KEY NOT NULL,
+                telegram_user_id INTEGER NOT NULL UNIQUE,
+                username TEXT,
+                display_name TEXT,
+                role TEXT NOT NULL DEFAULT 'observer',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_tusers_role
+                ON telegram_users(role);
+
+            CREATE TABLE IF NOT EXISTS telegram_user_cursors (
+                id TEXT PRIMARY KEY NOT NULL,
+                telegram_user_id INTEGER NOT NULL UNIQUE,
+                last_status_at TEXT,
+                last_dashboard_seen_at TEXT,
+                last_alert_ack_at TEXT,
+                last_digest_at TEXT,
+                last_seen_event_sequence_by_mission_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS telegram_mission_subscriptions (
+                id TEXT PRIMARY KEY NOT NULL,
+                telegram_user_id INTEGER NOT NULL,
+                mission_id TEXT NOT NULL,
+                interest_level TEXT NOT NULL DEFAULT 'normal',
+                reason TEXT,
+                expires_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(telegram_user_id, mission_id),
+                FOREIGN KEY (mission_id) REFERENCES missions(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_tsub_user_interest
+                ON telegram_mission_subscriptions(telegram_user_id, interest_level);
+            CREATE INDEX IF NOT EXISTS idx_tsub_mission
+                ON telegram_mission_subscriptions(mission_id);
+
+            CREATE TABLE IF NOT EXISTS telegram_alert_preferences (
+                id TEXT PRIMARY KEY NOT NULL,
+                telegram_user_id INTEGER NOT NULL,
+                scope TEXT NOT NULL,
+                scope_value TEXT,
+                rule_text TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_from_message_id INTEGER,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_talert_pref_user_scope
+                ON telegram_alert_preferences(telegram_user_id, scope, scope_value);
+
+            CREATE TABLE IF NOT EXISTS telegram_alerts (
+                id TEXT PRIMARY KEY NOT NULL,
+                telegram_user_id INTEGER NOT NULL,
+                mission_id TEXT,
+                event_kind TEXT NOT NULL,
+                importance TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                telegram_message_id INTEGER,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                sent_at TEXT,
+                acknowledged_at TEXT,
+                UNIQUE(telegram_user_id, mission_id, event_kind)
+            );
+            CREATE INDEX IF NOT EXISTS idx_talerts_user_status
+                ON telegram_alerts(telegram_user_id, status, created_at);",
+        )
+        .map_err(|e| format!("Failed to create Paloma Telegram state tables: {}", e))?;
 
         // Create telegram_chat_missions table if it doesn't exist
         conn.execute_batch(
@@ -5251,6 +5330,359 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn upsert_telegram_user(&self, user: TelegramUser) -> Result<TelegramUser, String> {
+        let conn = self.conn.clone();
+        let u = user.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO telegram_users
+                 (id, telegram_user_id, username, display_name, role, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(telegram_user_id) DO UPDATE SET
+                    username = excluded.username,
+                    display_name = excluded.display_name,
+                    role = excluded.role,
+                    updated_at = excluded.updated_at",
+                params![
+                    u.id.to_string(),
+                    u.telegram_user_id,
+                    u.username,
+                    u.display_name,
+                    telegram_user_role_to_str(u.role),
+                    u.created_at,
+                    u.updated_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok::<_, String>(())
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        Ok(user)
+    }
+
+    async fn get_telegram_user(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<Option<TelegramUser>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                "SELECT id, telegram_user_id, username, display_name, role, created_at, updated_at
+                 FROM telegram_users WHERE telegram_user_id = ?1",
+                params![telegram_user_id],
+                row_to_telegram_user,
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn get_or_create_telegram_user_cursor(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<TelegramUserCursor, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            if let Some(cursor) = conn
+                .query_row(
+                    "SELECT id, telegram_user_id, last_status_at, last_dashboard_seen_at,
+                            last_alert_ack_at, last_digest_at,
+                            last_seen_event_sequence_by_mission_json, created_at, updated_at
+                     FROM telegram_user_cursors WHERE telegram_user_id = ?1",
+                    params![telegram_user_id],
+                    row_to_telegram_user_cursor,
+                )
+                .optional()
+                .map_err(|e| e.to_string())?
+            {
+                return Ok(cursor);
+            }
+
+            let now = now_string();
+            let cursor = TelegramUserCursor {
+                id: Uuid::new_v4(),
+                telegram_user_id,
+                last_status_at: None,
+                last_dashboard_seen_at: None,
+                last_alert_ack_at: None,
+                last_digest_at: None,
+                last_seen_event_sequence_by_mission_json: "{}".to_string(),
+                created_at: now.clone(),
+                updated_at: now,
+            };
+            conn.execute(
+                "INSERT INTO telegram_user_cursors
+                 (id, telegram_user_id, last_status_at, last_dashboard_seen_at, last_alert_ack_at,
+                  last_digest_at, last_seen_event_sequence_by_mission_json, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    cursor.id.to_string(),
+                    cursor.telegram_user_id,
+                    cursor.last_status_at,
+                    cursor.last_dashboard_seen_at,
+                    cursor.last_alert_ack_at,
+                    cursor.last_digest_at,
+                    cursor.last_seen_event_sequence_by_mission_json,
+                    cursor.created_at,
+                    cursor.updated_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(cursor)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn update_telegram_user_last_status_at(
+        &self,
+        telegram_user_id: i64,
+        last_status_at: &str,
+        last_seen_event_sequence_by_mission_json: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let last_status_at = last_status_at.to_string();
+        let sequence_json = last_seen_event_sequence_by_mission_json.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let now = now_string();
+            conn.execute(
+                "INSERT INTO telegram_user_cursors
+                 (id, telegram_user_id, last_status_at, last_seen_event_sequence_by_mission_json, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(telegram_user_id) DO UPDATE SET
+                    last_status_at = excluded.last_status_at,
+                    last_seen_event_sequence_by_mission_json = excluded.last_seen_event_sequence_by_mission_json,
+                    updated_at = excluded.updated_at",
+                params![
+                    Uuid::new_v4().to_string(),
+                    telegram_user_id,
+                    last_status_at,
+                    sequence_json,
+                    now,
+                    now,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn upsert_telegram_mission_subscription(
+        &self,
+        subscription: TelegramMissionSubscription,
+    ) -> Result<TelegramMissionSubscription, String> {
+        let conn = self.conn.clone();
+        let s = subscription.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO telegram_mission_subscriptions
+                 (id, telegram_user_id, mission_id, interest_level, reason, expires_at, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(telegram_user_id, mission_id) DO UPDATE SET
+                    interest_level = excluded.interest_level,
+                    reason = excluded.reason,
+                    expires_at = excluded.expires_at,
+                    updated_at = excluded.updated_at",
+                params![
+                    s.id.to_string(),
+                    s.telegram_user_id,
+                    s.mission_id.to_string(),
+                    telegram_interest_to_str(s.interest_level),
+                    s.reason,
+                    s.expires_at,
+                    s.created_at,
+                    s.updated_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok::<_, String>(())
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        Ok(subscription)
+    }
+
+    async fn list_telegram_mission_subscriptions(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<Vec<TelegramMissionSubscription>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, telegram_user_id, mission_id, interest_level, reason, expires_at,
+                            created_at, updated_at
+                     FROM telegram_mission_subscriptions
+                     WHERE telegram_user_id = ?1
+                     ORDER BY updated_at DESC",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(
+                    params![telegram_user_id],
+                    row_to_telegram_mission_subscription,
+                )
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn create_telegram_alert_preference(
+        &self,
+        preference: TelegramAlertPreference,
+    ) -> Result<TelegramAlertPreference, String> {
+        let conn = self.conn.clone();
+        let p = preference.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO telegram_alert_preferences
+                 (id, telegram_user_id, scope, scope_value, rule_text, enabled,
+                  created_from_message_id, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    p.id.to_string(),
+                    p.telegram_user_id,
+                    p.scope,
+                    p.scope_value,
+                    p.rule_text,
+                    if p.enabled { 1 } else { 0 },
+                    p.created_from_message_id,
+                    p.created_at,
+                    p.updated_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok::<_, String>(())
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        Ok(preference)
+    }
+
+    async fn create_telegram_alert_if_absent(
+        &self,
+        alert: TelegramAlert,
+    ) -> Result<Option<TelegramAlert>, String> {
+        let conn = self.conn.clone();
+        let a = alert.clone();
+        let inserted = tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let changed = conn
+                .execute(
+                    "INSERT OR IGNORE INTO telegram_alerts
+                     (id, telegram_user_id, mission_id, event_kind, importance, title, body,
+                      status, telegram_message_id, last_error, created_at, sent_at, acknowledged_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                    params![
+                        a.id.to_string(),
+                        a.telegram_user_id,
+                        a.mission_id.map(|id| id.to_string()),
+                        a.event_kind,
+                        a.importance,
+                        a.title,
+                        a.body,
+                        a.status,
+                        a.telegram_message_id,
+                        a.last_error,
+                        a.created_at,
+                        a.sent_at,
+                        a.acknowledged_at,
+                    ],
+                )
+                .map_err(|e| e.to_string())?;
+            Ok::<_, String>(changed > 0)
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        Ok(inserted.then_some(alert))
+    }
+
+    async fn list_pending_telegram_alerts(
+        &self,
+        telegram_user_id: i64,
+        limit: usize,
+    ) -> Result<Vec<TelegramAlert>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, telegram_user_id, mission_id, event_kind, importance, title, body,
+                            status, telegram_message_id, last_error, created_at, sent_at, acknowledged_at
+                     FROM telegram_alerts
+                     WHERE telegram_user_id = ?1 AND status = 'pending'
+                     ORDER BY created_at ASC
+                     LIMIT ?2",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![telegram_user_id, limit as i64], row_to_telegram_alert)
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn mark_telegram_alert_sent(
+        &self,
+        id: Uuid,
+        telegram_message_id: Option<i64>,
+        sent_at: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let sent_at = sent_at.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE telegram_alerts
+                 SET status = 'sent', telegram_message_id = ?2, sent_at = ?3, last_error = NULL
+                 WHERE id = ?1",
+                params![id.to_string(), telegram_message_id, sent_at],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let error = error.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE telegram_alerts
+                 SET status = 'failed', last_error = ?2
+                 WHERE id = ?1",
+                params![id.to_string(), error],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn get_telegram_chat_mission(
         &self,
         channel_id: Uuid,
@@ -7214,6 +7646,111 @@ impl MissionStore for SqliteMissionStore {
     }
 }
 
+fn telegram_user_role_to_str(role: TelegramUserRole) -> &'static str {
+    match role {
+        TelegramUserRole::Owner => "owner",
+        TelegramUserRole::TrustedFriend => "trusted_friend",
+        TelegramUserRole::Observer => "observer",
+        TelegramUserRole::Blocked => "blocked",
+    }
+}
+
+fn parse_telegram_user_role(raw: String) -> TelegramUserRole {
+    match raw.as_str() {
+        "owner" => TelegramUserRole::Owner,
+        "trusted_friend" => TelegramUserRole::TrustedFriend,
+        "blocked" => TelegramUserRole::Blocked,
+        _ => TelegramUserRole::Observer,
+    }
+}
+
+fn telegram_interest_to_str(level: TelegramMissionInterestLevel) -> &'static str {
+    match level {
+        TelegramMissionInterestLevel::Muted => "muted",
+        TelegramMissionInterestLevel::Normal => "normal",
+        TelegramMissionInterestLevel::High => "high",
+    }
+}
+
+fn parse_telegram_interest(raw: String) -> TelegramMissionInterestLevel {
+    match raw.as_str() {
+        "muted" => TelegramMissionInterestLevel::Muted,
+        "high" => TelegramMissionInterestLevel::High,
+        _ => TelegramMissionInterestLevel::Normal,
+    }
+}
+
+fn row_to_telegram_user(row: &rusqlite::Row<'_>) -> Result<TelegramUser, rusqlite::Error> {
+    let id_str: String = row.get(0)?;
+    let role_str: String = row.get(4)?;
+    Ok(TelegramUser {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        telegram_user_id: row.get(1)?,
+        username: row.get(2)?,
+        display_name: row.get(3)?,
+        role: parse_telegram_user_role(role_str),
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
+    })
+}
+
+fn row_to_telegram_user_cursor(
+    row: &rusqlite::Row<'_>,
+) -> Result<TelegramUserCursor, rusqlite::Error> {
+    let id_str: String = row.get(0)?;
+    Ok(TelegramUserCursor {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        telegram_user_id: row.get(1)?,
+        last_status_at: row.get(2)?,
+        last_dashboard_seen_at: row.get(3)?,
+        last_alert_ack_at: row.get(4)?,
+        last_digest_at: row.get(5)?,
+        last_seen_event_sequence_by_mission_json: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+fn row_to_telegram_mission_subscription(
+    row: &rusqlite::Row<'_>,
+) -> Result<TelegramMissionSubscription, rusqlite::Error> {
+    let id_str: String = row.get(0)?;
+    let mission_id_str: String = row.get(2)?;
+    let interest_str: String = row.get(3)?;
+    Ok(TelegramMissionSubscription {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        telegram_user_id: row.get(1)?,
+        mission_id: Uuid::parse_str(&mission_id_str).unwrap_or_default(),
+        interest_level: parse_telegram_interest(interest_str),
+        reason: row.get(4)?,
+        expires_at: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+fn row_to_telegram_alert(row: &rusqlite::Row<'_>) -> Result<TelegramAlert, rusqlite::Error> {
+    let id_str: String = row.get(0)?;
+    let mission_id_str: Option<String> = row.get(2)?;
+    Ok(TelegramAlert {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        telegram_user_id: row.get(1)?,
+        mission_id: mission_id_str
+            .as_deref()
+            .and_then(|value| Uuid::parse_str(value).ok()),
+        event_kind: row.get(3)?,
+        importance: row.get(4)?,
+        title: row.get(5)?,
+        body: row.get(6)?,
+        status: row.get(7)?,
+        telegram_message_id: row.get(8)?,
+        last_error: row.get(9)?,
+        created_at: row.get(10)?,
+        sent_at: row.get(11)?,
+        acknowledged_at: row.get(12)?,
+    })
+}
+
 /// Parse a Telegram channel from a SQLite row.
 /// Column order: id(0), mission_id(1), bot_token(2), bot_username(3),
 ///   allowed_chat_ids(4), trigger_mode(5), active(6), webhook_secret(7),
@@ -7534,11 +8071,12 @@ mod tests {
     use super::{assistant_message_metadata, AssistantMessageMetadataInput, SqliteMissionStore};
     use crate::agents::CostSource;
     use crate::api::mission_store::{
-        MissionMode, MissionStatus, MissionStore, TelegramChannel, TelegramConversation,
-        TelegramConversationMessage, TelegramConversationMessageDirection,
-        TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
-        TelegramTriggerMode, TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind,
-        TelegramWorkflowStatus,
+        MissionMode, MissionStatus, MissionStore, TelegramAlert, TelegramAlertPreference,
+        TelegramChannel, TelegramConversation, TelegramConversationMessage,
+        TelegramConversationMessageDirection, TelegramMissionInterestLevel,
+        TelegramMissionSubscription, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
+        TelegramStructuredMemoryScope, TelegramTriggerMode, TelegramUser, TelegramUserRole,
+        TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus,
     };
     use crate::cost::TokenUsage;
     use rusqlite::params;
@@ -7611,6 +8149,143 @@ mod tests {
             .await
             .expect("telegram channel");
         channel.id
+    }
+
+    #[tokio::test]
+    async fn telegram_paloma_user_cursor_and_subscription_round_trip() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Paloma state"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        let user = store
+            .upsert_telegram_user(TelegramUser {
+                id: Uuid::new_v4(),
+                telegram_user_id: 1_139_694_048,
+                username: Some("thomas".to_string()),
+                display_name: Some("Thomas".to_string()),
+                role: TelegramUserRole::Owner,
+                created_at: "2026-05-20T10:00:00Z".to_string(),
+                updated_at: "2026-05-20T10:00:00Z".to_string(),
+            })
+            .await
+            .expect("upsert user");
+        assert_eq!(user.role, TelegramUserRole::Owner);
+
+        let loaded = store
+            .get_telegram_user(1_139_694_048)
+            .await
+            .expect("get user")
+            .expect("user exists");
+        assert_eq!(loaded.username.as_deref(), Some("thomas"));
+
+        let cursor = store
+            .get_or_create_telegram_user_cursor(1_139_694_048)
+            .await
+            .expect("cursor");
+        assert!(cursor.last_status_at.is_none());
+        store
+            .update_telegram_user_last_status_at(
+                1_139_694_048,
+                "2026-05-20T10:10:00Z",
+                "{\"mission\":7}",
+            )
+            .await
+            .expect("update cursor");
+        let cursor = store
+            .get_or_create_telegram_user_cursor(1_139_694_048)
+            .await
+            .expect("cursor reload");
+        assert_eq!(
+            cursor.last_status_at.as_deref(),
+            Some("2026-05-20T10:10:00Z")
+        );
+        assert_eq!(
+            cursor.last_seen_event_sequence_by_mission_json,
+            "{\"mission\":7}"
+        );
+
+        store
+            .upsert_telegram_mission_subscription(TelegramMissionSubscription {
+                id: Uuid::new_v4(),
+                telegram_user_id: 1_139_694_048,
+                mission_id: mission.id,
+                interest_level: TelegramMissionInterestLevel::High,
+                reason: Some("status command".to_string()),
+                expires_at: None,
+                created_at: "2026-05-20T10:00:00Z".to_string(),
+                updated_at: "2026-05-20T10:00:00Z".to_string(),
+            })
+            .await
+            .expect("subscription");
+        let subscriptions = store
+            .list_telegram_mission_subscriptions(1_139_694_048)
+            .await
+            .expect("subscriptions");
+        assert_eq!(subscriptions.len(), 1);
+        assert_eq!(
+            subscriptions[0].interest_level,
+            TelegramMissionInterestLevel::High
+        );
+
+        store
+            .create_telegram_alert_preference(TelegramAlertPreference {
+                id: Uuid::new_v4(),
+                telegram_user_id: 1_139_694_048,
+                scope: "mission".to_string(),
+                scope_value: Some(mission.id.to_string()),
+                rule_text: "mute from Telegram feedback".to_string(),
+                enabled: true,
+                created_from_message_id: Some(12),
+                created_at: "2026-05-20T10:00:00Z".to_string(),
+                updated_at: "2026-05-20T10:00:00Z".to_string(),
+            })
+            .await
+            .expect("alert preference");
+
+        let alert = TelegramAlert {
+            id: Uuid::new_v4(),
+            telegram_user_id: 1_139_694_048,
+            mission_id: Some(mission.id),
+            event_kind: "mission_completed".to_string(),
+            importance: "high".to_string(),
+            title: "Paloma state".to_string(),
+            body: "Paloma state is now completed.".to_string(),
+            status: "pending".to_string(),
+            telegram_message_id: None,
+            last_error: None,
+            created_at: "2026-05-20T10:00:00Z".to_string(),
+            sent_at: None,
+            acknowledged_at: None,
+        };
+        assert!(store
+            .create_telegram_alert_if_absent(alert.clone())
+            .await
+            .expect("first alert")
+            .is_some());
+        assert!(store
+            .create_telegram_alert_if_absent(alert)
+            .await
+            .expect("duplicate alert")
+            .is_none());
+        let pending = store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("pending alerts");
+        assert_eq!(pending.len(), 1);
+        store
+            .mark_telegram_alert_sent(pending[0].id, Some(99), "2026-05-20T10:01:00Z")
+            .await
+            .expect("mark sent");
+        assert!(store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("pending alerts after sent")
+            .is_empty());
     }
 
     #[tokio::test]

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -9,14 +9,16 @@
 //! 3. The webhook handler routes the message as `ControlCommand::UserMessage`
 //! 4. A response task streams `TextDelta` events back via `editMessageText`
 
-use crate::api::control::{AgentEvent, ControlCommand};
+use crate::api::control::{AgentEvent, ControlCommand, MissionStatus};
 use crate::api::mission_store::{
-    now_string, MissionMode, MissionStore, TelegramActionExecution, TelegramActionExecutionKind,
-    TelegramActionExecutionStatus, TelegramChannel, TelegramChatMission, TelegramConversation,
-    TelegramConversationMessage, TelegramConversationMessageDirection, TelegramScheduledMessage,
+    now_string, Mission, MissionMode, MissionStore, StoredEvent, TelegramActionExecution,
+    TelegramActionExecutionKind, TelegramActionExecutionStatus, TelegramAlert,
+    TelegramAlertPreference, TelegramChannel, TelegramChatMission, TelegramConversation,
+    TelegramConversationMessage, TelegramConversationMessageDirection,
+    TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramScheduledMessage,
     TelegramScheduledMessageStatus, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
-    TelegramStructuredMemoryScope, TelegramTriggerMode, TelegramWorkflow, TelegramWorkflowEvent,
-    TelegramWorkflowKind, TelegramWorkflowStatus,
+    TelegramStructuredMemoryScope, TelegramTriggerMode, TelegramUser, TelegramUserRole,
+    TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus,
 };
 use chrono::{Duration as ChronoDuration, Utc};
 use reqwest::Client;
@@ -62,6 +64,8 @@ struct TelegramReplyRecord {
 const TELEGRAM_UPDATE_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_REPLY_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const DEFAULT_PALOMA_OWNER_TELEGRAM_ID: i64 = 1_139_694_048;
+const DEFAULT_PALOMA_TRUSTED_FRIEND_TELEGRAM_ID: i64 = 0;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TelegramActionKind {
@@ -147,6 +151,681 @@ fn workflow_requires_direct_reply(workflow: &TelegramWorkflow) -> bool {
         workflow.target_chat_type.as_deref(),
         Some("group") | Some("supergroup")
     )
+}
+
+fn configured_telegram_id(env_name: &str, default_value: i64) -> Option<i64> {
+    std::env::var(env_name)
+        .ok()
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .or_else(|| (default_value != 0).then_some(default_value))
+}
+
+fn paloma_role_for_user(user_id: i64) -> TelegramUserRole {
+    if configured_telegram_id("PALOMA_TELEGRAM_OWNER_ID", DEFAULT_PALOMA_OWNER_TELEGRAM_ID)
+        == Some(user_id)
+    {
+        TelegramUserRole::Owner
+    } else if configured_telegram_id(
+        "PALOMA_TELEGRAM_TRUSTED_FRIEND_ID",
+        DEFAULT_PALOMA_TRUSTED_FRIEND_TELEGRAM_ID,
+    ) == Some(user_id)
+    {
+        TelegramUserRole::TrustedFriend
+    } else {
+        TelegramUserRole::Observer
+    }
+}
+
+fn telegram_display_name(user: &User) -> String {
+    match user.last_name.as_deref() {
+        Some(last) if !last.is_empty() => format!("{} {}", user.first_name, last),
+        _ => user.first_name.clone(),
+    }
+}
+
+async fn remember_paloma_user(ctx: &ChannelContext, msg: &Message) -> Option<TelegramUser> {
+    let from = msg.from.as_ref()?;
+    let now = now_string();
+    let user = TelegramUser {
+        id: Uuid::new_v4(),
+        telegram_user_id: from.id,
+        username: from.username.clone(),
+        display_name: Some(telegram_display_name(from)),
+        role: paloma_role_for_user(from.id),
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    match ctx.mission_store.upsert_telegram_user(user.clone()).await {
+        Ok(user) => Some(user),
+        Err(err) => {
+            tracing::warn!("Failed to upsert Telegram user role: {}", err);
+            Some(user)
+        }
+    }
+}
+
+fn is_owner_dm(user: Option<&TelegramUser>, msg: &Message) -> bool {
+    msg.chat.chat_type == "private"
+        && user
+            .map(|u| u.role == TelegramUserRole::Owner)
+            .unwrap_or(false)
+}
+
+fn is_paloma_command(text: &str, name: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed == name || trimmed.starts_with(&format!("{name} "))
+}
+
+fn redact_for_telegram(text: &str) -> String {
+    let token_re = regex::Regex::new(
+        r#"(?i)(bot[0-9]{6,}:[A-Za-z0-9_-]{20,}|[A-Za-z0-9_]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}|api[_-]?hash\s*[:=]\s*[A-Za-z0-9]{16,}|token\s*[:=]\s*\S+|secret\s*[:=]\s*\S+)"#,
+    )
+    .expect("telegram redaction regex must compile");
+    let path_re = regex::Regex::new(r#"(/(?:root|home|workspaces|tmp)/[^\s,)]+)"#)
+        .expect("telegram path redaction regex must compile");
+    let redacted = token_re.replace_all(text, "[redacted]");
+    path_re
+        .replace_all(&redacted, "[path redacted]")
+        .to_string()
+}
+
+fn mission_label(mission: &Mission) -> String {
+    mission
+        .title
+        .as_deref()
+        .or(mission.short_description.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Untitled mission")
+        .chars()
+        .take(80)
+        .collect()
+}
+
+fn event_summary_line(mission: &Mission, event: &StoredEvent) -> Option<String> {
+    let title = mission_label(mission);
+    match event.event_type.as_str() {
+        "mission_status_changed" => {
+            let status = event
+                .metadata
+                .get("status")
+                .and_then(|value| value.as_str())
+                .unwrap_or("updated");
+            Some(format!("{} is now {}.", title, status))
+        }
+        "assistant_message" => {
+            if event.content.trim().is_empty() {
+                None
+            } else {
+                let text = redact_for_telegram(event.content.trim());
+                let first = text.lines().next().unwrap_or("").trim();
+                if first.is_empty() {
+                    None
+                } else {
+                    Some(format!(
+                        "{} replied: {}",
+                        title,
+                        first.chars().take(140).collect::<String>()
+                    ))
+                }
+            }
+        }
+        "error" => Some(format!("{} reported an error.", title)),
+        "tool_call" => event
+            .tool_name
+            .as_deref()
+            .map(|tool| format!("{} used {}.", title, tool)),
+        _ => None,
+    }
+}
+
+fn mission_rank(mission: &Mission, interest: TelegramMissionInterestLevel) -> i32 {
+    let mut score = match interest {
+        TelegramMissionInterestLevel::High => 100,
+        TelegramMissionInterestLevel::Normal => 20,
+        TelegramMissionInterestLevel::Muted => -100,
+    };
+    score += match mission.status {
+        MissionStatus::Blocked | MissionStatus::Failed => 60,
+        MissionStatus::AwaitingUser => 50,
+        MissionStatus::Active => 40,
+        MissionStatus::Pending => 25,
+        MissionStatus::Interrupted => 20,
+        MissionStatus::Acknowledged | MissionStatus::Completed | MissionStatus::NotFeasible => 0,
+    };
+    if mission.parent_mission_id.is_none() {
+        score += 5;
+    }
+    score
+}
+
+async fn build_paloma_status(
+    ctx: &ChannelContext,
+    telegram_user_id: i64,
+) -> Result<(String, String), String> {
+    let cursor = ctx
+        .mission_store
+        .get_or_create_telegram_user_cursor(telegram_user_id)
+        .await?;
+    let since = cursor
+        .last_dashboard_seen_at
+        .as_deref()
+        .or(cursor.last_status_at.as_deref())
+        .map(|value| value.to_string());
+    let missions = ctx.mission_store.list_missions(80, 0).await?;
+    let mut lines = Vec::new();
+    let mut max_sequences = serde_json::Map::new();
+
+    for mission in &missions {
+        let events = ctx
+            .mission_store
+            .get_events(mission.id, None, Some(200), None)
+            .await
+            .unwrap_or_default();
+        if let Some(max) = events.iter().map(|event| event.sequence).max() {
+            max_sequences.insert(mission.id.to_string(), serde_json::json!(max));
+        }
+        for event in events {
+            if let Some(since) = since.as_deref() {
+                if event.timestamp.as_str() <= since {
+                    continue;
+                }
+            }
+            if let Some(line) = event_summary_line(mission, &event) {
+                lines.push(line);
+            }
+            if lines.len() >= 8 {
+                break;
+            }
+        }
+        if lines.len() >= 8 {
+            break;
+        }
+    }
+
+    let body = if lines.is_empty() {
+        match since {
+            Some(_) => "No meaningful changes since your last status check.".to_string(),
+            None => "No meaningful mission changes found yet.".to_string(),
+        }
+    } else {
+        let mut body = format!(
+            "{} meaningful change{} since you last checked.",
+            lines.len(),
+            if lines.len() == 1 { "" } else { "s" }
+        );
+        for (idx, line) in lines.into_iter().enumerate() {
+            body.push_str(&format!("\n\n{}. {}", idx + 1, line));
+        }
+        redact_for_telegram(&body)
+    };
+
+    Ok((body, serde_json::Value::Object(max_sequences).to_string()))
+}
+
+async fn build_paloma_missions(
+    ctx: &ChannelContext,
+    telegram_user_id: i64,
+) -> Result<String, String> {
+    let subscriptions = ctx
+        .mission_store
+        .list_telegram_mission_subscriptions(telegram_user_id)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|sub| (sub.mission_id, sub.interest_level))
+        .collect::<HashMap<_, _>>();
+    let mut missions = ctx.mission_store.list_missions(50, 0).await?;
+    missions.sort_by_key(|mission| {
+        let interest = subscriptions
+            .get(&mission.id)
+            .copied()
+            .unwrap_or(TelegramMissionInterestLevel::Normal);
+        -mission_rank(mission, interest)
+    });
+
+    let mut high = Vec::new();
+    let mut other_count = 0usize;
+    for mission in missions {
+        let interest = subscriptions
+            .get(&mission.id)
+            .copied()
+            .unwrap_or(TelegramMissionInterestLevel::Normal);
+        if interest == TelegramMissionInterestLevel::Muted {
+            continue;
+        }
+        let line = format!("- {}: {}", mission_label(&mission), mission.status);
+        if high.len() < 8 && mission_rank(&mission, interest) >= 40 {
+            high.push(line);
+        } else {
+            other_count += 1;
+        }
+    }
+
+    let mut body = "Active missions".to_string();
+    if high.is_empty() {
+        body.push_str("\n\nNo high-interest active missions.");
+    } else {
+        body.push_str("\n\nHigh interest");
+        for line in high {
+            body.push('\n');
+            body.push_str(&line);
+        }
+    }
+    if other_count > 0 {
+        body.push_str(&format!(
+            "\n\nOther\n- {} lower-priority mission{}",
+            other_count,
+            if other_count == 1 { "" } else { "s" }
+        ));
+    }
+    Ok(redact_for_telegram(&body))
+}
+
+fn parse_paloma_selector_and_payload<'a>(
+    text: &'a str,
+    command: &str,
+) -> Option<(&'a str, &'a str)> {
+    let tail = text.trim().strip_prefix(command)?.trim();
+    let (selector, payload) = tail.split_once(char::is_whitespace)?;
+    let payload = payload.trim();
+    if selector.trim().is_empty() || payload.is_empty() {
+        None
+    } else {
+        Some((selector.trim(), payload))
+    }
+}
+
+fn feedback_mutes_alerts(text: &str) -> bool {
+    let normalized = text.trim().to_ascii_lowercase();
+    normalized.contains("don't tell me about this again")
+        || normalized.contains("dont tell me about this again")
+        || normalized.contains("mute this")
+        || normalized.contains("stop alerting me about this")
+}
+
+fn feedback_raises_interest(text: &str) -> bool {
+    let normalized = text.trim().to_ascii_lowercase();
+    normalized.contains("tell me more about this")
+        || normalized.contains("keep me posted")
+        || normalized.contains("mark this high")
+}
+
+fn paloma_command_error_response(err: &str) -> &str {
+    if err.starts_with("Usage:") {
+        err
+    } else {
+        "I couldn't read mission status right now."
+    }
+}
+
+async fn select_paloma_mission(ctx: &ChannelContext, selector: &str) -> Result<Mission, String> {
+    let selector = selector.trim();
+    let missions = ctx.mission_store.list_missions(80, 0).await?;
+    if selector.eq_ignore_ascii_case("latest") || selector.eq_ignore_ascii_case("current") {
+        return missions
+            .into_iter()
+            .next()
+            .ok_or_else(|| "No missions are available.".to_string());
+    }
+    if let Ok(id) = Uuid::parse_str(selector) {
+        return ctx
+            .mission_store
+            .get_mission(id)
+            .await?
+            .ok_or_else(|| format!("Mission {} was not found.", id));
+    }
+
+    let needle = selector.to_ascii_lowercase();
+    missions
+        .into_iter()
+        .find(|mission| {
+            mission_label(mission)
+                .to_ascii_lowercase()
+                .contains(&needle)
+        })
+        .ok_or_else(|| format!("No mission matched '{}'.", selector))
+}
+
+async fn latest_interesting_mission(ctx: &ChannelContext) -> Result<Mission, String> {
+    let mut missions = ctx.mission_store.list_missions(80, 0).await?;
+    missions.sort_by_key(|mission| -mission_rank(mission, TelegramMissionInterestLevel::Normal));
+    missions
+        .into_iter()
+        .next()
+        .ok_or_else(|| "No missions are available.".to_string())
+}
+
+async fn build_paloma_summary(
+    ctx: &ChannelContext,
+    selector: Option<&str>,
+) -> Result<String, String> {
+    let mission = match selector.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(selector) => select_paloma_mission(ctx, selector).await?,
+        None => latest_interesting_mission(ctx).await?,
+    };
+    let events = ctx
+        .mission_store
+        .get_events(mission.id, None, Some(80), None)
+        .await
+        .unwrap_or_default();
+    let mut lines = Vec::new();
+    for event in events.into_iter().rev() {
+        if let Some(line) = event_summary_line(&mission, &event) {
+            lines.push(line);
+        }
+        if lines.len() >= 4 {
+            break;
+        }
+    }
+
+    let mut body = format!("{}: {}", mission_label(&mission), mission.status);
+    if lines.is_empty() {
+        body.push_str("\n\nNo concise recent summary is available yet.");
+    } else {
+        for line in lines {
+            body.push_str("\n- ");
+            body.push_str(&line);
+        }
+    }
+    Ok(redact_for_telegram(&body))
+}
+
+async fn send_paloma_mission_message(
+    ctx: &ChannelContext,
+    selector: &str,
+    payload: &str,
+) -> Result<String, String> {
+    let mission = select_paloma_mission(ctx, selector).await?;
+    let (queued_tx, _queued_rx) = tokio::sync::oneshot::channel();
+    ctx.cmd_tx
+        .send(ControlCommand::UserMessage {
+            id: Uuid::new_v4(),
+            content: payload.to_string(),
+            agent: None,
+            target_mission_id: Some(mission.id),
+            respond: queued_tx,
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(format!("Sent to {}.", mission_label(&mission)))
+}
+
+async fn apply_paloma_interest_feedback(
+    ctx: &ChannelContext,
+    user: &TelegramUser,
+    msg: &Message,
+    level: TelegramMissionInterestLevel,
+    rule_text: &str,
+) -> Result<String, String> {
+    let mission = latest_interesting_mission(ctx).await?;
+    let now = now_string();
+    let subscription = TelegramMissionSubscription {
+        id: Uuid::new_v4(),
+        telegram_user_id: user.telegram_user_id,
+        mission_id: mission.id,
+        interest_level: level,
+        reason: Some(rule_text.to_string()),
+        expires_at: None,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+    };
+    ctx.mission_store
+        .upsert_telegram_mission_subscription(subscription)
+        .await?;
+    let _ = ctx
+        .mission_store
+        .create_telegram_alert_preference(TelegramAlertPreference {
+            id: Uuid::new_v4(),
+            telegram_user_id: user.telegram_user_id,
+            scope: "mission".to_string(),
+            scope_value: Some(mission.id.to_string()),
+            rule_text: rule_text.to_string(),
+            enabled: true,
+            created_from_message_id: Some(msg.message_id),
+            created_at: now.clone(),
+            updated_at: now,
+        })
+        .await;
+    let response = match level {
+        TelegramMissionInterestLevel::Muted => {
+            format!(
+                "Noted. I muted routine alerts for {}.",
+                mission_label(&mission)
+            )
+        }
+        TelegramMissionInterestLevel::High => {
+            format!(
+                "Noted. I will prioritize updates for {}.",
+                mission_label(&mission)
+            )
+        }
+        TelegramMissionInterestLevel::Normal => {
+            format!(
+                "Noted. I reset {} to normal interest.",
+                mission_label(&mission)
+            )
+        }
+    };
+    Ok(redact_for_telegram(&response))
+}
+
+fn paloma_alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
+    match status {
+        MissionStatus::Completed => Some("mission_completed"),
+        MissionStatus::Failed => Some("mission_failed"),
+        MissionStatus::Blocked => Some("mission_blocked"),
+        MissionStatus::Interrupted => Some("mission_interrupted"),
+        _ => None,
+    }
+}
+
+async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
+    let Some(owner_id) =
+        configured_telegram_id("PALOMA_TELEGRAM_OWNER_ID", DEFAULT_PALOMA_OWNER_TELEGRAM_ID)
+    else {
+        return;
+    };
+    let subscriptions = ctx
+        .mission_store
+        .list_telegram_mission_subscriptions(owner_id)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|sub| (sub.mission_id, sub.interest_level))
+        .collect::<HashMap<_, _>>();
+    let missions = match ctx.mission_store.list_missions(80, 0).await {
+        Ok(missions) => missions,
+        Err(err) => {
+            tracing::warn!("Failed to load missions for Telegram alerts: {}", err);
+            return;
+        }
+    };
+
+    for mission in missions {
+        let Some(kind) = paloma_alert_kind_for_status(mission.status) else {
+            continue;
+        };
+        if subscriptions
+            .get(&mission.id)
+            .is_some_and(|level| *level == TelegramMissionInterestLevel::Muted)
+        {
+            continue;
+        }
+        let title = mission_label(&mission);
+        let body = redact_for_telegram(&format!("{} is now {}.", title, mission.status));
+        let now = now_string();
+        let _ = ctx
+            .mission_store
+            .create_telegram_alert_if_absent(TelegramAlert {
+                id: Uuid::new_v4(),
+                telegram_user_id: owner_id,
+                mission_id: Some(mission.id),
+                event_kind: kind.to_string(),
+                importance: "high".to_string(),
+                title,
+                body,
+                status: "pending".to_string(),
+                telegram_message_id: None,
+                last_error: None,
+                created_at: now,
+                sent_at: None,
+                acknowledged_at: None,
+            })
+            .await;
+    }
+
+    let pending = ctx
+        .mission_store
+        .list_pending_telegram_alerts(owner_id, 5)
+        .await
+        .unwrap_or_default();
+    if pending.is_empty() {
+        return;
+    }
+    let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
+    for alert in pending {
+        let text = format!("{}\n\n{}", alert.title, alert.body);
+        match send_message(http, &base_url, owner_id, &text, None).await {
+            Ok(message_id) => {
+                let _ = ctx
+                    .mission_store
+                    .mark_telegram_alert_sent(alert.id, Some(message_id), &now_string())
+                    .await;
+            }
+            Err(err) => {
+                tracing::warn!("Failed to send Telegram alert {}: {}", alert.id, err);
+                let _ = ctx
+                    .mission_store
+                    .mark_telegram_alert_failed(alert.id, &err)
+                    .await;
+            }
+        }
+    }
+}
+
+async fn handle_paloma_command(
+    ctx: &ChannelContext,
+    msg: &Message,
+    http: &Client,
+    user: Option<&TelegramUser>,
+    clean_text: &str,
+) -> bool {
+    let is_known_command = is_paloma_command(clean_text, "/status")
+        || is_paloma_command(clean_text, "/missions")
+        || is_paloma_command(clean_text, "/summary")
+        || is_paloma_command(clean_text, "/send")
+        || is_paloma_command(clean_text, "/approve");
+    let owner_feedback = user
+        .filter(|_| msg.chat.chat_type == "private")
+        .filter(|u| u.role == TelegramUserRole::Owner)
+        .and_then(|u| {
+            if feedback_mutes_alerts(clean_text) {
+                Some((
+                    u,
+                    TelegramMissionInterestLevel::Muted,
+                    "mute from Telegram feedback",
+                ))
+            } else if feedback_raises_interest(clean_text) {
+                Some((
+                    u,
+                    TelegramMissionInterestLevel::High,
+                    "high interest from Telegram feedback",
+                ))
+            } else {
+                None
+            }
+        });
+
+    if !is_known_command && owner_feedback.is_none() {
+        return false;
+    }
+
+    let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
+    if !is_owner_dm(user, msg) {
+        let _ = send_message(
+            http,
+            &base_url,
+            msg.chat.id,
+            "I can only show mission state to Thomas in DM.",
+            Some(msg.message_id),
+        )
+        .await;
+        return true;
+    }
+
+    let result = if let Some((user, level, rule_text)) = owner_feedback {
+        apply_paloma_interest_feedback(ctx, user, msg, level, rule_text)
+            .await
+            .map(|body| (body, None))
+    } else if is_paloma_command(clean_text, "/status") {
+        match user {
+            Some(user) => build_paloma_status(ctx, user.telegram_user_id)
+                .await
+                .map(|(body, sequences)| (body, Some(sequences))),
+            None => Err("Missing Telegram user identity.".to_string()),
+        }
+    } else if is_paloma_command(clean_text, "/missions") {
+        match user {
+            Some(user) => build_paloma_missions(ctx, user.telegram_user_id)
+                .await
+                .map(|body| (body, None)),
+            None => Err("Missing Telegram user identity.".to_string()),
+        }
+    } else if is_paloma_command(clean_text, "/summary") {
+        let selector = clean_text.trim().strip_prefix("/summary").map(str::trim);
+        build_paloma_summary(ctx, selector)
+            .await
+            .map(|body| (body, None))
+    } else if is_paloma_command(clean_text, "/send") {
+        match parse_paloma_selector_and_payload(clean_text, "/send") {
+            Some((selector, payload)) => send_paloma_mission_message(ctx, selector, payload)
+                .await
+                .map(|body| (body, None)),
+            None => Err("Usage: /send <mission selector> <message>".to_string()),
+        }
+    } else if is_paloma_command(clean_text, "/approve") {
+        let answer = clean_text
+            .trim()
+            .strip_prefix("/approve")
+            .unwrap_or("")
+            .trim();
+        if answer.is_empty() {
+            Err("Usage: /approve <answer>".to_string())
+        } else {
+            send_paloma_mission_message(ctx, "latest", answer)
+                .await
+                .map(|body| (body, None))
+        }
+    } else {
+        Err("Unknown Paloma command.".to_string())
+    };
+
+    match result {
+        Ok((body, sequence_json)) => {
+            if send_message(http, &base_url, msg.chat.id, &body, Some(msg.message_id))
+                .await
+                .is_ok()
+            {
+                if let (Some(user), Some(sequence_json)) = (user, sequence_json) {
+                    let _ = ctx
+                        .mission_store
+                        .update_telegram_user_last_status_at(
+                            user.telegram_user_id,
+                            &now_string(),
+                            &sequence_json,
+                        )
+                        .await;
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!("Paloma command failed: {}", err);
+            let body = paloma_command_error_response(&err);
+            let _ = send_message(http, &base_url, msg.chat.id, body, Some(msg.message_id)).await;
+        }
+    }
+    true
 }
 
 fn telegram_internal_action_secret() -> Option<String> {
@@ -396,6 +1075,8 @@ impl TelegramBridge {
                 .cloned()
                 .collect();
             for ctx in channels {
+                plan_and_deliver_paloma_alerts(&ctx, &self.http).await;
+
                 let due = match ctx
                     .mission_store
                     .list_due_telegram_scheduled_messages(ctx.channel.id, &now_string(), 32)
@@ -1455,6 +2136,10 @@ pub async fn process_webhook_message(
     remember_telegram_chat_title(ctx, &msg.chat).await;
 
     let clean_text = strip_bot_mention(text, &ctx.bot_username);
+    let paloma_user = remember_paloma_user(ctx, msg).await;
+    if handle_paloma_command(ctx, msg, http, paloma_user.as_ref(), &clean_text).await {
+        return;
+    }
     let memory_subject = telegram_memory_subject(msg, &sender_name);
 
     // Resolve target mission: auto-create per chat or legacy single-mission
@@ -3984,13 +4669,17 @@ pub async fn get_bot_username(http: &Client, base_url: &str) -> Result<String, S
 mod tests {
     use super::{
         build_internal_telegram_action_token, extract_structured_memory_from_text,
-        extract_telegram_actions, format_structured_memory_context, markdown_to_telegram_html,
-        merge_telegram_chat_metadata, render_telegram_chunk, sanitize_telegram_visible_text,
+        extract_telegram_actions, feedback_mutes_alerts, feedback_raises_interest,
+        format_structured_memory_context, is_paloma_command, markdown_to_telegram_html,
+        merge_telegram_chat_metadata, mission_label, paloma_alert_kind_for_status,
+        paloma_command_error_response, paloma_role_for_user, parse_paloma_selector_and_payload,
+        redact_for_telegram, render_telegram_chunk, sanitize_telegram_visible_text,
         scope_for_extracted_memory, telegram_action_target_matches, telegram_chat_display_title,
         truncate_for_telegram, verify_internal_telegram_action_token, workflow_reply_text,
-        workflow_request_delivery_text, Chat, ExtractedTelegramMemory, TelegramAction,
-        TelegramActionKind, TelegramBridge, TelegramMemorySubject, TelegramStructuredMemoryEntry,
-        TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
+        workflow_request_delivery_text, Chat, ExtractedTelegramMemory, Mission, MissionMode,
+        MissionStatus, TelegramAction, TelegramActionKind, TelegramBridge, TelegramMemorySubject,
+        TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
+        TelegramUserRole,
     };
     use uuid::Uuid;
 
@@ -4057,6 +4746,107 @@ mod tests {
             bridge.get_sent_reply_message(channel_id, 123, 999).await,
             None
         );
+    }
+
+    #[test]
+    fn paloma_command_matching_is_exact_command_or_argument_tail() {
+        assert!(is_paloma_command("/status", "/status"));
+        assert!(is_paloma_command("/status latest", "/status"));
+        assert!(!is_paloma_command("/statusplease", "/status"));
+        assert!(!is_paloma_command("status", "/status"));
+    }
+
+    #[test]
+    fn paloma_owner_role_defaults_to_thomas_and_others_observer() {
+        assert_eq!(paloma_role_for_user(1_139_694_048), TelegramUserRole::Owner);
+        assert_eq!(paloma_role_for_user(42), TelegramUserRole::Observer);
+    }
+
+    #[test]
+    fn paloma_redaction_removes_secrets_and_private_paths() {
+        let text =
+            "token=abc12345678901234567890 path /root/.sandboxed-sh/missions/missions-dev.db";
+        let redacted = redact_for_telegram(text);
+        assert!(redacted.contains("[redacted]"));
+        assert!(redacted.contains("[path redacted]"));
+        assert!(!redacted.contains("abc12345678901234567890"));
+        assert!(!redacted.contains("/root/.sandboxed-sh"));
+    }
+
+    #[test]
+    fn paloma_selector_parser_requires_selector_and_payload() {
+        assert_eq!(
+            parse_paloma_selector_and_payload("/send latest focus on tests", "/send"),
+            Some(("latest", "focus on tests"))
+        );
+        assert_eq!(
+            parse_paloma_selector_and_payload("/send latest", "/send"),
+            None
+        );
+    }
+
+    #[test]
+    fn paloma_feedback_parser_recognizes_interest_changes() {
+        assert!(feedback_mutes_alerts("Don't tell me about this again."));
+        assert!(feedback_raises_interest("Keep me posted on this."));
+        assert!(!feedback_mutes_alerts("what changed?"));
+    }
+
+    #[test]
+    fn paloma_command_error_response_preserves_usage_errors() {
+        assert_eq!(
+            paloma_command_error_response("Usage: /approve <answer>"),
+            "Usage: /approve <answer>"
+        );
+        assert_eq!(
+            paloma_command_error_response("database unavailable"),
+            "I couldn't read mission status right now."
+        );
+    }
+
+    #[test]
+    fn paloma_alert_kind_only_covers_terminal_attention_states() {
+        assert_eq!(
+            paloma_alert_kind_for_status(MissionStatus::Completed),
+            Some("mission_completed")
+        );
+        assert_eq!(paloma_alert_kind_for_status(MissionStatus::Active), None);
+    }
+
+    #[test]
+    fn mission_label_uses_public_metadata_without_ids() {
+        let mission = Mission {
+            id: Uuid::new_v4(),
+            status: MissionStatus::Active,
+            title: Some("Proof deployment".to_string()),
+            short_description: None,
+            metadata_updated_at: None,
+            metadata_source: None,
+            metadata_model: None,
+            metadata_version: None,
+            workspace_id: Uuid::new_v4(),
+            workspace_name: None,
+            agent: None,
+            model_override: None,
+            model_effort: None,
+            backend: "opencode".to_string(),
+            config_profile: None,
+            history: vec![],
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+            interrupted_at: None,
+            resumable: false,
+            desktop_sessions: vec![],
+            session_id: None,
+            terminal_reason: None,
+            parent_mission_id: None,
+            working_directory: None,
+            mission_mode: MissionMode::Task,
+            goal_mode: false,
+            goal_objective: None,
+            first_viewed_at: None,
+        };
+        assert_eq!(mission_label(&mission), "Proof deployment");
     }
 
     #[test]

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -318,19 +318,17 @@ async fn send_message_streaming_app_server(
             let _ = session_arc.shutdown().await;
             return Err(anyhow::anyhow!("codex thread/goal/set failed: {}", e));
         }
-    } else {
-        if let Err(e) = session_for_rpc
-            .turn_start(TurnStartParams {
-                thread_id: thread_id.clone(),
-                input: vec![UserInputItem::Text {
-                    text: user_payload.clone(),
-                }],
-            })
-            .await
-        {
-            let _ = session_arc.shutdown().await;
-            return Err(anyhow::anyhow!("codex turn/start failed: {}", e));
-        }
+    } else if let Err(e) = session_for_rpc
+        .turn_start(TurnStartParams {
+            thread_id: thread_id.clone(),
+            input: vec![UserInputItem::Text {
+                text: user_payload.clone(),
+            }],
+        })
+        .await
+    {
+        let _ = session_arc.shutdown().await;
+        return Err(anyhow::anyhow!("codex turn/start failed: {}", e));
     }
 
     let session_id = session.id.clone();


### PR DESCRIPTION
## Summary
- add Paloma Telegram roadmap doc
- add owner-safe Telegram `/status`, `/missions`, `/summary`, `/send`, `/approve`, feedback routing, cursors, subscriptions, alert preferences, and alert dedupe storage
- add focused tests for Telegram parsing, owner roles, cursors, alerts, redaction, and command routing

## Verification
- cargo fmt
- cargo test telegram --lib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Telegram command handling, owner-role gating, and proactive alert delivery backed by new persisted state tables; mistakes could expose mission state or increase notification noise. DB migrations and new polling logic also carry moderate operational risk.
> 
> **Overview**
> **Introduces “Paloma” ops controls in Telegram** with owner-only DM-gated commands (`/status`, `/missions`, `/summary`, `/send`, `/approve`) plus simple natural-language feedback to mute/raise mission interest.
> 
> Adds persistent Telegram state to the mission store (SQLite tables + `MissionStore` APIs) for user roles, per-user cursors, mission subscriptions, alert preferences, and deduped alerts; `/status` now produces a redacted delta summary and advances a cursor.
> 
> Adds a background poller that plans and sends deduped terminal-state alerts to the configured owner, plus focused unit/integration tests for parsing, redaction, role defaults, cursor/subscription round-trips, and alert lifecycle. Also adds a `PALOMA_TELEGRAM_ROADMAP.md` planning doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c52604231c29c923fee766a60755b441c5feb2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->