### PR TITLE
control: align IDB cache anchoring with server for short missions

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -505,17 +505,28 @@ const CONVERSATION_EVENT_TYPES = new Set([
 // stale or oversized cached tail would be replayed in full (slow load) and the
 // recent-message anchoring would be bypassed.
 function anchorEventsToRecentConversation(events: StoredEvent[]): StoredEvent[] {
+  // Anchor ONLY when at least N conversation messages exist, matching the
+  // server: `nth_recent_event_sequence(N)` returns None below N, in which case
+  // get_mission_snapshot falls back to the plain recent-events tail (no
+  // conversation trim). So set the anchor only on reaching the Nth-most-recent
+  // message; with fewer than N, leave `anchorIdx = -1` and keep everything
+  // (still bounded by the MAX cap below). Setting it on every message would
+  // drop any leading events before the oldest message and diverge from the
+  // backend for short (1–9 message) missions.
   let convoSeen = 0;
   let anchorIdx = -1;
   for (let i = events.length - 1; i >= 0; i--) {
     if (CONVERSATION_EVENT_TYPES.has(events[i].event_type)) {
-      anchorIdx = i;
       convoSeen += 1;
-      if (convoSeen >= SNAPSHOT_CONVERSATIONAL_MESSAGES) break;
+      if (convoSeen >= SNAPSHOT_CONVERSATIONAL_MESSAGES) {
+        anchorIdx = i;
+        break;
+      }
     }
   }
-  // Fewer than N conversation messages → keep all (still capped below).
   let start = anchorIdx === -1 ? 0 : anchorIdx;
+  // Hard cap: never replay more than MAX events (mirrors the server's
+  // overflow fallback to the most-recent MAX).
   if (events.length - start > SNAPSHOT_MAX_EVENTS) {
     start = events.length - SNAPSHOT_MAX_EVENTS;
   }


### PR DESCRIPTION
Follow-up to #477, addressing a second Cursor Bugbot finding ("IDB cache trims events when fewer than N conversations", Medium).

`anchorEventsToRecentConversation` (the client mirror of the server snapshot) diverged from the backend for missions with **1–9 conversation messages**: the server's `nth_recent_event_sequence(10)` returns `None` below the threshold, so `get_mission_snapshot` returns the plain recent-events tail (no conversation trim). The client, however, set `anchorIdx` on *every* matched message, so it anchored at the **oldest** message and dropped any leading events before it.

Fix: set the anchor only on reaching the **Nth**-most-recent message; with fewer than N, leave it unset and keep everything (still bounded by `SNAPSHOT_MAX_EVENTS`) — exactly matching the server fallback. Behavior for ≥N-message missions is unchanged.

Frontend lint + tsc clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side snapshot trimming fix for the control dashboard IDB cache path; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes **`anchorEventsToRecentConversation`** so IndexedDB cache replay matches the server’s **`get_mission_snapshot`** behavior for missions with fewer than 10 conversation messages.
> 
> Previously the client set the anchor on **every** user/assistant message while scanning backward, which anchored at the **oldest** message and dropped leading events. The server only conversation-anchors after the **Nth**-most-recent message; below that threshold it keeps the plain recent tail (still capped by **`SNAPSHOT_MAX_EVENTS`**). The loop now sets **`anchorIdx`** only when **`convoSeen >= SNAPSHOT_CONVERSATIONAL_MESSAGES`**; otherwise it leaves the anchor unset and keeps the full list subject to the max cap. Missions with ≥10 messages are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57cc750218db1d6db1357d715f81e9d818980425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->