### PR TITLE
model-routing: support Grok/xAI via OAuth (direct to api.x.ai)

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8956,3 +8956,66 @@ pub async fn refresh_oauth_token_with_lock(
     Ok((new_access, new_refresh, expires_at))
     // _lock is dropped here, releasing the file lock
 }
+
+/// Refresh OAuth tokens for **store-backed** accounts (AIProviderStore) of
+/// `provider_type` that expire within `refresh_threshold_ms`, writing the new
+/// tokens back to the store (and credential tiers).
+///
+/// The file-based [`oauth_token_refresher_loop`] only sees tokens written to
+/// `auth.json`/`credentials.json`. Providers connected via the dashboard live
+/// in the store (e.g. xAI/Grok), so without this their short-lived access
+/// token silently expires and `resolve_chain` drops the provider until the
+/// user reconnects. Returns `(found, refreshed)`.
+pub async fn refresh_due_store_oauth(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+    provider_type: ProviderType,
+    refresh_threshold_ms: i64,
+) -> (u32, u32) {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut found = 0u32;
+    let mut refreshed = 0u32;
+    for account in ai_providers.get_all_by_type(provider_type).await {
+        let Some(oauth) = account.oauth.as_ref() else {
+            continue;
+        };
+        if oauth.refresh_token.trim().is_empty() {
+            continue;
+        }
+        found += 1;
+        if oauth.expires_at - now_ms > refresh_threshold_ms {
+            continue;
+        }
+        // Serialize with the file-based refresher to avoid racing a rotating
+        // refresh token (best-effort — proceed unlocked if contended).
+        let _lock = acquire_oauth_refresh_lock(provider_type).ok();
+        match refresh_oauth_token_internal(&provider_type, &oauth.refresh_token).await {
+            Ok((access, refresh, expires_at)) => {
+                let mut updated = account.clone();
+                updated.oauth = Some(crate::ai_providers::OAuthCredentials {
+                    access_token: access.clone(),
+                    refresh_token: refresh.clone(),
+                    expires_at,
+                });
+                ai_providers.update(account.id, updated).await;
+                // Keep the credential tiers consistent too (best-effort).
+                let _ = sync_oauth_to_all_tiers(provider_type, &refresh, &access, expires_at);
+                refreshed += 1;
+                tracing::info!(
+                    provider = ?provider_type,
+                    account_id = %account.id,
+                    new_expires_at = expires_at,
+                    "Refreshed store-backed OAuth token"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = ?provider_type,
+                    account_id = %account.id,
+                    error = ?e,
+                    "Failed to refresh store-backed OAuth token (account may need reconnect)"
+                );
+            }
+        }
+    }
+    (found, refreshed)
+}

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2515,7 +2515,7 @@ async fn search_memory(Query(params): Query<SearchMemoryQuery>) -> Json<serde_js
 /// AIProviderStore, because OAuth tokens from the callback are stored in
 /// credentials.json but may not have a corresponding AIProvider entry.
 async fn oauth_token_refresher_loop(
-    _ai_providers: Arc<crate::ai_providers::AIProviderStore>,
+    ai_providers: Arc<crate::ai_providers::AIProviderStore>,
     working_dir: std::path::PathBuf,
 ) {
     use crate::ai_providers::ProviderType;
@@ -2657,9 +2657,22 @@ async fn oauth_token_refresher_loop(
             }
         }
 
+        // Also refresh store-backed OAuth accounts whose tokens live only in
+        // the AIProviderStore (not auth.json/credentials.json) — notably
+        // xAI/Grok connected via the dashboard. Without this their short-lived
+        // access token expires and model-routing silently drops the provider.
+        let (store_found, store_refreshed) = ai_providers_api::refresh_due_store_oauth(
+            &ai_providers,
+            ProviderType::Xai,
+            refresh_threshold_ms,
+        )
+        .await;
+
         tracing::debug!(
             oauth_tokens_found = found_count,
             oauth_tokens_refreshed = refreshed_count,
+            store_oauth_found = store_found,
+            store_oauth_refreshed = store_refreshed,
             "OAuth refresh check cycle complete"
         );
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2530,6 +2530,9 @@ async fn oauth_token_refresher_loop(
         ProviderType::Anthropic,
         ProviderType::OpenAI,
         ProviderType::Google,
+        // xAI/Grok OAuth (Grok Build) is routed directly to api.x.ai with the
+        // hoisted access token, so keep it refreshed like the others.
+        ProviderType::Xai,
     ];
 
     tracing::info!(

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1340,7 +1340,7 @@ async fn adopt_hermes_assistant(
             "TELEGRAM_HOME_CHANNEL",
             &home_channel_id.to_string(),
         ));
