### PR TITLE
Fix provider reconnect to open the OAuth flow instead of failing

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -462,9 +462,13 @@ export default function ProvidersPage() {
             fresh?.error || fresh?.status || 'unknown error'
           )}`
         );
+      } else {
+        toast.success('Provider reconnected');
       }
     } catch {
-      // Health probe is best-effort; the reconnect itself already succeeded.
+      // Health probe is best-effort; the reconnect itself already succeeded, so
+      // still surface success rather than leaving the action without feedback.
+      toast.success('Provider reconnected');
     }
   };
 

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -31,6 +31,10 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AddProviderModal } from '@/components/ui/add-provider-modal';
+import {
+  ReconnectProviderModal,
+  providerSupportsOAuthReconnect,
+} from '@/components/ui/reconnect-provider-modal';
 import { AsyncButton } from '@/components/ui/async-button';
 import { UsageOverview } from '@/components/ui/usage-overview';
 import type { UsageWindow } from '@/lib/api';
@@ -312,6 +316,7 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
 
 export default function ProvidersPage() {
   const [showAddModal, setShowAddModal] = useState(false);
+  const [reconnectProvider, setReconnectProvider] = useState<AIProvider | null>(null);
   const [authenticatingProviderId, setAuthenticatingProviderId] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
   const [expandedProvider, setExpandedProvider] = useState<string | null>(null);
@@ -427,7 +432,53 @@ export default function ProvidersPage() {
     [expandedProvider, fetchUsage, cachedSeen]
   );
 
+  // After a fresh usage probe, surface the real provider health rather than a
+  // misleading "authenticated" message, and patch the cached snapshots so the
+  // status indicator doesn't revert to the stale error before the next poll.
+  const probeProviderHealth = async (providerId: string) => {
+    const fresh = await refreshProviderUsage(providerId);
+    setUsageData((prev) => ({ ...prev, [providerId]: fresh }));
+    mutateBulkUsage(
+      (current) =>
+        current
+          ? { ...current, entries: { ...current.entries, [providerId]: fresh } }
+          : current,
+      { revalidate: false }
+    );
+    return fresh;
+  };
+
+  const handleReconnectSuccess = async (providerId: string) => {
+    mutateProviders();
+    try {
+      const fresh = await probeProviderHealth(providerId);
+      const stillBroken =
+        !!fresh?.error ||
+        (typeof fresh?.status === 'string' &&
+          !['connected', 'ok'].includes(fresh.status));
+      if (stillBroken) {
+        toast.error(
+          `Reconnected, but provider check still fails: ${String(
+            fresh?.error || fresh?.status || 'unknown error'
+          )}`
+        );
+      }
+    } catch {
+      // Health probe is best-effort; the reconnect itself already succeeded.
+    }
+  };
+
   const handleAuthenticate = async (provider: AIProvider) => {
+    // OAuth-backed providers (e.g. xAI/Grok, Anthropic) must go through the real
+    // OAuth flow to mint fresh tokens. The /auth endpoint only checks whether
+    // credentials *exist* (expired tokens still count), so it would report
+    // success and never open the authorization link. Route them to the OAuth
+    // reconnect modal instead. API-key providers keep the legacy path below.
+    if (providerSupportsOAuthReconnect(provider)) {
+      setReconnectProvider(provider);
+      return;
+    }
+
     setAuthenticatingProviderId(provider.id);
     try {
       const result = await authenticateAIProvider(provider.id);
@@ -438,17 +489,7 @@ export default function ProvidersPage() {
         // red. Force a fresh usage probe so the status indicator reflects
         // reality instead of the stale cached error, then surface the real
         // outcome rather than a misleading "authenticated" message.
-        const fresh = await refreshProviderUsage(provider.id);
-        setUsageData((prev) => ({ ...prev, [provider.id]: fresh }));
-        // Patch the bulk snapshot too so the next periodic poll doesn't
-        // revert this row to the old cached error before its 60s tick.
-        mutateBulkUsage(
-          (current) =>
-            current
-              ? { ...current, entries: { ...current.entries, [provider.id]: fresh } }
-              : current,
-          { revalidate: false }
-        );
+        const fresh = await probeProviderHealth(provider.id);
         const stillBroken =
           !!fresh?.error ||
           (typeof fresh?.status === 'string' &&
@@ -553,6 +594,13 @@ export default function ProvidersPage() {
         onClose={() => setShowAddModal(false)}
         onSuccess={() => mutateProviders()}
         providerTypes={providerTypes}
+      />
+
+      <ReconnectProviderModal
+        provider={reconnectProvider}
+        open={reconnectProvider !== null}
+        onClose={() => setReconnectProvider(null)}
+        onSuccess={(id) => handleReconnectSuccess(id)}
       />
 
       <div className="w-full max-w-4xl space-y-6">

--- a/dashboard/src/components/ui/reconnect-provider-modal.tsx
+++ b/dashboard/src/components/ui/reconnect-provider-modal.tsx
@@ -62,6 +62,11 @@ export function ReconnectProviderModal({
   onSuccess,
 }: ReconnectProviderModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  // Monotonic token to discard stale `oauthAuthorize` responses: closing the
+  // modal or switching providers while a request is in flight bumps this, so a
+  // late response can't apply its URL/step/loading state to a different (or
+  // already-closed) provider.
+  const authorizeReqRef = useRef(0);
 
   const [step, setStep] = useState<Step>('select-method');
   const [methodIndex, setMethodIndex] = useState<number | null>(null);
@@ -74,17 +79,22 @@ export function ReconnectProviderModal({
   const startAuthorize = useCallback(
     async (index: number) => {
       if (!provider) return;
+      const reqId = ++authorizeReqRef.current;
       setMethodIndex(index);
       setLoading(true);
       try {
         const response = await oauthAuthorize(provider.id, index);
+        // A newer authorize started, or the modal closed/switched providers —
+        // drop this stale response so it can't hijack the current state.
+        if (authorizeReqRef.current !== reqId) return;
         setOauthResponse(response);
         setStep('oauth-callback');
         window.open(response.url, '_blank');
       } catch (err) {
+        if (authorizeReqRef.current !== reqId) return;
         toast.error(`Failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
       } finally {
-        setLoading(false);
+        if (authorizeReqRef.current === reqId) setLoading(false);
       }
     },
     [provider]
