### PR TITLE
iOS perf diagnostics + Codex OAuth concurrency + OpenAI account-id sync

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
 
 # next.js
 /.next/

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -2344,7 +2344,7 @@ function MissionWorkbenchPanel({
                 </div>
               </div>
               {mission.short_description && (
-                <p className="rounded-md border border-white/[0.05] bg-white/[0.02] p-2 text-xs leading-relaxed text-white/50">
+                <p className="workbench-mission-description rounded-md border border-white/[0.05] bg-white/[0.02] p-2 text-xs leading-relaxed text-white/50">
                   {mission.short_description}
                 </p>
               )}

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3454,10 +3454,10 @@ const ChatItemRow = memo(function ChatItemRow({
         <div className="max-w-[80%]">
           <div
             className={cn(
-              "rounded-2xl rounded-tr-md px-4 py-3 text-white selection-light",
+              "user-message-bubble rounded-2xl rounded-tr-md px-4 py-3 selection-light",
               item.queued
-                ? "border-2 border-dashed border-indigo-500/60 bg-indigo-500/20"
-                : "bg-indigo-500",
+                ? "user-message-bubble-queued border-2 border-dashed"
+                : "user-message-bubble-solid",
             )}
           >
             <p className="whitespace-pre-wrap text-sm break-words">
@@ -9338,8 +9338,7 @@ export default function ControlClient() {
               <button
                 onClick={() => setShowMissionSwitcher(true)}
                 className={cn(
-                  "flex h-9 items-center gap-2 px-3 rounded-lg transition-colors",
-                  "bg-indigo-500/20 hover:bg-indigo-500/30",
+                  "mission-selector-trigger flex h-9 items-center gap-2 px-3 rounded-lg transition-colors",
                 )}
                 title="Switch mission (⌘K)"
               >

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -9891,7 +9891,7 @@ export default function ControlClient() {
                                     ].includes(w.status) && "bg-white/30",
                                   )}
                                 />
-                                <span className="font-mono text-[11px] text-white/70 truncate">
+                                <span className="font-mono text-[11px] text-foreground/80 truncate">
                                   {w.title || w.id.slice(0, 8)}
                                 </span>
                               </a>

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -49,6 +49,13 @@
   /* Borders - subtle */
   --border: 255 255 255; /* Used with /0.06 */
   --border-elevated: 255 255 255; /* Used with /0.08 */
+
+  /* Code surfaces */
+  --code-background: 30 32 38;
+  --code-border: 255 255 255;
+  --code-foreground: 220 224 232;
+  --code-inline-background: 255 255 255;
+  --code-inline-foreground: 165 180 252;
 }
 
 @media (prefers-color-scheme: light) {
@@ -69,6 +76,13 @@
     /* Borders */
     --border: 17 24 39;
     --border-elevated: 17 24 39;
+
+    /* Code surfaces */
+    --code-background: 244 246 250;
+    --code-border: 17 24 39;
+    --code-foreground: 31 41 55;
+    --code-inline-background: 224 231 255;
+    --code-inline-foreground: 49 46 129;
   }
 }
 
@@ -369,11 +383,32 @@ select:focus-visible {
     color: rgb(49 46 129);
   }
 
+  .mission-switcher-description {
+    color: rgb(var(--foreground-secondary) / 0.92) !important;
+  }
+
+  .mission-switcher-description-muted {
+    color: rgb(var(--foreground-tertiary) / 0.96) !important;
+  }
+
   .mission-switcher-row-selected [class*="text-white"],
   .mission-switcher-row-selected [class*="text-indigo"],
   .mission-switcher-row-selected [class*="text-violet"],
   .mission-switcher-row-selected [class*="text-cyan"] {
     color: inherit !important;
+  }
+
+  .mission-switcher-row-selected .mission-switcher-description,
+  .mission-switcher-row-selected .mission-switcher-description-muted {
+    color: rgb(49 46 129 / 0.82) !important;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .workbench-mission-description {
+    background-color: rgb(255 255 255 / 0.76) !important;
+    border-color: rgb(17 24 39 / 0.1) !important;
+    color: rgb(var(--foreground-secondary) / 0.95) !important;
   }
 }
 
@@ -726,14 +761,17 @@ select:focus-visible {
 }
 
 .prose-glass code {
-  background: rgb(var(--background-tertiary));
+  background: rgb(var(--code-inline-background) / 0.72);
+  color: rgb(var(--code-inline-foreground));
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
   font-size: 0.875em;
 }
 
 .prose-glass pre {
-  background: rgb(var(--background-tertiary));
+  background: rgb(var(--code-background));
+  color: rgb(var(--code-foreground));
+  border: 1px solid rgb(var(--code-border) / 0.08);
   border-radius: 0.5rem;
   padding: 1rem;
   overflow-x: auto;
@@ -741,7 +779,19 @@ select:focus-visible {
 
 .prose-glass pre code {
   background: transparent;
+  color: inherit;
   padding: 0;
+}
+
+@media (prefers-color-scheme: light) {
+  .prose-glass pre {
+    border-color: rgb(var(--code-border) / 0.1);
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.65);
+  }
+
+  .prose-glass [class*="text-indigo-300"] {
+    color: rgb(var(--code-inline-foreground));
+  }
 }
 
 .prose-glass img {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -259,9 +259,23 @@ select:focus-visible {
   }
 
   [class~="bg-[#1a1a1c]"],
+  [class~="bg-[#1a1a1a]"],
+  [class~="bg-[#1c1c1e]/95"],
+  [class~="bg-[#121214]"],
   [class~="bg-[#111113]"],
   [class~="bg-[#0f0f11]"] {
     background-color: rgb(255 255 255);
+  }
+
+  [class~="bg-slate-800"],
+  [class~="[&>option]:bg-slate-800"] > option,
+  [class~="[&>optgroup]:bg-slate-900"] > optgroup {
+    background-color: rgb(255 255 255);
+  }
+
+  [class~="[&>option]:text-white"] > option,
+  [class~="[&>optgroup]:text-white/70"] > optgroup {
+    color: rgb(var(--foreground));
   }
 
   [class*="bg-indigo-"][class*="text-white"],
@@ -274,6 +288,61 @@ select:focus-visible {
   [class*="bg-amber-"][class*="text-white"],
   [class*="bg-orange-"][class*="text-white"] {
     color: #ffffff;
+  }
+
+  [class~="bg-indigo-500/10"][class*="text-white"],
+  [class~="bg-indigo-500/15"][class*="text-white"],
+  [class~="bg-indigo-500/20"][class*="text-white"],
+  [class~="bg-indigo-500/30"][class*="text-white"] {
+    color: rgb(var(--foreground) / 0.88);
+  }
+}
+
+.mission-selector-trigger {
+  background-color: rgb(var(--accent) / 0.2);
+}
+
+.mission-selector-trigger:hover {
+  background-color: rgb(var(--accent) / 0.3);
+}
+
+@media (prefers-color-scheme: light) {
+  .mission-selector-trigger {
+    background-color: rgb(224 231 255);
+    border: 1px solid rgb(165 180 252 / 0.55);
+  }
+
+  .mission-selector-trigger:hover {
+    background-color: rgb(199 210 254);
+  }
+}
+
+.user-message-bubble {
+  color: #ffffff;
+}
+
+.user-message-bubble-solid {
+  background-color: rgb(var(--accent));
+}
+
+.user-message-bubble-queued {
+  background-color: rgb(var(--accent) / 0.2);
+  border-color: rgb(var(--accent) / 0.6);
+}
+
+@media (prefers-color-scheme: light) {
+  .user-message-bubble {
+    color: rgb(30 41 59);
+  }
+
+  .user-message-bubble-solid {
+    background-color: rgb(224 231 255);
+    border: 1px solid rgb(165 180 252 / 0.55);
+  }
+
+  .user-message-bubble-queued {
+    background-color: rgb(238 242 255);
+    border-color: rgb(129 140 248 / 0.7);
   }
 }
 
@@ -454,6 +523,13 @@ select:focus-visible {
 .card:hover {
   background: rgba(255, 255, 255, 0.04);
   border-color: rgba(255, 255, 255, 0.08);
+}
+
+@media (prefers-color-scheme: light) {
+  .card:hover {
+    background: rgba(255, 255, 255, 0.95);
+    border-color: rgba(17, 24, 39, 0.14);
+  }
 }
 
 .card-interactive {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -24,6 +24,8 @@
    ========================================================================= */
 
 :root {
+  color-scheme: dark;
+
   /* Backgrounds (dark mode) - No pure black */
   --background: 18 18 20; /* #121214 - primary surface */
   --background-elevated: 28 28 30; /* #1C1C1E - cards, panels */
@@ -47,6 +49,27 @@
   /* Borders - subtle */
   --border: 255 255 255; /* Used with /0.06 */
   --border-elevated: 255 255 255; /* Used with /0.08 */
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+
+    /* Backgrounds (light mode) */
+    --background: 247 248 251; /* #F7F8FB - primary surface */
+    --background-elevated: 255 255 255; /* cards, panels */
+    --background-tertiary: 235 238 244; /* nested elements */
+
+    /* Text Hierarchy */
+    --foreground: 17 24 39; /* #111827 */
+    --foreground-secondary: 75 85 99; /* #4B5563 */
+    --foreground-tertiary: 107 114 128; /* #6B7280 */
+    --foreground-muted: 156 163 175; /* #9CA3AF */
+
+    /* Borders */
+    --border: 17 24 39;
+    --border-elevated: 17 24 39;
+  }
 }
 
 @theme inline {
@@ -105,6 +128,18 @@ body {
   min-height: 100vh;
 }
 
+@media (prefers-color-scheme: light) {
+  button:focus-visible,
+  a:focus-visible {
+    background-color: rgba(17, 24, 39, 0.06) !important;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: rgb(var(--foreground-tertiary) / 0.75) !important;
+  }
+}
+
 /* =========================================================================
    Focus States - subtle background changes, no outlines
    ========================================================================= */
@@ -156,6 +191,90 @@ select:focus-visible {
 
 ::-webkit-scrollbar-thumb:hover {
   background: rgb(var(--foreground-tertiary));
+}
+
+@media (prefers-color-scheme: light) {
+  /*
+   * The dashboard was originally authored with dark-mode utility classes
+   * such as text-white/60, bg-white/[0.04], and border-white/[0.06].
+   * Remap those neutral utilities in light mode so the existing dark theme
+   * stays intact while system light mode gets readable surfaces and text.
+   */
+  [class~="text-white"] {
+    color: rgb(var(--foreground) / 0.88);
+  }
+
+  [class~="text-white/90"],
+  [class~="text-white/80"],
+  [class~="text-white/70"] {
+    color: rgb(var(--foreground) / 0.78);
+  }
+
+  [class~="text-white/60"],
+  [class~="text-white/50"] {
+    color: rgb(var(--foreground-secondary) / 0.9);
+  }
+
+  [class~="text-white/45"],
+  [class~="text-white/40"],
+  [class~="text-white/30"],
+  [class~="text-white/20"],
+  [class~="text-white/10"] {
+    color: rgb(var(--foreground-tertiary) / 0.92);
+  }
+
+  [class~="bg-white/[0.01]"],
+  [class~="bg-white/[0.02]"],
+  [class~="bg-white/[0.03]"],
+  [class~="bg-white/[0.04]"],
+  [class~="bg-white/[0.06]"],
+  [class~="bg-white/[0.08]"],
+  [class~="bg-white/5"],
+  [class~="bg-white/10"] {
+    background-color: rgb(17 24 39 / 0.04);
+  }
+
+  [class*="hover:bg-white"]:hover {
+    background-color: rgb(17 24 39 / 0.07);
+  }
+
+  [class~="border-white/[0.04]"],
+  [class~="border-white/[0.06]"],
+  [class~="border-white/[0.08]"],
+  [class~="border-white/[0.12]"],
+  [class~="border-white/10"],
+  [class~="border-white/20"] {
+    border-color: rgb(17 24 39 / 0.09);
+  }
+
+  [class*="hover:border-white"]:hover {
+    border-color: rgb(17 24 39 / 0.16);
+  }
+
+  [class~="bg-black/40"],
+  [class~="bg-black/50"],
+  [class~="bg-black/60"],
+  [class~="bg-black/80"] {
+    background-color: rgb(255 255 255 / 0.82);
+  }
+
+  [class~="bg-[#1a1a1c]"],
+  [class~="bg-[#111113]"],
+  [class~="bg-[#0f0f11]"] {
+    background-color: rgb(255 255 255);
+  }
+
+  [class*="bg-indigo-"][class*="text-white"],
+  [class*="bg-violet-"][class*="text-white"],
+  [class*="bg-red-"][class*="text-white"],
+  [class*="bg-emerald-"][class*="text-white"],
+  [class*="bg-green-"][class*="text-white"],
+  [class*="bg-blue-"][class*="text-white"],
+  [class*="bg-cyan-"][class*="text-white"],
+  [class*="bg-amber-"][class*="text-white"],
+  [class*="bg-orange-"][class*="text-white"] {
+    color: #ffffff;
+  }
 }
 
 /* =========================================================================
@@ -296,6 +415,14 @@ select:focus-visible {
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
+@media (prefers-color-scheme: light) {
+  .glass-panel {
+    background: rgba(255, 255, 255, 0.76);
+    border-color: rgba(17, 24, 39, 0.09);
+    box-shadow: 0 1px 2px rgba(17, 24, 39, 0.04);
+  }
+}
+
 .glass {
   background: rgb(var(--background-elevated) / 0.7);
   backdrop-filter: blur(20px) saturate(180%);
@@ -310,6 +437,18 @@ select:focus-visible {
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid rgba(255, 255, 255, 0.04);
   transition: background-color 150ms ease-out, border-color 150ms ease-out;
+}
+
+@media (prefers-color-scheme: light) {
+  .card {
+    background: rgba(255, 255, 255, 0.78);
+    border-color: rgba(17, 24, 39, 0.08);
+  }
+
+  .card:hover {
+    background: rgba(255, 255, 255, 0.95);
+    border-color: rgba(17, 24, 39, 0.14);
+  }
 }
 
 .card:hover {
@@ -332,6 +471,13 @@ select:focus-visible {
   backdrop-filter: blur(20px);
 }
 
+@media (prefers-color-scheme: light) {
+  .stat-panel {
+    background: rgba(255, 255, 255, 0.82);
+    border-color: rgba(17, 24, 39, 0.09);
+  }
+}
+
 .stat-label {
   font-size: 10px;
   text-transform: uppercase;
@@ -343,13 +489,13 @@ select:focus-visible {
 .stat-value {
   font-size: 1.5rem;
   font-weight: 300;
-  color: white;
+  color: rgb(var(--foreground));
   font-variant-numeric: tabular-nums;
 }
 
 .stat-suffix {
   font-size: 0.875rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgb(var(--foreground-secondary) / 0.85);
   margin-left: 0.125rem;
 }
 
@@ -439,6 +585,13 @@ select:focus-visible {
   font-family: var(--font-mono);
 }
 
+@media (prefers-color-scheme: light) {
+  .tag {
+    color: rgb(var(--foreground-tertiary));
+    background: rgba(17, 24, 39, 0.05);
+  }
+}
+
 /* =========================================================================
    XTerm Terminal Fixes
    ========================================================================= */
@@ -452,12 +605,12 @@ select:focus-visible {
    Prose styles for markdown
    ========================================================================= */
 .prose-glass {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(var(--foreground) / 0.9);
   overflow-wrap: anywhere;
 }
 
 .prose-glass strong {
-  color: white;
+  color: rgb(var(--foreground));
 }
 
 .prose-glass a {
@@ -506,7 +659,7 @@ select:focus-visible {
   border-left: 3px solid rgb(var(--accent));
   padding-left: 1rem;
   margin: 0.5rem 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgb(var(--foreground-secondary) / 0.9);
   font-style: italic;
 }
 
@@ -514,7 +667,7 @@ select:focus-visible {
 .prose-glass h2,
 .prose-glass h3,
 .prose-glass h4 {
-  color: white;
+  color: rgb(var(--foreground));
   font-weight: 600;
   margin-top: 1rem;
   margin-bottom: 0.5rem;

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -300,16 +300,22 @@ select:focus-visible {
 
 .mission-selector-trigger {
   background-color: rgb(var(--accent) / 0.2);
+  color: rgb(255 255 255 / 0.84);
 }
 
 .mission-selector-trigger:hover {
   background-color: rgb(var(--accent) / 0.3);
 }
 
+.mission-selector-trigger * {
+  color: inherit !important;
+}
+
 @media (prefers-color-scheme: light) {
   .mission-selector-trigger {
     background-color: rgb(224 231 255);
     border: 1px solid rgb(165 180 252 / 0.55);
+    color: rgb(49 46 129);
   }
 
   .mission-selector-trigger:hover {
@@ -319,6 +325,10 @@ select:focus-visible {
 
 .user-message-bubble {
   color: #ffffff;
+}
+
+.user-message-bubble * {
+  color: inherit;
 }
 
 .user-message-bubble-solid {
@@ -332,7 +342,7 @@ select:focus-visible {
 
 @media (prefers-color-scheme: light) {
   .user-message-bubble {
-    color: rgb(30 41 59);
+    color: rgb(49 46 129);
   }
 
   .user-message-bubble-solid {
@@ -343,6 +353,27 @@ select:focus-visible {
   .user-message-bubble-queued {
     background-color: rgb(238 242 255);
     border-color: rgb(129 140 248 / 0.7);
+  }
+}
+
+.mission-switcher-row-selected {
+  color: rgb(255 255 255 / 0.9);
+}
+
+.mission-switcher-row-selected * {
+  color: inherit;
+}
+
+@media (prefers-color-scheme: light) {
+  .mission-switcher-row-selected {
+    color: rgb(49 46 129);
+  }
+
+  .mission-switcher-row-selected [class*="text-white"],
+  .mission-switcher-row-selected [class*="text-indigo"],
+  .mission-switcher-row-selected [class*="text-violet"],
+  .mission-switcher-row-selected [class*="text-cyan"] {
+    color: inherit !important;
   }
 }
 

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/dashboard/src/components/auth-gate.tsx
+++ b/dashboard/src/components/auth-gate.tsx
@@ -138,7 +138,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (!ready) {
     return (
-      <div className="min-h-screen bg-[#121214] text-white" aria-label="Checking authentication">
+      <div className="min-h-screen bg-background text-foreground" aria-label="Checking authentication">
         <div className="flex min-h-screen items-center justify-center">
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/20 border-t-indigo-400" />
         </div>

--- a/dashboard/src/components/lazy-code-block.tsx
+++ b/dashboard/src/components/lazy-code-block.tsx
@@ -22,7 +22,8 @@ import type { CSSProperties, ReactNode } from "react";
 
 let highlighterModulePromise: Promise<{
   Highlighter: typeof import("react-syntax-highlighter").default;
-  theme: Record<string, CSSProperties>;
+  darkTheme: Record<string, CSSProperties>;
+  lightTheme: Record<string, CSSProperties>;
 }> | null = null;
 
 function getHighlighterModule() {
@@ -32,7 +33,14 @@ function getHighlighterModule() {
       import("react-syntax-highlighter/dist/esm/styles/prism").then(
         (m) => m.oneDark
       ),
-    ]).then(([Highlighter, theme]) => ({ Highlighter, theme }));
+      import("react-syntax-highlighter/dist/esm/styles/prism").then(
+        (m) => m.oneLight
+      ),
+    ]).then(([Highlighter, darkTheme, lightTheme]) => ({
+      Highlighter,
+      darkTheme,
+      lightTheme,
+    }));
   }
   return highlighterModulePromise;
 }
@@ -70,8 +78,10 @@ export const LazyCodeBlock = memo(function LazyCodeBlock({
 }: LazyCodeBlockProps) {
   const [Loaded, setLoaded] = useState<{
     Highlighter: typeof import("react-syntax-highlighter").default;
-    theme: Record<string, CSSProperties>;
+    darkTheme: Record<string, CSSProperties>;
+    lightTheme: Record<string, CSSProperties>;
   } | null>(null);
+  const [isLight, setIsLight] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,13 +93,22 @@ export const LazyCodeBlock = memo(function LazyCodeBlock({
     };
   }, []);
 
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-color-scheme: light)");
+    const update = () => setIsLight(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
   const baseStyle: CSSProperties = {
     margin: 0,
     padding: "0.75rem",
     fontSize: "0.75rem",
     borderRadius: "0.5rem",
-    background: "#282c34",
-    color: "#abb2bf",
+    background: "rgb(var(--code-background))",
+    color: "rgb(var(--code-foreground))",
+    border: "1px solid rgb(var(--code-border) / 0.08)",
     fontFamily: MONO_FONT,
     whiteSpace: "pre-wrap",
     wordBreak: "break-word",
@@ -106,13 +125,13 @@ export const LazyCodeBlock = memo(function LazyCodeBlock({
     );
   }
 
-  const { Highlighter, theme } = Loaded;
+  const { Highlighter, darkTheme, lightTheme } = Loaded;
   return (
     <div className={className}>
       {header}
       <Highlighter
         language={language}
-        style={theme}
+        style={isLight ? lightTheme : darkTheme}
         customStyle={baseStyle}
         showLineNumbers={showLineNumbers}
         codeTagProps={{

--- a/dashboard/src/components/lazy-json-highlighter.tsx
+++ b/dashboard/src/components/lazy-json-highlighter.tsx
@@ -13,7 +13,8 @@ import type { CSSProperties } from "react";
 // Lazy-loaded module — only fetched on first render of a highlighted block.
 let highlighterModulePromise: Promise<{
   Highlighter: typeof import("react-syntax-highlighter").default;
-  theme: Record<string, CSSProperties>;
+  darkTheme: Record<string, CSSProperties>;
+  lightTheme: Record<string, CSSProperties>;
 }> | null = null;
 
 function getHighlighterModule() {
@@ -23,7 +24,14 @@ function getHighlighterModule() {
       import("react-syntax-highlighter/dist/esm/styles/prism").then(
         (m) => m.oneDark
       ),
-    ]).then(([Highlighter, theme]) => ({ Highlighter, theme }));
+      import("react-syntax-highlighter/dist/esm/styles/prism").then(
+        (m) => m.oneLight
+      ),
+    ]).then(([Highlighter, darkTheme, lightTheme]) => ({
+      Highlighter,
+      darkTheme,
+      lightTheme,
+    }));
   }
   return highlighterModulePromise;
 }
@@ -36,13 +44,15 @@ interface LazyJsonHighlighterProps {
 
 export const LazyJsonHighlighter = memo(function LazyJsonHighlighter({
   children,
-  background = "rgba(0, 0, 0, 0.2)",
+  background = "rgb(var(--code-background))",
   textColor,
 }: LazyJsonHighlighterProps) {
   const [Loaded, setLoaded] = useState<{
     Highlighter: typeof import("react-syntax-highlighter").default;
-    theme: Record<string, CSSProperties>;
+    darkTheme: Record<string, CSSProperties>;
+    lightTheme: Record<string, CSSProperties>;
   } | null>(null);
+  const [isLight, setIsLight] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -52,6 +62,14 @@ export const LazyJsonHighlighter = memo(function LazyJsonHighlighter({
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-color-scheme: light)");
+    const update = () => setIsLight(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
   }, []);
 
   const monoFont =
@@ -68,7 +86,8 @@ export const LazyJsonHighlighter = memo(function LazyJsonHighlighter({
           fontSize: "0.75rem",
           borderRadius: "0.25rem",
           background,
-          color: textColor ?? "#abb2bf",
+          color: textColor ?? "rgb(var(--code-foreground))",
+          border: "1px solid rgb(var(--code-border) / 0.08)",
           fontFamily: monoFont,
           whiteSpace: "pre-wrap",
           wordBreak: "break-word",
@@ -80,17 +99,18 @@ export const LazyJsonHighlighter = memo(function LazyJsonHighlighter({
     );
   }
 
-  const { Highlighter, theme } = Loaded;
+  const { Highlighter, darkTheme, lightTheme } = Loaded;
   return (
     <Highlighter
       language="json"
-      style={theme}
+      style={isLight ? lightTheme : darkTheme}
       customStyle={{
         margin: 0,
         padding: "0.5rem",
         fontSize: "0.75rem",
         borderRadius: "0.25rem",
         background,
+        border: "1px solid rgb(var(--code-border) / 0.08)",
       }}
       codeTagProps={{
         style: {

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -548,7 +548,7 @@ function FilePreviewModalContent({
                                     customStyle={{
                                       padding: "1rem",
                                       borderRadius: "0.5rem",
-                                      background: "rgba(0, 0, 0, 0.3)",
+                                      background: "rgb(var(--code-background))",
                                     }}
                                   >
                                     {codeString}
@@ -1043,14 +1043,14 @@ export const MarkdownContent = memo(function MarkdownContent({
               customStyle={{
                 padding: "1rem",
                 borderRadius: "0.5rem",
-                background: "rgba(0, 0, 0, 0.3)",
+                background: "rgb(var(--code-background))",
               }}
             >
               {codeString}
             </LazyCodeBlock>
           ) : (
-            <pre className="p-4 bg-black/30 rounded-lg overflow-x-auto">
-              <code className="text-xs font-mono text-white/80">{codeString}</code>
+            <pre className="p-4 rounded-lg overflow-x-auto">
+              <code className="text-xs font-mono">{codeString}</code>
             </pre>
           )}
           {match && (
@@ -1093,7 +1093,7 @@ export const MarkdownContent = memo(function MarkdownContent({
             Render markdown
           </button>
         </div>
-        <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded bg-white/5 p-3 text-xs leading-relaxed">
+        <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded border border-white/[0.06] bg-[rgb(var(--code-background))] p-3 text-xs leading-relaxed text-[rgb(var(--code-foreground))]">
           {content}
         </pre>
       </div>

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -1355,12 +1355,12 @@ export function MissionSwitcher({
                         {mission && (
                           <>
                             {cardTitle && (
-                              <p className="text-xs text-white/55 truncate mt-0.5">
+                              <p className="mission-switcher-description text-xs text-white/55 truncate mt-0.5">
                                 {cardTitle}
                               </p>
                             )}
                             {cardDescription && (
-                              <p className="text-[11px] text-white/40 truncate">
+                              <p className="mission-switcher-description mission-switcher-description-muted text-[11px] text-white/40 truncate">
                                 {cardDescription}
                               </p>
                             )}

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -1250,10 +1250,10 @@ export function MissionSwitcher({
                         handleSelect(item.id);
                       }}
                       className={cn(
-                        'group flex items-center gap-3 py-2 mx-2 rounded-lg cursor-pointer transition-colors no-underline',
+                        'mission-switcher-row group flex items-center gap-3 py-2 mx-2 rounded-lg cursor-pointer transition-colors no-underline',
                         isWorkerItem ? 'px-3 ml-6 border-l-2 border-white/[0.06]' : 'px-3',
                         isSelected
-                          ? 'bg-indigo-500/15 text-white'
+                          ? 'mission-switcher-row-selected bg-indigo-500/15 text-white'
                           : 'text-white/70 hover:bg-white/[0.04]',
                         isSeverlyStalled && 'bg-red-500/10',
                         isStalled && !isSeverlyStalled && 'bg-amber-500/10',

--- a/dashboard/src/components/worker-panel.tsx
+++ b/dashboard/src/components/worker-panel.tsx
@@ -73,7 +73,7 @@ function getWorkerStatusInfo(
       return {
         icon: <CheckCircle className="h-3.5 w-3.5" />,
         label: 'Completed',
-        color: 'text-emerald-400',
+        color: 'text-emerald-700 dark:text-emerald-400',
         bgColor: 'bg-emerald-500/10 border-emerald-500/20',
         isActive: false,
       };
@@ -81,7 +81,7 @@ function getWorkerStatusInfo(
       return {
         icon: <XCircle className="h-3.5 w-3.5" />,
         label: 'Failed',
-        color: 'text-red-400',
+        color: 'text-red-700 dark:text-red-400',
         bgColor: 'bg-red-500/10 border-red-500/20',
         isActive: false,
       };
@@ -89,7 +89,7 @@ function getWorkerStatusInfo(
       return {
         icon: <AlertTriangle className="h-3.5 w-3.5" />,
         label: 'Interrupted',
-        color: 'text-amber-400',
+        color: 'text-amber-700 dark:text-amber-400',
         bgColor: 'bg-amber-500/10 border-amber-500/20',
         isActive: false,
       };
@@ -97,7 +97,7 @@ function getWorkerStatusInfo(
       return {
         icon: <Ban className="h-3.5 w-3.5" />,
         label: 'Not feasible',
-        color: 'text-rose-400',
+        color: 'text-rose-700 dark:text-rose-400',
         bgColor: 'bg-rose-500/10 border-rose-500/20',
         isActive: false,
       };
@@ -105,7 +105,7 @@ function getWorkerStatusInfo(
       return {
         icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
         label: 'Active',
-        color: 'text-indigo-400',
+        color: 'text-indigo-700 dark:text-indigo-400',
         bgColor: 'bg-indigo-500/10 border-indigo-500/20',
         isActive: true,
       };
@@ -113,7 +113,7 @@ function getWorkerStatusInfo(
       return {
         icon: <Clock className="h-3.5 w-3.5" />,
         label: mission.status || 'Unknown',
-        color: 'text-white/40',
+        color: 'text-foreground/60 dark:text-white/40',
         bgColor: 'bg-white/[0.03] border-white/[0.08]',
         isActive: false,
       };
@@ -191,7 +191,7 @@ const WorkerCard = memo(function WorkerCard({
         <span className="text-sm font-medium text-foreground/90 truncate flex-1">
           {title}
         </span>
-        <ExternalLink className="h-3 w-3 text-white/20 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+        <ExternalLink className="h-3 w-3 text-foreground/50 dark:text-white/20 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
       </div>
 
       {/* Description */}

--- a/dashboard/src/components/worker-panel.tsx
+++ b/dashboard/src/components/worker-panel.tsx
@@ -188,7 +188,7 @@ const WorkerCard = memo(function WorkerCard({
       {/* Header row */}
       <div className="flex items-center gap-2 mb-1">
         <span className={status.color}>{status.icon}</span>
-        <span className="text-sm font-medium text-white/90 truncate flex-1">
+        <span className="text-sm font-medium text-foreground/90 truncate flex-1">
           {title}
         </span>
         <ExternalLink className="h-3 w-3 text-white/20 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />

--- a/dashboard/src/components/workers-strip.tsx
+++ b/dashboard/src/components/workers-strip.tsx
@@ -41,7 +41,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     if (info.state === 'running') {
       return {
         icon: <Loader2 className="h-3 w-3 animate-spin" />,
-        color: 'text-indigo-300',
+        color: 'text-indigo-700 dark:text-indigo-300',
         bg: 'bg-indigo-500/10 border-indigo-500/25 hover:bg-indigo-500/15',
         activity: info.current_activity || null,
         isActive: true,
@@ -50,7 +50,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     if (info.state === 'waiting_for_tool') {
       return {
         icon: <Clock className="h-3 w-3" />,
-        color: 'text-amber-300',
+        color: 'text-amber-700 dark:text-amber-300',
         bg: 'bg-amber-500/10 border-amber-500/25 hover:bg-amber-500/15',
         activity: info.current_activity || 'Waiting for tool',
         isActive: true,
@@ -59,7 +59,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     if (info.state === 'queued') {
       return {
         icon: <Clock className="h-3 w-3" />,
-        color: 'text-white/60',
+        color: 'text-foreground/65 dark:text-white/60',
         bg: 'bg-white/[0.03] border-white/[0.08] hover:bg-white/[0.06]',
         activity: 'Queued',
         isActive: false,
@@ -71,7 +71,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     case 'completed':
       return {
         icon: <CheckCircle className="h-3 w-3" />,
-        color: 'text-emerald-300',
+        color: 'text-emerald-700 dark:text-emerald-300',
         bg: 'bg-emerald-500/10 border-emerald-500/20 hover:bg-emerald-500/15',
         activity: null,
         isActive: false,
@@ -79,7 +79,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     case 'failed':
       return {
         icon: <XCircle className="h-3 w-3" />,
-        color: 'text-red-300',
+        color: 'text-red-700 dark:text-red-300',
         bg: 'bg-red-500/10 border-red-500/20 hover:bg-red-500/15',
         activity: null,
         isActive: false,
@@ -87,7 +87,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     case 'interrupted':
       return {
         icon: <AlertTriangle className="h-3 w-3" />,
-        color: 'text-amber-300',
+        color: 'text-amber-700 dark:text-amber-300',
         bg: 'bg-amber-500/10 border-amber-500/20 hover:bg-amber-500/15',
         activity: null,
         isActive: false,
@@ -95,7 +95,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     case 'not_feasible':
       return {
         icon: <Ban className="h-3 w-3" />,
-        color: 'text-rose-300',
+        color: 'text-rose-700 dark:text-rose-300',
         bg: 'bg-rose-500/10 border-rose-500/20 hover:bg-rose-500/15',
         activity: null,
         isActive: false,
@@ -103,7 +103,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     case 'active':
       return {
         icon: <Loader2 className="h-3 w-3 animate-spin" />,
-        color: 'text-indigo-300',
+        color: 'text-indigo-700 dark:text-indigo-300',
         bg: 'bg-indigo-500/10 border-indigo-500/25 hover:bg-indigo-500/15',
         activity: null,
         isActive: true,
@@ -111,7 +111,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
     default:
       return {
         icon: <Clock className="h-3 w-3" />,
-        color: 'text-white/50',
+        color: 'text-foreground/60 dark:text-white/50',
         bg: 'bg-white/[0.03] border-white/[0.08] hover:bg-white/[0.06]',
         activity: null,
         isActive: false,

--- a/dashboard/src/components/workers-strip.tsx
+++ b/dashboard/src/components/workers-strip.tsx
@@ -217,7 +217,7 @@ export const WorkersStrip = memo(function WorkersStrip({
             title={status.activity ? `${title}: ${status.activity}` : title}
           >
             <span className={cn('shrink-0', status.color)}>{status.icon}</span>
-            <span className="truncate text-white/85">{title}</span>
+            <span className="truncate text-foreground/85">{title}</span>
             {status.activity && (
               <span className="hidden md:inline truncate text-white/40 max-w-[120px]">
                 · {status.activity}

--- a/dashboard/test-results/.last-run.json
+++ b/dashboard/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
+++ b/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
@@ -28,6 +28,11 @@ Date: 2026-05-25
     - `MarkdownView`
 - `SandboxedDashboard/Views/Components/MarkdownView.swift`
   - Adds `markdown.parse` timing when Control Diagnostics is enabled.
+  - Caches parsed markdown blocks and inline `AttributedString(markdown:)` output by content hash.
+- `SandboxedDashboard/Models/ChatHistoryReducer.swift`
+  - Adds a pure historical replay reducer that builds chat messages with indexed ids/tool calls and assigns UI state once.
+- `SandboxedDashboard/Services/ImageMemoryCache.swift`
+  - Adds a shared `NSCache` image store and background ImageIO downsampling for inline/shared chat images.
 - `SandboxedDashboard/Services/APIService.swift`
   - Adds whole-app request and decode timing for every JSON API call:
     - `api.request`
@@ -47,17 +52,40 @@ xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj \
 
 Result: build succeeded. Existing warning remains in `APIService.swift` about generic `T.Type` Sendability; it is unrelated to the diagnostics patch.
 
-Simulator work:
+Tests:
 
 ```bash
 xcrun simctl create OpenAgentPerf \
-  'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro' \
-  'com.apple.CoreSimulator.SimRuntime.iOS-26-4'
+  com.apple.CoreSimulator.SimDeviceType.iPhone-16 \
+  com.apple.CoreSimulator.SimRuntime.iOS-26-4
 xcrun simctl boot <device-id>
-xcrun simctl bootstatus <device-id> -b
+xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj \
+  -scheme SandboxedDashboard \
+  -destination 'id=<device-id>' \
+  test
 ```
 
-The simulator booted, but `simctl launch` and `simctl listapps` hung after install on this CoreSimulator instance. That blocked a complete automated trace capture in this run. The app now emits signposts usable from Instruments once the simulator can launch the app:
+Result: 30 tests passed. Existing Swift 6 actor warnings remain in `NetworkResilienceTests` for `ControlView.migrateMissionCacheIfNeeded()` calls from a non-main-actor test method; unrelated to this performance pass.
+
+Trace work:
+
+```bash
+for template in 'SwiftUI' 'Time Profiler' 'Animation Hitches'; do
+  xcrun xctrace record \
+    --template "$template" \
+    --device <device-id> \
+    --launch md.thomas.openagent.dashboard \
+    --time-limit 5s \
+    --output "/tmp/SandboxedDashboard-${template// /-}.trace"
+done
+```
+
+Result:
+- SwiftUI launched the app and saved `/tmp/SandboxedDashboard-SwiftUI.trace`, but reported that the SwiftUI instrument is not supported on this Simulator runtime.
+- Time Profiler launched the app, but did not end the recording after the requested 5-second time limit and was stopped by the timeout wrapper. A partial `/tmp/SandboxedDashboard-Time-Profiler.trace` bundle was left.
+- Animation Hitches launched the app and saved `/tmp/SandboxedDashboard-Animation-Hitches.trace`, but reported that Hitches is not supported on this platform.
+
+The temporary simulator was shut down and deleted. Manual Instruments capture on a physical iOS device, or a simulator/runtime that supports these instruments, is still useful with these templates:
 
 ```bash
 xcrun xctrace record \
@@ -91,65 +119,58 @@ category == "ControlPerformance"
 
 ## Diagnostics
 
-1. **Chat history replay is still O(events x messages) in practice.**
-   `applyViewingMissionWithEvents` replays every stored event through `handleStreamEvent`. Inside the replay, several event cases call `messages.contains`, `messages.firstIndex`, `messages.lastIndex`, and `messages.removeAll`. On long missions this becomes the dominant CPU path after the network snapshot returns.
+1. **Fixed: historical chat replay no longer replays through UI state.**
+   `applyViewingMissionWithEvents` now uses `ChatHistoryReducer.reduce(events:mission:)`, which builds `[ChatMessage]` in a pure pass with indexed ids/tool calls/text-op buffers and assigns `messages` once. Live tail deltas still use `handleStreamEvent`, which is acceptable because those batches are small.
 
-2. **Assistant markdown is reparsed in SwiftUI body.**
-   `MarkdownView.body` calls `MarkdownParser.parse(content)` every time SwiftUI evaluates the row. Large assistant messages, tables, code blocks, and image-rich responses can repeatedly pay regex + line parser + `AttributedString(markdown:)` costs. The new `markdown.parse` signpost should confirm this during scroll and mission load.
+2. **Fixed: assistant markdown parsing is cached.**
+   `MarkdownView` caches block parsing and inline attributed text by content hash. Cache misses still emit `markdown.parse` timing when Control Diagnostics is enabled.
 
-3. **Hot redraws are likely row-wide, not cell-local.**
-   `MessageBubble` receives full `ChatMessage` values and the parent view owns many unrelated `@State` values. State changes such as polling, queue count, copied id, connection status, diagnostics overlay updates, and running missions can cause visible chat rows to re-evaluate. The render probes will show whether `MessageBubble`/`MarkdownView` counts rise when unrelated toolbar or polling state changes.
+3. **Fixed: chat rows have a narrower render boundary.**
+   The conversation rows now live in `ConversationRowsView`, which receives only grouped items, copy/retry closures, and tool expansion state. Further row-level `Equatable` models are an optional follow-up if Instruments shows redraws from unrelated parent state.
 
 4. **The diagnostics overlay itself is intentionally debug-only but can perturb results.**
    When enabled, body probes mutate an in-memory counter and `markdown.parse` timing wraps parsing. Use it to identify suspicious paths, then confirm with Instruments signposts with the overlay hidden.
 
-5. **Mission switching has good cache-first behavior but still performs main-actor decode/replay.**
-   Cached mission data is read and decoded synchronously before render. This is good for perceived latency when files are small, but large cached missions still consume main-thread time before the first interactive frame.
+5. **Fixed: large mission cache decode moves off the first render.**
+   Small cache files keep the synchronous fast path. Cache files above the threshold are decoded in a detached task and applied only if they are still relevant and not older than an already-applied snapshot.
 
 6. **Running-mission and child-mission polling can still invalidate ControlView regularly.**
    The code already backs off on failures and gates child-mission fetches, but successful 5-second polling mutates `runningMissions` on the parent view. This can drive redraws in the chat subtree unless the chat list is isolated from polling state.
 
-7. **History, Files, and Settings perform sorted/filter computed properties in view render paths.**
-   Examples:
-   - `HistoryView.filteredMissions`
-   - `FilesView.sortedEntries`
-   - mission switcher/search helpers in `ControlView`
-   These are probably fine for small lists but should be measured if the whole app feels sluggish outside chat.
+7. **Fixed: list sorting/filtering is memoized outside body.**
+   `HistoryView.filteredMissions`, `FilesView.sortedEntries`, and mission switcher running/recent/search sections are now state-backed and recomputed when their inputs change.
 
-8. **Inline/shared image loading has no explicit memory cache.**
-   Inline markdown images and shared file images hold decoded `Data` in row state. Rows recreated during navigation or identity changes can refetch/redecode images. Use Instruments Allocations + Network to confirm when image-heavy chats are slow.
+8. **Fixed: inline/shared images use a memory cache and downsampling.**
+   `ImageMemoryCache` stores decoded images by URL and downscales large images off the main actor before SwiftUI renders them.
 
-9. **Timers in row/sheet components can contribute to unnecessary invalidations.**
-   Several control subviews start timers on appear for durations/progress. If many tool rows are visible, timer-driven body refreshes can stack. Render probes around `ToolGroupView` help detect this.
+9. **Fixed enough: row timers are scoped to visible active work.**
+   Tool/thinking timers only start after the row appears, only run while the tool/thought is active, and cancel on disappear/completion. A shared elapsed-time ticker is not needed unless future profiling shows many simultaneously active rows.
 
 ## Recommended Fixes
 
-1. **Replace replay-through-UI-state with a pure reducer.**
+1. **Done: replace replay-through-UI-state with a pure reducer.**
    Build `[ChatMessage]` from `[StoredEvent]` in a pure function using dictionaries/sets for ids (`messageById`, `toolById`, active thinking id). Assign `messages` once at the end. This removes repeated array scans and avoids transient SwiftUI invalidations during replay.
 
-2. **Cache parsed markdown per message id/content hash.**
+2. **Done: cache parsed markdown per content hash.**
    Move markdown parsing out of `body`, or introduce a `ParsedMarkdown` cache keyed by message id + content hash. For streaming content, debounce parsing to frame cadence or parse only the active message incrementally.
 
-3. **Isolate chat list state from toolbar/polling state.**
+3. **Done: isolate chat list state from toolbar/polling state.**
    Extract the conversation list into a small view model or child view that only receives `groupedItems`, copy/retry closures, and scroll state. Keep `runningMissions`, queue polling, sheets, and toolbar state out of the row subtree.
 
-4. **Track rendered message ids during replay.**
+4. **Done: track rendered message ids during replay.**
    Even before a full reducer refactor, maintain a temporary `Set<String>` during historical replay so duplicate checks are O(1) instead of `messages.contains`.
 
-5. **Move cache decode off the first render when the cache file is large.**
+5. **Done: move cache decode off the first render when the cache file is large.**
    For cache files over a small threshold, render the skeleton immediately and decode in a background task, then publish the decoded snapshot. Keep the current sync fast path for small cache files.
 
-6. **Memoize sorted/filter lists outside view bodies.**
+6. **Done: memoize sorted/filter lists outside view bodies.**
    For History, Files, and mission switcher/search, compute sorted/filter outputs when source arrays or query/filter settings change, not every `body` evaluation.
 
-7. **Use `EquatableView` or narrower Equatable row models for chat rows.**
+7. **Optional follow-up: use `EquatableView` or narrower Equatable row models for chat rows.**
    Make visible rows skip body work when unrelated state changes. This is especially important for assistant rows with expensive markdown.
 
-8. **Add image cache and downsampling.**
+8. **Done: add image cache and downsampling.**
    Use `URLCache`/`NSCache` keyed by resolved download URL and downsample large images before storing in SwiftUI state. This should reduce both network repeat work and memory spikes.
 
-9. **Run the three trace templates on a configured simulator session.**
-   After CoreSimulator launch is healthy, capture:
-   - SwiftUI: body invalidation and diffing hot spots.
-   - Time Profiler: reducer/replay/markdown CPU cost.
-   - Animation Hitches: chat load and scroll frame drops.
+9. **Done with current simulator limits: run trace templates on a configured simulator session.**
+   All three requested templates were run against a booted iPhone 16 simulator. SwiftUI and Animation Hitches are unsupported by this simulator/runtime; Time Profiler launches but does not stop cleanly from `xctrace` here. Use a physical device for complete trace data.

--- a/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
+++ b/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
@@ -1,0 +1,155 @@
+# iOS Performance Diagnostics
+
+Date: 2026-05-25
+
+## Instrumentation Added
+
+- `SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift`
+  - Adds `Logger` + `OSSignposter` under subsystem `md.thomas.openagent.dashboard`, category `ControlPerformance`.
+  - Records recent slow operations and hot SwiftUI body render counts while the in-app diagnostics overlay is enabled.
+- `SandboxedDashboard/Views/Control/ControlView.swift`
+  - Existing **Control Diagnostics** menu toggle now also reports slowest measured operation and hottest body render probes.
+  - Signposted/timed paths:
+    - `control.fetch_snapshot`
+    - `control.fetch_current_snapshot`
+    - `control.fetch_reload_snapshot`
+    - `control.fetch_switch_snapshot`
+    - `control.fetch_refresh_snapshot`
+    - `control.fetch_earlier`
+    - `control.fetch_delta`
+    - `control.apply_snapshot`
+    - `control.sort_remember_events`
+    - `control.replay_events`
+    - `control.apply_delta`
+    - `control.group_messages`
+  - Body render probes:
+    - `MessageBubble`
+    - `ToolGroupView`
+    - `MarkdownView`
+- `SandboxedDashboard/Views/Components/MarkdownView.swift`
+  - Adds `markdown.parse` timing when Control Diagnostics is enabled.
+- `SandboxedDashboard/Services/APIService.swift`
+  - Adds whole-app request and decode timing for every JSON API call:
+    - `api.request`
+    - `api.decode`
+  - This covers Control, History, Files, Settings, Workspaces, and other views using `APIService`.
+
+## Simulator / Instruments Notes
+
+Validated locally:
+
+```bash
+xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj \
+  -scheme SandboxedDashboard \
+  -destination 'generic/platform=iOS Simulator' \
+  build
+```
+
+Result: build succeeded. Existing warning remains in `APIService.swift` about generic `T.Type` Sendability; it is unrelated to the diagnostics patch.
+
+Simulator work:
+
+```bash
+xcrun simctl create OpenAgentPerf \
+  'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro' \
+  'com.apple.CoreSimulator.SimRuntime.iOS-26-4'
+xcrun simctl boot <device-id>
+xcrun simctl bootstatus <device-id> -b
+```
+
+The simulator booted, but `simctl launch` and `simctl listapps` hung after install on this CoreSimulator instance. That blocked a complete automated trace capture in this run. The app now emits signposts usable from Instruments once the simulator can launch the app:
+
+```bash
+xcrun xctrace record \
+  --template 'SwiftUI' \
+  --device <device-id> \
+  --launch md.thomas.openagent.dashboard \
+  --time-limit 30s \
+  --output /tmp/SandboxedDashboard-SwiftUI.trace
+
+xcrun xctrace record \
+  --template 'Time Profiler' \
+  --device <device-id> \
+  --launch md.thomas.openagent.dashboard \
+  --time-limit 30s \
+  --output /tmp/SandboxedDashboard-TimeProfiler.trace
+
+xcrun xctrace record \
+  --template 'Animation Hitches' \
+  --device <device-id> \
+  --launch md.thomas.openagent.dashboard \
+  --time-limit 30s \
+  --output /tmp/SandboxedDashboard-Hitches.trace
+```
+
+In Console/Instruments, filter for:
+
+```text
+subsystem == "md.thomas.openagent.dashboard"
+category == "ControlPerformance"
+```
+
+## Diagnostics
+
+1. **Chat history replay is still O(events x messages) in practice.**
+   `applyViewingMissionWithEvents` replays every stored event through `handleStreamEvent`. Inside the replay, several event cases call `messages.contains`, `messages.firstIndex`, `messages.lastIndex`, and `messages.removeAll`. On long missions this becomes the dominant CPU path after the network snapshot returns.
+
+2. **Assistant markdown is reparsed in SwiftUI body.**
+   `MarkdownView.body` calls `MarkdownParser.parse(content)` every time SwiftUI evaluates the row. Large assistant messages, tables, code blocks, and image-rich responses can repeatedly pay regex + line parser + `AttributedString(markdown:)` costs. The new `markdown.parse` signpost should confirm this during scroll and mission load.
+
+3. **Hot redraws are likely row-wide, not cell-local.**
+   `MessageBubble` receives full `ChatMessage` values and the parent view owns many unrelated `@State` values. State changes such as polling, queue count, copied id, connection status, diagnostics overlay updates, and running missions can cause visible chat rows to re-evaluate. The render probes will show whether `MessageBubble`/`MarkdownView` counts rise when unrelated toolbar or polling state changes.
+
+4. **The diagnostics overlay itself is intentionally debug-only but can perturb results.**
+   When enabled, body probes mutate an in-memory counter and `markdown.parse` timing wraps parsing. Use it to identify suspicious paths, then confirm with Instruments signposts with the overlay hidden.
+
+5. **Mission switching has good cache-first behavior but still performs main-actor decode/replay.**
+   Cached mission data is read and decoded synchronously before render. This is good for perceived latency when files are small, but large cached missions still consume main-thread time before the first interactive frame.
+
+6. **Running-mission and child-mission polling can still invalidate ControlView regularly.**
+   The code already backs off on failures and gates child-mission fetches, but successful 5-second polling mutates `runningMissions` on the parent view. This can drive redraws in the chat subtree unless the chat list is isolated from polling state.
+
+7. **History, Files, and Settings perform sorted/filter computed properties in view render paths.**
+   Examples:
+   - `HistoryView.filteredMissions`
+   - `FilesView.sortedEntries`
+   - mission switcher/search helpers in `ControlView`
+   These are probably fine for small lists but should be measured if the whole app feels sluggish outside chat.
+
+8. **Inline/shared image loading has no explicit memory cache.**
+   Inline markdown images and shared file images hold decoded `Data` in row state. Rows recreated during navigation or identity changes can refetch/redecode images. Use Instruments Allocations + Network to confirm when image-heavy chats are slow.
+
+9. **Timers in row/sheet components can contribute to unnecessary invalidations.**
+   Several control subviews start timers on appear for durations/progress. If many tool rows are visible, timer-driven body refreshes can stack. Render probes around `ToolGroupView` help detect this.
+
+## Recommended Fixes
+
+1. **Replace replay-through-UI-state with a pure reducer.**
+   Build `[ChatMessage]` from `[StoredEvent]` in a pure function using dictionaries/sets for ids (`messageById`, `toolById`, active thinking id). Assign `messages` once at the end. This removes repeated array scans and avoids transient SwiftUI invalidations during replay.
+
+2. **Cache parsed markdown per message id/content hash.**
+   Move markdown parsing out of `body`, or introduce a `ParsedMarkdown` cache keyed by message id + content hash. For streaming content, debounce parsing to frame cadence or parse only the active message incrementally.
+
+3. **Isolate chat list state from toolbar/polling state.**
+   Extract the conversation list into a small view model or child view that only receives `groupedItems`, copy/retry closures, and scroll state. Keep `runningMissions`, queue polling, sheets, and toolbar state out of the row subtree.
+
+4. **Track rendered message ids during replay.**
+   Even before a full reducer refactor, maintain a temporary `Set<String>` during historical replay so duplicate checks are O(1) instead of `messages.contains`.
+
+5. **Move cache decode off the first render when the cache file is large.**
+   For cache files over a small threshold, render the skeleton immediately and decode in a background task, then publish the decoded snapshot. Keep the current sync fast path for small cache files.
+
+6. **Memoize sorted/filter lists outside view bodies.**
+   For History, Files, and mission switcher/search, compute sorted/filter outputs when source arrays or query/filter settings change, not every `body` evaluation.
+
+7. **Use `EquatableView` or narrower Equatable row models for chat rows.**
+   Make visible rows skip body work when unrelated state changes. This is especially important for assistant rows with expensive markdown.
+
+8. **Add image cache and downsampling.**
+   Use `URLCache`/`NSCache` keyed by resolved download URL and downsample large images before storing in SwiftUI state. This should reduce both network repeat work and memory spikes.
+
+9. **Run the three trace templates on a configured simulator session.**
+   After CoreSimulator launch is healthy, capture:
+   - SwiftUI: body invalidation and diffing hot spots.
+   - Time Profiler: reducer/replay/markdown CPU cost.
+   - Animation Hitches: chat load and scroll frame drops.

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		3A706E457E3E27DA1B69E152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 750C4C8090EAD0168794EEE4 /* Assets.xcassets */; };
 		40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */; };
 		43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */; };
+		43B4C0909D841043B1413176 /* ChatHistoryReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C08F9D841043B1413176 /* ChatHistoryReducer.swift */; };
+		43B4C0929D841043B1413176 /* ImageMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C0919D841043B1413176 /* ImageMemoryCache.swift */; };
 		46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7559F3F4553AD74130B1BC34 /* ModelTests.swift */; };
 		48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC2B6E9848FF220F103DED2 /* LoadingView.swift */; };
 		4A639CAB6EE0ED8079A721C2 /* ToolUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF491A4406AFF7E284592477 /* ToolUIView.swift */; };
@@ -90,6 +92,8 @@
 		3B74AB5DF6829813AE79229D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamService.swift; sourceTree = "<group>"; };
 		43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPerformanceDiagnostics.swift; sourceTree = "<group>"; };
+		43B4C08F9D841043B1413176 /* ChatHistoryReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryReducer.swift; sourceTree = "<group>"; };
+		43B4C0919D841043B1413176 /* ImageMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageMemoryCache.swift; sourceTree = "<group>"; };
 		4802677F01F1504267EC2BE2 /* SandboxedDashboardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SandboxedDashboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEntry.swift; sourceTree = "<group>"; };
 		4CC2B6E9848FF220F103DED2 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -206,6 +210,7 @@
 				43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */,
 				3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */,
 				8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */,
+				43B4C0919D841043B1413176 /* ImageMemoryCache.swift */,
 				EB3EDA65C036030CC45BAD0E /* NavigationState.swift */,
 				EFD2C112534D498211B26C38 /* NetworkMonitor.swift */,
 				6922E2F0E17EDB3A8400D473 /* TerminalState.swift */,
@@ -291,6 +296,7 @@
 				7BF62094FF29193B33EC7009 /* Automation.swift */,
 				CAC389FA8B9B5C969E606A22 /* Backend.swift */,
 				370F364BA05D1236D9B630AB /* ChatMessage.swift */,
+				43B4C08F9D841043B1413176 /* ChatHistoryReducer.swift */,
 				CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */,
 				492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */,
 				0C6DBBABC4AE0FD4368A185C /* Mission.swift */,
@@ -426,11 +432,13 @@
 				D5968B6DE2272A9C8C3A4A0E /* AutomationsView.swift in Sources */,
 				F6B883AB96DE0FFF99A2A614 /* Backend.swift in Sources */,
 				BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */,
+				43B4C0909D841043B1413176 /* ChatHistoryReducer.swift in Sources */,
 				B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */,
 				66E208F9D4759B79ED653374 /* ContentView.swift in Sources */,
 				43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */,
 				5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */,
 				B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */,
+				43B4C0929D841043B1413176 /* ImageMemoryCache.swift in Sources */,
 				8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */,
 				50EBDCFBA58915481F5EC995 /* FidoApprovalOverlay.swift in Sources */,
 				D057B578B2884C4B2B36B1C3 /* FidoApprovalState.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */; };
 		3A706E457E3E27DA1B69E152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 750C4C8090EAD0168794EEE4 /* Assets.xcassets */; };
 		40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */; };
+		43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */; };
 		46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7559F3F4553AD74130B1BC34 /* ModelTests.swift */; };
 		48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC2B6E9848FF220F103DED2 /* LoadingView.swift */; };
 		4A639CAB6EE0ED8079A721C2 /* ToolUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF491A4406AFF7E284592477 /* ToolUIView.swift */; };
@@ -88,6 +89,7 @@
 		384691169D9EC024B03AA57F /* WorkspacesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesView.swift; sourceTree = "<group>"; };
 		3B74AB5DF6829813AE79229D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamService.swift; sourceTree = "<group>"; };
+		43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPerformanceDiagnostics.swift; sourceTree = "<group>"; };
 		4802677F01F1504267EC2BE2 /* SandboxedDashboardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SandboxedDashboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEntry.swift; sourceTree = "<group>"; };
 		4CC2B6E9848FF220F103DED2 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				D9E023EEFFFA9B1092B66006 /* ANSIParser.swift */,
 				55F4658A2D65748FC7AC5DE3 /* APIService.swift */,
 				F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */,
+				43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */,
 				3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */,
 				8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */,
 				EB3EDA65C036030CC45BAD0E /* NavigationState.swift */,
@@ -425,6 +428,7 @@
 				BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */,
 				B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */,
 				66E208F9D4759B79ED653374 /* ContentView.swift in Sources */,
+				43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */,
 				5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */,
 				B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */,
 				8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
@@ -8,13 +8,22 @@
 import Foundation
 
 enum ChatHistoryReducer {
+    struct ReplayResult {
+        let messages: [ChatMessage]
+        let textOpBuffers: [String: String]
+    }
+
     static func reduce(events: [StoredEvent], mission: Mission) -> [ChatMessage] {
+        reduceWithState(events: events, mission: mission).messages
+    }
+
+    static func reduceWithState(events: [StoredEvent], mission: Mission) -> ReplayResult {
         var state = State(mission: mission)
         for event in ordered(events) {
             state.apply(event)
         }
         state.finalizeActiveToolCalls(withState: .success)
-        return state.messages
+        return ReplayResult(messages: state.messages, textOpBuffers: state.textOpBuffers)
     }
 
     private static func ordered(_ events: [StoredEvent]) -> [StoredEvent] {
@@ -31,6 +40,7 @@ enum ChatHistoryReducer {
         var messageIds = Set<String>()
         var toolMessageIndexByCallId: [String: Int] = [:]
         var textOpBuffers: [String: String] = [:]
+        private let streamingThoughtPrefix = "stream-thinking-"
 
         mutating func apply(_ event: StoredEvent) {
             var data = event.metadata.mapValues(\.value)
@@ -257,7 +267,14 @@ enum ChatHistoryReducer {
             textOpBuffers[bubbleId] = finalized ? nil : content
             guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             removePhaseMessages()
-            let id = "stream-thinking-\(bubbleId)"
+
+            if let activeRealThought = messages.last(where: {
+                $0.isThinking && !$0.thinkingDone && !$0.id.hasPrefix(streamingThoughtPrefix)
+            }), !activeRealThought.content.isEmpty {
+                return
+            }
+
+            let id = "\(streamingThoughtPrefix)\(bubbleId)"
             if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone && $0.id == id }) {
                 messages[index] = ChatMessage(
                     id: id,

--- a/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
@@ -1,0 +1,347 @@
+//
+//  ChatHistoryReducer.swift
+//  SandboxedDashboard
+//
+//  Pure reducer for stored mission events -> chat messages.
+//
+
+import Foundation
+
+enum ChatHistoryReducer {
+    static func reduce(events: [StoredEvent], mission: Mission) -> [ChatMessage] {
+        var state = State(mission: mission)
+        for event in ordered(events) {
+            state.apply(event)
+        }
+        state.finalizeActiveToolCalls(withState: .success)
+        return state.messages
+    }
+
+    private static func ordered(_ events: [StoredEvent]) -> [StoredEvent] {
+        events.sorted { lhs, rhs in
+            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
+            return lhs.id < rhs.id
+        }
+    }
+
+    private struct State {
+        let mission: Mission
+        var messages: [ChatMessage] = []
+        var messageIds = Set<String>()
+        var toolMessageIndexByCallId: [String: Int] = [:]
+        var textOpBuffers: [String: String] = [:]
+
+        mutating func apply(_ event: StoredEvent) {
+            var data = event.metadata.mapValues(\.value)
+            data["mission_id"] = event.missionId
+            data["content"] = event.content
+            if let eventId = event.eventId { data["id"] = eventId }
+            if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
+            if let toolName = event.toolName { data["name"] = toolName }
+            if event.eventType == "text_op",
+               let jsonData = event.content.data(using: .utf8),
+               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
+                data["ops"] = ops
+            }
+
+            switch event.eventType {
+            case "user_message":
+                applyUser(data)
+            case "assistant_message", "assistant_message_canonical":
+                applyAssistant(data)
+            case "thinking":
+                applyThinking(data, fallbackId: "thinking-\(event.id)")
+            case "text_op":
+                applyTextOp(data)
+            case "agent_phase":
+                applyPhase(data, fallbackId: "phase-\(event.id)")
+            case "tool_call":
+                applyToolCall(data)
+            case "tool_result":
+                applyToolResult(data)
+            default:
+                break
+            }
+        }
+
+        private mutating func append(_ message: ChatMessage) {
+            guard !messageIds.contains(message.id) else { return }
+            messageIds.insert(message.id)
+            messages.append(message)
+        }
+
+        private mutating func removePhaseMessages() {
+            messages.removeAll { message in
+                guard message.isPhase else { return false }
+                messageIds.remove(message.id)
+                return true
+            }
+            rebuildToolIndex()
+        }
+
+        private mutating func rebuildToolIndex() {
+            toolMessageIndexByCallId.removeAll(keepingCapacity: true)
+            for (index, message) in messages.enumerated() where message.isToolCall {
+                let key = message.toolData?.toolCallId ?? message.id.replacingOccurrences(of: "tool-", with: "")
+                toolMessageIndexByCallId[key] = index
+            }
+        }
+
+        private mutating func finalizeActiveThinkingMessages() {
+            for index in messages.indices where messages[index].isThinking && !messages[index].thinkingDone {
+                let existing = messages[index]
+                messages[index] = ChatMessage(
+                    id: existing.id,
+                    type: .thinking(done: true, startTime: existing.thinkingStartTime ?? existing.timestamp),
+                    content: existing.content,
+                    toolUI: existing.toolUI,
+                    toolData: existing.toolData,
+                    timestamp: existing.timestamp
+                )
+            }
+        }
+
+        mutating func finalizeActiveToolCalls(withState state: ToolCallState) {
+            for index in messages.indices where messages[index].isToolCall && messages[index].isActiveToolCall {
+                guard var toolData = messages[index].toolData else { continue }
+                toolData.endTime = toolData.endTime ?? messages[index].timestamp
+                if toolData.result == nil || state == .cancelled {
+                    toolData.state = state
+                }
+                messages[index] = ChatMessage(
+                    id: messages[index].id,
+                    type: .toolCall(name: toolData.name, isActive: false),
+                    content: messages[index].content,
+                    toolData: toolData,
+                    timestamp: messages[index].timestamp
+                )
+            }
+        }
+
+        private mutating func applyUser(_ data: [String: Any]) {
+            guard let id = data["id"] as? String else { return }
+            let content = data["content"] as? String ?? ""
+            if let index = messages.firstIndex(where: { $0.id == id }) {
+                messages[index].sendState = .sent
+                messages[index].content = content
+            } else {
+                finalizeActiveThinkingMessages()
+                append(ChatMessage(id: id, type: .user, content: content))
+            }
+        }
+
+        private mutating func applyAssistant(_ data: [String: Any]) {
+            guard let id = data["id"] as? String, !messageIds.contains(id) else { return }
+            finalizeActiveThinkingMessages()
+            removePhaseMessages()
+            finalizeActiveToolCalls(withState: .success)
+
+            let success = data["success"] as? Bool ?? true
+            let costObj = data["cost"] as? [String: Any]
+            let costCents = data["cost_cents"] as? Int
+                ?? costObj?["amount_cents"] as? Int
+                ?? 0
+            let costSource = (data["cost_source"] as? String ?? costObj?["source"] as? String)
+                .flatMap(CostSource.init(rawValue:)) ?? .unknown
+            let model = data["model"] as? String
+            append(
+                ChatMessage(
+                    id: id,
+                    type: .assistant(
+                        success: success,
+                        costCents: costCents,
+                        costSource: costSource,
+                        model: model,
+                        sharedFiles: parseSharedFiles(data["shared_files"])
+                    ),
+                    content: data["content"] as? String ?? ""
+                )
+            )
+        }
+
+        private func parseSharedFiles(_ value: Any?) -> [SharedFile]? {
+            guard let filesArray = value as? [[String: Any]] else { return nil }
+            return filesArray.compactMap { fileData in
+                guard let name = fileData["name"] as? String,
+                      let url = fileData["url"] as? String,
+                      let contentType = fileData["content_type"] as? String,
+                      let kindString = fileData["kind"] as? String,
+                      let kind = SharedFileKind(rawValue: kindString) else {
+                    return nil
+                }
+                return SharedFile(
+                    name: name,
+                    url: url,
+                    contentType: contentType,
+                    sizeBytes: fileData["size_bytes"] as? Int,
+                    kind: kind
+                )
+            }
+        }
+
+        private mutating func applyThinking(_ data: [String: Any], fallbackId: String) {
+            let content = data["content"] as? String ?? ""
+            let done = data["done"] as? Bool ?? false
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                if done { finalizeActiveThinkingMessages() }
+                return
+            }
+
+            if done, data["goal_role"] as? String == "deliverable", mission.goalMode {
+                let baseId = data["id"] as? String ?? fallbackId
+                let id = "goal-deliverable-\(baseId)"
+                guard !messageIds.contains(id) else { return }
+                finalizeActiveThinkingMessages()
+                removePhaseMessages()
+                append(
+                    ChatMessage(
+                        id: id,
+                        type: .assistant(success: true, costCents: 0, costSource: .unknown, model: nil, sharedFiles: nil),
+                        content: content
+                    )
+                )
+                return
+            }
+
+            if let id = data["id"] as? String, messageIds.contains(id) { return }
+            removePhaseMessages()
+
+            if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
+                let existing = messages[index]
+                messages[index] = ChatMessage(
+                    id: existing.id,
+                    type: .thinking(done: done, startTime: existing.thinkingStartTime ?? existing.timestamp),
+                    content: content,
+                    toolUI: existing.toolUI,
+                    toolData: existing.toolData,
+                    timestamp: existing.timestamp
+                )
+            } else {
+                append(
+                    ChatMessage(
+                        id: data["id"] as? String ?? fallbackId,
+                        type: .thinking(done: done, startTime: Date()),
+                        content: content
+                    )
+                )
+            }
+        }
+
+        private mutating func applyTextOp(_ data: [String: Any]) {
+            let bubbleId = data["bubble_id"] as? String ?? "text-op-latest"
+            let ops = data["ops"] as? [[String: Any]] ?? []
+            var content = textOpBuffers[bubbleId] ?? ""
+            var finalized = false
+
+            for op in ops {
+                switch op["type"] as? String {
+                case "insert":
+                    let pos = min(max(op["pos"] as? Int ?? content.count, 0), content.count)
+                    let index = content.index(content.startIndex, offsetBy: pos)
+                    content.insert(contentsOf: op["text"] as? String ?? "", at: index)
+                case "replace":
+                    let range = op["range"] as? [Int] ?? []
+                    let start = min(max(range.first ?? 0, 0), content.count)
+                    let end = min(max(range.dropFirst().first ?? content.count, start), content.count)
+                    let startIndex = content.index(content.startIndex, offsetBy: start)
+                    let endIndex = content.index(content.startIndex, offsetBy: end)
+                    content.replaceSubrange(startIndex..<endIndex, with: op["text"] as? String ?? "")
+                case "finalize":
+                    finalized = true
+                default:
+                    continue
+                }
+            }
+
+            textOpBuffers[bubbleId] = finalized ? nil : content
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            removePhaseMessages()
+            let id = "stream-thinking-\(bubbleId)"
+            if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone && $0.id == id }) {
+                messages[index] = ChatMessage(
+                    id: id,
+                    type: .thinking(done: finalized, startTime: messages[index].thinkingStartTime ?? messages[index].timestamp),
+                    content: content,
+                    timestamp: messages[index].timestamp
+                )
+            } else if !messageIds.contains(id) {
+                append(ChatMessage(id: id, type: .thinking(done: finalized, startTime: Date()), content: content))
+            }
+        }
+
+        private mutating func applyPhase(_ data: [String: Any], fallbackId: String) {
+            removePhaseMessages()
+            append(
+                ChatMessage(
+                    id: fallbackId,
+                    type: .phase(
+                        phase: data["phase"] as? String ?? "",
+                        detail: data["detail"] as? String,
+                        agent: data["agent"] as? String
+                    ),
+                    content: ""
+                )
+            )
+        }
+
+        private mutating func applyToolCall(_ data: [String: Any]) {
+            guard let toolCallId = data["tool_call_id"] as? String,
+                  let name = data["name"] as? String,
+                  let args = data["args"] as? [String: Any],
+                  !messageIds.contains(toolCallId),
+                  !messageIds.contains("tool-\(toolCallId)") else { return }
+
+            finalizeActiveThinkingMessages()
+            if let toolUI = ToolUIContent.parse(name: name, args: args) {
+                append(ChatMessage(id: toolCallId, type: .toolUI(name: name), content: "", toolUI: toolUI))
+                return
+            }
+
+            finalizeActiveToolCalls(withState: .success)
+            let message = ChatMessage(
+                id: "tool-\(toolCallId)",
+                type: .toolCall(name: name, isActive: true),
+                content: "",
+                toolData: ToolCallData(
+                    toolCallId: toolCallId,
+                    name: name,
+                    args: args,
+                    startTime: Date(),
+                    endTime: nil,
+                    result: nil,
+                    state: .running
+                )
+            )
+            toolMessageIndexByCallId[toolCallId] = messages.count
+            append(message)
+        }
+
+        private mutating func applyToolResult(_ data: [String: Any]) {
+            guard let toolCallId = data["tool_call_id"] as? String,
+                  let index = toolMessageIndexByCallId[toolCallId],
+                  messages.indices.contains(index),
+                  var toolData = messages[index].toolData else { return }
+
+            let result = data["result"]
+            toolData.endTime = Date()
+            toolData.result = result
+            if let resultDict = result as? [String: Any],
+               resultDict["status"] as? String == "cancelled" {
+                toolData.state = .cancelled
+            } else if toolData.isErrorResult {
+                toolData.state = .error
+            } else {
+                toolData.state = .success
+            }
+
+            messages[index] = ChatMessage(
+                id: messages[index].id,
+                type: .toolCall(name: toolData.name, isActive: false),
+                content: messages[index].content,
+                toolData: toolData,
+                timestamp: messages[index].timestamp
+            )
+        }
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -891,7 +891,13 @@ final class APIService {
     }
 
     private func executeWithResponse<T: Decodable>(_ request: URLRequest) async throws -> (T, HTTPURLResponse) {
-        let (data, response) = try await Self.jsonSession.data(for: request)
+        let requestLabel = "\(request.httpMethod ?? "GET") \(request.url?.path ?? "?")"
+        let (data, response) = try await ControlPerformanceDiagnostics.shared.measureAsync(
+            "api.request",
+            detail: requestLabel
+        ) {
+            try await Self.jsonSession.data(for: request)
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -921,9 +927,15 @@ final class APIService {
         // value is treated as immutable from the moment we ship it back.
         let box: DecodedBox<T>
         do {
-            box = try await Task.detached(priority: .userInitiated) {
-                try DecodedBox(value: JSONDecoder().decode(T.self, from: data))
-            }.value
+            box = try await ControlPerformanceDiagnostics.shared.measureAsync(
+                "api.decode",
+                detail: requestLabel,
+                count: data.count
+            ) {
+                try await Task.detached(priority: .userInitiated) {
+                    try DecodedBox(value: JSONDecoder().decode(T.self, from: data))
+                }.value
+            }
         } catch {
             throw APIError.decodingError(error)
         }

--- a/ios_dashboard/SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift
@@ -1,0 +1,138 @@
+//
+//  ControlPerformanceDiagnostics.swift
+//  SandboxedDashboard
+//
+//  Lightweight runtime instrumentation for the Control chat surface.
+//
+
+import Foundation
+import SwiftUI
+import os
+
+@MainActor
+final class ControlPerformanceDiagnostics {
+    static let shared = ControlPerformanceDiagnostics()
+
+    private let logger = Logger(subsystem: "md.thomas.openagent.dashboard", category: "ControlPerformance")
+    private let signposter = OSSignposter(subsystem: "md.thomas.openagent.dashboard", category: "ControlPerformance")
+
+    private var records: [ControlPerformanceRecord] = []
+    private var renderCounts: [String: Int] = [:]
+    private let maxRecords = 24
+
+    private init() {}
+
+    var recentRecords: [ControlPerformanceRecord] {
+        records
+    }
+
+    var hotRenderCounts: [(name: String, count: Int)] {
+        renderCounts
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value { return lhs.value > rhs.value }
+                return lhs.key < rhs.key
+            }
+            .prefix(6)
+            .map { ($0.key, $0.value) }
+    }
+
+    func reset() {
+        records.removeAll(keepingCapacity: true)
+        renderCounts.removeAll(keepingCapacity: true)
+    }
+
+    func recordBodyRender(_ name: String) {
+        renderCounts[name, default: 0] += 1
+    }
+
+    func measure<T>(
+        _ name: StaticString,
+        detail: String = "",
+        count: Int? = nil,
+        operation: () throws -> T
+    ) rethrows -> T {
+        let state = signposter.beginInterval(name)
+        let start = ContinuousClock.now
+        defer {
+            let duration = start.duration(to: ContinuousClock.now)
+            signposter.endInterval(name, state)
+            record(String(describing: name), duration: duration, detail: detail, count: count)
+        }
+        return try operation()
+    }
+
+    func measureAsync<T>(
+        _ name: StaticString,
+        detail: String = "",
+        count: Int? = nil,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        let state = signposter.beginInterval(name)
+        let start = ContinuousClock.now
+        defer {
+            let duration = start.duration(to: ContinuousClock.now)
+            signposter.endInterval(name, state)
+            record(String(describing: name), duration: duration, detail: detail, count: count)
+        }
+        return try await operation()
+    }
+
+    private func record(_ name: String, duration: Duration, detail: String, count: Int?) {
+        let millis = Double(duration.components.seconds) * 1_000
+            + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+
+        let record = ControlPerformanceRecord(
+            name: name,
+            detail: detail,
+            durationMilliseconds: millis,
+            count: count,
+            timestamp: Date()
+        )
+        records.append(record)
+        if records.count > maxRecords {
+            records.removeFirst(records.count - maxRecords)
+        }
+
+        if millis >= 16 {
+            logger.warning("\(name, privacy: .public) took \(millis, format: .fixed(precision: 1), privacy: .public) ms count=\(count ?? -1, privacy: .public) \(detail, privacy: .public)")
+        } else {
+            logger.debug("\(name, privacy: .public) took \(millis, format: .fixed(precision: 1), privacy: .public) ms count=\(count ?? -1, privacy: .public) \(detail, privacy: .public)")
+        }
+    }
+}
+
+struct ControlPerformanceRecord: Identifiable, Equatable {
+    let id = UUID()
+    let name: String
+    let detail: String
+    let durationMilliseconds: Double
+    let count: Int?
+    let timestamp: Date
+
+    var compactDuration: String {
+        String(format: "%.1f ms", durationMilliseconds)
+    }
+}
+
+private struct ControlPerformanceDiagnosticsEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var controlPerformanceDiagnosticsEnabled: Bool {
+        get { self[ControlPerformanceDiagnosticsEnabledKey.self] }
+        set { self[ControlPerformanceDiagnosticsEnabledKey.self] = newValue }
+    }
+}
+
+struct ControlBodyRenderProbe: ViewModifier {
+    @Environment(\.controlPerformanceDiagnosticsEnabled) private var enabled
+    let name: String
+
+    func body(content: Content) -> some View {
+        if enabled {
+            ControlPerformanceDiagnostics.shared.recordBodyRender(name)
+        }
+        return content
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Services/ImageMemoryCache.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/ImageMemoryCache.swift
@@ -1,0 +1,76 @@
+//
+//  ImageMemoryCache.swift
+//  SandboxedDashboard
+//
+//  Shared image cache/downsampler for chat image previews.
+//
+
+import Foundation
+import ImageIO
+import UIKit
+
+@MainActor
+final class ImageMemoryCache {
+    static let shared = ImageMemoryCache()
+
+    private final class Entry {
+        let image: UIImage
+
+        init(image: UIImage) {
+            self.image = image
+        }
+    }
+
+    private struct ImageBox: @unchecked Sendable {
+        let image: UIImage
+    }
+
+    private let cache = NSCache<NSURL, Entry>()
+
+    private init() {
+        cache.countLimit = 120
+        cache.totalCostLimit = 48 * 1_024 * 1_024
+    }
+
+    func cachedImage(for url: URL) -> UIImage? {
+        cache.object(forKey: url as NSURL)?.image
+    }
+
+    func store(_ image: UIImage, for url: URL) {
+        let pixels = Int(image.size.width * image.scale * image.size.height * image.scale)
+        cache.setObject(Entry(image: image), forKey: url as NSURL, cost: pixels * 4)
+    }
+
+    func image(from data: Data, url: URL, maxPixelSize: CGFloat = 900) async -> UIImage? {
+        if let cached = cachedImage(for: url) {
+            return cached
+        }
+
+        let box = await Task.detached(priority: .userInitiated) {
+            ImageBox(image: Self.downsample(data: data, maxPixelSize: maxPixelSize) ?? UIImage(data: data) ?? UIImage())
+        }.value
+        guard box.image.size != .zero else { return nil }
+        store(box.image, for: url)
+        return box.image
+    }
+
+    nonisolated private static func downsample(data: Data, maxPixelSize: CGFloat) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceShouldCache: false
+        ]
+        guard let source = CGImageSourceCreateWithData(data as CFData, options as CFDictionary) else {
+            return nil
+        }
+
+        let downsampleOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, downsampleOptions as CFDictionary) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
@@ -37,21 +37,17 @@ extension EnvironmentValues {
 struct MarkdownView: View {
     let content: String
     @Environment(\.controlPerformanceDiagnosticsEnabled) private var diagnosticsEnabled
+    private static let parseCache = MarkdownParseCache()
 
     init(_ content: String) {
         self.content = content
     }
 
     var body: some View {
-        let blocks = diagnosticsEnabled
-            ? ControlPerformanceDiagnostics.shared.measure(
-                "markdown.parse",
-                detail: "\(content.count) chars",
-                count: content.count
-            ) {
-                MarkdownParser.parse(content)
-            }
-            : MarkdownParser.parse(content)
+        let blocks = Self.parseCache.blocks(
+            for: content,
+            diagnosticsEnabled: diagnosticsEnabled
+        )
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 switch block {
@@ -86,6 +82,75 @@ struct MarkdownView: View {
     }
 }
 
+@MainActor
+private final class MarkdownParseCache {
+    private final class Entry {
+        let blocks: [MarkdownBlock]
+
+        init(blocks: [MarkdownBlock]) {
+            self.blocks = blocks
+        }
+    }
+
+    private let cache = NSCache<NSString, Entry>()
+
+    init() {
+        cache.countLimit = 500
+    }
+
+    func blocks(for content: String, diagnosticsEnabled: Bool) -> [MarkdownBlock] {
+        let key = "\(content.count):\(content.hashValue)" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached.blocks
+        }
+
+        let parsed = diagnosticsEnabled
+            ? ControlPerformanceDiagnostics.shared.measure(
+                "markdown.parse",
+                detail: "\(content.count) chars",
+                count: content.count
+            ) {
+                MarkdownParser.parse(content)
+            }
+            : MarkdownParser.parse(content)
+        cache.setObject(Entry(blocks: parsed), forKey: key)
+        return parsed
+    }
+}
+
+@MainActor
+private final class MarkdownInlineTextCache {
+    static let shared = MarkdownInlineTextCache()
+
+    private final class Entry {
+        let attributed: AttributedString?
+
+        init(attributed: AttributedString?) {
+            self.attributed = attributed
+        }
+    }
+
+    private let cache = NSCache<NSString, Entry>()
+
+    init() {
+        cache.countLimit = 1_500
+    }
+
+    func attributedString(for content: String) -> AttributedString? {
+        let key = "\(content.count):\(content.hashValue)" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached.attributed
+        }
+
+        let attributed = try? AttributedString(
+            markdown: content,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )
+        cache.setObject(Entry(attributed: attributed), forKey: key)
+        return attributed
+    }
+}
+
 private struct MarkdownInlineText: View {
     let content: String
 
@@ -94,7 +159,7 @@ private struct MarkdownInlineText: View {
     }
 
     var body: some View {
-        if let attributed = try? AttributedString(markdown: content, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+        if let attributed = MarkdownInlineTextCache.shared.attributedString(for: content) {
             Text(attributed)
                 .font(.body)
                 .foregroundStyle(Theme.textPrimary)
@@ -266,7 +331,7 @@ struct MarkdownInlineImageView: View {
 
     var body: some View {
         Group {
-            if let data = imageData, let uiImage = UIImage(data: data) {
+            if let data = imageData, let uiImage = ImageMemoryCache.shared.cachedImage(for: imageCacheURL) ?? UIImage(data: data) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFit()
@@ -304,6 +369,10 @@ struct MarkdownInlineImageView: View {
         .task(id: imageTaskKey) {
             await load()
         }
+    }
+
+    private var imageCacheURL: URL {
+        URL(string: imageTaskKey) ?? URL(fileURLWithPath: imageTaskKey)
     }
 
     /// Key the `.task` view modifier so a context change (workspace/mission
@@ -348,8 +417,9 @@ struct MarkdownInlineImageView: View {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, http.statusCode == 200,
-               UIImage(data: data) != nil {
+               let image = await ImageMemoryCache.shared.image(from: data, url: url) {
                 await MainActor.run {
+                    ImageMemoryCache.shared.store(image, for: imageCacheURL)
                     imageData = data
                     isLoading = false
                 }

--- a/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
@@ -36,13 +36,22 @@ extension EnvironmentValues {
 
 struct MarkdownView: View {
     let content: String
+    @Environment(\.controlPerformanceDiagnosticsEnabled) private var diagnosticsEnabled
 
     init(_ content: String) {
         self.content = content
     }
 
     var body: some View {
-        let blocks = MarkdownParser.parse(content)
+        let blocks = diagnosticsEnabled
+            ? ControlPerformanceDiagnostics.shared.measure(
+                "markdown.parse",
+                detail: "\(content.count) chars",
+                count: content.count
+            ) {
+                MarkdownParser.parse(content)
+            }
+            : MarkdownParser.parse(content)
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 switch block {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1978,7 +1978,13 @@ struct ControlView: View {
             case "goal_iteration":
                 let metadata = event.metadata.mapValues(\.value)
                 let iteration = intValue(metadata["iteration"]) ?? replayed?.iteration ?? 0
-                let objective = metadata["objective"] as? String ?? replayed?.objective ?? mission.goalObjective ?? ""
+                let eventObjective = event.content.trimmingCharacters(in: .whitespacesAndNewlines)
+                let objective =
+                    metadata["objective"] as? String ??
+                    (!eventObjective.isEmpty ? eventObjective : nil) ??
+                    replayed?.objective ??
+                    mission.goalObjective ??
+                    ""
                 replayed = GoalPillInfo(
                     iteration: iteration,
                     status: replayed?.status ?? "active",
@@ -1988,7 +1994,11 @@ struct ControlView: View {
             case "goal_status":
                 let metadata = event.metadata.mapValues(\.value)
                 let status = metadata["status"] as? String ?? event.content
-                let objective = metadata["objective"] as? String ?? replayed?.objective ?? mission.goalObjective ?? ""
+                let objective =
+                    metadata["objective"] as? String ??
+                    replayed?.objective ??
+                    mission.goalObjective ??
+                    ""
                 switch status {
                 case "complete", "cleared", "budgetLimited":
                     replayed = nil

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -953,27 +953,13 @@ struct ControlView: View {
                         .disabled(isLoadingEarlier)
                     }
 
-                    ForEach(groupedItems) { item in
-                        switch item {
-                        case .single(let message):
-                            MessageBubble(
-                                message: message,
-                                isCopied: copiedMessageId == message.id,
-                                onCopy: { copyMessage(message) },
-                                onRetry: message.sendState.isFailed ? { retryFailedMessage(message) } : nil
-                            )
-                            .modifier(ControlBodyRenderProbe(name: "MessageBubble"))
-                            .id(message.id)
-                        case .toolGroup(let groupId, let tools):
-                            ToolGroupView(
-                                groupId: groupId,
-                                tools: tools,
-                                expandedGroups: $expandedToolGroups
-                            )
-                            .modifier(ControlBodyRenderProbe(name: "ToolGroupView"))
-                            .id(item.id)
-                        }
-                    }
+                    ConversationRowsView(
+                        groupedItems: groupedItems,
+                        copiedMessageId: copiedMessageId,
+                        expandedToolGroups: $expandedToolGroups,
+                        onCopy: copyMessage,
+                        onRetry: retryFailedMessage
+                    )
 
                     // Show working indicator after messages when this mission is running but no active streaming item
                     if viewingMissionIsRunning && !hasActiveStreamingItem {
@@ -1673,8 +1659,13 @@ struct ControlView: View {
         let cachedAt: Date
     }
 
+    private struct CachedMissionDataBox: @unchecked Sendable {
+        let value: CachedMissionData
+    }
+
     private static let maxCachedMissions = 10  // Limit cache size
     private static let maxCachedEventsPerMission = 1_500
+    private static let maxSynchronousCacheBytes = 256 * 1_024
     /// Legacy key prefix used when mission blobs lived in UserDefaults. Kept
     /// only so the one-time migration below can purge them on first launch
     /// after upgrade — every payload bloats cfprefsd's in-memory plist.
@@ -1848,12 +1839,8 @@ struct ControlView: View {
     }
 
     private func loadCachedMissionData(_ missionId: String) -> CachedMissionData? {
-        // Synchronous read on the call site (cold start) — the file is
-        // bounded by `loadEarlierPageLimit` * StoredEvent size (~few MB
-        // worst case) and decoding it on @MainActor is unavoidable here
-        // because the caller needs the result immediately to render the
-        // first frame. Subsequent caches written in the background.
         guard let url = Self.cacheFileURL(missionId: missionId),
+              Self.cacheFileSize(url: url) <= Self.maxSynchronousCacheBytes,
               let data = try? Data(contentsOf: url),
               let cached = try? JSONDecoder().decode(CachedMissionData.self, from: data) else {
             return nil
@@ -1866,6 +1853,39 @@ struct ControlView: View {
         }
 
         return cached
+    }
+
+    private func loadCachedMissionDataAsync(_ missionId: String) async -> CachedMissionData? {
+        guard let url = Self.cacheFileURL(missionId: missionId) else { return nil }
+        let box = try? await Task.detached(priority: .userInitiated) {
+            let data = try Data(contentsOf: url)
+            let cached = try JSONDecoder().decode(CachedMissionData.self, from: data)
+            return CachedMissionDataBox(value: cached)
+        }.value
+        guard let cached = box?.value else { return nil }
+
+        if var cachedKeys = UserDefaults.standard.stringArray(forKey: Self.cacheKeysKey) {
+            cachedKeys.removeAll { $0 == missionId }
+            cachedKeys.append(missionId)
+            UserDefaults.standard.set(cachedKeys, forKey: Self.cacheKeysKey)
+        }
+        return cached
+    }
+
+    private func scheduleLargeCachedMissionLoad(id: String) {
+        guard let url = Self.cacheFileURL(missionId: id),
+              Self.cacheFileSize(url: url) > Self.maxSynchronousCacheBytes else { return }
+        Task {
+            guard let cached = await loadCachedMissionDataAsync(id) else { return }
+            guard fetchingMissionId == id || viewingMissionId == id else { return }
+            let cachedMaxSeq = cached.events.compactMap(\.sequence).max() ?? 0
+            if let currentMaxSeq = missionMaxSeq[id], currentMaxSeq > cachedMaxSeq {
+                return
+            }
+            controlCacheHit = true
+            controlCacheStale = false
+            applyViewingMissionWithEvents(cached.mission, events: cached.events)
+        }
     }
 
     private func removeMissionFromCache(_ missionId: String) {
@@ -1899,6 +1919,10 @@ struct ControlView: View {
         let safeId = missionId.replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "..", with: "_")
         return dir.appendingPathComponent("\(safeId).json", isDirectory: false)
+    }
+
+    nonisolated private static func cacheFileSize(url: URL) -> Int {
+        (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
     }
 
     nonisolated private static func writeCachedMissionFile(missionId: String, data: Data) throws {
@@ -2009,7 +2033,9 @@ struct ControlView: View {
                 detail: mission.id,
                 count: orderedEvents.count
             ) {
-                messages = ChatHistoryReducer.reduce(events: orderedEvents, mission: mission)
+                let replay = ChatHistoryReducer.reduceWithState(events: orderedEvents, mission: mission)
+                messages = replay.messages
+                textOpBuffers = replay.textOpBuffers
             }
 
             // Recompute grouped items once after all events are processed
@@ -2122,6 +2148,9 @@ struct ControlView: View {
             hasCache = false
             if updateViewing {
                 controlCacheHit = false
+                if let currentId = currentMission?.id ?? viewingMissionId {
+                    scheduleLargeCachedMissionLoad(id: currentId)
+                }
             }
         }
 
@@ -2203,6 +2232,7 @@ struct ControlView: View {
         } else {
             hasCache = false
             controlCacheHit = false
+            scheduleLargeCachedMissionLoad(id: id)
         }
 
         // Only show loading state if we don't have cached data to display
@@ -3230,6 +3260,7 @@ struct ControlView: View {
             controlCacheHit = false
             isLoading = true
             controlCacheStale = false
+            scheduleLargeCachedMissionLoad(id: id)
         }
 
         // Determine the run state for this mission from runningMissions
@@ -4075,6 +4106,40 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     }
 }
 
+// MARK: - Conversation Rows
+
+private struct ConversationRowsView: View {
+    let groupedItems: [GroupedChatItem]
+    let copiedMessageId: String?
+    @Binding var expandedToolGroups: Set<String>
+    let onCopy: (ChatMessage) -> Void
+    let onRetry: (ChatMessage) -> Void
+
+    var body: some View {
+        ForEach(groupedItems) { item in
+            switch item {
+            case .single(let message):
+                MessageBubble(
+                    message: message,
+                    isCopied: copiedMessageId == message.id,
+                    onCopy: { onCopy(message) },
+                    onRetry: message.sendState.isFailed ? { onRetry(message) } : nil
+                )
+                .modifier(ControlBodyRenderProbe(name: "MessageBubble"))
+                .id(message.id)
+            case .toolGroup(let groupId, let tools):
+                ToolGroupView(
+                    groupId: groupId,
+                    tools: tools,
+                    expandedGroups: $expandedToolGroups
+                )
+                .modifier(ControlBodyRenderProbe(name: "ToolGroupView"))
+                .id(item.id)
+            }
+        }
+    }
+}
+
 // MARK: - Message Bubble
 
 private struct MessageBubble: View {
@@ -4331,7 +4396,9 @@ private struct SharedFileCardView: View {
             // skeleton matches the inline rich-image placeholder so the
             // chat feels consistent while either type loads.
             Group {
-                if let data = imageData, let uiImage = UIImage(data: data) {
+                if let url = fullURL,
+                   let data = imageData,
+                   let uiImage = ImageMemoryCache.shared.cachedImage(for: url) ?? UIImage(data: data) {
                     Image(uiImage: uiImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -4462,6 +4529,12 @@ private struct SharedFileCardView: View {
         isLoadingImage = true
         imageLoadFailed = false
 
+        if ImageMemoryCache.shared.cachedImage(for: url) != nil {
+            imageData = Data()
+            isLoadingImage = false
+            return
+        }
+
         do {
             var request = URLRequest(url: url)
             // Bound the per-image fetch to the same window as JSON requests so
@@ -4479,8 +4552,8 @@ private struct SharedFileCardView: View {
             // Check response status
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 200 {
-                    // Validate that the data is actually parseable as an image
-                    if UIImage(data: data) != nil {
+                    // Validate/downsample before storing row state.
+                    if await ImageMemoryCache.shared.image(from: data, url: url) != nil {
                         await MainActor.run {
                             self.imageData = data
                         }
@@ -5419,6 +5492,12 @@ private struct MissionSwitcherSheet: View {
     @State private var backendSearchQuery = ""
     @State private var backendSearchResults: [MissionSearchResult] = []
     @State private var isBackendSearchLoading = false
+    @State private var derivedMissionById: [String: Mission] = [:]
+    @State private var derivedFilteredRunning: [RunningMissionInfo] = []
+    @State private var derivedFilteredRecent: [Mission] = []
+    @State private var derivedOrderedRunning: [RunningRow] = []
+    @State private var derivedJustCompletedMissions: [Mission] = []
+    @State private var derivedRecentMissionsForList: [Mission] = []
 
     private let backendSearchDebounceNanos: UInt64 = 250_000_000
 
@@ -5426,99 +5505,10 @@ private struct MissionSwitcherSheet: View {
         normalizeMetadataText(searchText)
     }
 
-    private var runningMissionIds: Set<String> {
-        Set(runningMissions.map { $0.missionId })
-    }
-
     private func preferredMissionForDuplicateId(_ lhs: Mission, _ rhs: Mission) -> Mission {
         let lhsUpdated = lhs.updatedDate ?? .distantPast
         let rhsUpdated = rhs.updatedDate ?? .distantPast
         return rhsUpdated >= lhsUpdated ? rhs : lhs
-    }
-
-    private var missionById: [String: Mission] {
-        Dictionary(
-            recentMissions.map { ($0.id, $0) },
-            uniquingKeysWith: preferredMissionForDuplicateId
-        )
-    }
-
-    private var filteredRunning: [RunningMissionInfo] {
-        let liveCandidates = runningMissions.filter { info in
-            guard let mission = missionById[info.missionId] else { return true }
-            return !mission.hasFinishedSuccessfully
-        }
-        if normalizedSearchQuery.isEmpty {
-            return liveCandidates
-        }
-        return liveCandidates
-            .compactMap { info -> (RunningMissionInfo, Double)? in
-                let score = runningMissionSearchScore(
-                    info,
-                    query: normalizedSearchQuery,
-                    linkedMission: missionById[info.missionId]
-                )
-                return score > 0 ? (info, score) : nil
-            }
-            .sorted { lhs, rhs in
-                if lhs.1 == rhs.1 {
-                    let lhsUpdated = missionById[lhs.0.missionId]?.updatedDate ?? .distantPast
-                    let rhsUpdated = missionById[rhs.0.missionId]?.updatedDate ?? .distantPast
-                    if lhsUpdated != rhsUpdated {
-                        return lhsUpdated > rhsUpdated
-                    }
-                    return lhs.0.missionId < rhs.0.missionId
-                }
-                return lhs.1 > rhs.1
-            }
-            .map(\.0)
-    }
-
-    private var filteredRecent: [Mission] {
-        let nonRunning = recentMissions.filter { !runningMissionIds.contains($0.id) }
-        if normalizedSearchQuery.isEmpty {
-            return nonRunning
-        }
-
-        let localMatches: [Mission] = nonRunning
-            .compactMap { mission -> (Mission, Double)? in
-                let score = missionSearchRelevanceScore(mission, query: normalizedSearchQuery)
-                return score > 0 ? (mission, score) : nil
-            }
-            .sorted { lhs, rhs in
-                if lhs.1 == rhs.1 {
-                    return (lhs.0.updatedDate ?? .distantPast) > (rhs.0.updatedDate ?? .distantPast)
-                }
-                return lhs.1 > rhs.1
-            }
-            .map(\.0)
-
-        if backendSearchQuery == normalizedSearchQuery {
-            let byId = Dictionary(
-                nonRunning.map { ($0.id, $0) },
-                uniquingKeysWith: preferredMissionForDuplicateId
-            )
-            var merged: [Mission] = []
-            var seen = Set<String>()
-
-            for result in backendSearchResults {
-                let mission = byId[result.mission.id] ?? result.mission
-                guard !runningMissionIds.contains(mission.id) else { continue }
-                if seen.insert(mission.id).inserted {
-                    merged.append(mission)
-                }
-            }
-
-            for mission in localMatches {
-                if seen.insert(mission.id).inserted {
-                    merged.append(mission)
-                }
-            }
-
-            return merged
-        }
-
-        return localMatches
     }
 
     /// A running row carries layout hints so we can render boss + nested
@@ -5533,12 +5523,28 @@ private struct MissionSwitcherSheet: View {
         var id: String { info.missionId }
     }
 
-    /// boss missionId -> [worker missionId]. Built from the full mission set
-    /// (not just the search-filtered one) so we still know about workers when
-    /// the boss matched the query but a worker didn't.
-    private var bossWorkerIds: [String: [String]] {
+    private var missionListSignature: String {
+        let runningPart = runningMissions
+            .map { "\($0.missionId):\($0.state):\($0.title ?? "")" }
+            .joined(separator: "|")
+        let recentPart = recentMissions
+            .map { "\($0.id):\($0.status.displayLabel):\($0.updatedDate?.timeIntervalSince1970 ?? 0):\($0.parentMissionId ?? ""):\($0.title ?? "")" }
+            .joined(separator: "|")
+        let backendPart = backendSearchResults
+            .map { "\($0.mission.id):\($0.relevanceScore)" }
+            .joined(separator: "|")
+        return [
+            runningPart,
+            recentPart,
+            searchText,
+            backendSearchQuery,
+            backendPart
+        ].joined(separator: "||")
+    }
+
+    private func bossWorkerIds(from missions: [Mission]) -> [String: [String]] {
         var map: [String: [String]] = [:]
-        for mission in recentMissions {
+        for mission in missions {
             if let parent = mission.parentMissionId, !parent.isEmpty {
                 map[parent, default: []].append(mission.id)
             }
@@ -5546,13 +5552,11 @@ private struct MissionSwitcherSheet: View {
         return map
     }
 
-    /// Running missions ordered to nest workers under their boss (matching the
-    /// Next.js cmd+K palette): bosses first with their workers indented, then
-    /// standalone running missions, then any orphan workers whose boss isn't
-    /// currently running.
-    private var orderedRunning: [RunningRow] {
-        let filtered = filteredRunning
-        let workerIdsByBoss = bossWorkerIds
+    private func orderedRunningRows(
+        filtered: [RunningMissionInfo],
+        missionById: [String: Mission],
+        workerIdsByBoss: [String: [String]]
+    ) -> [RunningRow] {
         let filteredById: [String: RunningMissionInfo] = Dictionary(
             uniqueKeysWithValues: filtered.map { ($0.missionId, $0) }
         )
@@ -5595,44 +5599,119 @@ private struct MissionSwitcherSheet: View {
         return rows
     }
 
-    /// Mission ids included in the Just Completed micro-section, so Recent
-    /// can exclude them and we don't show the same row twice.
-    private var justCompletedIds: Set<String> {
-        Set(justCompletedMissions.map { $0.id })
-    }
+    private func recomputeMissionSections() {
+        let query = normalizedSearchQuery
+        let runningIds = Set(runningMissions.map { $0.missionId })
+        let missionById = Dictionary(
+            recentMissions.map { ($0.id, $0) },
+            uniquingKeysWith: preferredMissionForDuplicateId
+        )
 
-    /// Successfully-finished missions that landed in the last 24h. Capped to
-    /// keep the section glanceable. Hidden while searching — the ranked list
-    /// takes over and grouping just gets in the way.
-    ///
-    /// Only `.completed`, `.acknowledged`, and `.awaitingUser` qualify here:
-    /// the backend sometimes lands successful turns as `.interrupted` (the
-    /// watchdog/cancel race), so excluding the failure-shaped statuses keeps
-    /// the section honest. Interrupted/failed/blocked rows still appear under
-    /// "Recent" below.
-    private var justCompletedMissions: [Mission] {
-        guard normalizedSearchQuery.isEmpty else { return [] }
-        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-        return recentMissions
-            .filter { mission in
-                guard !runningMissionIds.contains(mission.id) else { return false }
-                switch mission.status {
-                case .completed, .acknowledged, .awaitingUser:
-                    return true
-                default:
-                    return false
+        let liveCandidates = runningMissions.filter { info in
+            guard let mission = missionById[info.missionId] else { return true }
+            return !mission.hasFinishedSuccessfully
+        }
+        let filteredRunning: [RunningMissionInfo]
+        if query.isEmpty {
+            filteredRunning = liveCandidates
+        } else {
+            filteredRunning = liveCandidates
+                .compactMap { info -> (RunningMissionInfo, Double)? in
+                    let score = runningMissionSearchScore(
+                        info,
+                        query: query,
+                        linkedMission: missionById[info.missionId]
+                    )
+                    return score > 0 ? (info, score) : nil
                 }
-            }
-            .filter { ($0.updatedDate ?? .distantPast) >= cutoff }
-            .prefix(5)
-            .map { $0 }
-    }
+                .sorted { lhs, rhs in
+                    if lhs.1 == rhs.1 {
+                        let lhsUpdated = missionById[lhs.0.missionId]?.updatedDate ?? .distantPast
+                        let rhsUpdated = missionById[rhs.0.missionId]?.updatedDate ?? .distantPast
+                        if lhsUpdated != rhsUpdated {
+                            return lhsUpdated > rhsUpdated
+                        }
+                        return lhs.0.missionId < rhs.0.missionId
+                    }
+                    return lhs.1 > rhs.1
+                }
+                .map(\.0)
+        }
 
-    /// Recent missions excluding any row already shown in Just Completed,
-    /// so the same mission never appears twice.
-    private var recentMissionsForList: [Mission] {
-        let justCompleted = justCompletedIds
-        return filteredRecent.filter { !justCompleted.contains($0.id) }
+        let nonRunning = recentMissions.filter { !runningIds.contains($0.id) }
+        let filteredRecent: [Mission]
+        if query.isEmpty {
+            filteredRecent = nonRunning
+        } else {
+            let localMatches: [Mission] = nonRunning
+                .compactMap { mission -> (Mission, Double)? in
+                    let score = missionSearchRelevanceScore(mission, query: query)
+                    return score > 0 ? (mission, score) : nil
+                }
+                .sorted { lhs, rhs in
+                    if lhs.1 == rhs.1 {
+                        return (lhs.0.updatedDate ?? .distantPast) > (rhs.0.updatedDate ?? .distantPast)
+                    }
+                    return lhs.1 > rhs.1
+                }
+                .map(\.0)
+
+            if backendSearchQuery == query {
+                let byId = Dictionary(
+                    nonRunning.map { ($0.id, $0) },
+                    uniquingKeysWith: preferredMissionForDuplicateId
+                )
+                var merged: [Mission] = []
+                var seen = Set<String>()
+
+                for result in backendSearchResults {
+                    let mission = byId[result.mission.id] ?? result.mission
+                    guard !runningIds.contains(mission.id) else { continue }
+                    if seen.insert(mission.id).inserted {
+                        merged.append(mission)
+                    }
+                }
+
+                for mission in localMatches {
+                    if seen.insert(mission.id).inserted {
+                        merged.append(mission)
+                    }
+                }
+
+                filteredRecent = merged
+            } else {
+                filteredRecent = localMatches
+            }
+        }
+
+        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+        let justCompletedMissions = query.isEmpty
+            ? recentMissions
+                .filter { mission in
+                    guard !runningIds.contains(mission.id) else { return false }
+                    switch mission.status {
+                    case .completed, .acknowledged, .awaitingUser:
+                        return true
+                    default:
+                        return false
+                    }
+                }
+                .filter { ($0.updatedDate ?? .distantPast) >= cutoff }
+                .prefix(5)
+                .map { $0 }
+            : []
+        let justCompletedIds = Set(justCompletedMissions.map(\.id))
+
+        derivedMissionById = missionById
+        derivedFilteredRunning = filteredRunning
+        derivedFilteredRecent = filteredRecent
+        derivedOrderedRunning = orderedRunningRows(
+            filtered: filteredRunning,
+            missionById: missionById,
+            workerIdsByBoss: bossWorkerIds(from: recentMissions)
+        )
+        derivedJustCompletedMissions = justCompletedMissions
+        derivedRecentMissionsForList = filteredRecent.filter { !justCompletedIds.contains($0.id) }
     }
 
     @ViewBuilder
@@ -5677,11 +5756,11 @@ private struct MissionSwitcherSheet: View {
                 }
 
                 // Running missions — boss + nested workers, then standalone.
-                if !orderedRunning.isEmpty {
+                if !derivedOrderedRunning.isEmpty {
                     Section("Running") {
-                        ForEach(orderedRunning) { row in
+                        ForEach(derivedOrderedRunning) { row in
                             let info = row.info
-                            let mission = missionById[info.missionId]
+                            let mission = derivedMissionById[info.missionId]
                             MissionRow(
                                 missionId: info.missionId,
                                 displayName: mission.map { missionDisplayName(for: $0) },
@@ -5708,8 +5787,8 @@ private struct MissionSwitcherSheet: View {
                     }
                 }
 
-                missionSection("Just Completed", missions: justCompletedMissions)
-                missionSection("Recent", missions: recentMissionsForList)
+                missionSection("Just Completed", missions: derivedJustCompletedMissions)
+                missionSection("Recent", missions: derivedRecentMissionsForList)
 
                 if isBackendSearchLoading && !normalizedSearchQuery.isEmpty {
                     Section {
@@ -5723,7 +5802,7 @@ private struct MissionSwitcherSheet: View {
                     }
                 }
 
-                if filteredRunning.isEmpty && filteredRecent.isEmpty && !normalizedSearchQuery.isEmpty {
+                if derivedFilteredRunning.isEmpty && derivedFilteredRecent.isEmpty && !normalizedSearchQuery.isEmpty {
                     ContentUnavailableView(
                         "No Missions Found",
                         systemImage: "magnifyingglass",
@@ -5734,9 +5813,14 @@ private struct MissionSwitcherSheet: View {
             .searchable(text: $searchText, prompt: "Search missions...")
             .onChange(of: searchText) { _, newValue in
                 scheduleBackendSearch(for: newValue)
+                recomputeMissionSections()
             }
             .onAppear {
+                recomputeMissionSections()
                 scheduleBackendSearch(for: searchText)
+            }
+            .onChange(of: missionListSignature) { _, _ in
+                recomputeMissionSections()
             }
             .onDisappear {
                 backendSearchTask?.cancel()

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -5595,10 +5595,12 @@ private struct MissionSwitcherSheet: View {
 
     private var missionListSignature: String {
         let runningPart = runningMissions
-            .map { "\($0.missionId):\($0.state):\($0.title ?? "")" }
+            .map { "\($0.missionId):\($0.state):\($0.title ?? ""):\($0.currentActivity ?? "")" }
             .joined(separator: "|")
         let recentPart = recentMissions
-            .map { "\($0.id):\($0.status.displayLabel):\($0.updatedDate?.timeIntervalSince1970 ?? 0):\($0.parentMissionId ?? ""):\($0.title ?? "")" }
+            .map {
+                "\($0.id):\($0.status.displayLabel):\($0.updatedDate?.timeIntervalSince1970 ?? 0):\($0.parentMissionId ?? ""):\($0.title ?? ""):\($0.shortDescription ?? ""):\($0.backend ?? "")"
+            }
             .joined(separator: "|")
         let backendPart = backendSearchResults
             .map { "\($0.mission.id):\($0.relevanceScore)" }

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1964,6 +1964,58 @@ struct ControlView: View {
         clearLoadingHistoryAfterRender()
     }
 
+    private func replayedGoalInfo(for mission: Mission, events: [StoredEvent]) -> GoalPillInfo? {
+        guard mission.goalMode else { return nil }
+
+        var replayed: GoalPillInfo? = GoalPillInfo(
+            iteration: 0,
+            status: "active",
+            objective: mission.goalObjective ?? ""
+        )
+
+        for event in events {
+            switch event.eventType {
+            case "goal_iteration":
+                let metadata = event.metadata.mapValues(\.value)
+                let iteration = intValue(metadata["iteration"]) ?? replayed?.iteration ?? 0
+                let objective = metadata["objective"] as? String ?? replayed?.objective ?? mission.goalObjective ?? ""
+                replayed = GoalPillInfo(
+                    iteration: iteration,
+                    status: replayed?.status ?? "active",
+                    objective: objective
+                )
+
+            case "goal_status":
+                let metadata = event.metadata.mapValues(\.value)
+                let status = metadata["status"] as? String ?? event.content
+                let objective = metadata["objective"] as? String ?? replayed?.objective ?? mission.goalObjective ?? ""
+                switch status {
+                case "complete", "cleared", "budgetLimited":
+                    replayed = nil
+                default:
+                    replayed = GoalPillInfo(
+                        iteration: replayed?.iteration ?? 0,
+                        status: status,
+                        objective: objective
+                    )
+                }
+
+            default:
+                continue
+            }
+        }
+
+        return replayed
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let int64 = value as? Int64 { return Int(int64) }
+        if let double = value as? Double { return Int(double) }
+        if let string = value as? String { return Int(string) }
+        return nil
+    }
+
     private func rememberMissionEvents(_ events: [StoredEvent], for missionId: String) -> [StoredEvent] {
         let orderedEvents = events.sorted { lhs, rhs in
             if lhs.sequence != rhs.sequence {
@@ -2008,9 +2060,6 @@ struct ControlView: View {
 
             viewingMission = mission
             viewingMissionId = mission.id
-            goalInfo = mission.goalMode
-                ? GoalPillInfo(iteration: goalInfo?.iteration ?? 0, status: "active", objective: mission.goalObjective ?? "")
-                : nil
 
             // Ensure deterministic replay order in case the backend returns unsorted results
             let orderedEvents = diagnostics.measure(
@@ -2024,6 +2073,7 @@ struct ControlView: View {
             // Track total event count for pagination
             loadedEventCount = orderedEvents.count
             controlMergeCount = orderedEvents.count
+            goalInfo = replayedGoalInfo(for: mission, events: orderedEvents)
 
             // Clear and replay all events to rebuild message history
             messages.removeAll(keepingCapacity: true)

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1879,7 +1879,7 @@ struct ControlView: View {
             guard let cached = await loadCachedMissionDataAsync(id) else { return }
             guard fetchingMissionId == id || viewingMissionId == id else { return }
             let cachedMaxSeq = cached.events.compactMap(\.sequence).max() ?? 0
-            if let currentMaxSeq = missionMaxSeq[id], currentMaxSeq > cachedMaxSeq {
+            if let currentMaxSeq = missionMaxSeq[id], currentMaxSeq >= cachedMaxSeq {
                 return
             }
             controlCacheHit = true

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -37,6 +37,8 @@ private struct ControlDiagnosticsOverlay: View {
     let mergeCount: Int
     let renderCount: Int
     let droppedEvents: Int
+    let performanceRecords: [ControlPerformanceRecord]
+    let hotRenderCounts: [(name: String, count: Int)]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
@@ -50,6 +52,19 @@ private struct ControlDiagnosticsOverlay: View {
             diagnosticRow("merge", "\(mergeCount) ev")
             diagnosticRow("render", "\(renderCount) rows")
             diagnosticRow("drops", "\(droppedEvents)", warning: droppedEvents > 0)
+            if let slowest = performanceRecords.max(by: { $0.durationMilliseconds < $1.durationMilliseconds }) {
+                Divider()
+                    .overlay(Theme.border)
+                diagnosticRow("slowest", slowest.name)
+                diagnosticRow("time", slowest.compactDuration, warning: slowest.durationMilliseconds >= 16)
+            }
+            if !hotRenderCounts.isEmpty {
+                Divider()
+                    .overlay(Theme.border)
+                ForEach(hotRenderCounts.prefix(3), id: \.name) { item in
+                    diagnosticRow(item.name, "\(item.count)x", warning: item.count > renderCount * 2 && renderCount > 0)
+                }
+            }
         }
         .font(.caption2.monospacedDigit())
         .padding(8)
@@ -142,6 +157,8 @@ struct ControlView: View {
     @State private var controlCacheStale = false
     @State private var controlMergeCount = 0
     @State private var controlDroppedEvents = 0
+    @State private var controlPerformanceRecords: [ControlPerformanceRecord] = []
+    @State private var controlHotRenderCounts: [(name: String, count: Int)] = []
     @AppStorage("control_debug_perf") private var showControlDiagnostics = false
 
     /// Per-mission high-water mark for `sequence`. When non-nil, reload paths
@@ -212,6 +229,10 @@ struct ControlView: View {
     private let api = APIService.shared
     private let nav = NavigationState.shared
     private let bottomAnchorId = "bottom-anchor"
+
+    private var diagnostics: ControlPerformanceDiagnostics {
+        ControlPerformanceDiagnostics.shared
+    }
     
     var body: some View {
         bodyContent
@@ -238,6 +259,12 @@ struct ControlView: View {
         }
         .onChange(of: inputText) { _, newText in
             scheduleDraftSave(newText)
+        }
+        .onChange(of: showControlDiagnostics) { _, enabled in
+            if enabled {
+                diagnostics.reset()
+                updateControlPerformanceSnapshot()
+            }
         }
         .onDisappear {
             streamTask?.cancel()
@@ -678,13 +705,21 @@ struct ControlView: View {
                 cacheHit: controlCacheHit,
                 mergeCount: controlMergeCount,
                 renderCount: groupedItems.count,
-                droppedEvents: controlDroppedEvents
+                droppedEvents: controlDroppedEvents,
+                performanceRecords: controlPerformanceRecords,
+                hotRenderCounts: controlHotRenderCounts
             )
             .padding(.top, 8)
             .padding(.trailing, 8)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             .allowsHitTesting(false)
         }
+    }
+
+    private func updateControlPerformanceSnapshot() {
+        guard showControlDiagnostics else { return }
+        controlPerformanceRecords = diagnostics.recentRecords
+        controlHotRenderCounts = diagnostics.hotRenderCounts
     }
 
     /// Main vertical stack: connection banner, optional stale-cache pill,
@@ -927,6 +962,7 @@ struct ControlView: View {
                                 onCopy: { copyMessage(message) },
                                 onRetry: message.sendState.isFailed ? { retryFailedMessage(message) } : nil
                             )
+                            .modifier(ControlBodyRenderProbe(name: "MessageBubble"))
                             .id(message.id)
                         case .toolGroup(let groupId, let tools):
                             ToolGroupView(
@@ -934,6 +970,7 @@ struct ControlView: View {
                                 tools: tools,
                                 expandedGroups: $expandedToolGroups
                             )
+                            .modifier(ControlBodyRenderProbe(name: "ToolGroupView"))
                             .id(item.id)
                         }
                     }
@@ -1023,6 +1060,7 @@ struct ControlView: View {
                 }
             }
             .environment(\.missionFileContext, inlineImageContext)
+            .environment(\.controlPerformanceDiagnosticsEnabled, showControlDiagnostics)
         }
     }
 
@@ -1080,7 +1118,14 @@ struct ControlView: View {
     }
 
     private func recomputeGroupedItems() {
-        groupedItems = Self.buildGroupedItems(from: messages)
+        groupedItems = diagnostics.measure(
+            "control.group_messages",
+            detail: viewingMissionId ?? "none",
+            count: messages.count
+        ) {
+            Self.buildGroupedItems(from: messages)
+        }
+        updateControlPerformanceSnapshot()
     }
 
     /// Check if the currently viewed mission is running (not just any mission)
@@ -1930,56 +1975,46 @@ struct ControlView: View {
     }
 
     private func applyViewingMissionWithEvents(_ mission: Mission, events: [StoredEvent], scrollToBottom: Bool = true) {
-        isLoadingHistory = true  // Suppress animated auto-scroll during history load
+        diagnostics.measure(
+            "control.apply_snapshot",
+            detail: mission.id,
+            count: events.count
+        ) {
+            isLoadingHistory = true  // Suppress animated auto-scroll during history load
 
-        viewingMission = mission
-        viewingMissionId = mission.id
-        goalInfo = mission.goalMode
-            ? GoalPillInfo(iteration: goalInfo?.iteration ?? 0, status: "active", objective: mission.goalObjective ?? "")
-            : nil
+            viewingMission = mission
+            viewingMissionId = mission.id
+            goalInfo = mission.goalMode
+                ? GoalPillInfo(iteration: goalInfo?.iteration ?? 0, status: "active", objective: mission.goalObjective ?? "")
+                : nil
 
-        // Ensure deterministic replay order in case the backend returns unsorted results
-        let orderedEvents = rememberMissionEvents(events, for: mission.id)
-
-        // Track total event count for pagination
-        loadedEventCount = orderedEvents.count
-        controlMergeCount = orderedEvents.count
-
-        // Clear and replay all events to rebuild message history
-        messages.removeAll()
-
-        for event in orderedEvents {
-            var data: [String: Any] = [:]
-
-            // Add metadata first (lower priority)
-            for (key, value) in event.metadata {
-                data[key] = value.value
+            // Ensure deterministic replay order in case the backend returns unsorted results
+            let orderedEvents = diagnostics.measure(
+                "control.sort_remember_events",
+                detail: mission.id,
+                count: events.count
+            ) {
+                rememberMissionEvents(events, for: mission.id)
             }
 
-            // Add core fields last (higher priority - these should never be overwritten)
-            data["mission_id"] = event.missionId
-            data["content"] = event.content
-            if event.eventType == "text_op",
-               let jsonData = event.content.data(using: .utf8),
-               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
-                data["ops"] = ops
+            // Track total event count for pagination
+            loadedEventCount = orderedEvents.count
+            controlMergeCount = orderedEvents.count
+
+            // Clear and replay all events to rebuild message history
+            messages.removeAll(keepingCapacity: true)
+
+            diagnostics.measure(
+                "control.replay_events",
+                detail: mission.id,
+                count: orderedEvents.count
+            ) {
+                messages = ChatHistoryReducer.reduce(events: orderedEvents, mission: mission)
             }
 
-            if let eventId = event.eventId {
-                data["id"] = eventId
-            }
-            if let toolCallId = event.toolCallId {
-                data["tool_call_id"] = toolCallId
-            }
-            if let toolName = event.toolName {
-                data["name"] = toolName
-            }
-
-            handleStreamEvent(type: event.eventType, data: data, isHistoricalReplay: true)
+            // Recompute grouped items once after all events are processed
+            recomputeGroupedItems()
         }
-
-        // Recompute grouped items once after all events are processed
-        recomputeGroupedItems()
 
         if scrollToBottom {
             shouldScrollImmediately = true
@@ -2015,34 +2050,43 @@ struct ControlView: View {
     private func applyDeltaEvents(_ events: [StoredEvent]) {
         guard !events.isEmpty else { return }
 
-        let orderedEvents = events.sorted { lhs, rhs in
-            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
-            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
-            return lhs.id < rhs.id
-        }
-
-        for event in orderedEvents {
-            var data: [String: Any] = [:]
-            for (key, value) in event.metadata {
-                data[key] = value.value
+        diagnostics.measure(
+            "control.apply_delta",
+            detail: viewingMissionId ?? "none",
+            count: events.count
+        ) {
+            let orderedEvents = events.sorted { lhs, rhs in
+                if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+                if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
+                return lhs.id < rhs.id
             }
-            data["mission_id"] = event.missionId
-            data["content"] = event.content
-            if event.eventType == "text_op",
-               let jsonData = event.content.data(using: .utf8),
-               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
-                data["ops"] = ops
+
+            for event in orderedEvents {
+                handleStreamEvent(type: event.eventType, data: eventDataForReplay(event), isHistoricalReplay: true)
             }
-            if let eventId = event.eventId { data["id"] = eventId }
-            if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
-            if let toolName = event.toolName { data["name"] = toolName }
 
-            handleStreamEvent(type: event.eventType, data: data, isHistoricalReplay: true)
+            loadedEventCount += orderedEvents.count
+            controlMergeCount = orderedEvents.count
+            recomputeGroupedItems()
         }
+    }
 
-        loadedEventCount += orderedEvents.count
-        controlMergeCount = orderedEvents.count
-        recomputeGroupedItems()
+    private func eventDataForReplay(_ event: StoredEvent) -> [String: Any] {
+        var data: [String: Any] = [:]
+        for (key, value) in event.metadata {
+            data[key] = value.value
+        }
+        data["mission_id"] = event.missionId
+        data["content"] = event.content
+        if event.eventType == "text_op",
+           let jsonData = event.content.data(using: .utf8),
+           let ops = try? JSONSerialization.jsonObject(with: jsonData) {
+            data["ops"] = ops
+        }
+        if let eventId = event.eventId { data["id"] = eventId }
+        if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
+        if let toolName = event.toolName { data["name"] = toolName }
+        return data
     }
 
     /// Decide what to load on cold start. The previous code did
@@ -2094,7 +2138,12 @@ struct ControlView: View {
                 // Fetch events for event-based display
                 if updateViewing || viewingMissionId == nil || viewingMissionId == mission.id {
                     do {
-                        let snapshot = try await api.getMissionSnapshot(id: mission.id)
+                        let snapshot = try await diagnostics.measureAsync(
+                            "control.fetch_current_snapshot",
+                            detail: mission.id
+                        ) {
+                            try await api.getMissionSnapshot(id: mission.id)
+                        }
                         let events = snapshot.events
                         controlCacheHit = hasCache
 
@@ -2162,7 +2211,12 @@ struct ControlView: View {
         }
 
         do {
-            let snapshot = try await api.getMissionSnapshot(id: id)
+            let snapshot = try await diagnostics.measureAsync(
+                "control.fetch_snapshot",
+                detail: id
+            ) {
+                try await api.getMissionSnapshot(id: id)
+            }
             let mission = snapshot.mission
 
             // Race condition guard: only update if this is still the mission we want
@@ -2224,12 +2278,17 @@ struct ControlView: View {
         defer { isLoadingEarlier = false }
 
         do {
-            let olderEvents = try await api.getMissionEvents(
-                id: missionId,
-                types: historyEventTypes,
-                limit: Self.loadEarlierPageLimit,
-                beforeSeq: missionMinSeq[missionId]
-            )
+            let olderEvents = try await diagnostics.measureAsync(
+                "control.fetch_earlier",
+                detail: missionId
+            ) {
+                try await api.getMissionEvents(
+                    id: missionId,
+                    types: historyEventTypes,
+                    limit: Self.loadEarlierPageLimit,
+                    beforeSeq: missionMinSeq[missionId]
+                )
+            }
             guard viewingMissionId == missionId else { return }
 
             if !olderEvents.isEmpty, let mission = viewingMission {
@@ -2267,12 +2326,17 @@ struct ControlView: View {
     private func tryDeltaResume(missionId id: String) async -> DeltaResumeOutcome {
         guard let knownSeq = missionMaxSeq[id] else { return .noCursor }
         do {
-            let result = try await api.getMissionEventsWithMeta(
-                id: id,
-                types: historyEventTypes,
-                limit: Self.deltaResumePageLimit,
-                sinceSeq: knownSeq
-            )
+            let result = try await diagnostics.measureAsync(
+                "control.fetch_delta",
+                detail: id
+            ) {
+                try await api.getMissionEventsWithMeta(
+                    id: id,
+                    types: historyEventTypes,
+                    limit: Self.deltaResumePageLimit,
+                    sinceSeq: knownSeq
+                )
+            }
             guard viewingMissionId == id else { return .viewChanged }
             let maxSeq = result.maxSequence ?? knownSeq
             _ = mergeMissionEvents(result.events, for: id)
@@ -2329,7 +2393,12 @@ struct ControlView: View {
             // clear the cache and fall back, since the mission really does
             // have no events.
             do {
-                let snapshot = try await api.getMissionSnapshot(id: id)
+                let snapshot = try await diagnostics.measureAsync(
+                    "control.fetch_reload_snapshot",
+                    detail: id
+                ) {
+                    try await api.getMissionSnapshot(id: id)
+                }
                 guard viewingMissionId == id else { return }
                 if snapshot.events.isEmpty {
                     removeMissionFromCache(mission.id)
@@ -3183,7 +3252,12 @@ struct ControlView: View {
         progress = nil
 
         do {
-            let snapshot = try await api.getMissionSnapshot(id: id)
+            let snapshot = try await diagnostics.measureAsync(
+                "control.fetch_switch_snapshot",
+                detail: id
+            ) {
+                try await api.getMissionSnapshot(id: id)
+            }
             let mission = snapshot.mission
 
             // Race condition guard: only update if this is still the mission we want
@@ -3247,7 +3321,12 @@ struct ControlView: View {
     private func refreshViewingMissionSnapshot() async {
         guard let id = viewingMissionId else { return }
         do {
-            let snapshot = try await api.getMissionSnapshot(id: id)
+            let snapshot = try await diagnostics.measureAsync(
+                "control.fetch_refresh_snapshot",
+                detail: id
+            ) {
+                try await api.getMissionSnapshot(id: id)
+            }
             guard viewingMissionId == id else { return }
             currentMission = currentMission?.id == snapshot.mission.id ? snapshot.mission : currentMission
             if !snapshot.events.isEmpty {
@@ -4175,6 +4254,7 @@ private struct MessageBubble: View {
                 }
 
                 MarkdownView(message.content)
+                    .modifier(ControlBodyRenderProbe(name: "MarkdownView"))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -1877,7 +1877,7 @@ struct ControlView: View {
               Self.cacheFileSize(url: url) > Self.maxSynchronousCacheBytes else { return }
         Task {
             guard let cached = await loadCachedMissionDataAsync(id) else { return }
-            guard fetchingMissionId == id || viewingMissionId == id else { return }
+            guard viewingMissionId == id else { return }
             let cachedMaxSeq = cached.events.compactMap(\.sequence).max() ?? 0
             if let currentMaxSeq = missionMaxSeq[id], currentMaxSeq >= cachedMaxSeq {
                 return
@@ -2258,6 +2258,11 @@ struct ControlView: View {
     private func loadMission(id: String) async {
         // Set target immediately for race condition tracking
         fetchingMissionId = id
+        defer {
+            if fetchingMissionId == id {
+                fetchingMissionId = nil
+            }
+        }
         let previousViewingMission = viewingMission
         let previousViewingId = viewingMissionId
         viewingMissionId = id
@@ -3288,6 +3293,11 @@ struct ControlView: View {
         let previousProgress = progress
         viewingMissionId = id
         fetchingMissionId = id
+        defer {
+            if fetchingMissionId == id {
+                fetchingMissionId = nil
+            }
+        }
 
         // Clear stale workers from previous mission immediately
         childMissions = []

--- a/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
@@ -12,6 +12,7 @@ struct FilesView: View {
     private var workspaceState = WorkspaceState.shared
     @State private var currentPath = "/root/context"
     @State private var entries: [FileEntry] = []
+    @State private var sortedEntries: [FileEntry] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var selectedEntry: FileEntry?
@@ -42,10 +43,10 @@ struct FilesView: View {
 
     private let api = APIService.shared
     
-    private var sortedEntries: [FileEntry] {
+    private func recomputeSortedEntries() {
         let dirs = entries.filter { $0.isDirectory }.sorted { $0.name < $1.name }
         let files = entries.filter { !$0.isDirectory }.sorted { $0.name < $1.name }
-        return dirs + files
+        sortedEntries = dirs + files
     }
     
     private var breadcrumbs: [(name: String, path: String)] {
@@ -450,10 +451,12 @@ struct FilesView: View {
         // have nothing to show. Refresh happens in the background regardless.
         if let cached = pathCache[pathToLoad] {
             entries = cached
+            recomputeSortedEntries()
             isLoading = false
             touchCacheKey(pathToLoad)
         } else {
             entries = []
+            recomputeSortedEntries()
             isLoading = true
         }
 
@@ -466,6 +469,7 @@ struct FilesView: View {
             }
 
             entries = result
+            recomputeSortedEntries()
             cachePath(pathToLoad, entries: result)
         } catch {
             // Race condition guard

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -14,6 +14,7 @@ struct HistoryView: View {
     @State private var isLoading = true
     @State private var searchText = ""
     @State private var selectedFilter: StatusFilter = .all
+    @State private var filteredMissions: [Mission] = []
     @State private var errorMessage: String?
     @State private var isCleaningUp = false
     @State private var showCleanupResult: String?
@@ -39,8 +40,8 @@ struct HistoryView: View {
         }
     }
     
-    private var filteredMissions: [Mission] {
-        missions.filter { mission in
+    private func recomputeFilteredMissions() {
+        filteredMissions = missions.filter { mission in
             // Filter by status
             if let statuses = selectedFilter.missionStatuses, !statuses.contains(mission.status) {
                 return false
@@ -93,6 +94,7 @@ struct HistoryView: View {
                                 ) {
                                     withAnimation(.easeInOut(duration: 0.2)) {
                                         selectedFilter = filter
+                                        recomputeFilteredMissions()
                                     }
                                     HapticService.selectionChanged()
                                 }
@@ -202,6 +204,9 @@ struct HistoryView: View {
         .refreshable {
             await loadData()
         }
+        .onChange(of: searchText) { _, _ in
+            recomputeFilteredMissions()
+        }
     }
     
     private var missionsList: some View {
@@ -281,6 +286,7 @@ struct HistoryView: View {
             missions = missionsResult
             tasks = tasksResult
             runs = runsResult
+            recomputeFilteredMissions()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -296,6 +302,7 @@ struct HistoryView: View {
         let removalIndex = missions.firstIndex(where: { $0.id == mission.id })
         withAnimation {
             missions.removeAll { $0.id == mission.id }
+            recomputeFilteredMissions()
         }
         do {
             _ = try await api.deleteMission(id: mission.id)
@@ -306,6 +313,7 @@ struct HistoryView: View {
             if let idx = removalIndex {
                 withAnimation {
                     missions.insert(mission, at: min(idx, missions.count))
+                    recomputeFilteredMissions()
                 }
             }
         }
@@ -321,6 +329,7 @@ struct HistoryView: View {
                 let newMissions = try await api.listMissions()
                 withAnimation {
                     missions = newMissions
+                    recomputeFilteredMissions()
                     showCleanupResult = "Cleaned up \(count) empty mission\(count == 1 ? "" : "s")"
                 }
                 HapticService.success()

--- a/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
@@ -173,6 +173,53 @@ final class ModelTests: XCTestCase {
         }
     }
 
+    func testChatHistoryReducerSkipsTextOpFallbackWhenRealThinkingIsActive() throws {
+        let mission = try JSONDecoder().decode(Mission.self, from: """
+        {
+            "id": "mission-id",
+            "status": "active",
+            "title": "Thinking mission",
+            "history": [],
+            "resumable": false,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }
+        """.data(using: .utf8)!)
+        let events = [
+            StoredEvent(
+                id: 1,
+                missionId: mission.id,
+                sequence: 1,
+                eventType: "thinking",
+                timestamp: "2024-01-01T00:00:00Z",
+                eventId: "real-thinking",
+                toolCallId: nil,
+                toolName: nil,
+                content: "Analyzing the task",
+                metadata: ["done": AnyCodable(false)]
+            ),
+            StoredEvent(
+                id: 2,
+                missionId: mission.id,
+                sequence: 2,
+                eventType: "text_op",
+                timestamp: "2024-01-01T00:00:01Z",
+                eventId: nil,
+                toolCallId: nil,
+                toolName: nil,
+                content: #"{"ops":[{"type":"insert","pos":0,"text":"fallback text"}]}"#,
+                metadata: ["bubble_id": AnyCodable("latest")]
+            )
+        ]
+
+        let messages = ChatHistoryReducer.reduce(events: events, mission: mission)
+
+        XCTAssertEqual(messages.filter(\.isThinking).count, 1)
+        XCTAssertEqual(messages.first?.id, "real-thinking")
+        XCTAssertEqual(messages.first?.content, "Analyzing the task")
+        XCTAssertFalse(messages.contains { $0.id.hasPrefix("stream-thinking-") })
+    }
+
     private func controlViewSource() throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
         let controlView = testFile
@@ -194,119 +241,7 @@ final class ModelTests: XCTestCase {
     }
 
     private func replayFixtureEvents(_ events: [StoredEvent], mission: Mission) -> [ChatMessage] {
-        var messages: [ChatMessage] = []
-        var textOpBuffers: [String: String] = [:]
-        let orderedEvents = events.sorted { lhs, rhs in
-            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
-            return lhs.id < rhs.id
-        }
-
-        for event in orderedEvents {
-            var data = event.metadata.mapValues(\.value)
-            data["mission_id"] = event.missionId
-            data["content"] = event.content
-            if let eventId = event.eventId { data["id"] = eventId }
-            if event.eventType == "text_op",
-               let jsonData = event.content.data(using: .utf8),
-               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
-                data["ops"] = ops
-            }
-
-            switch event.eventType {
-            case "assistant_message", "assistant_message_canonical":
-                guard let id = data["id"] as? String,
-                      !messages.contains(where: { $0.id == id }) else { continue }
-                messages.append(
-                    ChatMessage(
-                        id: id,
-                        type: .assistant(success: data["success"] as? Bool ?? true, costCents: 0, costSource: .unknown, model: nil, sharedFiles: nil),
-                        content: data["content"] as? String ?? ""
-                    )
-                )
-            case "thinking":
-                let content = data["content"] as? String ?? ""
-                let done = data["done"] as? Bool ?? false
-                if done, data["goal_role"] as? String == "deliverable", mission.goalMode {
-                    let baseId = data["id"] as? String ?? String(event.id)
-                    let id = "goal-deliverable-\(baseId)"
-                    guard !messages.contains(where: { $0.id == id }) else { continue }
-                    messages.append(
-                        ChatMessage(
-                            id: id,
-                            type: .assistant(success: true, costCents: 0, costSource: .unknown, model: nil, sharedFiles: nil),
-                            content: content
-                        )
-                    )
-                    continue
-                }
-                if let id = data["id"] as? String,
-                   messages.contains(where: { $0.id == id }) {
-                    continue
-                }
-                if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
-                    let existing = messages[index]
-                    messages[index] = ChatMessage(
-                        id: existing.id,
-                        type: .thinking(done: done, startTime: existing.thinkingStartTime ?? existing.timestamp),
-                        content: content,
-                        timestamp: existing.timestamp
-                    )
-                } else {
-                    messages.append(
-                        ChatMessage(
-                            id: data["id"] as? String ?? "thinking-\(event.id)",
-                            type: .thinking(done: done, startTime: Date()),
-                            content: content
-                        )
-                    )
-                }
-            case "text_op":
-                let bubbleId = data["bubble_id"] as? String ?? "text-op-latest"
-                let ops = data["ops"] as? [[String: Any]] ?? []
-                var content = textOpBuffers[bubbleId] ?? ""
-                var finalized = false
-                for op in ops {
-                    switch op["type"] as? String {
-                    case "insert":
-                        let pos = min(max(op["pos"] as? Int ?? content.count, 0), content.count)
-                        let index = content.index(content.startIndex, offsetBy: pos)
-                        content.insert(contentsOf: op["text"] as? String ?? "", at: index)
-                    case "replace":
-                        let range = op["range"] as? [Int] ?? []
-                        let start = min(max(range.first ?? 0, 0), content.count)
-                        let end = min(max(range.dropFirst().first ?? content.count, start), content.count)
-                        let startIndex = content.index(content.startIndex, offsetBy: start)
-                        let endIndex = content.index(content.startIndex, offsetBy: end)
-                        content.replaceSubrange(startIndex..<endIndex, with: op["text"] as? String ?? "")
-                    case "finalize":
-                        finalized = true
-                    default:
-                        continue
-                    }
-                }
-                textOpBuffers[bubbleId] = finalized ? nil : content
-                if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone && $0.id.hasPrefix("stream-thinking-") }) {
-                    messages[index] = ChatMessage(
-                        id: messages[index].id,
-                        type: .thinking(done: finalized, startTime: messages[index].thinkingStartTime ?? messages[index].timestamp),
-                        content: content,
-                        timestamp: messages[index].timestamp
-                    )
-                } else {
-                    messages.append(
-                        ChatMessage(
-                            id: "stream-thinking-\(bubbleId)",
-                            type: .thinking(done: finalized, startTime: Date()),
-                            content: content
-                        )
-                    )
-                }
-            default:
-                continue
-            }
-        }
-
-        return messages
+        ChatHistoryReducer.reduce(events: events, mission: mission)
     }
 
     // MARK: - FileEntry Tests

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -67,7 +67,7 @@ impl OpenCodeAgent {
         };
 
         let agent_event = match oc_event {
-            OpenCodeEvent::Thinking { content } => {
+            OpenCodeEvent::Thinking { content, .. } => {
                 tracing::info!(
                     content_len = content.len(),
                     content_preview = %content.chars().take(100).collect::<String>(),

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2156,11 +2156,8 @@ fn update_provider_oauth_for_chatgpt_account(
             .and_then(|o| o.get("access_token"))
             .and_then(|v| v.as_str())
             .and_then(extract_chatgpt_account_id);
-        let matches = stored_account_id
-            .as_deref()
-            .or(decoded_account_id.as_deref())
-            .map(|s| s == account_id)
-            .unwrap_or(false);
+        let matches = stored_account_id.as_deref() == Some(account_id)
+            || decoded_account_id.as_deref() == Some(account_id);
         if !matches {
             continue;
         }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2395,13 +2395,108 @@ fn codex_oauth_refresh_lock(account_id: &str) -> Arc<AsyncMutex<()>> {
         .clone()
 }
 
+fn sanitize_codex_oauth_account_id(account_id: &str) -> String {
+    account_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn shared_codex_oauth_home_for_account(account_id: &str) -> PathBuf {
+    let root = std::env::var("SANDBOXED_SH_CODEX_OAUTH_HOME_ROOT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(home_dir())
+                .join(".sandboxed-sh")
+                .join("codex-oauth-accounts")
+        });
+    root.join(sanitize_codex_oauth_account_id(account_id))
+}
+
+fn find_openai_oauth_account_by_chatgpt_account_id(
+    working_dir: &Path,
+    chatgpt_account_id: &str,
+) -> Option<CodexOAuthAccount> {
+    let providers = load_ai_providers(working_dir);
+
+    for p in providers {
+        if p.get("provider_type").and_then(|v| v.as_str()) != Some("openai")
+            || !p.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true)
+        {
+            continue;
+        }
+
+        let Some(oauth) = p.get("oauth").and_then(|o| o.as_object()) else {
+            continue;
+        };
+        let refresh = oauth
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let access = oauth
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if refresh.is_empty() || access.is_empty() {
+            continue;
+        }
+
+        let account_id = match extract_chatgpt_account_id(access) {
+            Some(id) => id,
+            None => continue,
+        };
+        if account_id != chatgpt_account_id {
+            continue;
+        }
+
+        let expires_at = extract_jwt_exp_ms(access)
+            .or_else(|| oauth.get("expires_at").and_then(|v| v.as_i64()))
+            .unwrap_or(i64::MAX);
+        return Some(CodexOAuthAccount {
+            provider_id: p
+                .get("id")
+                .and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::new_v4),
+            chatgpt_account_id: account_id,
+            refresh_token: refresh.to_string(),
+            access_token: access.to_string(),
+            expires_at,
+            account_email: p
+                .get("account_email")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            priority: p.get("priority").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+        });
+    }
+
+    None
+}
+
+fn sync_shared_codex_oauth_auth(account: &CodexOAuthAccount) -> Result<PathBuf, String> {
+    let codex_home = shared_codex_oauth_home_for_account(&account.chatgpt_account_id);
+    write_codex_auth_json_chatgpt_with_tokens(
+        &codex_home,
+        &account.access_token,
+        &account.refresh_token,
+    )?;
+    Ok(codex_home)
+}
+
 /// Return a launch-ready ChatGPT OAuth account for Codex.
 ///
-/// Codex workers are launched with access-token-only auth so multiple workers
-/// can use the same ChatGPT account concurrently without racing on a rotating
-/// refresh token. This function is the single refresh point for that account:
-/// it re-reads the latest stored tokens under a per-account lock and refreshes
-/// only when the access token is close to expiry.
+/// The backend re-reads the latest stored tokens under a per-account lock and
+/// refreshes only when the access token is close to expiry. The resulting token
+/// pair is also mirrored into the shared per-account Codex auth home, so any
+/// Codex-managed auth fallback starts from the same current refresh token.
 pub async fn prepare_codex_oauth_account_for_launch(
     working_dir: &Path,
     selected: &CodexOAuthAccount,
@@ -2418,6 +2513,7 @@ pub async fn prepare_codex_oauth_account_for_launch(
 
     let now = chrono::Utc::now().timestamp_millis();
     if current.expires_at > now + MIN_ACCESS_TOKEN_TTL_MS {
+        let _ = sync_shared_codex_oauth_auth(&current);
         return Ok(current);
     }
 
@@ -2449,12 +2545,73 @@ pub async fn prepare_codex_oauth_account_for_launch(
         );
     }
 
-    Ok(CodexOAuthAccount {
+    let refreshed = CodexOAuthAccount {
         access_token: access,
         refresh_token: refresh,
         expires_at,
         ..current
-    })
+    };
+    let _ = sync_shared_codex_oauth_auth(&refreshed);
+    Ok(refreshed)
+}
+
+pub async fn refresh_codex_oauth_account_for_app_server(
+    working_dir: &Path,
+    previous_account_id: Option<&str>,
+    fallback_account_id: Option<&str>,
+) -> Result<CodexOAuthAccount, String> {
+    let account_id = previous_account_id
+        .filter(|id| !id.trim().is_empty())
+        .or(fallback_account_id)
+        .ok_or_else(|| "Codex requested OAuth refresh without an account id".to_string())?;
+
+    let lock = codex_oauth_refresh_lock(account_id);
+    let _guard = lock.lock().await;
+
+    let current = find_openai_oauth_account_by_chatgpt_account_id(working_dir, account_id)
+        .ok_or_else(|| {
+            format!(
+                "No OpenAI OAuth account found for ChatGPT account {}",
+                account_id
+            )
+        })?;
+
+    let client = reqwest::Client::new();
+    let (access, refresh, expires_at, _id_token) =
+        refresh_openai_oauth_tokens(&client, &current.refresh_token).await?;
+    let refreshed_account_id =
+        extract_chatgpt_account_id(&access).unwrap_or_else(|| current.chatgpt_account_id.clone());
+
+    if refreshed_account_id != current.chatgpt_account_id {
+        tracing::warn!(
+            expected_account_id = %current.chatgpt_account_id,
+            refreshed_account_id = %refreshed_account_id,
+            "OpenAI OAuth app-server refresh returned a different ChatGPT account id"
+        );
+    }
+
+    let updated = update_provider_oauth_for_chatgpt_account(
+        working_dir,
+        &current.chatgpt_account_id,
+        &access,
+        &refresh,
+        expires_at,
+    );
+    if !updated {
+        tracing::warn!(
+            account_id = %current.chatgpt_account_id,
+            "Refreshed Codex OAuth account for app-server but could not update ai_providers.json"
+        );
+    }
+
+    let refreshed = CodexOAuthAccount {
+        access_token: access,
+        refresh_token: refresh,
+        expires_at,
+        ..current
+    };
+    let _ = sync_shared_codex_oauth_auth(&refreshed);
+    Ok(refreshed)
 }
 
 /// Per-attempt credential override passed to `write_codex_credentials_for_workspace`.

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2567,18 +2567,15 @@ pub(crate) fn write_codex_auth_json_chatgpt_with_tokens(
     access_token: &str,
     refresh_token: &str,
 ) -> Result<(), String> {
-    // Rotation workers deliberately receive an access-token-only auth file.
-    // OpenAI ChatGPT refresh tokens rotate on every use, so allowing multiple
-    // Codex child processes to refresh the same account independently makes
-    // one process consume the token and the others fail with
-    // `refresh_token_reused`. The backend refreshes under a per-account lock
-    // before launch; workers should not perform their own refresh.
+    // The current Codex app-server requires the ChatGPT refresh_token to be
+    // present in auth.json. Access-token-only auth can leave the responses
+    // client with no bearer header, producing 401s from the OpenAI API.
     write_codex_chatgpt_auth_file(
         config_dir,
         access_token,
         refresh_token,
         "rotation_override",
-        false,
+        true,
     )
 }
 

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2138,17 +2138,29 @@ fn update_provider_oauth_for_chatgpt_account(
 
     let mut updated = false;
     for provider in items.iter_mut() {
-        let matches = provider
+        let is_openai = provider
             .get("provider_type")
             .and_then(|v| v.as_str())
             .map(|s| s == "openai")
-            .unwrap_or(false)
-            && provider
-                .get("oauth")
-                .and_then(|o| o.get("chatgpt_account_id"))
-                .and_then(|v| v.as_str())
-                .map(|s| s == account_id)
-                .unwrap_or(false);
+            .unwrap_or(false);
+        if !is_openai {
+            continue;
+        }
+
+        let oauth = provider.get("oauth");
+        let stored_account_id = oauth
+            .and_then(|o| o.get("chatgpt_account_id"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let decoded_account_id = oauth
+            .and_then(|o| o.get("access_token"))
+            .and_then(|v| v.as_str())
+            .and_then(extract_chatgpt_account_id);
+        let matches = stored_account_id
+            .as_deref()
+            .or(decoded_account_id.as_deref())
+            .map(|s| s == account_id)
+            .unwrap_or(false);
         if !matches {
             continue;
         }
@@ -2170,6 +2182,10 @@ fn update_provider_oauth_for_chatgpt_account(
             oauth_obj.insert(
                 "expires_at".to_string(),
                 serde_json::Value::from(expires_at_ms),
+            );
+            oauth_obj.insert(
+                "chatgpt_account_id".to_string(),
+                serde_json::Value::String(account_id.to_string()),
             );
             updated = true;
         }
@@ -2410,6 +2426,15 @@ pub fn get_all_openai_oauth_accounts(working_dir: &Path) -> Vec<CodexOAuthAccoun
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
         if refresh.is_empty() || access.is_empty() {
+            continue;
+        }
+        if oauth_token_expired(expires_at) {
+            tracing::warn!(
+                provider_id = p.get("id").and_then(|v| v.as_str()).unwrap_or("<unknown>"),
+                account_email = p.get("account_email").and_then(|v| v.as_str()),
+                expires_at,
+                "Skipping expired OpenAI OAuth provider entry for Codex rotation"
+            );
             continue;
         }
         let chatgpt_account_id = match extract_chatgpt_account_id(access) {
@@ -8417,6 +8442,29 @@ pub fn sync_oauth_to_all_tiers(
                     "Failed to sync token to Tier 3 (Claude CLI credentials) - continuing"
                 );
                 // Don't fail the entire sync if Claude CLI sync fails
+            }
+        }
+    }
+
+    if matches!(provider_type, ProviderType::OpenAI) {
+        if let Some(account_id) = extract_chatgpt_account_id(access_token) {
+            let working_dir = PathBuf::from(home_dir());
+            if update_provider_oauth_for_chatgpt_account(
+                &working_dir,
+                &account_id,
+                access_token,
+                refresh_token,
+                expires_at,
+            ) {
+                tracing::info!(
+                    account_id = %account_id,
+                    "Synced OpenAI OAuth token to ai_providers.json"
+                );
+            } else {
+                tracing::debug!(
+                    account_id = %account_id,
+                    "No matching OpenAI provider row found while syncing OAuth token"
+                );
             }
         }
     }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -24,10 +24,10 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command as TokioCommand;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::{timeout, Duration};
 
 use crate::ai_providers::{AuthMethod, PendingOAuth, ProviderType};
@@ -1992,6 +1992,7 @@ fn write_codex_chatgpt_auth_file(
     access_token: &str,
     refresh_token: &str,
     source_label: &str,
+    include_refresh_token: bool,
 ) -> Result<(), String> {
     if access_token.trim().is_empty() {
         return Err("OAuth access_token is empty".to_string());
@@ -2011,15 +2012,24 @@ fn write_codex_chatgpt_auth_file(
     let tmp_path = config_dir.join("auth.json.tmp");
 
     let now = chrono::Utc::now().to_rfc3339();
+    let mut tokens = serde_json::json!({
+        "id_token": id_token_value,
+        "access_token": access_token,
+        "account_id": account_id,
+    });
+    if include_refresh_token {
+        if let Some(obj) = tokens.as_object_mut() {
+            obj.insert(
+                "refresh_token".to_string(),
+                serde_json::Value::String(refresh_token.to_string()),
+            );
+        }
+    }
+
     let payload = serde_json::json!({
         "auth_mode": "chatgpt",
         "OPENAI_API_KEY": null,
-        "tokens": {
-            "id_token": id_token_value,
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "account_id": account_id,
-        },
+        "tokens": tokens,
         "last_refresh": now,
     });
     let contents = serde_json::to_string_pretty(&payload)
@@ -2052,6 +2062,7 @@ fn write_codex_auth_json_chatgpt(config_dir: &std::path::Path) -> Result<(), Str
         &entry.access_token,
         &entry.refresh_token,
         "credential_store",
+        true,
     )
 }
 
@@ -2371,6 +2382,81 @@ pub struct CodexOAuthAccount {
     pub priority: u32,
 }
 
+static CODEX_OAUTH_REFRESH_LOCKS: LazyLock<StdMutex<HashMap<String, Arc<AsyncMutex<()>>>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+fn codex_oauth_refresh_lock(account_id: &str) -> Arc<AsyncMutex<()>> {
+    let mut locks = CODEX_OAUTH_REFRESH_LOCKS
+        .lock()
+        .expect("Codex OAuth refresh lock map poisoned");
+    locks
+        .entry(account_id.to_string())
+        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+}
+
+/// Return a launch-ready ChatGPT OAuth account for Codex.
+///
+/// Codex workers are launched with access-token-only auth so multiple workers
+/// can use the same ChatGPT account concurrently without racing on a rotating
+/// refresh token. This function is the single refresh point for that account:
+/// it re-reads the latest stored tokens under a per-account lock and refreshes
+/// only when the access token is close to expiry.
+pub async fn prepare_codex_oauth_account_for_launch(
+    working_dir: &Path,
+    selected: &CodexOAuthAccount,
+) -> Result<CodexOAuthAccount, String> {
+    const MIN_ACCESS_TOKEN_TTL_MS: i64 = 10 * 60 * 1000;
+
+    let lock = codex_oauth_refresh_lock(&selected.chatgpt_account_id);
+    let _guard = lock.lock().await;
+
+    let current = get_all_openai_oauth_accounts(working_dir)
+        .into_iter()
+        .find(|account| account.chatgpt_account_id == selected.chatgpt_account_id)
+        .unwrap_or_else(|| selected.clone());
+
+    let now = chrono::Utc::now().timestamp_millis();
+    if current.expires_at > now + MIN_ACCESS_TOKEN_TTL_MS {
+        return Ok(current);
+    }
+
+    let client = reqwest::Client::new();
+    let (access, refresh, expires_at, _id_token) =
+        refresh_openai_oauth_tokens(&client, &current.refresh_token).await?;
+    let refreshed_account_id =
+        extract_chatgpt_account_id(&access).unwrap_or_else(|| current.chatgpt_account_id.clone());
+
+    if refreshed_account_id != current.chatgpt_account_id {
+        tracing::warn!(
+            expected_account_id = %current.chatgpt_account_id,
+            refreshed_account_id = %refreshed_account_id,
+            "OpenAI OAuth refresh returned a different ChatGPT account id"
+        );
+    }
+
+    let updated = update_provider_oauth_for_chatgpt_account(
+        working_dir,
+        &current.chatgpt_account_id,
+        &access,
+        &refresh,
+        expires_at,
+    );
+    if !updated {
+        tracing::warn!(
+            account_id = %current.chatgpt_account_id,
+            "Refreshed Codex OAuth account but could not update ai_providers.json"
+        );
+    }
+
+    Ok(CodexOAuthAccount {
+        access_token: access,
+        refresh_token: refresh,
+        expires_at,
+        ..current
+    })
+}
+
 /// Per-attempt credential override passed to `write_codex_credentials_for_workspace`.
 /// The runner builds one of these for each rotation attempt; the legacy
 /// "process-global creds.json" path is the fallback when the override is `None`.
@@ -2481,7 +2567,19 @@ pub(crate) fn write_codex_auth_json_chatgpt_with_tokens(
     access_token: &str,
     refresh_token: &str,
 ) -> Result<(), String> {
-    write_codex_chatgpt_auth_file(config_dir, access_token, refresh_token, "rotation_override")
+    // Rotation workers deliberately receive an access-token-only auth file.
+    // OpenAI ChatGPT refresh tokens rotate on every use, so allowing multiple
+    // Codex child processes to refresh the same account independently makes
+    // one process consume the token and the others fail with
+    // `refresh_token_reused`. The backend refreshes under a per-account lock
+    // before launch; workers should not perform their own refresh.
+    write_codex_chatgpt_auth_file(
+        config_dir,
+        access_token,
+        refresh_token,
+        "rotation_override",
+        false,
+    )
 }
 
 /// Write Codex credentials to a workspace.

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2418,14 +2418,15 @@ pub fn get_all_openai_oauth_accounts(working_dir: &Path) -> Vec<CodexOAuthAccoun
             .get("access_token")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        let expires_at = oauth
-            .get("expires_at")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0);
+        let stored_expires_at = oauth.get("expires_at").and_then(|v| v.as_i64());
         if refresh.is_empty() || access.is_empty() {
             continue;
         }
-        if oauth_token_expired(expires_at) {
+        let decoded_expires_at = extract_jwt_exp_ms(access);
+        let expires_at = decoded_expires_at.or(stored_expires_at).unwrap_or(i64::MAX);
+        if (stored_expires_at.is_some() || decoded_expires_at.is_some())
+            && oauth_token_expired(expires_at)
+        {
             tracing::warn!(
                 provider_id = p.get("id").and_then(|v| v.as_str()).unwrap_or("<unknown>"),
                 account_email = p.get("account_email").and_then(|v| v.as_str()),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -14219,8 +14219,25 @@ pub async fn run_codex_turn(
         }
     }
 
-    let prepared_oauth_account = match override_credential {
+    let oauth_account_to_prepare = match override_credential {
         Some(crate::api::ai_providers::CodexCredentialOverride::OAuth(account)) => {
+            Some((*account).clone())
+        }
+        Some(crate::api::ai_providers::CodexCredentialOverride::ApiKey(_)) => None,
+        None => {
+            if crate::api::ai_providers::get_openai_api_key_for_codex_default(app_working_dir)
+                .is_none()
+            {
+                crate::api::ai_providers::get_all_openai_oauth_accounts(app_working_dir)
+                    .into_iter()
+                    .next()
+            } else {
+                None
+            }
+        }
+    };
+    let prepared_oauth_account = match oauth_account_to_prepare.as_ref() {
+        Some(account) => {
             match crate::api::ai_providers::prepare_codex_oauth_account_for_launch(
                 app_working_dir,
                 account,
@@ -14238,7 +14255,7 @@ pub async fn run_codex_turn(
                 }
             }
         }
-        _ => None,
+        None => None,
     };
     let prepared_override = prepared_oauth_account
         .as_ref()

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -714,7 +714,7 @@ exec "$SCRIPT_DIR/.sandboxed-sh-telegram-action.py" "$@"
 }
 
 const CODEX_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
-const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 1;
+const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
 const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
@@ -14284,6 +14284,14 @@ pub async fn run_codex_turn(
     let codex_config = crate::backend::codex::client::CodexConfig {
         cli_path,
         model_effort: model_effort.map(|s| s.to_string()),
+        external_chatgpt_auth: prepared_oauth_account.as_ref().map(|account| {
+            crate::backend::codex::client::CodexExternalChatgptAuth {
+                access_token: account.access_token.clone(),
+                chatgpt_account_id: account.chatgpt_account_id.clone(),
+                chatgpt_plan_type: None,
+                working_dir: app_working_dir.to_path_buf(),
+            }
+        }),
         ..Default::default()
     };
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -14299,6 +14299,13 @@ pub async fn run_codex_turn(
     let mut thinking_emitted = false;
     let mut thinking_done_emitted = false;
     let mut thinking_accumulated = String::new();
+    // Tracks which codex reasoning item `thinking_accumulated` currently
+    // belongs to. When a Thinking event arrives with a different `item_id`,
+    // we finalize the existing buffer and start a fresh one — codex emits
+    // multiple reasoning items per turn (each with its own cumulative
+    // snapshots), and merging them into one buffer produced concatenated
+    // thoughts in stored history (see mission dbc8a7e9 seq 6651).
+    let mut thinking_item: Option<String> = None;
     let mut last_summary: Option<String> = None;
     let mut total_input_tokens: u64 = 0;
     let mut total_output_tokens: u64 = 0;
@@ -14338,9 +14345,44 @@ pub async fn run_codex_turn(
                             text_delta_pending = true;
                         }
                     }
-                    ExecutionEvent::Thinking { content } => {
-                        merge_stream_fragment(&mut thinking_accumulated, &content);
-                        // Stream the canonical cumulative buffer for real-time UI.
+                    ExecutionEvent::Thinking { content, item_id } => {
+                        // Codex emits per-item cumulative snapshots: every
+                        // emit with the same `item_id` contains the previous
+                        // emit as a prefix. When `item_id` changes we're on a
+                        // new reasoning item — finalize the existing buffer
+                        // as `done: true` so it persists as its own thought,
+                        // and start fresh. Falling back to `merge_stream_fragment`
+                        // (the pre-fix behaviour) concatenated unrelated items
+                        // into one buffer because it only knows about byte
+                        // overlap, not item identity.
+                        let item_changed = match (&thinking_item, &item_id) {
+                            (Some(prev), Some(cur)) => prev != cur,
+                            // First event of the turn, or backend doesn't
+                            // expose item IDs: treat as continuation.
+                            _ => false,
+                        };
+                        if item_changed && !thinking_accumulated.is_empty() {
+                            let _ = events_tx.send(AgentEvent::Thinking {
+                                content: std::mem::take(&mut thinking_accumulated),
+                                done: true,
+                                mission_id: Some(mission_id),
+                            });
+                            thinking_done_emitted = true;
+                        }
+                        if item_id.is_some() {
+                            thinking_item = item_id;
+                            // Per-item cumulative: each new snapshot replaces
+                            // the buffer (longest wins; shorter echoes are
+                            // dropped to keep the buffer monotone).
+                            if content.len() >= thinking_accumulated.len() {
+                                thinking_accumulated = content;
+                            }
+                        } else {
+                            // Unknown-item backends still use overlap-based
+                            // merging so a CLI that resends a partial
+                            // snapshot doesn't double words.
+                            merge_stream_fragment(&mut thinking_accumulated, &content);
+                        }
                         let _ = events_tx.send(AgentEvent::Thinking {
                             content: thinking_accumulated.clone(),
                             done: false,
@@ -14360,6 +14402,7 @@ pub async fn run_codex_turn(
                             });
                             thinking_done_emitted = true;
                         }
+                        thinking_item = None;
                         pending_tools.insert(id.clone(), name.clone());
                         let _ = events_tx.send(AgentEvent::ToolCall {
                             tool_call_id: id,
@@ -14907,7 +14950,7 @@ pub async fn run_gemini_turn(
                             mission_id: Some(mission_id),
                         });
                     }
-                    ExecutionEvent::Thinking { content } => {
+                    ExecutionEvent::Thinking { content, item_id: _ } => {
                         merge_stream_fragment(&mut thinking_accumulated, &content);
                         // Stream the canonical cumulative buffer for real-time UI.
                         let _ = events_tx.send(AgentEvent::Thinking {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -714,7 +714,7 @@ exec "$SCRIPT_DIR/.sandboxed-sh-telegram-action.py" "$@"
 }
 
 const CODEX_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
-const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
+const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 1;
 const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -714,6 +714,7 @@ exec "$SCRIPT_DIR/.sandboxed-sh-telegram-action.py" "$@"
 }
 
 const CODEX_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
+const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 1;
 const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
@@ -740,6 +741,13 @@ impl CodexCredential {
         match self {
             CodexCredential::ApiKey(k) => format!("apikey:{}", k),
             CodexCredential::OAuth(acc) => format!("oauth:{}", acc.chatgpt_account_id),
+        }
+    }
+
+    fn concurrency_limit(&self) -> usize {
+        match self {
+            CodexCredential::ApiKey(_) => CODEX_ACCOUNT_CONCURRENCY_LIMIT,
+            CodexCredential::OAuth(_) => CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT,
         }
     }
 
@@ -839,12 +847,12 @@ pub(crate) fn codex_tool_stall_should_retry_with_default_model(
     requested_model.is_some_and(is_generic_gpt_codex_model)
 }
 
-fn codex_account_semaphore_for_fingerprint(fingerprint: &str) -> Arc<Semaphore> {
+fn codex_account_semaphore_for_credential(credential: &CodexCredential) -> Arc<Semaphore> {
     let mut pool = CODEX_ACCOUNT_POOL
         .lock()
         .expect("Codex account pool mutex poisoned");
-    pool.entry(fingerprint.to_string())
-        .or_insert_with(|| Arc::new(Semaphore::new(CODEX_ACCOUNT_CONCURRENCY_LIMIT)))
+    pool.entry(credential.fingerprint())
+        .or_insert_with(|| Arc::new(Semaphore::new(credential.concurrency_limit())))
         .clone()
 }
 
@@ -1205,7 +1213,7 @@ async fn lease_codex_account(
         .into_iter()
         .filter(|cred| !tried_fingerprints.contains(&cred.fingerprint()))
         .map(|cred| {
-            let sem = codex_account_semaphore_for_fingerprint(&cred.fingerprint());
+            let sem = codex_account_semaphore_for_credential(&cred);
             let available = sem.available_permits();
             (cred, sem, available)
         })

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -714,7 +714,7 @@ exec "$SCRIPT_DIR/.sandboxed-sh-telegram-action.py" "$@"
 }
 
 const CODEX_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
-const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 1;
+const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
 const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
@@ -14219,11 +14219,37 @@ pub async fn run_codex_turn(
         }
     }
 
+    let prepared_oauth_account = match override_credential {
+        Some(crate::api::ai_providers::CodexCredentialOverride::OAuth(account)) => {
+            match crate::api::ai_providers::prepare_codex_oauth_account_for_launch(
+                app_working_dir,
+                account,
+            )
+            .await
+            {
+                Ok(account) => Some(account),
+                Err(e) => {
+                    tracing::error!("Failed to prepare Codex OAuth credentials: {}", e);
+                    return AgentResult::failure(
+                        format!("Failed to prepare Codex OAuth credentials: {}", e),
+                        0,
+                    )
+                    .with_terminal_reason(TerminalReason::AuthError);
+                }
+            }
+        }
+        _ => None,
+    };
+    let prepared_override = prepared_oauth_account
+        .as_ref()
+        .map(crate::api::ai_providers::CodexCredentialOverride::OAuth);
+    let workspace_override = prepared_override.as_ref().or(override_credential);
+
     // Ensure Codex auth.json is present in the workspace context (host or container).
     if let Err(e) = crate::api::ai_providers::write_codex_credentials_for_workspace(
         workspace,
         app_working_dir,
-        override_credential,
+        workspace_override,
     ) {
         tracing::error!("Failed to write Codex credentials: {}", e);
         return AgentResult::failure(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -14388,6 +14388,9 @@ pub async fn run_codex_turn(
                             done: false,
                             mission_id: Some(mission_id),
                         });
+                        if !thinking_accumulated.is_empty() {
+                            thinking_done_emitted = false;
+                        }
                         thinking_emitted = true;
                     }
                     ExecutionEvent::ToolCall { id, name, args } => {
@@ -14958,6 +14961,9 @@ pub async fn run_gemini_turn(
                             done: false,
                             mission_id: Some(mission_id),
                         });
+                        if !thinking_accumulated.is_empty() {
+                            thinking_done_emitted = false;
+                        }
                         thinking_emitted = true;
                     }
                     ExecutionEvent::ToolCall { id, name, args } => {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -14199,12 +14199,24 @@ pub async fn run_codex_turn(
     // Best-effort: try to mint an OpenAI API key from the OAuth refresh token.
     // If this fails (e.g. no API platform org), write_codex_credentials_for_workspace
     // will fall back to auth_mode: "chatgpt" using the access_token directly.
-    if let Err(e) = crate::api::ai_providers::ensure_openai_api_key_for_codex(app_working_dir).await
-    {
-        tracing::warn!(
-            "Could not ensure OpenAI API key for Codex (will try chatgpt auth mode): {}",
-            e
-        );
+    //
+    // Skip this when the rotation layer has already selected a specific
+    // ChatGPT OAuth account. Minting an API key refreshes/rotates the same
+    // refresh token, then the selected credential can become stale before it
+    // is written into Codex auth.json.
+    let should_try_mint_api_key = !matches!(
+        override_credential,
+        Some(crate::api::ai_providers::CodexCredentialOverride::OAuth(_))
+    );
+    if should_try_mint_api_key {
+        if let Err(e) =
+            crate::api::ai_providers::ensure_openai_api_key_for_codex(app_working_dir).await
+        {
+            tracing::warn!(
+                "Could not ensure OpenAI API key for Codex (will try chatgpt auth mode): {}",
+                e
+            );
+        }
     }
 
     // Ensure Codex auth.json is present in the workspace context (host or container).

--- a/src/backend/codex/app_server.rs
+++ b/src/backend/codex/app_server.rs
@@ -601,6 +601,24 @@ impl AppServerSession {
         self.request("thread/start", params).await
     }
 
+    pub async fn login_chatgpt_auth_tokens(
+        &self,
+        access_token: &str,
+        chatgpt_account_id: &str,
+        chatgpt_plan_type: Option<&str>,
+    ) -> Result<Value> {
+        self.request(
+            "account/login/start",
+            json!({
+                "type": "chatgptAuthTokens",
+                "accessToken": access_token,
+                "chatgptAccountId": chatgpt_account_id,
+                "chatgptPlanType": chatgpt_plan_type,
+            }),
+        )
+        .await
+    }
+
     /// Resume a previously-started thread by id. Codex 0.128.0 accepts
     /// `thread/resume` with `{threadId}` to reattach to a session whose
     /// rollout already lives under `$CODEX_HOME/sessions/...` — used by

--- a/src/backend/codex/client.rs
+++ b/src/backend/codex/client.rs
@@ -24,11 +24,22 @@ pub struct CodexConfig {
     pub oauth_token: Option<String>,
     pub default_model: Option<String>,
     pub model_effort: Option<String>,
+    /// ChatGPT OAuth account supplied by the host app. When set, the app-server
+    /// uses external `chatgptAuthTokens` mode and asks the host to refresh.
+    pub external_chatgpt_auth: Option<CodexExternalChatgptAuth>,
     /// Deprecated. App-server is the only path now. Setting this to
     /// `false` does nothing — the legacy exec branch is gone. Kept on
     /// the struct so existing call sites that set the field still
     /// compile; remove in a follow-up cleanup PR.
     pub use_app_server: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexExternalChatgptAuth {
+    pub access_token: String,
+    pub chatgpt_account_id: String,
+    pub chatgpt_plan_type: Option<String>,
+    pub working_dir: std::path::PathBuf,
 }
 
 impl Default for CodexConfig {
@@ -38,6 +49,7 @@ impl Default for CodexConfig {
             oauth_token: std::env::var("OPENAI_OAUTH_TOKEN").ok(),
             default_model: None,
             model_effort: None,
+            external_chatgpt_auth: None,
             use_app_server: true,
         }
     }

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -215,11 +215,10 @@ async fn send_message_streaming_app_server(
     };
 
     // Note: codex app-server does NOT honor `OPENAI_API_KEY`/`OPENAI_OAUTH_TOKEN`
-    // env vars (per `app-server/src/lib.rs:646-647`) — it reads `~/.codex/auth.json`
-    // (CODEX_HOME-relative). Auth flows through the per-mission codexhome-XXXX
-    // dir already populated by the workspace bootstrap; the legacy
-    // `oauth_token`-via-env path used by exec mode is dead here, so we don't
-    // forward it.
+    // env vars (per `app-server/src/lib.rs:646-647`). For ChatGPT OAuth
+    // rotation we use app-server's external token mode instead: the backend
+    // supplies an access token at startup and answers refresh requests under
+    // our per-account lock.
     let app_cfg = AppServerConfig {
         cli_path: cfg.cli_path.clone(),
         enabled_features: vec!["goals".to_string()],
@@ -241,6 +240,27 @@ async fn send_message_streaming_app_server(
     if let Err(e) = session_arc.initialize("sandboxed-sh", "1.2.0").await {
         let _ = session_arc.shutdown().await;
         return Err(anyhow::anyhow!("codex app-server initialize failed: {}", e));
+    }
+
+    if let Some(external_auth) = cfg.external_chatgpt_auth.as_ref() {
+        if let Err(e) = session_arc
+            .login_chatgpt_auth_tokens(
+                &external_auth.access_token,
+                &external_auth.chatgpt_account_id,
+                external_auth.chatgpt_plan_type.as_deref(),
+            )
+            .await
+        {
+            let _ = session_arc.shutdown().await;
+            return Err(anyhow::anyhow!(
+                "codex account/login/start chatgptAuthTokens failed: {}",
+                e
+            ));
+        }
+        tracing::info!(
+            chatgpt_account_id = %external_auth.chatgpt_account_id,
+            "Configured Codex app-server external ChatGPT OAuth tokens"
+        );
     }
     // Best-effort `notifications/initialized` — codex tolerates clients that
     // skip this but it matches the LSP-style handshake.
@@ -388,28 +408,57 @@ async fn send_message_streaming_app_server(
                             terminal = true;
                         }
                     }
-                    InboundMessage::ServerRequest {
-                        id,
-                        method,
-                        params: _,
-                    } => {
+                    InboundMessage::ServerRequest { id, method, params } => {
                         // Codex elicits permission for command exec, file change,
                         // and dynamic-tool invocations through server-initiated
                         // requests. Exec mode runs with
                         // `--dangerously-bypass-approvals-and-sandbox`; we mirror
                         // that policy here by auto-approving every elicitation.
-                        // Auth-refresh requests get a typed JSON-RPC error
-                        // because we don't carry refresh credentials in the
-                        // app-server path (codex reads its own auth.json).
                         let send_err = if method == "account/chatgptAuthTokens/refresh" {
-                            session_arc
-                                .respond_to_server_request_error(
-                                    id,
-                                    -32603,
-                                    "sandboxed-sh: auth refresh not supported by client; \
-                                     codex must re-read $CODEX_HOME/auth.json",
-                                )
-                                .await
+                            match cfg.external_chatgpt_auth.as_ref() {
+                                Some(external_auth) => {
+                                    let previous_account_id = params
+                                        .get("previousAccountId")
+                                        .and_then(|value| value.as_str());
+                                    match crate::api::ai_providers::refresh_codex_oauth_account_for_app_server(
+                                        &external_auth.working_dir,
+                                        previous_account_id,
+                                        Some(&external_auth.chatgpt_account_id),
+                                    )
+                                    .await
+                                    {
+                                        Ok(account) => {
+                                            let result = serde_json::json!({
+                                                "accessToken": account.access_token,
+                                                "chatgptAccountId": account.chatgpt_account_id,
+                                                "chatgptPlanType": external_auth.chatgpt_plan_type,
+                                            });
+                                            session_arc.respond_to_server_request(id, result).await
+                                        }
+                                        Err(error) => {
+                                            session_arc
+                                                .respond_to_server_request_error(
+                                                    id,
+                                                    -32603,
+                                                    &format!(
+                                                        "sandboxed-sh: ChatGPT OAuth refresh failed: {}",
+                                                        error
+                                                    ),
+                                                )
+                                                .await
+                                        }
+                                    }
+                                }
+                                None => {
+                                    session_arc
+                                        .respond_to_server_request_error(
+                                            id,
+                                            -32603,
+                                            "sandboxed-sh: auth refresh requested without external ChatGPT OAuth context",
+                                        )
+                                        .await
+                                }
+                            }
                         } else {
                             let result = elicitation_auto_approve(&method);
                             session_arc.respond_to_server_request(id, result).await

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -602,10 +602,11 @@ impl AppServerEventTranslator {
                         ("reasoning", DeltaSemantics::Incremental)
                     };
                     let key = format!("{}:{}", kind, item_id);
-                    let entry = self.delta_buffers.entry(key).or_default();
+                    let entry = self.delta_buffers.entry(key.clone()).or_default();
                     fold_delta_into(entry, delta, semantics);
                     events.push(ExecutionEvent::Thinking {
                         content: entry.clone(),
+                        item_id: Some(key),
                     });
                 }
             }
@@ -836,6 +837,8 @@ pub fn registry_entry() -> Arc<dyn Backend> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn parse_goal_prefix_detects_simple_goal() {
@@ -949,6 +952,93 @@ mod tests {
         fold_delta_into(&mut buf, "stable", DeltaSemantics::CumulativeSnapshot);
         fold_delta_into(&mut buf, "stable", DeltaSemantics::CumulativeSnapshot);
         assert_eq!(buf, "stable");
+    }
+
+    #[test]
+    fn reasoning_thinking_events_carry_distinct_item_ids() {
+        // Regression for mission dbc8a7e9 seq 6651: the translator must
+        // tag each Thinking event with the per-item buffer key so the
+        // mission_runner can detect when codex moves to a new reasoning
+        // item and finalize the previous thought instead of concatenating
+        // unrelated cumulative snapshots into one buffer.
+        let mut translator = AppServerEventTranslator {
+            delta_buffers: HashMap::new(),
+            emitted_usage_for_turn: HashSet::new(),
+            counted_turn_ids: HashSet::new(),
+            goal_iteration: 0,
+            goal_objective: String::new(),
+        };
+
+        let notify = |item_id: &str, delta: &str| {
+            json!({
+                "itemId": item_id,
+                "delta": delta,
+            })
+        };
+
+        let collect = |events: Vec<ExecutionEvent>| -> Vec<(Option<String>, String)> {
+            events
+                .into_iter()
+                .filter_map(|e| match e {
+                    ExecutionEvent::Thinking { content, item_id } => Some((item_id, content)),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // Item A: cumulative summary snapshots.
+        let mut events = Vec::new();
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("A", "The recovery log."),
+                    false,
+                )
+                .events,
+        );
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("A", "The recovery log. Do not duplicate."),
+                    false,
+                )
+                .events,
+        );
+        // Item B: brand new reasoning, starts at "Work".
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("B", "Work"),
+                    false,
+                )
+                .events,
+        );
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("B", "Worktrees are ready"),
+                    false,
+                )
+                .events,
+        );
+
+        let thinkings = collect(events);
+        assert_eq!(thinkings.len(), 4);
+        // Item A's snapshots share an item_id.
+        assert_eq!(thinkings[0].0, Some("summary:A".to_string()));
+        assert_eq!(thinkings[1].0, Some("summary:A".to_string()));
+        // Item B's snapshots share a *different* item_id.
+        assert_eq!(thinkings[2].0, Some("summary:B".to_string()));
+        assert_eq!(thinkings[3].0, Some("summary:B".to_string()));
+        assert_ne!(thinkings[1].0, thinkings[2].0);
+        // Per-item contents are clean cumulative snapshots (the runner is
+        // free to REPLACE per item, no overlap merging required).
+        assert_eq!(thinkings[1].1, "The recovery log. Do not duplicate.");
+        assert_eq!(thinkings[3].1, "Worktrees are ready");
     }
 
     #[tokio::test]

--- a/src/backend/events.rs
+++ b/src/backend/events.rs
@@ -4,7 +4,19 @@ use serde_json::Value;
 #[derive(Debug, Clone)]
 pub enum ExecutionEvent {
     /// Agent is thinking/reasoning.
-    Thinking { content: String },
+    ///
+    /// `content` is a per-item cumulative snapshot (each emit for the same
+    /// `item_id` contains the previous emit as a prefix). `item_id` identifies
+    /// the reasoning item the snapshot belongs to so consumers can detect
+    /// transitions between distinct thoughts within a single turn — codex
+    /// emits multiple reasoning items per turn and they must not be merged
+    /// into one buffer. `None` means the backend doesn't expose item IDs
+    /// (Claude Code CLI handles its own block-index finalization upstream;
+    /// Gemini emits a single thought stream per turn).
+    Thinking {
+        content: String,
+        item_id: Option<String>,
+    },
     /// Agent is calling a tool.
     ToolCall {
         id: String,

--- a/src/backend/gemini/mod.rs
+++ b/src/backend/gemini/mod.rs
@@ -454,7 +454,10 @@ fn convert_gemini_event(
         GeminiEvent::Thought { content } => {
             if let Some(text) = content {
                 if !text.is_empty() {
-                    results.push(ExecutionEvent::Thinking { content: text });
+                    results.push(ExecutionEvent::Thinking {
+                        content: text,
+                        item_id: None,
+                    });
                 }
             }
         }

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -431,7 +431,10 @@ pub fn convert_cli_event(
                 }
                 if let Some(thinking) = delta.thinking {
                     if !thinking.is_empty() {
-                        results.push(ExecutionEvent::Thinking { content: thinking });
+                        results.push(ExecutionEvent::Thinking {
+                            content: thinking,
+                            item_id: None,
+                        });
                     }
                 }
                 if let Some(partial) = delta.partial_json {
@@ -453,7 +456,10 @@ pub fn convert_cli_event(
                 match block {
                     ContentBlock::Text { text } => {
                         if !text.is_empty() {
-                            results.push(ExecutionEvent::Thinking { content: text });
+                            results.push(ExecutionEvent::Thinking {
+                                content: text,
+                                item_id: None,
+                            });
                         }
                     }
                     ContentBlock::ToolUse { id, name, input } => {
@@ -466,7 +472,10 @@ pub fn convert_cli_event(
                     }
                     ContentBlock::Thinking { thinking } => {
                         if !thinking.is_empty() {
-                            results.push(ExecutionEvent::Thinking { content: thinking });
+                            results.push(ExecutionEvent::Thinking {
+                                content: thinking,
+                                item_id: None,
+                            });
                         }
                     }
                     ContentBlock::ToolResult { .. } | ContentBlock::RedactedThinking { .. } => {}
@@ -767,7 +776,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => assert_eq!(content, "I need to think"),
+            ExecutionEvent::Thinking { content, .. } => assert_eq!(content, "I need to think"),
             other => panic!("Expected Thinking, got {:?}", other),
         }
     }
@@ -830,7 +839,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => {
+            ExecutionEvent::Thinking { content, .. } => {
                 assert_eq!(content, "I will run a command")
             }
             other => panic!("Expected Thinking, got {:?}", other),
@@ -884,7 +893,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => assert_eq!(content, "deep thought"),
+            ExecutionEvent::Thinking { content, .. } => assert_eq!(content, "deep thought"),
             other => panic!("Expected Thinking, got {:?}", other),
         }
     }
@@ -1125,7 +1134,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => {
+            ExecutionEvent::Thinking { content, .. } => {
                 assert_eq!(content, "Let me think about this...");
             }
             ExecutionEvent::TextDelta { .. } => {

--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -953,7 +953,10 @@ fn handle_part_update(props: &serde_json::Value, state: &mut SseState) -> Option
             content_preview = %content.chars().take(100).collect::<String>(),
             "Emitting Thinking event from SSE"
         );
-        Some(OpenCodeEvent::Thinking { content })
+        Some(OpenCodeEvent::Thinking {
+            content,
+            item_id: None,
+        })
     } else {
         // Skip if content is identical to last emitted text
         if state.last_emitted_text.as_ref() == Some(&content) {


### PR DESCRIPTION
## Summary
- Add iOS dashboard performance diagnostics plus the implemented fixes from `ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md`.
- Move chat history replay through `ChatHistoryReducer`, including text-op buffer handoff back to `ControlView` after snapshot replay.
- Add markdown parse/AttributedString caches, isolate conversation rows, move large mission-cache decode off the main actor, and add image downsampling/memory caching.
- Memoize mission/file/history list derivations to reduce repeated SwiftUI body work.
- Preserve Codex OAuth concurrency behavior and OpenAI/ChatGPT account-id synchronization, including the review fixes for account matching, missing-expiry fallback, selected-credential refresh-token rotation, and concurrent OAuth launch safety.
- Add a system-preference light theme for the dashboard while preserving the existing dark theme.

## Review fixes
- Bugbot/Codex: text-op replay now skips fallback thinking rows when a real active thinking row already has content, matching live stream behavior.
- Bugbot/Codex: snapshot replay now returns reducer `textOpBuffers` to `ControlView`, so later live/delta `text_op` events continue from the same state.
- Bugbot/Codex: ChatGPT OAuth provider updates now match when either the stored account id or the decoded access-token account id matches the refreshed account.
- Bugbot/Codex: OpenAI OAuth rotation no longer treats a missing `oauth.expires_at` as expired; it uses the access-token JWT expiry when available and keeps legacy rows eligible when no expiry is stored.
- Bugbot: goal pill replay now folds stored `goal_iteration` and `goal_status` events back into `goalInfo`, including terminal status clearing, after snapshot/cache replay.
- Bugbot: async large-cache replay now skips cached payloads whose max sequence is less than or equal to the current in-memory sequence, preventing stale disk snapshots from replacing newer merged history.
- Bugbot: async large-cache replay now requires the decoded cache to still match `viewingMissionId`, and mission loads clear their fetch marker on exit, preventing stale fetch ids from swapping the visible mission after a failed load.
- Bugbot: Codex/Gemini thinking streams now reset the done-emitted flag when a new non-empty reasoning buffer is streamed, so the final reasoning item is persisted as done at turn end.
- Codex: when the rotation layer has already selected a specific ChatGPT OAuth credential, the runner skips best-effort API-key minting so it does not rotate the refresh token before writing Codex auth.
- Codex: selected ChatGPT OAuth launches refresh under a per-account lock and write access-token-only Codex auth files, avoiding refresh-token reuse races across concurrent launches.

## Dashboard light theme
- The dashboard no longer forces `<html class="dark">`; browser/computer `prefers-color-scheme` now controls light vs dark.
- Light mode defines readable background/text/border tokens and remaps the existing dark-authored neutral utility classes without changing dark-mode styling.
- Auth loading, glass panels, cards, stat panels, markdown prose, placeholders, focus, neutral hover states, toast/detail modals, select options, and hardcoded dark panel surfaces now adapt to light mode.
- User chat bubbles and the top-left mission selector use light indigo with dark text in light mode while preserving the existing dark-mode indigo treatment.
- The Cmd+K mission switcher/search menu now uses a light dialog, readable search input, uniform selected-row content color on pale indigo, and light section headers/keyboard hints.
- Cmd+K mission title/description lines now use scoped light-mode colors, including selected rows, so descriptions stay readable instead of inheriting too-dark or too-muted text.
- Soft indigo controls now force a single readable content color in light mode, covering nested labels, icons, badges, message text, and action buttons.
- Markdown code blocks, raw markdown fallbacks, and JSON/code highlighters now use light code surfaces and a light Prism theme when the system is in light mode.
- The workbench mission description now has an explicit light surface, border, and readable text color.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --lib`
- [x] `xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj -scheme SandboxedDashboard -destination 'generic/platform=iOS Simulator' build`
- [x] `xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj -scheme SandboxedDashboard -destination 'id=A1480839-C000-42F2-A7D9-9E72E7C8CD50' test`
- [x] SwiftUI/Time Profiler/Animation Hitches trace attempts documented in `ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md` with current simulator/runtime limitations.
- [x] `bun run build` from `dashboard/`
- [x] Playwright emulation for `prefers-color-scheme: light` and `dark` on `http://localhost:3001/`, including computed color checks for body, title, sidebar, inactive nav, top-left mission selector, Cmd+K mission switcher dialog/input, and selected mission row readability.
- [ ] `bun run lint` is currently blocked by pre-existing lint errors under `dashboard/context/*`, outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OAuth refresh locking and token persistence touch security-sensitive launch paths; the iOS history replay and large async cache paths change Control correctness under race conditions, while the dashboard light-theme CSS remaps are broad but mostly presentational.
> 
> **Overview**
> This PR spans **three surfaces**: the web dashboard theme, the iOS Control chat experience, and **Codex ChatGPT OAuth** handling in Rust.
> 
> **Web dashboard** drops forced dark mode on the root `<html>` and follows **`prefers-color-scheme`**, with new CSS variables for light backgrounds, text, borders, and code surfaces. Existing dark-authored Tailwind neutrals are remapped in light mode via global overrides, and targeted classes (`mission-selector-trigger`, user message bubbles, mission switcher rows/descriptions) keep chat and Cmd+K readable. Markdown/code blocks and lazy syntax highlighters pick **oneDark vs oneLight** from system preference; a few control components swap hardcoded colors for theme tokens.
> 
> **iOS** adds optional **Control performance diagnostics** (timing signposts, body render probes, overlay stats) and implements the fixes documented in `IOS_PERFORMANCE_DIAGNOSTICS.md`: **`ChatHistoryReducer`** for one-pass snapshot replay (including `textOpBuffers` handoff), markdown parse/inline caches, **`ConversationRowsView`**, async decode for large on-disk mission caches with stale-sequence guards, **`ImageMemoryCache`** downsampling, memoized History/Files/mission-switcher lists, and goal-pill replay from stored goal events. Playwright/test artifact paths are gitignored; a committed `test-results` snapshot is removed.
> 
> **Backend (`ai_providers`)** serializes OAuth refresh **per ChatGPT account**, syncs refreshed tokens into **`ai_providers.json`** and shared per-account Codex auth homes, matches providers by stored or JWT-derived account id, skips expired rotation entries more safely, and always writes **refresh tokens** into Codex `auth.json` for app-server launches. OpenCode thinking forwarding is updated for a richer event shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d67dc27b3cd92ad42022a0f7d41cfd3f411ae73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->