### PR TITLE
control: conversation-anchored mission snapshot (fast load + recent messages always visible)

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -488,18 +488,6 @@ const PerfOverlay = dynamic(() =>
 type ToolItem = Extract<ChatItem, { kind: "tool" }>;
 type SidePanelItem = Extract<ChatItem, { kind: "thinking" | "stream" }>;
 
-function scheduleBackgroundHistoryFill(callback: () => void) {
-  if (typeof window === "undefined") return;
-  const start = () => {
-    if ("requestIdleCallback" in window) {
-      window.requestIdleCallback(callback, { timeout: 5_000 });
-      return;
-    }
-    globalThis.setTimeout(callback, 250);
-  };
-  globalThis.setTimeout(start, 1_000);
-}
-
 // Module-level so all duration consumers share the same implementation.
 function formatDuration(seconds: number): string {
   if (seconds <= 0) return "<1s";
@@ -4457,28 +4445,43 @@ export default function ControlClient() {
     setThinkingPanelManuallyHidden(true);
   }, [setShowThinkingPanel, setThinkingPanelManuallyHidden]);
 
-  const adjustVisibleItemsLimit = useCallback((historyItems: ChatItem[]) => {
-    let lastAssistantIdx = -1;
-    for (let i = historyItems.length - 1; i >= 0; i--) {
-      if (historyItems[i].kind === "assistant") {
-        lastAssistantIdx = i;
-        break;
+  // Anchor the initial visible window on the last N conversation messages
+  // (user + assistant), not the last single assistant message. On tool-heavy
+  // missions a long run of tool calls would otherwise push the recent
+  // back-and-forth above the fold, behind "Load older messages". Expanding
+  // the window to span from the Nth-most-recent message through the newest
+  // item keeps the last ~10 turns (and the tool calls between them) visible
+  // immediately; everything older stays one click away.
+  const CONVERSATIONAL_ANCHOR_COUNT = 10;
+  const conversationalAnchorIndex = useCallback(
+    (historyItems: ChatItem[]): number => {
+      let convoSeen = 0;
+      let anchorIdx = -1;
+      for (let i = historyItems.length - 1; i >= 0; i--) {
+        const kind = historyItems[i].kind;
+        if (kind === "assistant" || kind === "user") {
+          anchorIdx = i;
+          convoSeen += 1;
+          if (convoSeen >= CONVERSATIONAL_ANCHOR_COUNT) break;
+        }
       }
-    }
+      return anchorIdx;
+    },
+    [],
+  );
 
-    if (lastAssistantIdx === -1) {
-      setVisibleItemsLimit(INITIAL_VISIBLE_ITEMS);
-      return;
-    }
-
-    const required = historyItems.length - lastAssistantIdx;
-    if (required <= INITIAL_VISIBLE_ITEMS) {
-      setVisibleItemsLimit(INITIAL_VISIBLE_ITEMS);
-      return;
-    }
-
-    setVisibleItemsLimit(required);
-  }, []);
+  const adjustVisibleItemsLimit = useCallback(
+    (historyItems: ChatItem[]) => {
+      const anchorIdx = conversationalAnchorIndex(historyItems);
+      if (anchorIdx === -1) {
+        setVisibleItemsLimit(INITIAL_VISIBLE_ITEMS);
+        return;
+      }
+      const required = historyItems.length - anchorIdx;
+      setVisibleItemsLimit(Math.max(INITIAL_VISIBLE_ITEMS, required));
+    },
+    [conversationalAnchorIndex],
+  );
 
   const HISTORY_EVENT_TYPES = useMemo(
     () => [
@@ -4508,22 +4511,12 @@ export default function ControlClient() {
    */
   const missionMaxSeqRef = useRef<Map<string, number>>(new Map());
 
-  // Page size for each backwards-paginate-older fetch (both the explicit
-  // "Load older messages" button and the post-initial background fill).
-  // Tuned for memory headroom on long missions — see the
-  // `chatScrollContainerRef` comment block above.
+  // Page size for each backwards-paginate-older fetch (the explicit
+  // "Load older messages" button / scroll-up). Tuned for memory headroom on
+  // long missions — see the `chatScrollContainerRef` comment block above.
   const HISTORY_PAGE_SIZE = 5000;
   const HISTORY_DELTA_PAGE_SIZE = 1000;
   const HISTORY_FALLBACK_PAGE_SIZE = 1000;
-  // Cap how far the background fill walks back from the head on first load.
-  // Past this depth the user has to click "Load older messages" — keeps
-  // memory + render cost predictable on huge missions while still feeling
-  // "complete" for typical ones.
-  const BACKGROUND_FILL_TARGET = 2000;
-  // Per-page size used by the background fill. Smaller than the explicit
-  // "Load older" button so each chunk costs less and we can interleave with
-  // live SSE events without long main-thread stalls.
-  const BACKGROUND_FILL_PAGE_SIZE = 500;
 
   const loadHistoryEvents = useCallback(
     async (id: string, opts?: { sinceSeq?: number }) => {
@@ -4686,32 +4679,15 @@ export default function ControlClient() {
         );
       }
 
-      // Kick off the background fill so the rest of the history streams in
-      // after first paint. Scheduled via setTimeout(0) so the caller's
-      // setItems/render commits first — running the next fetch synchronously
-      // here would just stall the same task we tried to free up. The ref
-      // indirection breaks TDZ against `streamOlderHistory`, which is
-      // declared after the older-paginator below.
-      const hasMoreLocal = metaTotal !== undefined && sorted.length < metaTotal;
-      if (hasMoreLocal) {
-        const fillFn = streamOlderHistoryRef.current;
-        if (fillFn) {
-          scheduleBackgroundHistoryFill(() => {
-            void fillFn(id);
-          });
-        }
-      }
+      // No eager background fill. The snapshot is conversation-anchored
+      // (it already includes the last N message turns plus the tool calls
+      // between them), so walking thousands more events back on open just
+      // re-replayed the whole accumulated set on the main thread per page —
+      // the "loads forever" jank on tool-heavy missions. Older history now
+      // loads purely on demand via "Load older messages" / scroll-up.
       return sorted;
     },
     [HISTORY_EVENT_TYPES],
-  );
-
-  // Bridge between `loadHistoryEvents` (declared above) and
-  // `streamOlderHistory` (declared below). `loadHistoryEvents` schedules
-  // the background fill at the tail end of its initial-load branch, but
-  // can't reference `streamOlderHistory` by name without a TDZ violation.
-  const streamOlderHistoryRef = useRef<((id: string) => Promise<void>) | null>(
-    null,
   );
 
   /**
@@ -4993,21 +4969,18 @@ export default function ControlClient() {
     return progressByMission[viewingMissionId] ?? null;
   }, [progressByMission, viewingMissionId]);
 
+  // As live events stream in, keep the last N conversation messages within
+  // the visible window. Mirrors `adjustVisibleItemsLimit` but only grows the
+  // window (never shrinks it) so unrelated growth elsewhere is preserved.
   useEffect(() => {
     if (items.length === 0) return;
-    let lastAssistantIdx = -1;
-    for (let i = items.length - 1; i >= 0; i--) {
-      if (items[i].kind === "assistant") {
-        lastAssistantIdx = i;
-        break;
-      }
-    }
-    if (lastAssistantIdx === -1) return;
+    const anchorIdx = conversationalAnchorIndex(items);
+    if (anchorIdx === -1) return;
     const visibleStart = Math.max(0, items.length - visibleItemsLimit);
-    if (lastAssistantIdx < visibleStart) {
-      setVisibleItemsLimit(items.length - lastAssistantIdx);
+    if (anchorIdx < visibleStart) {
+      setVisibleItemsLimit(items.length - anchorIdx);
     }
-  }, [items, visibleItemsLimit]);
+  }, [items, visibleItemsLimit, conversationalAnchorIndex]);
 
   const viewingMissionStallInfo = useMemo(() => {
     if (!viewingMissionId) return null;
@@ -6019,71 +5992,6 @@ export default function ControlClient() {
     [HISTORY_EVENT_TYPES, eventsToItems, computeHasMoreOlder, setItems],
   );
 
-  // Background fill: after the initial fetch shows the newest events,
-  // walk older pages until we've reached `BACKGROUND_FILL_TARGET` total
-  // history events or there are no more. Runs `silent` so the
-  // "Load older messages" button doesn't flash a loading state; bails
-  // if the user switches missions, if a fetch fails, or if the mission
-  // turns out to have fewer events than the target (server total reached).
-  const streamOlderHistory = useCallback(
-    async (id: string) => {
-      // Yield once so the initial-render setItems can commit and paint
-      // before we start eating network/main-thread time on background
-      // fills. Without this the first chunk can land before the user
-      // sees the latest message at all.
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const stillActive = (): boolean =>
-        currentMissionRef.current?.id === id ||
-        viewingMissionRef.current?.id === id;
-
-      // Up to a few page-loads, with a small inter-page yield so live
-      // SSE events can interleave on the main thread without jank.
-      // Hard ceiling (16) is a backstop; the loop normally exits via
-      // the `hasMore`/target check first.
-      for (let i = 0; i < 16; i++) {
-        if (!stillActive()) return;
-        const accumulated =
-          missionHistoricEventsRef.current.get(id)?.length ?? 0;
-        const total = missionTotalHistoryRef.current.get(id);
-        if (total !== undefined && accumulated >= total) return;
-        if (accumulated >= BACKGROUND_FILL_TARGET) return;
-        const minSeq = missionMinSeqRef.current.get(id);
-        if (minSeq === undefined || minSeq <= 1) return;
-
-        try {
-          await loadOlderHistoryEvents(id, {
-            silent: true,
-            limit: BACKGROUND_FILL_PAGE_SIZE,
-          });
-        } catch {
-          // Stop on error — the user's manual "Load older messages"
-          // path remains available for retry.
-          return;
-        }
-
-        // If accumulated didn't grow, the server returned an empty
-        // page and there's nothing left to fetch. Avoid the
-        // pathological tight loop.
-        const after = missionHistoricEventsRef.current.get(id)?.length ?? 0;
-        if (after <= accumulated) return;
-
-        // Small pause between pages so the main thread can run other
-        // work (live event handlers, scroll, input).
-        await new Promise((resolve) => setTimeout(resolve, 150));
-      }
-    },
-    [loadOlderHistoryEvents, BACKGROUND_FILL_PAGE_SIZE, BACKGROUND_FILL_TARGET],
-  );
-
-  // Wire the ref consumed by `loadHistoryEvents` (which is declared
-  // above `streamOlderHistory`, so it can't reference it directly).
-  useEffect(() => {
-    streamOlderHistoryRef.current = streamOlderHistory;
-    return () => {
-      streamOlderHistoryRef.current = null;
-    };
-  }, [streamOlderHistory]);
 
   // Load mission from URL param on mount (and retry on auth success)
   const [authRetryTrigger, setAuthRetryTrigger] = useState(0);

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -488,6 +488,40 @@ const PerfOverlay = dynamic(() =>
 type ToolItem = Extract<ChatItem, { kind: "tool" }>;
 type SidePanelItem = Extract<ChatItem, { kind: "thinking" | "stream" }>;
 
+// Mirror of the server's conversation-anchored snapshot (see
+// `get_mission_snapshot` in src/api/control.rs). Keep these in sync.
+const SNAPSHOT_CONVERSATIONAL_MESSAGES = 10;
+const SNAPSHOT_MAX_EVENTS = 1500;
+const CONVERSATION_EVENT_TYPES = new Set([
+  "user_message",
+  "assistant_message",
+  "assistant_message_canonical",
+]);
+
+// Trim a sequence-ASC event list to the conversation-anchored tail: everything
+// from the Nth-most-recent user/assistant message to the head (tool calls in
+// between included), hard-capped at SNAPSHOT_MAX_EVENTS. Applied to the IDB
+// cache path so a cache hit behaves like `getMissionSnapshot` — without it a
+// stale or oversized cached tail would be replayed in full (slow load) and the
+// recent-message anchoring would be bypassed.
+function anchorEventsToRecentConversation(events: StoredEvent[]): StoredEvent[] {
+  let convoSeen = 0;
+  let anchorIdx = -1;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (CONVERSATION_EVENT_TYPES.has(events[i].event_type)) {
+      anchorIdx = i;
+      convoSeen += 1;
+      if (convoSeen >= SNAPSHOT_CONVERSATIONAL_MESSAGES) break;
+    }
+  }
+  // Fewer than N conversation messages → keep all (still capped below).
+  let start = anchorIdx === -1 ? 0 : anchorIdx;
+  if (events.length - start > SNAPSHOT_MAX_EVENTS) {
+    start = events.length - SNAPSHOT_MAX_EVENTS;
+  }
+  return start === 0 ? events : events.slice(start);
+}
+
 // Module-level so all duration consumers share the same implementation.
 function formatDuration(seconds: number): string {
   if (seconds <= 0) return "<1s";
@@ -4596,7 +4630,12 @@ export default function ControlClient() {
               }
             }
             merged.sort((a, b) => a.sequence - b.sequence);
-            sorted = merged;
+            // Bound the cached tail to the conversation-anchored window, just
+            // like the server snapshot, so a cache hit doesn't replay a
+            // stale/oversized history or bypass the recent-message anchoring.
+            // `metaTotal` below stays the true server total, so trimming here
+            // simply leaves older events to the on-demand "Load older" path.
+            sorted = anchorEventsToRecentConversation(merged);
             metaMaxSeq = maxSequence;
             // The delta fetch above runs with `includeCounts: false`, so the
             // server omits `X-Total-Events` and `delta.meta.totalEvents` is
@@ -4613,7 +4652,7 @@ export default function ControlClient() {
                 ? cached.totalEvents + addedByDelta
                 : undefined);
             cacheHit = true;
-            eventMergeCount = merged.length;
+            eventMergeCount = sorted.length;
           }
         } catch {
           // Network or auth failure on the delta — fall through to the

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -4918,7 +4918,21 @@ const HISTORY_EVENT_TYPES: &[&str] = &[
     "goal_iteration",
     "goal_status",
 ];
-const SNAPSHOT_EVENT_LIMIT: usize = 200;
+/// Conversation message types used to anchor the snapshot tail. The snapshot
+/// guarantees the most recent `SNAPSHOT_CONVERSATIONAL_MESSAGES` of these are
+/// loaded (plus every tool call between them), so a tool-heavy mission opens
+/// on the actual conversation instead of a wall of tool output.
+const SNAPSHOT_ANCHOR_TYPES: &[&str] = &[
+    "user_message",
+    "assistant_message",
+    "assistant_message_canonical",
+];
+/// How many recent conversation messages the snapshot guarantees.
+const SNAPSHOT_CONVERSATIONAL_MESSAGES: usize = 10;
+/// Hard cap on snapshot size. Bounds payload if the recent conversation
+/// happens to span an unusually large number of tool calls; the rest stays
+/// reachable via backwards pagination ("Load older messages").
+const SNAPSHOT_MAX_EVENTS: usize = 1500;
 
 fn event_types_for_query(query: &GetEventsQuery) -> Option<Vec<String>> {
     if let Some(types) = query.types.as_ref() {
@@ -4990,16 +5004,66 @@ pub async fn get_mission_snapshot(
         mission.workspace_name = Some(workspace.name);
     }
 
-    let events = control
+    // Conversation-anchored snapshot tail: load everything from the
+    // Nth-most-recent conversation message to the head, so the recent
+    // back-and-forth is always present even when tool calls dominate the
+    // raw event stream. Falls back to a plain recent-events tail when the
+    // mission has fewer than N conversation messages, or (degenerate) when
+    // the anchored span would exceed the hard cap.
+    let anchor_seq = control
         .mission_store
-        .get_events_before(
+        .nth_recent_event_sequence(
             mission_id,
-            i64::MAX,
-            Some(HISTORY_EVENT_TYPES),
-            Some(SNAPSHOT_EVENT_LIMIT),
+            SNAPSHOT_ANCHOR_TYPES,
+            SNAPSHOT_CONVERSATIONAL_MESSAGES,
         )
         .await
         .map_err(internal_error)?;
+    let events = match anchor_seq {
+        Some(anchor) => {
+            // `get_events_since` is `sequence > since`, so subtract one to
+            // include the anchor itself. Fetch one past the cap to detect
+            // overflow without a separate count query.
+            let anchored = control
+                .mission_store
+                .get_events_since(
+                    mission_id,
+                    anchor.saturating_sub(1),
+                    Some(HISTORY_EVENT_TYPES),
+                    Some(SNAPSHOT_MAX_EVENTS + 1),
+                )
+                .await
+                .map_err(internal_error)?;
+            if anchored.len() > SNAPSHOT_MAX_EVENTS {
+                // The recent conversation spans more than the cap of tool
+                // calls. `get_events_since` returned the OLDEST events after
+                // the anchor (ASC), which would miss the newest — so fall
+                // back to the most-recent capped tail instead.
+                control
+                    .mission_store
+                    .get_events_before(
+                        mission_id,
+                        i64::MAX,
+                        Some(HISTORY_EVENT_TYPES),
+                        Some(SNAPSHOT_MAX_EVENTS),
+                    )
+                    .await
+                    .map_err(internal_error)?
+            } else {
+                anchored
+            }
+        }
+        None => control
+            .mission_store
+            .get_events_before(
+                mission_id,
+                i64::MAX,
+                Some(HISTORY_EVENT_TYPES),
+                Some(SNAPSHOT_MAX_EVENTS),
+            )
+            .await
+            .map_err(internal_error)?,
+    };
     let summary = if should_summarize_events(&mission) {
         summarize_inactive_stream_events(events)
     } else {

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1367,6 +1367,22 @@ pub trait MissionStore: Send + Sync {
         Ok(0)
     }
 
+    /// Sequence of the Nth-most-recent event whose type is in `anchor_types`
+    /// (e.g. the 10th-most-recent user/assistant message). Returns `None`
+    /// when the mission has fewer than `n` such events. Used to load a
+    /// *conversation-anchored* snapshot tail — everything from this sequence
+    /// to the head — instead of a raw event-count tail that, on tool-heavy
+    /// missions, would be dominated by tool calls and bury recent messages.
+    async fn nth_recent_event_sequence(
+        &self,
+        mission_id: Uuid,
+        anchor_types: &[&str],
+        n: usize,
+    ) -> Result<Option<i64>, String> {
+        let _ = (mission_id, anchor_types, n);
+        Ok(None)
+    }
+
     /// Get total cost in cents across all missions.
     /// Aggregates assistant_message metadata cost across all events.
     async fn get_total_cost_cents(&self) -> Result<u64, String> {

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -4159,6 +4159,43 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn nth_recent_event_sequence(
+        &self,
+        mission_id: Uuid,
+        anchor_types: &[&str],
+        n: usize,
+    ) -> Result<Option<i64>, String> {
+        if n == 0 {
+            return Ok(None);
+        }
+        let conn = self.conn.clone();
+        let mid = mission_id.to_string();
+        let types: Vec<String> = anchor_types.iter().map(|s| s.to_string()).collect();
+        // OFFSET is zero-based: the Nth-most-recent row is at offset N-1.
+        let offset = (n - 1) as i64;
+
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let types_json = serde_json::to_string(&types).unwrap_or_else(|_| "[]".to_string());
+            // Backed by idx_events_mission_type_sequence (mission_id,
+            // event_type, sequence) — the DESC walk + small OFFSET is cheap.
+            let seq: Option<i64> = conn
+                .query_row(
+                    "SELECT sequence FROM mission_events
+                     WHERE mission_id = ?1 AND event_type IN (SELECT value FROM json_each(?2))
+                     ORDER BY sequence DESC
+                     LIMIT 1 OFFSET ?3",
+                    params![&mid, &types_json, offset],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| e.to_string())?;
+            Ok(seq)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn count_events(
         &self,
         mission_id: Uuid,
@@ -11573,6 +11610,100 @@ mod tests {
         assert_eq!(
             contents,
             vec!["msg-45", "msg-46", "msg-47", "msg-48", "msg-49"]
+        );
+    }
+
+    #[tokio::test]
+    async fn nth_recent_event_sequence_anchors_on_conversation_messages() {
+        use crate::api::control::AgentEvent;
+        // The conversation-anchored snapshot needs the sequence of the
+        // Nth-most-recent user/assistant message, ignoring the (far more
+        // numerous) tool calls in between.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Tool heavy"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        let anchor_types = ["user_message", "assistant_message"];
+
+        // No conversation messages yet → None.
+        assert_eq!(
+            store
+                .nth_recent_event_sequence(mission.id, &anchor_types, 1)
+                .await
+                .expect("query"),
+            None
+        );
+
+        // Interleave 5 assistant messages with 3 tool calls between each.
+        // Record each assistant message's sequence as we go.
+        let mut assistant_seqs: Vec<i64> = Vec::new();
+        for n in 0..5 {
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::AssistantMessage {
+                        id: Uuid::new_v4(),
+                        content: format!("assistant-{n}"),
+                        success: true,
+                        cost_cents: 0,
+                        cost_source: CostSource::Unknown,
+                        usage: None,
+                        model: None,
+                        model_normalized: None,
+                        mission_id: Some(mission.id),
+                        shared_files: None,
+                        resumable: false,
+                        completion_evidence: None,
+                    },
+                )
+                .await
+                .expect("log assistant");
+            assistant_seqs.push(store.max_event_sequence(mission.id).await.expect("max"));
+            for t in 0..3 {
+                store
+                    .log_event(
+                        mission.id,
+                        &AgentEvent::ToolCall {
+                            tool_call_id: format!("tc-{n}-{t}"),
+                            name: "bash".to_string(),
+                            args: serde_json::json!({"cmd": "echo hi"}),
+                            mission_id: Some(mission.id),
+                        },
+                    )
+                    .await
+                    .expect("log tool");
+            }
+        }
+
+        // 1st-most-recent conversation message = the last assistant (index 4).
+        assert_eq!(
+            store
+                .nth_recent_event_sequence(mission.id, &anchor_types, 1)
+                .await
+                .expect("query"),
+            Some(assistant_seqs[4])
+        );
+        // 3rd-most-recent = assistant index 2, even though ~6 tool calls
+        // sit between it and the head.
+        assert_eq!(
+            store
+                .nth_recent_event_sequence(mission.id, &anchor_types, 3)
+                .await
+                .expect("query"),
+            Some(assistant_seqs[2])
+        );
+        // Asking for more conversation messages than exist → None.
+        assert_eq!(
+            store
+                .nth_recent_event_sequence(mission.id, &anchor_types, 6)
+                .await
+                .expect("query"),
+            None
         );
     }
 


### PR DESCRIPTION
## Problem

Opening a tool-heavy mission was slow *and* buried recent messages. Example: mission with **2991 events, 4.7 MB, 94% tool calls** (1410 calls + 1407 results), only 74 conversation messages.

Two root causes, both from loading **linearly by raw event count**:

1. **Recent messages buried** — the snapshot returned the last **200 raw events** (mostly tool calls → only ~5 conversation messages), and the visible window anchored on the *single* last assistant message. Your question + the agent's earlier replies got pushed behind "Load older messages".
2. **"Loads forever" jank** — after first paint a background fill walked back to **2000 events in 500-event pages**, re-running `eventsToItems()` over the *entire accumulated set on the main thread* each page (~4 MB replayed 4×), plus a full `deriveItemViews` + virtualizer recompute per page.

## Fix

**Backend**
- New `MissionStore::nth_recent_event_sequence` — indexed `ORDER BY sequence DESC LIMIT 1 OFFSET n-1` over conversation message types — finds the sequence of the Nth-most-recent user/assistant message.
- `get_mission_snapshot` now loads everything **from the 10th-most-recent conversation message to the head** (all tool calls between them included), capped at `SNAPSHOT_MAX_EVENTS=1500`. Falls back to a recent-events tail when the mission has <10 messages or the span exceeds the cap.

**Frontend**
- `adjustVisibleItemsLimit` (+ the live-stream effect) anchor the window on the **last 10 conversation messages**, not the last single assistant message.
- **Removed the eager background fill** entirely (the jank source). Older history loads on demand via the existing "Load older messages" / scroll-up path (unchanged).

## Impact (measured on the 2991-event mission)

| | Before | After |
|---|---|---|
| Initial snapshot | 200 raw events, then bg-fill to **2000 / ~4 MB** (4× main-thread replay) | **181 events / 0.12 MB**, single load |
| Conversation messages present on open | ~5 | **10 (guaranteed)** |
| Anchor query | — | **3 ms** (indexed) |

~40× less data on open, no main-thread replay loop, and the last 10 turns are always visible immediately.

## Tests
- New `nth_recent_event_sequence_anchors_on_conversation_messages` unit test (interleaves messages + tool calls, asserts the anchor ignores tool calls and returns None past the count).
- Deployed to dev; endpoint routes cleanly; DB-level simulation of the exact query confirms the numbers above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-paint payload and client history loading for all missions; behavior is well-bounded with fallbacks and tests, but incorrect anchoring could hide recent messages or break pagination UX.
> 
> **Overview**
> Mission open now loads a **conversation-anchored** event tail instead of a fixed count of raw events, and the control UI stops prefetching thousands of older events in the background.
> 
> **Backend:** `get_mission_snapshot` replaces the last-200-events tail with everything from the **10th-most-recent** user/assistant message through the head (tool events in between included), hard-capped at **1500** events, with fallbacks when there are fewer messages or the span exceeds the cap. New **`MissionStore::nth_recent_event_sequence`** (SQLite implementation + trait stub) powers the anchor lookup.
> 
> **Frontend:** Constants and **`anchorEventsToRecentConversation`** mirror the server window so IDB cache/delta merges stay bounded. The visible chat window anchors on the **last 10 conversation turns** (not just the last assistant message), including a live-stream effect that grows the window as needed. **Eager background history fill** (`scheduleBackgroundHistoryFill`, `streamOlderHistory`, related refs/constants) is removed; older history is **on demand** only via "Load older messages" / scroll-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9c05c03145e2587760b171dc3d770208f1c995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->