### PR TITLE
Adapt Paloma toward QwenPaw runtime model

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -851,6 +851,8 @@ function missionStatusLabel(
   }
 
   switch (status) {
+    case "pending":
+      return { label: "Pending", className: "bg-zinc-500/20 text-zinc-400" };
     case "active":
       return { label: "Active", className: "bg-indigo-500/20 text-indigo-400" };
     case "awaiting_user":

--- a/docs/PALOMA_QWENPAW_ADAPTATION_PLAN.md
+++ b/docs/PALOMA_QWENPAW_ADAPTATION_PLAN.md
@@ -1,0 +1,388 @@
+# Paloma / QwenPaw Adaptation Plan
+
+This plan is for evolving Paloma toward the useful parts of QwenPaw while
+keeping Sandboxed.sh as the control plane.
+
+## Decision
+
+Do not replace Paloma with a long-lived QwenPaw mission.
+
+Build Paloma as a Sandboxed.sh service and borrow QwenPaw's runtime patterns:
+
+- per-channel/session queueing
+- channel abstraction
+- named cron/heartbeat jobs
+- memory consolidation lifecycle
+- explicit tool/capability registry
+
+Do not borrow QwenPaw's proactive loop directly. It is memory/idle driven and
+too broad for mission operations. Paloma proactivity should be event and policy
+driven.
+
+## Current State
+
+`src/api/telegram.rs` already contains a good first Paloma:
+
+- owner and trusted-friend roles
+- `/status`, `/missions`, `/summary`, `/send`, `/approve`
+- shared-chat summary restrictions
+- natural command normalization
+- alert planning for long-running, awaiting-user, completed, failed, blocked,
+  interrupted, and not-feasible missions
+- quiet period after user messages
+- alert dedupe by event kind
+- digest formatting
+- mute/high-interest feedback
+- scheduled Telegram messages
+- structured Telegram memory
+- workflow/request-reply support
+
+The problem is not missing behavior. The problem is that behavior, policy,
+delivery, storage calls, and scheduler loops are mixed into one Telegram module.
+
+Latest `master` was pulled into `paloma-long-running-ios-fixes` on
+2026-05-22. The Paloma-specific local changes still apply cleanly and the
+focused Telegram/Paloma unit tests pass.
+
+## Target Shape
+
+```text
+Telegram webhook
+  -> channel adapter
+  -> Paloma event queue
+  -> Paloma planner
+  -> policy engine
+  -> decision log
+  -> delivery adapter
+  -> Telegram
+
+Mission store / runner events
+  -> Paloma observer
+  -> same planner/policy/delivery path
+
+Optional local satellite
+  -> capability registry
+  -> remote Paloma tool calls
+```
+
+Paloma should own decisions. Telegram should only deliver messages.
+
+LLM components may draft text or classify intent, but they should return
+proposals. Sandboxed.sh decides whether to send, suppress, batch, or ask for
+confirmation.
+
+This boundary is stricter than QwenPaw's current proactive implementation:
+QwenPaw can generate proactive work from idle/memory state and then send via its
+channel message API. Paloma should never give a long-lived brain that direct
+send path in production.
+
+## Module Split
+
+Start with a mechanical extraction from `telegram.rs`:
+
+```text
+src/api/paloma/
+  mod.rs
+  event.rs        normalized events and reason codes
+  policy.rs       deterministic allow/suppress rules
+  planner.rs      mission state -> alert proposals
+  digest.rs       alert body/digest formatting
+  commands.rs     /status, /missions, /summary, /send, /approve
+  memory.rs       structured preference/memory helpers
+  queue.rs        per-channel/session queue
+  decision_log.rs auditable decision records
+```
+
+Keep existing Telegram tables at first. Rename/generalize only after the module
+boundary is stable.
+
+## Policy Rules
+
+Default Paloma policy:
+
+- Always alert when a mission is awaiting user input.
+- Alert long-running active task missions only after the threshold.
+- Suppress long-running alerts if the user messaged the mission recently.
+- Alert terminal states only for long-running or high-interest missions.
+- Do not alert for assistant-mode missions.
+- Mute beats every other rule.
+- High-interest raises priority but does not bypass safety.
+- Batch multiple pending alerts into one digest.
+- Never let an LLM directly send proactive Telegram messages.
+
+Useful future rules:
+
+- max one proactive digest per user/window
+- active hours / sleep windows
+- project-level mute/high-interest
+- "only failures for this mission"
+- "keep me posted until this is done"
+- dashboard view updates briefing cursor
+
+## QwenPaw Patterns To Adapt
+
+### Queue
+
+QwenPaw's `UnifiedQueueManager` uses `(channel_id, session_id, priority)` keys,
+on-demand consumers, batch merging, queue metrics, and idle cleanup.
+
+Paloma should implement the same idea in Rust:
+
+```text
+QueueKey = { channel, chat/user, optional mission, priority }
+```
+
+Use it for:
+
+- inbound Telegram messages
+- natural feedback
+- alert planning
+- scheduled reminders
+- workflow replies
+
+Important adaptation: keep per-session serialization, bounded queueing,
+cleanup, and metrics, but do not allow separate priority queues for the same
+mission to reorder control messages unless the priority rule is explicit and
+tested.
+
+### Cron
+
+QwenPaw's cron manager separates job specs, runtime state, history, and
+execution. Paloma should replace the single Telegram scheduler loop with named
+jobs:
+
+- `paloma_alert_scan`
+- `paloma_due_messages`
+- `paloma_memory_consolidation`
+- `paloma_digest_flush`
+- `paloma_stale_recovery`
+
+Each job needs state/history and a single-writer lease in production.
+
+### Memory
+
+QwenPaw's useful pattern is the memory lifecycle:
+
+```text
+accumulate -> consolidate -> retrieve -> serve
+```
+
+For Paloma:
+
+- accumulate explicit facts/preferences from Telegram and mission feedback
+- consolidate duplicates/conflicts periodically
+- retrieve preferences during planning
+- serve only through deterministic policy gates
+
+Do not copy broad idle proactivity.
+
+### Tools / MCP
+
+QwenPaw exposes built-in tools and MCP per agent. Paloma should expose a smaller
+capability registry:
+
+- list/summarize missions
+- send message to mission
+- schedule reminder
+- update notification preference
+- request local satellite capability
+
+The future laptop satellite should register capabilities with remote Paloma. It
+must not become the canonical Paloma.
+
+## QwenPaw As Brain Prototype
+
+Later, QwenPaw can be tested behind a `PalomaBrain` interface:
+
+```text
+classify_message(context) -> intent
+draft_digest(context) -> text
+extract_preference(message) -> preference proposal
+summarize_mission(events) -> summary
+```
+
+It must not own:
+
+- Telegram sending
+- mission lifecycle
+- scheduler source of truth
+- durable memory
+- dedupe
+- alert policy
+- secrets
+
+Dev-only experiment:
+
+```text
+Paloma event/context
+  -> QwenPaw-backed brain
+  -> PalomaIntent proposals
+  -> decision log
+  -> policy engine
+  -> optional Telegram send
+```
+
+Run this in shadow mode first. Compare QwenPaw proposals against the
+deterministic planner, but suppress all QwenPaw-triggered sends until the
+decision log proves the proposals are useful and quiet.
+
+## Development Plan
+
+### 1. Shadow Decision Log
+
+Add `paloma_decisions` before changing behavior.
+
+Record:
+
+- event source
+- mission id
+- user id/channel
+- reason code
+- proposed action
+- allowed/suppressed
+- suppression reason
+- policy snapshot
+- generated text hash or preview
+
+Success gate:
+
+- every alert considered by current code is explainable
+- no Telegram behavior change yet
+
+### 2. Extract Paloma Core
+
+Move tested pure functions out of `telegram.rs` without changing behavior.
+
+Success gate:
+
+- existing Telegram/Paloma unit tests pass
+- code paths still use Telegram delivery exactly as before
+
+### 3. Add Queue
+
+Introduce Paloma queue with the QwenPaw key idea.
+
+Success gate:
+
+- burst Telegram messages serialize per chat/mission
+- unrelated chats/missions can proceed independently
+- queue metrics visible in logs/debug endpoint
+- queue shutdown is graceful during hotswap/deploy
+
+### 4. Split Scheduler Jobs
+
+Replace the single scheduler loop with named Paloma jobs.
+
+Success gate:
+
+- scheduled messages still claim atomically
+- alert scan cannot double-send after deploy/restart
+- job history explains last run and failures
+
+### 5. Preference Policy
+
+Promote feedback from text rules to structured policy.
+
+Success gate:
+
+- "mute this" suppresses future routine alerts
+- "only tell me if this fails" works
+- user can inspect why a message was sent or suppressed
+
+### 6. Memory Consolidation
+
+Add a conservative consolidation job for Paloma preferences and facts.
+
+Success gate:
+
+- no opaque prompt-only memory
+- each consolidated rule points back to source messages
+- conflicting rules prefer latest explicit user instruction
+
+### 7. Brain Interface
+
+Add pluggable `PalomaBrain`.
+
+Success gate:
+
+- default deterministic/current brain works
+- QwenPaw-backed brain can run in dev as shadow/proposal-only
+- LLM output never bypasses policy
+
+Initial brain methods should stay narrow:
+
+- `classify_user_message`
+- `extract_preference`
+- `draft_digest`
+- `summarize_mission`
+
+Do not expose arbitrary tool execution through this interface.
+
+### 8. Local Satellite
+
+Add outbound laptop satellite protocol.
+
+Success gate:
+
+- remote Paloma answers when satellite is offline
+- satellite registers tools/capabilities when online
+- local tools require explicit capability and audit logging
+
+## Testing Plan
+
+Unit tests:
+
+- policy matrix for statuses, interest, quiet windows, mute/high-interest
+- digest formatting and overflow
+- decision logging
+- queue serialization and cleanup
+- scheduler job claim/retry behavior
+
+Integration tests:
+
+- synthetic mission lifecycle to alert proposals
+- duplicate scheduler instance cannot double-send
+- Telegram webhook duplicate update ignored
+- dashboard cursor vs Telegram cursor behavior
+
+Live dev Telegram smoke:
+
+- `/status`
+- `/missions`
+- `/summary`
+- reply to alert routes to the right mission
+- mute/high-interest feedback
+- rapid burst messages
+- awaiting-user alert
+- long-running alert suppressed after recent user message
+- completed mission not mislabeled interrupted
+- file caption redaction for shared files
+- shared-chat `/summary` allowed only for trusted users in allowlisted chats
+
+Telegram access needed for these tests:
+
+- dev bot token or permission to use the existing Paloma bot in a dev channel
+- Thomas owner Telegram user id already allowlisted or provided for dev
+- one private DM with the bot for owner-control tests
+- one allowlisted shared test chat, ideally with a trusted-friend account
+- permission to send burst messages, replies to Paloma alerts, and mute/high
+  interest feedback during test windows
+- a way to inspect dev server logs/database while tests run
+
+Production canary:
+
+- shadow decision logs first
+- one trigger at a time
+- low frequency
+- inspect `paloma_decisions` before enabling sends
+
+## Open Risks
+
+- Mission status classification may still explain "completed shown as
+  interrupted"; verify with event logs from affected missions.
+- Current in-process scheduler guard prevents duplicate loops per process, but
+  production deploys may still need a DB lease for single-writer behavior.
+- QwenPaw proactive behavior is beta and idle/memory driven; use only in dev
+  shadow mode until policy gates are proven.
+- Generalizing Telegram tables too early could create churn. Extract modules
+  first, rename persistence later.

--- a/docs/PALOMA_QWENPAW_COMPLETION_AUDIT.md
+++ b/docs/PALOMA_QWENPAW_COMPLETION_AUDIT.md
@@ -1,0 +1,366 @@
+# Paloma / QwenPaw Completion Audit
+
+Date: 2026-05-22
+
+## Objective
+
+Implement the distilled plan in `docs/PALOMA_QWENPAW_ADAPTATION_PLAN.md` and
+test every feature using the user's Telegram account.
+
+## Prompt-to-Artifact Checklist
+
+- `PALOMA_QWENPAW_ADAPTATION_PLAN.md`: implemented as the active source plan in
+  `docs/`.
+- Keep Paloma as a Sandboxed.sh service, not a long-lived QwenPaw mission:
+  implemented in the existing Rust API service under `src/api/`.
+- Module split:
+  `src/api/paloma/{event,channel,policy,planner,digest,commands,memory,queue,decision_log,scheduler,brain,capability,satellite}.rs`.
+- Shadow decision log:
+  `paloma_decisions` store APIs, SQLite table, Telegram decision writes, and
+  `/api/control/paloma/decisions`.
+- Extract Paloma core:
+  Telegram delegates command parsing, policy/planning, digest formatting,
+  queueing, scheduling, decision logging, and memory consolidation to Paloma
+  modules while retaining Telegram as the delivery adapter.
+- Queue:
+  `paloma::queue`, webhook queue integration, per-session lock preservation,
+  and `/api/control/paloma/queue`.
+- Split scheduler jobs:
+  `paloma_scheduler_jobs` table, job claim/finish APIs, named Telegram scheduler
+  jobs, and `/api/control/paloma/jobs`.
+- Preference policy:
+  mute, high-interest, failure-only, `/why`, and feedback routing are covered by
+  code paths and unit/live smoke tests.
+- Memory consolidation:
+  `consolidate_telegram_structured_memory` keeps the latest explicit
+  fact/preference and removes stale FTS rows.
+- Brain interface:
+  `PalomaBrain`, deterministic implementation, and shadow/proposal-only wrapper.
+- Local satellite:
+  `LocalSatelliteRegistry`, capability request/response records, online checks,
+  and audit records.
+- Capability registry:
+  default audited capabilities for mission listing/summarizing, mission sends,
+  reminders, notification preferences, and satellite requests.
+- Unit/integration coverage:
+  `cargo test paloma --all-targets` and `cargo test --all-targets` pass on the
+  current working tree.
+- Live Telegram smoke:
+  `scripts/paloma_live_smoke.py` exists and passes against the available
+  deployed `ana_lfgbot` using the bundled Telethon user session.
+- Exact-checkout Telegram verification:
+  the handoff zip provides user-account control, not a bot token, local webhook
+  tunnel, or authenticated Sandboxed.sh control session. The local checkout is
+  therefore verified by Rust tests and the deployed Paloma path is verified by
+  live Telegram smoke, but this working tree is not connected to Telegram.
+
+## Implementation Evidence
+
+- Paloma remains a Sandboxed.sh service, not a long-lived QwenPaw mission.
+- Core modules were extracted under `src/api/paloma/`:
+  - `event.rs`
+  - `channel.rs`
+  - `policy.rs`
+  - `planner.rs`
+  - `digest.rs`
+  - `commands.rs`
+  - `memory.rs`
+  - `queue.rs`
+  - `decision_log.rs`
+  - `scheduler.rs`
+  - `brain.rs`
+  - `capability.rs`
+  - `satellite.rs`
+- Telegram now delegates command parsing, alert planning, digest formatting,
+  decision logging, queueing, and scheduler state to Paloma modules.
+- Paloma has normalized channel address and message envelopes for future
+  adapters while Telegram remains the concrete delivery adapter.
+- `paloma_decisions` and `paloma_scheduler_jobs` are persisted in SQLite.
+- Control endpoints expose:
+  - `GET /api/control/paloma/decisions`
+  - `GET /api/control/paloma/jobs`
+  - `GET /api/control/paloma/queue`
+- Named jobs have concrete behavior:
+  - `paloma_alert_scan`: plans and creates alert records.
+  - `paloma_due_messages`: atomically claims and sends due Telegram messages.
+  - `paloma_memory_consolidation`: removes stale explicit memory duplicates and
+    cleans memory search rows.
+  - `paloma_stale_recovery`: clears stale pending alert delivery errors.
+  - `paloma_digest_flush`: sends eligible pending alert digests.
+- `PalomaBrain` is proposal-only. Shadow/QwenPaw-backed proposals cannot bypass
+  policy or send directly.
+- The default Paloma capability surface is modeled:
+  - `list_missions`
+  - `summarize_mission`
+  - `send_message_to_mission`
+  - `schedule_reminder`
+  - `update_notification_preference`
+  - `request_local_satellite_capability`
+- Local satellite capability handling requires online registration, explicit
+  capability, request/response protocol records, and audit records.
+- `scripts/paloma_live_smoke.py` provides an executable Telegram-user smoke
+  checklist for DM commands, burst handling, alert feedback, and shared-chat
+  checks. It also has `--preflight-only` to verify local Telegram/API readiness
+  without connecting to Telegram or sending messages; preflight does not require
+  Telethon to be installed.
+
+## Local Verification
+
+Executed on the current working tree:
+
+```text
+cargo test paloma --all-targets
+```
+
+Result:
+
+```text
+46 passed; 0 failed
+```
+
+Executed on the current working tree:
+
+```text
+cargo test --all-targets
+```
+
+Result:
+
+```text
+main library: 805 passed; 0 failed; 2 ignored
+bin targets: passed
+```
+
+Executed on touched Rust files:
+
+```text
+rustfmt --edition 2021 --check \
+  src/api/control.rs \
+  src/api/mission_store/mod.rs \
+  src/api/mission_store/sqlite.rs \
+  src/api/mod.rs \
+  src/api/routes.rs \
+  src/api/telegram.rs \
+  src/api/paloma/*.rs
+```
+
+Result: passed.
+
+Executed on the live-smoke harness:
+
+```text
+python3 -m py_compile scripts/paloma_live_smoke.py
+```
+
+Result: passed.
+
+Executed dependency-light preflight with site packages disabled:
+
+```text
+python3 -S scripts/paloma_live_smoke.py --preflight-only \
+  --mission-db /root/.sandboxed-sh/missions/missions-dev.db \
+  --api-token "$SANDBOXED_PROXY_SECRET"
+```
+
+Result: preflight executed without importing Telethon and reported the expected
+missing Telegram/API readiness evidence.
+
+Executed the non-mutating live-smoke preflight against this environment:
+
+```text
+python3 scripts/paloma_live_smoke.py --preflight-only --api-token "$SANDBOXED_PROXY_SECRET"
+```
+
+Result:
+
+```text
+PASS telegram_api_id
+PASS telegram_api_hash
+PASS telegram_session_file
+FAIL local_telegram_channels: count=0
+PASS api_health
+FAIL api_control_auth: status=401, body='Invalid or expired token'
+```
+
+Executed the non-mutating live-smoke preflight with the encrypted local
+Telegram env:
+
+```text
+dotenvx run -f .env.telegram -fk .env.telegram.keys -- \
+  python3 scripts/paloma_live_smoke.py --preflight-only
+```
+
+Result:
+
+```text
+PASS telegram_api_id
+PASS telegram_api_hash
+PASS telegram_session_file
+FAIL local_telegram_channels: count=0
+PASS api_health
+FAIL api_control_auth: missing PALOMA_API_TOKEN/--api-token
+```
+
+## Live Telegram Verification
+
+The user's Telegram account session was used through Telethon.
+
+Reduced harness run against the available deployed bot `ana_lfgbot` passed:
+
+- `/status`
+- `/missions`
+- `/summary`
+- `/why`
+- `/approve` usage guard
+- `/send` usage guard
+- burst message handling
+
+The latest reduced harness command used the encrypted local Telegram env:
+
+```text
+dotenvx run -f .env.telegram -fk .env.telegram.keys -- \
+  python3 scripts/paloma_live_smoke.py \
+    --dm-chat ana_lfgbot \
+    --watch-seconds 45 \
+    --skip-shared \
+    --skip-alert-feedback
+```
+
+Result:
+
+```text
+/status: sent 252326, reply 252327
+/missions: sent 252328, reply 252329
+/summary: sent 252330, reply 252331
+/why: sent 252332, reply 252333
+/approve usage: sent 252334, reply 252335
+/send usage: sent 252336, reply 252337
+burst: sent 252338-252340, replies 252341-252343
+```
+
+Full harness run against the available deployed bot `ana_lfgbot` passed again
+after the handoff zip was revalidated:
+
+- `/status`
+- `/missions`
+- `/summary`
+- `/why`
+- `/approve` usage guard
+- `/send` usage guard
+- burst message handling
+- reply-to-alert high-interest feedback
+- reply-to-alert failure-only feedback
+- reply-to-alert mute feedback
+- restore high-interest feedback after mute
+- shared-chat plain `/summary` silence
+- shared-chat `@ana_lfgbot /summary` silence
+
+The full harness command used:
+
+```text
+python3 scripts/paloma_live_smoke.py \
+  --dm-chat ana_lfgbot \
+  --bot-username ana_lfgbot \
+  --watch-seconds 25 \
+  --alert-message-id 252182 \
+  --shared-chat -1001730152948
+```
+
+The latest successful run sent and received these key Telegram message ids:
+
+```text
+/status: sent 252298, reply 252299
+/missions: sent 252300, reply 252301
+/summary: sent 252302, reply 252303
+/why: sent 252304, reply 252305
+/approve usage: sent 252306, reply 252307
+/send usage: sent 252308, reply 252309
+burst: sent 252310-252312, replies 252313-252315
+alert feedback: sent 252316-252322, replies 252317-252323
+shared silence probes: sent 21072-21073, no bot reply
+```
+
+## Remaining Gap
+
+The live Telegram verification above exercised the available deployed bot with
+the user's Telegram account, not this exact local checkout.
+
+The provided handoff zip was set up and used successfully. It contains:
+
+- Telegram API credentials.
+- An authorized Telethon user session.
+- A client-side smoke helper.
+
+That is sufficient to act as the Telegram user and validate bot UX from the
+client side. It is not sufficient to run this local checkout behind Telegram,
+because Sandboxed.sh uses Telegram webhooks and local channel creation requires
+a bot token plus a public webhook URL or an authenticated deployed control API.
+
+The local checkout currently has no configured Telegram channel or bot token in
+the local mission databases, and the service already listening on
+`127.0.0.1:3000` is authenticated and appears to be a separate running
+deployment. Therefore, the strict requirement "test every feature using my
+Telegram account" is not fully satisfied for this exact working tree.
+
+Current blocker evidence:
+
+```text
+sqlite3 /root/.sandboxed-sh/missions/missions-dev.db \
+  "SELECT COUNT(*) AS telegram_channel_count FROM telegram_channels;"
+```
+
+Result:
+
+```text
+0
+```
+
+```text
+curl -sS http://127.0.0.1:3000/api/health
+```
+
+Result:
+
+```text
+{"status":"ok","version":"0.12.0","dev_mode":false,"auth_required":true,"auth_mode":"single_tenant",...}
+```
+
+Authenticated control calls with the available proxy secret return
+`Invalid or expired token`, so the local server cannot be configured or
+inspected through the API from this session.
+
+The configured public backend behaves the same way:
+
+```text
+curl -sS https://agent-backend.thomas.md/api/health
+```
+
+Result:
+
+```text
+{"status":"ok","version":"0.12.0","dev_mode":false,"auth_required":true,"auth_mode":"single_tenant",...}
+```
+
+Control calls to `https://agent-backend.thomas.md/api/control/...` with the
+available proxy secret also return `Invalid or expired token`.
+
+The dashboard stores API auth as `openagent.jwt`; Chrome local/session storage
+was inspected for `openagent.jwt`, `openagent.jwt_exp`, backend URLs, and
+JWT-shaped values. No usable dashboard JWT was present.
+
+```text
+rg -l '[0-9]{7,}:[A-Za-z0-9_-]{20,}' /workspaces/mission-8d49a528 /root/.sandboxed-sh
+```
+
+Result: only Telegram documentation files with example tokens matched; no local
+bot-token configuration was found.
+
+Completion requires one of:
+
+- running this branch behind the Telegram bot used by the user's account, or
+- configuring a dev Telegram bot/channel in this local checkout and pointing its
+  webhook at the local server, then running `scripts/paloma_live_smoke.py`
+  without skipped checks.
+
+Until that happens, the implementation is locally tested and deployed-bot smoke
+tested, but not fully live-verified against this exact checkout.

--- a/scripts/paloma_live_smoke.py
+++ b/scripts/paloma_live_smoke.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Run Paloma live-smoke checks from a real Telegram user account.
+
+This script is intentionally client-side: it uses Telethon with the user's
+Telegram session and treats the bot like a real user would. It can verify a
+deployed bot, or a local checkout once its Telegram channel/webhook points at
+the running local server.
+
+Required env is the same as scripts/telegram_user_smoke.py:
+  TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_PHONE, TELEGRAM_SESSION
+
+Typical usage:
+  TELEGRAM_CHAT=ana_lfgbot python3 scripts/paloma_live_smoke.py --dm-chat ana_lfgbot
+
+For alert-reply feedback checks, pass --alert-message-id with a recent Paloma
+alert message in the DM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from getpass import getpass
+from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+try:
+    from telethon import TelegramClient, events
+    from telethon.errors import SessionPasswordNeededError
+except ImportError as exc:
+    TelegramClient = None  # type: ignore[assignment]
+    events = None  # type: ignore[assignment]
+    SessionPasswordNeededError = None  # type: ignore[assignment]
+    TELETHON_IMPORT_ERROR = exc
+else:
+    TELETHON_IMPORT_ERROR = None
+
+
+def env_or(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.environ.get(name)
+    return value if value else default
+
+
+def die(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Paloma Telegram live-smoke checks from a real user account.",
+    )
+    parser.add_argument("--api-id", type=int, default=int(env_or("TELEGRAM_API_ID", "0") or "0"))
+    parser.add_argument("--api-hash", default=env_or("TELEGRAM_API_HASH"))
+    parser.add_argument("--phone", default=env_or("TELEGRAM_PHONE"))
+    parser.add_argument(
+        "--session",
+        default=env_or(
+            "TELEGRAM_SESSION",
+            str(Path.home() / ".cache" / "sandboxed-sh" / "telegram-user-smoke"),
+        ),
+    )
+    parser.add_argument("--dm-chat", default=env_or("TELEGRAM_CHAT", "ana_lfgbot"))
+    parser.add_argument("--bot-username", default=env_or("TELEGRAM_FROM_USER", "ana_lfgbot"))
+    parser.add_argument("--shared-chat", default=env_or("PALOMA_SHARED_CHAT"))
+    parser.add_argument("--alert-message-id", type=int, default=None)
+    parser.add_argument("--watch-seconds", type=int, default=int(env_or("TELEGRAM_WATCH_SECONDS", "45") or "45"))
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Check local prerequisites without connecting to Telegram or sending messages.",
+    )
+    parser.add_argument(
+        "--mission-db",
+        default=env_or("PALOMA_MISSION_DB", "/root/.sandboxed-sh/missions/missions-dev.db"),
+        help="SQLite mission DB to inspect for configured Telegram channels during preflight.",
+    )
+    parser.add_argument(
+        "--api-base",
+        default=env_or("PALOMA_API_BASE", "http://127.0.0.1:3000"),
+        help="Sandboxed.sh API base URL to probe during preflight.",
+    )
+    parser.add_argument(
+        "--api-token",
+        default=env_or("PALOMA_API_TOKEN"),
+        help="Optional API bearer token for authenticated control-endpoint preflight probes.",
+    )
+    parser.add_argument("--code", default=None)
+    parser.add_argument("--password", default=None)
+    parser.add_argument(
+        "--skip-shared",
+        action="store_true",
+        help="Skip shared-chat /summary silence/allowance checks.",
+    )
+    parser.add_argument(
+        "--skip-alert-feedback",
+        action="store_true",
+        help="Skip reply-to-alert feedback checks.",
+    )
+    return parser.parse_args()
+
+
+def http_get_text(url: str, token: Optional[str] = None) -> tuple[int, str]:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=10) as response:
+            body = response.read(2048).decode("utf-8", errors="replace")
+            return response.status, body
+    except HTTPError as exc:
+        body = exc.read(2048).decode("utf-8", errors="replace")
+        return exc.code, body
+    except URLError as exc:
+        return 0, str(exc)
+
+
+def count_configured_telegram_channels(db_path: str) -> tuple[Optional[int], str]:
+    path = Path(db_path).expanduser()
+    if not path.exists():
+        return None, f"mission DB not found: {path}"
+    try:
+        with sqlite3.connect(path) as conn:
+            table_count = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='telegram_channels'",
+            ).fetchone()[0]
+            if table_count == 0:
+                return None, "telegram_channels table missing"
+            channel_count = conn.execute("SELECT COUNT(*) FROM telegram_channels").fetchone()[0]
+            return int(channel_count), "ok"
+    except sqlite3.Error as exc:
+        return None, f"sqlite error: {exc}"
+
+
+def run_preflight(args: argparse.Namespace) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    results.append(CheckResult("telegram_api_id", bool(args.api_id), "set" if args.api_id else "missing"))
+    results.append(CheckResult("telegram_api_hash", bool(args.api_hash), "set" if args.api_hash else "missing"))
+
+    session_path = Path(args.session).expanduser()
+    session_file = session_path if session_path.suffix == ".session" else Path(f"{session_path}.session")
+    results.append(
+        CheckResult(
+            "telegram_session_file",
+            session_file.exists(),
+            str(session_file) if session_file.exists() else f"missing: {session_file}",
+        )
+    )
+
+    channel_count, channel_detail = count_configured_telegram_channels(args.mission_db)
+    results.append(
+        CheckResult(
+            "local_telegram_channels",
+            bool(channel_count and channel_count > 0),
+            f"count={channel_count}" if channel_count is not None else channel_detail,
+        )
+    )
+
+    api_base = args.api_base.rstrip("/")
+    health_status, health_body = http_get_text(f"{api_base}/api/health")
+    results.append(
+        CheckResult(
+            "api_health",
+            health_status == 200 and '"status":"ok"' in health_body,
+            f"status={health_status}",
+        )
+    )
+
+    if args.api_token:
+        control_status, control_body = http_get_text(f"{api_base}/api/control/telegram/bots", args.api_token)
+        results.append(
+            CheckResult(
+                "api_control_auth",
+                control_status == 200,
+                f"status={control_status}, body={control_body[:80]!r}",
+            )
+        )
+    else:
+        results.append(CheckResult("api_control_auth", False, "missing PALOMA_API_TOKEN/--api-token"))
+
+    return results
+
+
+def looks_numeric_chat(raw: str) -> bool:
+    return bool(raw) and (raw.isdigit() or (raw.startswith("-") and raw[1:].isdigit()))
+
+
+def normalize_username(username: Optional[str]) -> Optional[str]:
+    return username.lstrip("@").lower() if username else None
+
+
+async def ensure_authorized(
+    client: TelegramClient,
+    phone: Optional[str],
+    code: Optional[str],
+    password: Optional[str],
+) -> None:
+    await client.connect()
+    if await client.is_user_authorized():
+        return
+    if not phone:
+        die("Phone number is required for first-time authorization.")
+    sent = await client.send_code_request(phone)
+    login_code = code or input("Telegram login code: ").strip()
+    try:
+        await client.sign_in(phone=phone, code=login_code, phone_code_hash=sent.phone_code_hash)
+    except SessionPasswordNeededError:
+        login_password = password or getpass("Telegram 2FA password: ")
+        await client.sign_in(password=login_password)
+
+
+async def resolve_chat(client: TelegramClient, raw_chat: str):
+    if not raw_chat:
+        die("Chat is required.")
+    target = int(raw_chat) if looks_numeric_chat(raw_chat) else raw_chat
+    try:
+        return await client.get_entity(target)
+    except Exception as exc:
+        die(f"Failed to resolve chat '{raw_chat}': {exc}")
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class BotWatcher:
+    client: TelegramClient
+    entity: object
+    bot_username: str
+    messages: list[tuple[int, str]] = field(default_factory=list)
+
+    async def __aenter__(self):
+        target_username = normalize_username(self.bot_username)
+
+        @self.client.on(events.NewMessage(chats=self.entity))
+        async def handler(event) -> None:
+            sender = await event.get_sender()
+            username = normalize_username(getattr(sender, "username", None))
+            if target_username and username != target_username:
+                return
+            text = (event.raw_text or "").strip()
+            self.messages.append((event.message.id, text))
+            print(f"[bot:{event.message.id}] {text}")
+
+        self._handler = handler
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.client.remove_event_handler(self._handler)
+
+    async def wait_for(self, pattern: str, seconds: int, after_count: int = 0) -> Optional[tuple[int, str]]:
+        compiled = re.compile(pattern, re.I | re.S)
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            for message_id, text in self.messages[after_count:]:
+                if compiled.search(text):
+                    return message_id, text
+            await asyncio.sleep(0.5)
+        return None
+
+    def count(self) -> int:
+        return len(self.messages)
+
+
+async def send_and_expect(
+    client: TelegramClient,
+    watcher: BotWatcher,
+    entity,
+    name: str,
+    text: str,
+    expect: str,
+    watch_seconds: int,
+    reply_to: Optional[int] = None,
+) -> CheckResult:
+    before = watcher.count()
+    sent = await client.send_message(entity, text, reply_to=reply_to)
+    print(f"[sent:{sent.id}] {text}")
+    match = await watcher.wait_for(expect, watch_seconds, before)
+    if match:
+        return CheckResult(name, True, f"reply_id={match[0]}")
+    return CheckResult(name, False, f"no bot reply matching {expect!r}")
+
+
+async def send_and_expect_silence(
+    client: TelegramClient,
+    watcher: BotWatcher,
+    entity,
+    name: str,
+    text: str,
+    watch_seconds: int,
+) -> CheckResult:
+    before = watcher.count()
+    sent = await client.send_message(entity, text)
+    print(f"[sent:{sent.id}] {text}")
+    await asyncio.sleep(watch_seconds)
+    after = watcher.count()
+    if after == before:
+        return CheckResult(name, True, "no bot reply")
+    return CheckResult(name, False, f"unexpected bot replies={after - before}")
+
+
+async def run_smoke(args: argparse.Namespace) -> list[CheckResult]:
+    if TELETHON_IMPORT_ERROR is not None:
+        die(
+            "Telethon is not installed. Install it with:\n"
+            "  python3 -m pip install telethon"
+        )
+    if not args.api_id:
+        die("Missing Telegram API ID. Set TELEGRAM_API_ID or pass --api-id.")
+    if not args.api_hash:
+        die("Missing Telegram API hash. Set TELEGRAM_API_HASH or pass --api-hash.")
+
+    session_path = Path(args.session).expanduser()
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    client = TelegramClient(str(session_path), args.api_id, args.api_hash)
+    results: list[CheckResult] = []
+
+    try:
+        await ensure_authorized(client, args.phone, args.code, args.password)
+        me = await client.get_me()
+        print(f"Authorized as @{normalize_username(getattr(me, 'username', None)) or 'unknown'}")
+
+        dm = await resolve_chat(client, args.dm_chat)
+        async with BotWatcher(client, dm, args.bot_username) as watcher:
+            results.append(
+                await send_and_expect(
+                    client,
+                    watcher,
+                    dm,
+                    "dm_status",
+                    "/status",
+                    r"(meaningful changes|no meaningful changes|mission|status)",
+                    args.watch_seconds,
+                )
+            )
+            results.append(
+                await send_and_expect(
+                    client,
+                    watcher,
+                    dm,
+                    "dm_missions",
+                    "/missions",
+                    r"(mission|active|running|no active)",
+                    args.watch_seconds,
+                )
+            )
+            results.append(
+                await send_and_expect(
+                    client,
+                    watcher,
+                    dm,
+                    "dm_summary",
+                    "/summary",
+                    r"(summary|mission|no mission|couldn't|cannot|failed|active|awaiting|completed|interrupted|blocked|not feasible)",
+                    args.watch_seconds,
+                )
+            )
+            results.append(
+                await send_and_expect(
+                    client,
+                    watcher,
+                    dm,
+                    "dm_why",
+                    "/why",
+                    r"(decision|paloma|why|no recent)",
+                    args.watch_seconds,
+                )
+            )
+            results.append(
+                await send_and_expect(
+                    client,
+                    watcher,
+                    dm,
+                    "usage_approve",
+                    "/approve",
+                    r"usage: /approve",
+                    args.watch_seconds,
+                )
+            )
+            results.append(
+                await send_and_expect(
+                    client,
+                    watcher,
+                    dm,
+                    "usage_send",
+                    "/send latest",
+                    r"usage: /send",
+                    args.watch_seconds,
+                )
+            )
+
+            burst_before = watcher.count()
+            burst_messages = ["status", "what changed since my last check?", "/missions"]
+            for text in burst_messages:
+                sent = await client.send_message(dm, text)
+                print(f"[sent:{sent.id}] {text}")
+            deadline = time.monotonic() + args.watch_seconds
+            while time.monotonic() < deadline and watcher.count() - burst_before < 3:
+                await asyncio.sleep(0.5)
+            results.append(
+                CheckResult(
+                    "burst_serialization",
+                    watcher.count() - burst_before >= 3,
+                    f"bot_replies={watcher.count() - burst_before}",
+                )
+            )
+
+            if args.skip_alert_feedback:
+                results.append(CheckResult("alert_feedback", True, "skipped"))
+            elif args.alert_message_id:
+                feedback_cases = [
+                    ("feedback_high_interest", "keep me posted on this", r"(keep|posted|updates|watch)"),
+                    ("feedback_failure_only", "only tell me if this fails", r"(fail|failure|only)"),
+                    ("feedback_mute", "mute this", r"(mute|muted|quiet)"),
+                    ("feedback_restore_high_interest", "keep me posted on this", r"(keep|posted|updates|watch)"),
+                ]
+                for name, text, expect in feedback_cases:
+                    results.append(
+                        await send_and_expect(
+                            client,
+                            watcher,
+                            dm,
+                            name,
+                            text,
+                            expect,
+                            args.watch_seconds,
+                            reply_to=args.alert_message_id,
+                        )
+                    )
+            else:
+                results.append(
+                    CheckResult(
+                        "alert_feedback",
+                        False,
+                        "missing --alert-message-id for reply-to-alert feedback checks",
+                    )
+                )
+
+        if not args.skip_shared:
+            if not args.shared_chat:
+                results.append(CheckResult("shared_summary", False, "missing --shared-chat"))
+            else:
+                shared = await resolve_chat(client, args.shared_chat)
+                async with BotWatcher(client, shared, args.bot_username) as shared_watcher:
+                    results.append(
+                        await send_and_expect_silence(
+                            client,
+                            shared_watcher,
+                            shared,
+                            "shared_plain_summary_silence",
+                            "/summary",
+                            max(5, min(args.watch_seconds, 15)),
+                        )
+                    )
+                    results.append(
+                        await send_and_expect_silence(
+                            client,
+                            shared_watcher,
+                            shared,
+                            "shared_mention_summary_silence",
+                            f"@{args.bot_username.lstrip('@')} /summary",
+                            max(5, min(args.watch_seconds, 15)),
+                        )
+                    )
+        else:
+            results.append(CheckResult("shared_summary", True, "skipped"))
+
+        return results
+    finally:
+        await client.disconnect()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.preflight_only:
+        results = run_preflight(args)
+        heading = "Paloma live smoke preflight results:"
+    else:
+        results = asyncio.run(run_smoke(args))
+        heading = "Paloma live smoke results:"
+    print(f"\n{heading}")
+    failed = []
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        print(f"  {status:<4} {result.name}: {result.detail}")
+        if not result.passed:
+            failed.append(result)
+    if failed:
+        print("\nMissing evidence:")
+        for result in failed:
+            print(f"  - {result.name}: {result.detail}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -14027,6 +14027,54 @@ pub async fn list_bot_action_executions(
     Ok(Json(executions))
 }
 
