### PR TITLE
Add durable background jobs for long-running agent work

### DIFF
--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -156,6 +156,29 @@ async fn read_job(state: &AppState, id: Uuid) -> Result<DurableJob, String> {
     serde_json::from_slice(&bytes).map_err(|e| format!("invalid durable job entry: {}", e))
 }
 
+async fn write_terminal_job_state(
+    state: &AppState,
+    mut job: DurableJob,
+    status: DurableJobStatus,
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    updated_at: DateTime<Utc>,
+) -> DurableJob {
+    if let Ok(latest) = read_job(state, job.id).await {
+        if latest.status == DurableJobStatus::Cancelled {
+            return latest;
+        }
+        job = latest;
+    }
+
+    job.status = status;
+    job.exit_code = exit_code;
+    job.signal = signal;
+    job.updated_at = updated_at;
+    let _ = write_job(state, &job).await;
+    job
+}
+
 #[cfg(unix)]
 fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
@@ -188,16 +211,20 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
     ) {
         if let Ok(bytes) = tokio::fs::read(&job.status_file).await {
             if let Ok(exit) = serde_json::from_slice::<ExitRecord>(&bytes) {
-                job.status = if exit.exit_code == Some(0) {
+                let status = if exit.exit_code == Some(0) {
                     DurableJobStatus::Completed
                 } else {
                     DurableJobStatus::Failed
                 };
-                job.exit_code = exit.exit_code;
-                job.signal = exit.signal;
-                job.updated_at = exit.finished_at;
-                let _ = write_job(state, &job).await;
-                return job;
+                return write_terminal_job_state(
+                    state,
+                    job,
+                    status,
+                    exit.exit_code,
+                    exit.signal,
+                    exit.finished_at,
+                )
+                .await;
             }
         }
 
@@ -291,23 +318,28 @@ pub async fn start_job(
     tokio::spawn(async move {
         let mut child = child;
         if let Ok(status) = child.wait().await {
-            if let Ok(mut job) = read_job(&watcher_state, id).await {
-                let was_cancelled = job.status == DurableJobStatus::Cancelled;
-                if !was_cancelled {
-                    job.status = if status.success() {
-                        DurableJobStatus::Completed
-                    } else {
-                        DurableJobStatus::Failed
-                    };
-                }
-                job.exit_code = status.code();
+            if let Ok(job) = read_job(&watcher_state, id).await {
+                let job_status = if status.success() {
+                    DurableJobStatus::Completed
+                } else {
+                    DurableJobStatus::Failed
+                };
                 #[cfg(unix)]
-                {
+                let signal = {
                     use std::os::unix::process::ExitStatusExt;
-                    job.signal = status.signal();
-                }
-                job.updated_at = Utc::now();
-                let _ = write_job(&watcher_state, &job).await;
+                    status.signal()
+                };
+                #[cfg(not(unix))]
+                let signal = None;
+                let _ = write_terminal_job_state(
+                    &watcher_state,
+                    job,
+                    job_status,
+                    status.code(),
+                    signal,
+                    Utc::now(),
+                )
+                .await;
             }
         }
     });

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -159,6 +159,7 @@ async fn write_job(state: &AppState, job: &DurableJob) -> Result<DurableJob, Str
     std::fs::create_dir_all(parent).map_err(|e| format!("failed to create job dir: {}", e))?;
     let lock = std::fs::OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&lock_path)

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -143,6 +143,15 @@ fn resolve_cwd(base: &Path, raw: Option<&str>) -> Result<PathBuf, String> {
 
 fn merge_job_for_write(current: Option<DurableJob>, mut next: DurableJob) -> DurableJob {
     if let Some(current) = current {
+        if matches!(
+            current.status,
+            DurableJobStatus::Completed | DurableJobStatus::Failed | DurableJobStatus::Cancelled
+        ) && !matches!(
+            next.status,
+            DurableJobStatus::Completed | DurableJobStatus::Failed | DurableJobStatus::Cancelled
+        ) {
+            return current;
+        }
         if current.status == DurableJobStatus::Cancelled
             && next.status != DurableJobStatus::Cancelled
         {
@@ -571,6 +580,17 @@ mod tests {
         let merged = merge_job_for_write(Some(current), next);
 
         assert_eq!(merged.status, DurableJobStatus::Cancelled);
+    }
+
+    #[test]
+    fn merge_job_for_write_preserves_terminal_status_over_unknown_refresh() {
+        let current = test_job(DurableJobStatus::Completed);
+        let mut next = current.clone();
+        next.status = DurableJobStatus::Unknown;
+
+        let merged = merge_job_for_write(Some(current), next);
+
+        assert_eq!(merged.status, DurableJobStatus::Completed);
     }
 
     #[tokio::test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -15,6 +15,7 @@ use axum::{
     Json, Router,
 };
 use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use uuid::Uuid;
@@ -111,6 +112,10 @@ fn job_file(state: &AppState, id: Uuid) -> PathBuf {
     job_dir(state, id).join("job.json")
 }
 
+fn job_lock_file(state: &AppState, id: Uuid) -> PathBuf {
+    job_dir(state, id).join("job.lock")
+}
+
 fn resolve_cwd(base: &Path, raw: Option<&str>) -> Result<PathBuf, String> {
     let cwd = match raw {
         Some(value) if !value.trim().is_empty() => {
@@ -134,19 +139,43 @@ fn resolve_cwd(base: &Path, raw: Option<&str>) -> Result<PathBuf, String> {
     Ok(cwd)
 }
 
-async fn write_job(state: &AppState, job: &DurableJob) -> Result<(), String> {
+fn merge_job_for_write(current: Option<DurableJob>, mut next: DurableJob) -> DurableJob {
+    if let Some(current) = current {
+        if current.status == DurableJobStatus::Cancelled
+            && next.status != DurableJobStatus::Cancelled
+        {
+            next.status = DurableJobStatus::Cancelled;
+        }
+    }
+    next
+}
+
+async fn write_job(state: &AppState, job: &DurableJob) -> Result<DurableJob, String> {
     let path = job_file(state, job.id);
     let parent = path
         .parent()
         .ok_or_else(|| "invalid durable job path".to_string())?;
-    tokio::fs::create_dir_all(parent)
-        .await
-        .map_err(|e| format!("failed to create job dir: {}", e))?;
-    let bytes = serde_json::to_vec_pretty(job)
+    let lock_path = job_lock_file(state, job.id);
+    std::fs::create_dir_all(parent).map_err(|e| format!("failed to create job dir: {}", e))?;
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|e| format!("failed to open job lock: {}", e))?;
+    lock.lock_exclusive()
+        .map_err(|e| format!("failed to lock job registry entry: {}", e))?;
+
+    let current = match std::fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice::<DurableJob>(&bytes).ok(),
+        Err(_) => None,
+    };
+    let job = merge_job_for_write(current, job.clone());
+    let bytes = serde_json::to_vec_pretty(&job)
         .map_err(|e| format!("failed to serialize job registry entry: {}", e))?;
-    tokio::fs::write(path, bytes)
-        .await
-        .map_err(|e| format!("failed to write job registry entry: {}", e))
+    std::fs::write(path, bytes)
+        .map_err(|e| format!("failed to write job registry entry: {}", e))?;
+    Ok(job)
 }
 
 async fn read_job(state: &AppState, id: Uuid) -> Result<DurableJob, String> {
@@ -165,9 +194,6 @@ async fn write_terminal_job_state(
     updated_at: DateTime<Utc>,
 ) -> DurableJob {
     if let Ok(latest) = read_job(state, job.id).await {
-        if latest.status == DurableJobStatus::Cancelled {
-            return latest;
-        }
         job = latest;
     }
 
@@ -175,8 +201,7 @@ async fn write_terminal_job_state(
     job.exit_code = exit_code;
     job.signal = signal;
     job.updated_at = updated_at;
-    let _ = write_job(state, &job).await;
-    job
+    write_job(state, &job).await.unwrap_or(job)
 }
 
 #[cfg(unix)]
@@ -232,7 +257,7 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
             if !process_alive(pid) {
                 job.status = DurableJobStatus::Unknown;
                 job.updated_at = Utc::now();
-                let _ = write_job(state, &job).await;
+                job = write_job(state, &job).await.unwrap_or(job);
             }
         }
     }
@@ -424,7 +449,7 @@ pub async fn cancel_job(
         }
         job.status = DurableJobStatus::Cancelled;
         job.updated_at = Utc::now();
-        write_job(&state, &job)
+        job = write_job(&state, &job)
             .await
             .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
     }
@@ -443,6 +468,25 @@ pub fn routes() -> Router<Arc<AppState>> {
 mod tests {
     use super::*;
 
+    fn test_job(status: DurableJobStatus) -> DurableJob {
+        let now = Utc::now();
+        DurableJob {
+            id: Uuid::new_v4(),
+            command: "true".to_string(),
+            cwd: "/tmp".to_string(),
+            status,
+            pid: Some(123),
+            exit_code: None,
+            signal: None,
+            created_at: now,
+            updated_at: now,
+            started_by_mission_id: None,
+            stdout_log: "/tmp/stdout.log".to_string(),
+            stderr_log: "/tmp/stderr.log".to_string(),
+            status_file: "/tmp/exit.json".to_string(),
+        }
+    }
+
     #[test]
     fn resolve_cwd_defaults_to_base() {
         let base = std::env::current_dir().unwrap();
@@ -454,5 +498,29 @@ mod tests {
         let base = std::env::current_dir().unwrap();
         let result = resolve_cwd(&base, Some("__definitely_missing_durable_job_cwd__"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn merge_job_for_write_preserves_cancelled_status() {
+        let current = test_job(DurableJobStatus::Cancelled);
+        let mut next = current.clone();
+        next.status = DurableJobStatus::Completed;
+        next.exit_code = Some(0);
+
+        let merged = merge_job_for_write(Some(current), next);
+
+        assert_eq!(merged.status, DurableJobStatus::Cancelled);
+        assert_eq!(merged.exit_code, Some(0));
+    }
+
+    #[test]
+    fn merge_job_for_write_allows_explicit_cancelled_update() {
+        let current = test_job(DurableJobStatus::Running);
+        let mut next = current.clone();
+        next.status = DurableJobStatus::Cancelled;
+
+        let merged = merge_job_for_write(Some(current), next);
+
+        assert_eq!(merged.status, DurableJobStatus::Cancelled);
     }
 }

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use uuid::Uuid;
 
 use super::routes::AppState;
@@ -207,6 +207,36 @@ async fn write_terminal_job_state(
     write_job(state, &job).await.unwrap_or(job)
 }
 
+fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
+    tokio::spawn(async move {
+        if let Ok(status) = child.wait().await {
+            if let Ok(job) = read_job(&state, id).await {
+                let job_status = if status.success() {
+                    DurableJobStatus::Completed
+                } else {
+                    DurableJobStatus::Failed
+                };
+                #[cfg(unix)]
+                let signal = {
+                    use std::os::unix::process::ExitStatusExt;
+                    status.signal()
+                };
+                #[cfg(not(unix))]
+                let signal = None;
+                let _ = write_terminal_job_state(
+                    &state,
+                    job,
+                    job_status,
+                    status.code(),
+                    signal,
+                    Utc::now(),
+                )
+                .await;
+            }
+        }
+    });
+}
+
 #[cfg(unix)]
 fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
@@ -345,7 +375,7 @@ pub async fn start_job(
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    let mut child = match child.spawn() {
+    let child = match child.spawn() {
         Ok(child) => child,
         Err(e) => {
             job.status = DurableJobStatus::Failed;
@@ -362,7 +392,10 @@ pub async fn start_job(
             if let Some(pid) = job.pid {
                 terminate_process_group(pid);
             }
-            let _ = child.wait().await;
+            job.status = DurableJobStatus::Failed;
+            job.updated_at = Utc::now();
+            let _ = write_job(&state, &job).await;
+            spawn_job_watcher(Arc::clone(&state), id, child);
             return Err(err(StatusCode::INTERNAL_SERVER_ERROR, e));
         }
     };
@@ -372,34 +405,7 @@ pub async fn start_job(
         }
     }
 
-    let watcher_state = Arc::clone(&state);
-    tokio::spawn(async move {
-        if let Ok(status) = child.wait().await {
-            if let Ok(job) = read_job(&watcher_state, id).await {
-                let job_status = if status.success() {
-                    DurableJobStatus::Completed
-                } else {
-                    DurableJobStatus::Failed
-                };
-                #[cfg(unix)]
-                let signal = {
-                    use std::os::unix::process::ExitStatusExt;
-                    status.signal()
-                };
-                #[cfg(not(unix))]
-                let signal = None;
-                let _ = write_terminal_job_state(
-                    &watcher_state,
-                    job,
-                    job_status,
-                    status.code(),
-                    signal,
-                    Utc::now(),
-                )
-                .await;
-            }
-        }
-    });
+    spawn_job_watcher(Arc::clone(&state), id, child);
 
     Ok(Json(job))
 }

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -17,6 +17,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::process::Command;
 use uuid::Uuid;
 
@@ -323,18 +324,13 @@ pub async fn start_job(
         });
     }
 
-    let child = child
-        .spawn()
-        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let pid = child.id();
-
     let now = Utc::now();
-    let job = DurableJob {
+    let mut job = DurableJob {
         id,
         command: command.to_string(),
         cwd: cwd.to_string_lossy().to_string(),
         status: DurableJobStatus::Running,
-        pid,
+        pid: None,
         exit_code: None,
         signal: None,
         created_at: now,
@@ -344,9 +340,35 @@ pub async fn start_job(
         stderr_log: stderr_log.to_string_lossy().to_string(),
         status_file: status_file.to_string_lossy().to_string(),
     };
-    write_job(&state, &job)
+    job = write_job(&state, &job)
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let child = match child.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            job.status = DurableJobStatus::Failed;
+            job.updated_at = Utc::now();
+            let _ = write_job(&state, &job).await;
+            return Err(err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
+        }
+    };
+    job.pid = child.id();
+    job.updated_at = Utc::now();
+    job = match write_job(&state, &job).await {
+        Ok(job) => job,
+        Err(e) => {
+            if let Some(pid) = job.pid {
+                terminate_process_group(pid);
+            }
+            return Err(err(StatusCode::INTERNAL_SERVER_ERROR, e));
+        }
+    };
+    if job.status == DurableJobStatus::Cancelled {
+        if let Some(pid) = job.pid {
+            terminate_process_group(pid);
+        }
+    }
 
     let watcher_state = Arc::clone(&state);
     tokio::spawn(async move {
@@ -409,12 +431,22 @@ pub async fn get_job(
 }
 
 async fn tail_file(path: &str, max_bytes: usize) -> String {
-    let Ok(bytes) = tokio::fs::read(path).await else {
+    let keep = max_bytes.clamp(1, 256 * 1024);
+    let Ok(mut file) = tokio::fs::File::open(path).await else {
         return String::new();
     };
-    let keep = max_bytes.clamp(1, 256 * 1024);
-    let start = bytes.len().saturating_sub(keep);
-    String::from_utf8_lossy(&bytes[start..]).to_string()
+    let Ok(metadata) = file.metadata().await else {
+        return String::new();
+    };
+    let start = metadata.len().saturating_sub(keep as u64);
+    if file.seek(std::io::SeekFrom::Start(start)).await.is_err() {
+        return String::new();
+    }
+    let mut bytes = Vec::new();
+    if file.read_to_end(&mut bytes).await.is_err() {
+        return String::new();
+    }
+    String::from_utf8_lossy(&bytes).to_string()
 }
 
 pub async fn job_logs(
@@ -453,14 +485,14 @@ pub async fn cancel_job(
         .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
     job = refresh_job(&state, job).await;
     if job.status == DurableJobStatus::Running {
-        if let Some(pid) = job.pid {
-            terminate_process_group(pid);
-        }
         job.status = DurableJobStatus::Cancelled;
         job.updated_at = Utc::now();
         job = write_job(&state, &job)
             .await
             .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        if let Some(pid) = job.pid {
+            terminate_process_group(pid);
+        }
     }
     Ok(Json(job))
 }

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -301,9 +301,8 @@ pub async fn start_job(
         command
     );
 
-    let mut child = Command::new("setsid");
+    let mut child = Command::new("/bin/sh");
     child
-        .arg("/bin/sh")
         .arg("-lc")
         .arg(wrapper)
         .current_dir(&cwd)
@@ -313,6 +312,15 @@ pub async fn start_job(
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
+    #[cfg(unix)]
+    unsafe {
+        child.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
 
     let child = child
         .spawn()

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -1,0 +1,426 @@
+//! Durable background jobs.
+//!
+//! Jobs are launched by the API server rather than by an ephemeral agent shell.
+//! That places long-running commands under the server's lifecycle and gives
+//! later turns an explicit registry for status, logs, and cancellation.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+use uuid::Uuid;
+
+use super::routes::AppState;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DurableJobStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DurableJob {
+    pub id: Uuid,
+    pub command: String,
+    pub cwd: String,
+    pub status: DurableJobStatus,
+    pub pid: Option<u32>,
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub started_by_mission_id: Option<Uuid>,
+    pub stdout_log: String,
+    pub stderr_log: String,
+    pub status_file: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StartDurableJobRequest {
+    pub command: String,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub started_by_mission_id: Option<Uuid>,
+    #[serde(default)]
+    pub env: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JobLogsQuery {
+    #[serde(default = "default_tail_bytes")]
+    pub tail_bytes: usize,
+    #[serde(default)]
+    pub stream: Option<String>,
+}
+
+fn default_tail_bytes() -> usize {
+    16 * 1024
+}
+
+#[derive(Debug, Serialize)]
+pub struct JobLogsResponse {
+    pub job_id: Uuid,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ExitRecord {
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    finished_at: DateTime<Utc>,
+}
+
+fn err(status: StatusCode, message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn jobs_root(state: &AppState) -> PathBuf {
+    state.config.working_dir.join(".sandboxed-sh/durable-jobs")
+}
+
+fn job_dir(state: &AppState, id: Uuid) -> PathBuf {
+    jobs_root(state).join(id.to_string())
+}
+
+fn job_file(state: &AppState, id: Uuid) -> PathBuf {
+    job_dir(state, id).join("job.json")
+}
+
+fn resolve_cwd(base: &Path, raw: Option<&str>) -> Result<PathBuf, String> {
+    let cwd = match raw {
+        Some(value) if !value.trim().is_empty() => {
+            let path = PathBuf::from(value.trim());
+            if path.is_absolute() {
+                path
+            } else {
+                base.join(path)
+            }
+        }
+        _ => base.to_path_buf(),
+    };
+
+    if !cwd.exists() {
+        return Err(format!("cwd does not exist: {}", cwd.display()));
+    }
+    if !cwd.is_dir() {
+        return Err(format!("cwd is not a directory: {}", cwd.display()));
+    }
+
+    Ok(cwd)
+}
+
+async fn write_job(state: &AppState, job: &DurableJob) -> Result<(), String> {
+    let path = job_file(state, job.id);
+    let parent = path
+        .parent()
+        .ok_or_else(|| "invalid durable job path".to_string())?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|e| format!("failed to create job dir: {}", e))?;
+    let bytes = serde_json::to_vec_pretty(job)
+        .map_err(|e| format!("failed to serialize job registry entry: {}", e))?;
+    tokio::fs::write(path, bytes)
+        .await
+        .map_err(|e| format!("failed to write job registry entry: {}", e))
+}
+
+async fn read_job(state: &AppState, id: Uuid) -> Result<DurableJob, String> {
+    let bytes = tokio::fs::read(job_file(state, id))
+        .await
+        .map_err(|_| format!("durable job not found: {}", id))?;
+    serde_json::from_slice(&bytes).map_err(|e| format!("invalid durable job entry: {}", e))
+}
+
+#[cfg(unix)]
+fn process_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn process_alive(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn terminate_process_group(pid: u32) {
+    unsafe {
+        let pgid = libc::getpgid(pid as libc::pid_t);
+        if pgid > 0 {
+            let _ = libc::kill(-pgid, libc::SIGTERM);
+        } else {
+            let _ = libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_process_group(_pid: u32) {}
+
+async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
+    if matches!(
+        job.status,
+        DurableJobStatus::Running | DurableJobStatus::Unknown
+    ) {
+        if let Ok(bytes) = tokio::fs::read(&job.status_file).await {
+            if let Ok(exit) = serde_json::from_slice::<ExitRecord>(&bytes) {
+                job.status = if exit.exit_code == Some(0) {
+                    DurableJobStatus::Completed
+                } else {
+                    DurableJobStatus::Failed
+                };
+                job.exit_code = exit.exit_code;
+                job.signal = exit.signal;
+                job.updated_at = exit.finished_at;
+                let _ = write_job(state, &job).await;
+                return job;
+            }
+        }
+
+        if let Some(pid) = job.pid {
+            if !process_alive(pid) {
+                job.status = DurableJobStatus::Unknown;
+                job.updated_at = Utc::now();
+                let _ = write_job(state, &job).await;
+            }
+        }
+    }
+    job
+}
+
+pub async fn start_job(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<StartDurableJobRequest>,
+) -> Result<Json<DurableJob>, (StatusCode, Json<ErrorResponse>)> {
+    let command = req.command.trim();
+    if command.is_empty() {
+        return Err(err(StatusCode::BAD_REQUEST, "command is required"));
+    }
+
+    let cwd = resolve_cwd(&state.config.working_dir, req.cwd.as_deref())
+        .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
+
+    let id = Uuid::new_v4();
+    let dir = job_dir(&state, id);
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let stdout_log = dir.join("stdout.log");
+    let stderr_log = dir.join("stderr.log");
+    let status_file = dir.join("exit.json");
+
+    let stdout = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stdout_log)
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let stderr = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log)
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let wrapper = format!(
+        "cd \"$SANDBOXED_SH_DURABLE_CWD\" && {{ {}; }}\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n",
+        command
+    );
+
+    let mut child = Command::new("setsid");
+    child
+        .arg("/bin/sh")
+        .arg("-lc")
+        .arg(wrapper)
+        .current_dir(&cwd)
+        .env("SANDBOXED_SH_DURABLE_CWD", &cwd)
+        .env("SANDBOXED_SH_DURABLE_STATUS", &status_file)
+        .envs(req.env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+
+    let child = child
+        .spawn()
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let pid = child.id();
+
+    let now = Utc::now();
+    let job = DurableJob {
+        id,
+        command: command.to_string(),
+        cwd: cwd.to_string_lossy().to_string(),
+        status: DurableJobStatus::Running,
+        pid,
+        exit_code: None,
+        signal: None,
+        created_at: now,
+        updated_at: now,
+        started_by_mission_id: req.started_by_mission_id,
+        stdout_log: stdout_log.to_string_lossy().to_string(),
+        stderr_log: stderr_log.to_string_lossy().to_string(),
+        status_file: status_file.to_string_lossy().to_string(),
+    };
+    write_job(&state, &job)
+        .await
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let watcher_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let mut child = child;
+        if let Ok(status) = child.wait().await {
+            if let Ok(mut job) = read_job(&watcher_state, id).await {
+                let was_cancelled = job.status == DurableJobStatus::Cancelled;
+                if !was_cancelled {
+                    job.status = if status.success() {
+                        DurableJobStatus::Completed
+                    } else {
+                        DurableJobStatus::Failed
+                    };
+                }
+                job.exit_code = status.code();
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    job.signal = status.signal();
+                }
+                job.updated_at = Utc::now();
+                let _ = write_job(&watcher_state, &job).await;
+            }
+        }
+    });
+
+    Ok(Json(job))
+}
+
+pub async fn list_jobs(State(state): State<Arc<AppState>>) -> Json<Vec<DurableJob>> {
+    let mut jobs = Vec::new();
+    let root = jobs_root(&state);
+    if let Ok(mut entries) = tokio::fs::read_dir(root).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path().join("job.json");
+            if let Ok(bytes) = tokio::fs::read(path).await {
+                if let Ok(job) = serde_json::from_slice::<DurableJob>(&bytes) {
+                    jobs.push(refresh_job(&state, job).await);
+                }
+            }
+        }
+    }
+    jobs.sort_by_key(|job| std::cmp::Reverse(job.created_at));
+    Json(jobs)
+}
+
+pub async fn get_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<Uuid>,
+) -> Result<Json<DurableJob>, (StatusCode, Json<ErrorResponse>)> {
+    let job = read_job(&state, id)
+        .await
+        .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+    Ok(Json(refresh_job(&state, job).await))
+}
+
+async fn tail_file(path: &str, max_bytes: usize) -> String {
+    let Ok(bytes) = tokio::fs::read(path).await else {
+        return String::new();
+    };
+    let keep = max_bytes.clamp(1, 256 * 1024);
+    let start = bytes.len().saturating_sub(keep);
+    String::from_utf8_lossy(&bytes[start..]).to_string()
+}
+
+pub async fn job_logs(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<Uuid>,
+    axum::extract::Query(query): axum::extract::Query<JobLogsQuery>,
+) -> Result<Json<JobLogsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let job = read_job(&state, id)
+        .await
+        .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+
+    let stdout = if query.stream.as_deref() == Some("stderr") {
+        String::new()
+    } else {
+        tail_file(&job.stdout_log, query.tail_bytes).await
+    };
+    let stderr = if query.stream.as_deref() == Some("stdout") {
+        String::new()
+    } else {
+        tail_file(&job.stderr_log, query.tail_bytes).await
+    };
+
+    Ok(Json(JobLogsResponse {
+        job_id: id,
+        stdout,
+        stderr,
+    }))
+}
+
+pub async fn cancel_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<Uuid>,
+) -> Result<Json<DurableJob>, (StatusCode, Json<ErrorResponse>)> {
+    let mut job = read_job(&state, id)
+        .await
+        .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+    job = refresh_job(&state, job).await;
+    if job.status == DurableJobStatus::Running {
+        if let Some(pid) = job.pid {
+            terminate_process_group(pid);
+        }
+        job.status = DurableJobStatus::Cancelled;
+        job.updated_at = Utc::now();
+        write_job(&state, &job)
+            .await
+            .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    }
+    Ok(Json(job))
+}
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/", get(list_jobs).post(start_job))
+        .route("/:id", get(get_job))
+        .route("/:id/logs", get(job_logs))
+        .route("/:id/cancel", post(cancel_job))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_cwd_defaults_to_base() {
+        let base = std::env::current_dir().unwrap();
+        assert_eq!(resolve_cwd(&base, None).unwrap(), base);
+    }
+
+    #[test]
+    fn resolve_cwd_rejects_missing_path() {
+        let base = std::env::current_dir().unwrap();
+        let result = resolve_cwd(&base, Some("__definitely_missing_durable_job_cwd__"));
+        assert!(result.is_err());
+    }
+}

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -4,6 +4,7 @@
 //! That places long-running commands under the server's lifecycle and gives
 //! later turns an explicit registry for status, logs, and cancellation.
 
+use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -344,7 +345,7 @@ pub async fn start_job(
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    let child = match child.spawn() {
+    let mut child = match child.spawn() {
         Ok(child) => child,
         Err(e) => {
             job.status = DurableJobStatus::Failed;
@@ -361,6 +362,7 @@ pub async fn start_job(
             if let Some(pid) = job.pid {
                 terminate_process_group(pid);
             }
+            let _ = child.wait().await;
             return Err(err(StatusCode::INTERNAL_SERVER_ERROR, e));
         }
     };
@@ -372,7 +374,6 @@ pub async fn start_job(
 
     let watcher_state = Arc::clone(&state);
     tokio::spawn(async move {
-        let mut child = child;
         if let Ok(status) = child.wait().await {
             if let Ok(job) = read_job(&watcher_state, id).await {
                 let job_status = if status.success() {
@@ -439,10 +440,11 @@ async fn tail_file(path: &str, max_bytes: usize) -> String {
         return String::new();
     };
     let start = metadata.len().saturating_sub(keep as u64);
-    if file.seek(std::io::SeekFrom::Start(start)).await.is_err() {
+    if file.seek(SeekFrom::Start(start)).await.is_err() {
         return String::new();
     }
-    let mut bytes = Vec::new();
+
+    let mut bytes = Vec::with_capacity(keep);
     if file.read_to_end(&mut bytes).await.is_err() {
         return String::new();
     }
@@ -563,5 +565,16 @@ mod tests {
         let merged = merge_job_for_write(Some(current), next);
 
         assert_eq!(merged.status, DurableJobStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn tail_file_reads_only_requested_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout.log");
+        std::fs::write(&path, "0123456789abcdef").unwrap();
+
+        let tail = tail_file(path.to_str().unwrap(), 6).await;
+
+        assert_eq!(tail, "abcdef");
     }
 }

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -282,9 +282,9 @@ pub async fn start_job(
         .arg("-lc")
         .arg(wrapper)
         .current_dir(&cwd)
+        .envs(req.env)
         .env("SANDBOXED_SH_DURABLE_CWD", &cwd)
         .env("SANDBOXED_SH_DURABLE_STATUS", &status_file)
-        .envs(req.env)
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -26,6 +26,7 @@ pub mod control_metrics;
 pub mod deferred_proxy;
 pub mod desktop;
 mod desktop_stream;
+pub mod durable_jobs;
 pub mod fido;
 mod fs;
 mod github_auth;

--- a/src/api/paloma/cooldown.rs
+++ b/src/api/paloma/cooldown.rs
@@ -209,7 +209,7 @@ mod tests {
                 sent_at = now;
                 sends += 1;
             }
-            now = now + Duration::minutes(5);
+            now += Duration::minutes(5);
         }
 
         // Pre-fix behaviour was ~14 messages. We accept up to 4 (immediate,

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -66,6 +66,7 @@ use super::control;
 use super::deferred_proxy as deferred_proxy_api;
 use super::desktop;
 use super::desktop_stream;
+use super::durable_jobs;
 use super::fs;
 use super::github_auth;
 use super::library as library_api;
@@ -979,6 +980,8 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest("/api/settings", settings_api::routes())
         // Desktop session management endpoints
         .nest("/api/desktop", desktop::routes())
+        // Durable background jobs launched outside ephemeral agent-turn shells
+        .nest("/api/durable-jobs", durable_jobs::routes())
         // System component management endpoints
         .nest("/api/system", system_api::routes())
         // Auth management endpoints

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2614,7 +2614,8 @@ mod tests {
         // Sanity: a value below 60s would render the safety useless given
         // typical agent retry behavior. If you genuinely need to lower
         // this, change the test deliberately.
-        assert!(DEPLOY_DEBOUNCE_SECS >= 60);
+        let debounce_secs = DEPLOY_DEBOUNCE_SECS;
+        assert!(debounce_secs >= 60);
     }
 
     // ─── Pre-existing helpers ───────────────────────────────────────────────

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -170,6 +170,29 @@ struct BackendAuthStatusParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct DurableJobStartParams {
+    command: String,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    env: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableJobIdParams {
+    job_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurableJobLogsParams {
+    job_id: String,
+    #[serde(default)]
+    tail_bytes: Option<usize>,
+    #[serde(default)]
+    stream: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct CreateWorktreeParams {
     /// Path relative to the workspace root where the worktree will be created
     path: String,
@@ -354,6 +377,55 @@ impl OrchestratorMcp {
                             "description": "Optional single backend to inspect. If omitted, returns all common backends."
                         }
                     }
+                }),
+            },
+            ToolDefinition {
+                name: "durable_job_start".to_string(),
+                description: "Start a long-running server-managed background command that survives ephemeral agent session cleanup. Use this for multi-hour builds, large test suites, image builds, and similar work.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["command"],
+                    "properties": {
+                        "command": {"type": "string", "description": "Shell command to run."},
+                        "cwd": {"type": "string", "description": "Working directory. Relative paths resolve from the server working directory."},
+                        "env": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Environment variables to add."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "durable_job_list".to_string(),
+                description: "List durable background jobs with current status, pid, command, cwd, and log paths.".to_string(),
+                input_schema: json!({"type": "object", "properties": {}}),
+            },
+            ToolDefinition {
+                name: "durable_job_status".to_string(),
+                description: "Get current status for a durable background job.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["job_id"],
+                    "properties": {"job_id": {"type": "string", "description": "Durable job UUID."}}
+                }),
+            },
+            ToolDefinition {
+                name: "durable_job_logs".to_string(),
+                description: "Read the tail of stdout and/or stderr logs for a durable background job.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["job_id"],
+                    "properties": {
+                        "job_id": {"type": "string", "description": "Durable job UUID."},
+                        "tail_bytes": {"type": "integer", "description": "Maximum bytes to return from each selected stream. Defaults to 16384."},
+                        "stream": {"type": "string", "enum": ["stdout", "stderr"], "description": "Optional single stream to return. Omit for both."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "durable_job_cancel".to_string(),
+                description: "Cancel a running durable background job by terminating its process group.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["job_id"],
+                    "properties": {"job_id": {"type": "string", "description": "Durable job UUID."}}
                 }),
             },
             ToolDefinition {
@@ -1030,6 +1102,96 @@ impl OrchestratorMcp {
         })
     }
 
+    async fn durable_job_start(&self, params: DurableJobStartParams) -> Result<Value, String> {
+        let cwd = params.cwd.or_else(|| {
+            std::env::var("WORKING_DIR")
+                .ok()
+                .or_else(|| std::env::var("SANDBOXED_SH_WORKSPACE").ok())
+        });
+        let body = json!({
+            "command": params.command,
+            "cwd": cwd,
+            "env": params.env,
+            "started_by_mission_id": self.mission_id,
+        });
+        let response = self.api_post("/api/durable-jobs", body).await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to start durable job: {}", text));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse durable job response: {}", e))
+    }
+
+    async fn durable_job_list(&self) -> Result<Value, String> {
+        let response = self.api_get("/api/durable-jobs").await?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "Failed to list durable jobs: {}",
+                response.status()
+            ));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse durable job list: {}", e))
+    }
+
+    async fn durable_job_status(&self, params: DurableJobIdParams) -> Result<Value, String> {
+        let id = Uuid::parse_str(&params.job_id)
+            .map_err(|_| "Invalid durable job ID format".to_string())?;
+        let response = self.api_get(&format!("/api/durable-jobs/{}", id)).await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Durable job not found: {}", text));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse durable job status: {}", e))
+    }
+
+    async fn durable_job_logs(&self, params: DurableJobLogsParams) -> Result<Value, String> {
+        let id = Uuid::parse_str(&params.job_id)
+            .map_err(|_| "Invalid durable job ID format".to_string())?;
+        let mut path = format!(
+            "/api/durable-jobs/{}/logs?tail_bytes={}",
+            id,
+            params.tail_bytes.unwrap_or(16 * 1024)
+        );
+        if let Some(stream) = params.stream {
+            path.push_str("&stream=");
+            path.push_str(&urlencoding::encode(&stream));
+        }
+        let response = self.api_get(&path).await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to read durable job logs: {}", text));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse durable job logs: {}", e))
+    }
+
+    async fn durable_job_cancel(&self, params: DurableJobIdParams) -> Result<Value, String> {
+        let id = Uuid::parse_str(&params.job_id)
+            .map_err(|_| "Invalid durable job ID format".to_string())?;
+        let response = self
+            .api_post(&format!("/api/durable-jobs/{}/cancel", id), json!({}))
+            .await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to cancel durable job: {}", text));
+        }
+        response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse durable job cancellation: {}", e))
+    }
+
     fn create_worktree(&self, params: CreateWorktreeParams) -> Result<Value, String> {
         let path = &params.path;
         let branch = &params.branch;
@@ -1463,6 +1625,27 @@ impl OrchestratorMcp {
                 let params: BackendAuthStatusParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
                 Ok(self.get_backend_auth_status(params))
+            }
+            "durable_job_start" => {
+                let params: DurableJobStartParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.durable_job_start(params).await
+            }
+            "durable_job_list" => self.durable_job_list().await,
+            "durable_job_status" => {
+                let params: DurableJobIdParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.durable_job_status(params).await
+            }
+            "durable_job_logs" => {
+                let params: DurableJobLogsParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.durable_job_logs(params).await
+            }
+            "durable_job_cancel" => {
+                let params: DurableJobIdParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.durable_job_cancel(params).await
             }
             "create_worker_mission" => {
                 let params: CreateWorkerParams =


### PR DESCRIPTION
## Summary

Implements the first-class durable job escape hatch requested in #464.

- Adds protected `/api/durable-jobs` endpoints for start/list/status/logs/cancel.
- Launches commands from the API server with `setsid`, null stdin, explicit stdout/stderr log files, and a persisted registry under `.sandboxed-sh/durable-jobs`.
- Preserves a user-requested `cancelled` state even when the child exits via SIGTERM.
- Exposes the flow through `orchestrator-mcp` tools: `durable_job_start`, `durable_job_list`, `durable_job_status`, `durable_job_logs`, and `durable_job_cancel`.
- Defaults MCP-launched jobs to the mission `WORKING_DIR`/`SANDBOXED_SH_WORKSPACE` when `cwd` is omitted.

Fixes #464.

## Validation

- `cargo fmt --check`
- `cargo build --bin sandboxed-sh --bin orchestrator-mcp`
- `cargo test durable_jobs --lib --bins`
- `cargo test --lib` (878 passed, 2 ignored)
- Smoke-tested local API on `PORT=3199`:
  - start long-running job
  - read stdout/stderr logs
  - observe completion
  - cancel process group and verify final status remains `cancelled`
- Smoke-tested `orchestrator-mcp` JSON-RPC:
  - tool list includes durable job tools
  - `durable_job_start` can launch a job through the API
  - default cwd comes from `WORKING_DIR`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New capability runs arbitrary shell commands on the API server host (auth-protected like other routes); process-group kill and persisted job state add operational surface area worth reviewing for command injection and resource limits.
> 
> **Overview**
> Adds a **durable job** path so long-running shell work can outlive ephemeral agent turns. The API server starts commands directly (not inside mission shells), tracks them in `.sandboxed-sh/durable-jobs`, and exposes **start / list / status / log tail / cancel** under authenticated `/api/durable-jobs`.
> 
> Each job runs in its own process group (`setsid`), writes stdout/stderr to files, and records exit metadata via a wrapper script. Registry updates use file locks; **cancelled** status is sticky so a SIGTERM exit does not overwrite user cancellation. **orchestrator-mcp** gains matching tools (`durable_job_*`), defaulting `cwd` from mission `WORKING_DIR` / `SANDBOXED_SH_WORKSPACE` when omitted.
> 
> Unrelated nits: Paloma cooldown test uses `+=`; deploy debounce test binds the constant to a local before asserting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff2bd1e23dadde76990f9a5c6bd31c40608003c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->