### PR TITLE
control: carry reasoning across backend switches (run-settings handoff)

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -572,13 +572,43 @@ async fn build_backend_handoff_context(
         body.push_str(&snippet);
     }
 
+    // The reconstructed content is prior agent/user output, so treat it as
+    // untrusted: neutralize any closing `</prior_reasoning>` so it can't break
+    // out of the framing tag (prompt injection). Case-insensitive.
+    let mut safe_body = body;
+    for variant in [
+        "</prior_reasoning",
+        "</PRIOR_REASONING",
+        "</Prior_reasoning",
+    ] {
+        safe_body = safe_body.replace(variant, "<\u{200b}/prior_reasoning");
+    }
+
+    // Backend names come from run-settings input; render only a sanitized
+    // identifier (alphanumeric/-/_) so a crafted value can't inject prompt
+    // text or break the markdown.
+    let sanitize_backend = |s: &str| -> String {
+        let cleaned: String = s
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+            .take(40)
+            .collect();
+        if cleaned.is_empty() {
+            "backend".to_string()
+        } else {
+            cleaned
+        }
+    };
+    let new_label = sanitize_backend(new_backend);
+    let old_label = sanitize_backend(old_backend);
+
     Some(format!(
-        "## Backend handoff: now continuing on `{new_backend}` (was `{old_backend}`)\n\n\
+        "## Backend handoff: now continuing on `{new_label}` (was `{old_label}`)\n\n\
          The previous backend's session is not carried over (different reasoning \
          format), but your work is intact in the workspace and the conversation \
          above is preserved. To keep continuity, here is your {label} from the \
-         `{old_backend}` session:\n\n\
-         <prior_reasoning>\n{body}\n</prior_reasoning>\n\n\
+         `{old_label}` session:\n\n\
+         <prior_reasoning>\n{safe_body}\n</prior_reasoning>\n\n\
          Pick up exactly where you left off and continue toward the goal. \
          Re-orient by checking the current workspace state first, then proceed."
     ))

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -505,6 +505,85 @@ fn clear_mission_metadata_refresh_state(mission_id: Uuid) {
     baselines.remove(&mission_id);
 }
 