+pub async fn list_paloma_decisions(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Query(query): Query<TelegramBotListQuery>,
+) -> Result<Json<Vec<super::mission_store::PalomaDecision>>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let decisions = control
+        .mission_store
+        .list_paloma_decisions(query.limit.clamp(1, 100))
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(decisions))
+}
+
+pub async fn list_paloma_scheduler_jobs(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<Json<Vec<super::mission_store::PalomaSchedulerJob>>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let jobs = control
+        .mission_store
+        .list_paloma_scheduler_jobs()
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(jobs))
+}
+
+pub async fn get_paloma_queue_metrics(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<Json<super::paloma::queue::QueueMetrics>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let channels = control
+        .mission_store
+        .list_all_telegram_channels()
+        .await
+        .map_err(internal_error)?;
+    let channel_ids: HashSet<String> = channels
+        .into_iter()
+        .map(|channel| channel.id.to_string())
+        .collect();
+    let metrics = state
+        .telegram_bridge
+        .paloma_queue_metrics_for_channels(&channel_ids)
+        .await;
+    Ok(Json(metrics))
+}
+
 pub async fn list_bot_conversations(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -584,6 +584,45 @@ pub struct TelegramAlert {
     pub acknowledged_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PalomaDecision {
+    pub id: Uuid,
+    pub event_source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mission_id: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<i64>,
+    pub channel: String,
+    pub reason_code: String,
+    pub proposed_action: String,
+    pub allowed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suppression_reason: Option<String>,
+    pub policy_snapshot_json: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_text_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_text_preview: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PalomaSchedulerJob {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_finished_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub run_count: i64,
+    pub updated_at: String,
+}
+
 /// A mapping from a Telegram chat to an auto-created mission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelegramChatMission {
@@ -1527,6 +1566,26 @@ pub trait MissionStore: Send + Sync {
         Err("Not supported".to_string())
     }
 
+    /// Update the last successful Telegram alert digest delivery timestamp.
+    async fn update_telegram_user_last_digest_at(
+        &self,
+        telegram_user_id: i64,
+        last_digest_at: &str,
+    ) -> Result<(), String> {
+        let _ = (telegram_user_id, last_digest_at);
+        Err("Not supported".to_string())
+    }
+
+    /// Update the last Telegram alert acknowledgement timestamp.
+    async fn update_telegram_user_last_alert_ack_at(
+        &self,
+        telegram_user_id: i64,
+        last_alert_ack_at: &str,
+    ) -> Result<(), String> {
+        let _ = (telegram_user_id, last_alert_ack_at);
+        Err("Not supported".to_string())
+    }
+
     /// Upsert a mission subscription/interest row.
     async fn upsert_telegram_mission_subscription(
         &self,
@@ -1552,6 +1611,15 @@ pub trait MissionStore: Send + Sync {
     ) -> Result<TelegramAlertPreference, String> {
         let _ = preference;
         Err("Not supported".to_string())
+    }
+
+    /// List explicit Telegram alert preferences for a user.
+    async fn list_telegram_alert_preferences(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<Vec<TelegramAlertPreference>, String> {
+        let _ = telegram_user_id;
+        Ok(vec![])
     }
 
     /// Insert an alert unless an equivalent alert already exists.
@@ -1584,6 +1652,16 @@ pub trait MissionStore: Send + Sync {
         Err("Not supported".to_string())
     }
 
+    /// Find a sent Telegram alert by its Telegram message id.
+    async fn get_telegram_alert_by_message_id(
+        &self,
+        telegram_user_id: i64,
+        telegram_message_id: i64,
+    ) -> Result<Option<TelegramAlert>, String> {
+        let _ = (telegram_user_id, telegram_message_id);
+        Ok(None)
+    }
+
     /// Acknowledge queued alerts for a mission so they will not be delivered.
     async fn acknowledge_pending_telegram_alerts_for_mission(
         &self,
@@ -1595,10 +1673,85 @@ pub trait MissionStore: Send + Sync {
         Ok(0)
     }
 
+    /// Acknowledge a single queued alert so it will not be delivered.
+    async fn acknowledge_pending_telegram_alert(
+        &self,
+        telegram_user_id: i64,
+        alert_id: Uuid,
+        acknowledged_at: &str,
+    ) -> Result<bool, String> {
+        let _ = (telegram_user_id, alert_id, acknowledged_at);
+        Ok(false)
+    }
+
     /// Record a delivery failure without removing the alert from the retry queue.
     async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
         let _ = (id, error);
         Err("Not supported".to_string())
+    }
+
+    /// Clear stale pending alert delivery errors so future scans can retry cleanly.
+    async fn recover_stale_telegram_alerts(
+        &self,
+        before: &str,
+        limit: usize,
+    ) -> Result<usize, String> {
+        let _ = (before, limit);
+        Ok(0)
+    }
+
+    /// Append an auditable Paloma decision record.
+    async fn create_paloma_decision(
+        &self,
+        decision: PalomaDecision,
+    ) -> Result<PalomaDecision, String> {
+        let _ = decision;
+        Err("Not supported".to_string())
+    }
+
+    /// List recent Paloma decisions for debugging/canary review.
+    async fn list_paloma_decisions(&self, limit: usize) -> Result<Vec<PalomaDecision>, String> {
+        let _ = limit;
+        Ok(vec![])
+    }
+
+    /// Claim a named Paloma scheduler job if no live lease exists.
+    async fn claim_paloma_scheduler_job(
+        &self,
+        name: &str,
+        lease_owner: &str,
+        now: &str,
+        lease_expires_at: &str,
+    ) -> Result<bool, String> {
+        let _ = (name, lease_owner, now, lease_expires_at);
+        Ok(false)
+    }
+
+    /// Finish a named Paloma scheduler job and append its latest result.
+    async fn finish_paloma_scheduler_job(
+        &self,
+        name: &str,
+        lease_owner: &str,
+        finished_at: &str,
+        error: Option<&str>,
+    ) -> Result<(), String> {
+        let _ = (name, lease_owner, finished_at, error);
+        Ok(())
+    }
+
+    /// List named Paloma scheduler job state/history.
+    async fn list_paloma_scheduler_jobs(&self) -> Result<Vec<PalomaSchedulerJob>, String> {
+        Ok(vec![])
+    }
+
+    /// Consolidate explicit Telegram memory rows, keeping the latest user-provided rule/fact.
+    async fn consolidate_telegram_structured_memory(
+        &self,
+        channel_id: Uuid,
+        limit: usize,
+    ) -> Result<usize, String> {
+        let _ = (channel_id, limit);
+        Ok(0)
     }
 
     // === Telegram Chat-Mission mapping methods ===

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3,15 +3,16 @@
 use super::{
     now_string, sanitize_filename, Automation, AutomationExecution, CommandSource, DailyUsageStats,
     ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode,
-    MissionStatus, MissionStore, ModelUsageStats, RetryConfig, StopPolicy, StoredEvent,
-    TelegramActionExecution, TelegramActionExecutionKind, TelegramActionExecutionStatus,
-    TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramChatMission,
-    TelegramConversation, TelegramConversationMessage, TelegramConversationMessageDirection,
-    TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramScheduledMessage,
-    TelegramScheduledMessageStatus, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
-    TelegramStructuredMemoryScope, TelegramStructuredMemorySearchHit, TelegramUser,
-    TelegramUserCursor, TelegramUserRole, TelegramWorkflow, TelegramWorkflowEvent,
-    TelegramWorkflowKind, TelegramWorkflowStatus, TriggerType, WebhookConfig,
+    MissionStatus, MissionStore, ModelUsageStats, PalomaDecision, PalomaSchedulerJob, RetryConfig,
+    StopPolicy, StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
+    TelegramActionExecutionStatus, TelegramAlert, TelegramAlertPreference, TelegramChannel,
+    TelegramChatMission, TelegramConversation, TelegramConversationMessage,
+    TelegramConversationMessageDirection, TelegramMissionInterestLevel,
+    TelegramMissionSubscription, TelegramScheduledMessage, TelegramScheduledMessageStatus,
+    TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
+    TelegramStructuredMemorySearchHit, TelegramUser, TelegramUserCursor, TelegramUserRole,
+    TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus,
+    TriggerType, WebhookConfig,
 };
 use crate::api::control::{AgentEvent, AgentTreeNode, DesktopSessionInfo, TextOp};
 use async_trait::async_trait;
@@ -1523,7 +1524,38 @@ impl SqliteMissionStore {
                 UNIQUE(telegram_user_id, mission_id, event_kind)
             );
             CREATE INDEX IF NOT EXISTS idx_talerts_user_status
-                ON telegram_alerts(telegram_user_id, status, created_at);",
+                ON telegram_alerts(telegram_user_id, status, created_at);
+
+            CREATE TABLE IF NOT EXISTS paloma_decisions (
+                id TEXT PRIMARY KEY NOT NULL,
+                event_source TEXT NOT NULL,
+                mission_id TEXT,
+                user_id INTEGER,
+                channel TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                proposed_action TEXT NOT NULL,
+                allowed INTEGER NOT NULL,
+                suppression_reason TEXT,
+                policy_snapshot_json TEXT NOT NULL,
+                generated_text_hash TEXT,
+                generated_text_preview TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_paloma_decisions_created
+                ON paloma_decisions(created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_paloma_decisions_mission
+                ON paloma_decisions(mission_id, created_at DESC);
+
+            CREATE TABLE IF NOT EXISTS paloma_scheduler_jobs (
+                name TEXT PRIMARY KEY NOT NULL,
+                lease_owner TEXT,
+                lease_expires_at TEXT,
+                last_started_at TEXT,
+                last_finished_at TEXT,
+                last_error TEXT,
+                run_count INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT NOT NULL
+            );",
         )
         .map_err(|e| format!("Failed to create Paloma Telegram state tables: {}", e))?;
 
@@ -5503,6 +5535,70 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn update_telegram_user_last_digest_at(
+        &self,
+        telegram_user_id: i64,
+        last_digest_at: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let last_digest_at = last_digest_at.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let now = now_string();
+            conn.execute(
+                "INSERT INTO telegram_user_cursors
+                 (id, telegram_user_id, last_digest_at, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(telegram_user_id) DO UPDATE SET
+                    last_digest_at = excluded.last_digest_at,
+                    updated_at = excluded.updated_at",
+                params![
+                    Uuid::new_v4().to_string(),
+                    telegram_user_id,
+                    last_digest_at,
+                    now,
+                    now,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn update_telegram_user_last_alert_ack_at(
+        &self,
+        telegram_user_id: i64,
+        last_alert_ack_at: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let last_alert_ack_at = last_alert_ack_at.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let now = now_string();
+            conn.execute(
+                "INSERT INTO telegram_user_cursors
+                 (id, telegram_user_id, last_alert_ack_at, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(telegram_user_id) DO UPDATE SET
+                    last_alert_ack_at = excluded.last_alert_ack_at,
+                    updated_at = excluded.updated_at",
+                params![
+                    Uuid::new_v4().to_string(),
+                    telegram_user_id,
+                    last_alert_ack_at,
+                    now,
+                    now,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn upsert_telegram_mission_subscription(
         &self,
         subscription: TelegramMissionSubscription,
@@ -5602,6 +5698,33 @@ impl MissionStore for SqliteMissionStore {
         Ok(preference)
     }
 
+    async fn list_telegram_alert_preferences(
+        &self,
+        telegram_user_id: i64,
+    ) -> Result<Vec<TelegramAlertPreference>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, telegram_user_id, scope, scope_value, rule_text, enabled,
+                            created_from_message_id, created_at, updated_at
+                     FROM telegram_alert_preferences
+                     WHERE telegram_user_id = ?1 AND enabled = 1
+                     ORDER BY updated_at DESC, created_at DESC",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![telegram_user_id], row_to_telegram_alert_preference)
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn create_telegram_alert_if_absent(
         &self,
         alert: TelegramAlert,
@@ -5692,6 +5815,48 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn get_telegram_alert_by_message_id(
+        &self,
+        telegram_user_id: i64,
+        telegram_message_id: i64,
+    ) -> Result<Option<TelegramAlert>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*)
+                     FROM telegram_alerts
+                     WHERE telegram_user_id = ?1
+                       AND telegram_message_id = ?2",
+                    params![telegram_user_id, telegram_message_id],
+                    |row| row.get(0),
+                )
+                .map_err(|e| e.to_string())?;
+            if count != 1 {
+                if count > 1 {
+                    return Err("ambiguous_digest_reply".to_string());
+                }
+                return Ok(None);
+            }
+            conn.query_row(
+                "SELECT id, telegram_user_id, mission_id, event_kind, importance, title, body,
+                        status, telegram_message_id, last_error, created_at, sent_at, acknowledged_at
+                 FROM telegram_alerts
+                 WHERE telegram_user_id = ?1
+                   AND telegram_message_id = ?2
+                 ORDER BY sent_at DESC, created_at DESC
+                 LIMIT 1",
+                params![telegram_user_id, telegram_message_id],
+                row_to_telegram_alert,
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn acknowledge_pending_telegram_alerts_for_mission(
         &self,
         telegram_user_id: i64,
@@ -5718,6 +5883,32 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn acknowledge_pending_telegram_alert(
+        &self,
+        telegram_user_id: i64,
+        alert_id: Uuid,
+        acknowledged_at: &str,
+    ) -> Result<bool, String> {
+        let conn = self.conn.clone();
+        let acknowledged_at = acknowledged_at.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let changed = conn
+                .execute(
+                    "UPDATE telegram_alerts
+                     SET status = 'acknowledged', acknowledged_at = ?3, last_error = NULL
+                     WHERE telegram_user_id = ?1
+                       AND id = ?2
+                       AND status = 'pending'",
+                    params![telegram_user_id, alert_id.to_string(), acknowledged_at],
+                )
+                .map_err(|e| e.to_string())?;
+            Ok(changed > 0)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn mark_telegram_alert_failed(&self, id: Uuid, error: &str) -> Result<(), String> {
         let conn = self.conn.clone();
         let error = error.to_string();
@@ -5731,6 +5922,290 @@ impl MissionStore for SqliteMissionStore {
             )
             .map_err(|e| e.to_string())?;
             Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn recover_stale_telegram_alerts(
+        &self,
+        before: &str,
+        limit: usize,
+    ) -> Result<usize, String> {
+        let conn = self.conn.clone();
+        let before = before.to_string();
+        let limit = limit.clamp(1, 10_000) as i64;
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let ids = {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id
+                         FROM telegram_alerts
+                         WHERE status = 'pending'
+                           AND last_error IS NOT NULL
+                           AND created_at <= ?1
+                         ORDER BY created_at ASC
+                         LIMIT ?2",
+                    )
+                    .map_err(|e| e.to_string())?;
+                let rows = stmt
+                    .query_map(params![before, limit], |row| row.get::<_, String>(0))
+                    .map_err(|e| e.to_string())?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| e.to_string())?;
+                rows
+            };
+
+            for id in &ids {
+                conn.execute(
+                    "UPDATE telegram_alerts
+                     SET last_error = NULL
+                     WHERE id = ?1 AND status = 'pending'",
+                    params![id],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+
+            Ok(ids.len())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn create_paloma_decision(
+        &self,
+        decision: PalomaDecision,
+    ) -> Result<PalomaDecision, String> {
+        let conn = self.conn.clone();
+        let stored = decision.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO paloma_decisions (
+                    id, event_source, mission_id, user_id, channel, reason_code,
+                    proposed_action, allowed, suppression_reason, policy_snapshot_json,
+                    generated_text_hash, generated_text_preview, created_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                params![
+                    decision.id.to_string(),
+                    decision.event_source,
+                    decision.mission_id.map(|id| id.to_string()),
+                    decision.user_id,
+                    decision.channel,
+                    decision.reason_code,
+                    decision.proposed_action,
+                    if decision.allowed { 1 } else { 0 },
+                    decision.suppression_reason,
+                    decision.policy_snapshot_json,
+                    decision.generated_text_hash,
+                    decision.generated_text_preview,
+                    decision.created_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(stored)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn list_paloma_decisions(&self, limit: usize) -> Result<Vec<PalomaDecision>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, event_source, mission_id, user_id, channel, reason_code,
+                            proposed_action, allowed, suppression_reason, policy_snapshot_json,
+                            generated_text_hash, generated_text_preview, created_at
+                     FROM paloma_decisions
+                     ORDER BY created_at DESC
+                     LIMIT ?1",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![limit as i64], row_to_paloma_decision)
+                .map_err(|e| e.to_string())?;
+            let mut decisions = Vec::new();
+            for row in rows {
+                decisions.push(row.map_err(|e| e.to_string())?);
+            }
+            Ok(decisions)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn claim_paloma_scheduler_job(
+        &self,
+        name: &str,
+        lease_owner: &str,
+        now: &str,
+        lease_expires_at: &str,
+    ) -> Result<bool, String> {
+        let conn = self.conn.clone();
+        let name = name.to_string();
+        let lease_owner = lease_owner.to_string();
+        let now = now.to_string();
+        let lease_expires_at = lease_expires_at.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT OR IGNORE INTO paloma_scheduler_jobs
+                 (name, run_count, updated_at)
+                 VALUES (?1, 0, ?2)",
+                params![name, now],
+            )
+            .map_err(|e| e.to_string())?;
+            let changed = conn
+                .execute(
+                    "UPDATE paloma_scheduler_jobs
+                     SET lease_owner = ?2,
+                         lease_expires_at = ?4,
+                         last_started_at = ?3,
+                         updated_at = ?3
+                     WHERE name = ?1
+                       AND (lease_expires_at IS NULL OR lease_expires_at <= ?3 OR lease_owner = ?2)",
+                    params![name, lease_owner, now, lease_expires_at],
+                )
+                .map_err(|e| e.to_string())?;
+            Ok(changed > 0)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn finish_paloma_scheduler_job(
+        &self,
+        name: &str,
+        lease_owner: &str,
+        finished_at: &str,
+        error: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let name = name.to_string();
+        let lease_owner = lease_owner.to_string();
+        let finished_at = finished_at.to_string();
+        let error = error.map(ToOwned::to_owned);
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE paloma_scheduler_jobs
+                 SET lease_owner = NULL,
+                     lease_expires_at = NULL,
+                     last_finished_at = ?3,
+                     last_error = ?4,
+                     run_count = run_count + 1,
+                     updated_at = ?3
+                 WHERE name = ?1 AND lease_owner = ?2",
+                params![name, lease_owner, finished_at, error],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn list_paloma_scheduler_jobs(&self) -> Result<Vec<PalomaSchedulerJob>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name, lease_owner, lease_expires_at, last_started_at,
+                            last_finished_at, last_error, run_count, updated_at
+                     FROM paloma_scheduler_jobs
+                     ORDER BY name ASC",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map([], row_to_paloma_scheduler_job)
+                .map_err(|e| e.to_string())?;
+            let mut jobs = Vec::new();
+            for row in rows {
+                jobs.push(row.map_err(|e| e.to_string())?);
+            }
+            Ok(jobs)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn consolidate_telegram_structured_memory(
+        &self,
+        channel_id: Uuid,
+        limit: usize,
+    ) -> Result<usize, String> {
+        let conn = self.conn.clone();
+        let channel_id = channel_id.to_string();
+        let limit = limit.clamp(1, 10_000) as i64;
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "WITH ranked AS (
+                         SELECT id, channel_id, scope, chat_id, subject_user_id, normalized_label,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY channel_id, scope, chat_id,
+                                                 COALESCE(subject_user_id, -9223372036854775808),
+                                                 normalized_label
+                                    ORDER BY updated_at DESC, created_at DESC
+                                ) AS row_rank,
+                                MAX(updated_at) OVER (
+                                    PARTITION BY channel_id, scope, chat_id,
+                                                 COALESCE(subject_user_id, -9223372036854775808),
+                                                 normalized_label
+                                ) AS group_updated_at
+                         FROM telegram_structured_memory
+                         WHERE channel_id = ?1
+                           AND kind IN ('fact', 'preference')
+                           AND normalized_label IS NOT NULL
+                           AND source_role = 'user'
+                     ),
+                     selected_groups AS (
+                         SELECT DISTINCT channel_id, scope, chat_id, subject_user_id,
+                                         normalized_label, group_updated_at
+                         FROM ranked
+                         ORDER BY group_updated_at DESC
+                         LIMIT ?2
+                     )
+                     SELECT ranked.id
+                     FROM ranked
+                     WHERE ranked.row_rank > 1
+                       AND EXISTS (
+                           SELECT 1
+                           FROM selected_groups
+                           WHERE selected_groups.channel_id = ranked.channel_id
+                             AND selected_groups.scope = ranked.scope
+                             AND selected_groups.chat_id = ranked.chat_id
+                             AND COALESCE(selected_groups.subject_user_id, -9223372036854775808)
+                                 = COALESCE(ranked.subject_user_id, -9223372036854775808)
+                             AND selected_groups.normalized_label = ranked.normalized_label
+                       )",
+                )
+                .map_err(|e| e.to_string())?;
+            let delete_ids = stmt
+                .query_map(params![channel_id, limit], |row| row.get::<_, String>(0))
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+
+            for id in &delete_ids {
+                conn.execute(
+                    "DELETE FROM telegram_structured_memory WHERE id = ?1",
+                    params![id],
+                )
+                .map_err(|e| e.to_string())?;
+                conn.execute(
+                    "DELETE FROM telegram_structured_memory_fts WHERE entry_id = ?1",
+                    params![id],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+
+            Ok(delete_ids.len())
         })
         .await
         .map_err(|e| e.to_string())?
@@ -7804,6 +8279,24 @@ fn row_to_telegram_alert(row: &rusqlite::Row<'_>) -> Result<TelegramAlert, rusql
     })
 }
 
+fn row_to_telegram_alert_preference(
+    row: &rusqlite::Row<'_>,
+) -> Result<TelegramAlertPreference, rusqlite::Error> {
+    let id_str: String = row.get(0)?;
+    let enabled: i32 = row.get(5)?;
+    Ok(TelegramAlertPreference {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        telegram_user_id: row.get(1)?,
+        scope: row.get(2)?,
+        scope_value: row.get(3)?,
+        rule_text: row.get(4)?,
+        enabled: enabled != 0,
+        created_from_message_id: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
 /// Parse a Telegram channel from a SQLite row.
 /// Column order: id(0), mission_id(1), bot_token(2), bot_username(3),
 ///   allowed_chat_ids(4), trigger_mode(5), active(6), webhook_secret(7),
@@ -7839,6 +8332,40 @@ fn row_to_telegram_channel(row: &rusqlite::Row<'_>) -> TelegramChannel {
         created_at: row.get(9).unwrap_or_default(),
         updated_at: row.get(10).unwrap_or_default(),
     }
+}
+
+fn row_to_paloma_decision(row: &rusqlite::Row<'_>) -> rusqlite::Result<PalomaDecision> {
+    let id_str: String = row.get(0)?;
+    let mission_id_str: Option<String> = row.get(2)?;
+    let allowed: i32 = row.get(7)?;
+    Ok(PalomaDecision {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        event_source: row.get(1)?,
+        mission_id: mission_id_str.and_then(|id| Uuid::parse_str(&id).ok()),
+        user_id: row.get(3)?,
+        channel: row.get(4)?,
+        reason_code: row.get(5)?,
+        proposed_action: row.get(6)?,
+        allowed: allowed != 0,
+        suppression_reason: row.get(8)?,
+        policy_snapshot_json: row.get(9)?,
+        generated_text_hash: row.get(10)?,
+        generated_text_preview: row.get(11)?,
+        created_at: row.get(12)?,
+    })
+}
+
+fn row_to_paloma_scheduler_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<PalomaSchedulerJob> {
+    Ok(PalomaSchedulerJob {
+        name: row.get(0)?,
+        lease_owner: row.get(1)?,
+        lease_expires_at: row.get(2)?,
+        last_started_at: row.get(3)?,
+        last_finished_at: row.get(4)?,
+        last_error: row.get(5)?,
+        run_count: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
 }
 
 fn parse_telegram_scheduled_status(raw: String) -> TelegramScheduledMessageStatus {
@@ -8127,8 +8654,8 @@ mod tests {
     };
     use crate::api::mission_store::{
         now_string, Automation, AutomationDriver, CommandSource, FreshSession, MissionMode,
-        MissionStatus, MissionStore, RetryConfig, StopPolicy, TelegramAlert,
-        TelegramAlertPreference, TelegramChannel, TelegramConversation,
+        MissionStatus, MissionStore, PalomaDecision, PalomaSchedulerJob, RetryConfig, StopPolicy,
+        TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramConversation,
         TelegramConversationMessage, TelegramConversationMessageDirection,
         TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramStructuredMemoryEntry,
         TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramTriggerMode,
@@ -8265,6 +8792,42 @@ mod tests {
             cursor.last_seen_event_sequence_by_mission_json,
             "{\"mission\":7}"
         );
+        store
+            .update_telegram_user_last_digest_at(1_139_694_048, "2026-05-20T10:20:00Z")
+            .await
+            .expect("update digest cursor");
+        let cursor = store
+            .get_or_create_telegram_user_cursor(1_139_694_048)
+            .await
+            .expect("cursor after digest update");
+        assert_eq!(
+            cursor.last_digest_at.as_deref(),
+            Some("2026-05-20T10:20:00Z")
+        );
+        assert_eq!(
+            cursor.last_status_at.as_deref(),
+            Some("2026-05-20T10:10:00Z")
+        );
+        assert_eq!(
+            cursor.last_seen_event_sequence_by_mission_json,
+            "{\"mission\":7}"
+        );
+        store
+            .update_telegram_user_last_alert_ack_at(1_139_694_048, "2026-05-20T10:30:00Z")
+            .await
+            .expect("update alert ack cursor");
+        let cursor = store
+            .get_or_create_telegram_user_cursor(1_139_694_048)
+            .await
+            .expect("cursor after alert ack update");
+        assert_eq!(
+            cursor.last_alert_ack_at.as_deref(),
+            Some("2026-05-20T10:30:00Z")
+        );
+        assert_eq!(
+            cursor.last_digest_at.as_deref(),
+            Some("2026-05-20T10:20:00Z")
+        );
 
         store
             .upsert_telegram_mission_subscription(TelegramMissionSubscription {
@@ -8303,6 +8866,15 @@ mod tests {
             })
             .await
             .expect("alert preference");
+        let preferences = store
+            .list_telegram_alert_preferences(1_139_694_048)
+            .await
+            .expect("alert preferences");
+        assert_eq!(preferences.len(), 1);
+        assert_eq!(
+            preferences[0].rule_text,
+            "mute from Telegram feedback".to_string()
+        );
 
         let alert = TelegramAlert {
             id: Uuid::new_v4(),
@@ -8347,10 +8919,59 @@ mod tests {
             retryable[0].last_error.as_deref(),
             Some("temporary Telegram outage")
         );
+        assert_eq!(
+            store
+                .recover_stale_telegram_alerts("2026-05-20T10:00:30Z", 10)
+                .await
+                .expect("recover stale alert"),
+            1
+        );
+        let recovered = store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("recovered alerts");
+        assert_eq!(recovered.len(), 1);
+        assert!(recovered[0].last_error.is_none());
         store
-            .mark_telegram_alert_sent(retryable[0].id, Some(99), "2026-05-20T10:01:00Z")
+            .mark_telegram_alert_sent(recovered[0].id, Some(99), "2026-05-20T10:01:00Z")
             .await
             .expect("mark sent");
+        let sent_alert = store
+            .get_telegram_alert_by_message_id(1_139_694_048, 99)
+            .await
+            .expect("sent alert by message id")
+            .expect("sent alert exists");
+        assert_eq!(sent_alert.mission_id, Some(mission.id));
+        let second_digest_alert_id = Uuid::new_v4();
+        store
+            .create_telegram_alert_if_absent(TelegramAlert {
+                id: second_digest_alert_id,
+                telegram_user_id: 1_139_694_048,
+                mission_id: Some(mission.id),
+                event_kind: "mission_failed".to_string(),
+                importance: "high".to_string(),
+                title: "Paloma state".to_string(),
+                body: "Paloma state failed.".to_string(),
+                status: "pending".to_string(),
+                telegram_message_id: None,
+                last_error: None,
+                created_at: "2026-05-20T10:01:30Z".to_string(),
+                sent_at: None,
+                acknowledged_at: None,
+            })
+            .await
+            .expect("second digest alert");
+        store
+            .mark_telegram_alert_sent(second_digest_alert_id, Some(99), "2026-05-20T10:01:40Z")
+            .await
+            .expect("mark second digest alert sent");
+        assert_eq!(
+            store
+                .get_telegram_alert_by_message_id(1_139_694_048, 99)
+                .await
+                .expect_err("ambiguous digest alert lookup"),
+            "ambiguous_digest_reply"
+        );
         assert!(store
             .list_pending_telegram_alerts(1_139_694_048, 10)
             .await
@@ -8402,6 +9023,120 @@ mod tests {
             .await
             .expect("pending alerts after late failure")
             .is_empty());
+
+        let failure_alert_id = Uuid::new_v4();
+        let routine_alert_id = Uuid::new_v4();
+        let scoped_ack_mission_id = Uuid::new_v4();
+        for (id, event_kind, created_at) in [
+            (failure_alert_id, "mission_failed", "2026-05-20T10:04:00Z"),
+            (
+                routine_alert_id,
+                "mission_not_feasible",
+                "2026-05-20T10:04:01Z",
+            ),
+        ] {
+            store
+                .create_telegram_alert_if_absent(TelegramAlert {
+                    id,
+                    telegram_user_id: 1_139_694_048,
+                    mission_id: Some(scoped_ack_mission_id),
+                    event_kind: event_kind.to_string(),
+                    importance: "high".to_string(),
+                    title: "Paloma state".to_string(),
+                    body: format!("Paloma state: {event_kind}."),
+                    status: "pending".to_string(),
+                    telegram_message_id: None,
+                    last_error: None,
+                    created_at: created_at.to_string(),
+                    sent_at: None,
+                    acknowledged_at: None,
+                })
+                .await
+                .expect("create scoped ack alert");
+        }
+        assert!(store
+            .acknowledge_pending_telegram_alert(
+                1_139_694_048,
+                routine_alert_id,
+                "2026-05-20T10:05:00Z",
+            )
+            .await
+            .expect("acknowledge one pending alert"));
+        let pending_after_single_ack = store
+            .list_pending_telegram_alerts(1_139_694_048, 10)
+            .await
+            .expect("pending alerts after single ack");
+        assert_eq!(pending_after_single_ack.len(), 1);
+        assert_eq!(pending_after_single_ack[0].id, failure_alert_id);
+
+        let decision = PalomaDecision {
+            id: Uuid::new_v4(),
+            event_source: "scheduler".to_string(),
+            mission_id: Some(mission.id),
+            user_id: Some(1_139_694_048),
+            channel: "telegram".to_string(),
+            reason_code: "long_running".to_string(),
+            proposed_action: "create_alert".to_string(),
+            allowed: true,
+            suppression_reason: None,
+            policy_snapshot_json: serde_json::json!({
+                "long_running_minutes": 30,
+                "quiet_after_user_message_minutes": 30,
+            })
+            .to_string(),
+            generated_text_hash: Some("abc123".to_string()),
+            generated_text_preview: Some("Paloma state is still running.".to_string()),
+            created_at: "2026-05-20T10:04:00Z".to_string(),
+        };
+        store
+            .create_paloma_decision(decision.clone())
+            .await
+            .expect("paloma decision");
+        let decisions = store
+            .list_paloma_decisions(10)
+            .await
+            .expect("paloma decisions");
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0], decision);
+
+        assert!(store
+            .claim_paloma_scheduler_job(
+                "paloma_alert_scan",
+                "worker-a",
+                "2026-05-20T10:05:00Z",
+                "2026-05-20T10:06:00Z",
+            )
+            .await
+            .expect("claim scheduler job"));
+        assert!(!store
+            .claim_paloma_scheduler_job(
+                "paloma_alert_scan",
+                "worker-b",
+                "2026-05-20T10:05:30Z",
+                "2026-05-20T10:06:30Z",
+            )
+            .await
+            .expect("blocked by active lease"));
+        store
+            .finish_paloma_scheduler_job(
+                "paloma_alert_scan",
+                "worker-a",
+                "2026-05-20T10:05:40Z",
+                None,
+            )
+            .await
+            .expect("finish scheduler job");
+        let jobs: Vec<PalomaSchedulerJob> = store
+            .list_paloma_scheduler_jobs()
+            .await
+            .expect("scheduler jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].name, "paloma_alert_scan");
+        assert_eq!(jobs[0].run_count, 1);
+        assert_eq!(
+            jobs[0].last_finished_at.as_deref(),
+            Some("2026-05-20T10:05:40Z")
+        );
     }
 
     #[tokio::test]
@@ -9626,6 +10361,75 @@ mod tests {
         assert_eq!(hits[0].entry.label.as_deref(), Some("identifiant prod"));
         assert_eq!(hits[0].entry.value, "POLARIS-19");
         assert!(hits[0].score > hits.last().map(|hit| hit.score).unwrap_or(0.0));
+    }
+
+    #[tokio::test]
+    async fn paloma_memory_consolidation_deletes_older_explicit_rules_and_search_rows() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let channel_id = create_test_channel(&store).await;
+        let older_id = Uuid::new_v4();
+        let newer_id = Uuid::new_v4();
+        let channel_id_str = channel_id.to_string();
+
+        {
+            let conn = store.conn.lock().await;
+            for (id, value, updated_at) in [
+                (older_id, "tell me everything", "2026-05-20T10:00:00Z"),
+                (newer_id, "only failures", "2026-05-20T11:00:00Z"),
+            ] {
+                conn.execute(
+                    "INSERT INTO telegram_structured_memory (
+                        id, channel_id, chat_id, mission_id, scope, kind, label, normalized_label,
+                        value, subject_user_id, subject_username, subject_display_name,
+                        source_message_id, source_role, created_at, updated_at
+                     ) VALUES (?1, ?2, 10, NULL, 'user', 'preference', 'alerts', 'alerts',
+                        ?3, 42, 'th0rgal', '@th0rgal', 1, 'user',
+                        '2026-05-20T09:00:00Z', ?4)",
+                    params![id.to_string(), channel_id_str, value, updated_at],
+                )
+                .expect("insert duplicate memory");
+                conn.execute(
+                    "INSERT INTO telegram_structured_memory_fts (
+                        entry_id, channel_id, chat_id, scope, subject_user_id, search_text
+                     ) VALUES (?1, ?2, 10, 'user', 42, ?3)",
+                    params![
+                        id.to_string(),
+                        channel_id_str,
+                        format!("preference alerts {}", value)
+                    ],
+                )
+                .expect("insert duplicate memory search row");
+            }
+        }
+
+        let deleted = store
+            .consolidate_telegram_structured_memory(channel_id, 1)
+            .await
+            .expect("consolidate memory");
+        assert_eq!(deleted, 1);
+
+        let entries = store
+            .list_telegram_structured_memory(channel_id, Some(10), Some(42), 10)
+            .await
+            .expect("list memory");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, newer_id);
+        assert_eq!(entries[0].value, "only failures");
+
+        let old_hits = store
+            .search_telegram_memory_context(channel_id, 10, Some(42), "everything", 10)
+            .await
+            .expect("search old memory");
+        assert!(old_hits.is_empty());
+        let new_hits = store
+            .search_telegram_memory_context(channel_id, 10, Some(42), "failures", 10)
+            .await
+            .expect("search new memory");
+        assert_eq!(new_hits.len(), 1);
+        assert_eq!(new_hits[0].id, newer_id);
     }
 
     #[tokio::test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,6 +40,7 @@ mod model_routing;
 mod monitoring;
 mod native_loop_observer;
 pub mod opencode;
+pub mod paloma;
 mod provider_usage_cache;
 mod providers;
 pub(crate) mod proxy;

--- a/src/api/paloma/brain.rs
+++ b/src/api/paloma/brain.rs
@@ -1,0 +1,153 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrainProposal {
+    pub label: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShadowBrainRun {
+    pub deterministic: BrainProposal,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shadow: Option<BrainProposal>,
+    pub shadow_send_allowed: bool,
+}
+
+#[async_trait]
+pub trait PalomaBrain: Send + Sync {
+    async fn classify_user_message(&self, text: &str) -> BrainProposal;
+    async fn extract_preference(&self, text: &str) -> Option<BrainProposal>;
+    async fn draft_digest(&self, context: &str) -> BrainProposal;
+    async fn summarize_mission(&self, context: &str) -> BrainProposal;
+}
+
+pub struct ShadowPalomaBrain<B> {
+    inner: B,
+    label: String,
+}
+
+impl<B> ShadowPalomaBrain<B> {
+    pub fn new(inner: B, label: impl Into<String>) -> Self {
+        Self {
+            inner,
+            label: label.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl<B> PalomaBrain for ShadowPalomaBrain<B>
+where
+    B: PalomaBrain,
+{
+    async fn classify_user_message(&self, text: &str) -> BrainProposal {
+        let mut proposal = self.inner.classify_user_message(text).await;
+        proposal.label = format!("{}_{}", self.label, proposal.label);
+        proposal
+    }
+
+    async fn extract_preference(&self, text: &str) -> Option<BrainProposal> {
+        self.inner
+            .extract_preference(text)
+            .await
+            .map(|mut proposal| {
+                proposal.label = format!("{}_{}", self.label, proposal.label);
+                proposal
+            })
+    }
+
+    async fn draft_digest(&self, context: &str) -> BrainProposal {
+        let mut proposal = self.inner.draft_digest(context).await;
+        proposal.label = format!("{}_{}", self.label, proposal.label);
+        proposal
+    }
+
+    async fn summarize_mission(&self, context: &str) -> BrainProposal {
+        let mut proposal = self.inner.summarize_mission(context).await;
+        proposal.label = format!("{}_{}", self.label, proposal.label);
+        proposal
+    }
+}
+
+pub async fn compare_shadow_digest<D, S>(
+    deterministic: &D,
+    shadow: Option<&S>,
+    context: &str,
+) -> ShadowBrainRun
+where
+    D: PalomaBrain,
+    S: PalomaBrain,
+{
+    ShadowBrainRun {
+        deterministic: deterministic.draft_digest(context).await,
+        shadow: match shadow {
+            Some(shadow) => Some(shadow.draft_digest(context).await),
+            None => None,
+        },
+        // LLM/QwenPaw-backed brains are always proposal-only. Delivery must go
+        // through Paloma policy and decision logging.
+        shadow_send_allowed: false,
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DeterministicPalomaBrain;
+
+#[async_trait]
+impl PalomaBrain for DeterministicPalomaBrain {
+    async fn classify_user_message(&self, text: &str) -> BrainProposal {
+        BrainProposal {
+            label: if text.trim_start().starts_with('/') {
+                "command"
+            } else {
+                "message"
+            }
+            .to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    async fn extract_preference(&self, text: &str) -> Option<BrainProposal> {
+        let lowered = text.to_ascii_lowercase();
+        (lowered.contains("mute") || lowered.contains("only tell me")).then(|| BrainProposal {
+            label: "preference".to_string(),
+            text: text.to_string(),
+        })
+    }
+
+    async fn draft_digest(&self, context: &str) -> BrainProposal {
+        BrainProposal {
+            label: "deterministic_digest".to_string(),
+            text: context.to_string(),
+        }
+    }
+
+    async fn summarize_mission(&self, context: &str) -> BrainProposal {
+        BrainProposal {
+            label: "deterministic_summary".to_string(),
+            text: context.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shadow_brain_never_gets_direct_send_authority() {
+        let deterministic = DeterministicPalomaBrain;
+        let shadow = ShadowPalomaBrain::new(DeterministicPalomaBrain, "qwenpaw_shadow");
+
+        let run = compare_shadow_digest(&deterministic, Some(&shadow), "mission update").await;
+
+        assert_eq!(run.deterministic.label, "deterministic_digest");
+        assert_eq!(
+            run.shadow.expect("shadow proposal").label,
+            "qwenpaw_shadow_deterministic_digest"
+        );
+        assert!(!run.shadow_send_allowed);
+    }
+}

--- a/src/api/paloma/capability.rs
+++ b/src/api/paloma/capability.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PalomaCapability {
+    pub id: Uuid,
+    pub name: String,
+    pub source: String,
+    pub audit_required: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct CapabilityRegistry {
+    capabilities: Vec<PalomaCapability>,
+}
+
+impl CapabilityRegistry {
+    pub fn register(&mut self, capability: PalomaCapability) {
+        if let Some(existing) = self
+            .capabilities
+            .iter_mut()
+            .find(|item| item.name == capability.name && item.source == capability.source)
+        {
+            *existing = capability;
+        } else {
+            self.capabilities.push(capability);
+        }
+    }
+
+    pub fn list(&self) -> &[PalomaCapability] {
+        &self.capabilities
+    }
+
+    pub fn local_tool_allowed(&self, name: &str) -> bool {
+        self.capabilities
+            .iter()
+            .any(|capability| capability.name == name && capability.audit_required)
+    }
+}
+
+pub fn default_remote_capabilities() -> Vec<PalomaCapability> {
+    [
+        "list_missions",
+        "summarize_mission",
+        "send_message_to_mission",
+        "schedule_reminder",
+        "update_notification_preference",
+        "request_local_satellite_capability",
+    ]
+    .into_iter()
+    .map(|name| PalomaCapability {
+        id: Uuid::new_v4(),
+        name: name.to_string(),
+        source: "remote_paloma".to_string(),
+        audit_required: true,
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_upserts_by_name_and_source_and_requires_audit_flag_for_local_tools() {
+        let mut registry = CapabilityRegistry::default();
+        registry.register(PalomaCapability {
+            id: Uuid::new_v4(),
+            name: "open_local_file".to_string(),
+            source: "laptop".to_string(),
+            audit_required: false,
+        });
+        assert!(!registry.local_tool_allowed("open_local_file"));
+
+        registry.register(PalomaCapability {
+            id: Uuid::new_v4(),
+            name: "open_local_file".to_string(),
+            source: "laptop".to_string(),
+            audit_required: true,
+        });
+
+        assert_eq!(registry.list().len(), 1);
+        assert!(registry.local_tool_allowed("open_local_file"));
+        assert!(!registry.local_tool_allowed("read_keychain"));
+    }
+
+    #[test]
+    fn default_remote_capabilities_cover_paloma_control_surface() {
+        let capabilities = default_remote_capabilities();
+        let names = capabilities
+            .iter()
+            .map(|capability| capability.name.as_str())
+            .collect::<std::collections::HashSet<_>>();
+
+        for expected in [
+            "list_missions",
+            "summarize_mission",
+            "send_message_to_mission",
+            "schedule_reminder",
+            "update_notification_preference",
+            "request_local_satellite_capability",
+        ] {
+            assert!(names.contains(expected), "missing {expected}");
+        }
+        assert!(capabilities
+            .iter()
+            .all(|capability| capability.audit_required));
+        assert!(capabilities
+            .iter()
+            .all(|capability| capability.source == "remote_paloma"));
+    }
+}

--- a/src/api/paloma/channel.rs
+++ b/src/api/paloma/channel.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PalomaChannelKind {
+    Telegram,
+    LocalSatellite,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PalomaChannelAddress {
+    pub kind: PalomaChannelKind,
+    pub channel_id: String,
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mission_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PalomaInboundMessage {
+    pub address: PalomaChannelAddress,
+    pub sender_id: Option<i64>,
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PalomaDeliveryIntent {
+    Reply,
+    ProactiveAlert,
+    Digest,
+    ScheduledReminder,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PalomaOutboundMessage {
+    pub address: PalomaChannelAddress,
+    pub intent: PalomaDeliveryIntent,
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id: Option<i64>,
+}
+
+impl PalomaChannelAddress {
+    pub fn telegram(channel_id: Uuid, chat_id: i64, mission_id: Option<Uuid>) -> Self {
+        Self {
+            kind: PalomaChannelKind::Telegram,
+            channel_id: channel_id.to_string(),
+            session_id: chat_id.to_string(),
+            mission_id,
+        }
+    }
+
+    pub fn queue_session_key(&self) -> String {
+        match self.mission_id {
+            Some(mission_id) => format!("{}:{}:{}", self.channel_id, self.session_id, mission_id),
+            None => format!("{}:{}", self.channel_id, self.session_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn telegram_address_preserves_channel_chat_and_optional_mission() {
+        let channel_id = Uuid::new_v4();
+        let mission_id = Uuid::new_v4();
+
+        let address = PalomaChannelAddress::telegram(channel_id, 123, Some(mission_id));
+
+        assert_eq!(address.kind, PalomaChannelKind::Telegram);
+        assert_eq!(address.channel_id, channel_id.to_string());
+        assert_eq!(address.session_id, "123");
+        assert_eq!(address.mission_id, Some(mission_id));
+        assert_eq!(
+            address.queue_session_key(),
+            format!("{channel_id}:123:{mission_id}")
+        );
+    }
+
+    #[test]
+    fn outbound_message_keeps_delivery_intent_outside_text() {
+        let address = PalomaChannelAddress::telegram(Uuid::new_v4(), 123, None);
+        let outbound = PalomaOutboundMessage {
+            address: address.clone(),
+            intent: PalomaDeliveryIntent::Digest,
+            text: "2 mission updates".to_string(),
+            reply_to_message_id: None,
+        };
+
+        assert_eq!(outbound.address, address);
+        assert_eq!(outbound.intent, PalomaDeliveryIntent::Digest);
+        assert_eq!(outbound.text, "2 mission updates");
+    }
+}

--- a/src/api/paloma/commands.rs
+++ b/src/api/paloma/commands.rs
@@ -1,0 +1,127 @@
+/// Returns true when `text` is exactly `name` or `name` followed by arguments.
+pub fn is_command(text: &str, name: &str) -> bool {
+    let Some((command, _tail)) = split_command(text) else {
+        return false;
+    };
+    command_name(command) == name
+}
+
+/// Returns true only when `text` invokes `name` without arguments.
+pub fn is_exact_command(text: &str, name: &str) -> bool {
+    let Some((command, tail)) = split_command(text) else {
+        return false;
+    };
+    command_name(command) == name && tail.is_empty()
+}
+
+/// Keep the first Paloma natural-language command mapping deterministic.
+pub fn normalize_natural_command(text: &str) -> Option<&'static str> {
+    let trimmed = text.trim();
+    if trimmed.starts_with('/') || trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let mentions_missions = lower.contains("mission");
+    let asks_for_mission_list = mentions_missions
+        && (lower.contains("en cours")
+            || lower.contains("en ce moment")
+            || lower.contains("actif")
+            || lower.contains("active")
+            || lower.contains("liste")
+            || lower.contains("quelles")
+            || lower.contains("lesquelles")
+            || lower.contains("quoi")
+            || lower.contains("voir")
+            || lower.contains("list")
+            || lower.contains("show")
+            || lower.contains("current")
+            || lower.contains("running")
+            || lower.contains("montre"));
+    if asks_for_mission_list {
+        return Some("/missions");
+    }
+
+    if lower == "status"
+        || lower == "statut"
+        || lower.starts_with("status ")
+        || lower.starts_with("statut ")
+        || lower.contains("statut")
+        || lower.contains("update me")
+        || lower.contains("update moi")
+        || lower.contains("mets moi a jour")
+        || lower.contains("mets-moi a jour")
+        || lower.contains("mets moi à jour")
+        || lower.contains("mets-moi à jour")
+        || lower.contains("quoi de neuf")
+        || lower.contains("nouveau")
+        || lower.contains("what changed")
+    {
+        return Some("/status");
+    }
+    None
+}
+
+pub fn parse_selector_and_payload<'a>(text: &'a str, command: &str) -> Option<(&'a str, &'a str)> {
+    let (actual_command, tail) = split_command(text)?;
+    if command_name(actual_command) != command {
+        return None;
+    }
+    let (selector, payload) = tail.split_once(char::is_whitespace)?;
+    let payload = payload.trim();
+    if selector.trim().is_empty() || payload.is_empty() {
+        None
+    } else {
+        Some((selector.trim(), payload))
+    }
+}
+
+fn split_command(text: &str) -> Option<(&str, &str)> {
+    let trimmed = text.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+    match trimmed.find(char::is_whitespace) {
+        Some(idx) => Some((&trimmed[..idx], trimmed[idx..].trim())),
+        None => Some((trimmed, "")),
+    }
+}
+
+fn command_name(command: &str) -> &str {
+    command
+        .split_once('@')
+        .map(|(name, _)| name)
+        .unwrap_or(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_matching_requires_boundary() {
+        assert!(is_command("/status", "/status"));
+        assert!(is_command("/status latest", "/status"));
+        assert!(is_command("/status@paloma_test_bot latest", "/status"));
+        assert!(!is_command("/statusplease", "/status"));
+    }
+
+    #[test]
+    fn exact_command_allows_bot_suffix_without_arguments() {
+        assert!(is_exact_command("/summary", "/summary"));
+        assert!(is_exact_command("/summary@paloma_test_bot", "/summary"));
+        assert!(!is_exact_command("/summary latest", "/summary"));
+        assert!(!is_exact_command(
+            "/summary@paloma_test_bot latest",
+            "/summary"
+        ));
+    }
+
+    #[test]
+    fn selector_parser_allows_bot_suffix() {
+        assert_eq!(
+            parse_selector_and_payload("/send@paloma_test_bot latest go", "/send"),
+            Some(("latest", "go"))
+        );
+    }
+}

--- a/src/api/paloma/decision_log.rs
+++ b/src/api/paloma/decision_log.rs
@@ -1,0 +1,49 @@
+use crate::api::mission_store::PalomaDecision;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+pub fn generated_text_preview(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(240)
+        .collect()
+}
+
+pub fn generated_text_hash(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn new_decision(
+    event_source: &str,
+    mission_id: Option<Uuid>,
+    user_id: Option<i64>,
+    channel: &str,
+    reason_code: &str,
+    proposed_action: &str,
+    allowed: bool,
+    suppression_reason: Option<&str>,
+    policy_snapshot_json: &str,
+    generated_text: Option<&str>,
+    created_at: String,
+) -> PalomaDecision {
+    PalomaDecision {
+        id: Uuid::new_v4(),
+        event_source: event_source.to_string(),
+        mission_id,
+        user_id,
+        channel: channel.to_string(),
+        reason_code: reason_code.to_string(),
+        proposed_action: proposed_action.to_string(),
+        allowed,
+        suppression_reason: suppression_reason.map(ToOwned::to_owned),
+        policy_snapshot_json: policy_snapshot_json.to_string(),
+        generated_text_hash: generated_text.map(generated_text_hash),
+        generated_text_preview: generated_text.map(generated_text_preview),
+        created_at,
+    }
+}

--- a/src/api/paloma/digest.rs
+++ b/src/api/paloma/digest.rs
@@ -1,0 +1,72 @@
+use crate::api::mission_store::TelegramAlert;
+
+pub fn alert_rank(alert: &TelegramAlert) -> i32 {
+    match alert.importance.as_str() {
+        "high" => 0,
+        "normal" => 1,
+        _ => 2,
+    }
+}
+
+pub fn alert_digest_line(alert: &TelegramAlert) -> String {
+    let mut lines = alert.body.lines();
+    let lead = lines
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .unwrap_or(alert.title.as_str());
+    let latest = lines.find_map(|line| line.trim().strip_prefix("Latest: "));
+    match latest {
+        Some(latest) if !latest.trim().is_empty() => {
+            format!("- {lead} Latest: {}", latest.trim())
+        }
+        _ => format!("- {lead}"),
+    }
+}
+
+pub fn alert_digest_text<F>(alerts: &[TelegramAlert], redact: F) -> String
+where
+    F: Fn(&str) -> String,
+{
+    if alerts.len() == 1 {
+        return redact(alerts[0].body.trim());
+    }
+
+    let mut sorted = alerts.to_vec();
+    sorted.sort_by(|a, b| {
+        alert_rank(a)
+            .cmp(&alert_rank(b))
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+    let high_count = sorted
+        .iter()
+        .filter(|alert| alert.importance == "high")
+        .count();
+    let mut text = if high_count > 0 {
+        format!(
+            "{} mission update{} {} attention:",
+            high_count,
+            if high_count == 1 { "" } else { "s" },
+            if high_count == 1 { "needs" } else { "need" }
+        )
+    } else {
+        format!(
+            "{} mission update{}:",
+            sorted.len(),
+            if sorted.len() == 1 { "" } else { "s" }
+        )
+    };
+    for alert in sorted.iter().take(8) {
+        text.push('\n');
+        text.push_str(&alert_digest_line(alert));
+    }
+    let remaining = sorted.len().saturating_sub(8);
+    if remaining > 0 {
+        text.push_str(&format!(
+            "\n- {} more update{}",
+            remaining,
+            if remaining == 1 { "" } else { "s" }
+        ));
+    }
+    redact(&text)
+}

--- a/src/api/paloma/event.rs
+++ b/src/api/paloma/event.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PalomaEventSource {
+    TelegramWebhook,
+    MissionObserver,
+    Scheduler,
+    LocalSatellite,
+}
+
+impl PalomaEventSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TelegramWebhook => "telegram_webhook",
+            Self::MissionObserver => "mission_observer",
+            Self::Scheduler => "scheduler",
+            Self::LocalSatellite => "local_satellite",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PalomaReasonCode {
+    AwaitingUser,
+    LongRunning,
+    TerminalHighInterest,
+    TerminalLongRunning,
+    Muted,
+    QuietWindow,
+    AssistantMode,
+    NotActionable,
+    DigestSend,
+    DigestSuppressed,
+}
+
+impl PalomaReasonCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AwaitingUser => "awaiting_user",
+            Self::LongRunning => "long_running",
+            Self::TerminalHighInterest => "terminal_high_interest",
+            Self::TerminalLongRunning => "terminal_long_running",
+            Self::Muted => "muted",
+            Self::QuietWindow => "quiet_window",
+            Self::AssistantMode => "assistant_mode",
+            Self::NotActionable => "not_actionable",
+            Self::DigestSend => "digest_send",
+            Self::DigestSuppressed => "digest_suppressed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PalomaEvent {
+    pub source: PalomaEventSource,
+    pub channel: String,
+    pub user_id: Option<i64>,
+    pub mission_id: Option<Uuid>,
+    pub reason_code: PalomaReasonCode,
+}

--- a/src/api/paloma/memory.rs
+++ b/src/api/paloma/memory.rs
@@ -1,0 +1,71 @@
+use crate::api::mission_store::TelegramStructuredMemoryEntry;
+
+pub fn consolidate_latest_explicit(
+    mut entries: Vec<TelegramStructuredMemoryEntry>,
+) -> Vec<TelegramStructuredMemoryEntry> {
+    entries.sort_by(|a, b| {
+        a.channel_id
+            .cmp(&b.channel_id)
+            .then_with(|| format!("{:?}", a.scope).cmp(&format!("{:?}", b.scope)))
+            .then_with(|| a.chat_id.cmp(&b.chat_id))
+            .then_with(|| a.subject_user_id.cmp(&b.subject_user_id))
+            .then_with(|| a.label.cmp(&b.label))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+    });
+    entries.dedup_by(|a, b| {
+        a.channel_id == b.channel_id
+            && a.scope == b.scope
+            && a.chat_id == b.chat_id
+            && a.subject_user_id == b.subject_user_id
+            && a.label == b.label
+    });
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::mission_store::{TelegramStructuredMemoryKind, TelegramStructuredMemoryScope};
+    use uuid::Uuid;
+
+    fn entry(label: &str, value: &str, updated_at: &str) -> TelegramStructuredMemoryEntry {
+        TelegramStructuredMemoryEntry {
+            id: Uuid::new_v4(),
+            channel_id: Uuid::new_v4(),
+            chat_id: 123,
+            mission_id: None,
+            subject_user_id: Some(42),
+            subject_username: Some("tester".to_string()),
+            subject_display_name: Some("Tester".to_string()),
+            scope: TelegramStructuredMemoryScope::User,
+            kind: TelegramStructuredMemoryKind::Preference,
+            label: Some(label.to_string()),
+            value: value.to_string(),
+            source_message_id: Some(7),
+            source_role: "user".to_string(),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn consolidation_keeps_latest_explicit_rule_per_subject_and_label() {
+        let channel_id = Uuid::new_v4();
+        let mut older = entry("alerts", "tell me everything", "2026-05-20T00:00:00Z");
+        older.channel_id = channel_id;
+        let mut newer = entry("alerts", "only failures", "2026-05-20T01:00:00Z");
+        newer.channel_id = channel_id;
+        let mut other_label = entry("tone", "short", "2026-05-20T00:30:00Z");
+        other_label.channel_id = channel_id;
+
+        let consolidated = consolidate_latest_explicit(vec![older, other_label, newer]);
+
+        assert_eq!(consolidated.len(), 2);
+        assert!(consolidated.iter().any(
+            |entry| entry.label.as_deref() == Some("alerts") && entry.value == "only failures"
+        ));
+        assert!(consolidated
+            .iter()
+            .any(|entry| entry.label.as_deref() == Some("tone") && entry.value == "short"));
+    }
+}

--- a/src/api/paloma/mod.rs
+++ b/src/api/paloma/mod.rs
@@ -1,0 +1,18 @@
+//! Paloma core primitives.
+//!
+//! Telegram remains the delivery adapter; this module holds the small,
+//! deterministic building blocks that can be shared by future channels.
+
+pub mod brain;
+pub mod capability;
+pub mod channel;
+pub mod commands;
+pub mod decision_log;
+pub mod digest;
+pub mod event;
+pub mod memory;
+pub mod planner;
+pub mod policy;
+pub mod queue;
+pub mod satellite;
+pub mod scheduler;

--- a/src/api/paloma/planner.rs
+++ b/src/api/paloma/planner.rs
@@ -1,0 +1,183 @@
+use crate::api::control::MissionStatus;
+use crate::api::mission_store::{
+    Mission, MissionMode, StoredEvent, TelegramAlertPreference, TelegramMissionInterestLevel,
+};
+use crate::api::paloma::policy::{
+    evaluate_alert_policy, mission_policy_input, PalomaPolicyDecision,
+};
+use chrono::{DateTime, Duration, Utc};
+use uuid::Uuid;
+
+pub fn alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
+    match status {
+        MissionStatus::Active => Some("mission_long_running"),
+        MissionStatus::AwaitingUser => Some("mission_awaiting_user"),
+        MissionStatus::Completed => Some("mission_completed"),
+        MissionStatus::Failed => Some("mission_failed"),
+        MissionStatus::Blocked => Some("mission_blocked"),
+        MissionStatus::Interrupted => Some("mission_interrupted"),
+        MissionStatus::NotFeasible => Some("mission_not_feasible"),
+        _ => None,
+    }
+}
+
+pub fn alert_importance_for_mission(
+    mission: &Mission,
+    interest: TelegramMissionInterestLevel,
+) -> &'static str {
+    if interest == TelegramMissionInterestLevel::High {
+        return "high";
+    }
+    match mission.status {
+        MissionStatus::AwaitingUser | MissionStatus::Failed | MissionStatus::Blocked => "high",
+        MissionStatus::Active => "normal",
+        _ => "low",
+    }
+}
+
+pub fn parse_event_time(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+pub fn latest_user_message_at(events: &[StoredEvent]) -> Option<DateTime<Utc>> {
+    events
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "user_message")
+        .and_then(|event| parse_event_time(&event.timestamp))
+}
+
+pub fn mission_started_at(mission: &Mission) -> Option<DateTime<Utc>> {
+    parse_event_time(&mission.created_at).or_else(|| parse_event_time(&mission.updated_at))
+}
+
+pub fn evaluate_mission_alert_policy_at(
+    mission: &Mission,
+    events: &[StoredEvent],
+    interest: TelegramMissionInterestLevel,
+    now: DateTime<Utc>,
+    long_running_after: Duration,
+    quiet_after_user_message: Duration,
+) -> PalomaPolicyDecision {
+    let input = mission_policy_input(
+        mission,
+        interest,
+        mission_started_at(mission),
+        latest_user_message_at(events),
+        now,
+        long_running_after,
+        quiet_after_user_message,
+    );
+    evaluate_alert_policy(&input)
+}
+
+pub fn should_alert_long_running_mission_at(
+    mission: &Mission,
+    events: &[StoredEvent],
+    now: DateTime<Utc>,
+    long_running_after: Duration,
+    quiet_after_user_message: Duration,
+) -> bool {
+    if mission.status != MissionStatus::Active || mission.mission_mode == MissionMode::Assistant {
+        return false;
+    }
+    evaluate_mission_alert_policy_at(
+        mission,
+        events,
+        TelegramMissionInterestLevel::Normal,
+        now,
+        long_running_after,
+        quiet_after_user_message,
+    )
+    .allowed
+}
+
+pub fn should_alert_mission_at(
+    mission: &Mission,
+    events: &[StoredEvent],
+    interest: TelegramMissionInterestLevel,
+    now: DateTime<Utc>,
+    long_running_after: Duration,
+    quiet_after_user_message: Duration,
+) -> bool {
+    evaluate_mission_alert_policy_at(
+        mission,
+        events,
+        interest,
+        now,
+        long_running_after,
+        quiet_after_user_message,
+    )
+    .allowed
+}
+
+pub fn alert_suppression_reason(
+    mission: &Mission,
+    events: &[StoredEvent],
+    interest: TelegramMissionInterestLevel,
+    now: DateTime<Utc>,
+    long_running_after: Duration,
+    quiet_after_user_message: Duration,
+) -> &'static str {
+    evaluate_mission_alert_policy_at(
+        mission,
+        events,
+        interest,
+        now,
+        long_running_after,
+        quiet_after_user_message,
+    )
+    .suppression_reason
+    .unwrap_or("policy_suppressed")
+}
+
+pub fn alert_event_kind_at(
+    mission: &Mission,
+    base_kind: &str,
+    events: &[StoredEvent],
+    now: DateTime<Utc>,
+    long_running_alert_bucket: Duration,
+) -> String {
+    if mission.status == MissionStatus::Active && base_kind == "mission_long_running" {
+        let bucket_seconds = long_running_alert_bucket.num_seconds().max(1);
+        let bucket = now.timestamp().div_euclid(bucket_seconds);
+        return format!("{base_kind}:{bucket}");
+    }
+
+    let status = mission.status.to_string();
+    let updated = events
+        .iter()
+        .rev()
+        .find(|event| {
+            event.event_type == "mission_status_changed"
+                && event
+                    .metadata
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    == Some(status.as_str())
+        })
+        .map(|event| event.timestamp.as_str())
+        .unwrap_or(mission.updated_at.as_str());
+    format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
+}
+
+pub fn preference_is_failure_only(preference: &TelegramAlertPreference) -> bool {
+    let rule = preference.rule_text.to_ascii_lowercase();
+    preference.enabled
+        && rule.contains("only")
+        && (rule.contains("fail") || rule.contains("failure"))
+}
+
+pub fn mission_has_failure_only_preference(
+    preferences: &[TelegramAlertPreference],
+    mission_id: Uuid,
+) -> bool {
+    let mission_id = mission_id.to_string();
+    preferences.iter().any(|preference| {
+        preference.scope == "mission"
+            && preference.scope_value.as_deref() == Some(mission_id.as_str())
+            && preference_is_failure_only(preference)
+    })
+}

--- a/src/api/paloma/policy.rs
+++ b/src/api/paloma/policy.rs
@@ -1,0 +1,275 @@
+use crate::api::control::MissionStatus;
+use crate::api::mission_store::{Mission, MissionMode, TelegramMissionInterestLevel};
+use crate::api::paloma::event::PalomaReasonCode;
+use chrono::{DateTime, Duration, Utc};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PalomaPolicyInput {
+    pub status: MissionStatus,
+    pub mission_mode: MissionMode,
+    pub interest: TelegramMissionInterestLevel,
+    pub started_at: Option<DateTime<Utc>>,
+    pub last_user_message_at: Option<DateTime<Utc>>,
+    pub now: DateTime<Utc>,
+    pub long_running_after: Duration,
+    pub quiet_after_user_message: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PalomaPolicyDecision {
+    pub allowed: bool,
+    pub reason_code: PalomaReasonCode,
+    pub suppression_reason: Option<&'static str>,
+    pub priority: &'static str,
+}
+
+pub fn mission_policy_input(
+    mission: &Mission,
+    interest: TelegramMissionInterestLevel,
+    started_at: Option<DateTime<Utc>>,
+    last_user_message_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+    long_running_after: Duration,
+    quiet_after_user_message: Duration,
+) -> PalomaPolicyInput {
+    PalomaPolicyInput {
+        status: mission.status,
+        mission_mode: mission.mission_mode.clone(),
+        interest,
+        started_at,
+        last_user_message_at,
+        now,
+        long_running_after,
+        quiet_after_user_message,
+    }
+}
+
+pub fn evaluate_alert_policy(input: &PalomaPolicyInput) -> PalomaPolicyDecision {
+    if input.interest == TelegramMissionInterestLevel::Muted {
+        return PalomaPolicyDecision {
+            allowed: false,
+            reason_code: PalomaReasonCode::Muted,
+            suppression_reason: Some("mission_muted"),
+            priority: "low",
+        };
+    }
+    if input.mission_mode == MissionMode::Assistant {
+        return PalomaPolicyDecision {
+            allowed: false,
+            reason_code: PalomaReasonCode::AssistantMode,
+            suppression_reason: Some("assistant_mode"),
+            priority: "low",
+        };
+    }
+
+    match input.status {
+        MissionStatus::AwaitingUser => PalomaPolicyDecision {
+            allowed: true,
+            reason_code: PalomaReasonCode::AwaitingUser,
+            suppression_reason: None,
+            priority: "high",
+        },
+        MissionStatus::Active => {
+            let Some(started_at) = input.started_at else {
+                return PalomaPolicyDecision {
+                    allowed: false,
+                    reason_code: PalomaReasonCode::NotActionable,
+                    suppression_reason: Some("missing_started_at"),
+                    priority: "normal",
+                };
+            };
+            if input.now - started_at < input.long_running_after {
+                return PalomaPolicyDecision {
+                    allowed: false,
+                    reason_code: PalomaReasonCode::NotActionable,
+                    suppression_reason: Some("below_long_running_threshold"),
+                    priority: "normal",
+                };
+            }
+            if input
+                .last_user_message_at
+                .map(|last| input.now - last < input.quiet_after_user_message)
+                .unwrap_or(false)
+            {
+                return PalomaPolicyDecision {
+                    allowed: false,
+                    reason_code: PalomaReasonCode::QuietWindow,
+                    suppression_reason: Some("recent_user_message"),
+                    priority: "normal",
+                };
+            }
+            PalomaPolicyDecision {
+                allowed: true,
+                reason_code: PalomaReasonCode::LongRunning,
+                suppression_reason: None,
+                priority: "normal",
+            }
+        }
+        MissionStatus::Completed
+        | MissionStatus::Failed
+        | MissionStatus::Blocked
+        | MissionStatus::Interrupted
+        | MissionStatus::NotFeasible => {
+            let high_interest = input.interest == TelegramMissionInterestLevel::High;
+            let long_running = input
+                .started_at
+                .map(|started| input.now - started >= input.long_running_after)
+                .unwrap_or(false);
+            if high_interest || long_running {
+                PalomaPolicyDecision {
+                    allowed: true,
+                    reason_code: if high_interest {
+                        PalomaReasonCode::TerminalHighInterest
+                    } else {
+                        PalomaReasonCode::TerminalLongRunning
+                    },
+                    suppression_reason: None,
+                    priority: if matches!(
+                        input.status,
+                        MissionStatus::Failed | MissionStatus::Blocked
+                    ) {
+                        "high"
+                    } else {
+                        "low"
+                    },
+                }
+            } else {
+                PalomaPolicyDecision {
+                    allowed: false,
+                    reason_code: PalomaReasonCode::NotActionable,
+                    suppression_reason: Some("terminal_not_long_running_or_high_interest"),
+                    priority: "low",
+                }
+            }
+        }
+        _ => PalomaPolicyDecision {
+            allowed: false,
+            reason_code: PalomaReasonCode::NotActionable,
+            suppression_reason: Some("status_not_actionable"),
+            priority: "low",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn input_for(status: MissionStatus) -> PalomaPolicyInput {
+        let now = Utc.with_ymd_and_hms(2026, 5, 20, 1, 0, 0).unwrap();
+        PalomaPolicyInput {
+            status,
+            mission_mode: MissionMode::Task,
+            interest: TelegramMissionInterestLevel::Normal,
+            started_at: Some(Utc.with_ymd_and_hms(2026, 5, 20, 0, 0, 0).unwrap()),
+            last_user_message_at: None,
+            now,
+            long_running_after: Duration::minutes(30),
+            quiet_after_user_message: Duration::minutes(30),
+        }
+    }
+
+    #[test]
+    fn muted_wins_over_awaiting_user() {
+        let input = PalomaPolicyInput {
+            status: MissionStatus::AwaitingUser,
+            mission_mode: MissionMode::Task,
+            interest: TelegramMissionInterestLevel::Muted,
+            started_at: None,
+            last_user_message_at: None,
+            now: Utc.with_ymd_and_hms(2026, 5, 20, 1, 0, 0).unwrap(),
+            long_running_after: Duration::minutes(30),
+            quiet_after_user_message: Duration::minutes(30),
+        };
+        let decision = evaluate_alert_policy(&input);
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason_code, PalomaReasonCode::Muted);
+    }
+
+    #[test]
+    fn awaiting_user_alerts_by_default() {
+        let decision = evaluate_alert_policy(&input_for(MissionStatus::AwaitingUser));
+
+        assert!(decision.allowed);
+        assert_eq!(decision.reason_code, PalomaReasonCode::AwaitingUser);
+        assert_eq!(decision.priority, "high");
+    }
+
+    #[test]
+    fn active_requires_long_running_and_quiet_window() {
+        let mut missing_start = input_for(MissionStatus::Active);
+        missing_start.started_at = None;
+        let missing_start_decision = evaluate_alert_policy(&missing_start);
+        assert!(!missing_start_decision.allowed);
+        assert_eq!(
+            missing_start_decision.suppression_reason,
+            Some("missing_started_at")
+        );
+
+        let mut fresh = input_for(MissionStatus::Active);
+        fresh.started_at = Some(Utc.with_ymd_and_hms(2026, 5, 20, 0, 45, 0).unwrap());
+        let fresh_decision = evaluate_alert_policy(&fresh);
+        assert!(!fresh_decision.allowed);
+        assert_eq!(
+            fresh_decision.suppression_reason,
+            Some("below_long_running_threshold")
+        );
+
+        let mut recently_messaged = input_for(MissionStatus::Active);
+        recently_messaged.last_user_message_at =
+            Some(Utc.with_ymd_and_hms(2026, 5, 20, 0, 45, 0).unwrap());
+        let quiet_decision = evaluate_alert_policy(&recently_messaged);
+        assert!(!quiet_decision.allowed);
+        assert_eq!(quiet_decision.reason_code, PalomaReasonCode::QuietWindow);
+
+        let allowed = evaluate_alert_policy(&input_for(MissionStatus::Active));
+        assert!(allowed.allowed);
+        assert_eq!(allowed.reason_code, PalomaReasonCode::LongRunning);
+    }
+
+    #[test]
+    fn terminal_statuses_need_long_running_or_high_interest() {
+        let mut short_completed = input_for(MissionStatus::Completed);
+        short_completed.started_at = Some(Utc.with_ymd_and_hms(2026, 5, 20, 0, 45, 0).unwrap());
+        let suppressed = evaluate_alert_policy(&short_completed);
+        assert!(!suppressed.allowed);
+        assert_eq!(
+            suppressed.suppression_reason,
+            Some("terminal_not_long_running_or_high_interest")
+        );
+
+        short_completed.interest = TelegramMissionInterestLevel::High;
+        let high_interest = evaluate_alert_policy(&short_completed);
+        assert!(high_interest.allowed);
+        assert_eq!(
+            high_interest.reason_code,
+            PalomaReasonCode::TerminalHighInterest
+        );
+
+        let long_running_failed = evaluate_alert_policy(&input_for(MissionStatus::Failed));
+        assert!(long_running_failed.allowed);
+        assert_eq!(long_running_failed.priority, "high");
+
+        let mut missing_started_at = input_for(MissionStatus::Failed);
+        missing_started_at.started_at = None;
+        let missing_started_at_decision = evaluate_alert_policy(&missing_started_at);
+        assert!(!missing_started_at_decision.allowed);
+        assert_eq!(
+            missing_started_at_decision.suppression_reason,
+            Some("terminal_not_long_running_or_high_interest")
+        );
+    }
+
+    #[test]
+    fn assistant_mode_is_suppressed_before_status_policy() {
+        let mut input = input_for(MissionStatus::AwaitingUser);
+        input.mission_mode = MissionMode::Assistant;
+
+        let decision = evaluate_alert_policy(&input);
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason_code, PalomaReasonCode::AssistantMode);
+        assert_eq!(decision.suppression_reason, Some("assistant_mode"));
+    }
+}

--- a/src/api/paloma/queue.rs
+++ b/src/api/paloma/queue.rs
@@ -1,0 +1,170 @@
+use serde::Serialize;
+use std::collections::{HashMap, HashSet, VecDeque};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueueKey {
+    pub channel: String,
+    pub session_id: String,
+    pub mission_id: Option<Uuid>,
+    pub priority: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct QueueMetrics {
+    pub pending_items: usize,
+    pub active_sessions: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct PalomaQueue<T> {
+    queues: HashMap<QueueKey, VecDeque<T>>,
+    max_per_key: usize,
+}
+
+impl<T> PalomaQueue<T> {
+    pub fn new(max_per_key: usize) -> Self {
+        Self {
+            queues: HashMap::new(),
+            max_per_key,
+        }
+    }
+
+    pub fn push(&mut self, key: QueueKey, item: T) -> Result<(), T> {
+        let queue = self.queues.entry(key).or_default();
+        if queue.len() >= self.max_per_key {
+            return Err(item);
+        }
+        queue.push_back(item);
+        Ok(())
+    }
+
+    pub fn pop(&mut self, key: &QueueKey) -> Option<T> {
+        let item = self.queues.get_mut(key)?.pop_front();
+        if self.queues.get(key).is_some_and(VecDeque::is_empty) {
+            self.queues.remove(key);
+        }
+        item
+    }
+
+    pub fn cleanup_idle(&mut self) {
+        self.queues.retain(|_, queue| !queue.is_empty());
+    }
+
+    pub fn metrics(&self) -> QueueMetrics {
+        QueueMetrics {
+            pending_items: self.queues.values().map(VecDeque::len).sum(),
+            active_sessions: self.queues.len(),
+        }
+    }
+
+    pub fn metrics_for_channels(&self, channel_ids: &HashSet<String>) -> QueueMetrics {
+        let mut pending_items = 0;
+        let mut active_sessions = 0;
+        for (key, queue) in &self.queues {
+            if channel_ids.contains(&key.channel) {
+                pending_items += queue.len();
+                active_sessions += 1;
+            }
+        }
+        QueueMetrics {
+            pending_items,
+            active_sessions,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_per_key_without_merging_sessions() {
+        let mut queue = PalomaQueue::new(8);
+        let key_a = QueueKey {
+            channel: "telegram".to_string(),
+            session_id: "chat-a".to_string(),
+            mission_id: None,
+            priority: 5,
+        };
+        let key_b = QueueKey {
+            session_id: "chat-b".to_string(),
+            ..key_a.clone()
+        };
+        queue.push(key_a.clone(), 1).unwrap();
+        queue.push(key_a.clone(), 2).unwrap();
+        queue.push(key_b.clone(), 9).unwrap();
+        assert_eq!(queue.pop(&key_a), Some(1));
+        assert_eq!(queue.pop(&key_b), Some(9));
+        assert_eq!(queue.pop(&key_a), Some(2));
+    }
+
+    #[test]
+    fn bounds_queue_per_key_and_cleans_idle_sessions() {
+        let mut queue = PalomaQueue::new(1);
+        let key = QueueKey {
+            channel: "telegram".to_string(),
+            session_id: "chat-a".to_string(),
+            mission_id: None,
+            priority: 5,
+        };
+
+        assert!(queue.push(key.clone(), "first").is_ok());
+        assert_eq!(queue.push(key.clone(), "overflow"), Err("overflow"));
+        assert_eq!(
+            queue.metrics(),
+            QueueMetrics {
+                pending_items: 1,
+                active_sessions: 1,
+            }
+        );
+
+        assert_eq!(queue.pop(&key), Some("first"));
+        queue.cleanup_idle();
+        assert_eq!(
+            queue.metrics(),
+            QueueMetrics {
+                pending_items: 0,
+                active_sessions: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn metrics_can_be_scoped_to_known_channels() {
+        let mut queue = PalomaQueue::new(8);
+        let channel_a = Uuid::new_v4().to_string();
+        let channel_b = Uuid::new_v4().to_string();
+        queue
+            .push(
+                QueueKey {
+                    channel: channel_a.clone(),
+                    session_id: "chat-a".to_string(),
+                    mission_id: None,
+                    priority: 0,
+                },
+                1,
+            )
+            .unwrap();
+        queue
+            .push(
+                QueueKey {
+                    channel: channel_b,
+                    session_id: "chat-b".to_string(),
+                    mission_id: None,
+                    priority: 0,
+                },
+                2,
+            )
+            .unwrap();
+
+        let channel_ids = HashSet::from([channel_a]);
+        assert_eq!(
+            queue.metrics_for_channels(&channel_ids),
+            QueueMetrics {
+                pending_items: 1,
+                active_sessions: 1,
+            }
+        );
+    }
+}

--- a/src/api/paloma/satellite.rs
+++ b/src/api/paloma/satellite.rs
@@ -1,0 +1,253 @@
+use crate::api::paloma::capability::{CapabilityRegistry, PalomaCapability};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SatelliteRegistration {
+    pub satellite_id: String,
+    pub registered_at: String,
+    pub expires_at: String,
+    pub capabilities: Vec<PalomaCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SatelliteAuditRecord {
+    pub id: Uuid,
+    pub satellite_id: String,
+    pub capability_name: String,
+    pub allowed: bool,
+    pub reason: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SatelliteCapabilityDecision {
+    Allowed,
+    Denied(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SatelliteToolRequest {
+    pub id: Uuid,
+    pub satellite_id: String,
+    pub capability_name: String,
+    pub payload_json: String,
+    pub requested_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SatelliteToolResponse {
+    pub request_id: Uuid,
+    pub accepted: bool,
+    pub reason: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Default)]
+pub struct LocalSatelliteRegistry {
+    capabilities: CapabilityRegistry,
+    registration: Option<SatelliteRegistration>,
+    audit_log: Vec<SatelliteAuditRecord>,
+}
+
+impl LocalSatelliteRegistry {
+    pub fn register(
+        &mut self,
+        satellite_id: impl Into<String>,
+        capabilities: Vec<PalomaCapability>,
+        now: DateTime<Utc>,
+        ttl: Duration,
+    ) -> SatelliteRegistration {
+        let registration = SatelliteRegistration {
+            satellite_id: satellite_id.into(),
+            registered_at: now.to_rfc3339(),
+            expires_at: (now + ttl).to_rfc3339(),
+            capabilities,
+        };
+        for capability in &registration.capabilities {
+            self.capabilities.register(capability.clone());
+        }
+        self.registration = Some(registration.clone());
+        registration
+    }
+
+    pub fn is_online_at(&self, now: DateTime<Utc>) -> bool {
+        self.registration
+            .as_ref()
+            .and_then(|registration| {
+                DateTime::parse_from_rfc3339(&registration.expires_at)
+                    .ok()
+                    .map(|expires_at| expires_at.with_timezone(&Utc) > now)
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn decide_capability(
+        &mut self,
+        capability_name: &str,
+        now: DateTime<Utc>,
+    ) -> SatelliteCapabilityDecision {
+        let Some(registration) = self.registration.as_ref() else {
+            self.audit(capability_name, false, "satellite_offline", now);
+            return SatelliteCapabilityDecision::Denied("satellite_offline".to_string());
+        };
+        let satellite_id = registration.satellite_id.clone();
+        if !self.is_online_at(now) {
+            self.audit_for(
+                &satellite_id,
+                capability_name,
+                false,
+                "satellite_offline",
+                now,
+            );
+            return SatelliteCapabilityDecision::Denied("satellite_offline".to_string());
+        }
+        if !self.capabilities.local_tool_allowed(capability_name) {
+            self.audit_for(
+                &satellite_id,
+                capability_name,
+                false,
+                "missing_explicit_capability",
+                now,
+            );
+            return SatelliteCapabilityDecision::Denied("missing_explicit_capability".to_string());
+        }
+        self.audit_for(&satellite_id, capability_name, true, "allowed", now);
+        SatelliteCapabilityDecision::Allowed
+    }
+
+    pub fn request_capability(
+        &mut self,
+        request: &SatelliteToolRequest,
+        now: DateTime<Utc>,
+    ) -> SatelliteToolResponse {
+        match self.decide_capability(&request.capability_name, now) {
+            SatelliteCapabilityDecision::Allowed => SatelliteToolResponse {
+                request_id: request.id,
+                accepted: true,
+                reason: "accepted".to_string(),
+                created_at: now.to_rfc3339(),
+            },
+            SatelliteCapabilityDecision::Denied(reason) => SatelliteToolResponse {
+                request_id: request.id,
+                accepted: false,
+                reason,
+                created_at: now.to_rfc3339(),
+            },
+        }
+    }
+
+    pub fn remote_paloma_can_answer(&self, now: DateTime<Utc>) -> bool {
+        !self.is_online_at(now)
+    }
+
+    pub fn audit_log(&self) -> &[SatelliteAuditRecord] {
+        &self.audit_log
+    }
+
+    fn audit(&mut self, capability_name: &str, allowed: bool, reason: &str, now: DateTime<Utc>) {
+        self.audit_for("offline", capability_name, allowed, reason, now);
+    }
+
+    fn audit_for(
+        &mut self,
+        satellite_id: &str,
+        capability_name: &str,
+        allowed: bool,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) {
+        self.audit_log.push(SatelliteAuditRecord {
+            id: Uuid::new_v4(),
+            satellite_id: satellite_id.to_string(),
+            capability_name: capability_name.to_string(),
+            allowed,
+            reason: reason.to_string(),
+            created_at: now.to_rfc3339(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn satellite_requires_online_explicit_audited_capability() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap();
+        let mut registry = LocalSatelliteRegistry::default();
+
+        assert!(registry.remote_paloma_can_answer(now));
+        assert_eq!(
+            registry.decide_capability("open_local_file", now),
+            SatelliteCapabilityDecision::Denied("satellite_offline".to_string())
+        );
+
+        registry.register(
+            "laptop",
+            vec![PalomaCapability {
+                id: Uuid::new_v4(),
+                name: "open_local_file".to_string(),
+                source: "laptop".to_string(),
+                audit_required: true,
+            }],
+            now,
+            Duration::minutes(5),
+        );
+
+        assert_eq!(
+            registry.decide_capability("open_local_file", now),
+            SatelliteCapabilityDecision::Allowed
+        );
+        assert_eq!(
+            registry.decide_capability("read_keychain", now),
+            SatelliteCapabilityDecision::Denied("missing_explicit_capability".to_string())
+        );
+        assert_eq!(registry.audit_log().len(), 3);
+    }
+
+    #[test]
+    fn satellite_tool_request_protocol_accepts_only_audited_capabilities() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap();
+        let mut registry = LocalSatelliteRegistry::default();
+        registry.register(
+            "laptop",
+            vec![PalomaCapability {
+                id: Uuid::new_v4(),
+                name: "open_local_file".to_string(),
+                source: "laptop".to_string(),
+                audit_required: true,
+            }],
+            now,
+            Duration::minutes(5),
+        );
+
+        let allowed = registry.request_capability(
+            &SatelliteToolRequest {
+                id: Uuid::new_v4(),
+                satellite_id: "laptop".to_string(),
+                capability_name: "open_local_file".to_string(),
+                payload_json: "{}".to_string(),
+                requested_at: now.to_rfc3339(),
+            },
+            now,
+        );
+        assert!(allowed.accepted);
+        assert_eq!(allowed.reason, "accepted");
+
+        let denied = registry.request_capability(
+            &SatelliteToolRequest {
+                id: Uuid::new_v4(),
+                satellite_id: "laptop".to_string(),
+                capability_name: "read_keychain".to_string(),
+                payload_json: "{}".to_string(),
+                requested_at: now.to_rfc3339(),
+            },
+            now,
+        );
+        assert!(!denied.accepted);
+        assert_eq!(denied.reason, "missing_explicit_capability");
+    }
+}

--- a/src/api/paloma/scheduler.rs
+++ b/src/api/paloma/scheduler.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PalomaJobState {
+    pub name: &'static str,
+    pub runs: u64,
+    pub last_success_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct PalomaJobRegistry {
+    jobs: HashMap<&'static str, PalomaJobState>,
+}
+
+impl PalomaJobRegistry {
+    pub fn with_default_jobs() -> Self {
+        let mut registry = Self::default();
+        for name in [
+            "paloma_alert_scan",
+            "paloma_due_messages",
+            "paloma_memory_consolidation",
+            "paloma_digest_flush",
+            "paloma_stale_recovery",
+        ] {
+            registry.jobs.insert(
+                name,
+                PalomaJobState {
+                    name,
+                    runs: 0,
+                    last_success_at: None,
+                    last_error: None,
+                },
+            );
+        }
+        registry
+    }
+
+    pub fn record_success(&mut self, name: &'static str, at: String) {
+        let state = self.jobs.entry(name).or_insert(PalomaJobState {
+            name,
+            runs: 0,
+            last_success_at: None,
+            last_error: None,
+        });
+        state.runs += 1;
+        state.last_success_at = Some(at);
+        state.last_error = None;
+    }
+
+    pub fn record_failure(&mut self, name: &'static str, error: String) {
+        let state = self.jobs.entry(name).or_insert(PalomaJobState {
+            name,
+            runs: 0,
+            last_success_at: None,
+            last_error: None,
+        });
+        state.runs += 1;
+        state.last_error = Some(error);
+    }
+
+    pub fn states(&self) -> Vec<PalomaJobState> {
+        let mut states = self.jobs.values().cloned().collect::<Vec<_>>();
+        states.sort_by_key(|state| state.name);
+        states
+    }
+}

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -842,6 +842,18 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             get(control::list_bot_action_executions),
         )
         .route(
+            "/api/control/paloma/decisions",
+            get(control::list_paloma_decisions),
+        )
+        .route(
+            "/api/control/paloma/jobs",
+            get(control::list_paloma_scheduler_jobs),
+        )
+        .route(
+            "/api/control/paloma/queue",
+            get(control::get_paloma_queue_metrics),
+        )
+        .route(
             "/api/control/telegram/bots/:id/conversations",
             get(control::list_bot_conversations),
         )

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1365,7 +1365,7 @@ fn stream_sandboxed_update(
         let src = format!("{}/target/debug/{}", repo_path.display(), exe_name);
 
         let install_result = if versioned_install {
-            install_versioned_binary(&repo_path, &exe_name, &latest_tag, &install_dest).await
+            install_versioned_binary(repo_path, &exe_name, &latest_tag, &install_dest).await
         } else {
             // Legacy path: write straight to `install_dest`. Keep until the
             // operator opts into versioned installs.

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -20,10 +20,13 @@ use crate::api::mission_store::{
     TelegramStructuredMemoryScope, TelegramTriggerMode, TelegramUser, TelegramUserRole,
     TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus,
 };
+use crate::api::paloma::queue::{PalomaQueue, QueueKey, QueueMetrics};
+use crate::api::paloma::scheduler::{PalomaJobRegistry, PalomaJobState};
+use crate::api::paloma::{commands as paloma_commands, decision_log, digest, planner};
 use chrono::{Duration as ChronoDuration, Utc};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -33,6 +36,15 @@ use uuid::Uuid;
 /// Shared handle to the Telegram bridge manager.
 pub type SharedTelegramBridge = Arc<TelegramBridge>;
 type TelegramChatLockMap = HashMap<(Uuid, i64), Arc<Mutex<()>>>;
+type PalomaSessionLockMap = HashMap<(Uuid, i64), Arc<Mutex<()>>>;
+
+fn paloma_channel_job_name(base_name: &str, channel_id: Uuid) -> String {
+    format!("{base_name}:{channel_id}")
+}
+
+fn paloma_scheduler_lease_expires_at() -> String {
+    (Utc::now() + ChronoDuration::seconds(PALOMA_SCHEDULER_JOB_LEASE_SECONDS)).to_rfc3339()
+}
 
 /// Manages Telegram webhook registrations and channel routing context.
 pub struct TelegramBridge {
@@ -40,6 +52,12 @@ pub struct TelegramBridge {
     active_channels: RwLock<HashMap<Uuid, ChannelContext>>,
     /// Per-chat locks to serialize auto-create mission resolution.
     chat_locks: RwLock<TelegramChatLockMap>,
+    /// Per-channel/chat Paloma session locks to serialize inbound control messages.
+    paloma_session_locks: RwLock<PalomaSessionLockMap>,
+    /// Bounded per-session queue for inbound Paloma work.
+    paloma_session_queue: Mutex<PalomaQueue<()>>,
+    /// Runtime state for named Paloma scheduler jobs.
+    paloma_jobs: Mutex<PalomaJobRegistry>,
     /// Recently seen Telegram update IDs for webhook idempotence.
     recent_updates: RwLock<HashMap<(Uuid, i64), Instant>>,
     /// Sent outbound reply messages keyed by the inbound Telegram message they reply to.
@@ -64,10 +82,12 @@ struct TelegramReplyRecord {
 const TELEGRAM_UPDATE_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_REPLY_DEDUP_TTL: Duration = Duration::from_secs(15 * 60);
 const TELEGRAM_SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const PALOMA_SCHEDULER_JOB_LEASE_SECONDS: i64 = 300;
 const PALOMA_LONG_RUNNING_MINUTES: i64 = 30;
 const PALOMA_USER_MESSAGE_QUIET_MINUTES: i64 = 30;
 const PALOMA_LONG_RUNNING_ALERT_BUCKET_MINUTES: i64 = 30;
 const PALOMA_ALERT_DIGEST_LIMIT: usize = 12;
+const PALOMA_SESSION_QUEUE_MAX_PER_KEY: usize = 256;
 const DEFAULT_PALOMA_OWNER_TELEGRAM_ID: i64 = 1_139_694_048;
 const DEFAULT_PALOMA_TRUSTED_FRIEND_TELEGRAM_ID: i64 = 0;
 
@@ -215,62 +235,55 @@ fn is_owner_dm(user: Option<&TelegramUser>, msg: &Message) -> bool {
             .unwrap_or(false)
 }
 
+fn paloma_chat_is_allowed(channel: &TelegramChannel, msg: &Message) -> bool {
+    msg.chat.chat_type == "private"
+        || channel.allowed_chat_ids.is_empty()
+        || channel.allowed_chat_ids.contains(&msg.chat.id)
+}
+
+fn is_paloma_shared_summary_allowed(
+    channel: &TelegramChannel,
+    user: Option<&TelegramUser>,
+    msg: &Message,
+    command_text: &str,
+) -> bool {
+    if !matches!(msg.chat.chat_type.as_str(), "group" | "supergroup") {
+        return false;
+    }
+    if channel.allowed_chat_ids.is_empty() || !paloma_chat_is_allowed(channel, msg) {
+        return false;
+    }
+    if !paloma_commands::is_exact_command(command_text, "/summary") {
+        return false;
+    }
+    matches!(
+        user.map(|u| u.role),
+        Some(TelegramUserRole::Owner | TelegramUserRole::TrustedFriend)
+    )
+}
+
+fn should_silence_paloma_shared_command(
+    channel: &TelegramChannel,
+    user: Option<&TelegramUser>,
+    msg: &Message,
+    command_text: &str,
+) -> bool {
+    matches!(msg.chat.chat_type.as_str(), "group" | "supergroup")
+        && command_text.trim().starts_with('/')
+        && !is_paloma_shared_summary_allowed(channel, user, msg, command_text)
+}
+
 fn is_paloma_command(text: &str, name: &str) -> bool {
-    let trimmed = text.trim();
-    trimmed == name || trimmed.starts_with(&format!("{name} "))
+    paloma_commands::is_command(text, name)
 }
 
 fn normalize_paloma_natural_command(text: &str) -> Option<&'static str> {
-    let trimmed = text.trim();
-    if trimmed.starts_with('/') || trimmed.is_empty() {
-        return None;
-    }
-
-    let lower = trimmed.to_ascii_lowercase();
-    let mentions_missions = lower.contains("mission");
-    let asks_for_mission_list = mentions_missions
-        && (lower.contains("en cours")
-            || lower.contains("en ce moment")
-            || lower.contains("actif")
-            || lower.contains("active")
-            || lower.contains("liste")
-            || lower.contains("quelles")
-            || lower.contains("lesquelles")
-            || lower.contains("quoi")
-            || lower.contains("voir")
-            || lower.contains("list")
-            || lower.contains("show")
-            || lower.contains("current")
-            || lower.contains("running")
-            || lower.contains("montre"));
-    if asks_for_mission_list {
-        return Some("/missions");
-    }
-
-    if lower == "status"
-        || lower == "statut"
-        || lower.starts_with("status ")
-        || lower.starts_with("statut ")
-        || lower.contains("statut")
-        || lower.contains("update me")
-        || lower.contains("update moi")
-        || lower.contains("mets moi a jour")
-        || lower.contains("mets-moi a jour")
-        || lower.contains("mets moi à jour")
-        || lower.contains("mets-moi à jour")
-        || lower.contains("quoi de neuf")
-        || lower.contains("nouveau")
-        || lower.contains("what changed")
-    {
-        return Some("/status");
-    }
-
-    None
+    paloma_commands::normalize_natural_command(text)
 }
 
 fn redact_for_telegram(text: &str) -> String {
     let token_re = regex::Regex::new(
-        r#"(?i)(bot[0-9]{6,}:[A-Za-z0-9_-]{20,}|[A-Za-z0-9_]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}|api[_-]?hash\s*[:=]\s*[A-Za-z0-9]{16,}|token\s*[:=]\s*\S+|secret\s*[:=]\s*\S+)"#,
+        r#"(?i)(bot[0-9]{6,}:[A-Za-z0-9_-]{20,}|[A-Za-z0-9_]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}|api[_-]?hash\s*[:=]\s*[A-Za-z0-9]{16,}|token\s*[:=]\s*\S+|token[-_][A-Za-z0-9_-]{16,}|secret\s*[:=]\s*\S+)"#,
     )
     .expect("telegram redaction regex must compile");
     let path_re = regex::Regex::new(r#"(/(?:root|home|workspaces|tmp)/[^\s,)]+)"#)
@@ -351,6 +364,51 @@ fn mission_rank(mission: &Mission, interest: TelegramMissionInterestLevel) -> i3
     score
 }
 
+fn paloma_status_seen_sequences(cursor_json: &str) -> HashMap<String, i64> {
+    serde_json::from_str::<serde_json::Value>(cursor_json)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(mission_id, sequence)| sequence.as_i64().map(|seq| (mission_id, seq)))
+        .collect()
+}
+
+fn paloma_dashboard_cursor_is_newer(
+    status_cursor: Option<&str>,
+    dashboard_cursor: Option<&str>,
+) -> bool {
+    match (status_cursor, dashboard_cursor) {
+        (_, None) => false,
+        (None, Some(_)) => true,
+        (Some(status), Some(dashboard)) => dashboard > status,
+    }
+}
+
+fn paloma_status_event_is_new(
+    mission_id: Uuid,
+    event: &StoredEvent,
+    seen_sequences: &HashMap<String, i64>,
+    status_since: Option<&str>,
+    dashboard_since: Option<&str>,
+) -> bool {
+    if paloma_dashboard_cursor_is_newer(status_since, dashboard_since)
+        && dashboard_since
+            .map(|since| event.timestamp.as_str() <= since)
+            .unwrap_or(false)
+    {
+        return false;
+    }
+
+    if let Some(seen_sequence) = seen_sequences.get(&mission_id.to_string()) {
+        return event.sequence > *seen_sequence;
+    }
+
+    status_since
+        .map(|since| event.timestamp.as_str() > since)
+        .unwrap_or(true)
+}
+
 async fn build_paloma_status(
     ctx: &ChannelContext,
     telegram_user_id: i64,
@@ -359,11 +417,10 @@ async fn build_paloma_status(
         .mission_store
         .get_or_create_telegram_user_cursor(telegram_user_id)
         .await?;
-    let since = cursor
-        .last_dashboard_seen_at
-        .as_deref()
-        .or(cursor.last_status_at.as_deref())
-        .map(|value| value.to_string());
+    let status_since = cursor.last_status_at.as_deref();
+    let dashboard_since = cursor.last_dashboard_seen_at.as_deref();
+    let seen_sequences =
+        paloma_status_seen_sequences(&cursor.last_seen_event_sequence_by_mission_json);
     let missions = ctx.mission_store.list_missions(80, 0).await?;
     let mut lines = Vec::new();
     let mut max_sequences = serde_json::Map::new();
@@ -378,10 +435,14 @@ async fn build_paloma_status(
             max_sequences.insert(mission.id.to_string(), serde_json::json!(max));
         }
         for event in events {
-            if let Some(since) = since.as_deref() {
-                if event.timestamp.as_str() <= since {
-                    continue;
-                }
+            if !paloma_status_event_is_new(
+                mission.id,
+                &event,
+                &seen_sequences,
+                status_since,
+                dashboard_since,
+            ) {
+                continue;
             }
             if let Some(line) = event_summary_line(mission, &event) {
                 lines.push(line);
@@ -396,7 +457,7 @@ async fn build_paloma_status(
     }
 
     let body = if lines.is_empty() {
-        match since {
+        match status_since.or(dashboard_since) {
             Some(_) => "No meaningful changes since your last status check.".to_string(),
             None => "No meaningful mission changes found yet.".to_string(),
         }
@@ -478,14 +539,7 @@ fn parse_paloma_selector_and_payload<'a>(
     text: &'a str,
     command: &str,
 ) -> Option<(&'a str, &'a str)> {
-    let tail = text.trim().strip_prefix(command)?.trim();
-    let (selector, payload) = tail.split_once(char::is_whitespace)?;
-    let payload = payload.trim();
-    if selector.trim().is_empty() || payload.is_empty() {
-        None
-    } else {
-        Some((selector.trim(), payload))
-    }
+    paloma_commands::parse_selector_and_payload(text, command)
 }
 
 fn feedback_mutes_alerts(text: &str) -> bool {
@@ -511,9 +565,20 @@ fn feedback_raises_interest(text: &str) -> bool {
         || normalized.contains("mark this high")
 }
 
+fn feedback_only_failures(text: &str) -> bool {
+    let normalized = text.trim().to_ascii_lowercase();
+    normalized.contains("only tell me if this fails")
+        || normalized.contains("only tell me when this fails")
+        || normalized.contains("only failures")
+        || normalized.contains("only failure updates")
+        || normalized.contains("just failures")
+}
+
 fn paloma_command_error_response(err: &str) -> &str {
     if err.starts_with("Usage:") {
         err
+    } else if err == "ambiguous_digest_reply" {
+        "That digest covers multiple missions. Use /summary <mission> or /send <mission> <message>."
     } else {
         "I couldn't read mission status right now."
     }
@@ -556,6 +621,17 @@ async fn latest_interesting_mission(ctx: &ChannelContext) -> Result<Mission, Str
         .ok_or_else(|| "No missions are available.".to_string())
 }
 
+fn select_latest_awaiting_user_mission(mut missions: Vec<Mission>) -> Option<Mission> {
+    missions.retain(|mission| mission.status == MissionStatus::AwaitingUser);
+    missions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    missions.into_iter().next()
+}
+
+async fn latest_awaiting_user_mission(ctx: &ChannelContext) -> Result<Mission, String> {
+    select_latest_awaiting_user_mission(ctx.mission_store.list_missions(80, 0).await?)
+        .ok_or_else(|| "No mission is waiting for approval right now.".to_string())
+}
+
 async fn build_paloma_summary(
     ctx: &ChannelContext,
     selector: Option<&str>,
@@ -564,6 +640,13 @@ async fn build_paloma_summary(
         Some(selector) => select_paloma_mission(ctx, selector).await?,
         None => latest_interesting_mission(ctx).await?,
     };
+    build_paloma_summary_for_mission(ctx, &mission).await
+}
+
+async fn build_paloma_summary_for_mission(
+    ctx: &ChannelContext,
+    mission: &Mission,
+) -> Result<String, String> {
     let events = ctx
         .mission_store
         .get_events(mission.id, None, Some(80), None)
@@ -571,7 +654,7 @@ async fn build_paloma_summary(
         .unwrap_or_default();
     let mut lines = Vec::new();
     for event in events.into_iter().rev() {
-        if let Some(line) = event_summary_line(&mission, &event) {
+        if let Some(line) = event_summary_line(mission, &event) {
             lines.push(line);
         }
         if lines.len() >= 4 {
@@ -579,7 +662,7 @@ async fn build_paloma_summary(
         }
     }
 
-    let mut body = format!("{}: {}", mission_label(&mission), mission.status);
+    let mut body = format!("{}: {}", mission_label(mission), mission.status);
     if lines.is_empty() {
         body.push_str("\n\nNo concise recent summary is available yet.");
     } else {
@@ -591,12 +674,61 @@ async fn build_paloma_summary(
     Ok(redact_for_telegram(&body))
 }
 
+fn paloma_shared_summary_body(mission: &Mission) -> String {
+    redact_for_telegram(&format!(
+        "{}: {}\n\nShared-chat summary is limited to high-level status.",
+        mission_label(mission),
+        mission.status
+    ))
+}
+
+async fn build_paloma_shared_summary(ctx: &ChannelContext) -> Result<String, String> {
+    latest_interesting_mission(ctx)
+        .await
+        .map(|mission| paloma_shared_summary_body(&mission))
+}
+
+async fn build_paloma_why(ctx: &ChannelContext) -> Result<String, String> {
+    let decisions = ctx.mission_store.list_paloma_decisions(8).await?;
+    if decisions.is_empty() {
+        return Ok("No Paloma decisions have been recorded yet.".to_string());
+    }
+    let mut body = "Recent Paloma decisions".to_string();
+    for decision in decisions {
+        let mission = decision
+            .mission_id
+            .map(|id| id.simple().to_string().chars().take(8).collect::<String>())
+            .unwrap_or_else(|| "no mission".to_string());
+        let outcome = if decision.allowed {
+            "allowed"
+        } else {
+            decision
+                .suppression_reason
+                .as_deref()
+                .unwrap_or("suppressed")
+        };
+        body.push_str(&format!(
+            "\n- {} {} {} ({})",
+            decision.reason_code, decision.proposed_action, outcome, mission
+        ));
+    }
+    Ok(redact_for_telegram(&body))
+}
+
 async fn send_paloma_mission_message(
     ctx: &ChannelContext,
     selector: &str,
     payload: &str,
 ) -> Result<String, String> {
     let mission = select_paloma_mission(ctx, selector).await?;
+    send_user_message_to_mission(ctx, &mission, payload).await
+}
+
+async fn send_user_message_to_mission(
+    ctx: &ChannelContext,
+    mission: &Mission,
+    payload: &str,
+) -> Result<String, String> {
     let (queued_tx, _queued_rx) = tokio::sync::oneshot::channel();
     ctx.cmd_tx
         .send(ControlCommand::UserMessage {
@@ -608,7 +740,44 @@ async fn send_paloma_mission_message(
         })
         .await
         .map_err(|e| e.to_string())?;
-    Ok(format!("Sent to {}.", mission_label(&mission)))
+    Ok(format!("Sent to {}.", mission_label(mission)))
+}
+
+async fn send_paloma_approval(ctx: &ChannelContext, payload: &str) -> Result<String, String> {
+    let mission = latest_awaiting_user_mission(ctx).await?;
+    send_user_message_to_mission(ctx, &mission, payload).await
+}
+
+async fn paloma_replied_alert_mission(
+    ctx: &ChannelContext,
+    user: &TelegramUser,
+    msg: &Message,
+) -> Result<Option<Mission>, String> {
+    if let Some(reply_message_id) = msg.reply_to_message.as_ref().map(|reply| reply.message_id) {
+        if let Some(alert) = ctx
+            .mission_store
+            .get_telegram_alert_by_message_id(user.telegram_user_id, reply_message_id)
+            .await?
+        {
+            if let Some(mission_id) = alert.mission_id {
+                if let Some(mission) = ctx.mission_store.get_mission(mission_id).await? {
+                    return Ok(Some(mission));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn paloma_feedback_target_mission(
+    ctx: &ChannelContext,
+    user: &TelegramUser,
+    msg: &Message,
+) -> Result<Mission, String> {
+    if let Some(mission) = paloma_replied_alert_mission(ctx, user, msg).await? {
+        return Ok(mission);
+    }
+    latest_interesting_mission(ctx).await
 }
 
 async fn apply_paloma_interest_feedback(
@@ -618,7 +787,7 @@ async fn apply_paloma_interest_feedback(
     level: TelegramMissionInterestLevel,
     rule_text: &str,
 ) -> Result<String, String> {
-    let mission = latest_interesting_mission(ctx).await?;
+    let mission = paloma_feedback_target_mission(ctx, user, msg).await?;
     let now = now_string();
     let subscription = TelegramMissionSubscription {
         id: Uuid::new_v4(),
@@ -641,6 +810,10 @@ async fn apply_paloma_interest_feedback(
                 mission.id,
                 &now,
             )
+            .await;
+        let _ = ctx
+            .mission_store
+            .update_telegram_user_last_alert_ack_at(user.telegram_user_id, &now)
             .await;
     }
     let _ = ctx
@@ -680,30 +853,58 @@ async fn apply_paloma_interest_feedback(
     Ok(redact_for_telegram(&response))
 }
 
+async fn apply_paloma_failure_only_feedback(
+    ctx: &ChannelContext,
+    user: &TelegramUser,
+    msg: &Message,
+) -> Result<String, String> {
+    let mission = paloma_feedback_target_mission(ctx, user, msg).await?;
+    let now = now_string();
+    ctx.mission_store
+        .upsert_telegram_mission_subscription(TelegramMissionSubscription {
+            id: Uuid::new_v4(),
+            telegram_user_id: user.telegram_user_id,
+            mission_id: mission.id,
+            interest_level: TelegramMissionInterestLevel::Normal,
+            reason: Some("only failures from Telegram feedback".to_string()),
+            expires_at: None,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        })
+        .await?;
+    let _ = ctx
+        .mission_store
+        .create_telegram_alert_preference(TelegramAlertPreference {
+            id: Uuid::new_v4(),
+            telegram_user_id: user.telegram_user_id,
+            scope: "mission".to_string(),
+            scope_value: Some(mission.id.to_string()),
+            rule_text: "only failures from Telegram feedback".to_string(),
+            enabled: true,
+            created_from_message_id: Some(msg.message_id),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        })
+        .await;
+    let _ = ctx
+        .mission_store
+        .acknowledge_pending_telegram_alerts_for_mission(user.telegram_user_id, mission.id, &now)
+        .await;
+    Ok(redact_for_telegram(&format!(
+        "Noted. I will only alert you if {} fails.",
+        mission_label(&mission)
+    )))
+}
+
 fn paloma_alert_kind_for_status(status: MissionStatus) -> Option<&'static str> {
-    match status {
-        MissionStatus::Active => Some("mission_long_running"),
-        _ => None,
-    }
+    planner::alert_kind_for_status(status)
 }
 
 fn paloma_alert_importance_for_mission(
     mission: &Mission,
     interest: TelegramMissionInterestLevel,
 ) -> &'static str {
-    if interest == TelegramMissionInterestLevel::High {
-        return "high";
-    }
-    match mission.status {
-        MissionStatus::Active => "normal",
-        _ => "low",
-    }
-}
-
-fn parse_paloma_event_time(value: &str) -> Option<chrono::DateTime<Utc>> {
-    chrono::DateTime::parse_from_rfc3339(value)
-        .ok()
-        .map(|dt| dt.with_timezone(&Utc))
+    planner::alert_importance_for_mission(mission, interest)
 }
 
 fn paloma_alert_event_kind_at(
@@ -712,68 +913,117 @@ fn paloma_alert_event_kind_at(
     events: &[StoredEvent],
     now: chrono::DateTime<Utc>,
 ) -> String {
-    if mission.status == MissionStatus::Active && base_kind == "mission_long_running" {
-        let bucket_seconds = PALOMA_LONG_RUNNING_ALERT_BUCKET_MINUTES * 60;
-        let bucket = now.timestamp().div_euclid(bucket_seconds);
-        return format!("{base_kind}:{bucket}");
-    }
-
-    let status = mission.status.to_string();
-    let updated = events
-        .iter()
-        .rev()
-        .find(|event| {
-            event.event_type == "mission_status_changed"
-                && event
-                    .metadata
-                    .get("status")
-                    .and_then(|value| value.as_str())
-                    == Some(status.as_str())
-        })
-        .map(|event| event.timestamp.as_str())
-        .unwrap_or(mission.updated_at.as_str());
-    format!("{base_kind}:{}", updated.replace([':', '.', '+'], "-"))
+    planner::alert_event_kind_at(
+        mission,
+        base_kind,
+        events,
+        now,
+        ChronoDuration::minutes(PALOMA_LONG_RUNNING_ALERT_BUCKET_MINUTES),
+    )
 }
 
-fn paloma_latest_user_message_at(events: &[StoredEvent]) -> Option<chrono::DateTime<Utc>> {
-    events
-        .iter()
-        .rev()
-        .find(|event| event.event_type == "user_message")
-        .and_then(|event| parse_paloma_event_time(&event.timestamp))
-}
-
-fn paloma_mission_started_at(mission: &Mission) -> Option<chrono::DateTime<Utc>> {
-    parse_paloma_event_time(&mission.created_at)
-        .or_else(|| parse_paloma_event_time(&mission.updated_at))
-}
-
+#[cfg(test)]
 fn paloma_should_alert_long_running_mission_at(
     mission: &Mission,
     events: &[StoredEvent],
     now: chrono::DateTime<Utc>,
 ) -> bool {
-    if mission.status != MissionStatus::Active {
-        return false;
+    planner::should_alert_long_running_mission_at(
+        mission,
+        events,
+        now,
+        ChronoDuration::minutes(PALOMA_LONG_RUNNING_MINUTES),
+        ChronoDuration::minutes(PALOMA_USER_MESSAGE_QUIET_MINUTES),
+    )
+}
+
+fn paloma_should_alert_mission_at(
+    mission: &Mission,
+    events: &[StoredEvent],
+    interest: TelegramMissionInterestLevel,
+    now: chrono::DateTime<Utc>,
+) -> bool {
+    planner::should_alert_mission_at(
+        mission,
+        events,
+        interest,
+        now,
+        ChronoDuration::minutes(PALOMA_LONG_RUNNING_MINUTES),
+        ChronoDuration::minutes(PALOMA_USER_MESSAGE_QUIET_MINUTES),
+    )
+}
+
+fn paloma_alert_suppression_reason(
+    mission: &Mission,
+    events: &[StoredEvent],
+    interest: TelegramMissionInterestLevel,
+    now: chrono::DateTime<Utc>,
+) -> &'static str {
+    planner::alert_suppression_reason(
+        mission,
+        events,
+        interest,
+        now,
+        ChronoDuration::minutes(PALOMA_LONG_RUNNING_MINUTES),
+        ChronoDuration::minutes(PALOMA_USER_MESSAGE_QUIET_MINUTES),
+    )
+}
+
+fn paloma_mission_has_failure_only_preference(
+    preferences: &[TelegramAlertPreference],
+    mission_id: Uuid,
+) -> bool {
+    planner::mission_has_failure_only_preference(preferences, mission_id)
+}
+
+fn paloma_policy_snapshot_json(
+    mission: &Mission,
+    interest: TelegramMissionInterestLevel,
+    alert_now: chrono::DateTime<Utc>,
+) -> String {
+    serde_json::json!({
+        "status": mission.status.to_string(),
+        "mission_mode": format!("{:?}", mission.mission_mode),
+        "interest": interest,
+        "long_running_minutes": PALOMA_LONG_RUNNING_MINUTES,
+        "quiet_after_user_message_minutes": PALOMA_USER_MESSAGE_QUIET_MINUTES,
+        "evaluated_at": alert_now.to_rfc3339(),
+    })
+    .to_string()
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn log_paloma_alert_decision(
+    ctx: &ChannelContext,
+    owner_id: i64,
+    mission: &Mission,
+    reason_code: &str,
+    proposed_action: &str,
+    allowed: bool,
+    suppression_reason: Option<&str>,
+    policy_snapshot_json: String,
+    generated_text: Option<&str>,
+) {
+    let decision = decision_log::new_decision(
+        "scheduler",
+        Some(mission.id),
+        Some(owner_id),
+        "telegram",
+        reason_code,
+        proposed_action,
+        allowed,
+        suppression_reason,
+        &policy_snapshot_json,
+        generated_text,
+        now_string(),
+    );
+    if let Err(err) = ctx.mission_store.create_paloma_decision(decision).await {
+        tracing::debug!(
+            mission_id = %mission.id,
+            "Failed to record Paloma decision: {}",
+            err
+        );
     }
-    if mission.mission_mode == MissionMode::Assistant {
-        return false;
-    }
-    let Some(started_at) = paloma_mission_started_at(mission) else {
-        return true;
-    };
-    if now - started_at < ChronoDuration::minutes(PALOMA_LONG_RUNNING_MINUTES) {
-        return false;
-    }
-    if paloma_latest_user_message_at(events)
-        .map(|last_user_message_at| {
-            now - last_user_message_at < ChronoDuration::minutes(PALOMA_USER_MESSAGE_QUIET_MINUTES)
-        })
-        .unwrap_or(false)
-    {
-        return false;
-    }
-    true
 }
 
 fn paloma_latest_attention_line(mission: &Mission, events: &[StoredEvent]) -> Option<String> {
@@ -807,80 +1057,45 @@ fn paloma_alert_body(mission: &Mission, events: &[StoredEvent]) -> String {
     }
 }
 
-fn paloma_alert_rank(alert: &TelegramAlert) -> i32 {
-    match alert.importance.as_str() {
-        "high" => 0,
-        "normal" => 1,
-        _ => 2,
-    }
-}
-
-fn paloma_alert_digest_line(alert: &TelegramAlert) -> String {
-    let mut lines = alert.body.lines();
-    let lead = lines
-        .next()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .unwrap_or(alert.title.as_str());
-    let latest = lines.find_map(|line| line.trim().strip_prefix("Latest: "));
-    match latest {
-        Some(latest) if !latest.trim().is_empty() => {
-            format!("- {lead} Latest: {}", latest.trim())
-        }
-        _ => format!("- {lead}"),
-    }
-}
-
 fn paloma_alert_digest_text(alerts: &[TelegramAlert]) -> String {
-    if alerts.len() == 1 {
-        return redact_for_telegram(alerts[0].body.trim());
-    }
+    digest::alert_digest_text(alerts, redact_for_telegram)
+}
 
-    let mut sorted = alerts.to_vec();
-    sorted.sort_by(|a, b| {
-        paloma_alert_rank(a)
-            .cmp(&paloma_alert_rank(b))
-            .then_with(|| a.created_at.cmp(&b.created_at))
-    });
-
-    let high_count = sorted
-        .iter()
-        .filter(|alert| alert.importance == "high")
-        .count();
-    let mut text = if high_count > 0 {
-        format!(
-            "{} mission update{} {} attention:",
-            high_count,
-            if high_count == 1 { "" } else { "s" },
-            if high_count == 1 { "needs" } else { "need" }
-        )
-    } else {
-        format!(
-            "{} mission update{}:",
-            sorted.len(),
-            if sorted.len() == 1 { "" } else { "s" }
-        )
-    };
-
-    let visible = sorted.len().min(8);
-    for alert in sorted.iter().take(visible) {
-        text.push('\n');
-        text.push_str(&paloma_alert_digest_line(alert));
+fn telegram_shared_file_caption(
+    mission_id: Uuid,
+    file: &crate::api::control::SharedFile,
+    context: &str,
+) -> String {
+    let mut caption = format!(
+        "Mission {} shared {}",
+        mission_id
+            .simple()
+            .to_string()
+            .chars()
+            .take(8)
+            .collect::<String>(),
+        file.name
+    );
+    let context = sanitize_telegram_visible_text(context);
+    let first_context_line = context
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("");
+    if !first_context_line.is_empty() {
+        caption.push('\n');
+        caption.push_str(&first_context_line.chars().take(180).collect::<String>());
     }
-    let remaining = sorted.len().saturating_sub(visible);
-    if remaining > 0 {
-        text.push_str(&format!(
-            "\n- {} more update{}",
-            remaining,
-            if remaining == 1 { "" } else { "s" }
-        ));
-    }
-    redact_for_telegram(&text)
+    redact_for_telegram(&caption)
+        .chars()
+        .take(900)
+        .collect::<String>()
 }
 
 async fn paloma_pending_alert_still_eligible(
     ctx: &ChannelContext,
     alert: &TelegramAlert,
+    interest: TelegramMissionInterestLevel,
     now: chrono::DateTime<Utc>,
 ) -> bool {
     let Some(mission_id) = alert.mission_id else {
@@ -889,7 +1104,10 @@ async fn paloma_pending_alert_still_eligible(
     let Ok(Some(mission)) = ctx.mission_store.get_mission(mission_id).await else {
         return false;
     };
-    if mission.status != MissionStatus::Active {
+    let Some(current_kind) = paloma_alert_kind_for_status(mission.status) else {
+        return false;
+    };
+    if !alert.event_kind.starts_with(current_kind) {
         return false;
     }
     let events = ctx
@@ -897,7 +1115,7 @@ async fn paloma_pending_alert_still_eligible(
         .get_events(mission.id, None, Some(40), None)
         .await
         .unwrap_or_default();
-    paloma_should_alert_long_running_mission_at(&mission, &events, now)
+    paloma_should_alert_mission_at(&mission, &events, interest, now)
 }
 
 async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
@@ -914,6 +1132,11 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
         .into_iter()
         .map(|sub| (sub.mission_id, sub.interest_level))
         .collect::<HashMap<_, _>>();
+    let alert_preferences = ctx
+        .mission_store
+        .list_telegram_alert_preferences(owner_id)
+        .await
+        .unwrap_or_default();
     let missions = match ctx.mission_store.list_missions(80, 0).await {
         Ok(missions) => missions,
         Err(err) => {
@@ -930,9 +1153,6 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
             .get(&mission.id)
             .copied()
             .unwrap_or(TelegramMissionInterestLevel::Normal);
-        if interest == TelegramMissionInterestLevel::Muted {
-            continue;
-        }
         let title = mission_label(&mission);
         let events = ctx
             .mission_store
@@ -940,10 +1160,69 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
             .await
             .unwrap_or_default();
         let alert_now = Utc::now();
-        if !paloma_should_alert_long_running_mission_at(&mission, &events, alert_now) {
+        let policy_snapshot = paloma_policy_snapshot_json(&mission, interest, alert_now);
+        if interest == TelegramMissionInterestLevel::Muted {
+            log_paloma_alert_decision(
+                ctx,
+                owner_id,
+                &mission,
+                base_kind,
+                "create_alert",
+                false,
+                Some("mission_muted"),
+                policy_snapshot,
+                None,
+            )
+            .await;
+            continue;
+        }
+        if paloma_mission_has_failure_only_preference(&alert_preferences, mission.id)
+            && mission.status != MissionStatus::Failed
+        {
+            log_paloma_alert_decision(
+                ctx,
+                owner_id,
+                &mission,
+                base_kind,
+                "create_alert",
+                false,
+                Some("only_failures_preference"),
+                policy_snapshot,
+                None,
+            )
+            .await;
+            continue;
+        }
+        if !paloma_should_alert_mission_at(&mission, &events, interest, alert_now) {
+            log_paloma_alert_decision(
+                ctx,
+                owner_id,
+                &mission,
+                base_kind,
+                "create_alert",
+                false,
+                Some(paloma_alert_suppression_reason(
+                    &mission, &events, interest, alert_now,
+                )),
+                policy_snapshot,
+                None,
+            )
+            .await;
             continue;
         }
         let body = paloma_alert_body(&mission, &events);
+        log_paloma_alert_decision(
+            ctx,
+            owner_id,
+            &mission,
+            base_kind,
+            "create_alert",
+            true,
+            None,
+            policy_snapshot,
+            Some(&body),
+        )
+        .await;
         let now = now_string();
         let _ = ctx
             .mission_store
@@ -981,7 +1260,21 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
                 == TelegramMissionInterestLevel::Muted
         })
         .collect::<Vec<_>>();
-    if !muted_pending.is_empty() {
+    let failure_only_pending = pending
+        .iter()
+        .filter_map(|alert| alert.mission_id.map(|mission_id| (alert.id, mission_id)))
+        .filter(|(_, mission_id)| {
+            paloma_mission_has_failure_only_preference(&alert_preferences, *mission_id)
+        })
+        .filter(|(alert_id, _)| {
+            pending
+                .iter()
+                .find(|alert| alert.id == *alert_id)
+                .map(|alert| !alert.event_kind.starts_with("mission_failed"))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    if !muted_pending.is_empty() || !failure_only_pending.is_empty() {
         let acknowledged_at = now_string();
         for (_, mission_id) in &muted_pending {
             let _ = ctx
@@ -993,13 +1286,23 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
                 )
                 .await;
         }
+        for (alert_id, _) in &failure_only_pending {
+            let _ = ctx
+                .mission_store
+                .acknowledge_pending_telegram_alert(owner_id, *alert_id, &acknowledged_at)
+                .await;
+        }
         pending.retain(|alert| {
             alert.mission_id.is_none_or(|mission_id| {
-                subscriptions
+                let muted = subscriptions
                     .get(&mission_id)
                     .copied()
                     .unwrap_or(TelegramMissionInterestLevel::Normal)
-                    != TelegramMissionInterestLevel::Muted
+                    == TelegramMissionInterestLevel::Muted;
+                let failure_only_suppressed = failure_only_pending
+                    .iter()
+                    .any(|(pending_alert_id, _)| *pending_alert_id == alert.id);
+                !muted && !failure_only_suppressed
             })
         });
     }
@@ -1008,16 +1311,16 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
         let mut eligible_pending = Vec::with_capacity(pending.len());
         let acknowledged_at = now_string();
         for alert in pending {
-            if paloma_pending_alert_still_eligible(ctx, &alert, checked_at).await {
+            let interest = alert
+                .mission_id
+                .and_then(|mission_id| subscriptions.get(&mission_id).copied())
+                .unwrap_or(TelegramMissionInterestLevel::Normal);
+            if paloma_pending_alert_still_eligible(ctx, &alert, interest, checked_at).await {
                 eligible_pending.push(alert);
-            } else if let Some(mission_id) = alert.mission_id {
+            } else {
                 let _ = ctx
                     .mission_store
-                    .acknowledge_pending_telegram_alerts_for_mission(
-                        owner_id,
-                        mission_id,
-                        &acknowledged_at,
-                    )
+                    .acknowledge_pending_telegram_alert(owner_id, alert.id, &acknowledged_at)
                     .await;
             }
         }
@@ -1028,9 +1331,34 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
     }
     let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
     let text = paloma_alert_digest_text(&pending);
+    let digest_snapshot = serde_json::json!({
+        "pending_alerts": pending.len(),
+        "digest_limit": PALOMA_ALERT_DIGEST_LIMIT,
+    })
+    .to_string();
     match send_message(http, &base_url, owner_id, &text, None).await {
         Ok(message_id) => {
             let sent_at = now_string();
+            let _ = ctx
+                .mission_store
+                .update_telegram_user_last_digest_at(owner_id, &sent_at)
+                .await;
+            if let Some(first_alert) = pending.first() {
+                let decision = decision_log::new_decision(
+                    "scheduler",
+                    first_alert.mission_id,
+                    Some(owner_id),
+                    "telegram",
+                    "digest_send",
+                    "send_digest",
+                    true,
+                    None,
+                    &digest_snapshot,
+                    Some(&text),
+                    sent_at.clone(),
+                );
+                let _ = ctx.mission_store.create_paloma_decision(decision).await;
+            }
             for alert in pending {
                 let _ = ctx
                     .mission_store
@@ -1050,6 +1378,165 @@ async fn plan_and_deliver_paloma_alerts(ctx: &ChannelContext, http: &Client) {
     }
 }
 
+async fn flush_pending_paloma_digest(
+    ctx: &ChannelContext,
+    http: &Client,
+    owner_id: i64,
+) -> Result<usize, String> {
+    let subscriptions = ctx
+        .mission_store
+        .list_telegram_mission_subscriptions(owner_id)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|sub| (sub.mission_id, sub.interest_level))
+        .collect::<HashMap<_, _>>();
+    let alert_preferences = ctx
+        .mission_store
+        .list_telegram_alert_preferences(owner_id)
+        .await
+        .unwrap_or_default();
+    let mut pending = ctx
+        .mission_store
+        .list_pending_telegram_alerts(owner_id, PALOMA_ALERT_DIGEST_LIMIT)
+        .await
+        .map_err(|err| format!("failed_to_load_pending_alerts: {err}"))?;
+
+    let muted_pending = pending
+        .iter()
+        .filter_map(|alert| alert.mission_id.map(|mission_id| (alert.id, mission_id)))
+        .filter(|(_, mission_id)| {
+            subscriptions
+                .get(mission_id)
+                .copied()
+                .unwrap_or(TelegramMissionInterestLevel::Normal)
+                == TelegramMissionInterestLevel::Muted
+        })
+        .collect::<Vec<_>>();
+    let failure_only_pending = pending
+        .iter()
+        .filter_map(|alert| alert.mission_id.map(|mission_id| (alert.id, mission_id)))
+        .filter(|(_, mission_id)| {
+            paloma_mission_has_failure_only_preference(&alert_preferences, *mission_id)
+        })
+        .filter(|(alert_id, _)| {
+            pending
+                .iter()
+                .find(|alert| alert.id == *alert_id)
+                .map(|alert| !alert.event_kind.starts_with("mission_failed"))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    if !muted_pending.is_empty() || !failure_only_pending.is_empty() {
+        let acknowledged_at = now_string();
+        for (_, mission_id) in &muted_pending {
+            let _ = ctx
+                .mission_store
+                .acknowledge_pending_telegram_alerts_for_mission(
+                    owner_id,
+                    *mission_id,
+                    &acknowledged_at,
+                )
+                .await;
+        }
+        for (alert_id, _) in &failure_only_pending {
+            let _ = ctx
+                .mission_store
+                .acknowledge_pending_telegram_alert(owner_id, *alert_id, &acknowledged_at)
+                .await;
+        }
+        pending.retain(|alert| {
+            alert.mission_id.is_none_or(|mission_id| {
+                let muted = subscriptions
+                    .get(&mission_id)
+                    .copied()
+                    .unwrap_or(TelegramMissionInterestLevel::Normal)
+                    == TelegramMissionInterestLevel::Muted;
+                let failure_only_suppressed = failure_only_pending
+                    .iter()
+                    .any(|(pending_alert_id, _)| *pending_alert_id == alert.id);
+                !muted && !failure_only_suppressed
+            })
+        });
+    }
+
+    if !pending.is_empty() {
+        let checked_at = Utc::now();
+        let mut eligible_pending = Vec::with_capacity(pending.len());
+        let acknowledged_at = now_string();
+        for alert in pending {
+            let interest = alert
+                .mission_id
+                .and_then(|mission_id| subscriptions.get(&mission_id).copied())
+                .unwrap_or(TelegramMissionInterestLevel::Normal);
+            if paloma_pending_alert_still_eligible(ctx, &alert, interest, checked_at).await {
+                eligible_pending.push(alert);
+            } else {
+                let _ = ctx
+                    .mission_store
+                    .acknowledge_pending_telegram_alert(owner_id, alert.id, &acknowledged_at)
+                    .await;
+            }
+        }
+        pending = eligible_pending;
+    }
+    if pending.is_empty() {
+        return Ok(0);
+    }
+
+    let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
+    let text = paloma_alert_digest_text(&pending);
+    let digest_snapshot = serde_json::json!({
+        "pending_alerts": pending.len(),
+        "digest_limit": PALOMA_ALERT_DIGEST_LIMIT,
+        "source": "paloma_digest_flush",
+    })
+    .to_string();
+    match send_message(http, &base_url, owner_id, &text, None).await {
+        Ok(message_id) => {
+            let sent_at = now_string();
+            let _ = ctx
+                .mission_store
+                .update_telegram_user_last_digest_at(owner_id, &sent_at)
+                .await;
+            if let Some(first_alert) = pending.first() {
+                let decision = decision_log::new_decision(
+                    "scheduler",
+                    first_alert.mission_id,
+                    Some(owner_id),
+                    "telegram",
+                    "digest_flush",
+                    "send_digest",
+                    true,
+                    None,
+                    &digest_snapshot,
+                    Some(&text),
+                    sent_at.clone(),
+                );
+                let _ = ctx.mission_store.create_paloma_decision(decision).await;
+            }
+            let sent_count = pending.len();
+            for alert in pending {
+                let _ = ctx
+                    .mission_store
+                    .mark_telegram_alert_sent(alert.id, Some(message_id), &sent_at)
+                    .await;
+            }
+            Ok(sent_count)
+        }
+        Err(err) => {
+            for alert in pending {
+                tracing::warn!("Failed to flush Telegram alert {}: {}", alert.id, err);
+                let _ = ctx
+                    .mission_store
+                    .mark_telegram_alert_failed(alert.id, &err)
+                    .await;
+            }
+            Err(err)
+        }
+    }
+}
+
 async fn handle_paloma_command(
     ctx: &ChannelContext,
     msg: &Message,
@@ -1063,7 +1550,15 @@ async fn handle_paloma_command(
         || is_paloma_command(command_text, "/missions")
         || is_paloma_command(command_text, "/summary")
         || is_paloma_command(command_text, "/send")
-        || is_paloma_command(command_text, "/approve");
+        || is_paloma_command(command_text, "/approve")
+        || is_paloma_command(command_text, "/why");
+    if is_known_command && !paloma_chat_is_allowed(&ctx.channel, msg) {
+        return false;
+    }
+    let owner_failure_only_feedback = user
+        .filter(|_| msg.chat.chat_type == "private")
+        .filter(|u| u.role == TelegramUserRole::Owner)
+        .filter(|_| feedback_only_failures(clean_text));
     let owner_feedback = user
         .filter(|_| msg.chat.chat_type == "private")
         .filter(|u| u.role == TelegramUserRole::Owner)
@@ -1084,12 +1579,57 @@ async fn handle_paloma_command(
                 None
             }
         });
+    let owner_alert_reply =
+        if !is_known_command && owner_feedback.is_none() && owner_failure_only_feedback.is_none() {
+            match user.filter(|_| msg.chat.chat_type == "private") {
+                Some(u) if u.role == TelegramUserRole::Owner => {
+                    match paloma_replied_alert_mission(ctx, u, msg).await {
+                        Ok(Some(mission)) => Some((u, mission)),
+                        Ok(None) => None,
+                        Err(err) => {
+                            tracing::warn!("Failed to resolve Paloma alert reply target: {}", err);
+                            None
+                        }
+                    }
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
 
-    if !is_known_command && owner_feedback.is_none() {
+    if !is_known_command
+        && owner_feedback.is_none()
+        && owner_failure_only_feedback.is_none()
+        && owner_alert_reply.is_none()
+    {
         return false;
     }
 
     let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
+    if is_paloma_shared_summary_allowed(&ctx.channel, user, msg, command_text) {
+        match build_paloma_shared_summary(ctx).await {
+            Ok(body) => {
+                let _ =
+                    send_message(http, &base_url, msg.chat.id, &body, Some(msg.message_id)).await;
+            }
+            Err(err) => {
+                tracing::warn!("Paloma shared summary failed: {}", err);
+                let _ = send_message(
+                    http,
+                    &base_url,
+                    msg.chat.id,
+                    "I couldn't read mission status right now.",
+                    Some(msg.message_id),
+                )
+                .await;
+            }
+        }
+        return true;
+    }
+    if should_silence_paloma_shared_command(&ctx.channel, user, msg, command_text) {
+        return true;
+    }
     if !is_owner_dm(user, msg) {
         let _ = send_message(
             http,
@@ -1102,8 +1642,16 @@ async fn handle_paloma_command(
         return true;
     }
 
-    let result = if let Some((user, level, rule_text)) = owner_feedback {
+    let result = if let Some(user) = owner_failure_only_feedback {
+        apply_paloma_failure_only_feedback(ctx, user, msg)
+            .await
+            .map(|body| (body, None))
+    } else if let Some((user, level, rule_text)) = owner_feedback {
         apply_paloma_interest_feedback(ctx, user, msg, level, rule_text)
+            .await
+            .map(|body| (body, None))
+    } else if let Some((_user, mission)) = owner_alert_reply {
+        send_user_message_to_mission(ctx, &mission, clean_text)
             .await
             .map(|body| (body, None))
     } else if is_paloma_command(command_text, "/status") {
@@ -1122,9 +1670,25 @@ async fn handle_paloma_command(
         }
     } else if is_paloma_command(command_text, "/summary") {
         let selector = command_text.trim().strip_prefix("/summary").map(str::trim);
-        build_paloma_summary(ctx, selector)
-            .await
-            .map(|body| (body, None))
+        match selector.filter(|value| !value.is_empty()) {
+            Some(selector) => build_paloma_summary(ctx, Some(selector))
+                .await
+                .map(|body| (body, None)),
+            None => match user {
+                Some(user) => match paloma_replied_alert_mission(ctx, user, msg).await {
+                    Ok(Some(mission)) => build_paloma_summary_for_mission(ctx, &mission)
+                        .await
+                        .map(|body| (body, None)),
+                    Ok(None) => build_paloma_summary(ctx, None)
+                        .await
+                        .map(|body| (body, None)),
+                    Err(err) => Err(err),
+                },
+                None => build_paloma_summary(ctx, None)
+                    .await
+                    .map(|body| (body, None)),
+            },
+        }
     } else if is_paloma_command(command_text, "/send") {
         match parse_paloma_selector_and_payload(command_text, "/send") {
             Some((selector, payload)) => send_paloma_mission_message(ctx, selector, payload)
@@ -1132,6 +1696,8 @@ async fn handle_paloma_command(
                 .map(|body| (body, None)),
             None => Err("Usage: /send <mission selector> <message>".to_string()),
         }
+    } else if is_paloma_command(command_text, "/why") {
+        build_paloma_why(ctx).await.map(|body| (body, None))
     } else if is_paloma_command(command_text, "/approve") {
         let answer = command_text
             .trim()
@@ -1141,7 +1707,7 @@ async fn handle_paloma_command(
         if answer.is_empty() {
             Err("Usage: /approve <answer>".to_string())
         } else {
-            send_paloma_mission_message(ctx, "latest", answer)
+            send_paloma_approval(ctx, answer)
                 .await
                 .map(|body| (body, None))
         }
@@ -1226,6 +1792,9 @@ impl TelegramBridge {
         Self {
             active_channels: RwLock::new(HashMap::new()),
             chat_locks: RwLock::new(HashMap::new()),
+            paloma_session_locks: RwLock::new(HashMap::new()),
+            paloma_session_queue: Mutex::new(PalomaQueue::new(PALOMA_SESSION_QUEUE_MAX_PER_KEY)),
+            paloma_jobs: Mutex::new(PalomaJobRegistry::with_default_jobs()),
             recent_updates: RwLock::new(HashMap::new()),
             recent_replies: RwLock::new(HashMap::new()),
             scheduler_started: AtomicBool::new(false),
@@ -1316,6 +1885,101 @@ impl TelegramBridge {
                 .entry((channel_id, chat_id))
                 .or_insert_with(|| Arc::new(Mutex::new(()))),
         )
+    }
+
+    /// Get or create the Paloma session mutex used to serialize inbound work per chat.
+    pub async fn paloma_session_lock(&self, channel_id: Uuid, chat_id: i64) -> Arc<Mutex<()>> {
+        {
+            let locks = self.paloma_session_locks.read().await;
+            if let Some(lock) = locks.get(&(channel_id, chat_id)) {
+                return Arc::clone(lock);
+            }
+        }
+
+        let mut locks = self.paloma_session_locks.write().await;
+        Arc::clone(
+            locks
+                .entry((channel_id, chat_id))
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        )
+    }
+
+    pub async fn enqueue_paloma_session(
+        &self,
+        channel_id: Uuid,
+        chat_id: i64,
+        mission_id: Option<Uuid>,
+    ) -> Option<QueueKey> {
+        let key = QueueKey {
+            channel: channel_id.to_string(),
+            session_id: chat_id.to_string(),
+            mission_id,
+            priority: 0,
+        };
+        let mut queue = self.paloma_session_queue.lock().await;
+        match queue.push(key.clone(), ()) {
+            Ok(()) => {
+                let metrics = queue.metrics();
+                tracing::debug!(
+                    pending_items = metrics.pending_items,
+                    active_sessions = metrics.active_sessions,
+                    "Paloma session queue accepted inbound work"
+                );
+                Some(key)
+            }
+            Err(()) => {
+                let metrics = queue.metrics();
+                tracing::warn!(
+                    pending_items = metrics.pending_items,
+                    active_sessions = metrics.active_sessions,
+                    channel_id = %channel_id,
+                    chat_id,
+                    "Paloma session queue rejected inbound work because the session queue is full"
+                );
+                None
+            }
+        }
+    }
+
+    pub async fn dequeue_paloma_session(&self, key: &QueueKey) {
+        let mut queue = self.paloma_session_queue.lock().await;
+        let _ = queue.pop(key);
+        queue.cleanup_idle();
+        let metrics = queue.metrics();
+        tracing::debug!(
+            pending_items = metrics.pending_items,
+            active_sessions = metrics.active_sessions,
+            "Paloma session queue started inbound work"
+        );
+    }
+
+    pub async fn paloma_queue_metrics(&self) -> QueueMetrics {
+        self.paloma_session_queue.lock().await.metrics()
+    }
+
+    pub async fn paloma_queue_metrics_for_channels(
+        &self,
+        channel_ids: &HashSet<String>,
+    ) -> QueueMetrics {
+        self.paloma_session_queue
+            .lock()
+            .await
+            .metrics_for_channels(channel_ids)
+    }
+
+    pub async fn paloma_job_states(&self) -> Vec<PalomaJobState> {
+        self.paloma_jobs.lock().await.states()
+    }
+
+    async fn record_paloma_job_success(&self, name: &'static str) {
+        self.paloma_jobs
+            .lock()
+            .await
+            .record_success(name, now_string());
+    }
+
+    async fn record_paloma_job_failure(&self, name: &'static str, error: String) {
+        self.paloma_jobs.lock().await.record_failure(name, error);
     }
 
     /// Register a webhook for a Telegram channel and store routing context.
@@ -1411,6 +2075,7 @@ impl TelegramBridge {
 
     async fn run_scheduler_loop(self: Arc<Self>, _mission_store: Arc<dyn MissionStore>) {
         let mut interval = tokio::time::interval(TELEGRAM_SCHEDULE_POLL_INTERVAL);
+        let lease_owner = format!("telegram-bridge-{}", std::process::id());
         interval.tick().await;
 
         loop {
@@ -1423,90 +2088,353 @@ impl TelegramBridge {
                 .cloned()
                 .collect();
             for ctx in channels {
-                plan_and_deliver_paloma_alerts(&ctx, &self.http).await;
-
-                let due = match ctx
+                let alert_job_name = paloma_channel_job_name("paloma_alert_scan", ctx.channel.id);
+                let alert_job_started = now_string();
+                let alert_job_lease_expires = paloma_scheduler_lease_expires_at();
+                if ctx
                     .mission_store
-                    .list_due_telegram_scheduled_messages(ctx.channel.id, &now_string(), 32)
-                    .await
-                {
-                    Ok(messages) => messages,
-                    Err(err) => {
-                        tracing::warn!(
-                            channel_id = %ctx.channel.id,
-                            "Failed to load due Telegram scheduled messages: {}",
-                            err
-                        );
-                        continue;
-                    }
-                };
-
-                for message in due {
-                    // Claim this message atomically: UPDATE … WHERE status='pending'
-                    // so concurrent ticks cannot pick up the same message.
-                    let claimed = ctx
-                        .mission_store
-                        .claim_telegram_scheduled_message(message.id)
-                        .await;
-                    match claimed {
-                        Ok(false) => continue, // Another tick already claimed it
-                        Err(err) => {
-                            tracing::warn!(
-                                scheduled_message_id = %message.id,
-                                "Failed to claim Telegram scheduled message: {}",
-                                err
-                            );
-                            continue;
-                        }
-                        Ok(true) => {} // Claimed successfully, proceed
-                    }
-
-                    let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
-                    match send_chunked_message(
-                        &self.http,
-                        &base_url,
-                        message.chat_id,
-                        &message.text,
-                        None,
+                    .claim_paloma_scheduler_job(
+                        &alert_job_name,
+                        &lease_owner,
+                        &alert_job_started,
+                        &alert_job_lease_expires,
                     )
                     .await
+                    .unwrap_or(false)
+                {
+                    plan_and_deliver_paloma_alerts(&ctx, &self.http).await;
+                    let _ = ctx
+                        .mission_store
+                        .finish_paloma_scheduler_job(
+                            &alert_job_name,
+                            &lease_owner,
+                            &now_string(),
+                            None,
+                        )
+                        .await;
+                    self.record_paloma_job_success("paloma_alert_scan").await;
+                }
+
+                let due_job_name = paloma_channel_job_name("paloma_due_messages", ctx.channel.id);
+                let due_job_started = now_string();
+                let due_job_lease_expires = paloma_scheduler_lease_expires_at();
+                if ctx
+                    .mission_store
+                    .claim_paloma_scheduler_job(
+                        &due_job_name,
+                        &lease_owner,
+                        &due_job_started,
+                        &due_job_lease_expires,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
+                    match ctx
+                        .mission_store
+                        .list_due_telegram_scheduled_messages(ctx.channel.id, &now_string(), 32)
+                        .await
                     {
-                        Ok(()) => {
-                            // Mark as sent AFTER successful delivery.
+                        Ok(due) => {
+                            for message in due {
+                                // Claim this message atomically: UPDATE … WHERE status='pending'
+                                // so concurrent ticks cannot pick up the same message.
+                                let claimed = ctx
+                                    .mission_store
+                                    .claim_telegram_scheduled_message(message.id)
+                                    .await;
+                                match claimed {
+                                    Ok(false) => continue, // Another tick already claimed it
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            scheduled_message_id = %message.id,
+                                            "Failed to claim Telegram scheduled message: {}",
+                                            err
+                                        );
+                                        continue;
+                                    }
+                                    Ok(true) => {} // Claimed successfully, proceed
+                                }
+
+                                let base_url = format!(
+                                    "https://api.telegram.org/bot{}",
+                                    ctx.channel.bot_token
+                                );
+                                match send_chunked_message(
+                                    &self.http,
+                                    &base_url,
+                                    message.chat_id,
+                                    &message.text,
+                                    None,
+                                )
+                                .await
+                                {
+                                    Ok(()) => {
+                                        // Mark as sent AFTER successful delivery.
+                                        let _ = ctx
+                                            .mission_store
+                                            .mark_telegram_scheduled_message_sent(
+                                                message.id,
+                                                &now_string(),
+                                            )
+                                            .await;
+                                        let _ = ctx
+                                            .mission_store
+                                            .mark_telegram_action_execution_by_scheduled_message(
+                                                message.id,
+                                                TelegramActionExecutionStatus::Sent,
+                                                None,
+                                                &now_string(),
+                                            )
+                                            .await;
+                                    }
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            scheduled_message_id = %message.id,
+                                            chat_id = message.chat_id,
+                                            "Failed to deliver scheduled Telegram message: {}",
+                                            err
+                                        );
+                                        let _ = ctx
+                                            .mission_store
+                                            .mark_telegram_scheduled_message_failed(
+                                                message.id, &err,
+                                            )
+                                            .await;
+                                        let _ = ctx
+                                            .mission_store
+                                            .mark_telegram_action_execution_by_scheduled_message(
+                                                message.id,
+                                                TelegramActionExecutionStatus::Failed,
+                                                Some(&err),
+                                                &now_string(),
+                                            )
+                                            .await;
+                                    }
+                                }
+                            }
                             let _ = ctx
                                 .mission_store
-                                .mark_telegram_scheduled_message_sent(message.id, &now_string())
+                                .finish_paloma_scheduler_job(
+                                    &due_job_name,
+                                    &lease_owner,
+                                    &now_string(),
+                                    None,
+                                )
+                                .await;
+                            self.record_paloma_job_success("paloma_due_messages").await;
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                channel_id = %ctx.channel.id,
+                                "Failed to load due Telegram scheduled messages: {}",
+                                err
+                            );
+                            self.record_paloma_job_failure("paloma_due_messages", err)
                                 .await;
                             let _ = ctx
                                 .mission_store
-                                .mark_telegram_action_execution_by_scheduled_message(
-                                    message.id,
-                                    TelegramActionExecutionStatus::Sent,
-                                    None,
+                                .finish_paloma_scheduler_job(
+                                    &due_job_name,
+                                    &lease_owner,
                                     &now_string(),
+                                    Some("failed_to_load_due_messages"),
                                 )
+                                .await;
+                        }
+                    }
+                }
+                let memory_job_name =
+                    paloma_channel_job_name("paloma_memory_consolidation", ctx.channel.id);
+                let memory_job_started = now_string();
+                let memory_job_lease_expires = paloma_scheduler_lease_expires_at();
+                if ctx
+                    .mission_store
+                    .claim_paloma_scheduler_job(
+                        &memory_job_name,
+                        &lease_owner,
+                        &memory_job_started,
+                        &memory_job_lease_expires,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
+                    match ctx
+                        .mission_store
+                        .consolidate_telegram_structured_memory(ctx.channel.id, 2048)
+                        .await
+                    {
+                        Ok(deleted) => {
+                            tracing::debug!(
+                                channel_id = %ctx.channel.id,
+                                deleted,
+                                "Paloma memory consolidation finished"
+                            );
+                            let _ = ctx
+                                .mission_store
+                                .finish_paloma_scheduler_job(
+                                    &memory_job_name,
+                                    &lease_owner,
+                                    &now_string(),
+                                    None,
+                                )
+                                .await;
+                            self.record_paloma_job_success("paloma_memory_consolidation")
                                 .await;
                         }
                         Err(err) => {
                             tracing::warn!(
-                                scheduled_message_id = %message.id,
-                                chat_id = message.chat_id,
-                                "Failed to deliver scheduled Telegram message: {}",
+                                channel_id = %ctx.channel.id,
+                                "Paloma memory consolidation failed: {}",
                                 err
                             );
                             let _ = ctx
                                 .mission_store
-                                .mark_telegram_scheduled_message_failed(message.id, &err)
-                                .await;
-                            let _ = ctx
-                                .mission_store
-                                .mark_telegram_action_execution_by_scheduled_message(
-                                    message.id,
-                                    TelegramActionExecutionStatus::Failed,
-                                    Some(&err),
+                                .finish_paloma_scheduler_job(
+                                    &memory_job_name,
+                                    &lease_owner,
                                     &now_string(),
+                                    Some("memory_consolidation_failed"),
                                 )
                                 .await;
+                            self.record_paloma_job_failure("paloma_memory_consolidation", err)
+                                .await;
+                        }
+                    }
+                }
+
+                let stale_job_name =
+                    paloma_channel_job_name("paloma_stale_recovery", ctx.channel.id);
+                let stale_job_started = now_string();
+                let stale_job_lease_expires = paloma_scheduler_lease_expires_at();
+                if ctx
+                    .mission_store
+                    .claim_paloma_scheduler_job(
+                        &stale_job_name,
+                        &lease_owner,
+                        &stale_job_started,
+                        &stale_job_lease_expires,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
+                    let before = (Utc::now() - ChronoDuration::minutes(10)).to_rfc3339();
+                    match ctx
+                        .mission_store
+                        .recover_stale_telegram_alerts(&before, 128)
+                        .await
+                    {
+                        Ok(recovered) => {
+                            tracing::debug!(
+                                channel_id = %ctx.channel.id,
+                                recovered,
+                                "Paloma stale recovery finished"
+                            );
+                            let _ = ctx
+                                .mission_store
+                                .finish_paloma_scheduler_job(
+                                    &stale_job_name,
+                                    &lease_owner,
+                                    &now_string(),
+                                    None,
+                                )
+                                .await;
+                            self.record_paloma_job_success("paloma_stale_recovery")
+                                .await;
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                channel_id = %ctx.channel.id,
+                                "Paloma stale recovery failed: {}",
+                                err
+                            );
+                            let _ = ctx
+                                .mission_store
+                                .finish_paloma_scheduler_job(
+                                    &stale_job_name,
+                                    &lease_owner,
+                                    &now_string(),
+                                    Some("stale_recovery_failed"),
+                                )
+                                .await;
+                            self.record_paloma_job_failure("paloma_stale_recovery", err)
+                                .await;
+                        }
+                    }
+                }
+
+                let digest_job_name =
+                    paloma_channel_job_name("paloma_digest_flush", ctx.channel.id);
+                let digest_job_started = now_string();
+                let digest_job_lease_expires = paloma_scheduler_lease_expires_at();
+                if ctx
+                    .mission_store
+                    .claim_paloma_scheduler_job(
+                        &digest_job_name,
+                        &lease_owner,
+                        &digest_job_started,
+                        &digest_job_lease_expires,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
+                    match configured_telegram_id(
+                        "PALOMA_TELEGRAM_OWNER_ID",
+                        DEFAULT_PALOMA_OWNER_TELEGRAM_ID,
+                    ) {
+                        Some(owner_id) => {
+                            match flush_pending_paloma_digest(&ctx, &self.http, owner_id).await {
+                                Ok(sent_count) => {
+                                    tracing::debug!(
+                                        channel_id = %ctx.channel.id,
+                                        sent_count,
+                                        "Paloma digest flush finished"
+                                    );
+                                    let _ = ctx
+                                        .mission_store
+                                        .finish_paloma_scheduler_job(
+                                            &digest_job_name,
+                                            &lease_owner,
+                                            &now_string(),
+                                            None,
+                                        )
+                                        .await;
+                                    self.record_paloma_job_success("paloma_digest_flush").await;
+                                }
+                                Err(err) => {
+                                    tracing::warn!(
+                                        channel_id = %ctx.channel.id,
+                                        "Paloma digest flush failed: {}",
+                                        err
+                                    );
+                                    let _ = ctx
+                                        .mission_store
+                                        .finish_paloma_scheduler_job(
+                                            &digest_job_name,
+                                            &lease_owner,
+                                            &now_string(),
+                                            Some("digest_flush_failed"),
+                                        )
+                                        .await;
+                                    self.record_paloma_job_failure("paloma_digest_flush", err)
+                                        .await;
+                                }
+                            }
+                        }
+                        None => {
+                            let _ = ctx
+                                .mission_store
+                                .finish_paloma_scheduler_job(
+                                    &digest_job_name,
+                                    &lease_owner,
+                                    &now_string(),
+                                    Some("missing_owner_id"),
+                                )
+                                .await;
+                            self.record_paloma_job_failure(
+                                "paloma_digest_flush",
+                                "missing_owner_id".to_string(),
+                            )
+                            .await;
                         }
                     }
                 }
@@ -2481,6 +3409,28 @@ pub async fn process_webhook_message(
         return;
     }
 
+    let Some(paloma_queue_key) = bridge
+        .enqueue_paloma_session(ctx.channel.id, msg.chat.id, None)
+        .await
+    else {
+        let base_url = format!("https://api.telegram.org/bot{}", ctx.channel.bot_token);
+        let _ = send_message(
+            http,
+            &base_url,
+            msg.chat.id,
+            "I'm still handling earlier messages in this chat. Please retry in a moment.",
+            Some(msg.message_id),
+        )
+        .await;
+        return;
+    };
+
+    let paloma_session_lock = bridge
+        .paloma_session_lock(ctx.channel.id, msg.chat.id)
+        .await;
+    let _paloma_session_guard = paloma_session_lock.lock().await;
+    bridge.dequeue_paloma_session(&paloma_queue_key).await;
+
     let should_respond = should_process_message(&ctx.channel, msg, &ctx.bot_username);
 
     let sender_name = msg
@@ -2553,26 +3503,6 @@ pub async fn process_webhook_message(
     let conversation =
         upsert_telegram_conversation(ctx, &msg.chat, target_mission_id, Some(now_string())).await;
 
-    if let Some(conversation) = conversation.as_ref() {
-        log_telegram_conversation_message(
-            &ctx.mission_store,
-            conversation.id,
-            ctx.channel.id,
-            msg.chat.id,
-            Some(target_mission_id),
-            None,
-            Some(msg.message_id),
-            TelegramConversationMessageDirection::Inbound,
-            "user",
-            memory_subject.user_id,
-            memory_subject.username.clone(),
-            memory_subject.display_name.clone(),
-            msg.reply_to_message.as_ref().map(|reply| reply.message_id),
-            &clean_text,
-        )
-        .await;
-    }
-
     persist_structured_memory_for_message(
         ctx,
         msg.chat.id,
@@ -2613,6 +3543,27 @@ pub async fn process_webhook_message(
     } else {
         None
     };
+
+    if let Some(conversation) = conversation.as_ref() {
+        let conversation_text = workflow_reply_text(&clean_text, file_annotation.as_deref());
+        log_telegram_conversation_message(
+            &ctx.mission_store,
+            conversation.id,
+            ctx.channel.id,
+            msg.chat.id,
+            Some(target_mission_id),
+            None,
+            Some(msg.message_id),
+            TelegramConversationMessageDirection::Inbound,
+            "user",
+            memory_subject.user_id,
+            memory_subject.username.clone(),
+            memory_subject.display_name.clone(),
+            msg.reply_to_message.as_ref().map(|reply| reply.message_id),
+            &conversation_text,
+        )
+        .await;
+    }
 
     // Build message content with optional system instructions and file info
     let mut parts = Vec::new();
@@ -4423,7 +5374,12 @@ pub async fn stream_response(
                         // Send shared files as Telegram documents/photos
                         if let Some(files) = shared_files {
                             for file in &files {
-                                if let Err(e) = send_file_to_telegram(http, &base_url, chat_id, file).await {
+                                let caption =
+                                    telegram_shared_file_caption(mission_id, file, &delivery_text);
+                                if let Err(e) =
+                                    send_file_to_telegram(http, &base_url, chat_id, file, &caption)
+                                        .await
+                                {
                                     tracing::warn!("Failed to send file {} to Telegram: {}", file.name, e);
                                 }
                             }
@@ -4502,6 +5458,7 @@ async fn send_file_to_telegram(
     base_url: &str,
     chat_id: i64,
     file: &crate::api::control::SharedFile,
+    caption: &str,
 ) -> Result<(), String> {
     use reqwest::multipart;
 
@@ -4595,6 +5552,7 @@ async fn send_file_to_telegram(
 
     let form = multipart::Form::new()
         .text("chat_id", chat_id.to_string())
+        .text("caption", caption.to_string())
         .part(field_name, file_part);
 
     let response = http
@@ -5034,23 +5992,32 @@ pub async fn get_bot_username(http: &Client, base_url: &str) -> Result<String, S
 mod tests {
     use super::{
         build_internal_telegram_action_token, extract_structured_memory_from_text,
-        extract_telegram_actions, feedback_mutes_alerts, feedback_raises_interest,
-        format_structured_memory_context, is_paloma_command, markdown_to_telegram_html,
-        merge_telegram_chat_metadata, mission_label, normalize_paloma_natural_command,
-        paloma_alert_body, paloma_alert_digest_text, paloma_alert_event_kind_at,
-        paloma_alert_importance_for_mission, paloma_alert_kind_for_status,
-        paloma_command_error_response, paloma_role_for_user,
-        paloma_should_alert_long_running_mission_at, parse_paloma_selector_and_payload,
-        redact_for_telegram, render_telegram_chunk, sanitize_telegram_visible_text,
-        scope_for_extracted_memory, telegram_action_target_matches, telegram_chat_display_title,
+        extract_telegram_actions, feedback_mutes_alerts, feedback_only_failures,
+        feedback_raises_interest, format_structured_memory_context, is_paloma_command,
+        is_paloma_shared_summary_allowed, markdown_to_telegram_html, merge_telegram_chat_metadata,
+        mission_label, normalize_paloma_natural_command, paloma_alert_body,
+        paloma_alert_digest_text, paloma_alert_event_kind_at, paloma_alert_importance_for_mission,
+        paloma_alert_kind_for_status, paloma_channel_job_name, paloma_chat_is_allowed,
+        paloma_command_error_response, paloma_mission_has_failure_only_preference,
+        paloma_role_for_user, paloma_shared_summary_body,
+        paloma_should_alert_long_running_mission_at, paloma_should_alert_mission_at,
+        paloma_status_event_is_new, paloma_status_seen_sequences,
+        parse_paloma_selector_and_payload, redact_for_telegram, render_telegram_chunk,
+        sanitize_telegram_visible_text, scope_for_extracted_memory,
+        select_latest_awaiting_user_mission, should_silence_paloma_shared_command,
+        telegram_action_target_matches, telegram_chat_display_title, telegram_shared_file_caption,
         truncate_for_telegram, verify_internal_telegram_action_token, workflow_reply_text,
-        workflow_request_delivery_text, Chat, ExtractedTelegramMemory, Mission, MissionMode,
-        MissionStatus, TelegramAction, TelegramActionKind, TelegramAlert, TelegramBridge,
-        TelegramMemorySubject, TelegramMissionInterestLevel, TelegramStructuredMemoryEntry,
-        TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramUserRole,
+        workflow_request_delivery_text, Chat, ExtractedTelegramMemory, Message, Mission,
+        MissionMode, MissionStatus, TelegramAction, TelegramActionKind, TelegramAlert,
+        TelegramAlertPreference, TelegramBridge, TelegramChannel, TelegramMemorySubject,
+        TelegramMissionInterestLevel, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
+        TelegramStructuredMemoryScope, TelegramTriggerMode, TelegramUser, TelegramUserRole,
+        PALOMA_SCHEDULER_JOB_LEASE_SECONDS,
     };
+    use crate::api::control::SharedFile;
     use crate::api::mission_store::StoredEvent;
     use chrono::{TimeZone, Utc};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn test_mission(title: &str, status: MissionStatus) -> Mission {
@@ -5105,6 +6072,66 @@ mod tests {
         }
     }
 
+    fn test_paloma_channel(allowed_chat_ids: Vec<i64>) -> TelegramChannel {
+        TelegramChannel {
+            id: Uuid::new_v4(),
+            mission_id: Uuid::new_v4(),
+            bot_token: "test-token".to_string(),
+            bot_username: Some("paloma_test_bot".to_string()),
+            allowed_chat_ids,
+            trigger_mode: TelegramTriggerMode::MentionOrDm,
+            active: true,
+            webhook_secret: None,
+            instructions: None,
+            auto_create_missions: true,
+            default_backend: None,
+            default_model_override: None,
+            default_model_effort: None,
+            default_workspace_id: None,
+            default_config_profile: None,
+            default_agent: None,
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
+    fn test_paloma_message(chat_id: i64, chat_type: &str, text: &str) -> Message {
+        Message {
+            message_id: 77,
+            chat: Chat {
+                id: chat_id,
+                chat_type: chat_type.to_string(),
+                title: Some("Shared chat".to_string()),
+                username: None,
+                first_name: None,
+                last_name: None,
+            },
+            from: None,
+            text: Some(text.to_string()),
+            caption: None,
+            reply_to_message: None,
+            entities: None,
+            caption_entities: None,
+            document: None,
+            photo: None,
+            voice: None,
+            audio: None,
+            video: None,
+        }
+    }
+
+    fn test_paloma_user(role: TelegramUserRole) -> TelegramUser {
+        TelegramUser {
+            id: Uuid::new_v4(),
+            telegram_user_id: 42,
+            username: Some("tester".to_string()),
+            display_name: Some("Tester".to_string()),
+            role,
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
     #[test]
     fn truncate_for_telegram_preserves_valid_html_boundaries() {
         let text = "**bold** ".repeat(700);
@@ -5144,6 +6171,54 @@ mod tests {
         assert!(!bridge.register_update_once(channel_id, 42).await);
         assert!(bridge.register_update_once(channel_id, 43).await);
         assert!(bridge.register_update_once(Uuid::new_v4(), 42).await);
+    }
+
+    #[tokio::test]
+    async fn telegram_bridge_tracks_paloma_session_locks_and_jobs() {
+        let bridge = TelegramBridge::new();
+        let channel_id = Uuid::new_v4();
+
+        let first = bridge.paloma_session_lock(channel_id, 123).await;
+        let second = bridge.paloma_session_lock(channel_id, 123).await;
+        let other = bridge.paloma_session_lock(channel_id, 456).await;
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(!Arc::ptr_eq(&first, &other));
+
+        let queue_key = bridge
+            .enqueue_paloma_session(channel_id, 123, Some(Uuid::new_v4()))
+            .await
+            .expect("queue accepts inbound work");
+        assert_eq!(bridge.paloma_queue_metrics().await.pending_items, 1);
+        bridge.dequeue_paloma_session(&queue_key).await;
+        assert_eq!(bridge.paloma_queue_metrics().await.pending_items, 0);
+
+        bridge.record_paloma_job_success("paloma_alert_scan").await;
+        let states = bridge.paloma_job_states().await;
+        let alert_scan = states
+            .iter()
+            .find(|state| state.name == "paloma_alert_scan")
+            .expect("alert scan job");
+        assert_eq!(alert_scan.runs, 1);
+        assert!(alert_scan.last_success_at.is_some());
+    }
+
+    #[test]
+    fn paloma_scheduler_job_names_are_scoped_per_channel() {
+        let channel_a = Uuid::new_v4();
+        let channel_b = Uuid::new_v4();
+
+        assert_ne!(
+            paloma_channel_job_name("paloma_alert_scan", channel_a),
+            paloma_channel_job_name("paloma_alert_scan", channel_b)
+        );
+        assert!(paloma_channel_job_name("paloma_alert_scan", channel_a)
+            .starts_with("paloma_alert_scan:"));
+    }
+
+    #[test]
+    fn paloma_scheduler_lease_covers_slow_alert_work() {
+        let lease_seconds = std::hint::black_box(PALOMA_SCHEDULER_JOB_LEASE_SECONDS);
+        assert!(lease_seconds >= 300);
     }
 
     #[tokio::test]
@@ -5211,6 +6286,183 @@ mod tests {
     }
 
     #[test]
+    fn paloma_shared_summary_is_limited_to_allowlisted_owner_or_friend() {
+        let channel = test_paloma_channel(vec![-100]);
+        let msg = test_paloma_message(-100, "supergroup", "/summary");
+        let friend = test_paloma_user(TelegramUserRole::TrustedFriend);
+        let owner = test_paloma_user(TelegramUserRole::Owner);
+        let observer = test_paloma_user(TelegramUserRole::Observer);
+
+        assert!(is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&friend),
+            &msg,
+            "/summary"
+        ));
+        assert!(is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&owner),
+            &msg,
+            "/summary"
+        ));
+        assert!(!is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&observer),
+            &msg,
+            "/summary"
+        ));
+        assert!(!is_paloma_shared_summary_allowed(
+            &test_paloma_channel(vec![]),
+            Some(&friend),
+            &msg,
+            "/summary"
+        ));
+        assert!(!is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&friend),
+            &test_paloma_message(-101, "supergroup", "/summary"),
+            "/summary"
+        ));
+    }
+
+    #[test]
+    fn paloma_group_commands_obey_channel_allowlist() {
+        let channel = test_paloma_channel(vec![-100]);
+        let allowed_group = test_paloma_message(-100, "supergroup", "/status");
+        let blocked_group = test_paloma_message(-101, "supergroup", "/status");
+        let dm = test_paloma_message(42, "private", "/status");
+
+        assert!(paloma_chat_is_allowed(&channel, &allowed_group));
+        assert!(!paloma_chat_is_allowed(&channel, &blocked_group));
+        assert!(paloma_chat_is_allowed(&channel, &dm));
+    }
+
+    #[test]
+    fn paloma_shared_summary_does_not_allow_control_commands_or_private_dm() {
+        let channel = test_paloma_channel(vec![-100]);
+        let friend = test_paloma_user(TelegramUserRole::TrustedFriend);
+
+        assert!(!is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&friend),
+            &test_paloma_message(-100, "supergroup", "/send latest go"),
+            "/send latest go"
+        ));
+        assert!(!is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&friend),
+            &test_paloma_message(-100, "private", "/summary"),
+            "/summary"
+        ));
+        assert!(!is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&friend),
+            &test_paloma_message(-100, "supergroup", "/summary latest"),
+            "/summary latest"
+        ));
+        assert!(is_paloma_shared_summary_allowed(
+            &channel,
+            Some(&friend),
+            &test_paloma_message(-100, "supergroup", "/summary@paloma_test_bot"),
+            "/summary@paloma_test_bot"
+        ));
+    }
+
+    #[test]
+    fn paloma_shared_commands_stay_silent_except_safe_summary() {
+        let channel = test_paloma_channel(vec![-100]);
+        let friend = test_paloma_user(TelegramUserRole::TrustedFriend);
+        let owner = test_paloma_user(TelegramUserRole::Owner);
+        let observer = test_paloma_user(TelegramUserRole::Observer);
+        let group = test_paloma_message(-100, "supergroup", "/status");
+
+        assert!(should_silence_paloma_shared_command(
+            &channel,
+            Some(&observer),
+            &group,
+            "/status"
+        ));
+        assert!(should_silence_paloma_shared_command(
+            &channel,
+            Some(&owner),
+            &test_paloma_message(-100, "supergroup", "/send latest go"),
+            "/send latest go"
+        ));
+        assert!(!should_silence_paloma_shared_command(
+            &channel,
+            Some(&friend),
+            &test_paloma_message(-100, "supergroup", "/summary"),
+            "/summary"
+        ));
+        assert!(!should_silence_paloma_shared_command(
+            &channel,
+            Some(&observer),
+            &test_paloma_message(42, "private", "/status"),
+            "/status"
+        ));
+        assert!(!should_silence_paloma_shared_command(
+            &channel,
+            Some(&observer),
+            &test_paloma_message(-100, "supergroup", "status please"),
+            "status please"
+        ));
+    }
+
+    #[test]
+    fn paloma_shared_summary_excludes_recent_event_details() {
+        let mission = test_mission("Proof deployment", MissionStatus::Active);
+        let body = paloma_shared_summary_body(&mission);
+
+        assert!(body.contains("Proof deployment: active"));
+        assert!(body.contains("high-level status"));
+        assert!(!body.contains("Latest:"));
+        assert!(!body.contains("replied:"));
+    }
+
+    #[test]
+    fn telegram_shared_file_caption_includes_origin_and_short_context() {
+        let mission_id = Uuid::parse_str("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb").unwrap();
+        let file = SharedFile::new(
+            "report.pdf",
+            "/tmp/report.pdf",
+            "application/pdf",
+            Some(128),
+        );
+
+        let caption = telegram_shared_file_caption(
+            mission_id,
+            &file,
+            "Finished the deployment report.\nSecond line should be ignored.",
+        );
+
+        assert!(caption.contains("Mission aaaaaaaa shared report.pdf"));
+        assert!(caption.contains("Finished the deployment report."));
+        assert!(!caption.contains("Second line"));
+    }
+
+    #[test]
+    fn telegram_shared_file_caption_redacts_sensitive_details() {
+        let mission_id = Uuid::parse_str("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb").unwrap();
+        let file = SharedFile::new(
+            "token-abc12345678901234567890.txt",
+            "/tmp/report.txt",
+            "text/plain",
+            Some(128),
+        );
+
+        let caption = telegram_shared_file_caption(
+            mission_id,
+            &file,
+            "Saved under /root/.sandboxed-sh/missions/missions-dev.db",
+        );
+
+        assert!(caption.contains("[redacted]"));
+        assert!(caption.contains("[path redacted]"));
+        assert!(!caption.contains("abc12345678901234567890"));
+        assert!(!caption.contains("/root/.sandboxed-sh"));
+    }
+
+    #[test]
     fn paloma_redaction_removes_secrets_and_private_paths() {
         let text =
             "token=abc12345678901234567890 path /root/.sandboxed-sh/missions/missions-dev.db";
@@ -5234,6 +6486,86 @@ mod tests {
     }
 
     #[test]
+    fn paloma_status_cursor_uses_per_mission_sequences() {
+        let mission = test_mission("Cursor test", MissionStatus::Active);
+        let seen_sequences = paloma_status_seen_sequences(&format!(r#"{{"{}":2}}"#, mission.id));
+        let new_sequence_old_timestamp = StoredEvent {
+            id: 1,
+            mission_id: mission.id,
+            sequence: 3,
+            event_type: "assistant_message".to_string(),
+            timestamp: "2026-05-20T00:00:01Z".to_string(),
+            event_id: None,
+            tool_call_id: None,
+            tool_name: None,
+            content: "New by sequence despite old clock.".to_string(),
+            metadata: serde_json::json!({}),
+        };
+        let old_sequence = StoredEvent {
+            sequence: 2,
+            content: "Already seen.".to_string(),
+            ..new_sequence_old_timestamp.clone()
+        };
+
+        assert!(paloma_status_event_is_new(
+            mission.id,
+            &new_sequence_old_timestamp,
+            &seen_sequences,
+            Some("2026-05-20T01:00:00Z"),
+            None,
+        ));
+        assert!(!paloma_status_event_is_new(
+            mission.id,
+            &old_sequence,
+            &seen_sequences,
+            Some("2026-05-20T00:00:00Z"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn paloma_status_cursor_respects_newer_dashboard_view() {
+        let mission = test_mission("Dashboard cursor", MissionStatus::Active);
+        let seen_sequences = paloma_status_seen_sequences(&format!(r#"{{"{}":2}}"#, mission.id));
+        let event = StoredEvent {
+            id: 1,
+            mission_id: mission.id,
+            sequence: 3,
+            event_type: "assistant_message".to_string(),
+            timestamp: "2026-05-20T00:30:00Z".to_string(),
+            event_id: None,
+            tool_call_id: None,
+            tool_name: None,
+            content: "Viewed on dashboard.".to_string(),
+            metadata: serde_json::json!({}),
+        };
+
+        assert!(!paloma_status_event_is_new(
+            mission.id,
+            &event,
+            &seen_sequences,
+            Some("2026-05-20T00:10:00Z"),
+            Some("2026-05-20T00:40:00Z"),
+        ));
+    }
+
+    #[test]
+    fn paloma_approval_targets_newest_awaiting_user_mission() {
+        let mut failed = test_mission("Failed", MissionStatus::Failed);
+        failed.updated_at = "2026-05-20T00:30:00Z".to_string();
+        let mut older_waiting = test_mission("Older question", MissionStatus::AwaitingUser);
+        older_waiting.updated_at = "2026-05-20T00:10:00Z".to_string();
+        let mut newer_waiting = test_mission("Newer question", MissionStatus::AwaitingUser);
+        newer_waiting.updated_at = "2026-05-20T00:20:00Z".to_string();
+
+        let selected =
+            select_latest_awaiting_user_mission(vec![failed, older_waiting, newer_waiting])
+                .expect("awaiting mission");
+
+        assert_eq!(mission_label(&selected), "Newer question");
+    }
+
+    #[test]
     fn paloma_feedback_parser_recognizes_interest_changes() {
         assert!(feedback_mutes_alerts("Don't tell me about this again."));
         assert!(feedback_mutes_alerts(
@@ -5242,7 +6574,34 @@ mod tests {
         assert!(feedback_mutes_alerts("This is too many updates."));
         assert!(feedback_mutes_alerts("Stop these updates please."));
         assert!(feedback_raises_interest("Keep me posted on this."));
+        assert!(feedback_only_failures("Only tell me if this fails."));
+        assert!(feedback_only_failures("Only failures please."));
         assert!(!feedback_mutes_alerts("what changed?"));
+    }
+
+    #[test]
+    fn paloma_failure_only_preference_matches_mission_scope() {
+        let mission_id = Uuid::new_v4();
+        let preferences = vec![TelegramAlertPreference {
+            id: Uuid::new_v4(),
+            telegram_user_id: 42,
+            scope: "mission".to_string(),
+            scope_value: Some(mission_id.to_string()),
+            rule_text: "only failures from Telegram feedback".to_string(),
+            enabled: true,
+            created_from_message_id: Some(10),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+        }];
+
+        assert!(paloma_mission_has_failure_only_preference(
+            &preferences,
+            mission_id
+        ));
+        assert!(!paloma_mission_has_failure_only_preference(
+            &preferences,
+            Uuid::new_v4()
+        ));
     }
 
     #[test]
@@ -5250,6 +6609,10 @@ mod tests {
         assert_eq!(
             paloma_command_error_response("Usage: /approve <answer>"),
             "Usage: /approve <answer>"
+        );
+        assert_eq!(
+            paloma_command_error_response("ambiguous_digest_reply"),
+            "That digest covers multiple missions. Use /summary <mission> or /send <mission> <message>."
         );
         assert_eq!(
             paloma_command_error_response("database unavailable"),
@@ -5263,14 +6626,25 @@ mod tests {
             paloma_alert_kind_for_status(MissionStatus::Active),
             Some("mission_long_running")
         );
-        assert_eq!(paloma_alert_kind_for_status(MissionStatus::Completed), None);
+        assert_eq!(
+            paloma_alert_kind_for_status(MissionStatus::Completed),
+            Some("mission_completed")
+        );
         assert_eq!(
             paloma_alert_kind_for_status(MissionStatus::AwaitingUser),
-            None
+            Some("mission_awaiting_user")
+        );
+        assert_eq!(
+            paloma_alert_kind_for_status(MissionStatus::Failed),
+            Some("mission_failed")
+        );
+        assert_eq!(
+            paloma_alert_kind_for_status(MissionStatus::Blocked),
+            Some("mission_blocked")
         );
         assert_eq!(
             paloma_alert_kind_for_status(MissionStatus::NotFeasible),
-            None
+            Some("mission_not_feasible")
         );
     }
 
@@ -5405,6 +6779,52 @@ mod tests {
         assert!(!paloma_should_alert_long_running_mission_at(
             &assistant,
             &[],
+            now
+        ));
+    }
+
+    #[test]
+    fn paloma_alert_status_rules_cover_questions_and_long_running_terminal_states() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 20, 1, 0, 0).unwrap();
+
+        let awaiting = test_mission("Needs answer", MissionStatus::AwaitingUser);
+        assert!(paloma_should_alert_mission_at(
+            &awaiting,
+            &[],
+            TelegramMissionInterestLevel::Normal,
+            now
+        ));
+
+        let mut completed = test_mission("Done", MissionStatus::Completed);
+        completed.created_at = "2026-05-20T00:00:00Z".to_string();
+        assert!(paloma_should_alert_mission_at(
+            &completed,
+            &[],
+            TelegramMissionInterestLevel::Normal,
+            now
+        ));
+
+        let mut short_completed = completed.clone();
+        short_completed.created_at = "2026-05-20T00:45:00Z".to_string();
+        assert!(!paloma_should_alert_mission_at(
+            &short_completed,
+            &[],
+            TelegramMissionInterestLevel::Normal,
+            now
+        ));
+        assert!(paloma_should_alert_mission_at(
+            &short_completed,
+            &[],
+            TelegramMissionInterestLevel::High,
+            now
+        ));
+
+        let mut failed = test_mission("Failed deploy", MissionStatus::Failed);
+        failed.created_at = "2026-05-20T00:00:00Z".to_string();
+        assert!(paloma_should_alert_mission_at(
+            &failed,
+            &[],
+            TelegramMissionInterestLevel::Normal,
             now
         ));
     }


### PR DESCRIPTION
## Summary
- Extract Paloma core primitives around policy, planner, digesting, commands, queueing, memory, brain proposals, and local satellite capabilities.
- Add Paloma decision logging, scheduler job visibility, and queue metrics endpoints.
- Wire Telegram alert handling through the new policy/planner/digest helpers while preserving Sandboxed.sh ownership of delivery, dedupe, mission state, and memory.
- Add a Telethon live-smoke harness and audit/architecture docs for the QwenPaw-inspired adaptation path.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test paloma --all-targets`
- `cargo test --lib` (`805 passed, 2 ignored`)
- `python3 -m py_compile scripts/paloma_live_smoke.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Paloma policy/planning/queueing primitives plus new SQLite tables and control endpoints; while largely additive, it touches Telegram alert delivery/scheduling paths and persistence, which could affect notification behavior and job leasing.
> 
> **Overview**
> Refactors Paloma toward a QwenPaw-inspired runtime model by introducing a new `src/api/paloma/` module set (policy/planner/digest/commands/queue/memory/brain/capability/satellite/scheduler) and routing Telegram alert evaluation/digest formatting/queueing through these deterministic helpers.
> 
> Adds persistence and control-plane visibility for Paloma operations: new SQLite tables for `paloma_decisions` and `paloma_scheduler_jobs`, mission-store APIs to write/query decisions, manage job leases, recover stale alerts, and consolidate structured memory, plus new control endpoints `GET /api/control/paloma/{decisions,jobs,queue}`.
> 
> Also adds a Telethon-based `scripts/paloma_live_smoke.py` harness and Paloma/QwenPaw planning docs, and updates the dashboard status badge to display a new `pending` mission state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9822ea65f6adfb099c08f8791b05251accaef45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->