### PR TITLE
control: light-theme banner contrast + graceful empty question payload

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -921,7 +921,30 @@ function QuestionToolItem({
   item: ToolItem;
   onSubmit: (toolCallId: string, answers: string[][]) => Promise<void>;
 }) {
-  const questions = useMemo(() => parseQuestionArgs(item.args), [item.args]);
+  const parsedQuestions = useMemo(
+    () => parseQuestionArgs(item.args),
+    [item.args],
+  );
+  // Fallback for empty/malformed payloads (e.g. a question tool-call whose
+  // streamed input never assembled into args): render a single free-text
+  // reply so the user can still answer and unblock the mission, instead of a
+  // dead-end "Failed to render" error.
+  const isFallback = parsedQuestions.length === 0;
+  const questions = useMemo<QuestionInfo[]>(
+    () =>
+      isFallback
+        ? [
+            {
+              question:
+                "The agent asked for your input, but the question didn't include any content. Reply below to continue.",
+              options: [],
+              multiple: false,
+              freeTextOnly: true,
+            },
+          ]
+        : parsedQuestions,
+    [isFallback, parsedQuestions],
+  );
   const [answers, setAnswers] = useState<string[][]>(() =>
     questions.map(() => []),
   );

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -10526,14 +10526,14 @@ export default function ControlClient() {
                   {/* Waiting banner for interactive user-input tools */}
                   {hasPendingUserInput && (
                     <div className="flex justify-center py-4 animate-fade-in">
-                      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 rounded-xl px-5 py-4 bg-indigo-500/10 border border-indigo-500/20">
+                      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 rounded-xl px-5 py-4 bg-indigo-500/10 border border-indigo-500/30">
                         <div className="flex items-center gap-3">
-                          <HelpCircle className="h-5 w-5 shrink-0 text-indigo-300" />
+                          <HelpCircle className="h-5 w-5 shrink-0 text-indigo-500" />
                           <div className="text-sm">
-                            <span className="font-medium text-indigo-200">
+                            <span className="font-medium text-foreground">
                               Waiting for your response
                             </span>
-                            <p className="text-white/50">
+                            <p className="text-muted-foreground">
                               The agent is paused until you answer the prompt
                               above.
                             </p>
@@ -10542,7 +10542,7 @@ export default function ControlClient() {
                         <button
                           type="button"
                           onClick={handleShowPendingUserInput}
-                          className="shrink-0 inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium bg-indigo-500/20 text-indigo-200 hover:bg-indigo-500/30 border border-indigo-500/30 transition-colors"
+                          className="shrink-0 inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 border border-indigo-600 transition-colors"
                         >
                           <ArrowDown className="h-3.5 w-3.5" />
                           Show prompt


### PR DESCRIPTION
Two small control-client fixes:

1. **Light theme banner** — the 'Waiting for your response' / 'Show prompt' banner used dark-only colors (`text-white/50`, `text-indigo-200`) that were invisible/washed-out in light theme. Switched to theme-aware semantic utilities (`text-foreground` / `text-muted-foreground`, which respect the `data-theme` toggle via CSS vars) + a solid indigo button readable in both themes.

2. **Empty question payload** — a question tool-call whose streamed input never assembled into args was stored empty, so the UI showed a dead-end 'Failed to render question payload' the user couldn't act on. Now synthesizes a single free-text reply so the user can answer and unblock the mission.

Lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized control UI and styling changes with a defensive fallback for malformed question payloads; no auth, API, or data-layer changes.
> 
> **Overview**
> **Waiting for your response** banner styling moves off dark-only indigo/white opacity classes to **theme-aware** tokens (`text-foreground`, `text-muted-foreground`, stronger border) and a **solid indigo** “Show prompt” button so the pause state stays readable in light theme.
> 
> When a **question** tool call has **empty or malformed `args`** (e.g. streamed input never assembled), the UI no longer stops at a non-actionable error; it **synthesizes one free-text question** with an explanatory message so the user can submit an answer and resume the agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e384671bdc5c8bb6328099b7acd90ea6bd174af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->