### PR TITLE
iOS perf diagnostics + Codex OAuth concurrency + OpenAI account-id sync

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
 
 # next.js
 /.next/

--- a/dashboard/test-results/.last-run.json
+++ b/dashboard/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
+++ b/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
@@ -28,6 +28,11 @@ Date: 2026-05-25
     - `MarkdownView`
 - `SandboxedDashboard/Views/Components/MarkdownView.swift`
   - Adds `markdown.parse` timing when Control Diagnostics is enabled.
+  - Caches parsed markdown blocks and inline `AttributedString(markdown:)` output by content hash.
+- `SandboxedDashboard/Models/ChatHistoryReducer.swift`
+  - Adds a pure historical replay reducer that builds chat messages with indexed ids/tool calls and assigns UI state once.
+- `SandboxedDashboard/Services/ImageMemoryCache.swift`
+  - Adds a shared `NSCache` image store and background ImageIO downsampling for inline/shared chat images.
 - `SandboxedDashboard/Services/APIService.swift`
   - Adds whole-app request and decode timing for every JSON API call:
     - `api.request`
@@ -47,17 +52,40 @@ xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj \
 
 Result: build succeeded. Existing warning remains in `APIService.swift` about generic `T.Type` Sendability; it is unrelated to the diagnostics patch.
 
-Simulator work:
+Tests:
 
 ```bash
 xcrun simctl create OpenAgentPerf \
-  'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro' \
-  'com.apple.CoreSimulator.SimRuntime.iOS-26-4'
+  com.apple.CoreSimulator.SimDeviceType.iPhone-16 \
+  com.apple.CoreSimulator.SimRuntime.iOS-26-4
 xcrun simctl boot <device-id>
-xcrun simctl bootstatus <device-id> -b
+xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj \
+  -scheme SandboxedDashboard \
+  -destination 'id=<device-id>' \
+  test
 ```
 
