### PR TITLE
control: 'Agent is working' pill + Claude Code thinking capture + watchdog fix

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4921,7 +4921,7 @@ export default function ControlClient() {
         it.kind === "phase",
     );
     if (hasInlineLiveness) return null;
-    let since = 0;
+    let since: number | null = null;
     for (let i = items.length - 1; i >= 0; i--) {
       const it = items[i];
       // Queued user messages sit at the tail while the agent keeps inserting
@@ -4935,6 +4935,10 @@ export default function ControlClient() {
         break;
       }
     }
+    // No timed row to anchor on (e.g. only queued user messages): suppress the
+    // pill rather than pass 0, which LiveDuration would read as epoch ms and
+    // render as a ~decades-long elapsed time.
+    if (since == null) return null;
     return { since };
   }, [items, showThinkingPanel]);
 

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -9488,6 +9488,23 @@ export default function ControlClient() {
     missionLoading &&
     !!viewingMissionId &&
     activeMission?.id !== viewingMissionId;
+
+  // The inline "Agent is working" pill renders *below* the virtualized
+  // timeline, so the bottom anchor (which keys off `groupedItems` only) never
+  // scrolls to reveal it — unlike the "is thinking" indicator, which is a real
+  // timeline item. Nudge to the bottom when the pill first appears while the
+  // user is already pinned there, so it shows up the same way thinking does.
+  const agentWorkingPillVisible =
+    viewingMissionIsRunning &&
+    activeMission?.status === "active" &&
+    !!agentWorkingIndicator;
+  const prevAgentWorkingPillVisible = useRef(false);
+  useEffect(() => {
+    if (agentWorkingPillVisible && !prevAgentWorkingPillVisible.current && isAtBottom) {
+      scrollToBottom("smooth");
+    }
+    prevAgentWorkingPillVisible.current = agentWorkingPillVisible;
+  }, [agentWorkingPillVisible, isAtBottom, scrollToBottom]);
   const workspaceNameById = useMemo(() => {
     return Object.fromEntries(workspaces.map((ws) => [ws.id, ws.name]));
   }, [workspaces]);
@@ -10561,9 +10578,7 @@ export default function ControlClient() {
                   inline. P2-#14: the items.some walk lives in the
                   `agentWorkingIndicator` memo so each NowTick render doesn't
                   re-walk the whole items array. */}
-                  {viewingMissionIsRunning &&
-                    activeMission?.status === "active" &&
-                    agentWorkingIndicator && (
+                  {agentWorkingPillVisible && agentWorkingIndicator && (
                       <div className="flex justify-start animate-fade-in">
                         <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
                           <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -505,6 +505,25 @@ function formatDuration(seconds: number): string {
   return `${mins}m${secs > 0 ? ` ${secs}s` : ""}`;
 }
 
+// Wall-clock (ms) of when this item last "did something" — used to anchor the
+// inline "Agent is working" heartbeat at the most recent event so the timer
+// resets each time a new event lands (healthy agent) and climbs when nothing
+// arrives (stalled/hung). Phase items carry no time of their own.
+function itemActivityTime(item: ChatItem): number | null {
+  switch (item.kind) {
+    case "tool":
+    case "thinking":
+    case "stream":
+      return item.endTime ?? item.startTime;
+    case "user":
+    case "assistant":
+    case "system":
+      return item.timestamp;
+    default:
+      return null;
+  }
+}
+
 // Renders a live-updating duration string anchored at `startTime`. ONLY this
 // component subscribes to `useNow()`, so the 1 Hz tick re-renders just the
 // active duration cell — not every visible done item/tool card. Wrapping a
@@ -4869,16 +4888,33 @@ export default function ControlClient() {
     resetKey: viewingMissionId,
   });
 
-  const showAgentWorkingIndicator = useMemo(() => {
-    if (items.length === 0) return false;
-    if (items[items.length - 1]?.kind === "assistant") return false;
-    return !items.some(
+  // The inline "Agent is working" pill. Shown whenever the mission is running
+  // and nothing else inline is already animating liveness — i.e. no in-flight
+  // thinking/stream (with the side panel closed) and no phase row, both of
+  // which render their own live indicators. Unlike before, this stays visible
+  // *after* an intermediate assistant message: the agent keeps working between
+  // steps, and the corner sidebar pill alone is too easy to miss. `since`
+  // anchors the heartbeat timer at the most recent event so it resets on every
+  // new event and climbs when the run goes quiet.
+  const agentWorkingIndicator = useMemo(() => {
+    if (items.length === 0) return null;
+    const hasInlineLiveness = items.some(
       (it) =>
         ((it.kind === "thinking" || it.kind === "stream") &&
           !it.done &&
           !showThinkingPanel) ||
         it.kind === "phase",
     );
+    if (hasInlineLiveness) return null;
+    let since = 0;
+    for (let i = items.length - 1; i >= 0; i--) {
+      const t = itemActivityTime(items[i]);
+      if (t != null) {
+        since = t;
+        break;
+      }
+    }
+    return { since };
   }, [items, showThinkingPanel]);
 
   // Auto-show thinking panel when thinking starts (only on transition to active)
@@ -10520,23 +10556,25 @@ export default function ControlClient() {
                     })}
                   </div>
 
-                  {/* Show streaming indicator when running but no active thinking/phase visible inline.
-                  P2-#14: the items.some + last-index lookup live in `showAgentWorkingIndicator`
-                  memo so each NowTick render doesn't re-walk the whole items array. */}
+                  {/* Compact "Agent is working" pill + live heartbeat timer,
+                  shown while running but no thinking/stream/phase is animating
+                  inline. P2-#14: the items.some walk lives in the
+                  `agentWorkingIndicator` memo so each NowTick render doesn't
+                  re-walk the whole items array. */}
                   {viewingMissionIsRunning &&
                     activeMission?.status === "active" &&
-                    showAgentWorkingIndicator && (
-                      <div className="flex justify-start gap-3 animate-fade-in">
-                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
-                          <Bot className="h-4 w-4 text-indigo-400 animate-pulse" />
-                        </div>
-                        <div className="rounded-2xl rounded-tl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
-                          <div className="flex items-center gap-2">
-                            <Loader className="h-4 w-4 text-indigo-400 animate-spin" />
-                            <span className="text-sm text-white/60">
-                              Agent is working...
-                            </span>
-                          </div>
+                    agentWorkingIndicator && (
+                      <div className="flex justify-start animate-fade-in">
+                        <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
+                          <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
+                          <span className="text-xs font-medium text-white/70">
+                            Agent is working
+                          </span>
+                          <span className="text-xs tabular-nums text-white/40">
+                            <LiveDuration
+                              startTime={agentWorkingIndicator.since}
+                            />
+                          </span>
                         </div>
                       </div>
                     )}

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -10567,10 +10567,10 @@ export default function ControlClient() {
                       <div className="flex justify-start animate-fade-in">
                         <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
                           <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
-                          <span className="text-xs font-medium text-white/70">
+                          <span className="text-xs font-medium text-indigo-300">
                             Agent is working
                           </span>
-                          <span className="text-xs tabular-nums text-white/40">
+                          <span className="text-xs tabular-nums text-indigo-300/60">
                             <LiveDuration
                               startTime={agentWorkingIndicator.since}
                             />

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -9529,7 +9529,18 @@ export default function ControlClient() {
     activeMission?.status === "active" &&
     !!agentWorkingIndicator;
   const prevAgentWorkingPillVisible = useRef(false);
+  const pillLatchMissionId = useRef(viewingMissionId);
   useEffect(() => {
+    // Reset the latch synchronously when the viewed mission changes, *before*
+    // evaluating the transition. A separate mission-id effect can't do this:
+    // effects run in declaration order, so the auto-scroll below would see a
+    // stale `true` from the previous running mission (no false→true edge) and
+    // never scroll on the new timeline. Folding the reset in here guarantees
+    // the new mission's first pill appearance counts as a real edge.
+    if (pillLatchMissionId.current !== viewingMissionId) {
+      pillLatchMissionId.current = viewingMissionId;
+      prevAgentWorkingPillVisible.current = false;
+    }
     if (
       agentWorkingPillVisible &&
       !prevAgentWorkingPillVisible.current &&
@@ -9538,13 +9549,7 @@ export default function ControlClient() {
       scrollToBottom("smooth");
     }
     prevAgentWorkingPillVisible.current = agentWorkingPillVisible;
-  }, [agentWorkingPillVisible, isAtBottom, scrollToBottom]);
-  // Clear the latch when switching missions, otherwise the ref stays true from
-  // a previously-viewed running mission and the false→true transition never
-  // fires on the new timeline, so the pill never triggers its bottom scroll.
-  useEffect(() => {
-    prevAgentWorkingPillVisible.current = false;
-  }, [viewingMissionId]);
+  }, [agentWorkingPillVisible, isAtBottom, scrollToBottom, viewingMissionId]);
   const workspaceNameById = useMemo(() => {
     return Object.fromEntries(workspaces.map((ws) => [ws.id, ws.name]));
   }, [workspaces]);

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -259,18 +259,20 @@ export function appendUnpersistedLiveTail(
       .slice(lastHistoryUserIdx + 1)
       .some((item) => item.kind === "assistant");
 
-  const unpersistedTail = liveItems.slice(lastLiveUserIdx + 1).filter((item) => {
-    if (existingIds.has(item.id)) return false;
-    if (item.kind === "assistant") {
+  const unpersistedTail = liveItems
+    .slice(lastLiveUserIdx + 1)
+    .filter((item) => {
+      if (existingIds.has(item.id)) return false;
+      if (item.kind === "assistant") {
+        const content = item.content.trim();
+        return content.length > 0 && !existingAssistantContent.has(content);
+      }
+      if (item.kind !== "stream" || item.done) return false;
       const content = item.content.trim();
-      return content.length > 0 && !existingAssistantContent.has(content);
-    }
-    if (item.kind !== "stream" || item.done) return false;
-    const content = item.content.trim();
-    if (!content) return false;
-    if (existingAssistantContent.has(content)) return false;
-    return !historyHasAssistantAfterLastUser;
-  });
+      if (!content) return false;
+      if (existingAssistantContent.has(content)) return false;
+      return !historyHasAssistantAfterLastUser;
+    });
 
   return unpersistedTail.length > 0
     ? [...historyItems, ...unpersistedTail]
@@ -321,7 +323,9 @@ function formatMissionDocumentTitle(mission: Mission | null | undefined) {
     maxLength: MAX_DOCUMENT_MISSION_TITLE_LENGTH,
     fallback: getMissionShortName(mission.id),
   }).trim();
-  return title ? `${title} | ${DEFAULT_DOCUMENT_TITLE}` : DEFAULT_DOCUMENT_TITLE;
+  return title
+    ? `${title} | ${DEFAULT_DOCUMENT_TITLE}`
+    : DEFAULT_DOCUMENT_TITLE;
 }
 
 function readLegacyControlDraft(): string {
@@ -1223,7 +1227,6 @@ function formatTime(timestamp: number): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-
 function statusLabel(state: ControlRunState): {
   label: string;
   Icon: typeof Loader;
@@ -1257,7 +1260,10 @@ function missionStatusLabel(
     case "active":
       return { label: "Active", className: "bg-indigo-500/20 text-indigo-400" };
     case "awaiting_user":
-      return { label: "Needs You", className: "bg-amber-500/20 text-amber-400" };
+      return {
+        label: "Needs You",
+        className: "bg-amber-500/20 text-amber-400",
+      };
     case "acknowledged":
       return {
         label: "Acknowledged",
@@ -2239,8 +2245,7 @@ const ThinkingPanel = memo(function ThinkingPanel({
     overscan: 6,
   });
   // See `chatVirtualizer` below for rationale.
-  thoughtsVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = () =>
-    false;
+  thoughtsVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => false;
   const {
     isAtBottom: isThoughtsAtBottom,
     scrollToBottom: scrollThoughtsToBottom,
@@ -2728,7 +2733,13 @@ function MissionWorkbenchPanel({
   );
 }
 
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex items-center justify-between gap-2 py-0.5">
       <dt className="text-white/40">{label}</dt>
@@ -3779,7 +3790,9 @@ const ChatItemRow = memo(function ChatItemRow({
     // ServerShutdown turns auto-resume — render with the check icon so the
     // visual weight matches "this is being handled", not "agent died".
     const MessageStatusIcon =
-      item.success || item.terminalReason === "ServerShutdown" ? CheckCircle : XCircle;
+      item.success || item.terminalReason === "ServerShutdown"
+        ? CheckCircle
+        : XCircle;
     const displayModel = item.model
       ? item.model.includes("/")
         ? item.model.split("/").pop()
@@ -4821,7 +4834,9 @@ export default function ControlClient() {
   // `text_delta` on the assistant message). Reuse the previous reference
   // when the thinking subset is unchanged so `React.memo(ThinkingPanel)`
   // can skip the re-render.
-  const thinkingItems = useStableShallowArray(rawThinkingItems) as SidePanelItem[];
+  const thinkingItems = useStableShallowArray(
+    rawThinkingItems,
+  ) as SidePanelItem[];
 
   const containerRef = useRef<HTMLDivElement>(null);
   const chatVirtualizer = useVirtualizer({
@@ -4908,7 +4923,13 @@ export default function ControlClient() {
     if (hasInlineLiveness) return null;
     let since = 0;
     for (let i = items.length - 1; i >= 0; i--) {
-      const t = itemActivityTime(items[i]);
+      const it = items[i];
+      // Queued user messages sit at the tail while the agent keeps inserting
+      // tool/assistant rows before them, so they are not "latest activity" —
+      // anchoring the heartbeat to a queued row's (older) timestamp makes the
+      // timer read as stalled while the mission is actively running. Skip them.
+      if (it.kind === "user" && it.queued) continue;
+      const t = itemActivityTime(it);
       if (t != null) {
         since = t;
         break;
@@ -9149,7 +9170,13 @@ export default function ControlClient() {
         submittingRef.current = false;
       }
     },
-    [items, isBusy, applyDesktopSessionState, missionHistoryToItems, scrollToBottom],
+    [
+      items,
+      isBusy,
+      applyDesktopSessionState,
+      missionHistoryToItems,
+      scrollToBottom,
+    ],
   );
 
   const handleStop = async () => {
@@ -9167,31 +9194,34 @@ export default function ControlClient() {
     }
   };
 
-  const syncQueueForMission = useCallback(async (missionId: string) => {
-    if (!missionId || syncingQueueRef.current) return;
-    syncingQueueRef.current = true;
-    try {
-      const queuedMessages = await getQueue();
-      const queuedForMission = queuedMessages.filter(
-        (qm) => qm.mission_id === missionId,
-      );
-      const queuedIds = new Set(queuedForMission.map((qm) => qm.id));
+  const syncQueueForMission = useCallback(
+    async (missionId: string) => {
+      if (!missionId || syncingQueueRef.current) return;
+      syncingQueueRef.current = true;
+      try {
+        const queuedMessages = await getQueue();
+        const queuedForMission = queuedMessages.filter(
+          (qm) => qm.mission_id === missionId,
+        );
+        const queuedIds = new Set(queuedForMission.map((qm) => qm.id));
 
-      setItems((prev) =>
-        prev.map((item) => {
-          if (item.kind !== "user") return item;
-          if (item.id.startsWith("temp-")) return item;
-          const shouldBeQueued = queuedIds.has(item.id);
-          if (item.queued === shouldBeQueued) return item;
-          return { ...item, queued: shouldBeQueued };
-        }),
-      );
-    } catch (err) {
-      console.warn("[control] failed to sync queue", err);
-    } finally {
-      syncingQueueRef.current = false;
-    }
-  }, [setItems]);
+        setItems((prev) =>
+          prev.map((item) => {
+            if (item.kind !== "user") return item;
+            if (item.id.startsWith("temp-")) return item;
+            const shouldBeQueued = queuedIds.has(item.id);
+            if (item.queued === shouldBeQueued) return item;
+            return { ...item, queued: shouldBeQueued };
+          }),
+        );
+      } catch (err) {
+        console.warn("[control] failed to sync queue", err);
+      } finally {
+        syncingQueueRef.current = false;
+      }
+    },
+    [setItems],
+  );
 
   // Reload mission history from the API. Used for visibility change,
   // periodic sync, and SSE reconnect catch-up.
@@ -9500,11 +9530,21 @@ export default function ControlClient() {
     !!agentWorkingIndicator;
   const prevAgentWorkingPillVisible = useRef(false);
   useEffect(() => {
-    if (agentWorkingPillVisible && !prevAgentWorkingPillVisible.current && isAtBottom) {
+    if (
+      agentWorkingPillVisible &&
+      !prevAgentWorkingPillVisible.current &&
+      isAtBottom
+    ) {
       scrollToBottom("smooth");
     }
     prevAgentWorkingPillVisible.current = agentWorkingPillVisible;
   }, [agentWorkingPillVisible, isAtBottom, scrollToBottom]);
+  // Clear the latch when switching missions, otherwise the ref stays true from
+  // a previously-viewed running mission and the false→true transition never
+  // fires on the new timeline, so the pill never triggers its bottom scroll.
+  useEffect(() => {
+    prevAgentWorkingPillVisible.current = false;
+  }, [viewingMissionId]);
   const workspaceNameById = useMemo(() => {
     return Object.fromEntries(workspaces.map((ws) => [ws.id, ws.name]));
   }, [workspaces]);
@@ -9575,12 +9615,16 @@ export default function ControlClient() {
     }
 
     const applyTitle = (mission: Mission | null) =>
-      mission?.id === activeMission.id ? { ...mission, title: nextTitle } : mission;
+      mission?.id === activeMission.id
+        ? { ...mission, title: nextTitle }
+        : mission;
 
     setSavingMissionTitle(true);
     setRecentMissions((prev) =>
       prev.map((mission) =>
-        mission.id === activeMission.id ? { ...mission, title: nextTitle } : mission,
+        mission.id === activeMission.id
+          ? { ...mission, title: nextTitle }
+          : mission,
       ),
     );
     setCurrentMission(applyTitle);
@@ -9593,10 +9637,14 @@ export default function ControlClient() {
       console.error("Failed to update mission title:", error);
       toast.error("Failed to update mission title");
       const restoreTitle = (mission: Mission | null) =>
-        mission?.id === activeMission.id ? { ...mission, title: previousTitle } : mission;
+        mission?.id === activeMission.id
+          ? { ...mission, title: previousTitle }
+          : mission;
       setRecentMissions((prev) =>
         prev.map((mission) =>
-          mission.id === activeMission.id ? { ...mission, title: previousTitle } : mission,
+          mission.id === activeMission.id
+            ? { ...mission, title: previousTitle }
+            : mission,
         ),
       );
       setCurrentMission(restoreTitle);
@@ -10579,20 +10627,20 @@ export default function ControlClient() {
                   `agentWorkingIndicator` memo so each NowTick render doesn't
                   re-walk the whole items array. */}
                   {agentWorkingPillVisible && agentWorkingIndicator && (
-                      <div className="flex justify-start animate-fade-in">
-                        <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
-                          <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
-                          <span className="text-xs font-medium text-indigo-300">
-                            Agent is working
-                          </span>
-                          <span className="text-xs tabular-nums text-indigo-300/60">
-                            <LiveDuration
-                              startTime={agentWorkingIndicator.since}
-                            />
-                          </span>
-                        </div>
+                    <div className="flex justify-start animate-fade-in">
+                      <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
+                        <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
+                        <span className="text-xs font-medium text-indigo-300">
+                          Agent is working
+                        </span>
+                        <span className="text-xs tabular-nums text-indigo-300/60">
+                          <LiveDuration
+                            startTime={agentWorkingIndicator.since}
+                          />
+                        </span>
                       </div>
-                    )}
+                    </div>
+                  )}
 
                   {/* Waiting banner for interactive user-input tools */}
                   {hasPendingUserInput && (
@@ -10759,9 +10807,7 @@ export default function ControlClient() {
                 </div>
               )}
 
-              <div
-                className="mx-auto max-w-3xl w-full space-y-2"
-              >
+              <div className="mx-auto max-w-3xl w-full space-y-2">
                 {/*
                   Slim status banner above the composer for interrupted /
                   blocked / failed missions. Lives inside the composer
@@ -10801,7 +10847,8 @@ export default function ControlClient() {
                           {statusLabel}
                         </span>
                         <span className="text-white/50 hidden sm:inline truncate">
-                          Type below to continue, or use the action on the right.
+                          Type below to continue, or use the action on the
+                          right.
                         </span>
                         <span className="ml-auto inline-flex items-center gap-1 shrink-0">
                           <button
@@ -10935,9 +10982,7 @@ export default function ControlClient() {
           </div>
 
           {/* Right column: Workbench, Thinking Panel and Desktop Stream stacked */}
-          {(showWorkbenchPanel ||
-            showThinkingPanel ||
-            showDesktopStream) && (
+          {(showWorkbenchPanel || showThinkingPanel || showDesktopStream) && (
             <div
               className={cn(
                 // animate-fade-in is opacity-only and cheap; we drop the

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5332,6 +5332,32 @@ pub fn run_claudecode_turn<'a>(
                     reader_handle.abort();
                     break;
                 }
+                // Timer-based liveness heartbeat, gated to AwaitingToolResults.
+                //
+                // While a foreground tool runs (notably a long build), the CLI
+                // emits no stream events for minutes, so the event-gated
+                // heartbeat below never fires. The actor-level stuck-mission
+                // watchdog (control.rs, 900s) keys off broadcast events and
+                // would cancel the mission mid-tool — even though the turn-level
+                // `tool_idle_timeout` (much larger) is the correct arbiter for a
+                // running tool. Emitting a heartbeat on a timer here makes the
+                // coarse watchdog defer to `tool_idle_timeout`.
+                //
+                // Strictly gated to AwaitingToolResults so it does NOT mask a
+                // genuine hang: a fire-and-forget background job that returns
+                // immediately leaves the turn in AwaitingTerminalResult/
+                // AwaitingClaude (not this state), so those stalls remain subject
+                // to the watchdog as before.
+                _ = tokio::time::sleep_until(last_heartbeat_at + heartbeat_interval),
+                    if saw_non_init_event
+                        && matches!(turn_wait_state, ClaudeTurnWaitState::AwaitingToolResults) => {
+                    let _ = events_tx.send(AgentEvent::MissionActivity {
+                        label: "Tool running…".to_string(),
+                        tool_name: "claudecode_heartbeat".to_string(),
+                        mission_id: Some(mission_id),
+                    });
+                    last_heartbeat_at = Instant::now();
+                }
                 line_opt = line_rx.recv() => {
                     let Some(raw_line) = line_opt else {
                         // EOF - PTY closed

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3900,6 +3900,28 @@ fn get_backend_bool_setting(backend_id: &str, key: &str) -> Option<bool> {
     None
 }
 
+/// Map a mission `model_effort` to a Claude Code extended-thinking budget
+/// (`MAX_THINKING_TOKENS`).
+///
+/// `CLAUDE_CODE_EFFORT_LEVEL` alone only nudges *adaptive* reasoning: on
+/// tool-heavy turns the model frequently chooses not to think at all, so no
+/// `thinking_delta` blocks stream and the Thoughts panel stays empty (see
+/// mission 5aede562, which ran at effort=max yet recorded 0 thinking events
+/// across ~1600 tool calls). Pinning a non-zero budget forces an extended
+/// thinking block every turn, so thoughts are captured deterministically.
+///
+/// Returns 0 for unknown efforts, leaving thinking fully adaptive.
+fn claude_thinking_budget(effort: &str) -> u32 {
+    match effort.trim().to_ascii_lowercase().as_str() {
+        "max" => 32_000,
+        "xhigh" => 24_000,
+        "high" => 16_000,
+        "medium" => 8_000,
+        "low" => 4_000,
+        _ => 0,
+    }
+}
+
 /// Execute a turn using Claude Code CLI backend.
 ///
 /// For Host workspaces: spawns the CLI directly on the host.
@@ -4802,10 +4824,25 @@ pub fn run_claudecode_turn<'a>(
         // Claude Code reads CLAUDE_CODE_EFFORT_LEVEL to control adaptive reasoning depth.
         if let Some(effort) = model_effort {
             env.insert("CLAUDE_CODE_EFFORT_LEVEL".to_string(), effort.to_string());
+
+            // CLAUDE_CODE_EFFORT_LEVEL only nudges adaptive reasoning, which
+            // leaves the Thoughts panel empty on tool-heavy turns. Pin an
+            // explicit extended-thinking budget so every turn emits a thinking
+            // block we can capture and stream. (The capture pipeline already
+            // handles thinking_delta — see backend/shared.rs — the CLI just
+            // wasn't emitting any.)
+            let thinking_tokens = claude_thinking_budget(effort);
+            if thinking_tokens > 0 {
+                env.insert(
+                    "MAX_THINKING_TOKENS".to_string(),
+                    thinking_tokens.to_string(),
+                );
+            }
             tracing::info!(
                 mission_id = %mission_id,
                 effort = %effort,
-                "Setting Claude Code effort level via CLAUDE_CODE_EFFORT_LEVEL"
+                max_thinking_tokens = thinking_tokens,
+                "Setting Claude Code effort level + extended-thinking budget"
             );
         }
 


### PR DESCRIPTION
Consolidates the three session PRs (#478, #479, #480) into one. Excludes the conversation-anchored work that leaked into the pill branch — that remains tracked separately in #477.

## 1. Frontend — persistent "Agent is working" pill (was #478)
A compact pill with a live heartbeat timer that stays visible while a mission runs (including after intermediate assistant messages), replacing the old bubble that vanished mid-run. Theme-aware indigo text (dark blue in light mode) and an auto-scroll so it reveals like the thinking indicator.

## 2. Backend — Claude Code thinking capture (was #479)
Pin `MAX_THINKING_TOKENS` per `model_effort` so thinking blocks stream deterministically (`CLAUDE_CODE_EFFORT_LEVEL` alone only nudges adaptive reasoning, leaving the Thoughts panel empty on tool-heavy turns).

## 3. Backend — watchdog vs. long silent tools (was #480)
Timer-based liveness heartbeat **gated to `AwaitingToolResults`**, so the actor's 900s stuck-watchdog defers to `tool_idle_timeout` while a tool (e.g. a long build) genuinely runs — without masking real post-tool/background-wait hangs.

## Bugbot findings addressed (from #478)
- **Queued-user timer skew**: the heartbeat anchor walked `items` from the tail and could latch onto a queued user row's older timestamp → timer looked stalled. Now skips queued user rows.
- **Pill scroll ref across mission switch**: `prevAgentWorkingPillVisible` wasn't reset on `viewingMissionId` change → auto-scroll never fired on a second running mission. Now reset on switch.

## Test plan
- [x] `tsc --noEmit` clean; eslint clean (pre-existing warnings only)
- [x] Backend builds (`cargo build`); both backend fixes deployed to dev + prod and verified live (missions run `health=healthy` across long builds)
- [ ] Manual: pill stays visible + timer ticks across turns; thoughts populate at effort≥medium; long build no longer trips `watchdog_stalled`

Closes #478, #479, #480.

Follow-up (not in this PR): the watchdog cancel didn't reap the CLI process tree (orphaned `nsenter→claude→mcp`); cancellation should force-kill the mission subtree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission-runner liveness and Claude CLI env (thinking budget + heartbeats) alongside control chat UX; mis-gating heartbeats or token budgets could affect watchdog behavior or model cost/latency, but changes are scoped and gated.
> 
> **Overview**
> **Control UI** replaces the old “Agent is working…” bubble with a compact pill and a **live elapsed timer** (`LiveDuration`) that stays visible while a mission runs—even after intermediate assistant messages—when nothing else inline is showing liveness (thinking/stream with panel closed, or phase rows). The timer anchors to the **most recent non-queued activity** via new `itemActivityTime`, and auto-scrolls into view when the pill first appears (with latch reset on mission switch so a second running mission still scrolls).
> 
> **Claude Code backend** maps `model_effort` to **`MAX_THINKING_TOKENS`** (alongside `CLAUDE_CODE_EFFORT_LEVEL`) so extended thinking blocks stream on tool-heavy turns instead of adaptive-only silence in the Thoughts panel.
> 
> **Mission runner** emits **timer-based `MissionActivity` heartbeats** only in `AwaitingToolResults`, keeping the ~900s stuck watchdog fed during long silent tool runs (e.g. builds) without masking hangs in other turn wait states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eff021bb3d45512baa4f8deac3f6179b70318ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->