### PR TITLE
claudecode: pin MAX_THINKING_TOKENS so thinking is captured

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3900,6 +3900,28 @@ fn get_backend_bool_setting(backend_id: &str, key: &str) -> Option<bool> {
     None
 }
 
+/// Map a mission `model_effort` to a Claude Code extended-thinking budget
+/// (`MAX_THINKING_TOKENS`).
+///
+/// `CLAUDE_CODE_EFFORT_LEVEL` alone only nudges *adaptive* reasoning: on
+/// tool-heavy turns the model frequently chooses not to think at all, so no
+/// `thinking_delta` blocks stream and the Thoughts panel stays empty (see
+/// mission 5aede562, which ran at effort=max yet recorded 0 thinking events
+/// across ~1600 tool calls). Pinning a non-zero budget forces an extended
+/// thinking block every turn, so thoughts are captured deterministically.
+///
+/// Returns 0 for unknown efforts, leaving thinking fully adaptive.
+fn claude_thinking_budget(effort: &str) -> u32 {
+    match effort.trim().to_ascii_lowercase().as_str() {
+        "max" => 32_000,
+        "xhigh" => 24_000,
+        "high" => 16_000,
+        "medium" => 8_000,
+        "low" => 4_000,
+        _ => 0,
+    }
+}
+
 /// Execute a turn using Claude Code CLI backend.
 ///
 /// For Host workspaces: spawns the CLI directly on the host.
@@ -4802,10 +4824,25 @@ pub fn run_claudecode_turn<'a>(
         // Claude Code reads CLAUDE_CODE_EFFORT_LEVEL to control adaptive reasoning depth.
         if let Some(effort) = model_effort {
             env.insert("CLAUDE_CODE_EFFORT_LEVEL".to_string(), effort.to_string());
+
+            // CLAUDE_CODE_EFFORT_LEVEL only nudges adaptive reasoning, which
+            // leaves the Thoughts panel empty on tool-heavy turns. Pin an
+            // explicit extended-thinking budget so every turn emits a thinking
+            // block we can capture and stream. (The capture pipeline already
+            // handles thinking_delta — see backend/shared.rs — the CLI just
+            // wasn't emitting any.)
+            let thinking_tokens = claude_thinking_budget(effort);
+            if thinking_tokens > 0 {
+                env.insert(
+                    "MAX_THINKING_TOKENS".to_string(),
+                    thinking_tokens.to_string(),
+                );
+            }
             tracing::info!(
                 mission_id = %mission_id,
                 effort = %effort,
-                "Setting Claude Code effort level via CLAUDE_CODE_EFFORT_LEVEL"
+                max_thinking_tokens = thinking_tokens,
+                "Setting Claude Code effort level + extended-thinking budget"
             );
         }
 


### PR DESCRIPTION
## Problem

Claude Code missions intermittently recorded **zero `thinking` events**, leaving the Thoughts panel empty. Mission `5aede562` ran at `model_effort = max` across ~1600 tool calls and captured 0 thinking events; other claudecode missions (e.g. `0d9ca73a`, 945 thinking events) prove the capture pipeline works.

Root cause: we only set `CLAUDE_CODE_EFFORT_LEVEL`, which nudges *adaptive* reasoning — on tool-heavy turns the model frequently chooses not to think at all, so no `thinking_delta` blocks stream. The capture/parse path (`backend/shared.rs`, both `thinking_delta` and `ContentBlock::Thinking`) was already correct; the CLI just wasn't producing thinking.

## Change

`mission_runner.rs`: when a mission has a `model_effort`, also pin an explicit extended-thinking budget via `MAX_THINKING_TOKENS`, forcing a thinking block every turn. Budget scales with effort:

| effort | MAX_THINKING_TOKENS |
|---|---|
| max | 32000 |
| xhigh | 24000 |
| high | 16000 |
| medium | 8000 |
| low | 4000 |
| (unset/unknown) | not set — fully adaptive |

## Test plan
- [x] Builds (`cargo build`) and deployed+verified on the dev backend (binary contains `MAX_THINKING_TOKENS` + the new log line).
- [ ] Run a tool-heavy claudecode mission at effort≥medium and confirm `thinking` events stream into the Thoughts panel.

## Notes
Surfaced while debugging mission `5aede562`, which was also interrupted by the inactivity watchdog. That stall is a **separate** systemic issue (the actor's 900s stuck-watchdog can fire before a long silent foreground tool / extended-thinking stretch completes, because the liveness heartbeat only fires on stream-event receipt) — tracked separately, not in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude Code runtime env for all missions with model_effort set, increasing thinking token use (cost/latency) but not touching auth or data paths.
> 
> **Overview**
> Claude Code missions that only had **`CLAUDE_CODE_EFFORT_LEVEL`** set could run with **no streamed thinking**, so the Thoughts panel stayed empty on tool-heavy turns even at high effort. This change keeps the existing effort env var and **also sets `MAX_THINKING_TOKENS`** when the mission has a known `model_effort`, scaling the budget from low (4k) through max (32k).
> 
> A new **`claude_thinking_budget`** helper in `mission_runner.rs` performs the mapping; unknown or unset effort still skips the cap so thinking stays fully adaptive. Startup logging now includes the pinned token budget alongside effort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1c867f3367b888d97dc1dd6fefef05549ddcb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->