-        env.push_str(&env_line("TELEGRAM_HOME_CHANNEL_NAME", &home_channel_name));
+        env.push_str(&env_line("TELEGRAM_HOME_CHANNEL_NAME", home_channel_name));
     }
     if req.allow_all_users {
         env.push_str("GATEWAY_ALLOW_ALL_USERS=true\n");

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -1152,14 +1152,22 @@ impl ModelChainStore {
                     .map(|oauth| oauth.expires_at > now_ms + 60_000)
                     .unwrap_or(false);
                 // Hoist the OAuth access token to `api_key` so the proxy can
-                // forward it as a Bearer credential — but only for Anthropic,
-                // where `api.anthropic.com/v1/messages` accepts the OAuth JWT
-                // with the `oauth-2025-04-20` beta header. OpenAI (Codex) JWTs
-                // don't work at `api.openai.com/v1/chat/completions`; those
-                // accounts are routed through the CLI-proxy adapter, which
-                // needs `api_key = None, has_oauth = true` to trigger.
+                // forward it as a Bearer credential. This works for providers
+                // whose chat endpoint accepts the OAuth access token directly:
+                //   - Anthropic: `api.anthropic.com/v1/messages` (with the
+                //     `oauth-2025-04-20` beta header), and
+                //   - xAI/Grok: `api.x.ai/v1/chat/completions` accepts the
+                //     Grok-Build OAuth token as a Bearer (scope `api:access`).
+                // OpenAI (Codex) JWTs do NOT work at
+                // `api.openai.com/v1/chat/completions`; those accounts keep
+                // `api_key = None, has_oauth = true` and route through the
+                // CLI-proxy adapter instead.
                 let routed_api_key = account.api_key.clone().or_else(|| {
-                    if provider_type != crate::ai_providers::ProviderType::Anthropic {
+                    if !matches!(
+                        provider_type,
+                        crate::ai_providers::ProviderType::Anthropic
+                            | crate::ai_providers::ProviderType::Xai
+                    ) {
                         return None;
                     }
                     if !oauth_is_fresh {


### PR DESCRIPTION
Makes `Connect Grok Build` in Settings enough for model-routing — no cli-proxy, no separate login.

**Verified:** `api.x.ai/v1` accepts the Grok-Build OAuth access token as a Bearer directly (live test). End-to-end test on dev: a chain through `xai/grok-3-mini` resolved as routable (hoisted token) and a real completion returned a grok-4.3 response.

- `resolve_chain`: hoist the store account's OAuth access token into the entry `api_key` for xAI (as it already did for Anthropic); the existing generic path forwards it as `Bearer` to api.x.ai.
- `refresh_due_store_oauth` + wire into `oauth_token_refresher_loop`: keep the short-lived store-backed xAI token refreshed (the dashboard connect writes only the store, which the file-based refresher never saw).

Supersedes #(grok-oauth-cli-proxy) — the CLI-proxy approach is unnecessary since the token works directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth refresh and credential routing for xAI; mistakes could drop providers from chains or mishandle rotating refresh tokens, though the flow reuses existing refresh/lock helpers.
> 
> **Overview**
> **Grok Build (xAI) OAuth connected via Settings** can stay on model-routing end-to-end: the proxy sends the OAuth access token as **Bearer** to `api.x.ai`, matching the Anthropic hoisting pattern.
> 
> **`resolve_chain`** now treats **xAI** like Anthropic for fresh OAuth—copying the access token into the resolved entry’s `api_key` when there is no API key—while OpenAI OAuth still skips hoisting and uses the CLI-proxy path.
> 
> **Background refresh** adds **`refresh_due_store_oauth`**, which walks **AIProviderStore** accounts (not just `auth.json` / `credentials.json`), refreshes tokens due within the 1-hour window, updates the store, and best-effort syncs credential tiers under the same file lock as the existing refresher. The **15-minute OAuth loop** takes a live **`AIProviderStore`**, includes **`ProviderType::Xai`** among OAuth-capable types, and each cycle refreshes store-backed xAI tokens with extra debug metrics.
> 
> A small **Telegram env** fix passes **`TELEGRAM_HOME_CHANNEL_NAME`** as a string reference to `env_line`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7516876183e6f37b60ec608e3cc4186c77f9c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->