### PR TITLE
Reduce Paloma alert spam and polish iOS mission states

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -186,6 +186,10 @@ struct Mission: Codable, Identifiable, Hashable {
     var canResume: Bool {
         resumable && status.canResume
     }
+
+    var hasFinishedSuccessfully: Bool {
+        status == .completed || status == .acknowledged
+    }
 }
 
 enum TaskStatus: String, Codable, CaseIterable {

--- a/ios_dashboard/SandboxedDashboard/Views/Components/RunningMissionsBar.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/RunningMissionsBar.swift
@@ -132,18 +132,19 @@ struct RunningMissionsBar: View {
                 onSelectMission(mission.missionId)
             } label: {
                 HStack(spacing: 6) {
-                    // Status dot with animation
-                    Circle()
-                        .fill(statusColor(for: mission))
-                        .frame(width: 6, height: 6)
-                        .overlay {
-                            if mission.isRunning && !isStalled {
-                                Circle()
-                                    .stroke(statusColor(for: mission).opacity(0.5), lineWidth: 1.5)
-                                    .frame(width: 10, height: 10)
-                                    .opacity(0.6)
-                            }
-                        }
+                    // Running missions use the blue spinner treatment from
+                    // the mission switcher, so they do not read as completed.
+                    if mission.isRunning && !isStalled {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(Theme.accent)
+                            .scaleEffect(0.55)
+                            .frame(width: 10, height: 10)
+                    } else {
+                        Circle()
+                            .fill(statusColor(for: mission))
+                            .frame(width: 6, height: 6)
+                    }
 
                     // Mission title or short ID
                     Text(mission.displayLabel)
@@ -217,7 +218,7 @@ struct RunningMissionsBar: View {
         } else if mission.isStalled {
             return Theme.warning
         } else if mission.isRunning {
-            return Theme.success
+            return Theme.accent
         } else {
             return Theme.warning
         }

--- a/ios_dashboard/SandboxedDashboard/Views/Components/RunningMissionsBar.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/RunningMissionsBar.swift
@@ -137,7 +137,7 @@ struct RunningMissionsBar: View {
                     if mission.isRunning && !isStalled {
                         ProgressView()
                             .progressViewStyle(.circular)
-                            .tint(Theme.accent)
+                            .tint(Theme.info)
                             .scaleEffect(0.55)
                             .frame(width: 10, height: 10)
                     } else {
@@ -218,7 +218,7 @@ struct RunningMissionsBar: View {
         } else if mission.isStalled {
             return Theme.warning
         } else if mission.isRunning {
-            return Theme.accent
+            return Theme.info
         } else {
             return Theme.warning
         }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1282,6 +1282,7 @@ struct ControlView: View {
     }
 
     private var latestVisibleThought: ChatMessage? {
+        guard viewingMissionIsRunning else { return nil }
         messages.last { message in
             guard message.isThinking else { return false }
             return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -3467,12 +3468,25 @@ struct ControlView: View {
             if let statusStr = data["status"] as? String,
                let missionId = data["mission_id"] as? String {
                 let newStatus = MissionStatus(rawValue: statusStr) ?? .unknown
+                let recentCompletedStatusKnown = recentMissions.contains(where: {
+                    $0.id == missionId && $0.hasFinishedSuccessfully
+                })
+                let completedStatusAlreadyKnown =
+                    (viewingMission?.id == missionId && viewingMission?.hasFinishedSuccessfully == true)
+                    || (currentMission?.id == missionId && currentMission?.hasFinishedSuccessfully == true)
+                    || recentCompletedStatusKnown
+                if newStatus == .interrupted && completedStatusAlreadyKnown {
+                    return
+                }
 
                 // If mission is no longer active AND it's the currently viewed mission,
                 // mark all pending tools as cancelled
                 if newStatus != .active && viewingMissionId == missionId {
                     finalizeActiveThinkingMessages()
                     markActiveToolCallsAsCompleted(withState: .cancelled)
+                }
+                if newStatus != .active {
+                    runningMissions.removeAll { $0.missionId == missionId }
                 }
 
                 // Update the viewing mission status if it matches
@@ -4940,10 +4954,14 @@ private struct MissionSwitcherSheet: View {
     }
 
     private var filteredRunning: [RunningMissionInfo] {
-        if normalizedSearchQuery.isEmpty {
-            return runningMissions
+        let liveCandidates = runningMissions.filter { info in
+            guard let mission = missionById[info.missionId] else { return true }
+            return !mission.hasFinishedSuccessfully
         }
-        return runningMissions
+        if normalizedSearchQuery.isEmpty {
+            return liveCandidates
+        }
+        return liveCandidates
             .compactMap { info -> (RunningMissionInfo, Double)? in
                 let score = runningMissionSearchScore(
                     info,
@@ -5644,11 +5662,11 @@ private struct MissionRow: View {
 
     private var statusColor: Color {
         if isRunning {
-            return Theme.success
+            return Theme.accent
         }
         switch status {
         case .pending: return Theme.warning
-        case .active: return Theme.success
+        case .active: return Theme.accent
         case .awaitingUser: return Theme.warning
         case .acknowledged: return Theme.success
         case .completed: return Theme.textMuted
@@ -5661,7 +5679,7 @@ private struct MissionRow: View {
 
     private var statusIcon: String {
         if isRunning {
-            return "play.circle.fill"
+            return "arrow.trianglehead.2.clockwise"
         }
         switch status {
         case .pending: return "clock.fill"
@@ -5710,10 +5728,10 @@ private struct MissionRow: View {
             if isRunning, let state = runningState {
                 Text(state)
                     .font(.caption2)
-                    .foregroundStyle(Theme.textMuted)
+                    .foregroundStyle(Theme.accent)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Theme.backgroundSecondary)
+                    .background(Theme.accent.opacity(0.12))
                     .clipShape(Capsule())
             } else {
                 Text(status.displayLabel)
@@ -5749,11 +5767,20 @@ private struct MissionRow: View {
                     }
                 }
 
-                Image(systemName: statusIcon)
-                    .font(.system(size: 18))
-                    .foregroundStyle(statusColor)
-                    .symbolEffect(.pulse, options: (isRunning && runningState == "running") ? .repeating : .nonRepeating)
-                    .frame(width: 24, height: 24)
+                Group {
+                    if isRunning && runningState == "running" {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(Theme.accent)
+                            .scaleEffect(0.7)
+                    } else {
+                        Image(systemName: statusIcon)
+                            .font(.system(size: 18))
+                            .foregroundStyle(statusColor)
+                            .symbolEffect(.pulse, options: (isRunning && runningState == "running") ? .repeating : .nonRepeating)
+                    }
+                }
+                .frame(width: 24, height: 24)
 
                 VStack(alignment: .leading, spacing: 2) {
                     // Title (or short id when there is no title) is the primary

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -995,13 +995,23 @@ struct ControlView: View {
     private var viewingMissionIsRunning: Bool {
         guard let viewingId = viewingMissionId else {
             // No specific mission being viewed - fall back to global state
+            if let currentMission, missionIsTerminalForInlineThinking(currentMission) {
+                return false
+            }
             return runState != .idle
+        }
+        if let viewingMission, viewingMission.id == viewingId, missionIsTerminalForInlineThinking(viewingMission) {
+            return false
         }
         // Check if this specific mission is in the running missions list
         guard let missionInfo = runningMissions.first(where: { $0.missionId == viewingId }) else {
             return false
         }
         return missionInfo.state == "running" || missionInfo.state == "waiting_for_tool"
+    }
+
+    private func missionIsTerminalForInlineThinking(_ mission: Mission) -> Bool {
+        mission.status.statusType == .completed || mission.status.statusType == .failed
     }
     
     private var agentWorkingIndicator: some View {
@@ -1285,6 +1295,7 @@ struct ControlView: View {
         guard viewingMissionIsRunning else { return nil }
         messages.last { message in
             guard message.isThinking else { return false }
+            guard !message.thinkingDone else { return false }
             return !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
@@ -5662,7 +5673,7 @@ private struct MissionRow: View {
 
     private var statusColor: Color {
         if isRunning {
-            return Theme.accent
+            return Theme.info
         }
         switch status {
         case .pending: return Theme.warning
@@ -5728,10 +5739,10 @@ private struct MissionRow: View {
             if isRunning, let state = runningState {
                 Text(state)
                     .font(.caption2)
-                    .foregroundStyle(Theme.accent)
+                    .foregroundStyle(Theme.info)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Theme.accent.opacity(0.12))
+                    .background(Theme.info.opacity(0.12))
                     .clipShape(Capsule())
             } else {
                 Text(status.displayLabel)
@@ -5771,7 +5782,7 @@ private struct MissionRow: View {
                     if isRunning && runningState == "running" {
                         ProgressView()
                             .progressViewStyle(.circular)
-                            .tint(Theme.accent)
+                            .tint(Theme.info)
                             .scaleEffect(0.7)
                     } else {
                         Image(systemName: statusIcon)

--- a/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
@@ -130,6 +130,7 @@ final class ModelTests: XCTestCase {
         let source = try controlViewSource()
 
         XCTAssertTrue(source.contains("control-inline-thinking"))
+        XCTAssertTrue(source.contains("guard viewingMissionIsRunning else { return nil }"))
         XCTAssertTrue(source.contains("thoughts-timeline"))
         XCTAssertTrue(source.contains("thought-latest"))
         XCTAssertTrue(source.contains("thoughts-bottom"))
@@ -154,6 +155,8 @@ final class ModelTests: XCTestCase {
         XCTAssertTrue(source.contains("controlDroppedEvents"))
         XCTAssertTrue(source.contains("goal_role"))
         XCTAssertTrue(source.contains("goal-deliverable-"))
+        XCTAssertTrue(source.contains("completedStatusAlreadyKnown"))
+        XCTAssertTrue(source.contains("runningMissions.removeAll { $0.missionId == missionId }"))
     }
 
     func testSharedControlReducerFixturesReplayOnIOS() throws {

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6503,6 +6503,13 @@ async fn stuck_mission_watchdog_loop(
             if running_ids.contains(&mission.id) {
                 continue;
             }
+            if mission.mission_mode == super::mission_store::MissionMode::Assistant {
+                tracing::debug!(
+                    mission_id = %mission.id,
+                    "Stuck-mission watchdog: leaving idle assistant-mode mission active"
+                );
+                continue;
+            }
             tracing::warn!(
                 "Stuck-mission watchdog: orphan {} (no live runner); marking interrupted",
                 mission.id

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -263,7 +263,10 @@ pub fn inject_telegram_identity_into_claude_md(
             "A CLI tool is available via `{cmd}` for sending Telegram messages \
              and scheduling reminders. Use it ONLY when the user explicitly asks \
              you to send a message, set a reminder, post in another chat, or ask \
-             someone in another chat for information. For normal replies, \
+             someone in another chat for information. You may also use it when a \
+             Telegram conversation creates an obvious follow-up obligation, such as \
+             a promised reminder, a timed check-in, or a request that must be routed \
+             to another chat before you can answer. For normal replies, \
              acknowledgements, and factual answers, do NOT use it.\n\n\
              Commands:\n\
              - `{cmd} reply \"MESSAGE\"` — immediate message to the current chat\n\
@@ -272,7 +275,8 @@ pub fn inject_telegram_identity_into_claude_md(
              - `{cmd} remind-title SECONDS \"CHAT TITLE\" \"MESSAGE\"` — delayed message to another chat\n\
              - `{cmd} ask-title \"CHAT TITLE\" \"MESSAGE\"` — cross-chat request: ask another chat, wait for reply, summarize back\n\n\
              The task is incomplete until the command succeeds. Never simulate an action \
-             by merely replying with the text or saying you will do it later.\n\
+             by merely replying with the text or saying you will do it later. If a Telegram \
+             action command fails, report the failure and what still needs to happen.\n\
              Never echo internal prefixes like `[Telegram from ...]` or `[Instructions: ...]`.\n",
             cmd = action_cmd,
         ));
@@ -284,7 +288,11 @@ pub fn inject_telegram_identity_into_claude_md(
          When a `[Structured memory]` block is present in the user \
          message, it contains facts, notes, and preferences that you \
          previously stored about the user, the chat, or the channel. \
-         Use this information to personalise your responses. \
+         Use this information to personalise your responses and to avoid \
+         re-asking for facts the user has already provided. Treat user-scoped \
+         memory as portable across chats, and chat-scoped memory as local to \
+         the current Telegram conversation. If current user text conflicts \
+         with memory, trust the latest user text and mention the change briefly. \
          If the user asks about your memory, describe what you \
          currently know based on the structured memory block.\n",
     );

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1584,6 +1584,17 @@ pub trait MissionStore: Send + Sync {
         Err("Not supported".to_string())
     }
 
+    /// Acknowledge queued alerts for a mission so they will not be delivered.
+    async fn acknowledge_pending_telegram_alerts_for_mission(
+        &self,
+        telegram_user_id: i64,
+        mission_id: Uuid,
+        acknowledged_at: &str,
+    ) -> Result<usize, String> {
+        let _ = (telegram_user_id, mission_id, acknowledged_at);
+        Ok(0)
+    }
+
     /// Record a delivery failure without removing the alert from the retry queue.
     async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
         let _ = (id, error);

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1584,7 +1584,7 @@ pub trait MissionStore: Send + Sync {
         Err("Not supported".to_string())
     }
 
-    /// Mark an alert as failed.
+    /// Record a delivery failure without removing the alert from the retry queue.
     async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
         let _ = (id, error);
         Err("Not supported".to_string())

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -5665,6 +5665,32 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn acknowledge_pending_telegram_alerts_for_mission(
+        &self,
+        telegram_user_id: i64,
+        mission_id: Uuid,
+        acknowledged_at: &str,
+    ) -> Result<usize, String> {
+        let conn = self.conn.clone();
+        let acknowledged_at = acknowledged_at.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let changed = conn
+                .execute(
+                    "UPDATE telegram_alerts
+                     SET status = 'acknowledged', acknowledged_at = ?3, last_error = NULL
+                     WHERE telegram_user_id = ?1
+                       AND mission_id = ?2
+                       AND status = 'pending'",
+                    params![telegram_user_id, mission_id.to_string(), acknowledged_at],
+                )
+                .map_err(|e| e.to_string())?;
+            Ok(changed)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
         let conn = self.conn.clone();
         let error = error.to_string();
@@ -8298,6 +8324,42 @@ mod tests {
             .list_pending_telegram_alerts(1_139_694_048, 10)
             .await
             .expect("pending alerts after sent")
+            .is_empty());
+
+        let queued_after_mute = TelegramAlert {
+            id: Uuid::new_v4(),
+            telegram_user_id: 1_139_694_048,
+            mission_id: Some(mission.id),
+            event_kind: "mission_awaiting_user".to_string(),
+            importance: "high".to_string(),
+            title: "Paloma state".to_string(),
+            body: "Paloma state needs input.".to_string(),
+            status: "pending".to_string(),
+            telegram_message_id: None,
+            last_error: Some("previous retry".to_string()),
+            created_at: "2026-05-20T10:02:00Z".to_string(),
+            sent_at: None,
+            acknowledged_at: None,
+        };
+        store
+            .create_telegram_alert_if_absent(queued_after_mute)
+            .await
+            .expect("queued alert after mute");
+        assert_eq!(
+            store
+                .acknowledge_pending_telegram_alerts_for_mission(
+                    1_139_694_048,
+                    mission.id,
+                    "2026-05-20T10:03:00Z",
+                )
+                .await
+                .expect("acknowledge pending alerts"),
+            1
+        );
+        assert!(store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("pending alerts after ack")
             .is_empty());
     }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -5672,7 +5672,7 @@ impl MissionStore for SqliteMissionStore {
             let conn = conn.blocking_lock();
             conn.execute(
                 "UPDATE telegram_alerts
-                 SET status = 'failed', last_error = ?2
+                 SET status = 'pending', last_error = ?2
                  WHERE id = ?1",
                 params![id.to_string(), error],
             )
@@ -8278,7 +8278,20 @@ mod tests {
             .expect("pending alerts");
         assert_eq!(pending.len(), 1);
         store
-            .mark_telegram_alert_sent(pending[0].id, Some(99), "2026-05-20T10:01:00Z")
+            .mark_telegram_alert_failed(pending[0].id, "temporary Telegram outage")
+            .await
+            .expect("record failed attempt");
+        let retryable = store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("retryable alerts");
+        assert_eq!(retryable.len(), 1);
+        assert_eq!(
+            retryable[0].last_error.as_deref(),
+            Some("temporary Telegram outage")
+        );
+        store
+            .mark_telegram_alert_sent(retryable[0].id, Some(99), "2026-05-20T10:01:00Z")
             .await
             .expect("mark sent");
         assert!(store

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -5699,7 +5699,7 @@ impl MissionStore for SqliteMissionStore {
             conn.execute(
                 "UPDATE telegram_alerts
                  SET status = 'pending', last_error = ?2
-                 WHERE id = ?1",
+                 WHERE id = ?1 AND status = 'pending'",
                 params![id.to_string(), error],
             )
             .map_err(|e| e.to_string())?;
@@ -8326,8 +8326,9 @@ mod tests {
             .expect("pending alerts after sent")
             .is_empty());
 
+        let queued_after_mute_id = Uuid::new_v4();
         let queued_after_mute = TelegramAlert {
-            id: Uuid::new_v4(),
+            id: queued_after_mute_id,
             telegram_user_id: 1_139_694_048,
             mission_id: Some(mission.id),
             event_kind: "mission_awaiting_user".to_string(),
@@ -8360,6 +8361,15 @@ mod tests {
             .list_pending_telegram_alerts(1_139_694_048, 10)
             .await
             .expect("pending alerts after ack")
+            .is_empty());
+        store
+            .mark_telegram_alert_failed(queued_after_mute_id, "late Telegram failure")
+            .await
+            .expect("late failure should not requeue acknowledged alert");
+        assert!(store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("pending alerts after late failure")
             .is_empty());
     }
 

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -660,11 +660,72 @@ async fn apply_paloma_interest_feedback(
 
 fn paloma_alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
     match status {
+        MissionStatus::AwaitingUser => Some("mission_awaiting_user"),
         MissionStatus::Completed => Some("mission_completed"),
         MissionStatus::Failed => Some("mission_failed"),
         MissionStatus::Blocked => Some("mission_blocked"),
         MissionStatus::Interrupted => Some("mission_interrupted"),
+        MissionStatus::NotFeasible => Some("mission_not_feasible"),
         _ => None,
+    }
+}
+
+fn paloma_alert_importance_for_mission(
+    mission: &Mission,
+    interest: TelegramMissionInterestLevel,
+) -> &'static str {
+    if interest == TelegramMissionInterestLevel::High {
+        return "high";
+    }
+    match mission.status {
+        MissionStatus::Failed | MissionStatus::Blocked | MissionStatus::Interrupted => "high",
+        MissionStatus::AwaitingUser | MissionStatus::NotFeasible => "normal",
+        MissionStatus::Completed => {
+            if mission.parent_mission_id.is_some() {
+                "normal"
+            } else {
+                "low"
+            }
+        }
+        _ => "low",
+    }
+}
+
+fn paloma_alert_event_kind(mission: &Mission, base_kind: &str) -> String {
+    let updated = mission
+        .metadata_updated_at
+        .as_deref()
+        .unwrap_or(mission.updated_at.as_str());
+    format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
+}
+
+fn paloma_latest_attention_line(mission: &Mission, events: &[StoredEvent]) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find_map(|event| match event.event_type.as_str() {
+            "assistant_message" | "error" | "mission_status_changed" => {
+                event_summary_line(mission, event)
+            }
+            _ => None,
+        })
+}
+
+fn paloma_alert_body(mission: &Mission, events: &[StoredEvent]) -> String {
+    let title = mission_label(mission);
+    let lead = match mission.status {
+        MissionStatus::AwaitingUser => format!("{title} is waiting for your input."),
+        MissionStatus::Completed => format!("{title} completed."),
+        MissionStatus::Failed => format!("{title} failed."),
+        MissionStatus::Blocked => format!("{title} is blocked."),
+        MissionStatus::Interrupted => format!("{title} was interrupted."),
+        MissionStatus::NotFeasible => format!("{title} was marked not feasible."),
+        _ => format!("{title} is now {}.", mission.status),
+    };
+
+    match paloma_latest_attention_line(mission, events) {
+        Some(line) => redact_for_telegram(&format!("{lead}\n\nLatest: {line}")),
+        None => redact_for_telegram(&lead),
     }
 }
 
@@ -691,17 +752,23 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
     };
 
     for mission in missions {
-        let Some(kind) = paloma_alert_kind_for_status(mission.status) else {
+        let Some(base_kind) = paloma_alert_kind_for_status(mission.status) else {
             continue;
         };
-        if subscriptions
+        let interest = subscriptions
             .get(&mission.id)
-            .is_some_and(|level| *level == TelegramMissionInterestLevel::Muted)
-        {
+            .copied()
+            .unwrap_or(TelegramMissionInterestLevel::Normal);
+        if interest == TelegramMissionInterestLevel::Muted {
             continue;
         }
         let title = mission_label(&mission);
-        let body = redact_for_telegram(&format!("{} is now {}.", title, mission.status));
+        let events = ctx
+            .mission_store
+            .get_events(mission.id, None, Some(40), None)
+            .await
+            .unwrap_or_default();
+        let body = paloma_alert_body(&mission, &events);
         let now = now_string();
         let _ = ctx
             .mission_store
@@ -709,8 +776,8 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
                 id: Uuid::new_v4(),
                 telegram_user_id: owner_id,
                 mission_id: Some(mission.id),
-                event_kind: kind.to_string(),
-                importance: "high".to_string(),
+                event_kind: paloma_alert_event_kind(&mission, base_kind),
+                importance: paloma_alert_importance_for_mission(&mission, interest).to_string(),
                 title,
                 body,
                 status: "pending".to_string(),
@@ -1959,8 +2026,10 @@ fn extract_structured_memory_from_text(text: &str) -> Vec<ExtractedTelegramMemor
     }
 
     let mut entries = Vec::new();
-    let remember_re = regex::Regex::new(r"(?i)^(?:souviens[- ]toi que|remember that)\s+(.+)$")
-        .expect("telegram remember extraction regex must compile");
+    let remember_re = regex::Regex::new(
+        r"(?i)^(?:souviens[- ]toi que|remember that|please remember that|note that)\s+(.+)$",
+    )
+    .expect("telegram remember extraction regex must compile");
 
     if let Some(captures) = remember_re.captures(trimmed) {
         let body = normalize_memory_text(&strip_memory_follow_up_directives(
@@ -1993,6 +2062,21 @@ fn extract_structured_memory_from_text(text: &str) -> Vec<ExtractedTelegramMemor
         if !value.is_empty() {
             entries.push(ExtractedTelegramMemory {
                 kind: TelegramStructuredMemoryKind::Preference,
+                label: None,
+                value,
+            });
+        }
+    }
+
+    let task_re = regex::Regex::new(r"(?i)^(?:remind me to|rappelle[- ]moi de)\s+(.+)$")
+        .expect("telegram task extraction regex must compile");
+    if let Some(captures) = task_re.captures(trimmed) {
+        let value = normalize_memory_text(&strip_memory_follow_up_directives(
+            captures.get(1).map(|m| m.as_str()).unwrap_or(""),
+        ));
+        if !value.is_empty() {
+            entries.push(ExtractedTelegramMemory {
+                kind: TelegramStructuredMemoryKind::Task,
                 label: None,
                 value,
             });
@@ -4722,16 +4806,52 @@ mod tests {
         extract_telegram_actions, feedback_mutes_alerts, feedback_raises_interest,
         format_structured_memory_context, is_paloma_command, markdown_to_telegram_html,
         merge_telegram_chat_metadata, mission_label, normalize_paloma_natural_command,
+        paloma_alert_body, paloma_alert_event_kind, paloma_alert_importance_for_mission,
         paloma_alert_kind_for_status, paloma_command_error_response, paloma_role_for_user,
         parse_paloma_selector_and_payload, redact_for_telegram, render_telegram_chunk,
         sanitize_telegram_visible_text, scope_for_extracted_memory, telegram_action_target_matches,
         telegram_chat_display_title, truncate_for_telegram, verify_internal_telegram_action_token,
         workflow_reply_text, workflow_request_delivery_text, Chat, ExtractedTelegramMemory,
         Mission, MissionMode, MissionStatus, TelegramAction, TelegramActionKind, TelegramBridge,
-        TelegramMemorySubject, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
-        TelegramStructuredMemoryScope, TelegramUserRole,
+        TelegramMemorySubject, TelegramMissionInterestLevel, TelegramStructuredMemoryEntry,
+        TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramUserRole,
     };
+    use crate::api::mission_store::StoredEvent;
     use uuid::Uuid;
+
+    fn test_mission(title: &str, status: MissionStatus) -> Mission {
+        Mission {
+            id: Uuid::new_v4(),
+            status,
+            title: Some(title.to_string()),
+            short_description: None,
+            metadata_updated_at: None,
+            metadata_source: None,
+            metadata_model: None,
+            metadata_version: None,
+            workspace_id: Uuid::new_v4(),
+            workspace_name: None,
+            agent: None,
+            model_override: None,
+            model_effort: None,
+            backend: "opencode".to_string(),
+            config_profile: None,
+            history: vec![],
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+            interrupted_at: None,
+            resumable: false,
+            desktop_sessions: vec![],
+            session_id: None,
+            terminal_reason: None,
+            parent_mission_id: None,
+            working_directory: None,
+            mission_mode: MissionMode::Task,
+            goal_mode: false,
+            goal_objective: None,
+            first_viewed_at: None,
+        }
+    }
 
     #[test]
     fn truncate_for_telegram_preserves_valid_html_boundaries() {
@@ -4881,47 +5001,63 @@ mod tests {
     }
 
     #[test]
-    fn paloma_alert_kind_only_covers_terminal_attention_states() {
+    fn paloma_alert_kind_covers_attention_states() {
         assert_eq!(
             paloma_alert_kind_for_status(MissionStatus::Completed),
             Some("mission_completed")
+        );
+        assert_eq!(
+            paloma_alert_kind_for_status(MissionStatus::AwaitingUser),
+            Some("mission_awaiting_user")
+        );
+        assert_eq!(
+            paloma_alert_kind_for_status(MissionStatus::NotFeasible),
+            Some("mission_not_feasible")
         );
         assert_eq!(paloma_alert_kind_for_status(MissionStatus::Active), None);
     }
 
     #[test]
+    fn paloma_alert_body_includes_latest_attention_context() {
+        let mission = test_mission("Checkout fix", MissionStatus::AwaitingUser);
+        let events = vec![StoredEvent {
+            id: 1,
+            mission_id: mission.id,
+            sequence: 1,
+            event_type: "assistant_message".to_string(),
+            timestamp: "2026-05-20T00:01:00Z".to_string(),
+            event_id: None,
+            tool_call_id: None,
+            tool_name: None,
+            content: "Please confirm the deploy window.".to_string(),
+            metadata: serde_json::json!({}),
+        }];
+
+        let body = paloma_alert_body(&mission, &events);
+
+        assert!(body.contains("waiting for your input"));
+        assert!(body.contains("Please confirm the deploy window"));
+    }
+
+    #[test]
+    fn paloma_alert_event_kind_is_state_specific_and_subscription_can_raise_importance() {
+        let mission = test_mission("Checkout fix", MissionStatus::Completed);
+
+        assert!(paloma_alert_event_kind(&mission, "mission_completed")
+            .starts_with("mission_completed:2026-05-20T00-00-00Z"));
+        assert_eq!(
+            paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::Normal),
+            "low"
+        );
+        assert_eq!(
+            paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::High),
+            "high"
+        );
+    }
+
+    #[test]
     fn mission_label_uses_public_metadata_without_ids() {
-        let mission = Mission {
-            id: Uuid::new_v4(),
-            status: MissionStatus::Active,
-            title: Some("Proof deployment".to_string()),
-            short_description: None,
-            metadata_updated_at: None,
-            metadata_source: None,
-            metadata_model: None,
-            metadata_version: None,
-            workspace_id: Uuid::new_v4(),
-            workspace_name: None,
-            agent: None,
-            model_override: None,
-            model_effort: None,
-            backend: "opencode".to_string(),
-            config_profile: None,
-            history: vec![],
-            created_at: "2026-05-20T00:00:00Z".to_string(),
-            updated_at: "2026-05-20T00:00:00Z".to_string(),
-            interrupted_at: None,
-            resumable: false,
-            desktop_sessions: vec![],
-            session_id: None,
-            terminal_reason: None,
-            parent_mission_id: None,
-            working_directory: None,
-            mission_mode: MissionMode::Task,
-            goal_mode: false,
-            goal_objective: None,
-            first_viewed_at: None,
-        };
+        let mission = test_mission("Proof deployment", MissionStatus::Active);
         assert_eq!(mission_label(&mission), "Proof deployment");
     }
 
@@ -5133,6 +5269,20 @@ mod tests {
         assert_eq!(entries[0].kind, TelegramStructuredMemoryKind::Preference);
         assert_eq!(entries[0].label, None);
         assert_eq!(entries[0].value, "les réponses courtes");
+    }
+
+    #[test]
+    fn extract_structured_memory_captures_explicit_notes_and_tasks() {
+        let note_entries =
+            extract_structured_memory_from_text("Please remember that staging deploys need Alice.");
+        assert_eq!(note_entries.len(), 1);
+        assert_eq!(note_entries[0].kind, TelegramStructuredMemoryKind::Note);
+        assert_eq!(note_entries[0].value, "staging deploys need Alice");
+
+        let task_entries = extract_structured_memory_from_text("Remind me to check CI tomorrow.");
+        assert_eq!(task_entries.len(), 1);
+        assert_eq!(task_entries[0].kind, TelegramStructuredMemoryKind::Task);
+        assert_eq!(task_entries[0].value, "check CI tomorrow");
     }
 
     #[test]

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -801,7 +801,7 @@ fn paloma_alert_digest_text(alerts: &[TelegramAlert]) -> String {
     let remaining = sorted.len().saturating_sub(visible);
     if remaining > 0 {
         text.push_str(&format!(
-            "\n- {} more lower-priority update{}",
+            "\n- {} more update{}",
             remaining,
             if remaining == 1 { "" } else { "s" }
         ));
@@ -5168,6 +5168,25 @@ mod tests {
         assert!(body.contains("- Checkout fix is waiting for your input. Latest: Please confirm"));
         assert!(body.contains("- Inventory completed. Latest: Wrote the report."));
         assert!(!body.contains("Checkout fix\n\nCheckout fix"));
+    }
+
+    #[test]
+    fn paloma_alert_digest_overflow_does_not_downgrade_hidden_alerts() {
+        let alerts = (0..9)
+            .map(|idx| {
+                test_alert(
+                    &format!("Mission {idx}"),
+                    &format!("Mission {idx} failed."),
+                    "high",
+                    &format!("2026-05-20T00:{idx:02}:00Z"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let body = paloma_alert_digest_text(&alerts);
+
+        assert!(body.contains("- 1 more update"));
+        assert!(!body.contains("lower-priority"));
     }
 
     #[test]

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -64,7 +64,9 @@ struct TelegramReplyRecord {
 const TELEGRAM_UPDATE_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_REPLY_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(2);
-const PALOMA_ALERT_RECENCY_WINDOW_MINUTES: i64 = 60;
+const PALOMA_LONG_RUNNING_MINUTES: i64 = 30;
+const PALOMA_USER_MESSAGE_QUIET_MINUTES: i64 = 30;
+const PALOMA_LONG_RUNNING_ALERT_BUCKET_MINUTES: i64 = 30;
 const PALOMA_ALERT_DIGEST_LIMIT: usize = 12;
 const DEFAULT_PALOMA_OWNER_TELEGRAM_ID: i64 = 1_139_694_048;
 const DEFAULT_PALOMA_TRUSTED_FRIEND_TELEGRAM_ID: i64 = 0;
@@ -680,12 +682,7 @@ async fn apply_paloma_interest_feedback(
 
 fn paloma_alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
     match status {
-        MissionStatus::AwaitingUser => Some("mission_awaiting_user"),
-        MissionStatus::Completed => Some("mission_completed"),
-        MissionStatus::Failed => Some("mission_failed"),
-        MissionStatus::Blocked => Some("mission_blocked"),
-        MissionStatus::Interrupted => Some("mission_interrupted"),
-        MissionStatus::NotFeasible => Some("mission_not_feasible"),
+        MissionStatus::Active => Some("mission_long_running"),
         _ => None,
     }
 }
@@ -698,15 +695,29 @@ fn paloma_alert_importance_for_mission(
         return "high";
     }
     match mission.status {
-        MissionStatus::Failed | MissionStatus::Blocked | MissionStatus::Interrupted => "high",
-        MissionStatus::AwaitingUser | MissionStatus::NotFeasible => "normal",
-        MissionStatus::Completed if mission.parent_mission_id.is_some() => "normal",
-        MissionStatus::Completed => "low",
+        MissionStatus::Active => "normal",
         _ => "low",
     }
 }
 
-fn paloma_alert_event_kind(mission: &Mission, base_kind: &str, events: &[StoredEvent]) -> String {
+fn parse_paloma_event_time(value: &str) -> Option<chrono::DateTime<Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn paloma_alert_event_kind_at(
+    mission: &Mission,
+    base_kind: &str,
+    events: &[StoredEvent],
+    now: chrono::DateTime<Utc>,
+) -> String {
+    if mission.status == MissionStatus::Active && base_kind == "mission_long_running" {
+        let bucket_seconds = PALOMA_LONG_RUNNING_ALERT_BUCKET_MINUTES * 60;
+        let bucket = now.timestamp().div_euclid(bucket_seconds);
+        return format!("{base_kind}:{bucket}");
+    }
+
     let status = mission.status.to_string();
     let updated = events
         .iter()
@@ -724,13 +735,42 @@ fn paloma_alert_event_kind(mission: &Mission, base_kind: &str, events: &[StoredE
     format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
 }
 
-fn paloma_alert_transition_is_recent(mission: &Mission) -> bool {
-    let updated = mission.updated_at.as_str();
-    let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(updated) else {
+fn paloma_latest_user_message_at(events: &[StoredEvent]) -> Option<chrono::DateTime<Utc>> {
+    events
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "user_message")
+        .and_then(|event| parse_paloma_event_time(&event.timestamp))
+}
+
+fn paloma_mission_started_at(mission: &Mission) -> Option<chrono::DateTime<Utc>> {
+    parse_paloma_event_time(&mission.created_at)
+        .or_else(|| parse_paloma_event_time(&mission.updated_at))
+}
+
+fn paloma_should_alert_long_running_mission_at(
+    mission: &Mission,
+    events: &[StoredEvent],
+    now: chrono::DateTime<Utc>,
+) -> bool {
+    if mission.status != MissionStatus::Active {
+        return false;
+    }
+    let Some(started_at) = paloma_mission_started_at(mission) else {
         return true;
     };
-    Utc::now() - updated_at.with_timezone(&Utc)
-        <= ChronoDuration::minutes(PALOMA_ALERT_RECENCY_WINDOW_MINUTES)
+    if now - started_at < ChronoDuration::minutes(PALOMA_LONG_RUNNING_MINUTES) {
+        return false;
+    }
+    if paloma_latest_user_message_at(events)
+        .map(|last_user_message_at| {
+            now - last_user_message_at < ChronoDuration::minutes(PALOMA_USER_MESSAGE_QUIET_MINUTES)
+        })
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    true
 }
 
 fn paloma_latest_attention_line(mission: &Mission, events: &[StoredEvent]) -> Option<String> {
@@ -748,6 +788,7 @@ fn paloma_latest_attention_line(mission: &Mission, events: &[StoredEvent]) -> Op
 fn paloma_alert_body(mission: &Mission, events: &[StoredEvent]) -> String {
     let title = mission_label(mission);
     let lead = match mission.status {
+        MissionStatus::Active => format!("{title} is still running."),
         MissionStatus::AwaitingUser => format!("{title} is waiting for your input."),
         MissionStatus::Completed => format!("{title} completed."),
         MissionStatus::Failed => format!("{title} failed."),
@@ -860,9 +901,6 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
         let Some(base_kind) = paloma_alert_kind_for_status(mission.status) else {
             continue;
         };
-        if !paloma_alert_transition_is_recent(&mission) {
-            continue;
-        }
         let interest = subscriptions
             .get(&mission.id)
             .copied()
@@ -876,6 +914,10 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
             .get_events(mission.id, None, Some(40), None)
             .await
             .unwrap_or_default();
+        let alert_now = Utc::now();
+        if !paloma_should_alert_long_running_mission_at(&mission, &events, alert_now) {
+            continue;
+        }
         let body = paloma_alert_body(&mission, &events);
         let now = now_string();
         let _ = ctx
@@ -884,7 +926,7 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
                 id: Uuid::new_v4(),
                 telegram_user_id: owner_id,
                 mission_id: Some(mission.id),
-                event_kind: paloma_alert_event_kind(&mission, base_kind, &events),
+                event_kind: paloma_alert_event_kind_at(&mission, base_kind, &events, alert_now),
                 importance: paloma_alert_importance_for_mission(&mission, interest).to_string(),
                 title,
                 body,
@@ -4950,19 +4992,20 @@ mod tests {
         extract_telegram_actions, feedback_mutes_alerts, feedback_raises_interest,
         format_structured_memory_context, is_paloma_command, markdown_to_telegram_html,
         merge_telegram_chat_metadata, mission_label, normalize_paloma_natural_command,
-        paloma_alert_body, paloma_alert_digest_text, paloma_alert_event_kind,
+        paloma_alert_body, paloma_alert_digest_text, paloma_alert_event_kind_at,
         paloma_alert_importance_for_mission, paloma_alert_kind_for_status,
-        paloma_alert_transition_is_recent, paloma_command_error_response, paloma_role_for_user,
-        parse_paloma_selector_and_payload, redact_for_telegram, render_telegram_chunk,
-        sanitize_telegram_visible_text, scope_for_extracted_memory, telegram_action_target_matches,
-        telegram_chat_display_title, truncate_for_telegram, verify_internal_telegram_action_token,
-        workflow_reply_text, workflow_request_delivery_text, Chat, ExtractedTelegramMemory,
-        Mission, MissionMode, MissionStatus, TelegramAction, TelegramActionKind, TelegramAlert,
-        TelegramBridge, TelegramMemorySubject, TelegramMissionInterestLevel,
-        TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
-        TelegramUserRole,
+        paloma_command_error_response, paloma_role_for_user,
+        paloma_should_alert_long_running_mission_at, parse_paloma_selector_and_payload,
+        redact_for_telegram, render_telegram_chunk, sanitize_telegram_visible_text,
+        scope_for_extracted_memory, telegram_action_target_matches, telegram_chat_display_title,
+        truncate_for_telegram, verify_internal_telegram_action_token, workflow_reply_text,
+        workflow_request_delivery_text, Chat, ExtractedTelegramMemory, Mission, MissionMode,
+        MissionStatus, TelegramAction, TelegramActionKind, TelegramAlert, TelegramBridge,
+        TelegramMemorySubject, TelegramMissionInterestLevel, TelegramStructuredMemoryEntry,
+        TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramUserRole,
     };
-    use crate::api::mission_store::{now_string, StoredEvent};
+    use crate::api::mission_store::StoredEvent;
+    use chrono::{TimeZone, Utc};
     use uuid::Uuid;
 
     fn test_mission(title: &str, status: MissionStatus) -> Mission {
@@ -5172,23 +5215,23 @@ mod tests {
     #[test]
     fn paloma_alert_kind_covers_attention_states() {
         assert_eq!(
-            paloma_alert_kind_for_status(MissionStatus::Completed),
-            Some("mission_completed")
+            paloma_alert_kind_for_status(MissionStatus::Active),
+            Some("mission_long_running")
         );
+        assert_eq!(paloma_alert_kind_for_status(MissionStatus::Completed), None);
         assert_eq!(
             paloma_alert_kind_for_status(MissionStatus::AwaitingUser),
-            Some("mission_awaiting_user")
+            None
         );
         assert_eq!(
             paloma_alert_kind_for_status(MissionStatus::NotFeasible),
-            Some("mission_not_feasible")
+            None
         );
-        assert_eq!(paloma_alert_kind_for_status(MissionStatus::Active), None);
     }
 
     #[test]
     fn paloma_alert_body_includes_latest_attention_context() {
-        let mission = test_mission("Checkout fix", MissionStatus::AwaitingUser);
+        let mission = test_mission("Checkout fix", MissionStatus::Active);
         let events = vec![StoredEvent {
             id: 1,
             mission_id: mission.id,
@@ -5204,7 +5247,7 @@ mod tests {
 
         let body = paloma_alert_body(&mission, &events);
 
-        assert!(body.contains("waiting for your input"));
+        assert!(body.contains("still running"));
         assert!(body.contains("Please confirm the deploy window"));
     }
 
@@ -5268,46 +5311,70 @@ mod tests {
     }
 
     #[test]
-    fn paloma_alert_backfill_guard_skips_old_terminal_missions() {
-        let mut old = test_mission("Old outage", MissionStatus::Failed);
-        old.updated_at = "2026-01-01T00:00:00Z".to_string();
-        assert!(!paloma_alert_transition_is_recent(&old));
+    fn paloma_alert_only_surfaces_long_running_quiet_active_missions() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 20, 1, 0, 0).unwrap();
 
-        let mut recent = test_mission("Current outage", MissionStatus::Failed);
-        recent.updated_at = now_string();
-        assert!(paloma_alert_transition_is_recent(&recent));
+        let mut active = test_mission("Long build", MissionStatus::Active);
+        active.created_at = "2026-05-20T00:00:00Z".to_string();
+        assert!(paloma_should_alert_long_running_mission_at(
+            &active,
+            &[],
+            now
+        ));
 
-        let mut stale_metadata_recent_status = test_mission("Recent status", MissionStatus::Failed);
-        stale_metadata_recent_status.metadata_updated_at = Some("2026-01-01T00:00:00Z".to_string());
-        stale_metadata_recent_status.updated_at = now_string();
-        assert!(paloma_alert_transition_is_recent(
-            &stale_metadata_recent_status
+        let mut fresh = active.clone();
+        fresh.created_at = "2026-05-20T00:45:00Z".to_string();
+        assert!(!paloma_should_alert_long_running_mission_at(
+            &fresh,
+            &[],
+            now
+        ));
+
+        let recent_user_message = vec![StoredEvent {
+            id: 1,
+            mission_id: active.id,
+            sequence: 1,
+            event_type: "user_message".to_string(),
+            timestamp: "2026-05-20T00:45:00Z".to_string(),
+            event_id: None,
+            tool_call_id: None,
+            tool_name: None,
+            content: "any update?".to_string(),
+            metadata: serde_json::json!({}),
+        }];
+        assert!(!paloma_should_alert_long_running_mission_at(
+            &active,
+            &recent_user_message,
+            now
+        ));
+
+        let completed = test_mission("Done", MissionStatus::Completed);
+        assert!(!paloma_should_alert_long_running_mission_at(
+            &completed,
+            &[],
+            now
         ));
     }
 
     #[test]
-    fn paloma_alert_event_kind_is_state_specific_and_subscription_can_raise_importance() {
-        let mission = test_mission("Checkout fix", MissionStatus::Completed);
-        let events = vec![StoredEvent {
-            id: 1,
-            mission_id: mission.id,
-            sequence: 1,
-            event_type: "mission_status_changed".to_string(),
-            timestamp: "2026-05-20T00:00:00Z".to_string(),
-            event_id: None,
-            tool_call_id: None,
-            tool_name: None,
-            content: String::new(),
-            metadata: serde_json::json!({ "status": "completed" }),
-        }];
+    fn paloma_alert_event_kind_is_bucketed_and_subscription_can_raise_importance() {
+        let mission = test_mission("Checkout fix", MissionStatus::Active);
+        let events = Vec::new();
+        let first_bucket = Utc.with_ymd_and_hms(2026, 5, 20, 1, 5, 0).unwrap();
+        let same_bucket = Utc.with_ymd_and_hms(2026, 5, 20, 1, 29, 0).unwrap();
+        let next_bucket = Utc.with_ymd_and_hms(2026, 5, 20, 1, 31, 0).unwrap();
 
-        assert!(
-            paloma_alert_event_kind(&mission, "mission_completed", &events)
-                .starts_with("mission_completed:2026-05-20T00-00-00Z")
+        assert_eq!(
+            paloma_alert_event_kind_at(&mission, "mission_long_running", &events, first_bucket),
+            paloma_alert_event_kind_at(&mission, "mission_long_running", &events, same_bucket)
+        );
+        assert_ne!(
+            paloma_alert_event_kind_at(&mission, "mission_long_running", &events, first_bucket),
+            paloma_alert_event_kind_at(&mission, "mission_long_running", &events, next_bucket)
         );
         assert_eq!(
             paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::Normal),
-            "low"
+            "normal"
         );
         assert_eq!(
             paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::High),
@@ -5347,7 +5414,12 @@ mod tests {
         ];
 
         assert_eq!(
-            paloma_alert_event_kind(&mission, "mission_awaiting_user", &events),
+            paloma_alert_event_kind_at(
+                &mission,
+                "mission_awaiting_user",
+                &events,
+                Utc.with_ymd_and_hms(2026, 5, 20, 1, 0, 0).unwrap()
+            ),
             "mission_awaiting_user:2026-05-20T00-05-00Z"
         );
     }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -682,13 +682,8 @@ fn paloma_alert_importance_for_mission(
     match mission.status {
         MissionStatus::Failed | MissionStatus::Blocked | MissionStatus::Interrupted => "high",
         MissionStatus::AwaitingUser | MissionStatus::NotFeasible => "normal",
-        MissionStatus::Completed => {
-            if mission.parent_mission_id.is_some() {
-                "normal"
-            } else {
-                "low"
-            }
-        }
+        MissionStatus::Completed if mission.parent_mission_id.is_some() => "normal",
+        MissionStatus::Completed => "low",
         _ => "low",
     }
 }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -689,18 +689,12 @@ fn paloma_alert_importance_for_mission(
 }
 
 fn paloma_alert_event_kind(mission: &Mission, base_kind: &str) -> String {
-    let updated = mission
-        .metadata_updated_at
-        .as_deref()
-        .unwrap_or(mission.updated_at.as_str());
+    let updated = mission.updated_at.as_str();
     format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
 }
 
 fn paloma_alert_transition_is_recent(mission: &Mission) -> bool {
-    let updated = mission
-        .metadata_updated_at
-        .as_deref()
-        .unwrap_or(mission.updated_at.as_str());
+    let updated = mission.updated_at.as_str();
     let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(updated) else {
         return true;
     };
@@ -5213,6 +5207,13 @@ mod tests {
         let mut recent = test_mission("Current outage", MissionStatus::Failed);
         recent.updated_at = now_string();
         assert!(paloma_alert_transition_is_recent(&recent));
+
+        let mut stale_metadata_recent_status = test_mission("Recent status", MissionStatus::Failed);
+        stale_metadata_recent_status.metadata_updated_at = Some("2026-01-01T00:00:00Z".to_string());
+        stale_metadata_recent_status.updated_at = now_string();
+        assert!(paloma_alert_transition_is_recent(
+            &stale_metadata_recent_status
+        ));
     }
 
     #[test]

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -631,6 +631,16 @@ async fn apply_paloma_interest_feedback(
     ctx.mission_store
         .upsert_telegram_mission_subscription(subscription)
         .await?;
+    if level == TelegramMissionInterestLevel::Muted {
+        let _ = ctx
+            .mission_store
+            .acknowledge_pending_telegram_alerts_for_mission(
+                user.telegram_user_id,
+                mission.id,
+                &now,
+            )
+            .await;
+    }
     let _ = ctx
         .mission_store
         .create_telegram_alert_preference(TelegramAlertPreference {
@@ -888,11 +898,44 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
             .await;
     }
 
-    let pending = ctx
+    let mut pending = ctx
         .mission_store
         .list_pending_telegram_alerts(owner_id, PALOMA_ALERT_DIGEST_LIMIT)
         .await
         .unwrap_or_default();
+    let muted_pending = pending
+        .iter()
+        .filter_map(|alert| alert.mission_id.map(|mission_id| (alert.id, mission_id)))
+        .filter(|(_, mission_id)| {
+            subscriptions
+                .get(mission_id)
+                .copied()
+                .unwrap_or(TelegramMissionInterestLevel::Normal)
+                == TelegramMissionInterestLevel::Muted
+        })
+        .collect::<Vec<_>>();
+    if !muted_pending.is_empty() {
+        let acknowledged_at = now_string();
+        for (_, mission_id) in &muted_pending {
+            let _ = ctx
+                .mission_store
+                .acknowledge_pending_telegram_alerts_for_mission(
+                    owner_id,
+                    *mission_id,
+                    &acknowledged_at,
+                )
+                .await;
+        }
+        pending.retain(|alert| {
+            alert.mission_id.is_none_or(|mission_id| {
+                subscriptions
+                    .get(&mission_id)
+                    .copied()
+                    .unwrap_or(TelegramMissionInterestLevel::Normal)
+                    != TelegramMissionInterestLevel::Muted
+            })
+        });
+    }
     if pending.is_empty() {
         return;
     }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -64,6 +64,8 @@ struct TelegramReplyRecord {
 const TELEGRAM_UPDATE_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_REPLY_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const PALOMA_ALERT_RECENCY_WINDOW_MINUTES: i64 = 60;
+const PALOMA_ALERT_DIGEST_LIMIT: usize = 12;
 const DEFAULT_PALOMA_OWNER_TELEGRAM_ID: i64 = 1_139_694_048;
 const DEFAULT_PALOMA_TRUSTED_FRIEND_TELEGRAM_ID: i64 = 0;
 
@@ -699,6 +701,18 @@ fn paloma_alert_event_kind(mission: &Mission, base_kind: &str) -> String {
     format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
 }
 
+fn paloma_alert_transition_is_recent(mission: &Mission) -> bool {
+    let updated = mission
+        .metadata_updated_at
+        .as_deref()
+        .unwrap_or(mission.updated_at.as_str());
+    let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(updated) else {
+        return true;
+    };
+    Utc::now() - updated_at.with_timezone(&Utc)
+        <= ChronoDuration::minutes(PALOMA_ALERT_RECENCY_WINDOW_MINUTES)
+}
+
 fn paloma_latest_attention_line(mission: &Mission, events: &[StoredEvent]) -> Option<String> {
     events
         .iter()
@@ -729,6 +743,77 @@ fn paloma_alert_body(mission: &Mission, events: &[StoredEvent]) -> String {
     }
 }
 
+fn paloma_alert_rank(alert: &TelegramAlert) -> i32 {
+    match alert.importance.as_str() {
+        "high" => 0,
+        "normal" => 1,
+        _ => 2,
+    }
+}
+
+fn paloma_alert_digest_line(alert: &TelegramAlert) -> String {
+    let mut lines = alert.body.lines();
+    let lead = lines
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .unwrap_or(alert.title.as_str());
+    let latest = lines.find_map(|line| line.trim().strip_prefix("Latest: "));
+    match latest {
+        Some(latest) if !latest.trim().is_empty() => {
+            format!("- {lead} Latest: {}", latest.trim())
+        }
+        _ => format!("- {lead}"),
+    }
+}
+
+fn paloma_alert_digest_text(alerts: &[TelegramAlert]) -> String {
+    if alerts.len() == 1 {
+        return redact_for_telegram(alerts[0].body.trim());
+    }
+
+    let mut sorted = alerts.to_vec();
+    sorted.sort_by(|a, b| {
+        paloma_alert_rank(a)
+            .cmp(&paloma_alert_rank(b))
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+
+    let high_count = sorted
+        .iter()
+        .filter(|alert| alert.importance == "high")
+        .count();
+    let mut text = if high_count > 0 {
+        format!(
+            "{} mission update{} {} attention:",
+            high_count,
+            if high_count == 1 { "" } else { "s" },
+            if high_count == 1 { "needs" } else { "need" }
+        )
+    } else {
+        format!(
+            "{} mission update{}:",
+            sorted.len(),
+            if sorted.len() == 1 { "" } else { "s" }
+        )
+    };
+
+    let visible = sorted.len().min(8);
+    for alert in sorted.iter().take(visible) {
+        text.push('\n');
+        text.push_str(&paloma_alert_digest_line(alert));
+    }
+    let remaining = sorted.len().saturating_sub(visible);
+    if remaining > 0 {
+        text.push_str(&format!(
+            "\n- {} more lower-priority update{}",
+            remaining,
+            if remaining == 1 { "" } else { "s" }
+        ));
+    }
+    redact_for_telegram(&text)
+}
+
 async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
     let Some(owner_id) =
         configured_telegram_id("PALOMA_TELEGRAM_OWNER_ID", DEFAULT_PALOMA_OWNER_TELEGRAM_ID)
@@ -755,6 +840,9 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
         let Some(base_kind) = paloma_alert_kind_for_status(mission.status) else {
             continue;
         };
+        if !paloma_alert_transition_is_recent(&mission) {
+            continue;
+        }
         let interest = subscriptions
             .get(&mission.id)
             .copied()
@@ -792,23 +880,26 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
 
     let pending = ctx
         .mission_store
-        .list_pending_telegram_alerts(owner_id, 5)
+        .list_pending_telegram_alerts(owner_id, PALOMA_ALERT_DIGEST_LIMIT)
         .await
         .unwrap_or_default();
     if pending.is_empty() {
         return;
     }
     let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
-    for alert in pending {
-        let text = format!("{}\n\n{}", alert.title, alert.body);
-        match send_message(http, &base_url, owner_id, &text, None).await {
-            Ok(message_id) => {
+    let text = paloma_alert_digest_text(&pending);
+    match send_message(http, &base_url, owner_id, &text, None).await {
+        Ok(message_id) => {
+            let sent_at = now_string();
+            for alert in pending {
                 let _ = ctx
                     .mission_store
-                    .mark_telegram_alert_sent(alert.id, Some(message_id), &now_string())
+                    .mark_telegram_alert_sent(alert.id, Some(message_id), &sent_at)
                     .await;
             }
-            Err(err) => {
+        }
+        Err(err) => {
+            for alert in pending {
                 tracing::warn!("Failed to send Telegram alert {}: {}", alert.id, err);
                 let _ = ctx
                     .mission_store
@@ -4806,17 +4897,19 @@ mod tests {
         extract_telegram_actions, feedback_mutes_alerts, feedback_raises_interest,
         format_structured_memory_context, is_paloma_command, markdown_to_telegram_html,
         merge_telegram_chat_metadata, mission_label, normalize_paloma_natural_command,
-        paloma_alert_body, paloma_alert_event_kind, paloma_alert_importance_for_mission,
-        paloma_alert_kind_for_status, paloma_command_error_response, paloma_role_for_user,
+        paloma_alert_body, paloma_alert_digest_text, paloma_alert_event_kind,
+        paloma_alert_importance_for_mission, paloma_alert_kind_for_status,
+        paloma_alert_transition_is_recent, paloma_command_error_response, paloma_role_for_user,
         parse_paloma_selector_and_payload, redact_for_telegram, render_telegram_chunk,
         sanitize_telegram_visible_text, scope_for_extracted_memory, telegram_action_target_matches,
         telegram_chat_display_title, truncate_for_telegram, verify_internal_telegram_action_token,
         workflow_reply_text, workflow_request_delivery_text, Chat, ExtractedTelegramMemory,
-        Mission, MissionMode, MissionStatus, TelegramAction, TelegramActionKind, TelegramBridge,
-        TelegramMemorySubject, TelegramMissionInterestLevel, TelegramStructuredMemoryEntry,
-        TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramUserRole,
+        Mission, MissionMode, MissionStatus, TelegramAction, TelegramActionKind, TelegramAlert,
+        TelegramBridge, TelegramMemorySubject, TelegramMissionInterestLevel,
+        TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
+        TelegramUserRole,
     };
-    use crate::api::mission_store::StoredEvent;
+    use crate::api::mission_store::{now_string, StoredEvent};
     use uuid::Uuid;
 
     fn test_mission(title: &str, status: MissionStatus) -> Mission {
@@ -4850,6 +4943,24 @@ mod tests {
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+        }
+    }
+
+    fn test_alert(title: &str, body: &str, importance: &str, created_at: &str) -> TelegramAlert {
+        TelegramAlert {
+            id: Uuid::new_v4(),
+            telegram_user_id: 1_139_694_048,
+            mission_id: Some(Uuid::new_v4()),
+            event_kind: format!("mission_update:{title}"),
+            importance: importance.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            status: "pending".to_string(),
+            telegram_message_id: None,
+            last_error: None,
+            created_at: created_at.to_string(),
+            sent_at: None,
+            acknowledged_at: None,
         }
     }
 
@@ -5037,6 +5148,57 @@ mod tests {
 
         assert!(body.contains("waiting for your input"));
         assert!(body.contains("Please confirm the deploy window"));
+    }
+
+    #[test]
+    fn paloma_alert_digest_coalesces_bursts_without_repeating_titles() {
+        let alerts = vec![
+            test_alert(
+                "Inventory",
+                "Inventory completed.\n\nLatest: Wrote the report.",
+                "low",
+                "2026-05-20T00:02:00Z",
+            ),
+            test_alert(
+                "Checkout fix",
+                "Checkout fix is waiting for your input.\n\nLatest: Please confirm the deploy window.",
+                "high",
+                "2026-05-20T00:01:00Z",
+            ),
+        ];
+
+        let body = paloma_alert_digest_text(&alerts);
+
+        assert!(body.starts_with("1 mission update needs attention:"));
+        assert!(body.contains("- Checkout fix is waiting for your input. Latest: Please confirm"));
+        assert!(body.contains("- Inventory completed. Latest: Wrote the report."));
+        assert!(!body.contains("Checkout fix\n\nCheckout fix"));
+    }
+
+    #[test]
+    fn paloma_single_alert_uses_body_only() {
+        let alerts = vec![test_alert(
+            "Checkout fix",
+            "Checkout fix failed.\n\nLatest: Tests failed.",
+            "high",
+            "2026-05-20T00:01:00Z",
+        )];
+
+        assert_eq!(
+            paloma_alert_digest_text(&alerts),
+            "Checkout fix failed.\n\nLatest: Tests failed."
+        );
+    }
+
+    #[test]
+    fn paloma_alert_backfill_guard_skips_old_terminal_missions() {
+        let mut old = test_mission("Old outage", MissionStatus::Failed);
+        old.updated_at = "2026-01-01T00:00:00Z".to_string();
+        assert!(!paloma_alert_transition_is_recent(&old));
+
+        let mut recent = test_mission("Current outage", MissionStatus::Failed);
+        recent.updated_at = now_string();
+        assert!(paloma_alert_transition_is_recent(&recent));
     }
 
     #[test]

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -490,8 +490,16 @@ fn feedback_mutes_alerts(text: &str) -> bool {
     let normalized = text.trim().to_ascii_lowercase();
     normalized.contains("don't tell me about this again")
         || normalized.contains("dont tell me about this again")
+        || normalized.contains("i am not interested in these updates")
+        || normalized.contains("i'm not interested in these updates")
+        || normalized.contains("not interested in these updates")
+        || normalized.contains("not interested in this")
         || normalized.contains("mute this")
+        || normalized.contains("too many updates")
+        || normalized.contains("stop these updates")
         || normalized.contains("stop alerting me about this")
+        || normalized.contains("stop sending me updates about this")
+        || normalized.contains("stop updating me about this")
 }
 
 fn feedback_raises_interest(text: &str) -> bool {
@@ -5097,6 +5105,11 @@ mod tests {
     #[test]
     fn paloma_feedback_parser_recognizes_interest_changes() {
         assert!(feedback_mutes_alerts("Don't tell me about this again."));
+        assert!(feedback_mutes_alerts(
+            "I'm not interested in these updates."
+        ));
+        assert!(feedback_mutes_alerts("This is too many updates."));
+        assert!(feedback_mutes_alerts("Stop these updates please."));
         assert!(feedback_raises_interest("Keep me posted on this."));
         assert!(!feedback_mutes_alerts("what changed?"));
     }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -688,8 +688,21 @@ fn paloma_alert_importance_for_mission(
     }
 }
 
-fn paloma_alert_event_kind(mission: &Mission, base_kind: &str) -> String {
-    let updated = mission.updated_at.as_str();
+fn paloma_alert_event_kind(mission: &Mission, base_kind: &str, events: &[StoredEvent]) -> String {
+    let status = mission.status.to_string();
+    let updated = events
+        .iter()
+        .rev()
+        .find(|event| {
+            event.event_type == "mission_status_changed"
+                && event
+                    .metadata
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    == Some(status.as_str())
+        })
+        .map(|event| event.timestamp.as_str())
+        .unwrap_or(mission.updated_at.as_str());
     format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
 }
 
@@ -853,7 +866,7 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
                 id: Uuid::new_v4(),
                 telegram_user_id: owner_id,
                 mission_id: Some(mission.id),
-                event_kind: paloma_alert_event_kind(&mission, base_kind),
+                event_kind: paloma_alert_event_kind(&mission, base_kind, &events),
                 importance: paloma_alert_importance_for_mission(&mission, interest).to_string(),
                 title,
                 body,
@@ -5219,9 +5232,23 @@ mod tests {
     #[test]
     fn paloma_alert_event_kind_is_state_specific_and_subscription_can_raise_importance() {
         let mission = test_mission("Checkout fix", MissionStatus::Completed);
+        let events = vec![StoredEvent {
+            id: 1,
+            mission_id: mission.id,
+            sequence: 1,
+            event_type: "mission_status_changed".to_string(),
+            timestamp: "2026-05-20T00:00:00Z".to_string(),
+            event_id: None,
+            tool_call_id: None,
+            tool_name: None,
+            content: String::new(),
+            metadata: serde_json::json!({ "status": "completed" }),
+        }];
 
-        assert!(paloma_alert_event_kind(&mission, "mission_completed")
-            .starts_with("mission_completed:2026-05-20T00-00-00Z"));
+        assert!(
+            paloma_alert_event_kind(&mission, "mission_completed", &events)
+                .starts_with("mission_completed:2026-05-20T00-00-00Z")
+        );
         assert_eq!(
             paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::Normal),
             "low"
@@ -5229,6 +5256,43 @@ mod tests {
         assert_eq!(
             paloma_alert_importance_for_mission(&mission, TelegramMissionInterestLevel::High),
             "high"
+        );
+    }
+
+    #[test]
+    fn paloma_alert_event_kind_ignores_non_status_mission_updates() {
+        let mut mission = test_mission("Checkout fix", MissionStatus::AwaitingUser);
+        mission.updated_at = "2026-05-20T00:20:00Z".to_string();
+        let events = vec![
+            StoredEvent {
+                id: 1,
+                mission_id: mission.id,
+                sequence: 1,
+                event_type: "mission_status_changed".to_string(),
+                timestamp: "2026-05-20T00:05:00Z".to_string(),
+                event_id: None,
+                tool_call_id: None,
+                tool_name: None,
+                content: String::new(),
+                metadata: serde_json::json!({ "status": "awaiting_user" }),
+            },
+            StoredEvent {
+                id: 2,
+                mission_id: mission.id,
+                sequence: 2,
+                event_type: "assistant_message".to_string(),
+                timestamp: "2026-05-20T00:15:00Z".to_string(),
+                event_id: None,
+                tool_call_id: None,
+                tool_name: None,
+                content: "Still waiting for approval.".to_string(),
+                metadata: serde_json::json!({}),
+            },
+        ];
+
+        assert_eq!(
+            paloma_alert_event_kind(&mission, "mission_awaiting_user", &events),
+            "mission_awaiting_user:2026-05-20T00-05-00Z"
         );
     }
 

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -756,6 +756,9 @@ fn paloma_should_alert_long_running_mission_at(
     if mission.status != MissionStatus::Active {
         return false;
     }
+    if mission.mission_mode == MissionMode::Assistant {
+        return false;
+    }
     let Some(started_at) = paloma_mission_started_at(mission) else {
         return true;
     };
@@ -875,6 +878,28 @@ fn paloma_alert_digest_text(alerts: &[TelegramAlert]) -> String {
     redact_for_telegram(&text)
 }
 
+async fn paloma_pending_alert_still_eligible(
+    ctx: &ChannelContext,
+    alert: &TelegramAlert,
+    now: chrono::DateTime<Utc>,
+) -> bool {
+    let Some(mission_id) = alert.mission_id else {
+        return true;
+    };
+    let Ok(Some(mission)) = ctx.mission_store.get_mission(mission_id).await else {
+        return false;
+    };
+    if mission.status != MissionStatus::Active {
+        return false;
+    }
+    let events = ctx
+        .mission_store
+        .get_events(mission.id, None, Some(40), None)
+        .await
+        .unwrap_or_default();
+    paloma_should_alert_long_running_mission_at(&mission, &events, now)
+}
+
 async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
     let Some(owner_id) =
         configured_telegram_id("PALOMA_TELEGRAM_OWNER_ID", DEFAULT_PALOMA_OWNER_TELEGRAM_ID)
@@ -977,6 +1002,26 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
                     != TelegramMissionInterestLevel::Muted
             })
         });
+    }
+    if !pending.is_empty() {
+        let checked_at = Utc::now();
+        let mut eligible_pending = Vec::with_capacity(pending.len());
+        let acknowledged_at = now_string();
+        for alert in pending {
+            if paloma_pending_alert_still_eligible(ctx, &alert, checked_at).await {
+                eligible_pending.push(alert);
+            } else if let Some(mission_id) = alert.mission_id {
+                let _ = ctx
+                    .mission_store
+                    .acknowledge_pending_telegram_alerts_for_mission(
+                        owner_id,
+                        mission_id,
+                        &acknowledged_at,
+                    )
+                    .await;
+            }
+        }
+        pending = eligible_pending;
     }
     if pending.is_empty() {
         return;
@@ -5351,6 +5396,14 @@ mod tests {
         let completed = test_mission("Done", MissionStatus::Completed);
         assert!(!paloma_should_alert_long_running_mission_at(
             &completed,
+            &[],
+            now
+        ));
+
+        let mut assistant = active.clone();
+        assistant.mission_mode = MissionMode::Assistant;
+        assert!(!paloma_should_alert_long_running_mission_at(
+            &assistant,
             &[],
             now
         ));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -3211,6 +3211,7 @@ fn read_custom_providers_from_file(workspace_root: &Path) -> Vec<AIProvider> {
 /// MCP mints a service JWT scoped to that user — putting any worker missions
 /// it creates into the same per-user mission store as the boss instead of the
 /// MCP's own implicit `orchestrator-mcp` store.
+#[allow(clippy::too_many_arguments)]
 pub async fn prepare_mission_workspace_with_skills_backend(
     workspace: &Workspace,
     mcp: &McpRegistry,


### PR DESCRIPTION
## Summary
- make Paloma alert only on long-running missions that need attention and suppress updates when the user recently messaged the mission
- batch/dedupe proactive Telegram alerts, respect mute feedback, avoid stale terminal backfill, and keep retry state reliable
- align completed/interrupted mission status semantics used by Telegram and the iOS app
- polish iOS mission UI by hiding latest-thought footer for finished missions and using a blue spinner-style running indicator

## Verification
- cargo fmt --check
- cargo clippy --locked --workspace -- -D clippy::all
- cargo check
- cargo test telegram::tests::paloma_alert --lib -- --nocapture
- cargo test telegram::tests::extract_structured_memory --lib -- --nocapture
- cargo test mission_runner::tests::inject_telegram_identity --lib -- --nocapture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Telegram alert planning/delivery and alert persistence semantics (dedupe, retry, acknowledging), which could change notification behavior and require careful validation. iOS changes are mostly UI/state filtering but interact with mission lifecycle edge cases.
> 
> **Overview**
> **Paloma/Telegram alerts are redesigned to be quieter and more reliable.** Alerts now focus on *long-running active missions* (with time + recent-user-message quiet windows), dedupe using bucketed `event_kind`, and deliver as a single digest message (ranked by importance) instead of one message per alert.
> 
> **Alert persistence and muting semantics change.** Telegram alert failures are now recorded while keeping alerts `pending` for retry, and a new store API acknowledges all pending alerts for a muted mission so they won’t be delivered or re-queued; watchdog logic also avoids auto-interrupting idle `Assistant`-mode missions.
> 
> **iOS mission state polish.** Running indicators switch to a blue spinner treatment and use `Theme.info` instead of success-green; inline “latest thought” rendering is gated to only show while the viewed mission is truly running, and “interrupted” updates are ignored if the mission already finished successfully, with finished missions filtered out of the running list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a4f44fe193950a2c6de0af595045c4a7dc01d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->