### PR TITLE
dashboard: render paired <file> tags with inner-text labels

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1178,12 +1178,7 @@ function QuestionToolItem({
               <button
                 onClick={handleSubmit}
                 disabled={!canSubmit || submitting}
-                className={cn(
-                  "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
-                  !canSubmit || submitting
-                    ? "bg-white/5 text-white/30 cursor-not-allowed"
-                    : "bg-indigo-500/20 text-indigo-200 hover:bg-indigo-500/30",
-                )}
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-indigo-500"
               >
                 {submitting ? "Sending…" : "Submit Answer"}
               </button>

--- a/dashboard/src/lib/rich-tags.test.ts
+++ b/dashboard/src/lib/rich-tags.test.ts
@@ -73,6 +73,11 @@ describe("parseRichTags", () => {
     const tags = parseRichTags('<file path="./r.pdf" name="Attr">Inner</file>');
     expect(tags[0].name).toBe("Attr");
   });
+
+  it("treats an empty name attribute as absent, matching the rendered label", () => {
+    const tags = parseRichTags('<file path="./r.pdf" name="">Inner</file>');
+    expect(tags[0].name).toBe("Inner");
+  });
 });
 
 describe("transformRichTags", () => {
@@ -136,6 +141,21 @@ describe("transformRichTags", () => {
       '<file path="./a.pdf">Report [v2]\n  draft</file>',
     );
     expect(result).toBe("[Report \\[v2\\] draft](sandboxed-file://.%2Fa.pdf)");
+  });
+
+  it("treats an empty name attribute as absent and uses inner text", () => {
+    const result = transformRichTags('<file path="./a.pdf" name="">Inner Label</file>');
+    expect(result).toBe("[Inner Label](sandboxed-file://.%2Fa.pdf)");
+  });
+
+  it("falls back to filename for a whitespace-only name (no empty label)", () => {
+    const result = transformRichTags('<file path="./a.pdf" name="   "></file>');
+    expect(result).toBe("[a.pdf](sandboxed-file://.%2Fa.pdf)");
+  });
+
+  it("falls back to filename for a whitespace-only image alt", () => {
+    const result = transformRichTags('<image path="./a.png" alt="  " />');
+    expect(result).toBe("![a.png](sandboxed-image://.%2Fa.png)");
   });
 });
 

--- a/dashboard/src/lib/rich-tags.test.ts
+++ b/dashboard/src/lib/rich-tags.test.ts
@@ -54,6 +54,25 @@ describe("parseRichTags", () => {
       { type: "file", path: "./roadmap.md", alt: undefined, name: "Roadmap" },
     ]);
   });