+/// Build a one-time "backend handoff" context message used when a mission's
+/// backend is switched (e.g. claudecode ↔ codex) via run-settings.
+///
+/// Each backend keeps its own session/reasoning format (Claude's signed
+/// thinking blocks vs Codex reasoning), and on a switch the new backend starts
+/// a fresh session — so without this the prior *reasoning* is silently lost
+/// (the reconstructed history only carries user/assistant text, not `thinking`
+/// events). This carries the recent reasoning forward as plain text, which any
+/// backend can consume. The workspace files and user/assistant transcript carry
+/// over on their own. Returns `None` when there's nothing worth carrying.
+async fn build_backend_handoff_context(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    old_backend: &str,
+    new_backend: &str,
+) -> Option<String> {
+    const MAX_TRACES: usize = 6;
+    const MAX_TRACE_CHARS: usize = 1500;
+    const MAX_BODY_CHARS: usize = 6000;
+
+    // Scan recent events for the latest reasoning. Prefer `thinking` traces;
+    // fall back to recent assistant messages when a backend produced none.
+    let events = mission_store
+        .get_latest_events(mission_id, 600)
+        .await
+        .ok()?;
+    let pick = |event_type: &str, limit: usize| -> Vec<String> {
+        let mut picked: Vec<String> = events
+            .iter()
+            .rev()
+            .filter(|e| e.event_type == event_type && !e.content.trim().is_empty())
+            .take(limit)
+            .map(|e| e.content.trim().to_string())
+            .collect();
+        picked.reverse();
+        picked
+    };
+
+    let (label, traces) = {
+        let thinking = pick("thinking", MAX_TRACES);
+        if !thinking.is_empty() {
+            ("most recent reasoning", thinking)
+        } else {
+            ("most recent progress notes", pick("assistant_message", 4))
+        }
+    };
+    if traces.is_empty() {
+        return None;
+    }
+
+    let mut body = String::new();
+    for trace in traces {
+        let idx = safe_truncate_index(&trace, MAX_TRACE_CHARS);
+        let snippet = if idx < trace.len() {
+            format!("{}…", &trace[..idx])
+        } else {
+            trace
+        };
+        if body.len() + snippet.len() > MAX_BODY_CHARS && !body.is_empty() {
+            break;
+        }
+        if !body.is_empty() {
+            body.push_str("\n\n---\n\n");
+        }
+        body.push_str(&snippet);
+    }
+
+    Some(format!(
+        "## Backend handoff: now continuing on `{new_backend}` (was `{old_backend}`)\n\n\
+         The previous backend's session is not carried over (different reasoning \
+         format), but your work is intact in the workspace and the conversation \
+         above is preserved. To keep continuity, here is your {label} from the \
+         `{old_backend}` session:\n\n\
+         <prior_reasoning>\n{body}\n</prior_reasoning>\n\n\
+         Pick up exactly where you left off and continue toward the goal. \
+         Re-orient by checking the current workspace state first, then proceed."
+    ))
+}
+
 async fn clear_stale_mission_metadata_refresh_state(mission_store: &Arc<dyn MissionStore>) {
     let tracked_ids: std::collections::HashSet<Uuid> = {
         let tasks = MISSION_METADATA_REFRESH_TASKS
@@ -9329,6 +9408,13 @@ async fn control_actor_loop(
                             continue;
                         }
 
+                        // Capture the backend before the update so we can detect
+                        // a switch and carry reasoning across (see below).
+                        let old_backend = load_mission_record(&mission_store, id)
+                            .await
+                            .ok()
+                            .map(|m| m.backend);
+
                         let result = mission_store
                             .update_mission_run_settings(
                                 id,
@@ -9352,6 +9438,50 @@ async fn control_actor_loop(
                                 session_id: updated.session_id.clone(),
                                 updated_at: updated.updated_at.clone(),
                             });
+
+                            // Backend switch handoff: the new backend starts a
+                            // fresh session and can't replay the old backend's
+                            // reasoning format, so carry the recent reasoning
+                            // forward as a plain-text context message. It lands
+                            // in the conversation history and is picked up by
+                            // the next turn (resume or message) on either
+                            // backend. Workspace + transcript carry over already.
+                            let backend_switched = old_backend
+                                .as_deref()
+                                .map(|prev| prev != updated.backend.as_str())
+                                .unwrap_or(false);
+                            if backend_switched {
+                                let prev = old_backend.as_deref().unwrap_or("the previous backend");
+                                if let Some(handoff) = build_backend_handoff_context(
+                                    &mission_store,
+                                    id,
+                                    prev,
+                                    &updated.backend,
+                                )
+                                .await
+                                {
+                                    let event = AgentEvent::UserMessage {
+                                        id: Uuid::new_v4(),
+                                        content: handoff,
+                                        queued: false,
+                                        mission_id: Some(id),
+                                    };
+                                    if let Err(e) = mission_store.log_event(id, &event).await {
+                                        tracing::warn!(
+                                            mission_id = %id,
+                                            error = %e,
+                                            "Failed to persist backend handoff context"
+                                        );
+                                    }
+                                    let _ = events_tx.send(event);
+                                    tracing::info!(
+                                        mission_id = %id,
+                                        old_backend = ?old_backend,
+                                        new_backend = %updated.backend,
+                                        "Injected backend-switch handoff context to preserve reasoning"
+                                    );
+                                }
+                            }
                         }
 
                         let _ = respond.send(result);


### PR DESCRIPTION
Switching a mission's backend in run-settings (e.g. claudecode ↔ codex) starts a fresh session on the new backend, which can't replay the old backend's reasoning format. The reconstructed history only carries user/assistant text, so the prior **reasoning was silently dropped** — codex/claude resumed without the thoughts (exactly the gap hit when migrating off Claude after a usage limit).

**Fix:** when `UpdateMissionSettings` changes the backend, build a one-time "backend handoff" context from the recent reasoning (recent `thinking` traces, falling back to recent assistant messages), capped, and log it as a `user_message` so it lands in the conversation history. The next turn (resume or message) on either backend picks it up automatically. Workspace files + the user/assistant transcript already carry over.

**Verified on dev:** switching a mission's backend (codex→opencode) auto-logged the `## Backend handoff` context message. (Manually validated the same approach migrating two live missions claudecode→codex/gpt-5.5 — both continued their work seamlessly.)

**Security:** backend names are sanitized to `[A-Za-z0-9_-]` and the reconstructed body's closing `</prior_reasoning>` is neutralized (prompt-injection hardening from the automated review).

Backend-agnostic; a no-op when there's no reasoning to carry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission event history and prompt content on backend switches; mitigations limit size and injection, but the handoff still feeds untrusted prior output into the next turn.
> 
> **Overview**
> When **run-settings** changes a mission’s backend while the mission is idle, the control layer now detects the switch and injects a one-time **backend handoff** message into the event log as a `UserMessage`.
> 
> The new **`build_backend_handoff_context`** helper pulls recent `thinking` events (or recent assistant text if there is no thinking), caps size, wraps it in `<prior_reasoning>`, and explains that the new backend should re-orient in the workspace and continue. That closes the gap where a fresh backend session only replayed user/assistant text and dropped prior reasoning.
> 
> **Hardening:** backend labels in the message are restricted to safe identifiers, and closing `</prior_reasoning>` sequences in the copied body are neutralized so reconstructed content cannot break out of the framing tag. If there is nothing to carry, or the backend did not change, behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b70e4a8c88367931b566f78134339430c0c8455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->