-The simulator booted, but `simctl launch` and `simctl listapps` hung after install on this CoreSimulator instance. That blocked a complete automated trace capture in this run. The app now emits signposts usable from Instruments once the simulator can launch the app:
+Result: 30 tests passed. Existing Swift 6 actor warnings remain in `NetworkResilienceTests` for `ControlView.migrateMissionCacheIfNeeded()` calls from a non-main-actor test method; unrelated to this performance pass.
+
+Trace work:
+
+```bash
+for template in 'SwiftUI' 'Time Profiler' 'Animation Hitches'; do
+  xcrun xctrace record \
+    --template "$template" \
+    --device <device-id> \
+    --launch md.thomas.openagent.dashboard \
+    --time-limit 5s \
+    --output "/tmp/SandboxedDashboard-${template// /-}.trace"
+done
+```
+
+Result:
+- SwiftUI launched the app and saved `/tmp/SandboxedDashboard-SwiftUI.trace`, but reported that the SwiftUI instrument is not supported on this Simulator runtime.
+- Time Profiler launched the app, but did not end the recording after the requested 5-second time limit and was stopped by the timeout wrapper. A partial `/tmp/SandboxedDashboard-Time-Profiler.trace` bundle was left.
+- Animation Hitches launched the app and saved `/tmp/SandboxedDashboard-Animation-Hitches.trace`, but reported that Hitches is not supported on this platform.
+
+The temporary simulator was shut down and deleted. Manual Instruments capture on a physical iOS device, or a simulator/runtime that supports these instruments, is still useful with these templates:
 
 ```bash
 xcrun xctrace record \
@@ -91,65 +119,58 @@ category == "ControlPerformance"
 
 ## Diagnostics
 
-1. **Chat history replay is still O(events x messages) in practice.**
-   `applyViewingMissionWithEvents` replays every stored event through `handleStreamEvent`. Inside the replay, several event cases call `messages.contains`, `messages.firstIndex`, `messages.lastIndex`, and `messages.removeAll`. On long missions this becomes the dominant CPU path after the network snapshot returns.
+1. **Fixed: historical chat replay no longer replays through UI state.**
+   `applyViewingMissionWithEvents` now uses `ChatHistoryReducer.reduce(events:mission:)`, which builds `[ChatMessage]` in a pure pass with indexed ids/tool calls/text-op buffers and assigns `messages` once. Live tail deltas still use `handleStreamEvent`, which is acceptable because those batches are small.
 
-2. **Assistant markdown is reparsed in SwiftUI body.**
-   `MarkdownView.body` calls `MarkdownParser.parse(content)` every time SwiftUI evaluates the row. Large assistant messages, tables, code blocks, and image-rich responses can repeatedly pay regex + line parser + `AttributedString(markdown:)` costs. The new `markdown.parse` signpost should confirm this during scroll and mission load.
+2. **Fixed: assistant markdown parsing is cached.**
+   `MarkdownView` caches block parsing and inline attributed text by content hash. Cache misses still emit `markdown.parse` timing when Control Diagnostics is enabled.
 
-3. **Hot redraws are likely row-wide, not cell-local.**
-   `MessageBubble` receives full `ChatMessage` values and the parent view owns many unrelated `@State` values. State changes such as polling, queue count, copied id, connection status, diagnostics overlay updates, and running missions can cause visible chat rows to re-evaluate. The render probes will show whether `MessageBubble`/`MarkdownView` counts rise when unrelated toolbar or polling state changes.
+3. **Fixed: chat rows have a narrower render boundary.**
+   The conversation rows now live in `ConversationRowsView`, which receives only grouped items, copy/retry closures, and tool expansion state. Further row-level `Equatable` models are an optional follow-up if Instruments shows redraws from unrelated parent state.
 
 4. **The diagnostics overlay itself is intentionally debug-only but can perturb results.**
    When enabled, body probes mutate an in-memory counter and `markdown.parse` timing wraps parsing. Use it to identify suspicious paths, then confirm with Instruments signposts with the overlay hidden.
 
-5. **Mission switching has good cache-first behavior but still performs main-actor decode/replay.**
-   Cached mission data is read and decoded synchronously before render. This is good for perceived latency when files are small, but large cached missions still consume main-thread time before the first interactive frame.
+5. **Fixed: large mission cache decode moves off the first render.**
+   Small cache files keep the synchronous fast path. Cache files above the threshold are decoded in a detached task and applied only if they are still relevant and not older than an already-applied snapshot.
 
 6. **Running-mission and child-mission polling can still invalidate ControlView regularly.**
    The code already backs off on failures and gates child-mission fetches, but successful 5-second polling mutates `runningMissions` on the parent view. This can drive redraws in the chat subtree unless the chat list is isolated from polling state.
 
-7. **History, Files, and Settings perform sorted/filter computed properties in view render paths.**
-   Examples:
-   - `HistoryView.filteredMissions`
-   - `FilesView.sortedEntries`
-   - mission switcher/search helpers in `ControlView`
-   These are probably fine for small lists but should be measured if the whole app feels sluggish outside chat.
+7. **Fixed: list sorting/filtering is memoized outside body.**
+   `HistoryView.filteredMissions`, `FilesView.sortedEntries`, and mission switcher running/recent/search sections are now state-backed and recomputed when their inputs change.
 
-8. **Inline/shared image loading has no explicit memory cache.**
-   Inline markdown images and shared file images hold decoded `Data` in row state. Rows recreated during navigation or identity changes can refetch/redecode images. Use Instruments Allocations + Network to confirm when image-heavy chats are slow.
+8. **Fixed: inline/shared images use a memory cache and downsampling.**
+   `ImageMemoryCache` stores decoded images by URL and downscales large images off the main actor before SwiftUI renders them.
 
-9. **Timers in row/sheet components can contribute to unnecessary invalidations.**
-   Several control subviews start timers on appear for durations/progress. If many tool rows are visible, timer-driven body refreshes can stack. Render probes around `ToolGroupView` help detect this.
+9. **Fixed enough: row timers are scoped to visible active work.**
+   Tool/thinking timers only start after the row appears, only run while the tool/thought is active, and cancel on disappear/completion. A shared elapsed-time ticker is not needed unless future profiling shows many simultaneously active rows.
 
 ## Recommended Fixes
 
-1. **Replace replay-through-UI-state with a pure reducer.**
+1. **Done: replace replay-through-UI-state with a pure reducer.**
    Build `[ChatMessage]` from `[StoredEvent]` in a pure function using dictionaries/sets for ids (`messageById`, `toolById`, active thinking id). Assign `messages` once at the end. This removes repeated array scans and avoids transient SwiftUI invalidations during replay.
 
-2. **Cache parsed markdown per message id/content hash.**
+2. **Done: cache parsed markdown per content hash.**
    Move markdown parsing out of `body`, or introduce a `ParsedMarkdown` cache keyed by message id + content hash. For streaming content, debounce parsing to frame cadence or parse only the active message incrementally.
 
-3. **Isolate chat list state from toolbar/polling state.**
+3. **Done: isolate chat list state from toolbar/polling state.**
    Extract the conversation list into a small view model or child view that only receives `groupedItems`, copy/retry closures, and scroll state. Keep `runningMissions`, queue polling, sheets, and toolbar state out of the row subtree.
 
-4. **Track rendered message ids during replay.**
+4. **Done: track rendered message ids during replay.**
    Even before a full reducer refactor, maintain a temporary `Set<String>` during historical replay so duplicate checks are O(1) instead of `messages.contains`.
 
-5. **Move cache decode off the first render when the cache file is large.**
+5. **Done: move cache decode off the first render when the cache file is large.**
    For cache files over a small threshold, render the skeleton immediately and decode in a background task, then publish the decoded snapshot. Keep the current sync fast path for small cache files.
 
-6. **Memoize sorted/filter lists outside view bodies.**
+6. **Done: memoize sorted/filter lists outside view bodies.**
    For History, Files, and mission switcher/search, compute sorted/filter outputs when source arrays or query/filter settings change, not every `body` evaluation.
 
-7. **Use `EquatableView` or narrower Equatable row models for chat rows.**
+7. **Optional follow-up: use `EquatableView` or narrower Equatable row models for chat rows.**
    Make visible rows skip body work when unrelated state changes. This is especially important for assistant rows with expensive markdown.
 
-8. **Add image cache and downsampling.**
+8. **Done: add image cache and downsampling.**
    Use `URLCache`/`NSCache` keyed by resolved download URL and downsample large images before storing in SwiftUI state. This should reduce both network repeat work and memory spikes.
 
-9. **Run the three trace templates on a configured simulator session.**
-   After CoreSimulator launch is healthy, capture:
-   - SwiftUI: body invalidation and diffing hot spots.
-   - Time Profiler: reducer/replay/markdown CPU cost.
-   - Animation Hitches: chat load and scroll frame drops.
+9. **Done with current simulator limits: run trace templates on a configured simulator session.**
+   All three requested templates were run against a booted iPhone 16 simulator. SwiftUI and Animation Hitches are unsupported by this simulator/runtime; Time Profiler launches but does not stop cleanly from `xctrace` here. Use a physical device for complete trace data.

--- a/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
+++ b/ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md
@@ -1,0 +1,155 @@
+# iOS Performance Diagnostics
+
+Date: 2026-05-25
+
+## Instrumentation Added
+
+- `SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift`
+  - Adds `Logger` + `OSSignposter` under subsystem `md.thomas.openagent.dashboard`, category `ControlPerformance`.
+  - Records recent slow operations and hot SwiftUI body render counts while the in-app diagnostics overlay is enabled.
+- `SandboxedDashboard/Views/Control/ControlView.swift`
+  - Existing **Control Diagnostics** menu toggle now also reports slowest measured operation and hottest body render probes.
+  - Signposted/timed paths:
+    - `control.fetch_snapshot`
+    - `control.fetch_current_snapshot`
+    - `control.fetch_reload_snapshot`
+    - `control.fetch_switch_snapshot`
+    - `control.fetch_refresh_snapshot`
+    - `control.fetch_earlier`
+    - `control.fetch_delta`
+    - `control.apply_snapshot`
+    - `control.sort_remember_events`
+    - `control.replay_events`
+    - `control.apply_delta`
+    - `control.group_messages`
+  - Body render probes:
+    - `MessageBubble`
+    - `ToolGroupView`
+    - `MarkdownView`
+- `SandboxedDashboard/Views/Components/MarkdownView.swift`
+  - Adds `markdown.parse` timing when Control Diagnostics is enabled.
+- `SandboxedDashboard/Services/APIService.swift`
+  - Adds whole-app request and decode timing for every JSON API call:
+    - `api.request`
+    - `api.decode`
+  - This covers Control, History, Files, Settings, Workspaces, and other views using `APIService`.
+
+## Simulator / Instruments Notes
+
+Validated locally:
+
+```bash
+xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj \
+  -scheme SandboxedDashboard \
+  -destination 'generic/platform=iOS Simulator' \
+  build
+```
+
+Result: build succeeded. Existing warning remains in `APIService.swift` about generic `T.Type` Sendability; it is unrelated to the diagnostics patch.
+
+Simulator work:
+
+```bash
+xcrun simctl create OpenAgentPerf \
+  'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro' \
+  'com.apple.CoreSimulator.SimRuntime.iOS-26-4'
+xcrun simctl boot <device-id>
+xcrun simctl bootstatus <device-id> -b
+```
+
+The simulator booted, but `simctl launch` and `simctl listapps` hung after install on this CoreSimulator instance. That blocked a complete automated trace capture in this run. The app now emits signposts usable from Instruments once the simulator can launch the app:
+
+```bash
+xcrun xctrace record \
+  --template 'SwiftUI' \
+  --device <device-id> \
+  --launch md.thomas.openagent.dashboard \
+  --time-limit 30s \
+  --output /tmp/SandboxedDashboard-SwiftUI.trace
+
+xcrun xctrace record \
+  --template 'Time Profiler' \
+  --device <device-id> \
+  --launch md.thomas.openagent.dashboard \
+  --time-limit 30s \
+  --output /tmp/SandboxedDashboard-TimeProfiler.trace
+
+xcrun xctrace record \
+  --template 'Animation Hitches' \
+  --device <device-id> \
+  --launch md.thomas.openagent.dashboard \
+  --time-limit 30s \
+  --output /tmp/SandboxedDashboard-Hitches.trace
+```
+
+In Console/Instruments, filter for:
+
+```text
+subsystem == "md.thomas.openagent.dashboard"
+category == "ControlPerformance"
+```
+
+## Diagnostics
+
+1. **Chat history replay is still O(events x messages) in practice.**
+   `applyViewingMissionWithEvents` replays every stored event through `handleStreamEvent`. Inside the replay, several event cases call `messages.contains`, `messages.firstIndex`, `messages.lastIndex`, and `messages.removeAll`. On long missions this becomes the dominant CPU path after the network snapshot returns.
+
+2. **Assistant markdown is reparsed in SwiftUI body.**
+   `MarkdownView.body` calls `MarkdownParser.parse(content)` every time SwiftUI evaluates the row. Large assistant messages, tables, code blocks, and image-rich responses can repeatedly pay regex + line parser + `AttributedString(markdown:)` costs. The new `markdown.parse` signpost should confirm this during scroll and mission load.
+
+3. **Hot redraws are likely row-wide, not cell-local.**
+   `MessageBubble` receives full `ChatMessage` values and the parent view owns many unrelated `@State` values. State changes such as polling, queue count, copied id, connection status, diagnostics overlay updates, and running missions can cause visible chat rows to re-evaluate. The render probes will show whether `MessageBubble`/`MarkdownView` counts rise when unrelated toolbar or polling state changes.
+
+4. **The diagnostics overlay itself is intentionally debug-only but can perturb results.**
+   When enabled, body probes mutate an in-memory counter and `markdown.parse` timing wraps parsing. Use it to identify suspicious paths, then confirm with Instruments signposts with the overlay hidden.
+
+5. **Mission switching has good cache-first behavior but still performs main-actor decode/replay.**
+   Cached mission data is read and decoded synchronously before render. This is good for perceived latency when files are small, but large cached missions still consume main-thread time before the first interactive frame.
+
+6. **Running-mission and child-mission polling can still invalidate ControlView regularly.**
+   The code already backs off on failures and gates child-mission fetches, but successful 5-second polling mutates `runningMissions` on the parent view. This can drive redraws in the chat subtree unless the chat list is isolated from polling state.
+
+7. **History, Files, and Settings perform sorted/filter computed properties in view render paths.**
+   Examples:
+   - `HistoryView.filteredMissions`
+   - `FilesView.sortedEntries`
+   - mission switcher/search helpers in `ControlView`
+   These are probably fine for small lists but should be measured if the whole app feels sluggish outside chat.
+
+8. **Inline/shared image loading has no explicit memory cache.**
+   Inline markdown images and shared file images hold decoded `Data` in row state. Rows recreated during navigation or identity changes can refetch/redecode images. Use Instruments Allocations + Network to confirm when image-heavy chats are slow.
+
+9. **Timers in row/sheet components can contribute to unnecessary invalidations.**
+   Several control subviews start timers on appear for durations/progress. If many tool rows are visible, timer-driven body refreshes can stack. Render probes around `ToolGroupView` help detect this.
+
+## Recommended Fixes
+
+1. **Replace replay-through-UI-state with a pure reducer.**
+   Build `[ChatMessage]` from `[StoredEvent]` in a pure function using dictionaries/sets for ids (`messageById`, `toolById`, active thinking id). Assign `messages` once at the end. This removes repeated array scans and avoids transient SwiftUI invalidations during replay.
+
+2. **Cache parsed markdown per message id/content hash.**
+   Move markdown parsing out of `body`, or introduce a `ParsedMarkdown` cache keyed by message id + content hash. For streaming content, debounce parsing to frame cadence or parse only the active message incrementally.
+
+3. **Isolate chat list state from toolbar/polling state.**
+   Extract the conversation list into a small view model or child view that only receives `groupedItems`, copy/retry closures, and scroll state. Keep `runningMissions`, queue polling, sheets, and toolbar state out of the row subtree.
+
+4. **Track rendered message ids during replay.**
+   Even before a full reducer refactor, maintain a temporary `Set<String>` during historical replay so duplicate checks are O(1) instead of `messages.contains`.
+
+5. **Move cache decode off the first render when the cache file is large.**
+   For cache files over a small threshold, render the skeleton immediately and decode in a background task, then publish the decoded snapshot. Keep the current sync fast path for small cache files.
+
+6. **Memoize sorted/filter lists outside view bodies.**
+   For History, Files, and mission switcher/search, compute sorted/filter outputs when source arrays or query/filter settings change, not every `body` evaluation.
+
+7. **Use `EquatableView` or narrower Equatable row models for chat rows.**
+   Make visible rows skip body work when unrelated state changes. This is especially important for assistant rows with expensive markdown.
+
+8. **Add image cache and downsampling.**
+   Use `URLCache`/`NSCache` keyed by resolved download URL and downsample large images before storing in SwiftUI state. This should reduce both network repeat work and memory spikes.
+
+9. **Run the three trace templates on a configured simulator session.**
+   After CoreSimulator launch is healthy, capture:
+   - SwiftUI: body invalidation and diffing hot spots.
+   - Time Profiler: reducer/replay/markdown CPU cost.
+   - Animation Hitches: chat load and scroll frame drops.

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		3A706E457E3E27DA1B69E152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 750C4C8090EAD0168794EEE4 /* Assets.xcassets */; };
 		40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */; };
 		43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */; };
+		43B4C0909D841043B1413176 /* ChatHistoryReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C08F9D841043B1413176 /* ChatHistoryReducer.swift */; };
+		43B4C0929D841043B1413176 /* ImageMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C0919D841043B1413176 /* ImageMemoryCache.swift */; };
 		46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7559F3F4553AD74130B1BC34 /* ModelTests.swift */; };
 		48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC2B6E9848FF220F103DED2 /* LoadingView.swift */; };
 		4A639CAB6EE0ED8079A721C2 /* ToolUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF491A4406AFF7E284592477 /* ToolUIView.swift */; };
@@ -90,6 +92,8 @@
 		3B74AB5DF6829813AE79229D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamService.swift; sourceTree = "<group>"; };
 		43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPerformanceDiagnostics.swift; sourceTree = "<group>"; };
+		43B4C08F9D841043B1413176 /* ChatHistoryReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryReducer.swift; sourceTree = "<group>"; };
+		43B4C0919D841043B1413176 /* ImageMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageMemoryCache.swift; sourceTree = "<group>"; };
 		4802677F01F1504267EC2BE2 /* SandboxedDashboardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SandboxedDashboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEntry.swift; sourceTree = "<group>"; };
 		4CC2B6E9848FF220F103DED2 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -206,6 +210,7 @@
 				43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */,
 				3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */,
 				8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */,
+				43B4C0919D841043B1413176 /* ImageMemoryCache.swift */,
 				EB3EDA65C036030CC45BAD0E /* NavigationState.swift */,
 				EFD2C112534D498211B26C38 /* NetworkMonitor.swift */,
 				6922E2F0E17EDB3A8400D473 /* TerminalState.swift */,
@@ -291,6 +296,7 @@
 				7BF62094FF29193B33EC7009 /* Automation.swift */,
 				CAC389FA8B9B5C969E606A22 /* Backend.swift */,
 				370F364BA05D1236D9B630AB /* ChatMessage.swift */,
+				43B4C08F9D841043B1413176 /* ChatHistoryReducer.swift */,
 				CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */,
 				492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */,
 				0C6DBBABC4AE0FD4368A185C /* Mission.swift */,
@@ -426,11 +432,13 @@
 				D5968B6DE2272A9C8C3A4A0E /* AutomationsView.swift in Sources */,
 				F6B883AB96DE0FFF99A2A614 /* Backend.swift in Sources */,
 				BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */,
+				43B4C0909D841043B1413176 /* ChatHistoryReducer.swift in Sources */,
 				B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */,
 				66E208F9D4759B79ED653374 /* ContentView.swift in Sources */,
 				43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */,
 				5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */,
 				B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */,
+				43B4C0929D841043B1413176 /* ImageMemoryCache.swift in Sources */,
 				8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */,
 				50EBDCFBA58915481F5EC995 /* FidoApprovalOverlay.swift in Sources */,
 				D057B578B2884C4B2B36B1C3 /* FidoApprovalState.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */; };
 		3A706E457E3E27DA1B69E152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 750C4C8090EAD0168794EEE4 /* Assets.xcassets */; };
 		40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */; };
+		43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */; };
 		46420BF679A3BD9FD381FB0A /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7559F3F4553AD74130B1BC34 /* ModelTests.swift */; };
 		48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC2B6E9848FF220F103DED2 /* LoadingView.swift */; };
 		4A639CAB6EE0ED8079A721C2 /* ToolUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF491A4406AFF7E284592477 /* ToolUIView.swift */; };
@@ -88,6 +89,7 @@
 		384691169D9EC024B03AA57F /* WorkspacesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesView.swift; sourceTree = "<group>"; };
 		3B74AB5DF6829813AE79229D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamService.swift; sourceTree = "<group>"; };
+		43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPerformanceDiagnostics.swift; sourceTree = "<group>"; };
 		4802677F01F1504267EC2BE2 /* SandboxedDashboardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SandboxedDashboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEntry.swift; sourceTree = "<group>"; };
 		4CC2B6E9848FF220F103DED2 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				D9E023EEFFFA9B1092B66006 /* ANSIParser.swift */,
 				55F4658A2D65748FC7AC5DE3 /* APIService.swift */,
 				F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */,
+				43B4C08D9D841043B1413176 /* ControlPerformanceDiagnostics.swift */,
 				3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */,
 				8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */,
 				EB3EDA65C036030CC45BAD0E /* NavigationState.swift */,
@@ -425,6 +428,7 @@
 				BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */,
 				B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */,
 				66E208F9D4759B79ED653374 /* ContentView.swift in Sources */,
+				43B4C08E9D841043B1413176 /* ControlPerformanceDiagnostics.swift in Sources */,
 				5D1FB1BE4D58CC95A500B684 /* ControlView.swift in Sources */,
 				B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */,
 				8573A897FBBC1697AE1AA7BA /* DesktopStreamView.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
@@ -8,13 +8,22 @@
 import Foundation
 
 enum ChatHistoryReducer {
+    struct ReplayResult {
+        let messages: [ChatMessage]
+        let textOpBuffers: [String: String]
+    }
+
     static func reduce(events: [StoredEvent], mission: Mission) -> [ChatMessage] {
+        reduceWithState(events: events, mission: mission).messages
+    }
+
+    static func reduceWithState(events: [StoredEvent], mission: Mission) -> ReplayResult {
         var state = State(mission: mission)
         for event in ordered(events) {
             state.apply(event)
         }
         state.finalizeActiveToolCalls(withState: .success)
-        return state.messages
+        return ReplayResult(messages: state.messages, textOpBuffers: state.textOpBuffers)
     }
 
     private static func ordered(_ events: [StoredEvent]) -> [StoredEvent] {
@@ -31,6 +40,7 @@ enum ChatHistoryReducer {
         var messageIds = Set<String>()
         var toolMessageIndexByCallId: [String: Int] = [:]
         var textOpBuffers: [String: String] = [:]
+        private let streamingThoughtPrefix = "stream-thinking-"
 
         mutating func apply(_ event: StoredEvent) {
             var data = event.metadata.mapValues(\.value)
@@ -257,7 +267,14 @@ enum ChatHistoryReducer {
             textOpBuffers[bubbleId] = finalized ? nil : content
             guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             removePhaseMessages()
-            let id = "stream-thinking-\(bubbleId)"
+
+            if let activeRealThought = messages.last(where: {
+                $0.isThinking && !$0.thinkingDone && !$0.id.hasPrefix(streamingThoughtPrefix)
+            }), !activeRealThought.content.isEmpty {
+                return
+            }
+
+            let id = "\(streamingThoughtPrefix)\(bubbleId)"
             if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone && $0.id == id }) {
                 messages[index] = ChatMessage(
                     id: id,

--- a/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/ChatHistoryReducer.swift
@@ -1,0 +1,347 @@
+//
+//  ChatHistoryReducer.swift
+//  SandboxedDashboard
+//
+//  Pure reducer for stored mission events -> chat messages.
+//
+
+import Foundation
+
+enum ChatHistoryReducer {
+    static func reduce(events: [StoredEvent], mission: Mission) -> [ChatMessage] {
+        var state = State(mission: mission)
+        for event in ordered(events) {
+            state.apply(event)
+        }
+        state.finalizeActiveToolCalls(withState: .success)
+        return state.messages
+    }
+
+    private static func ordered(_ events: [StoredEvent]) -> [StoredEvent] {
+        events.sorted { lhs, rhs in
+            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
+            return lhs.id < rhs.id
+        }
+    }
+
+    private struct State {
+        let mission: Mission
+        var messages: [ChatMessage] = []
+        var messageIds = Set<String>()
+        var toolMessageIndexByCallId: [String: Int] = [:]
+        var textOpBuffers: [String: String] = [:]
+
+        mutating func apply(_ event: StoredEvent) {
+            var data = event.metadata.mapValues(\.value)
+            data["mission_id"] = event.missionId
+            data["content"] = event.content
+            if let eventId = event.eventId { data["id"] = eventId }
+            if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
+            if let toolName = event.toolName { data["name"] = toolName }
+            if event.eventType == "text_op",
+               let jsonData = event.content.data(using: .utf8),
+               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
+                data["ops"] = ops
+            }
+
+            switch event.eventType {
+            case "user_message":
+                applyUser(data)
+            case "assistant_message", "assistant_message_canonical":
+                applyAssistant(data)
+            case "thinking":
+                applyThinking(data, fallbackId: "thinking-\(event.id)")
+            case "text_op":
+                applyTextOp(data)
+            case "agent_phase":
+                applyPhase(data, fallbackId: "phase-\(event.id)")
+            case "tool_call":
+                applyToolCall(data)
+            case "tool_result":
+                applyToolResult(data)
+            default:
+                break
+            }
+        }
+
+        private mutating func append(_ message: ChatMessage) {
+            guard !messageIds.contains(message.id) else { return }
+            messageIds.insert(message.id)
+            messages.append(message)
+        }
+
+        private mutating func removePhaseMessages() {
+            messages.removeAll { message in
+                guard message.isPhase else { return false }
+                messageIds.remove(message.id)
+                return true
+            }
+            rebuildToolIndex()
+        }
+
+        private mutating func rebuildToolIndex() {
+            toolMessageIndexByCallId.removeAll(keepingCapacity: true)
+            for (index, message) in messages.enumerated() where message.isToolCall {
+                let key = message.toolData?.toolCallId ?? message.id.replacingOccurrences(of: "tool-", with: "")
+                toolMessageIndexByCallId[key] = index
+            }
+        }
+
+        private mutating func finalizeActiveThinkingMessages() {
+            for index in messages.indices where messages[index].isThinking && !messages[index].thinkingDone {
+                let existing = messages[index]
+                messages[index] = ChatMessage(
+                    id: existing.id,
+                    type: .thinking(done: true, startTime: existing.thinkingStartTime ?? existing.timestamp),
+                    content: existing.content,
+                    toolUI: existing.toolUI,
+                    toolData: existing.toolData,
+                    timestamp: existing.timestamp
+                )
+            }
+        }
+
+        mutating func finalizeActiveToolCalls(withState state: ToolCallState) {
+            for index in messages.indices where messages[index].isToolCall && messages[index].isActiveToolCall {
+                guard var toolData = messages[index].toolData else { continue }
+                toolData.endTime = toolData.endTime ?? messages[index].timestamp
+                if toolData.result == nil || state == .cancelled {
+                    toolData.state = state
+                }
+                messages[index] = ChatMessage(
+                    id: messages[index].id,
+                    type: .toolCall(name: toolData.name, isActive: false),
+                    content: messages[index].content,
+                    toolData: toolData,
+                    timestamp: messages[index].timestamp
+                )
+            }
+        }
+
+        private mutating func applyUser(_ data: [String: Any]) {
+            guard let id = data["id"] as? String else { return }
+            let content = data["content"] as? String ?? ""
+            if let index = messages.firstIndex(where: { $0.id == id }) {
+                messages[index].sendState = .sent
+                messages[index].content = content
+            } else {
+                finalizeActiveThinkingMessages()
+                append(ChatMessage(id: id, type: .user, content: content))
+            }
+        }
+
+        private mutating func applyAssistant(_ data: [String: Any]) {
+            guard let id = data["id"] as? String, !messageIds.contains(id) else { return }
+            finalizeActiveThinkingMessages()
+            removePhaseMessages()
+            finalizeActiveToolCalls(withState: .success)
+
+            let success = data["success"] as? Bool ?? true
+            let costObj = data["cost"] as? [String: Any]
+            let costCents = data["cost_cents"] as? Int
+                ?? costObj?["amount_cents"] as? Int
+                ?? 0
+            let costSource = (data["cost_source"] as? String ?? costObj?["source"] as? String)
+                .flatMap(CostSource.init(rawValue:)) ?? .unknown
+            let model = data["model"] as? String
+            append(
+                ChatMessage(
+                    id: id,
+                    type: .assistant(
+                        success: success,
+                        costCents: costCents,
+                        costSource: costSource,
+                        model: model,
+                        sharedFiles: parseSharedFiles(data["shared_files"])
+                    ),
+                    content: data["content"] as? String ?? ""
+                )
+            )
+        }
+
+        private func parseSharedFiles(_ value: Any?) -> [SharedFile]? {
+            guard let filesArray = value as? [[String: Any]] else { return nil }
+            return filesArray.compactMap { fileData in
+                guard let name = fileData["name"] as? String,
+                      let url = fileData["url"] as? String,
+                      let contentType = fileData["content_type"] as? String,
+                      let kindString = fileData["kind"] as? String,
+                      let kind = SharedFileKind(rawValue: kindString) else {
+                    return nil
+                }
+                return SharedFile(
+                    name: name,
+                    url: url,
+                    contentType: contentType,
+                    sizeBytes: fileData["size_bytes"] as? Int,
+                    kind: kind
+                )
+            }
+        }
+
+        private mutating func applyThinking(_ data: [String: Any], fallbackId: String) {
+            let content = data["content"] as? String ?? ""
+            let done = data["done"] as? Bool ?? false
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                if done { finalizeActiveThinkingMessages() }
+                return
+            }
+
+            if done, data["goal_role"] as? String == "deliverable", mission.goalMode {
+                let baseId = data["id"] as? String ?? fallbackId
+                let id = "goal-deliverable-\(baseId)"
+                guard !messageIds.contains(id) else { return }
+                finalizeActiveThinkingMessages()
+                removePhaseMessages()
+                append(
+                    ChatMessage(
+                        id: id,
+                        type: .assistant(success: true, costCents: 0, costSource: .unknown, model: nil, sharedFiles: nil),
+                        content: content
+                    )
+                )
+                return
+            }
+
+            if let id = data["id"] as? String, messageIds.contains(id) { return }
+            removePhaseMessages()
+
+            if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
+                let existing = messages[index]
+                messages[index] = ChatMessage(
+                    id: existing.id,
+                    type: .thinking(done: done, startTime: existing.thinkingStartTime ?? existing.timestamp),
+                    content: content,
+                    toolUI: existing.toolUI,
+                    toolData: existing.toolData,
+                    timestamp: existing.timestamp
+                )
+            } else {
+                append(
+                    ChatMessage(
+                        id: data["id"] as? String ?? fallbackId,
+                        type: .thinking(done: done, startTime: Date()),
+                        content: content
+                    )
+                )
+            }
+        }
+
+        private mutating func applyTextOp(_ data: [String: Any]) {
+            let bubbleId = data["bubble_id"] as? String ?? "text-op-latest"
+            let ops = data["ops"] as? [[String: Any]] ?? []
+            var content = textOpBuffers[bubbleId] ?? ""
+            var finalized = false
+
+            for op in ops {
+                switch op["type"] as? String {
+                case "insert":
+                    let pos = min(max(op["pos"] as? Int ?? content.count, 0), content.count)
+                    let index = content.index(content.startIndex, offsetBy: pos)
+                    content.insert(contentsOf: op["text"] as? String ?? "", at: index)
+                case "replace":
+                    let range = op["range"] as? [Int] ?? []
+                    let start = min(max(range.first ?? 0, 0), content.count)
+                    let end = min(max(range.dropFirst().first ?? content.count, start), content.count)
+                    let startIndex = content.index(content.startIndex, offsetBy: start)
+                    let endIndex = content.index(content.startIndex, offsetBy: end)
+                    content.replaceSubrange(startIndex..<endIndex, with: op["text"] as? String ?? "")
+                case "finalize":
+                    finalized = true
+                default:
+                    continue
+                }
+            }
+
+            textOpBuffers[bubbleId] = finalized ? nil : content
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            removePhaseMessages()
+            let id = "stream-thinking-\(bubbleId)"
+            if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone && $0.id == id }) {
+                messages[index] = ChatMessage(
+                    id: id,
+                    type: .thinking(done: finalized, startTime: messages[index].thinkingStartTime ?? messages[index].timestamp),
+                    content: content,
+                    timestamp: messages[index].timestamp
+                )
+            } else if !messageIds.contains(id) {
+                append(ChatMessage(id: id, type: .thinking(done: finalized, startTime: Date()), content: content))
+            }
+        }
+
+        private mutating func applyPhase(_ data: [String: Any], fallbackId: String) {
+            removePhaseMessages()
+            append(
+                ChatMessage(
+                    id: fallbackId,
+                    type: .phase(
+                        phase: data["phase"] as? String ?? "",
+                        detail: data["detail"] as? String,
+                        agent: data["agent"] as? String
+                    ),
+                    content: ""
+                )
+            )
+        }
+
+        private mutating func applyToolCall(_ data: [String: Any]) {
+            guard let toolCallId = data["tool_call_id"] as? String,
+                  let name = data["name"] as? String,
+                  let args = data["args"] as? [String: Any],
+                  !messageIds.contains(toolCallId),
+                  !messageIds.contains("tool-\(toolCallId)") else { return }
+
+            finalizeActiveThinkingMessages()
+            if let toolUI = ToolUIContent.parse(name: name, args: args) {
+                append(ChatMessage(id: toolCallId, type: .toolUI(name: name), content: "", toolUI: toolUI))
+                return
+            }
+
+            finalizeActiveToolCalls(withState: .success)
+            let message = ChatMessage(
+                id: "tool-\(toolCallId)",
+                type: .toolCall(name: name, isActive: true),
+                content: "",
+                toolData: ToolCallData(
+                    toolCallId: toolCallId,
+                    name: name,
+                    args: args,
+                    startTime: Date(),
+                    endTime: nil,
+                    result: nil,
+                    state: .running
+                )
+            )
+            toolMessageIndexByCallId[toolCallId] = messages.count
+            append(message)
+        }
+
+        private mutating func applyToolResult(_ data: [String: Any]) {
+            guard let toolCallId = data["tool_call_id"] as? String,
+                  let index = toolMessageIndexByCallId[toolCallId],
+                  messages.indices.contains(index),
+                  var toolData = messages[index].toolData else { return }
+
+            let result = data["result"]
+            toolData.endTime = Date()
+            toolData.result = result
+            if let resultDict = result as? [String: Any],
+               resultDict["status"] as? String == "cancelled" {
+                toolData.state = .cancelled
+            } else if toolData.isErrorResult {
+                toolData.state = .error
+            } else {
+                toolData.state = .success
+            }
+
+            messages[index] = ChatMessage(
+                id: messages[index].id,
+                type: .toolCall(name: toolData.name, isActive: false),
+                content: messages[index].content,
+                toolData: toolData,
+                timestamp: messages[index].timestamp
+            )
+        }
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -891,7 +891,13 @@ final class APIService {
     }
 
     private func executeWithResponse<T: Decodable>(_ request: URLRequest) async throws -> (T, HTTPURLResponse) {
-        let (data, response) = try await Self.jsonSession.data(for: request)
+        let requestLabel = "\(request.httpMethod ?? "GET") \(request.url?.path ?? "?")"
+        let (data, response) = try await ControlPerformanceDiagnostics.shared.measureAsync(
+            "api.request",
+            detail: requestLabel
+        ) {
+            try await Self.jsonSession.data(for: request)
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -921,9 +927,15 @@ final class APIService {
         // value is treated as immutable from the moment we ship it back.
         let box: DecodedBox<T>
         do {
-            box = try await Task.detached(priority: .userInitiated) {
-                try DecodedBox(value: JSONDecoder().decode(T.self, from: data))
-            }.value
+            box = try await ControlPerformanceDiagnostics.shared.measureAsync(
+                "api.decode",
+                detail: requestLabel,
+                count: data.count
+            ) {
+                try await Task.detached(priority: .userInitiated) {
+                    try DecodedBox(value: JSONDecoder().decode(T.self, from: data))
+                }.value
+            }
         } catch {
             throw APIError.decodingError(error)
         }

--- a/ios_dashboard/SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/ControlPerformanceDiagnostics.swift
@@ -1,0 +1,138 @@
+//
+//  ControlPerformanceDiagnostics.swift
+//  SandboxedDashboard
+//
+//  Lightweight runtime instrumentation for the Control chat surface.
+//
+
+import Foundation
+import SwiftUI
+import os
+
+@MainActor
+final class ControlPerformanceDiagnostics {
+    static let shared = ControlPerformanceDiagnostics()
+
+    private let logger = Logger(subsystem: "md.thomas.openagent.dashboard", category: "ControlPerformance")
+    private let signposter = OSSignposter(subsystem: "md.thomas.openagent.dashboard", category: "ControlPerformance")
+
+    private var records: [ControlPerformanceRecord] = []
+    private var renderCounts: [String: Int] = [:]
+    private let maxRecords = 24
+
+    private init() {}
+
+    var recentRecords: [ControlPerformanceRecord] {
+        records
+    }
+
+    var hotRenderCounts: [(name: String, count: Int)] {
+        renderCounts
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value { return lhs.value > rhs.value }
+                return lhs.key < rhs.key
+            }
+            .prefix(6)
+            .map { ($0.key, $0.value) }
+    }
+
+    func reset() {
+        records.removeAll(keepingCapacity: true)
+        renderCounts.removeAll(keepingCapacity: true)
+    }
+
+    func recordBodyRender(_ name: String) {
+        renderCounts[name, default: 0] += 1
+    }
+
+    func measure<T>(
+        _ name: StaticString,
+        detail: String = "",
+        count: Int? = nil,
+        operation: () throws -> T
+    ) rethrows -> T {
+        let state = signposter.beginInterval(name)
+        let start = ContinuousClock.now
+        defer {
+            let duration = start.duration(to: ContinuousClock.now)
+            signposter.endInterval(name, state)
+            record(String(describing: name), duration: duration, detail: detail, count: count)
+        }
+        return try operation()
+    }
+
+    func measureAsync<T>(
+        _ name: StaticString,
+        detail: String = "",
+        count: Int? = nil,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        let state = signposter.beginInterval(name)
+        let start = ContinuousClock.now
+        defer {
+            let duration = start.duration(to: ContinuousClock.now)
+            signposter.endInterval(name, state)
+            record(String(describing: name), duration: duration, detail: detail, count: count)
+        }
+        return try await operation()
+    }
+
+    private func record(_ name: String, duration: Duration, detail: String, count: Int?) {
+        let millis = Double(duration.components.seconds) * 1_000
+            + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+
+        let record = ControlPerformanceRecord(
+            name: name,
+            detail: detail,
+            durationMilliseconds: millis,
+            count: count,
+            timestamp: Date()
+        )
+        records.append(record)
+        if records.count > maxRecords {
+            records.removeFirst(records.count - maxRecords)
+        }
+
+        if millis >= 16 {
+            logger.warning("\(name, privacy: .public) took \(millis, format: .fixed(precision: 1), privacy: .public) ms count=\(count ?? -1, privacy: .public) \(detail, privacy: .public)")
+        } else {
+            logger.debug("\(name, privacy: .public) took \(millis, format: .fixed(precision: 1), privacy: .public) ms count=\(count ?? -1, privacy: .public) \(detail, privacy: .public)")
+        }
+    }
+}
+
+struct ControlPerformanceRecord: Identifiable, Equatable {
+    let id = UUID()
+    let name: String
+    let detail: String
+    let durationMilliseconds: Double
+    let count: Int?
+    let timestamp: Date
+
+    var compactDuration: String {
+        String(format: "%.1f ms", durationMilliseconds)
+    }
+}
+
+private struct ControlPerformanceDiagnosticsEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var controlPerformanceDiagnosticsEnabled: Bool {
+        get { self[ControlPerformanceDiagnosticsEnabledKey.self] }
+        set { self[ControlPerformanceDiagnosticsEnabledKey.self] = newValue }
+    }
+}
+
+struct ControlBodyRenderProbe: ViewModifier {
+    @Environment(\.controlPerformanceDiagnosticsEnabled) private var enabled
+    let name: String
+
+    func body(content: Content) -> some View {
+        if enabled {
+            ControlPerformanceDiagnostics.shared.recordBodyRender(name)
+        }
+        return content
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Services/ImageMemoryCache.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/ImageMemoryCache.swift
@@ -1,0 +1,76 @@
+//
+//  ImageMemoryCache.swift
+//  SandboxedDashboard
+//
+//  Shared image cache/downsampler for chat image previews.
+//
+
+import Foundation
+import ImageIO
+import UIKit
+
+@MainActor
+final class ImageMemoryCache {
+    static let shared = ImageMemoryCache()
+
+    private final class Entry {
+        let image: UIImage
+
+        init(image: UIImage) {
+            self.image = image
+        }
+    }
+
+    private struct ImageBox: @unchecked Sendable {
+        let image: UIImage
+    }
+
+    private let cache = NSCache<NSURL, Entry>()
+
+    private init() {
+        cache.countLimit = 120
+        cache.totalCostLimit = 48 * 1_024 * 1_024
+    }
+
+    func cachedImage(for url: URL) -> UIImage? {
+        cache.object(forKey: url as NSURL)?.image
+    }
+
+    func store(_ image: UIImage, for url: URL) {
+        let pixels = Int(image.size.width * image.scale * image.size.height * image.scale)
+        cache.setObject(Entry(image: image), forKey: url as NSURL, cost: pixels * 4)
+    }
+
+    func image(from data: Data, url: URL, maxPixelSize: CGFloat = 900) async -> UIImage? {
+        if let cached = cachedImage(for: url) {
+            return cached
+        }
+
+        let box = await Task.detached(priority: .userInitiated) {
+            ImageBox(image: Self.downsample(data: data, maxPixelSize: maxPixelSize) ?? UIImage(data: data) ?? UIImage())
+        }.value
+        guard box.image.size != .zero else { return nil }
+        store(box.image, for: url)
+        return box.image
+    }
+
+    nonisolated private static func downsample(data: Data, maxPixelSize: CGFloat) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceShouldCache: false
+        ]
+        guard let source = CGImageSourceCreateWithData(data as CFData, options as CFDictionary) else {
+            return nil
+        }
+
+        let downsampleOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, downsampleOptions as CFDictionary) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
@@ -37,21 +37,17 @@ extension EnvironmentValues {
 struct MarkdownView: View {
     let content: String
     @Environment(\.controlPerformanceDiagnosticsEnabled) private var diagnosticsEnabled
+    private static let parseCache = MarkdownParseCache()
 
     init(_ content: String) {
         self.content = content
     }
 
     var body: some View {
-        let blocks = diagnosticsEnabled
-            ? ControlPerformanceDiagnostics.shared.measure(
-                "markdown.parse",
-                detail: "\(content.count) chars",
-                count: content.count
-            ) {
-                MarkdownParser.parse(content)
-            }
-            : MarkdownParser.parse(content)
+        let blocks = Self.parseCache.blocks(
+            for: content,
+            diagnosticsEnabled: diagnosticsEnabled
+        )
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 switch block {
@@ -86,6 +82,75 @@ struct MarkdownView: View {
     }
 }
 
+@MainActor
+private final class MarkdownParseCache {
+    private final class Entry {
+        let blocks: [MarkdownBlock]
+
+        init(blocks: [MarkdownBlock]) {
+            self.blocks = blocks
+        }
+    }
+
+    private let cache = NSCache<NSString, Entry>()
+
+    init() {
+        cache.countLimit = 500
+    }
+
+    func blocks(for content: String, diagnosticsEnabled: Bool) -> [MarkdownBlock] {
+        let key = "\(content.count):\(content.hashValue)" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached.blocks
+        }
+
+        let parsed = diagnosticsEnabled
+            ? ControlPerformanceDiagnostics.shared.measure(
+                "markdown.parse",
+                detail: "\(content.count) chars",
+                count: content.count
+            ) {
+                MarkdownParser.parse(content)
+            }
+            : MarkdownParser.parse(content)
+        cache.setObject(Entry(blocks: parsed), forKey: key)
+        return parsed
+    }
+}
+
+@MainActor
+private final class MarkdownInlineTextCache {
+    static let shared = MarkdownInlineTextCache()
+
+    private final class Entry {
+        let attributed: AttributedString?
+
+        init(attributed: AttributedString?) {
+            self.attributed = attributed
+        }
+    }
+
+    private let cache = NSCache<NSString, Entry>()
+
+    init() {
+        cache.countLimit = 1_500
+    }
+
+    func attributedString(for content: String) -> AttributedString? {
+        let key = "\(content.count):\(content.hashValue)" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached.attributed
+        }
+
+        let attributed = try? AttributedString(
+            markdown: content,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )
+        cache.setObject(Entry(attributed: attributed), forKey: key)
+        return attributed
+    }
+}
+
 private struct MarkdownInlineText: View {
     let content: String
 
@@ -94,7 +159,7 @@ private struct MarkdownInlineText: View {
     }
 
     var body: some View {
-        if let attributed = try? AttributedString(markdown: content, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+        if let attributed = MarkdownInlineTextCache.shared.attributedString(for: content) {
             Text(attributed)
                 .font(.body)
                 .foregroundStyle(Theme.textPrimary)
@@ -266,7 +331,7 @@ struct MarkdownInlineImageView: View {
 
     var body: some View {
         Group {
-            if let data = imageData, let uiImage = UIImage(data: data) {
+            if let data = imageData, let uiImage = ImageMemoryCache.shared.cachedImage(for: imageCacheURL) ?? UIImage(data: data) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFit()
@@ -304,6 +369,10 @@ struct MarkdownInlineImageView: View {
         .task(id: imageTaskKey) {
             await load()
         }
+    }
+
+    private var imageCacheURL: URL {
+        URL(string: imageTaskKey) ?? URL(fileURLWithPath: imageTaskKey)
     }
 
     /// Key the `.task` view modifier so a context change (workspace/mission
@@ -348,8 +417,9 @@ struct MarkdownInlineImageView: View {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, http.statusCode == 200,
-               UIImage(data: data) != nil {
+               let image = await ImageMemoryCache.shared.image(from: data, url: url) {
                 await MainActor.run {
+                    ImageMemoryCache.shared.store(image, for: imageCacheURL)
                     imageData = data
                     isLoading = false
                 }

--- a/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/MarkdownView.swift
@@ -36,13 +36,22 @@ extension EnvironmentValues {
 
 struct MarkdownView: View {
     let content: String
+    @Environment(\.controlPerformanceDiagnosticsEnabled) private var diagnosticsEnabled
 
     init(_ content: String) {
         self.content = content
     }
 
     var body: some View {
-        let blocks = MarkdownParser.parse(content)
+        let blocks = diagnosticsEnabled
+            ? ControlPerformanceDiagnostics.shared.measure(
+                "markdown.parse",
+                detail: "\(content.count) chars",
+                count: content.count
+            ) {
+                MarkdownParser.parse(content)
+            }
+            : MarkdownParser.parse(content)
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 switch block {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -953,27 +953,13 @@ struct ControlView: View {
                         .disabled(isLoadingEarlier)
                     }
 
-                    ForEach(groupedItems) { item in
-                        switch item {
-                        case .single(let message):
-                            MessageBubble(
-                                message: message,
-                                isCopied: copiedMessageId == message.id,
-                                onCopy: { copyMessage(message) },
-                                onRetry: message.sendState.isFailed ? { retryFailedMessage(message) } : nil
-                            )
-                            .modifier(ControlBodyRenderProbe(name: "MessageBubble"))
-                            .id(message.id)
-                        case .toolGroup(let groupId, let tools):
-                            ToolGroupView(
-                                groupId: groupId,
-                                tools: tools,
-                                expandedGroups: $expandedToolGroups
-                            )
-                            .modifier(ControlBodyRenderProbe(name: "ToolGroupView"))
-                            .id(item.id)
-                        }
-                    }
+                    ConversationRowsView(
+                        groupedItems: groupedItems,
+                        copiedMessageId: copiedMessageId,
+                        expandedToolGroups: $expandedToolGroups,
+                        onCopy: copyMessage,
+                        onRetry: retryFailedMessage
+                    )
 
                     // Show working indicator after messages when this mission is running but no active streaming item
                     if viewingMissionIsRunning && !hasActiveStreamingItem {
@@ -1673,8 +1659,13 @@ struct ControlView: View {
         let cachedAt: Date
     }
 
+    private struct CachedMissionDataBox: @unchecked Sendable {
+        let value: CachedMissionData
+    }
+
     private static let maxCachedMissions = 10  // Limit cache size
     private static let maxCachedEventsPerMission = 1_500
+    private static let maxSynchronousCacheBytes = 256 * 1_024
     /// Legacy key prefix used when mission blobs lived in UserDefaults. Kept
     /// only so the one-time migration below can purge them on first launch
     /// after upgrade — every payload bloats cfprefsd's in-memory plist.
@@ -1848,12 +1839,8 @@ struct ControlView: View {
     }
 
     private func loadCachedMissionData(_ missionId: String) -> CachedMissionData? {
-        // Synchronous read on the call site (cold start) — the file is
-        // bounded by `loadEarlierPageLimit` * StoredEvent size (~few MB
-        // worst case) and decoding it on @MainActor is unavoidable here
-        // because the caller needs the result immediately to render the
-        // first frame. Subsequent caches written in the background.
         guard let url = Self.cacheFileURL(missionId: missionId),
+              Self.cacheFileSize(url: url) <= Self.maxSynchronousCacheBytes,
               let data = try? Data(contentsOf: url),
               let cached = try? JSONDecoder().decode(CachedMissionData.self, from: data) else {
             return nil
@@ -1866,6 +1853,39 @@ struct ControlView: View {
         }
 
         return cached
+    }
+
+    private func loadCachedMissionDataAsync(_ missionId: String) async -> CachedMissionData? {
+        guard let url = Self.cacheFileURL(missionId: missionId) else { return nil }
+        let box = try? await Task.detached(priority: .userInitiated) {
+            let data = try Data(contentsOf: url)
+            let cached = try JSONDecoder().decode(CachedMissionData.self, from: data)
+            return CachedMissionDataBox(value: cached)
+        }.value
+        guard let cached = box?.value else { return nil }
+
+        if var cachedKeys = UserDefaults.standard.stringArray(forKey: Self.cacheKeysKey) {
+            cachedKeys.removeAll { $0 == missionId }
+            cachedKeys.append(missionId)
+            UserDefaults.standard.set(cachedKeys, forKey: Self.cacheKeysKey)
+        }
+        return cached
+    }
+
+    private func scheduleLargeCachedMissionLoad(id: String) {
+        guard let url = Self.cacheFileURL(missionId: id),
+              Self.cacheFileSize(url: url) > Self.maxSynchronousCacheBytes else { return }
+        Task {
+            guard let cached = await loadCachedMissionDataAsync(id) else { return }
+            guard fetchingMissionId == id || viewingMissionId == id else { return }
+            let cachedMaxSeq = cached.events.compactMap(\.sequence).max() ?? 0
+            if let currentMaxSeq = missionMaxSeq[id], currentMaxSeq > cachedMaxSeq {
+                return
+            }
+            controlCacheHit = true
+            controlCacheStale = false
+            applyViewingMissionWithEvents(cached.mission, events: cached.events)
+        }
     }
 
     private func removeMissionFromCache(_ missionId: String) {
@@ -1899,6 +1919,10 @@ struct ControlView: View {
         let safeId = missionId.replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "..", with: "_")
         return dir.appendingPathComponent("\(safeId).json", isDirectory: false)
+    }
+
+    nonisolated private static func cacheFileSize(url: URL) -> Int {
+        (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
     }
 
     nonisolated private static func writeCachedMissionFile(missionId: String, data: Data) throws {
@@ -2009,7 +2033,9 @@ struct ControlView: View {
                 detail: mission.id,
                 count: orderedEvents.count
             ) {
-                messages = ChatHistoryReducer.reduce(events: orderedEvents, mission: mission)
+                let replay = ChatHistoryReducer.reduceWithState(events: orderedEvents, mission: mission)
+                messages = replay.messages
+                textOpBuffers = replay.textOpBuffers
             }
 
             // Recompute grouped items once after all events are processed
@@ -2122,6 +2148,9 @@ struct ControlView: View {
             hasCache = false
             if updateViewing {
                 controlCacheHit = false
+                if let currentId = currentMission?.id ?? viewingMissionId {
+                    scheduleLargeCachedMissionLoad(id: currentId)
+                }
             }
         }
 
@@ -2203,6 +2232,7 @@ struct ControlView: View {
         } else {
             hasCache = false
             controlCacheHit = false
+            scheduleLargeCachedMissionLoad(id: id)
         }
 
         // Only show loading state if we don't have cached data to display
@@ -3230,6 +3260,7 @@ struct ControlView: View {
             controlCacheHit = false
             isLoading = true
             controlCacheStale = false
+            scheduleLargeCachedMissionLoad(id: id)
         }
 
         // Determine the run state for this mission from runningMissions
@@ -4075,6 +4106,40 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     }
 }
 
+// MARK: - Conversation Rows
+
+private struct ConversationRowsView: View {
+    let groupedItems: [GroupedChatItem]
+    let copiedMessageId: String?
+    @Binding var expandedToolGroups: Set<String>
+    let onCopy: (ChatMessage) -> Void
+    let onRetry: (ChatMessage) -> Void
+
+    var body: some View {
+        ForEach(groupedItems) { item in
+            switch item {
+            case .single(let message):
+                MessageBubble(
+                    message: message,
+                    isCopied: copiedMessageId == message.id,
+                    onCopy: { onCopy(message) },
+                    onRetry: message.sendState.isFailed ? { onRetry(message) } : nil
+                )
+                .modifier(ControlBodyRenderProbe(name: "MessageBubble"))
+                .id(message.id)
+            case .toolGroup(let groupId, let tools):
+                ToolGroupView(
+                    groupId: groupId,
+                    tools: tools,
+                    expandedGroups: $expandedToolGroups
+                )
+                .modifier(ControlBodyRenderProbe(name: "ToolGroupView"))
+                .id(item.id)
+            }
+        }
+    }
+}
+
 // MARK: - Message Bubble
 
 private struct MessageBubble: View {
@@ -4331,7 +4396,9 @@ private struct SharedFileCardView: View {
             // skeleton matches the inline rich-image placeholder so the
             // chat feels consistent while either type loads.
             Group {
-                if let data = imageData, let uiImage = UIImage(data: data) {
+                if let url = fullURL,
+                   let data = imageData,
+                   let uiImage = ImageMemoryCache.shared.cachedImage(for: url) ?? UIImage(data: data) {
                     Image(uiImage: uiImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -4462,6 +4529,12 @@ private struct SharedFileCardView: View {
         isLoadingImage = true
         imageLoadFailed = false
 
+        if ImageMemoryCache.shared.cachedImage(for: url) != nil {
+            imageData = Data()
+            isLoadingImage = false
+            return
+        }
+
         do {
             var request = URLRequest(url: url)
             // Bound the per-image fetch to the same window as JSON requests so
@@ -4479,8 +4552,8 @@ private struct SharedFileCardView: View {
             // Check response status
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 200 {
-                    // Validate that the data is actually parseable as an image
-                    if UIImage(data: data) != nil {
+                    // Validate/downsample before storing row state.
+                    if await ImageMemoryCache.shared.image(from: data, url: url) != nil {
                         await MainActor.run {
                             self.imageData = data
                         }
@@ -5419,6 +5492,12 @@ private struct MissionSwitcherSheet: View {
     @State private var backendSearchQuery = ""
     @State private var backendSearchResults: [MissionSearchResult] = []
     @State private var isBackendSearchLoading = false
+    @State private var derivedMissionById: [String: Mission] = [:]
+    @State private var derivedFilteredRunning: [RunningMissionInfo] = []
+    @State private var derivedFilteredRecent: [Mission] = []
+    @State private var derivedOrderedRunning: [RunningRow] = []
+    @State private var derivedJustCompletedMissions: [Mission] = []
+    @State private var derivedRecentMissionsForList: [Mission] = []
 
     private let backendSearchDebounceNanos: UInt64 = 250_000_000
 
@@ -5426,99 +5505,10 @@ private struct MissionSwitcherSheet: View {
         normalizeMetadataText(searchText)
     }
 
-    private var runningMissionIds: Set<String> {
-        Set(runningMissions.map { $0.missionId })
-    }
-
     private func preferredMissionForDuplicateId(_ lhs: Mission, _ rhs: Mission) -> Mission {
         let lhsUpdated = lhs.updatedDate ?? .distantPast
         let rhsUpdated = rhs.updatedDate ?? .distantPast
         return rhsUpdated >= lhsUpdated ? rhs : lhs
-    }
-
-    private var missionById: [String: Mission] {
-        Dictionary(
-            recentMissions.map { ($0.id, $0) },
-            uniquingKeysWith: preferredMissionForDuplicateId
-        )
-    }
-
-    private var filteredRunning: [RunningMissionInfo] {
-        let liveCandidates = runningMissions.filter { info in
-            guard let mission = missionById[info.missionId] else { return true }
-            return !mission.hasFinishedSuccessfully
-        }
-        if normalizedSearchQuery.isEmpty {
-            return liveCandidates
-        }
-        return liveCandidates
-            .compactMap { info -> (RunningMissionInfo, Double)? in
-                let score = runningMissionSearchScore(
-                    info,
-                    query: normalizedSearchQuery,
-                    linkedMission: missionById[info.missionId]
-                )
-                return score > 0 ? (info, score) : nil
-            }
-            .sorted { lhs, rhs in
-                if lhs.1 == rhs.1 {
-                    let lhsUpdated = missionById[lhs.0.missionId]?.updatedDate ?? .distantPast
-                    let rhsUpdated = missionById[rhs.0.missionId]?.updatedDate ?? .distantPast
-                    if lhsUpdated != rhsUpdated {
-                        return lhsUpdated > rhsUpdated
-                    }
-                    return lhs.0.missionId < rhs.0.missionId
-                }
-                return lhs.1 > rhs.1
-            }
-            .map(\.0)
-    }
-
-    private var filteredRecent: [Mission] {
-        let nonRunning = recentMissions.filter { !runningMissionIds.contains($0.id) }
-        if normalizedSearchQuery.isEmpty {
-            return nonRunning
-        }
-
-        let localMatches: [Mission] = nonRunning
-            .compactMap { mission -> (Mission, Double)? in
-                let score = missionSearchRelevanceScore(mission, query: normalizedSearchQuery)
-                return score > 0 ? (mission, score) : nil
-            }
-            .sorted { lhs, rhs in
-                if lhs.1 == rhs.1 {
-                    return (lhs.0.updatedDate ?? .distantPast) > (rhs.0.updatedDate ?? .distantPast)
-                }
-                return lhs.1 > rhs.1
-            }
-            .map(\.0)
-
-        if backendSearchQuery == normalizedSearchQuery {
-            let byId = Dictionary(
-                nonRunning.map { ($0.id, $0) },
-                uniquingKeysWith: preferredMissionForDuplicateId
-            )
-            var merged: [Mission] = []
-            var seen = Set<String>()
-
-            for result in backendSearchResults {
-                let mission = byId[result.mission.id] ?? result.mission
-                guard !runningMissionIds.contains(mission.id) else { continue }
-                if seen.insert(mission.id).inserted {
-                    merged.append(mission)
-                }
-            }
-
-            for mission in localMatches {
-                if seen.insert(mission.id).inserted {
-                    merged.append(mission)
-                }
-            }
-
-            return merged
-        }
-
-        return localMatches
     }
 
     /// A running row carries layout hints so we can render boss + nested
@@ -5533,12 +5523,28 @@ private struct MissionSwitcherSheet: View {
         var id: String { info.missionId }
     }
 
-    /// boss missionId -> [worker missionId]. Built from the full mission set
-    /// (not just the search-filtered one) so we still know about workers when
-    /// the boss matched the query but a worker didn't.
-    private var bossWorkerIds: [String: [String]] {
+    private var missionListSignature: String {
+        let runningPart = runningMissions
+            .map { "\($0.missionId):\($0.state):\($0.title ?? "")" }
+            .joined(separator: "|")
+        let recentPart = recentMissions
+            .map { "\($0.id):\($0.status.displayLabel):\($0.updatedDate?.timeIntervalSince1970 ?? 0):\($0.parentMissionId ?? ""):\($0.title ?? "")" }
+            .joined(separator: "|")
+        let backendPart = backendSearchResults
+            .map { "\($0.mission.id):\($0.relevanceScore)" }
+            .joined(separator: "|")
+        return [
+            runningPart,
+            recentPart,
+            searchText,
+            backendSearchQuery,
+            backendPart
+        ].joined(separator: "||")
+    }
+
+    private func bossWorkerIds(from missions: [Mission]) -> [String: [String]] {
         var map: [String: [String]] = [:]
-        for mission in recentMissions {
+        for mission in missions {
             if let parent = mission.parentMissionId, !parent.isEmpty {
                 map[parent, default: []].append(mission.id)
             }
@@ -5546,13 +5552,11 @@ private struct MissionSwitcherSheet: View {
         return map
     }
 
-    /// Running missions ordered to nest workers under their boss (matching the
-    /// Next.js cmd+K palette): bosses first with their workers indented, then
-    /// standalone running missions, then any orphan workers whose boss isn't
-    /// currently running.
-    private var orderedRunning: [RunningRow] {
-        let filtered = filteredRunning
-        let workerIdsByBoss = bossWorkerIds
+    private func orderedRunningRows(
+        filtered: [RunningMissionInfo],
+        missionById: [String: Mission],
+        workerIdsByBoss: [String: [String]]
+    ) -> [RunningRow] {
         let filteredById: [String: RunningMissionInfo] = Dictionary(
             uniqueKeysWithValues: filtered.map { ($0.missionId, $0) }
         )
@@ -5595,44 +5599,119 @@ private struct MissionSwitcherSheet: View {
         return rows
     }
 
-    /// Mission ids included in the Just Completed micro-section, so Recent
-    /// can exclude them and we don't show the same row twice.
-    private var justCompletedIds: Set<String> {
-        Set(justCompletedMissions.map { $0.id })
-    }
+    private func recomputeMissionSections() {
+        let query = normalizedSearchQuery
+        let runningIds = Set(runningMissions.map { $0.missionId })
+        let missionById = Dictionary(
+            recentMissions.map { ($0.id, $0) },
+            uniquingKeysWith: preferredMissionForDuplicateId
+        )
 
-    /// Successfully-finished missions that landed in the last 24h. Capped to
-    /// keep the section glanceable. Hidden while searching — the ranked list
-    /// takes over and grouping just gets in the way.
-    ///
-    /// Only `.completed`, `.acknowledged`, and `.awaitingUser` qualify here:
-    /// the backend sometimes lands successful turns as `.interrupted` (the
-    /// watchdog/cancel race), so excluding the failure-shaped statuses keeps
-    /// the section honest. Interrupted/failed/blocked rows still appear under
-    /// "Recent" below.
-    private var justCompletedMissions: [Mission] {
-        guard normalizedSearchQuery.isEmpty else { return [] }
-        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-        return recentMissions
-            .filter { mission in
-                guard !runningMissionIds.contains(mission.id) else { return false }
-                switch mission.status {
-                case .completed, .acknowledged, .awaitingUser:
-                    return true
-                default:
-                    return false
+        let liveCandidates = runningMissions.filter { info in
+            guard let mission = missionById[info.missionId] else { return true }
+            return !mission.hasFinishedSuccessfully
+        }
+        let filteredRunning: [RunningMissionInfo]
+        if query.isEmpty {
+            filteredRunning = liveCandidates
+        } else {
+            filteredRunning = liveCandidates
+                .compactMap { info -> (RunningMissionInfo, Double)? in
+                    let score = runningMissionSearchScore(
+                        info,
+                        query: query,
+                        linkedMission: missionById[info.missionId]
+                    )
+                    return score > 0 ? (info, score) : nil
                 }
-            }
-            .filter { ($0.updatedDate ?? .distantPast) >= cutoff }
-            .prefix(5)
-            .map { $0 }
-    }
+                .sorted { lhs, rhs in
+                    if lhs.1 == rhs.1 {
+                        let lhsUpdated = missionById[lhs.0.missionId]?.updatedDate ?? .distantPast
+                        let rhsUpdated = missionById[rhs.0.missionId]?.updatedDate ?? .distantPast
+                        if lhsUpdated != rhsUpdated {
+                            return lhsUpdated > rhsUpdated
+                        }
+                        return lhs.0.missionId < rhs.0.missionId
+                    }
+                    return lhs.1 > rhs.1
+                }
+                .map(\.0)
+        }
 
-    /// Recent missions excluding any row already shown in Just Completed,
-    /// so the same mission never appears twice.
-    private var recentMissionsForList: [Mission] {
-        let justCompleted = justCompletedIds
-        return filteredRecent.filter { !justCompleted.contains($0.id) }
+        let nonRunning = recentMissions.filter { !runningIds.contains($0.id) }
+        let filteredRecent: [Mission]
+        if query.isEmpty {
+            filteredRecent = nonRunning
+        } else {
+            let localMatches: [Mission] = nonRunning
+                .compactMap { mission -> (Mission, Double)? in
+                    let score = missionSearchRelevanceScore(mission, query: query)
+                    return score > 0 ? (mission, score) : nil
+                }
+                .sorted { lhs, rhs in
+                    if lhs.1 == rhs.1 {
+                        return (lhs.0.updatedDate ?? .distantPast) > (rhs.0.updatedDate ?? .distantPast)
+                    }
+                    return lhs.1 > rhs.1
+                }
+                .map(\.0)
+
+            if backendSearchQuery == query {
+                let byId = Dictionary(
+                    nonRunning.map { ($0.id, $0) },
+                    uniquingKeysWith: preferredMissionForDuplicateId
+                )
+                var merged: [Mission] = []
+                var seen = Set<String>()
+
+                for result in backendSearchResults {
+                    let mission = byId[result.mission.id] ?? result.mission
+                    guard !runningIds.contains(mission.id) else { continue }
+                    if seen.insert(mission.id).inserted {
+                        merged.append(mission)
+                    }
+                }
+
+                for mission in localMatches {
+                    if seen.insert(mission.id).inserted {
+                        merged.append(mission)
+                    }
+                }
+
+                filteredRecent = merged
+            } else {
+                filteredRecent = localMatches
+            }
+        }
+
+        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+        let justCompletedMissions = query.isEmpty
+            ? recentMissions
+                .filter { mission in
+                    guard !runningIds.contains(mission.id) else { return false }
+                    switch mission.status {
+                    case .completed, .acknowledged, .awaitingUser:
+                        return true
+                    default:
+                        return false
+                    }
+                }
+                .filter { ($0.updatedDate ?? .distantPast) >= cutoff }
+                .prefix(5)
+                .map { $0 }
+            : []
+        let justCompletedIds = Set(justCompletedMissions.map(\.id))
+
+        derivedMissionById = missionById
+        derivedFilteredRunning = filteredRunning
+        derivedFilteredRecent = filteredRecent
+        derivedOrderedRunning = orderedRunningRows(
+            filtered: filteredRunning,
+            missionById: missionById,
+            workerIdsByBoss: bossWorkerIds(from: recentMissions)
+        )
+        derivedJustCompletedMissions = justCompletedMissions
+        derivedRecentMissionsForList = filteredRecent.filter { !justCompletedIds.contains($0.id) }
     }
 
     @ViewBuilder
@@ -5677,11 +5756,11 @@ private struct MissionSwitcherSheet: View {
                 }
 
                 // Running missions — boss + nested workers, then standalone.
-                if !orderedRunning.isEmpty {
+                if !derivedOrderedRunning.isEmpty {
                     Section("Running") {
-                        ForEach(orderedRunning) { row in
+                        ForEach(derivedOrderedRunning) { row in
                             let info = row.info
-                            let mission = missionById[info.missionId]
+                            let mission = derivedMissionById[info.missionId]
                             MissionRow(
                                 missionId: info.missionId,
                                 displayName: mission.map { missionDisplayName(for: $0) },
@@ -5708,8 +5787,8 @@ private struct MissionSwitcherSheet: View {
                     }
                 }
 
-                missionSection("Just Completed", missions: justCompletedMissions)
-                missionSection("Recent", missions: recentMissionsForList)
+                missionSection("Just Completed", missions: derivedJustCompletedMissions)
+                missionSection("Recent", missions: derivedRecentMissionsForList)
 
                 if isBackendSearchLoading && !normalizedSearchQuery.isEmpty {
                     Section {
@@ -5723,7 +5802,7 @@ private struct MissionSwitcherSheet: View {
                     }
                 }
 
-                if filteredRunning.isEmpty && filteredRecent.isEmpty && !normalizedSearchQuery.isEmpty {
+                if derivedFilteredRunning.isEmpty && derivedFilteredRecent.isEmpty && !normalizedSearchQuery.isEmpty {
                     ContentUnavailableView(
                         "No Missions Found",
                         systemImage: "magnifyingglass",
@@ -5734,9 +5813,14 @@ private struct MissionSwitcherSheet: View {
             .searchable(text: $searchText, prompt: "Search missions...")
             .onChange(of: searchText) { _, newValue in
                 scheduleBackendSearch(for: newValue)
+                recomputeMissionSections()
             }
             .onAppear {
+                recomputeMissionSections()
                 scheduleBackendSearch(for: searchText)
+            }
+            .onChange(of: missionListSignature) { _, _ in
+                recomputeMissionSections()
             }
             .onDisappear {
                 backendSearchTask?.cancel()

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -37,6 +37,8 @@ private struct ControlDiagnosticsOverlay: View {
     let mergeCount: Int
     let renderCount: Int
     let droppedEvents: Int
+    let performanceRecords: [ControlPerformanceRecord]
+    let hotRenderCounts: [(name: String, count: Int)]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
@@ -50,6 +52,19 @@ private struct ControlDiagnosticsOverlay: View {
             diagnosticRow("merge", "\(mergeCount) ev")
             diagnosticRow("render", "\(renderCount) rows")
             diagnosticRow("drops", "\(droppedEvents)", warning: droppedEvents > 0)
+            if let slowest = performanceRecords.max(by: { $0.durationMilliseconds < $1.durationMilliseconds }) {
+                Divider()
+                    .overlay(Theme.border)
+                diagnosticRow("slowest", slowest.name)
+                diagnosticRow("time", slowest.compactDuration, warning: slowest.durationMilliseconds >= 16)
+            }
+            if !hotRenderCounts.isEmpty {
+                Divider()
+                    .overlay(Theme.border)
+                ForEach(hotRenderCounts.prefix(3), id: \.name) { item in
+                    diagnosticRow(item.name, "\(item.count)x", warning: item.count > renderCount * 2 && renderCount > 0)
+                }
+            }
         }
         .font(.caption2.monospacedDigit())
         .padding(8)
@@ -142,6 +157,8 @@ struct ControlView: View {
     @State private var controlCacheStale = false
     @State private var controlMergeCount = 0
     @State private var controlDroppedEvents = 0
+    @State private var controlPerformanceRecords: [ControlPerformanceRecord] = []
+    @State private var controlHotRenderCounts: [(name: String, count: Int)] = []
     @AppStorage("control_debug_perf") private var showControlDiagnostics = false
 
     /// Per-mission high-water mark for `sequence`. When non-nil, reload paths
@@ -212,6 +229,10 @@ struct ControlView: View {
     private let api = APIService.shared
     private let nav = NavigationState.shared
     private let bottomAnchorId = "bottom-anchor"
+
+    private var diagnostics: ControlPerformanceDiagnostics {
+        ControlPerformanceDiagnostics.shared
+    }
     
     var body: some View {
         bodyContent
@@ -238,6 +259,12 @@ struct ControlView: View {
         }
         .onChange(of: inputText) { _, newText in
             scheduleDraftSave(newText)
+        }
+        .onChange(of: showControlDiagnostics) { _, enabled in
+            if enabled {
+                diagnostics.reset()
+                updateControlPerformanceSnapshot()
+            }
         }
         .onDisappear {
             streamTask?.cancel()
@@ -678,13 +705,21 @@ struct ControlView: View {
                 cacheHit: controlCacheHit,
                 mergeCount: controlMergeCount,
                 renderCount: groupedItems.count,
-                droppedEvents: controlDroppedEvents
+                droppedEvents: controlDroppedEvents,
+                performanceRecords: controlPerformanceRecords,
+                hotRenderCounts: controlHotRenderCounts
             )
             .padding(.top, 8)
             .padding(.trailing, 8)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             .allowsHitTesting(false)
         }
+    }
+
+    private func updateControlPerformanceSnapshot() {
+        guard showControlDiagnostics else { return }
+        controlPerformanceRecords = diagnostics.recentRecords
+        controlHotRenderCounts = diagnostics.hotRenderCounts
     }
 
     /// Main vertical stack: connection banner, optional stale-cache pill,
@@ -927,6 +962,7 @@ struct ControlView: View {
                                 onCopy: { copyMessage(message) },
                                 onRetry: message.sendState.isFailed ? { retryFailedMessage(message) } : nil
                             )
+                            .modifier(ControlBodyRenderProbe(name: "MessageBubble"))
                             .id(message.id)
                         case .toolGroup(let groupId, let tools):
                             ToolGroupView(
@@ -934,6 +970,7 @@ struct ControlView: View {
                                 tools: tools,
                                 expandedGroups: $expandedToolGroups
                             )
+                            .modifier(ControlBodyRenderProbe(name: "ToolGroupView"))
                             .id(item.id)
                         }
                     }
@@ -1023,6 +1060,7 @@ struct ControlView: View {
                 }
             }
             .environment(\.missionFileContext, inlineImageContext)
+            .environment(\.controlPerformanceDiagnosticsEnabled, showControlDiagnostics)
         }
     }
 
@@ -1080,7 +1118,14 @@ struct ControlView: View {
     }
 
     private func recomputeGroupedItems() {
-        groupedItems = Self.buildGroupedItems(from: messages)
+        groupedItems = diagnostics.measure(
+            "control.group_messages",
+            detail: viewingMissionId ?? "none",
+            count: messages.count
+        ) {
+            Self.buildGroupedItems(from: messages)
+        }
+        updateControlPerformanceSnapshot()
     }
 
     /// Check if the currently viewed mission is running (not just any mission)
@@ -1930,56 +1975,46 @@ struct ControlView: View {
     }
 
     private func applyViewingMissionWithEvents(_ mission: Mission, events: [StoredEvent], scrollToBottom: Bool = true) {
-        isLoadingHistory = true  // Suppress animated auto-scroll during history load
+        diagnostics.measure(
+            "control.apply_snapshot",
+            detail: mission.id,
+            count: events.count
+        ) {
+            isLoadingHistory = true  // Suppress animated auto-scroll during history load
 
-        viewingMission = mission
-        viewingMissionId = mission.id
-        goalInfo = mission.goalMode
-            ? GoalPillInfo(iteration: goalInfo?.iteration ?? 0, status: "active", objective: mission.goalObjective ?? "")
-            : nil
+            viewingMission = mission
+            viewingMissionId = mission.id
+            goalInfo = mission.goalMode
+                ? GoalPillInfo(iteration: goalInfo?.iteration ?? 0, status: "active", objective: mission.goalObjective ?? "")
+                : nil
 
-        // Ensure deterministic replay order in case the backend returns unsorted results
-        let orderedEvents = rememberMissionEvents(events, for: mission.id)
-
-        // Track total event count for pagination
-        loadedEventCount = orderedEvents.count
-        controlMergeCount = orderedEvents.count
-
-        // Clear and replay all events to rebuild message history
-        messages.removeAll()
-
-        for event in orderedEvents {
-            var data: [String: Any] = [:]
-
-            // Add metadata first (lower priority)
-            for (key, value) in event.metadata {
-                data[key] = value.value
+            // Ensure deterministic replay order in case the backend returns unsorted results
+            let orderedEvents = diagnostics.measure(
+                "control.sort_remember_events",
+                detail: mission.id,
+                count: events.count
+            ) {
+                rememberMissionEvents(events, for: mission.id)
             }
 
-            // Add core fields last (higher priority - these should never be overwritten)
-            data["mission_id"] = event.missionId
-            data["content"] = event.content
-            if event.eventType == "text_op",
-               let jsonData = event.content.data(using: .utf8),
-               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
-                data["ops"] = ops
+            // Track total event count for pagination
+            loadedEventCount = orderedEvents.count
+            controlMergeCount = orderedEvents.count
+
+            // Clear and replay all events to rebuild message history
+            messages.removeAll(keepingCapacity: true)
+
+            diagnostics.measure(
+                "control.replay_events",
+                detail: mission.id,
+                count: orderedEvents.count
+            ) {
+                messages = ChatHistoryReducer.reduce(events: orderedEvents, mission: mission)
             }
 
-            if let eventId = event.eventId {
-                data["id"] = eventId
-            }
-            if let toolCallId = event.toolCallId {
-                data["tool_call_id"] = toolCallId
-            }
-            if let toolName = event.toolName {
-                data["name"] = toolName
-            }
-
-            handleStreamEvent(type: event.eventType, data: data, isHistoricalReplay: true)
+            // Recompute grouped items once after all events are processed
+            recomputeGroupedItems()
         }
-
-        // Recompute grouped items once after all events are processed
-        recomputeGroupedItems()
 
         if scrollToBottom {
             shouldScrollImmediately = true
@@ -2015,34 +2050,43 @@ struct ControlView: View {
     private func applyDeltaEvents(_ events: [StoredEvent]) {
         guard !events.isEmpty else { return }
 
-        let orderedEvents = events.sorted { lhs, rhs in
-            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
-            if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
-            return lhs.id < rhs.id
-        }
-
-        for event in orderedEvents {
-            var data: [String: Any] = [:]
-            for (key, value) in event.metadata {
-                data[key] = value.value
+        diagnostics.measure(
+            "control.apply_delta",
+            detail: viewingMissionId ?? "none",
+            count: events.count
+        ) {
+            let orderedEvents = events.sorted { lhs, rhs in
+                if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+                if lhs.timestamp != rhs.timestamp { return lhs.timestamp < rhs.timestamp }
+                return lhs.id < rhs.id
             }
-            data["mission_id"] = event.missionId
-            data["content"] = event.content
-            if event.eventType == "text_op",
-               let jsonData = event.content.data(using: .utf8),
-               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
-                data["ops"] = ops
+
+            for event in orderedEvents {
+                handleStreamEvent(type: event.eventType, data: eventDataForReplay(event), isHistoricalReplay: true)
             }
-            if let eventId = event.eventId { data["id"] = eventId }
-            if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
-            if let toolName = event.toolName { data["name"] = toolName }
 
-            handleStreamEvent(type: event.eventType, data: data, isHistoricalReplay: true)
+            loadedEventCount += orderedEvents.count
+            controlMergeCount = orderedEvents.count
+            recomputeGroupedItems()
         }
+    }
 
-        loadedEventCount += orderedEvents.count
-        controlMergeCount = orderedEvents.count
-        recomputeGroupedItems()
+    private func eventDataForReplay(_ event: StoredEvent) -> [String: Any] {
+        var data: [String: Any] = [:]
+        for (key, value) in event.metadata {
+            data[key] = value.value
+        }
+        data["mission_id"] = event.missionId
+        data["content"] = event.content
+        if event.eventType == "text_op",
+           let jsonData = event.content.data(using: .utf8),
+           let ops = try? JSONSerialization.jsonObject(with: jsonData) {
+            data["ops"] = ops
+        }
+        if let eventId = event.eventId { data["id"] = eventId }
+        if let toolCallId = event.toolCallId { data["tool_call_id"] = toolCallId }
+        if let toolName = event.toolName { data["name"] = toolName }
+        return data
     }
 
     /// Decide what to load on cold start. The previous code did
@@ -2094,7 +2138,12 @@ struct ControlView: View {
                 // Fetch events for event-based display
                 if updateViewing || viewingMissionId == nil || viewingMissionId == mission.id {
                     do {
-                        let snapshot = try await api.getMissionSnapshot(id: mission.id)
+                        let snapshot = try await diagnostics.measureAsync(
+                            "control.fetch_current_snapshot",
+                            detail: mission.id
+                        ) {
+                            try await api.getMissionSnapshot(id: mission.id)
+                        }
                         let events = snapshot.events
                         controlCacheHit = hasCache
 
@@ -2162,7 +2211,12 @@ struct ControlView: View {
         }
 
         do {
-            let snapshot = try await api.getMissionSnapshot(id: id)
+            let snapshot = try await diagnostics.measureAsync(
+                "control.fetch_snapshot",
+                detail: id
+            ) {
+                try await api.getMissionSnapshot(id: id)
+            }
             let mission = snapshot.mission
 
             // Race condition guard: only update if this is still the mission we want
@@ -2224,12 +2278,17 @@ struct ControlView: View {
         defer { isLoadingEarlier = false }
 
         do {
-            let olderEvents = try await api.getMissionEvents(
-                id: missionId,
-                types: historyEventTypes,
-                limit: Self.loadEarlierPageLimit,
-                beforeSeq: missionMinSeq[missionId]
-            )
+            let olderEvents = try await diagnostics.measureAsync(
+                "control.fetch_earlier",
+                detail: missionId
+            ) {
+                try await api.getMissionEvents(
+                    id: missionId,
+                    types: historyEventTypes,
+                    limit: Self.loadEarlierPageLimit,
+                    beforeSeq: missionMinSeq[missionId]
+                )
+            }
             guard viewingMissionId == missionId else { return }
 
             if !olderEvents.isEmpty, let mission = viewingMission {
@@ -2267,12 +2326,17 @@ struct ControlView: View {
     private func tryDeltaResume(missionId id: String) async -> DeltaResumeOutcome {
         guard let knownSeq = missionMaxSeq[id] else { return .noCursor }
         do {
-            let result = try await api.getMissionEventsWithMeta(
-                id: id,
-                types: historyEventTypes,
-                limit: Self.deltaResumePageLimit,
-                sinceSeq: knownSeq
-            )
+            let result = try await diagnostics.measureAsync(
+                "control.fetch_delta",
+                detail: id
+            ) {
+                try await api.getMissionEventsWithMeta(
+                    id: id,
+                    types: historyEventTypes,
+                    limit: Self.deltaResumePageLimit,
+                    sinceSeq: knownSeq
+                )
+            }
             guard viewingMissionId == id else { return .viewChanged }
             let maxSeq = result.maxSequence ?? knownSeq
             _ = mergeMissionEvents(result.events, for: id)
@@ -2329,7 +2393,12 @@ struct ControlView: View {
             // clear the cache and fall back, since the mission really does
             // have no events.
             do {
-                let snapshot = try await api.getMissionSnapshot(id: id)
+                let snapshot = try await diagnostics.measureAsync(
+                    "control.fetch_reload_snapshot",
+                    detail: id
+                ) {
+                    try await api.getMissionSnapshot(id: id)
+                }
                 guard viewingMissionId == id else { return }
                 if snapshot.events.isEmpty {
                     removeMissionFromCache(mission.id)
@@ -3183,7 +3252,12 @@ struct ControlView: View {
         progress = nil
 
         do {
-            let snapshot = try await api.getMissionSnapshot(id: id)
+            let snapshot = try await diagnostics.measureAsync(
+                "control.fetch_switch_snapshot",
+                detail: id
+            ) {
+                try await api.getMissionSnapshot(id: id)
+            }
             let mission = snapshot.mission
 
             // Race condition guard: only update if this is still the mission we want
@@ -3247,7 +3321,12 @@ struct ControlView: View {
     private func refreshViewingMissionSnapshot() async {
         guard let id = viewingMissionId else { return }
         do {
-            let snapshot = try await api.getMissionSnapshot(id: id)
+            let snapshot = try await diagnostics.measureAsync(
+                "control.fetch_refresh_snapshot",
+                detail: id
+            ) {
+                try await api.getMissionSnapshot(id: id)
+            }
             guard viewingMissionId == id else { return }
             currentMission = currentMission?.id == snapshot.mission.id ? snapshot.mission : currentMission
             if !snapshot.events.isEmpty {
@@ -4175,6 +4254,7 @@ private struct MessageBubble: View {
                 }
 
                 MarkdownView(message.content)
+                    .modifier(ControlBodyRenderProbe(name: "MarkdownView"))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)

--- a/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Files/FilesView.swift
@@ -12,6 +12,7 @@ struct FilesView: View {
     private var workspaceState = WorkspaceState.shared
     @State private var currentPath = "/root/context"
     @State private var entries: [FileEntry] = []
+    @State private var sortedEntries: [FileEntry] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var selectedEntry: FileEntry?
@@ -42,10 +43,10 @@ struct FilesView: View {
 
     private let api = APIService.shared
     
-    private var sortedEntries: [FileEntry] {
+    private func recomputeSortedEntries() {
         let dirs = entries.filter { $0.isDirectory }.sorted { $0.name < $1.name }
         let files = entries.filter { !$0.isDirectory }.sorted { $0.name < $1.name }
-        return dirs + files
+        sortedEntries = dirs + files
     }
     
     private var breadcrumbs: [(name: String, path: String)] {
@@ -450,10 +451,12 @@ struct FilesView: View {
         // have nothing to show. Refresh happens in the background regardless.
         if let cached = pathCache[pathToLoad] {
             entries = cached
+            recomputeSortedEntries()
             isLoading = false
             touchCacheKey(pathToLoad)
         } else {
             entries = []
+            recomputeSortedEntries()
             isLoading = true
         }
 
@@ -466,6 +469,7 @@ struct FilesView: View {
             }
 
             entries = result
+            recomputeSortedEntries()
             cachePath(pathToLoad, entries: result)
         } catch {
             // Race condition guard

--- a/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/History/HistoryView.swift
@@ -14,6 +14,7 @@ struct HistoryView: View {
     @State private var isLoading = true
     @State private var searchText = ""
     @State private var selectedFilter: StatusFilter = .all
+    @State private var filteredMissions: [Mission] = []
     @State private var errorMessage: String?
     @State private var isCleaningUp = false
     @State private var showCleanupResult: String?
@@ -39,8 +40,8 @@ struct HistoryView: View {
         }
     }
     
-    private var filteredMissions: [Mission] {
-        missions.filter { mission in
+    private func recomputeFilteredMissions() {
+        filteredMissions = missions.filter { mission in
             // Filter by status
             if let statuses = selectedFilter.missionStatuses, !statuses.contains(mission.status) {
                 return false
@@ -93,6 +94,7 @@ struct HistoryView: View {
                                 ) {
                                     withAnimation(.easeInOut(duration: 0.2)) {
                                         selectedFilter = filter
+                                        recomputeFilteredMissions()
                                     }
                                     HapticService.selectionChanged()
                                 }
@@ -202,6 +204,9 @@ struct HistoryView: View {
         .refreshable {
             await loadData()
         }
+        .onChange(of: searchText) { _, _ in
+            recomputeFilteredMissions()
+        }
     }
     
     private var missionsList: some View {
@@ -281,6 +286,7 @@ struct HistoryView: View {
             missions = missionsResult
             tasks = tasksResult
             runs = runsResult
+            recomputeFilteredMissions()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -296,6 +302,7 @@ struct HistoryView: View {
         let removalIndex = missions.firstIndex(where: { $0.id == mission.id })
         withAnimation {
             missions.removeAll { $0.id == mission.id }
+            recomputeFilteredMissions()
         }
         do {
             _ = try await api.deleteMission(id: mission.id)
@@ -306,6 +313,7 @@ struct HistoryView: View {
             if let idx = removalIndex {
                 withAnimation {
                     missions.insert(mission, at: min(idx, missions.count))
+                    recomputeFilteredMissions()
                 }
             }
         }
@@ -321,6 +329,7 @@ struct HistoryView: View {
                 let newMissions = try await api.listMissions()
                 withAnimation {
                     missions = newMissions
+                    recomputeFilteredMissions()
                     showCleanupResult = "Cleaned up \(count) empty mission\(count == 1 ? "" : "s")"
                 }
                 HapticService.success()

--- a/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ModelTests.swift
@@ -173,6 +173,53 @@ final class ModelTests: XCTestCase {
         }
     }
 
+    func testChatHistoryReducerSkipsTextOpFallbackWhenRealThinkingIsActive() throws {
+        let mission = try JSONDecoder().decode(Mission.self, from: """
+        {
+            "id": "mission-id",
+            "status": "active",
+            "title": "Thinking mission",
+            "history": [],
+            "resumable": false,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }
+        """.data(using: .utf8)!)
+        let events = [
+            StoredEvent(
+                id: 1,
+                missionId: mission.id,
+                sequence: 1,
+                eventType: "thinking",
+                timestamp: "2024-01-01T00:00:00Z",
+                eventId: "real-thinking",
+                toolCallId: nil,
+                toolName: nil,
+                content: "Analyzing the task",
+                metadata: ["done": AnyCodable(false)]
+            ),
+            StoredEvent(
+                id: 2,
+                missionId: mission.id,
+                sequence: 2,
+                eventType: "text_op",
+                timestamp: "2024-01-01T00:00:01Z",
+                eventId: nil,
+                toolCallId: nil,
+                toolName: nil,
+                content: #"{"ops":[{"type":"insert","pos":0,"text":"fallback text"}]}"#,
+                metadata: ["bubble_id": AnyCodable("latest")]
+            )
+        ]
+
+        let messages = ChatHistoryReducer.reduce(events: events, mission: mission)
+
+        XCTAssertEqual(messages.filter(\.isThinking).count, 1)
+        XCTAssertEqual(messages.first?.id, "real-thinking")
+        XCTAssertEqual(messages.first?.content, "Analyzing the task")
+        XCTAssertFalse(messages.contains { $0.id.hasPrefix("stream-thinking-") })
+    }
+
     private func controlViewSource() throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
         let controlView = testFile
@@ -194,119 +241,7 @@ final class ModelTests: XCTestCase {
     }
 
     private func replayFixtureEvents(_ events: [StoredEvent], mission: Mission) -> [ChatMessage] {
-        var messages: [ChatMessage] = []
-        var textOpBuffers: [String: String] = [:]
-        let orderedEvents = events.sorted { lhs, rhs in
-            if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
-            return lhs.id < rhs.id
-        }
-
-        for event in orderedEvents {
-            var data = event.metadata.mapValues(\.value)
-            data["mission_id"] = event.missionId
-            data["content"] = event.content
-            if let eventId = event.eventId { data["id"] = eventId }
-            if event.eventType == "text_op",
-               let jsonData = event.content.data(using: .utf8),
-               let ops = try? JSONSerialization.jsonObject(with: jsonData) {
-                data["ops"] = ops
-            }
-
-            switch event.eventType {
-            case "assistant_message", "assistant_message_canonical":
-                guard let id = data["id"] as? String,
-                      !messages.contains(where: { $0.id == id }) else { continue }
-                messages.append(
-                    ChatMessage(
-                        id: id,
-                        type: .assistant(success: data["success"] as? Bool ?? true, costCents: 0, costSource: .unknown, model: nil, sharedFiles: nil),
-                        content: data["content"] as? String ?? ""
-                    )
-                )
-            case "thinking":
-                let content = data["content"] as? String ?? ""
-                let done = data["done"] as? Bool ?? false
-                if done, data["goal_role"] as? String == "deliverable", mission.goalMode {
-                    let baseId = data["id"] as? String ?? String(event.id)
-                    let id = "goal-deliverable-\(baseId)"
-                    guard !messages.contains(where: { $0.id == id }) else { continue }
-                    messages.append(
-                        ChatMessage(
-                            id: id,
-                            type: .assistant(success: true, costCents: 0, costSource: .unknown, model: nil, sharedFiles: nil),
-                            content: content
-                        )
-                    )
-                    continue
-                }
-                if let id = data["id"] as? String,
-                   messages.contains(where: { $0.id == id }) {
-                    continue
-                }
-                if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone }) {
-                    let existing = messages[index]
-                    messages[index] = ChatMessage(
-                        id: existing.id,
-                        type: .thinking(done: done, startTime: existing.thinkingStartTime ?? existing.timestamp),
-                        content: content,
-                        timestamp: existing.timestamp
-                    )
-                } else {
-                    messages.append(
-                        ChatMessage(
-                            id: data["id"] as? String ?? "thinking-\(event.id)",
-                            type: .thinking(done: done, startTime: Date()),
-                            content: content
-                        )
-                    )
-                }
-            case "text_op":
-                let bubbleId = data["bubble_id"] as? String ?? "text-op-latest"
-                let ops = data["ops"] as? [[String: Any]] ?? []
-                var content = textOpBuffers[bubbleId] ?? ""
-                var finalized = false
-                for op in ops {
-                    switch op["type"] as? String {
-                    case "insert":
-                        let pos = min(max(op["pos"] as? Int ?? content.count, 0), content.count)
-                        let index = content.index(content.startIndex, offsetBy: pos)
-                        content.insert(contentsOf: op["text"] as? String ?? "", at: index)
-                    case "replace":
-                        let range = op["range"] as? [Int] ?? []
-                        let start = min(max(range.first ?? 0, 0), content.count)
-                        let end = min(max(range.dropFirst().first ?? content.count, start), content.count)
-                        let startIndex = content.index(content.startIndex, offsetBy: start)
-                        let endIndex = content.index(content.startIndex, offsetBy: end)
-                        content.replaceSubrange(startIndex..<endIndex, with: op["text"] as? String ?? "")
-                    case "finalize":
-                        finalized = true
-                    default:
-                        continue
-                    }
-                }
-                textOpBuffers[bubbleId] = finalized ? nil : content
-                if let index = messages.lastIndex(where: { $0.isThinking && !$0.thinkingDone && $0.id.hasPrefix("stream-thinking-") }) {
-                    messages[index] = ChatMessage(
-                        id: messages[index].id,
-                        type: .thinking(done: finalized, startTime: messages[index].thinkingStartTime ?? messages[index].timestamp),
-                        content: content,
-                        timestamp: messages[index].timestamp
-                    )
-                } else {
-                    messages.append(
-                        ChatMessage(
-                            id: "stream-thinking-\(bubbleId)",
-                            type: .thinking(done: finalized, startTime: Date()),
-                            content: content
-                        )
-                    )
-                }
-            default:
-                continue
-            }
-        }
-
-        return messages
+        ChatHistoryReducer.reduce(events: events, mission: mission)
     }
 
     // MARK: - FileEntry Tests

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -67,7 +67,7 @@ impl OpenCodeAgent {
         };
 
         let agent_event = match oc_event {
-            OpenCodeEvent::Thinking { content } => {
+            OpenCodeEvent::Thinking { content, .. } => {
                 tracing::info!(
                     content_len = content.len(),
                     content_preview = %content.chars().take(100).collect::<String>(),

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2156,11 +2156,8 @@ fn update_provider_oauth_for_chatgpt_account(
             .and_then(|o| o.get("access_token"))
             .and_then(|v| v.as_str())
             .and_then(extract_chatgpt_account_id);
-        let matches = stored_account_id
-            .as_deref()
-            .or(decoded_account_id.as_deref())
-            .map(|s| s == account_id)
-            .unwrap_or(false);
+        let matches = stored_account_id.as_deref() == Some(account_id)
+            || decoded_account_id.as_deref() == Some(account_id);
         if !matches {
             continue;
         }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2138,17 +2138,29 @@ fn update_provider_oauth_for_chatgpt_account(
 
     let mut updated = false;
     for provider in items.iter_mut() {
-        let matches = provider
+        let is_openai = provider
             .get("provider_type")
             .and_then(|v| v.as_str())
             .map(|s| s == "openai")
-            .unwrap_or(false)
-            && provider
-                .get("oauth")
-                .and_then(|o| o.get("chatgpt_account_id"))
-                .and_then(|v| v.as_str())
-                .map(|s| s == account_id)
-                .unwrap_or(false);
+            .unwrap_or(false);
+        if !is_openai {
+            continue;
+        }
+
+        let oauth = provider.get("oauth");
+        let stored_account_id = oauth
+            .and_then(|o| o.get("chatgpt_account_id"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let decoded_account_id = oauth
+            .and_then(|o| o.get("access_token"))
+            .and_then(|v| v.as_str())
+            .and_then(extract_chatgpt_account_id);
+        let matches = stored_account_id
+            .as_deref()
+            .or(decoded_account_id.as_deref())
+            .map(|s| s == account_id)
+            .unwrap_or(false);
         if !matches {
             continue;
         }
@@ -2170,6 +2182,10 @@ fn update_provider_oauth_for_chatgpt_account(
             oauth_obj.insert(
                 "expires_at".to_string(),
                 serde_json::Value::from(expires_at_ms),
+            );
+            oauth_obj.insert(
+                "chatgpt_account_id".to_string(),
+                serde_json::Value::String(account_id.to_string()),
             );
             updated = true;
         }
@@ -2410,6 +2426,15 @@ pub fn get_all_openai_oauth_accounts(working_dir: &Path) -> Vec<CodexOAuthAccoun
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
         if refresh.is_empty() || access.is_empty() {
+            continue;
+        }
+        if oauth_token_expired(expires_at) {
+            tracing::warn!(
+                provider_id = p.get("id").and_then(|v| v.as_str()).unwrap_or("<unknown>"),
+                account_email = p.get("account_email").and_then(|v| v.as_str()),
+                expires_at,
+                "Skipping expired OpenAI OAuth provider entry for Codex rotation"
+            );
             continue;
         }
         let chatgpt_account_id = match extract_chatgpt_account_id(access) {
@@ -8417,6 +8442,29 @@ pub fn sync_oauth_to_all_tiers(
                     "Failed to sync token to Tier 3 (Claude CLI credentials) - continuing"
                 );
                 // Don't fail the entire sync if Claude CLI sync fails
+            }
+        }
+    }
+
+    if matches!(provider_type, ProviderType::OpenAI) {
+        if let Some(account_id) = extract_chatgpt_account_id(access_token) {
+            let working_dir = PathBuf::from(home_dir());
+            if update_provider_oauth_for_chatgpt_account(
+                &working_dir,
+                &account_id,
+                access_token,
+                refresh_token,
+                expires_at,
+            ) {
+                tracing::info!(
+                    account_id = %account_id,
+                    "Synced OpenAI OAuth token to ai_providers.json"
+                );
+            } else {
+                tracing::debug!(
+                    account_id = %account_id,
+                    "No matching OpenAI provider row found while syncing OAuth token"
+                );
             }
         }
     }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -2418,14 +2418,15 @@ pub fn get_all_openai_oauth_accounts(working_dir: &Path) -> Vec<CodexOAuthAccoun
             .get("access_token")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        let expires_at = oauth
-            .get("expires_at")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0);
+        let stored_expires_at = oauth.get("expires_at").and_then(|v| v.as_i64());
         if refresh.is_empty() || access.is_empty() {
             continue;
         }
-        if oauth_token_expired(expires_at) {
+        let decoded_expires_at = extract_jwt_exp_ms(access);
+        let expires_at = decoded_expires_at.or(stored_expires_at).unwrap_or(i64::MAX);
+        if (stored_expires_at.is_some() || decoded_expires_at.is_some())
+            && oauth_token_expired(expires_at)
+        {
             tracing::warn!(
                 provider_id = p.get("id").and_then(|v| v.as_str()).unwrap_or("<unknown>"),
                 account_email = p.get("account_email").and_then(|v| v.as_str()),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -14299,6 +14299,13 @@ pub async fn run_codex_turn(
     let mut thinking_emitted = false;
     let mut thinking_done_emitted = false;
     let mut thinking_accumulated = String::new();
+    // Tracks which codex reasoning item `thinking_accumulated` currently
+    // belongs to. When a Thinking event arrives with a different `item_id`,
+    // we finalize the existing buffer and start a fresh one — codex emits
+    // multiple reasoning items per turn (each with its own cumulative
+    // snapshots), and merging them into one buffer produced concatenated
+    // thoughts in stored history (see mission dbc8a7e9 seq 6651).
+    let mut thinking_item: Option<String> = None;
     let mut last_summary: Option<String> = None;
     let mut total_input_tokens: u64 = 0;
     let mut total_output_tokens: u64 = 0;
@@ -14338,9 +14345,44 @@ pub async fn run_codex_turn(
                             text_delta_pending = true;
                         }
                     }
-                    ExecutionEvent::Thinking { content } => {
-                        merge_stream_fragment(&mut thinking_accumulated, &content);
-                        // Stream the canonical cumulative buffer for real-time UI.
+                    ExecutionEvent::Thinking { content, item_id } => {
+                        // Codex emits per-item cumulative snapshots: every
+                        // emit with the same `item_id` contains the previous
+                        // emit as a prefix. When `item_id` changes we're on a
+                        // new reasoning item — finalize the existing buffer
+                        // as `done: true` so it persists as its own thought,
+                        // and start fresh. Falling back to `merge_stream_fragment`
+                        // (the pre-fix behaviour) concatenated unrelated items
+                        // into one buffer because it only knows about byte
+                        // overlap, not item identity.
+                        let item_changed = match (&thinking_item, &item_id) {
+                            (Some(prev), Some(cur)) => prev != cur,
+                            // First event of the turn, or backend doesn't
+                            // expose item IDs: treat as continuation.
+                            _ => false,
+                        };
+                        if item_changed && !thinking_accumulated.is_empty() {
+                            let _ = events_tx.send(AgentEvent::Thinking {
+                                content: std::mem::take(&mut thinking_accumulated),
+                                done: true,
+                                mission_id: Some(mission_id),
+                            });
+                            thinking_done_emitted = true;
+                        }
+                        if item_id.is_some() {
+                            thinking_item = item_id;
+                            // Per-item cumulative: each new snapshot replaces
+                            // the buffer (longest wins; shorter echoes are
+                            // dropped to keep the buffer monotone).
+                            if content.len() >= thinking_accumulated.len() {
+                                thinking_accumulated = content;
+                            }
+                        } else {
+                            // Unknown-item backends still use overlap-based
+                            // merging so a CLI that resends a partial
+                            // snapshot doesn't double words.
+                            merge_stream_fragment(&mut thinking_accumulated, &content);
+                        }
                         let _ = events_tx.send(AgentEvent::Thinking {
                             content: thinking_accumulated.clone(),
                             done: false,
@@ -14360,6 +14402,7 @@ pub async fn run_codex_turn(
                             });
                             thinking_done_emitted = true;
                         }
+                        thinking_item = None;
                         pending_tools.insert(id.clone(), name.clone());
                         let _ = events_tx.send(AgentEvent::ToolCall {
                             tool_call_id: id,
@@ -14907,7 +14950,7 @@ pub async fn run_gemini_turn(
                             mission_id: Some(mission_id),
                         });
                     }
-                    ExecutionEvent::Thinking { content } => {
+                    ExecutionEvent::Thinking { content, item_id: _ } => {
                         merge_stream_fragment(&mut thinking_accumulated, &content);
                         // Stream the canonical cumulative buffer for real-time UI.
                         let _ = events_tx.send(AgentEvent::Thinking {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -714,6 +714,7 @@ exec "$SCRIPT_DIR/.sandboxed-sh-telegram-action.py" "$@"
 }
 
 const CODEX_ACCOUNT_CONCURRENCY_LIMIT: usize = 5;
+const CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT: usize = 1;
 const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
@@ -740,6 +741,13 @@ impl CodexCredential {
         match self {
             CodexCredential::ApiKey(k) => format!("apikey:{}", k),
             CodexCredential::OAuth(acc) => format!("oauth:{}", acc.chatgpt_account_id),
+        }
+    }
+
+    fn concurrency_limit(&self) -> usize {
+        match self {
+            CodexCredential::ApiKey(_) => CODEX_ACCOUNT_CONCURRENCY_LIMIT,
+            CodexCredential::OAuth(_) => CODEX_OAUTH_ACCOUNT_CONCURRENCY_LIMIT,
         }
     }
 
@@ -839,12 +847,12 @@ pub(crate) fn codex_tool_stall_should_retry_with_default_model(
     requested_model.is_some_and(is_generic_gpt_codex_model)
 }
 
-fn codex_account_semaphore_for_fingerprint(fingerprint: &str) -> Arc<Semaphore> {
+fn codex_account_semaphore_for_credential(credential: &CodexCredential) -> Arc<Semaphore> {
     let mut pool = CODEX_ACCOUNT_POOL
         .lock()
         .expect("Codex account pool mutex poisoned");
-    pool.entry(fingerprint.to_string())
-        .or_insert_with(|| Arc::new(Semaphore::new(CODEX_ACCOUNT_CONCURRENCY_LIMIT)))
+    pool.entry(credential.fingerprint())
+        .or_insert_with(|| Arc::new(Semaphore::new(credential.concurrency_limit())))
         .clone()
 }
 
@@ -1205,7 +1213,7 @@ async fn lease_codex_account(
         .into_iter()
         .filter(|cred| !tried_fingerprints.contains(&cred.fingerprint()))
         .map(|cred| {
-            let sem = codex_account_semaphore_for_fingerprint(&cred.fingerprint());
+            let sem = codex_account_semaphore_for_credential(&cred);
             let available = sem.available_permits();
             (cred, sem, available)
         })

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -602,10 +602,11 @@ impl AppServerEventTranslator {
                         ("reasoning", DeltaSemantics::Incremental)
                     };
                     let key = format!("{}:{}", kind, item_id);
-                    let entry = self.delta_buffers.entry(key).or_default();
+                    let entry = self.delta_buffers.entry(key.clone()).or_default();
                     fold_delta_into(entry, delta, semantics);
                     events.push(ExecutionEvent::Thinking {
                         content: entry.clone(),
+                        item_id: Some(key),
                     });
                 }
             }
@@ -836,6 +837,8 @@ pub fn registry_entry() -> Arc<dyn Backend> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn parse_goal_prefix_detects_simple_goal() {
@@ -949,6 +952,93 @@ mod tests {
         fold_delta_into(&mut buf, "stable", DeltaSemantics::CumulativeSnapshot);
         fold_delta_into(&mut buf, "stable", DeltaSemantics::CumulativeSnapshot);
         assert_eq!(buf, "stable");
+    }
+
+    #[test]
+    fn reasoning_thinking_events_carry_distinct_item_ids() {
+        // Regression for mission dbc8a7e9 seq 6651: the translator must
+        // tag each Thinking event with the per-item buffer key so the
+        // mission_runner can detect when codex moves to a new reasoning
+        // item and finalize the previous thought instead of concatenating
+        // unrelated cumulative snapshots into one buffer.
+        let mut translator = AppServerEventTranslator {
+            delta_buffers: HashMap::new(),
+            emitted_usage_for_turn: HashSet::new(),
+            counted_turn_ids: HashSet::new(),
+            goal_iteration: 0,
+            goal_objective: String::new(),
+        };
+
+        let notify = |item_id: &str, delta: &str| {
+            json!({
+                "itemId": item_id,
+                "delta": delta,
+            })
+        };
+
+        let collect = |events: Vec<ExecutionEvent>| -> Vec<(Option<String>, String)> {
+            events
+                .into_iter()
+                .filter_map(|e| match e {
+                    ExecutionEvent::Thinking { content, item_id } => Some((item_id, content)),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // Item A: cumulative summary snapshots.
+        let mut events = Vec::new();
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("A", "The recovery log."),
+                    false,
+                )
+                .events,
+        );
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("A", "The recovery log. Do not duplicate."),
+                    false,
+                )
+                .events,
+        );
+        // Item B: brand new reasoning, starts at "Work".
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("B", "Work"),
+                    false,
+                )
+                .events,
+        );
+        events.extend(
+            translator
+                .handle_notification(
+                    "item/reasoning/summaryTextDelta",
+                    &notify("B", "Worktrees are ready"),
+                    false,
+                )
+                .events,
+        );
+
+        let thinkings = collect(events);
+        assert_eq!(thinkings.len(), 4);
+        // Item A's snapshots share an item_id.
+        assert_eq!(thinkings[0].0, Some("summary:A".to_string()));
+        assert_eq!(thinkings[1].0, Some("summary:A".to_string()));
+        // Item B's snapshots share a *different* item_id.
+        assert_eq!(thinkings[2].0, Some("summary:B".to_string()));
+        assert_eq!(thinkings[3].0, Some("summary:B".to_string()));
+        assert_ne!(thinkings[1].0, thinkings[2].0);
+        // Per-item contents are clean cumulative snapshots (the runner is
+        // free to REPLACE per item, no overlap merging required).
+        assert_eq!(thinkings[1].1, "The recovery log. Do not duplicate.");
+        assert_eq!(thinkings[3].1, "Worktrees are ready");
     }
 
     #[tokio::test]

--- a/src/backend/events.rs
+++ b/src/backend/events.rs
@@ -4,7 +4,19 @@ use serde_json::Value;
 #[derive(Debug, Clone)]
 pub enum ExecutionEvent {
     /// Agent is thinking/reasoning.
-    Thinking { content: String },
+    ///
+    /// `content` is a per-item cumulative snapshot (each emit for the same
+    /// `item_id` contains the previous emit as a prefix). `item_id` identifies
+    /// the reasoning item the snapshot belongs to so consumers can detect
+    /// transitions between distinct thoughts within a single turn — codex
+    /// emits multiple reasoning items per turn and they must not be merged
+    /// into one buffer. `None` means the backend doesn't expose item IDs
+    /// (Claude Code CLI handles its own block-index finalization upstream;
+    /// Gemini emits a single thought stream per turn).
+    Thinking {
+        content: String,
+        item_id: Option<String>,
+    },
     /// Agent is calling a tool.
     ToolCall {
         id: String,

--- a/src/backend/gemini/mod.rs
+++ b/src/backend/gemini/mod.rs
@@ -454,7 +454,10 @@ fn convert_gemini_event(
         GeminiEvent::Thought { content } => {
             if let Some(text) = content {
                 if !text.is_empty() {
-                    results.push(ExecutionEvent::Thinking { content: text });
+                    results.push(ExecutionEvent::Thinking {
+                        content: text,
+                        item_id: None,
+                    });
                 }
             }
         }

--- a/src/backend/shared.rs
+++ b/src/backend/shared.rs
@@ -431,7 +431,10 @@ pub fn convert_cli_event(
                 }
                 if let Some(thinking) = delta.thinking {
                     if !thinking.is_empty() {
-                        results.push(ExecutionEvent::Thinking { content: thinking });
+                        results.push(ExecutionEvent::Thinking {
+                            content: thinking,
+                            item_id: None,
+                        });
                     }
                 }
                 if let Some(partial) = delta.partial_json {
@@ -453,7 +456,10 @@ pub fn convert_cli_event(
                 match block {
                     ContentBlock::Text { text } => {
                         if !text.is_empty() {
-                            results.push(ExecutionEvent::Thinking { content: text });
+                            results.push(ExecutionEvent::Thinking {
+                                content: text,
+                                item_id: None,
+                            });
                         }
                     }
                     ContentBlock::ToolUse { id, name, input } => {
@@ -466,7 +472,10 @@ pub fn convert_cli_event(
                     }
                     ContentBlock::Thinking { thinking } => {
                         if !thinking.is_empty() {
-                            results.push(ExecutionEvent::Thinking { content: thinking });
+                            results.push(ExecutionEvent::Thinking {
+                                content: thinking,
+                                item_id: None,
+                            });
                         }
                     }
                     ContentBlock::ToolResult { .. } | ContentBlock::RedactedThinking { .. } => {}
@@ -767,7 +776,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => assert_eq!(content, "I need to think"),
+            ExecutionEvent::Thinking { content, .. } => assert_eq!(content, "I need to think"),
             other => panic!("Expected Thinking, got {:?}", other),
         }
     }
@@ -830,7 +839,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => {
+            ExecutionEvent::Thinking { content, .. } => {
                 assert_eq!(content, "I will run a command")
             }
             other => panic!("Expected Thinking, got {:?}", other),
@@ -884,7 +893,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => assert_eq!(content, "deep thought"),
+            ExecutionEvent::Thinking { content, .. } => assert_eq!(content, "deep thought"),
             other => panic!("Expected Thinking, got {:?}", other),
         }
     }
@@ -1125,7 +1134,7 @@ mod tests {
         let results = convert_cli_event(event, &mut pending);
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ExecutionEvent::Thinking { content } => {
+            ExecutionEvent::Thinking { content, .. } => {
                 assert_eq!(content, "Let me think about this...");
             }
             ExecutionEvent::TextDelta { .. } => {

--- a/src/opencode/mod.rs
+++ b/src/opencode/mod.rs
@@ -953,7 +953,10 @@ fn handle_part_update(props: &serde_json::Value, state: &mut SseState) -> Option
             content_preview = %content.chars().take(100).collect::<String>(),
             "Emitting Thinking event from SSE"
         );
-        Some(OpenCodeEvent::Thinking { content })
+        Some(OpenCodeEvent::Thinking {
+            content,
+            item_id: None,
+        })
     } else {
         // Skip if content is identical to last emitted text
         if state.last_emitted_text.as_ref() == Some(&content) {


### PR DESCRIPTION
Supersedes #463.

## Summary
- Add iOS dashboard performance diagnostics plus the implemented fixes from `ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md`.
- Move chat history replay through `ChatHistoryReducer`, including text-op buffer handoff back to `ControlView` after snapshot replay.
- Add markdown parse/AttributedString caches, isolate conversation rows, move large mission-cache decode off the main actor, and add image downsampling/memory caching.
- Memoize mission/file/history list derivations to reduce repeated SwiftUI body work.
- Preserve Codex OAuth concurrency behavior and OpenAI/ChatGPT account-id synchronization, including the review fixes for account matching and missing-expiry fallback.

## Review fixes
- Bugbot/Codex: text-op replay now skips fallback thinking rows when a real active thinking row already has content, matching live stream behavior.
- Bugbot/Codex: snapshot replay now returns reducer `textOpBuffers` to `ControlView`, so later live/delta `text_op` events continue from the same state.
- Bugbot/Codex: ChatGPT OAuth provider updates now match when either the stored account id or the decoded access-token account id matches the refreshed account.
- Bugbot/Codex: OpenAI OAuth rotation no longer treats a missing `oauth.expires_at` as expired; it uses the access-token JWT expiry when available and keeps legacy rows eligible when no expiry is stored.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check --lib`
- [x] `xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj -scheme SandboxedDashboard -destination 'generic/platform=iOS Simulator' build`\n- [x] `xcodebuild -project ios_dashboard/SandboxedDashboard.xcodeproj -scheme SandboxedDashboard -destination 'id=A1480839-C000-42F2-A7D9-9E72E7C8CD50' test`\n- [x] SwiftUI/Time Profiler/Animation Hitches trace attempts documented in `ios_dashboard/IOS_PERFORMANCE_DIAGNOSTICS.md` with current simulator/runtime limitations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission event replay, Codex thinking persistence, and OAuth provider matching/concurrency—areas where subtle regressions could affect chat history or auth-backed runs, though changes are largely performance and targeted bug fixes with tests.
> 
> **Overview**
> **iOS dashboard** gains a **Control Performance** diagnostics layer (`Logger`/`OSSignposter`, overlay slowest ops and hot SwiftUI body counts) and wraps Control fetch/replay paths plus global `APIService` request/decode timing. Historical mission loads now rebuild chat via a pure **`ChatHistoryReducer`** (single `messages` assign, **`textOpBuffers`** restored for live `text_op`), with markdown parse/inline caches, **`ImageMemoryCache`** downsampling, **`ConversationRowsView`** isolation, async decode for large on-disk mission caches, and memoized History/Files/mission-switcher lists. Playwright/test artifact paths are gitignored; a diagnostics write-up is added.
> 
> **Backend** extends **`ExecutionEvent::Thinking`** with optional **`item_id`**: Codex reasoning deltas tag per-item keys, and **`mission_runner`** finalizes a thought when the item changes instead of concatenating unrelated reasoning snapshots. **Codex OAuth** accounts get concurrency **1** (API keys stay at **5**). **OpenAI OAuth** sync/rotation matches providers by stored or JWT-decoded **`chatgpt_account_id`**, persists that id on refresh, skips expired tokens for rotation, and syncs tokens into **`ai_providers.json`** on OAuth sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b42cfe19c2256f8ef5a90f52950148971f4313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->