@@ -94,6 +104,8 @@ export function ReconnectProviderModal({
   // selection step and kick off authorization immediately.
   useEffect(() => {
     if (open && provider) {
+      // Invalidate any authorize request still in flight from a previous open.
+      authorizeReqRef.current += 1;
       setStep('select-method');
       setMethodIndex(null);
       setOauthResponse(null);
@@ -107,6 +119,8 @@ export function ReconnectProviderModal({
   }, [open, provider?.id]);
 
   const handleClose = useCallback(() => {
+    // Supersede any in-flight authorize so its late response is ignored.
+    authorizeReqRef.current += 1;
     onClose();
   }, [onClose]);
 
@@ -139,7 +153,9 @@ export function ReconnectProviderModal({
     setLoading(true);
     try {
       await oauthCallback(provider.id, methodIndex, oauthCode, provider.use_for_backends);
-      toast.success('Provider reconnected');
+      // Don't celebrate yet — `onSuccess` runs a usage probe and owns the
+      // success/failure toast, so we avoid showing "reconnected" followed by a
+      // "check still fails" error for the same action.
       onSuccess(provider.id);
       onClose();
     } catch (err) {

--- a/dashboard/src/components/ui/reconnect-provider-modal.tsx
+++ b/dashboard/src/components/ui/reconnect-provider-modal.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { X, ExternalLink, Loader } from 'lucide-react';
+import { toast } from '@/components/toast';
+import { cn } from '@/lib/utils';
+import {
+  oauthAuthorize,
+  oauthCallback,
+  AIProvider,
+  OAuthAuthorizeResponse,
+} from '@/lib/api';
+
+interface ReconnectMethod {
+  /** Index into the backend `ProviderType::auth_methods()` list. */
+  index: number;
+  label: string;
+  description: string;
+}
+
+// OAuth methods available for reconnecting each provider type. The `index`
+// MUST match the ordering of `ProviderType::auth_methods()` in
+// `src/api/ai_providers.rs`, since the backend resolves the method (and, for
+// Anthropic, the OAuth mode) by that index.
+const RECONNECT_OAUTH_METHODS: Record<string, ReconnectMethod[]> = {
+  anthropic: [
+    { index: 0, label: 'Claude Pro/Max', description: 'Reconnect with your Claude subscription' },
+    { index: 1, label: 'Create API Key', description: 'Create a new key via OAuth' },
+  ],
+  openai: [
+    { index: 0, label: 'ChatGPT Plus/Pro (OAuth)', description: 'Reconnect via official OpenAI OAuth' },
+  ],
+  google: [
+    { index: 0, label: 'OAuth with Google (Gemini CLI)', description: 'Reconnect via Google OAuth' },
+  ],
+  xai: [
+    { index: 0, label: 'Grok Build OAuth', description: 'Reconnect via grok.com device authorization' },
+  ],
+};
+
+export function providerSupportsOAuthReconnect(provider: AIProvider): boolean {
+  return (
+    provider.uses_oauth &&
+    !provider.has_api_key &&
+    RECONNECT_OAUTH_METHODS[provider.provider_type] !== undefined
+  );
+}
+
+interface ReconnectProviderModalProps {
+  provider: AIProvider | null;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (providerId: string) => void;
+}
+
+type Step = 'select-method' | 'oauth-callback';
+
+export function ReconnectProviderModal({
+  provider,
+  open,
+  onClose,
+  onSuccess,
+}: ReconnectProviderModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const [step, setStep] = useState<Step>('select-method');
+  const [methodIndex, setMethodIndex] = useState<number | null>(null);
+  const [oauthResponse, setOauthResponse] = useState<OAuthAuthorizeResponse | null>(null);
+  const [oauthCode, setOauthCode] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const methods = provider ? RECONNECT_OAUTH_METHODS[provider.provider_type] ?? [] : [];
+
+  const startAuthorize = useCallback(
+    async (index: number) => {
+      if (!provider) return;
+      setMethodIndex(index);
+      setLoading(true);
+      try {
+        const response = await oauthAuthorize(provider.id, index);
+        setOauthResponse(response);
+        setStep('oauth-callback');
+        window.open(response.url, '_blank');
+      } catch (err) {
+        toast.error(`Failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [provider]
+  );
+
+  // Reset on open. When only a single OAuth method exists (e.g. xAI), skip the
+  // selection step and kick off authorization immediately.
+  useEffect(() => {
+    if (open && provider) {
+      setStep('select-method');
+      setMethodIndex(null);
+      setOauthResponse(null);
+      setOauthCode('');
+      setLoading(false);
+      if (methods.length === 1) {
+        startAuthorize(methods[0].index);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, provider?.id]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  // Escape to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open && !loading) handleClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleClose, open, loading]);
+
+  // Click outside to close
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node) && !loading) {
+        handleClose();
+      }
+    };
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [handleClose, open, loading]);
+
+  const handleSubmitCode = async () => {
+    if (!provider || methodIndex === null) return;
+    if (!oauthCode.trim() && oauthResponse?.method !== 'auto') return;
+
+    setLoading(true);
+    try {
+      await oauthCallback(provider.id, methodIndex, oauthCode, provider.use_for_backends);
+      toast.success('Provider reconnected');
+      onSuccess(provider.id);
+      onClose();
+    } catch (err) {
+      toast.error(`Failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open || !provider) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-sm max-h-[calc(100vh-2rem)] flex flex-col rounded-2xl bg-[#1a1a1a] border border-white/[0.06] shadow-xl animate-in fade-in zoom-in-95 duration-200"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.06]">
+          <h3 className="text-base font-semibold text-white">
+            Reconnect {provider.label || provider.provider_type_name}
+          </h3>
+          <button
+            onClick={handleClose}
+            disabled={loading}
+            className="p-1 rounded-lg text-white/40 hover:text-white/70 hover:bg-white/[0.08] transition-colors cursor-pointer disabled:opacity-50"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-4 overflow-y-auto">
+          {step === 'select-method' && (
+            <div className="space-y-1">
+              {methods.length === 0 ? (
+                <p className="text-sm text-white/60 p-3">
+                  No OAuth reconnect method available for this provider.
+                </p>
+              ) : (
+                methods.map((method) => (
+                  <button
+                    key={method.index}
+                    onClick={() => startAuthorize(method.index)}
+                    disabled={loading}
+                    className={cn(
+                      'w-full flex items-center gap-3 p-3 rounded-xl transition-colors cursor-pointer text-left hover:bg-white/[0.04]',
+                      loading && 'opacity-50 cursor-not-allowed'
+                    )}
+                  >
+                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/[0.04]">
+                      {loading && methodIndex === method.index ? (
+                        <Loader className="h-4 w-4 text-white/40 animate-spin" />
+                      ) : (
+                        <ExternalLink className="h-4 w-4 text-white/40" />
+                      )}
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-sm text-white">{method.label}</div>
+                      <div className="text-xs text-white/40">{method.description}</div>
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+
+          {step === 'oauth-callback' && oauthResponse && (
+            <div className="space-y-4">
+              <div className="text-sm text-white/60 whitespace-pre-line">
+                {oauthResponse.instructions}
+              </div>
+              <input
+                type="text"
+                value={oauthCode}
+                onChange={(e) => setOauthCode(e.target.value)}
+                placeholder={oauthResponse.method === 'auto' ? 'No code required' : 'sk-ant-oc01-...#...'}
+                disabled={oauthResponse.method === 'auto'}
+                autoFocus
+                className="w-full rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3 text-sm text-white placeholder-white/30 focus:outline-none focus:border-indigo-500/50 font-mono disabled:opacity-60"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => window.open(oauthResponse.url, '_blank')}
+                  className="flex-1 rounded-xl border border-white/[0.06] px-4 py-3 text-sm text-white/70 hover:bg-white/[0.04] transition-colors cursor-pointer"
+                >
+                  Open Link Again
+                </button>
+                <button
+                  onClick={handleSubmitCode}
+                  disabled={loading || (!oauthCode.trim() && oauthResponse.method !== 'auto')}
+                  className="flex-1 rounded-xl bg-indigo-500 px-4 py-3 text-sm font-medium text-white hover:bg-indigo-600 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {loading ? <Loader className="h-4 w-4 animate-spin mx-auto" /> : 'Connect'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -7714,14 +7714,33 @@ async fn oauth_callback(
     let provider_type_id = id.clone();
     match oauth_callback_inner(State(state.clone()), AxumPath(id), Json(req)).await {
         Ok(json) => {
-            if ProviderType::from_id(&provider_type_id) == Some(ProviderType::Xai) {
+            // Resolve the provider type. The add-provider flow passes a
+            // provider-type id ("anthropic", ...); the reconnect button passes
+            // the stored provider's *UUID*, which `ProviderType::from_id` does
+            // not recognize. Look the UUID up in the store so reconnect still
+            // mirrors the fresh OAuth into the row instead of leaving it with
+            // expired tokens.
+            let resolved_type_and_uuid = match ProviderType::from_id(&provider_type_id) {
+                Some(pt) => Some((pt, None)),
+                None => match uuid::Uuid::parse_str(&provider_type_id) {
+                    Ok(uuid) => state
+                        .ai_providers
+                        .get(uuid)
+                        .await
+                        .map(|existing| (existing.provider_type, Some(uuid))),
+                    Err(_) => None,
+                },
+            };
+
+            if resolved_type_and_uuid.map(|(pt, _)| pt) == Some(ProviderType::Xai) {
+                // xAI tracks creds in auth.json only; don't mirror to the store.
                 return json.into_response();
             }
 
             // After successful OAuth, upsert the provider in AIProviderStore.
             // The OAuth callback already synced creds to auth.json; now mirror that
             // into the store so multiple accounts of the same type are tracked.
-            if let Some(provider_type) = ProviderType::from_id(&provider_type_id) {
+            if let Some((provider_type, existing_uuid)) = resolved_type_and_uuid {
                 let backends = use_for_backends
                     .unwrap_or_else(|| default_backends_for_provider(provider_type));
 
@@ -7782,9 +7801,8 @@ async fn oauth_callback(
                 // If the caller referenced an existing provider by UUID (the
                 // reconnect button passes the stored provider's id), refresh
                 // that row in place instead of inserting a duplicate. The
-                // add-provider flow passes a provider-type id (not a UUID) and
-                // falls through to `add`.
-                if let Ok(uuid) = uuid::Uuid::parse_str(&provider_type_id) {
+                // add-provider flow has no UUID and falls through to `add`.
+                if let Some(uuid) = existing_uuid {
                     if let Some(mut existing) = state.ai_providers.get(uuid).await {
                         existing.api_key = provider.api_key.clone();
                         existing.oauth = provider.oauth.clone();

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -532,6 +532,7 @@ async fn upsert_grok_oauth_provider(
     state: &super::routes::AppState,
     entry: &serde_json::Value,
     use_for_backends: Option<Vec<String>>,
+    target_id: Option<uuid::Uuid>,
 ) -> Result<ProviderResponse, (StatusCode, String)> {
     let access_token = entry
         .get("key")
@@ -556,12 +557,13 @@ async fn upsert_grok_oauth_provider(
     let account_email = grok_auth_email(entry);
     let backends = use_for_backends.unwrap_or_else(|| vec!["grok".to_string()]);
 
-    let mut provider = state
-        .ai_providers
-        .get_all_by_type(ProviderType::Xai)
-        .await
-        .into_iter()
-        .find(|p| p.has_oauth())
+    // When reconnect targets a specific row (UUID), update *that* row so the
+    // health probe checks the same id the user clicked. Otherwise fall back to
+    // the first OAuth row, or create a new one.
+    let existing_xai = state.ai_providers.get_all_by_type(ProviderType::Xai).await;
+    let mut provider = target_id
+        .and_then(|tid| existing_xai.iter().find(|p| p.id == tid).cloned())
+        .or_else(|| existing_xai.iter().find(|p| p.has_oauth()).cloned())
         .unwrap_or_else(|| {
             crate::ai_providers::AIProvider::new(
                 ProviderType::Xai,
@@ -7800,25 +7802,47 @@ async fn oauth_callback(
 
                 // If the caller referenced an existing provider by UUID (the
                 // reconnect button passes the stored provider's id), refresh
-                // that row in place instead of inserting a duplicate. The
-                // add-provider flow has no UUID and falls through to `add`.
+                // that row in place. We must NEVER fall through to `add` here:
+                // inserting a second account for the same OAuth completion would
+                // leave the targeted row stale and duplicate the credential. Any
+                // failure path returns an explicit error instead.
                 if let Some(uuid) = existing_uuid {
-                    if let Some(mut existing) = state.ai_providers.get(uuid).await {
+                    let Some(mut existing) = state.ai_providers.get(uuid).await else {
+                        // The OAuth creds are already synced to auth.json; the
+                        // targeted row just vanished. Report rather than insert
+                        // a duplicate.
+                        return (
+                            axum::http::StatusCode::NOT_FOUND,
+                            "Provider to reconnect no longer exists".to_string(),
+                        )
+                            .into_response();
+                    };
+                    // Only replace the stored credentials when the callback
+                    // actually produced fresh ones. If `read_opencode_auth`
+                    // returned nothing (e.g. a failed auth.json sync that still
+                    // reported success), keep the existing creds rather than
+                    // wiping a row the user just re-authorized.
+                    if provider.api_key.is_some() || provider.oauth.is_some() {
                         existing.api_key = provider.api_key.clone();
                         existing.oauth = provider.oauth.clone();
-                        existing.use_for_backends = provider.use_for_backends.clone();
-                        existing.enabled = true;
-                        // Only overwrite the display name/email when the new
-                        // credentials carry an identity; otherwise keep what
-                        // the user already had.
-                        if provider.account_email.is_some() {
-                            existing.account_email = provider.account_email.clone();
-                            existing.name = provider.name.clone();
-                        }
-                        if let Some(stored) = state.ai_providers.update(uuid, existing).await {
-                            return Json(build_response_from_store(&stored)).into_response();
-                        }
                     }
+                    existing.use_for_backends = provider.use_for_backends.clone();
+                    existing.enabled = true;
+                    // Only overwrite the display name/email when the new
+                    // credentials carry an identity; otherwise keep what the
+                    // user already had.
+                    if provider.account_email.is_some() {
+                        existing.account_email = provider.account_email.clone();
+                        existing.name = provider.name.clone();
+                    }
+                    return match state.ai_providers.update(uuid, existing).await {
+                        Some(stored) => Json(build_response_from_store(&stored)).into_response(),
+                        None => (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to persist reconnected provider".to_string(),
+                        )
+                            .into_response(),
+                    };
                 }
 
                 let store_id = state.ai_providers.add(provider.clone()).await;
@@ -7867,8 +7891,12 @@ async fn oauth_callback_inner(
                     .to_string(),
             )
         })?;
+        // Reconnect passes the row's UUID as the path id; thread it through so
+        // we update that exact row instead of the first OAuth xAI account.
+        let target_id = uuid::Uuid::parse_str(&id).ok();
         let response =
-            upsert_grok_oauth_provider(&state, &entry, req.use_for_backends.clone()).await?;
+            upsert_grok_oauth_provider(&state, &entry, req.use_for_backends.clone(), target_id)
+                .await?;
         return Ok(Json(response));
     }
 

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -7779,6 +7779,30 @@ async fn oauth_callback(
                     }
                 }
 
+                // If the caller referenced an existing provider by UUID (the
+                // reconnect button passes the stored provider's id), refresh
+                // that row in place instead of inserting a duplicate. The
+                // add-provider flow passes a provider-type id (not a UUID) and
+                // falls through to `add`.
+                if let Ok(uuid) = uuid::Uuid::parse_str(&provider_type_id) {
+                    if let Some(mut existing) = state.ai_providers.get(uuid).await {
+                        existing.api_key = provider.api_key.clone();
+                        existing.oauth = provider.oauth.clone();
+                        existing.use_for_backends = provider.use_for_backends.clone();
+                        existing.enabled = true;
+                        // Only overwrite the display name/email when the new
+                        // credentials carry an identity; otherwise keep what
+                        // the user already had.
+                        if provider.account_email.is_some() {
+                            existing.account_email = provider.account_email.clone();
+                            existing.name = provider.name.clone();
+                        }
+                        if let Some(stored) = state.ai_providers.update(uuid, existing).await {
+                            return Json(build_response_from_store(&stored)).into_response();
+                        }
+                    }
+                }
+
                 let store_id = state.ai_providers.add(provider.clone()).await;
                 // Return a response with the store UUID so the frontend can reference it
                 let stored = state.ai_providers.get(store_id).await.unwrap_or(provider);

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2757,12 +2757,34 @@ fn is_claudecode_incomplete_turn_transport_error(result: &AgentResult) -> bool {
         || out.contains("Claude Code did not emit a terminal result event before the turn ended")
 }
 
+/// Detects Anthropic's "stale thinking block" rejection surfaced through the
+/// Claude Code turn output: a replayed `thinking`/`redacted_thinking` block in
+/// the session transcript no longer matches what the API issued (typically
+/// because it was produced under a different model). Resuming the same session
+/// just replays the same blocks, so this must escalate straight to a fresh
+/// session rather than a same-session retry.
+pub(crate) fn is_stale_thinking_error(result: &AgentResult) -> bool {
+    let output = result.output.to_lowercase();
+    output.contains("cannot be modified")
+        && (output.contains("thinking") || output.contains("redacted_thinking"))
+}
+
 pub(crate) fn claudecode_transport_recovery_strategy(
     result: &AgentResult,
     has_session_id: bool,
     attempted_same_session_resume: bool,
     attempted_session_reset: bool,
 ) -> ClaudeTransportRecoveryStrategy {
+    // A stale-thinking rejection lives in the replayed session transcript;
+    // resuming the same session would hit it again, so go straight to a fresh
+    // session (which rebuilds context as text and drops the signed thinking).
+    if is_stale_thinking_error(result) {
+        if attempted_session_reset {
+            return ClaudeTransportRecoveryStrategy::None;
+        }
+        return ClaudeTransportRecoveryStrategy::ResetSessionFresh;
+    }
+
     if !is_session_corruption_error(result) {
         return ClaudeTransportRecoveryStrategy::None;
     }
@@ -16086,6 +16108,29 @@ mod tests {
         assert_eq!(
             claudecode_transport_recovery_strategy(&result, true, false, false),
             ClaudeTransportRecoveryStrategy::ResumeCurrentSession
+        );
+    }
+
+    #[test]
+    fn claudecode_transport_recovery_strategy_resets_fresh_for_stale_thinking() {
+        // The stale-thinking 400 lives in the replayed transcript, so the
+        // strategy must go straight to a fresh session — even though a session
+        // id exists and no same-session resume was attempted yet (a resume
+        // would just replay the same rejected blocks).
+        let result = AgentResult::failure(
+            "API Error: 400 messages.7.content.17: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.",
+            0,
+        )
+        .with_terminal_reason(TerminalReason::LlmError);
+
+        assert_eq!(
+            claudecode_transport_recovery_strategy(&result, true, false, false),
+            ClaudeTransportRecoveryStrategy::ResetSessionFresh
+        );
+        // Once a reset has been attempted, give up rather than loop.
+        assert_eq!(
+            claudecode_transport_recovery_strategy(&result, true, true, true),
+            ClaudeTransportRecoveryStrategy::None
         );
     }
 

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1749,8 +1749,10 @@ fn anthropic_model_omits_sampling_params(model_id: &str) -> bool {
 /// must strip the now-stale thinking blocks before forwarding. This matches
 /// Anthropic's guidance for switching models mid-conversation.
 ///
-/// An assistant turn that contained *only* thinking is left untouched (we never
-/// emit an empty `content` array, which Anthropic would also reject).
+/// If stripping removes every block (a thinking-only assistant turn), we
+/// substitute a single placeholder text block: Anthropic rejects an empty
+/// `content` array, and we must not forward the stale, cross-model thinking
+/// either — so neither leaving it as-is nor emptying it is valid.
 fn strip_thinking_blocks(messages: &mut [serde_json::Value]) {
     for message in messages.iter_mut() {
         if message.get("role").and_then(|v| v.as_str()) != Some("assistant") {
@@ -1759,18 +1761,21 @@ fn strip_thinking_blocks(messages: &mut [serde_json::Value]) {
         let Some(content) = message.get_mut("content").and_then(|v| v.as_array_mut()) else {
             continue;
         };
-        let filtered: Vec<serde_json::Value> = content
-            .iter()
-            .filter(|block| {
-                !matches!(
-                    block.get("type").and_then(|v| v.as_str()),
-                    Some("thinking") | Some("redacted_thinking")
-                )
-            })
-            .cloned()
-            .collect();
-        if !filtered.is_empty() && filtered.len() != content.len() {
-            *content = filtered;
+        let before = content.len();
+        content.retain(|block| {
+            !matches!(
+                block.get("type").and_then(|v| v.as_str()),
+                Some("thinking") | Some("redacted_thinking")
+            )
+        });
+        if content.len() == before {
+            continue; // nothing was stripped
+        }
+        if content.is_empty() {
+            content.push(serde_json::json!({
+                "type": "text",
+                "text": "(prior reasoning omitted after model change)"
+            }));
         }
     }
 }
@@ -4548,6 +4553,37 @@ mod tests {
             blocks.iter().any(|b| b["type"] == "thinking"),
             "thinking must be preserved verbatim when the model is unchanged"
         );
+    }
+
+    #[test]
+    fn anthropic_cli_proxy_strips_thinking_only_turn_on_model_change() {
+        // A thinking-only assistant turn must not survive a model switch, and
+        // must not be left with an empty content array either.
+        let body = serde_json::json!({
+            "model": "claude-opus-4-7",
+            "max_tokens": 16,
+            "messages": [
+                { "role": "user", "content": "hi" },
+                { "role": "assistant", "content": [
+                    { "type": "thinking", "thinking": "only thinking", "signature": "sig-x" }
+                ]}
+            ]
+        });
+        let payload = rewrite_model_for_anthropic_cli_proxy(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "claude-opus-4-8",
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(payload.as_ref()).unwrap();
+        let blocks = value["messages"][1]["content"].as_array().unwrap();
+        assert!(!blocks.is_empty(), "content must never be left empty");
+        assert!(
+            blocks
+                .iter()
+                .all(|b| b["type"] != "thinking" && b["type"] != "redacted_thinking"),
+            "thinking-only turns must still be stripped on model change"
+        );
+        assert_eq!(blocks[0]["type"], "text");
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1738,13 +1738,61 @@ fn anthropic_model_omits_sampling_params(model_id: &str) -> bool {
     model_id.contains("claude-opus-4-8") || model_id.contains("claude-opus-4-7")
 }
 
+/// Drop `thinking`/`redacted_thinking` blocks from assistant messages.
+///
+/// Thinking blocks carry a signature that is cryptographically bound to the
+/// exact model that produced them. Replaying them under a *different* model
+/// makes Anthropic reject the whole request with
+/// "`thinking` or `redacted_thinking` blocks in the latest assistant message
+/// cannot be modified". We force `model` on every forwarded request (fallback
+/// chains, default-model changes), so when the conversation's model changes we
+/// must strip the now-stale thinking blocks before forwarding. This matches
+/// Anthropic's guidance for switching models mid-conversation.
+///
+/// An assistant turn that contained *only* thinking is left untouched (we never
+/// emit an empty `content` array, which Anthropic would also reject).
+fn strip_thinking_blocks(messages: &mut [serde_json::Value]) {
+    for message in messages.iter_mut() {
+        if message.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(content) = message.get_mut("content").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+        let filtered: Vec<serde_json::Value> = content
+            .iter()
+            .filter(|block| {
+                !matches!(
+                    block.get("type").and_then(|v| v.as_str()),
+                    Some("thinking") | Some("redacted_thinking")
+                )
+            })
+            .cloned()
+            .collect();
+        if !filtered.is_empty() && filtered.len() != content.len() {
+            *content = filtered;
+        }
+    }
+}
+
 fn rewrite_model_for_anthropic_cli_proxy(
     body: &[u8],
     new_model: &str,
 ) -> Result<bytes::Bytes, String> {
     let mut value: serde_json::Value =
         serde_json::from_slice(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let original_model = value
+        .get("model")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
     value["model"] = serde_json::Value::String(new_model.to_string());
+    // When we rewrite onto a different model, prior thinking blocks were signed
+    // by the original model and can no longer be replayed — strip them.
+    if matches!(&original_model, Some(m) if m != new_model) {
+        if let Some(messages) = value.get_mut("messages").and_then(|v| v.as_array_mut()) {
+            strip_thinking_blocks(messages);
+        }
+    }
     if anthropic_model_omits_sampling_params(new_model) {
         if let Some(obj) = value.as_object_mut() {
             for key in ["temperature", "top_p", "top_k"] {
@@ -2514,12 +2562,22 @@ fn build_anthropic_upstream_request(
         out.insert("stop_sequences".to_string(), stop_sequences);
     }
 
-    let (system, messages) = anthropic_messages_from_openai(
+    let (system, mut messages) = anthropic_messages_from_openai(
         req.get("messages")
             .and_then(|v| v.as_array())
             .map(|v| v.as_slice())
             .unwrap_or(&[]),
     );
+    // This adapter also forces `model` to `model_id`. If that differs from the
+    // model the request was authored under, prior thinking blocks were signed
+    // by a different model and must be stripped before replay.
+    let model_changed = req
+        .get("model")
+        .and_then(|v| v.as_str())
+        .is_some_and(|m| m != model_id);
+    if model_changed {
+        strip_thinking_blocks(&mut messages);
+    }
     if !system.is_empty() {
         out.insert("system".to_string(), serde_json::Value::String(system));
     }
@@ -2689,6 +2747,28 @@ fn anthropic_content_blocks_from_openai(
                         "source": { "type": "url", "url": url }
                     }));
                 }
+            }
+            "thinking" => {
+                // Preserve the block verbatim (text + signature). Dropping it
+                // corrupts the assistant turn so Anthropic rejects the replay;
+                // callers strip these explicitly on a model switch instead.
+                let mut block = serde_json::Map::new();
+                block.insert("type".to_string(), serde_json::json!("thinking"));
+                if let Some(text) = part.get("thinking").and_then(|v| v.as_str()) {
+                    block.insert("thinking".to_string(), serde_json::json!(text));
+                }
+                if let Some(sig) = part.get("signature").and_then(|v| v.as_str()) {
+                    block.insert("signature".to_string(), serde_json::json!(sig));
+                }
+                out.push(serde_json::Value::Object(block));
+            }
+            "redacted_thinking" => {
+                let mut block = serde_json::Map::new();
+                block.insert("type".to_string(), serde_json::json!("redacted_thinking"));
+                if let Some(data) = part.get("data").and_then(|v| v.as_str()) {
+                    block.insert("data".to_string(), serde_json::json!(data));
+                }
+                out.push(serde_json::Value::Object(block));
             }
             _ => {}
         }
@@ -4415,6 +4495,75 @@ mod tests {
         assert!(value.get("top_p").is_none());
         assert!(value.get("top_k").is_none());
         assert_eq!(value["thinking"], serde_json::json!({ "type": "disabled" }));
+    }
+
+    fn assistant_msg_with_thinking() -> serde_json::Value {
+        serde_json::json!({
+            "model": "claude-opus-4-7",
+            "max_tokens": 16,
+            "messages": [
+                { "role": "user", "content": "hi" },
+                { "role": "assistant", "content": [
+                    { "type": "thinking", "thinking": "ponder", "signature": "sig-abc" },
+                    { "type": "text", "text": "hello" }
+                ]}
+            ]
+        })
+    }
+
+    #[test]
+    fn anthropic_cli_proxy_strips_thinking_when_model_changes() {
+        // Conversation authored under opus-4-7, now forwarded under opus-4-8:
+        // the stale thinking block must be dropped, the text kept.
+        let payload = rewrite_model_for_anthropic_cli_proxy(
+            serde_json::to_vec(&assistant_msg_with_thinking())
+                .unwrap()
+                .as_slice(),
+            "claude-opus-4-8",
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(payload.as_ref()).unwrap();
+        let blocks = value["messages"][1]["content"].as_array().unwrap();
+        assert!(
+            blocks
+                .iter()
+                .all(|b| b["type"] != "thinking" && b["type"] != "redacted_thinking"),
+            "thinking blocks should be stripped on model change"
+        );
+        assert!(blocks.iter().any(|b| b["type"] == "text"));
+    }
+
+    #[test]
+    fn anthropic_cli_proxy_keeps_thinking_when_model_unchanged() {
+        let payload = rewrite_model_for_anthropic_cli_proxy(
+            serde_json::to_vec(&assistant_msg_with_thinking())
+                .unwrap()
+                .as_slice(),
+            "claude-opus-4-7",
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(payload.as_ref()).unwrap();
+        let blocks = value["messages"][1]["content"].as_array().unwrap();
+        assert!(
+            blocks.iter().any(|b| b["type"] == "thinking"),
+            "thinking must be preserved verbatim when the model is unchanged"
+        );
+    }
+
+    #[test]
+    fn anthropic_content_blocks_preserve_thinking() {
+        let content = serde_json::json!([
+            { "type": "thinking", "thinking": "deep", "signature": "sig-1" },
+            { "type": "redacted_thinking", "data": "enc" },
+            { "type": "text", "text": "answer" }
+        ]);
+        let blocks = anthropic_content_blocks_from_openai(Some(&content));
+        assert_eq!(blocks.len(), 3, "thinking blocks must not be dropped");
+        assert_eq!(blocks[0]["type"], "thinking");
+        assert_eq!(blocks[0]["signature"], "sig-1");
+        assert_eq!(blocks[1]["type"], "redacted_thinking");
+        assert_eq!(blocks[1]["data"], "enc");
+        assert_eq!(blocks[2]["type"], "text");
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -671,7 +671,7 @@ async fn chat_completions(
         );
 
         let request_start = std::time::Instant::now();
-        let upstream_resp = match upstream_req.send().await {
+        let mut upstream_resp = match upstream_req.send().await {
             Ok(resp) => resp,
             Err(e) => {
                 let elapsed_ms = request_start.elapsed().as_millis() as u64;
@@ -709,7 +709,101 @@ async fn chat_completions(
             }
         };
 
-        let status = upstream_resp.status();
+        let mut status = upstream_resp.status();
+
+        // Reactive recovery for stale extended-thinking blocks. Anthropic
+        // rejects a replayed thinking/redacted_thinking block that no longer
+        // matches what it issued (e.g. it was produced under a different
+        // model). The harness can't detect this, so on that specific 400 we
+        // strip thinking + disable it and retry once against the same upstream
+        // — the mission continues instead of hard-failing. Scoped strictly to
+        // the Anthropic adapters and a 400 response.
+        if status == StatusCode::BAD_REQUEST
+            && (use_anthropic_oauth_cli_proxy_adapter || use_anthropic_adapter)
+        {
+            // Consume the 400 body to classify it. Errors arrive non-streamed
+            // even for streaming requests, so this read is single-shot and
+            // safe. NOTE: this moves `upstream_resp`; every path below either
+            // reassigns it (successful retry) or `continue`s.
+            let err_bytes = upstream_resp.bytes().await.unwrap_or_default();
+            let retry_body = if anthropic_error_is_stale_thinking(&err_bytes) {
+                let base = if use_anthropic_oauth_cli_proxy_adapter {
+                    rewrite_model_for_anthropic_cli_proxy(&body, &entry.model_id)
+                } else {
+                    build_anthropic_upstream_request(&body, &entry.model_id, is_stream)
+                };
+                base.and_then(|b| anthropic_body_drop_thinking_and_disable(&b))
+                    .map_err(
+                        |e| tracing::warn!(error = %e, "Failed to build thinking-stripped retry"),
+                    )
+                    .ok()
+            } else {
+                None
+            };
+
+            let retried = match retry_body {
+                Some(rb) => {
+                    let mut retry_req = state
+                        .http_client
+                        .post(&url)
+                        .header("Content-Type", "application/json")
+                        .body(rb);
+                    for (name, value) in &extra_headers {
+                        retry_req = retry_req.header(name, value);
+                    }
+                    if let Some(org) = headers.get("openai-organization") {
+                        retry_req = retry_req.header("OpenAI-Organization", org);
+                    }
+                    if !is_stream {
+                        retry_req = retry_req.timeout(std::time::Duration::from_secs(300));
+                    }
+                    retry_req
+                        .send()
+                        .await
+                        .map_err(|e| tracing::warn!(error = %e, "Thinking-stripped retry failed to send"))
+                        .ok()
+                }
+                None => None,
+            };
+
+            match retried {
+                Some(r) => {
+                    tracing::info!(
+                        provider = %entry.provider_id,
+                        account_id = %entry.account_id,
+                        "Retried Anthropic request with thinking stripped after stale-thinking 400"
+                    );
+                    upstream_resp = r;
+                    status = upstream_resp.status();
+                }
+                None => {
+                    // Not the stale-thinking error, or the retry could not be
+                    // built/sent. The original 400 body is already consumed, so
+                    // record the client failure here (mirroring the 4xx
+                    // branches) and move to the next chain entry.
+                    let elapsed_ms = request_start.elapsed().as_millis() as u64;
+                    let cooldown = state
+                        .health_tracker
+                        .record_entry_failure(entry, CooldownReason::ClientError, None)
+                        .await;
+                    pending_fallback_events.push(crate::provider_health::FallbackEvent {
+                        timestamp: chrono::Utc::now(),
+                        chain_id: chain_id.clone(),
+                        from_provider: entry.provider_id.clone(),
+                        from_model: entry.model_id.clone(),
+                        from_account_id: entry.account_id,
+                        reason: CooldownReason::ClientError,
+                        cooldown_secs: Some(cooldown.as_secs_f64()),
+                        to_provider: None,
+                        latency_ms: Some(elapsed_ms),
+                        attempt_number: (entry_idx + 1) as u32,
+                        chain_length,
+                    });
+                    client_error_count += 1;
+                    continue;
+                }
+            }
+        }
 
         if use_anthropic_adapter {
             if is_stream && status.is_success() {
@@ -1804,6 +1898,40 @@ fn rewrite_model_for_anthropic_cli_proxy(
                 obj.remove(key);
             }
         }
+    }
+    serde_json::to_vec(&value)
+        .map(bytes::Bytes::from)
+        .map_err(|e| format!("Failed to serialize: {}", e))
+}
+
+/// True when an Anthropic 4xx body is the "stale thinking block" rejection,
+/// i.e. a replayed `thinking`/`redacted_thinking` block no longer matches what
+/// the API issued (typically because it was produced under a different model).
+fn anthropic_error_is_stale_thinking(body: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(body);
+    text.contains("cannot be modified")
+        && (text.contains("thinking") || text.contains("redacted_thinking"))
+}
+
+/// Last-resort recovery for the stale-thinking rejection: drop every
+/// `thinking`/`redacted_thinking` block from the (Anthropic-format) request and
+/// disable extended thinking for the retry. Without disabling thinking the API
+/// would instead demand the (now-removed) block before a tool_use, so we turn
+/// it off for this one turn — the mission continues, just without replayed
+/// reasoning.
+fn anthropic_body_drop_thinking_and_disable(body: &[u8]) -> Result<bytes::Bytes, String> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    if let Some(messages) = value.get_mut("messages").and_then(|v| v.as_array_mut()) {
+        strip_thinking_blocks(messages);
+    }
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "thinking".to_string(),
+            serde_json::json!({ "type": "disabled" }),
+        );
+        // Sampling params are valid again once thinking is disabled, but the
+        // original request already omitted them for these models; leave as-is.
     }
     serde_json::to_vec(&value)
         .map(bytes::Bytes::from)
@@ -4584,6 +4712,38 @@ mod tests {
             "thinking-only turns must still be stripped on model change"
         );
         assert_eq!(blocks[0]["type"], "text");
+    }
+
+    #[test]
+    fn detects_stale_thinking_error_body() {
+        let err = br#"{"type":"error","error":{"type":"invalid_request_error","message":"messages.7.content.17: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."}}"#;
+        assert!(anthropic_error_is_stale_thinking(err));
+        let other = br#"{"type":"error","error":{"message":"rate limit exceeded"}}"#;
+        assert!(!anthropic_error_is_stale_thinking(other));
+    }
+
+    #[test]
+    fn drop_thinking_and_disable_strips_and_disables() {
+        let body = serde_json::json!({
+            "model": "claude-opus-4-8",
+            "max_tokens": 16,
+            "thinking": { "type": "enabled", "budget_tokens": 2048 },
+            "messages": [
+                { "role": "user", "content": "hi" },
+                { "role": "assistant", "content": [
+                    { "type": "thinking", "thinking": "stale", "signature": "sig" },
+                    { "type": "text", "text": "answer" }
+                ]}
+            ]
+        });
+        let out =
+            anthropic_body_drop_thinking_and_disable(serde_json::to_vec(&body).unwrap().as_slice())
+                .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(out.as_ref()).unwrap();
+        assert_eq!(value["thinking"], serde_json::json!({ "type": "disabled" }));
+        let blocks = value["messages"][1]["content"].as_array().unwrap();
+        assert!(blocks.iter().all(|b| b["type"] != "thinking"));
+        assert!(blocks.iter().any(|b| b["type"] == "text"));
     }
 
     #[test]

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1368,9 +1368,12 @@ async fn adopt_hermes_assistant(
     )
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
-    write_private_file(&soul_path, &hermes_soul_markdown(&channel, home_channel.as_ref()))
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    write_private_file(
+        &soul_path,
+        &hermes_soul_markdown(&channel, home_channel.as_ref()),
+    )
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
     let service_path = format!("/etc/systemd/system/{service_name}");
     let service_after = if runtime_name.ends_with("-dev") {


### PR DESCRIPTION
## Problem

On `settings/providers`, clicking **Reconnect** for an OAuth provider (xAI/Grok, Anthropic) with an expired/revoked token produced:

> Re-authenticated, but provider check still fails: xAI OAuth token expired; reconnect Grok Build

instead of opening the OAuth link.

## Root cause

The Reconnect button calls `POST /api/ai/providers/:id/auth`, whose only check is `has_credentials()` — which returns `true` whenever an `oauth` blob merely *exists*, even if expired/revoked. So the endpoint returned `{success: true, auth_url: null}`, the frontend skipped opening the link, ran a live usage probe, and surfaced the probe's failure.

## Fix

**Frontend**
- New `ReconnectProviderModal` that drives the real `oauthAuthorize → confirm-code → oauthCallback` flow already used by the add-provider modal.
- OAuth-backed providers (`uses_oauth && !has_api_key`) route to it; API-key providers keep the legacy path.
- Method indices are pinned to the backend `ProviderType::auth_methods()` ordering (Anthropic Pro/Max vs console mode resolves correctly); single-method providers (xAI) auto-start.
- Post-auth health probe factored into a shared helper.

**Backend**
- `oauth_callback` updates the existing provider in place when the path id is a known UUID (what Reconnect sends), instead of always inserting a new row — prevents duplicate provider entries on reconnect. The add-provider flow passes a type id (not a UUID) and still falls through to `add()`.

## Testing

Deployed to the dev backend and verified against the live xAI provider stuck in `needs_reauth`:

| Path | Endpoint | Result |
|---|---|---|
| Old (bug) | `POST /:id/auth` | `{"success":true,...,"auth_url":null}` |
| New (fix) | `POST /:id/oauth/authorize` | xAI → `accounts.x.ai/oauth2/device?user_code=…`; Anthropic → `claude.ai/oauth/authorize` (Pro/Max) and `console.anthropic.com/oauth/authorize` (API key) |

- `cargo check` + `cargo fmt --all --check` clean; backend builds on Linux, deploys to dev, service healthy.
- `tsc --noEmit` + `eslint` clean; full Next.js production build passes with `/settings/providers` present.
- No OAuth callback was completed during testing, so no credentials/provider state changed.

Note: the literal button click and the duplicate-row dedup end-to-end were not automated (browser auth gate / would mint real tokens).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth credential persistence and in-place provider updates (auth-critical), plus Anthropic request rewriting and session reset behavior on the inference path.
> 
> **Overview**
> **Reconnect** on the providers settings page now runs the real **OAuth authorize → callback** path for OAuth-only providers (xAI, Anthropic, etc.) instead of `POST …/auth`, which treated expired tokens as “authenticated” and never opened the auth link. A dedicated **ReconnectProviderModal** mirrors the add-provider OAuth UX (method indices aligned with the backend); post-reconnect health probing is shared via `probeProviderHealth`.
> 
> On the backend, **OAuth callback** accepts the provider **UUID** from reconnect and **updates that row in place** (including xAI Grok upsert by `target_id`), avoiding duplicate provider rows. API-key reconnect still uses the legacy auth endpoint.
> 
> Separately, the **Anthropic proxy and mission runner** gain handling for **stale extended-thinking blocks** when the model changes or blocks are replayed: strip thinking on model rewrite, preserve thinking in the OpenAI→Anthropic adapter, one-shot retry with thinking disabled after the specific 400, and Claude Code transport recovery that **resets to a fresh session** instead of resuming when that error appears in turn output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e62f1e139ff7833edbe6a18977d8bff310b32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->