+
+  it("uses inner text as the file name when no name attribute is given", () => {
+    const tags = parseRichTags(
+      '<file path="./report.pdf" type="application/pdf">Unlink Round-1 Scope Audit (final)</file>',
+    );
+    expect(tags).toEqual([
+      {
+        type: "file",
+        path: "./report.pdf",
+        alt: undefined,
+        name: "Unlink Round-1 Scope Audit (final)",
+      },
+    ]);
+  });
+
+  it("prefers the name attribute over inner text", () => {
+    const tags = parseRichTags('<file path="./r.pdf" name="Attr">Inner</file>');
+    expect(tags[0].name).toBe("Attr");
+  });
 });
 
 describe("transformRichTags", () => {
@@ -101,6 +120,22 @@ describe("transformRichTags", () => {
   it("transforms paired rich tags", () => {
     const result = transformRichTags("<file path='./report.md' name='Report'></file>");
     expect(result).toBe("[Report](sandboxed-file://.%2Freport.md)");
+  });
+
+  it("uses inner text as the link label for paired file tags", () => {
+    const result = transformRichTags(
+      '<file path="./report.pdf" type="application/pdf">Unlink Round-1 Scope Audit (final, table-layout fixes)</file>',
+    );
+    expect(result).toBe(
+      "[Unlink Round-1 Scope Audit (final, table-layout fixes)](sandboxed-file://.%2Freport.pdf)",
+    );
+  });
+
+  it("escapes brackets and collapses whitespace in inner text labels", () => {
+    const result = transformRichTags(
+      '<file path="./a.pdf">Report [v2]\n  draft</file>',
+    );
+    expect(result).toBe("[Report \\[v2\\] draft](sandboxed-file://.%2Fa.pdf)");
   });
 });
 
@@ -153,5 +188,13 @@ describe("hasPartialRichTag", () => {
 
   it("returns false for closed html tags", () => {
     expect(hasPartialRichTag("<b>bold</b>")).toBe(false);
+  });
+
+  it("detects a paired tag still streaming its inner text", () => {
+    expect(hasPartialRichTag('<file path="./r.pdf">Unlink Round-1 Sco')).toBe(true);
+  });
+
+  it("returns false for a fully closed paired tag", () => {
+    expect(hasPartialRichTag('<file path="./r.pdf">Report</file>')).toBe(false);
   });
 });

--- a/dashboard/src/lib/rich-tags.ts
+++ b/dashboard/src/lib/rich-tags.ts
@@ -22,9 +22,20 @@ const TAG_RE = /<(image|file)\s+([^>]*?)(?:\/\s*>|>([\s\S]*?)<\/\1\s*>)/gi;
 const PARTIAL_TAG_RE =
   /<(?:image|file)(?:\s+[^>]*)?$|<(?:image|file)\s+[^>]*[^/>]>(?:(?!<\/(?:image|file)\s*>)[\s\S])*$/i;
 
-/** Normalize a display name/alt to a single line safe for markdown link text. */
-function cleanDisplayText(value: string): string {
-  return value.trim().replace(/\s+/g, " ").replace(/[[\]]/g, "\\$&");
+/**
+ * Trim and collapse whitespace; returns undefined when the value is empty or
+ * whitespace-only. Used so an explicit empty/blank attribute (`name=""`,
+ * `alt="  "`) is treated as absent consistently across parse/transform/strip —
+ * falling back to inner text, then the path basename.
+ */
+function presentText(value: string | undefined): string | undefined {
+  const collapsed = value?.trim().replace(/\s+/g, " ");
+  return collapsed ? collapsed : undefined;
+}
+
+/** Escape markdown link/image label delimiters so freeform text stays inert. */
+function escapeLinkText(value: string): string {
+  return value.replace(/[[\]]/g, "\\$&");
 }
 
 interface RichTag {
@@ -54,12 +65,12 @@ export function parseRichTags(content: string): RichTag[] {
     const tagType = m[1].toLowerCase() as "image" | "file";
     const attrs = parseAttrs(m[2]);
     if (!attrs.path) continue;
-    const innerText = (m[3] ?? "").trim() || undefined;
+    const innerText = presentText(m[3]);
     tags.push({
       type: tagType,
       path: attrs.path,
-      alt: attrs.alt ?? (tagType === "image" ? innerText : undefined),
-      name: attrs.name ?? (tagType === "file" ? innerText : undefined),
+      alt: presentText(attrs.alt) ?? (tagType === "image" ? innerText : undefined),
+      name: presentText(attrs.name) ?? (tagType === "file" ? innerText : undefined),
     });
   }
   return tags;
@@ -78,14 +89,15 @@ export function transformRichTags(content: string): string {
     (_match, tagType: string, attrStr: string, inner?: string) => {
       const attrs = parseAttrs(attrStr);
       if (!attrs.path) return _match; // leave malformed tags as-is
-      const innerText = (inner ?? "").trim();
+      const innerText = presentText(inner);
+      const basename = attrs.path.split("/").pop();
       const encodedPath = encodeURIComponent(attrs.path);
       if (tagType.toLowerCase() === "image") {
-        const alt = attrs.alt || innerText || attrs.path.split("/").pop() || "image";
-        return `![${cleanDisplayText(alt)}](sandboxed-image://${encodedPath})`;
+        const alt = presentText(attrs.alt) ?? innerText ?? basename ?? "image";
+        return `![${escapeLinkText(alt)}](sandboxed-image://${encodedPath})`;
       } else {
-        const name = attrs.name || innerText || attrs.path.split("/").pop() || "file";
-        return `[${cleanDisplayText(name)}](sandboxed-file://${encodedPath})`;
+        const name = presentText(attrs.name) ?? innerText ?? basename ?? "file";
+        return `[${escapeLinkText(name)}](sandboxed-file://${encodedPath})`;
       }
     },
   );
@@ -130,7 +142,7 @@ export function stripRichFileTagsByName(
     if (tagType.toLowerCase() !== "file") return match;
     const attrs = parseAttrs(attrStr);
     const base = basename(attrs.path);
-    const displayName = attrs.name || (inner ?? "").trim() || base;
+    const displayName = presentText(attrs.name) ?? presentText(inner) ?? base;
     const candidates = [
       displayName,
       base,

--- a/dashboard/src/lib/rich-tags.ts
+++ b/dashboard/src/lib/rich-tags.ts
@@ -8,12 +8,24 @@
  */
 
 // Matches self-closing <image .../>/<file .../> tags and paired
-// <file ...></file> tags. Agents vary the exact XML-ish spelling while
-// streaming, so keep this parser deliberately small but permissive.
-const TAG_RE = /<(image|file)\s+([^>]*?)(?:\/\s*>|>\s*<\/\1\s*>)/gi;
+// <file ...>inner text</file> tags. The paired form captures any inner text
+// (group 3) so a display name written between the tags — e.g.
+// `<file path="r.pdf">My Report</file>` — is recognized instead of rendered
+// raw. Agents vary the exact XML-ish spelling while streaming, so keep this
+// parser deliberately small but permissive.
+const TAG_RE = /<(image|file)\s+([^>]*?)(?:\/\s*>|>([\s\S]*?)<\/\1\s*>)/gi;
 
-// Matches a partial (unclosed) tag at the end of streaming content
-const PARTIAL_TAG_RE = /<(?:image|file)(?:\s+[^>]*)?$/i;
+// Matches a partial (unclosed) tag at the end of streaming content: either a
+// half-written opening tag (`<file path="bar` — no `>` yet) or a fully opened
+// paired tag whose closing `</file>` hasn't streamed in yet
+// (`<file path="x">partial nam`). Excludes self-closing `/>` tags.
+const PARTIAL_TAG_RE =
+  /<(?:image|file)(?:\s+[^>]*)?$|<(?:image|file)\s+[^>]*[^/>]>(?:(?!<\/(?:image|file)\s*>)[\s\S])*$/i;
+
+/** Normalize a display name/alt to a single line safe for markdown link text. */
+function cleanDisplayText(value: string): string {
+  return value.trim().replace(/\s+/g, " ").replace(/[[\]]/g, "\\$&");
+}
 
 interface RichTag {
   type: "image" | "file";
@@ -42,11 +54,12 @@ export function parseRichTags(content: string): RichTag[] {
     const tagType = m[1].toLowerCase() as "image" | "file";
     const attrs = parseAttrs(m[2]);
     if (!attrs.path) continue;
+    const innerText = (m[3] ?? "").trim() || undefined;
     tags.push({
       type: tagType,
       path: attrs.path,
-      alt: attrs.alt,
-      name: attrs.name,
+      alt: attrs.alt ?? (tagType === "image" ? innerText : undefined),
+      name: attrs.name ?? (tagType === "file" ? innerText : undefined),
     });
   }
   return tags;
@@ -60,18 +73,22 @@ export function parseRichTags(content: string): RichTag[] {
  * Paths are URI-encoded to handle spaces and special characters.
  */
 export function transformRichTags(content: string): string {
-  return content.replace(TAG_RE, (_match, tagType: string, attrStr: string) => {
-    const attrs = parseAttrs(attrStr);
-    if (!attrs.path) return _match; // leave malformed tags as-is
-    const encodedPath = encodeURIComponent(attrs.path);
-    if (tagType.toLowerCase() === "image") {
-      const alt = attrs.alt || attrs.path.split("/").pop() || "image";
-      return `![${alt}](sandboxed-image://${encodedPath})`;
-    } else {
-      const name = attrs.name || attrs.path.split("/").pop() || "file";
-      return `[${name}](sandboxed-file://${encodedPath})`;
-    }
-  });
+  return content.replace(
+    TAG_RE,
+    (_match, tagType: string, attrStr: string, inner?: string) => {
+      const attrs = parseAttrs(attrStr);
+      if (!attrs.path) return _match; // leave malformed tags as-is
+      const innerText = (inner ?? "").trim();
+      const encodedPath = encodeURIComponent(attrs.path);
+      if (tagType.toLowerCase() === "image") {
+        const alt = attrs.alt || innerText || attrs.path.split("/").pop() || "image";
+        return `![${cleanDisplayText(alt)}](sandboxed-image://${encodedPath})`;
+      } else {
+        const name = attrs.name || innerText || attrs.path.split("/").pop() || "file";
+        return `[${cleanDisplayText(name)}](sandboxed-file://${encodedPath})`;
+      }
+    },
+  );
 }
 
 function fileStem(value: string): string {
@@ -109,11 +126,11 @@ export function stripRichFileTagsByName(
   }
   if (nameSet.size === 0) return content;
 
-  return content.replace(TAG_RE, (match, tagType: string, attrStr: string) => {
+  return content.replace(TAG_RE, (match, tagType: string, attrStr: string, inner?: string) => {
     if (tagType.toLowerCase() !== "file") return match;
     const attrs = parseAttrs(attrStr);
     const base = basename(attrs.path);
-    const displayName = attrs.name || base;
+    const displayName = attrs.name || (inner ?? "").trim() || base;
     const candidates = [
       displayName,
       base,


### PR DESCRIPTION
## Problem

In a mission's rich view, this rendered as **literal text** instead of a file card:

```
<file path="./report.pdf" type="application/pdf">Unlink Round-1 Scope Audit (final, table-layout fixes)</file>
```

(observed on mission `5aede562`).

## Cause

`TAG_RE` in `rich-tags.ts` matched the paired form only as `>\s*</file>` — i.e. when the gap between `>` and `</file>` was **whitespace**. When the agent put the display name as **text content** between the tags (rather than a `name="..."` attribute), the regex didn't match, `transformRichTags` left it untouched, and react-markdown rendered the raw tag as plain text.

## Fix

- Capture inner text (`>([\s\S]*?)</file>`) and use it as the file **name** / image **alt** when no `name`/`alt` attribute is present — in `parseRichTags`, `transformRichTags`, and `stripRichFileTagsByName`.
- Collapse whitespace and escape `[` `]` in the derived label so freeform inner text can't break the generated markdown link.
- Extend `hasPartialRichTag` to also detect a paired tag whose closing `</file>` hasn't streamed in yet, so these don't flash raw mid-stream.
- `name`/`alt` attributes still take precedence over inner text.

## Tests

Added cases for inner-text parse/transform, attribute precedence, bracket/whitespace escaping, and the streaming partial-tag case. Full `rich-tags` suite green (32 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown preprocessing and a small UI tweak; no auth, data, or API changes.
> 
> **Overview**
> **Rich `<file>` / `<image>` tags** now treat text between opening and closing tags as the display label when `name` or `alt` is missing or blank. The tag regex captures inner content instead of only empty paired tags, and **parse**, **transform**, and **strip-by-name** paths share **`presentText`** (trim/collapse whitespace) plus **`escapeLinkText`** for `[`/`]` so generated markdown links stay valid.
> 
> **Streaming** detection in **`hasPartialRichTag`** also hides in-progress paired tags until `</file>` arrives, avoiding raw XML flashing in the stream.
> 
> Separately, the control panel **Submit Answer** button uses a solid indigo style with **`disabled:`** opacity instead of conditional muted classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5782228ded9f5873eee9da1b7fb61ad6cde20fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->