### PR TITLE
claudecode: timer heartbeat during tool execution so the watchdog doesn't kill long builds

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5295,6 +5295,32 @@ pub fn run_claudecode_turn<'a>(
                     reader_handle.abort();
                     break;
                 }
+                // Timer-based liveness heartbeat, gated to AwaitingToolResults.
+                //
+                // While a foreground tool runs (notably a long build), the CLI
+                // emits no stream events for minutes, so the event-gated
+                // heartbeat below never fires. The actor-level stuck-mission
+                // watchdog (control.rs, 900s) keys off broadcast events and
+                // would cancel the mission mid-tool — even though the turn-level
+                // `tool_idle_timeout` (much larger) is the correct arbiter for a
+                // running tool. Emitting a heartbeat on a timer here makes the
+                // coarse watchdog defer to `tool_idle_timeout`.
+                //
+                // Strictly gated to AwaitingToolResults so it does NOT mask a
+                // genuine hang: a fire-and-forget background job that returns
+                // immediately leaves the turn in AwaitingTerminalResult/
+                // AwaitingClaude (not this state), so those stalls remain subject
+                // to the watchdog as before.
+                _ = tokio::time::sleep_until(last_heartbeat_at + heartbeat_interval),
+                    if saw_non_init_event
+                        && matches!(turn_wait_state, ClaudeTurnWaitState::AwaitingToolResults) => {
+                    let _ = events_tx.send(AgentEvent::MissionActivity {
+                        label: "Tool running…".to_string(),
+                        tool_name: "claudecode_heartbeat".to_string(),
+                        mission_id: Some(mission_id),
+                    });
+                    last_heartbeat_at = Instant::now();
+                }
                 line_opt = line_rx.recv() => {
                     let Some(raw_line) = line_opt else {
                         // EOF - PTY closed


### PR DESCRIPTION
## Problem

The actor stuck-mission watchdog (`control.rs`, `STUCK_SECONDS = 900`) keys off **broadcast events**. A long foreground tool — e.g. a Lean/forge build — runs as one `tool_call` → minutes of silence → `tool_result`, emitting no stream events in between. So the event-gated liveness heartbeat (`mission_runner.rs`, only fires on stream-event receipt) never fires, `seconds_since_activity` climbs unchecked, and the 900s watchdog cancels the mission **mid-build** — even though the turn-level `tool_idle_timeout` (1800s) is the correct arbiter for a running tool.

This is what stalled mission `5aede562` (verity rebuild): `STUCK_SECONDS(900) < tool_idle_timeout(1800)`, so the coarse watchdog preempted the build.

## Change

Add a timer-based heartbeat branch to the Claude turn `select!`, **strictly gated to `AwaitingToolResults`**, so the coarse actor watchdog defers to `tool_idle_timeout` while a tool is genuinely executing.

The gate is the safety property: a fire-and-forget background job returns immediately and leaves the turn in `AwaitingTerminalResult`/`AwaitingClaude` (not `AwaitingToolResults`), so genuine post-tool/background-wait hangs remain subject to the watchdog exactly as before. We only suppress the false-positive (a tool that's actually running).

## Test plan
- [x] Builds (`cargo build`); deployed to prod and verified — three active missions (incl. a long Lean build) run `health=healthy` across the window.
- [ ] Confirm a >900s single foreground build completes without a `watchdog_stalled` interrupt.

## Related
Found alongside the Claude Code thinking-capture gap (#479) while debugging mission `5aede562`. A separate follow-up worth doing: the watchdog cancel did not reap the CLI process tree (an orphaned `nsenter→claude→mcp` tree lingered ~52 min); cancellation should force-kill the mission's process subtree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission liveness signaling during tool execution; mis-gating could delay watchdog detection of real hangs, though the PR limits the timer to `AwaitingToolResults` only.
> 
> **Overview**
> Adds a **timer-based `MissionActivity` heartbeat** to the Claude Code turn `select!` loop so missions stay “active” while a foreground tool runs with no stream output.
> 
> The new branch fires on `heartbeat_interval` only when the turn is in **`AwaitingToolResults`** (and after a non-init event), emitting `claudecode_heartbeat` with label “Tool running…”. That keeps the **900s stuck-mission watchdog** from canceling long builds that are still within **`tool_idle_timeout`**, without changing watchdog behavior for stalls in **`AwaitingClaude`** / **`AwaitingTerminalResult`** (e.g. fire-and-forget background jobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd945543d32edc3ba8a57d108a98969a90752cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->