### PR TITLE
ios: drain full delta backlog on resume so mission tail isn't stale

### DIFF
--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -2601,7 +2601,7 @@ struct ControlView: View {
             _ = mergeMissionEvents(drain.events, for: id)
             applyDeltaEvents(drain.events)
         }
-        missionMaxSeq[id] = max(drain.finalCursor, initialCursor)
+        missionMaxSeq[id] = max(drain.finalCursor, missionMaxSeq[id] ?? initialCursor)
         return .applied
     }
 

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -2520,38 +2520,89 @@ struct ControlView: View {
     /// (post SSE reconnect) and `reloadMissionFromServer` (post scene-phase active).
     /// Caller is responsible for the fallback path when this returns anything
     /// other than `.applied`.
-    private func tryDeltaResume(missionId id: String) async -> DeltaResumeOutcome {
-        guard let knownSeq = missionMaxSeq[id] else { return .noCursor }
-        do {
-            let result = try await diagnostics.measureAsync(
-                "control.fetch_delta",
-                detail: id
-            ) {
-                try await api.getMissionEventsWithMeta(
-                    id: id,
-                    types: historyEventTypes,
-                    limit: Self.deltaResumePageLimit,
-                    sinceSeq: knownSeq
-                )
+    /// Safety cap on the number of pages a single delta-resume will drain
+    /// (50 * 5000 = 250k events). Prevents an unbounded loop on a pathological
+    /// mission while still catching up multi-day backlogs in one pass.
+    static let deltaResumeMaxPages = 50
+
+    /// Result of draining the delta backlog: the events fetched and the
+    /// sequence the cursor should advance to.
+    struct DeltaDrain {
+        let events: [StoredEvent]
+        let finalCursor: Int64
+        let pages: Int
+    }
+
+    /// Pure, dependency-free paginator: keep calling `fetchPage(cursor)` until a
+    /// page comes back short (fully caught up), the page reaches the server's
+    /// reported max sequence, the page makes no forward progress (defensive
+    /// guard), or we hit `maxPages`. Returns every event drained plus the cursor
+    /// to persist.
+    ///
+    /// This loop is the fix for the staleness bug: the SSE stream does NOT
+    /// replay events missed while disconnected (the server ignores `since_seq`
+    /// on the stream), so this delta fetch is the only gap-filler. The previous
+    /// code fetched a single page, leaving a multi-day backlog permanently
+    /// behind (the tail froze on an old message). Extracted as `static` so it's
+    /// unit-testable without a live `APIService`.
+    static func drainDelta(
+        from initialCursor: Int64,
+        pageLimit: Int,
+        maxPages: Int,
+        fetchPage: (Int64) async throws -> (events: [StoredEvent], maxSeq: Int64)
+    ) async rethrows -> DeltaDrain {
+        var cursor = initialCursor
+        var collected: [StoredEvent] = []
+        var pages = 0
+        while pages < maxPages {
+            let (events, maxSeq) = try await fetchPage(cursor)
+            collected.append(contentsOf: events)
+            pages += 1
+            let pageMax = events.map { $0.sequence }.max() ?? cursor
+            let fullPage = events.count >= pageLimit
+            if !fullPage || pageMax >= maxSeq || pageMax <= cursor {
+                return DeltaDrain(events: collected, finalCursor: max(maxSeq, pageMax), pages: pages)
             }
-            guard viewingMissionId == id else { return .viewChanged }
-            let maxSeq = result.maxSequence ?? knownSeq
-            _ = mergeMissionEvents(result.events, for: id)
-            applyDeltaEvents(result.events)
-            // If the page was capped by the limit, advance the cursor to the
-            // largest sequence we actually saw so the next call resumes from
-            // there — otherwise we'd skip rows between this page and the
-            // true max. Use `max()` rather than `last`: the API contract is
-            // ASC-by-sequence but defensive callers shouldn't trust input
-            // ordering.
-            let pageMax = result.events.map { $0.sequence }.max() ?? knownSeq
-            let cursor = (result.events.count >= Self.deltaResumePageLimit && pageMax < maxSeq) ? pageMax : maxSeq
-            missionMaxSeq[id] = cursor
-            return .applied
+            cursor = pageMax
+        }
+        return DeltaDrain(events: collected, finalCursor: cursor, pages: pages)
+    }
+
+    private func tryDeltaResume(missionId id: String) async -> DeltaResumeOutcome {
+        guard let initialCursor = missionMaxSeq[id] else { return .noCursor }
+        let drain: DeltaDrain
+        do {
+            drain = try await Self.drainDelta(
+                from: initialCursor,
+                pageLimit: Self.deltaResumePageLimit,
+                maxPages: Self.deltaResumeMaxPages
+            ) { cursor in
+                let result = try await diagnostics.measureAsync(
+                    "control.fetch_delta",
+                    detail: id
+                ) {
+                    try await api.getMissionEventsWithMeta(
+                        id: id,
+                        types: historyEventTypes,
+                        limit: Self.deltaResumePageLimit,
+                        sinceSeq: cursor
+                    )
+                }
+                return (result.events, result.maxSequence ?? cursor)
+            }
         } catch {
             print("Delta resume failed: \(error)")
             return .failed
         }
+        // Apply only if the user is still viewing this mission (a long drain may
+        // have outlived the selection).
+        guard viewingMissionId == id else { return .viewChanged }
+        if !drain.events.isEmpty {
+            _ = mergeMissionEvents(drain.events, for: id)
+            applyDeltaEvents(drain.events)
+        }
+        missionMaxSeq[id] = max(drain.finalCursor, initialCursor)
+        return .applied
     }
 
     // Reload mission from server without showing loading state or cache.

--- a/ios_dashboard/SandboxedDashboardTests/NetworkResilienceTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/NetworkResilienceTests.swift
@@ -152,6 +152,59 @@ final class NetworkResilienceTests: XCTestCase {
                        "idempotent: a fresh write after migration must not be touched again")
     }
 
+    /// Regression for the mission-staleness bug: a long catch-up gap (e.g. the
+    /// app away for days, the SSE stream not replaying missed events) must be
+    /// fully drained in one resume. The pre-fix logic fetched a single page, so
+    /// a backlog larger than one page left the conversation tail frozen on an
+    /// old message. `drainDelta` must page through the entire gap.
+    func testDeltaResumeDrainsEntireBacklogNotJustOnePage() async throws {
+        let pageLimit = 5000
+        let serverMax: Int64 = 16_001          // > 3 full pages
+        func makeEvent(_ seq: Int64) -> StoredEvent {
+            StoredEvent(id: seq, missionId: "m", sequence: seq, eventType: "assistant_message",
+                        timestamp: "t", eventId: nil, toolCallId: nil, toolName: nil,
+                        content: "c", metadata: [:])
+        }
+
+        var pageCalls = 0
+        let drain = await ControlView.drainDelta(
+            from: 0, pageLimit: pageLimit, maxPages: ControlView.deltaResumeMaxPages
+        ) { cursor in
+            pageCalls += 1
+            let start = cursor + 1
+            let end = min(cursor + Int64(pageLimit), serverMax)
+            guard start <= end else { return ([], serverMax) }
+            let events = (start...end).map { makeEvent($0) }
+            return (events, serverMax)
+        }
+
+        // Pre-fix behavior would stop after one page (5000 events). The drain
+        // must collect every event in the gap and advance the cursor to the max.
+        XCTAssertEqual(drain.events.count, Int(serverMax),
+                       "delta resume must drain the entire backlog, not a single page")
+        XCTAssertEqual(drain.finalCursor, serverMax,
+                       "cursor must advance to the server max after draining")
+        XCTAssertGreaterThanOrEqual(pageCalls, 4,
+                       "a >3-page backlog must require multiple page fetches")
+    }
+
+    /// A short first page (already caught up) must stop after one fetch and
+    /// advance the cursor to the server's max — even when the only events
+    /// returned are fewer than a page (or zero, when newer events are all
+    /// filtered-out types like tool calls).
+    func testDeltaResumeStopsWhenCaughtUp() async throws {
+        var pageCalls = 0
+        let drain = await ControlView.drainDelta(
+            from: 100, pageLimit: 5000, maxPages: 50
+        ) { _ in
+            pageCalls += 1
+            return ([], 137)   // no new conversation rows, but server advanced to 137
+        }
+        XCTAssertEqual(pageCalls, 1, "an empty/short page means caught up; stop immediately")
+        XCTAssertEqual(drain.finalCursor, 137, "cursor advances past filtered-only gap to server max")
+        XCTAssertTrue(drain.events.isEmpty)
+    }
+
     private func apiServiceSource() throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
         let apiService = testFile

--- a/ios_dashboard/SandboxedDashboardTests/ThemeTests.swift
+++ b/ios_dashboard/SandboxedDashboardTests/ThemeTests.swift
@@ -75,7 +75,10 @@ final class ThemeTests: XCTestCase {
     }
 
     func testStatusTypeIcons() {
-        // All status types should have an icon
+        // Every status must map to a Phosphor icon + weight. `phosphorIcon`
+        // replaced the old string `icon` property (Phosphor refactor); since
+        // it's a non-optional enum, exercising the full switch here is what
+        // guards against a missing/unhandled case.
         let statuses: [StatusType] = [
             .pending, .running, .active, .completed, .failed,
             .cancelled, .idle, .error, .connected, .disconnected,
@@ -83,7 +86,8 @@ final class ThemeTests: XCTestCase {
         ]
 
         for status in statuses {
-            XCTAssertFalse(status.icon.isEmpty, "Status \(status.label) should have an icon")
+            _ = status.phosphorIcon
+            _ = status.phosphorWeight
         }
     }
 


### PR DESCRIPTION
## Problem

On iOS, a long-running mission could show a **stale conversation tail** — e.g. frozen on a 3-day-old "You've hit your usage limit" reply — while the web dashboard showed the mission live-streaming. The data was current server-side; the iOS client just wasn't catching up.

**Root cause (two parts):**
1. The control **SSE stream does not replay** events missed while disconnected — the backend's `StreamQuery` ignores `since_seq` and only pushes live events from connect-time forward. So the `/events?since_seq=` delta fetch (`tryDeltaResume`) is the *only* gap-filler.
2. `tryDeltaResume` fetched a **single 5000-row page** and the caller returned on `.applied` without looping. A backlog larger than one page (app away for days ≈ tens of thousands of events) never fully drained, leaving the tail frozen.

## Fix

Extract the pagination into a pure, testable `drainDelta(from:pageLimit:maxPages:fetchPage:)` that loops until a page comes back short (caught up), reaches the server's max sequence, makes no forward progress (defensive), or hits a 50-page safety cap (250k events). `tryDeltaResume` now applies the full drained backlog and advances the cursor to the true max.

## Reproduce + verify (iOS simulator, iOS 26.4)

- `testDeltaResumeDrainsEntireBacklogNotJustOnePage` — a >3-page backlog must fully drain. **Confirmed it fails on the pre-fix single-page behavior** (`5000 ≠ 16001`, `pageCalls 1 < 4`) and passes with the fix.
- `testDeltaResumeStopsWhenCaughtUp` — short/empty page stops after one fetch and advances the cursor past filtered-only gaps.
- `xcodebuild ... test` on the simulator: **TEST SUCCEEDED** (full `NetworkResilienceTests` suite green).

Also fixes a pre-existing stale compile error in `ThemeTests` (`StatusType.icon` → `phosphorIcon`, left over from the Phosphor refactor) that was blocking the whole test target.

## Follow-up (not in this PR)
The deeper contract fix is server-side: make `/api/control/stream` honor `since_seq` and replay the gap (the client already sends it). That would make catch-up authoritative rather than relying solely on the client delta fetch. Happy to do it as a separate backend PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission sync and cursor advancement on reconnect/scene-active paths; incorrect pagination could skip or duplicate events, though logic is isolated and covered by new unit tests.
> 
> **Overview**
> Fixes **stale mission conversation tails** on iOS when the app was away long enough to accumulate more events than one delta page (5000 rows). Because live SSE does not replay missed events, **`tryDeltaResume` is the only catch-up path** — it previously stopped after a single fetch, so large backlogs never applied.
> 
> The change introduces a pure **`drainDelta`** loop (up to **50 pages / ~250k events**) that keeps paging until caught up, hits server max sequence, or stops on defensive guards, then **`tryDeltaResume`** merges and applies the full drained batch and advances **`missionMaxSeq`** to the true cursor. **`NetworkResilienceTests`** add regression coverage for multi-page drain and short/empty “caught up” pages.
> 
> **`ThemeTests`** is updated to assert **`phosphorIcon` / `phosphorWeight`** instead of the removed **`StatusType.icon`**, unblocking the test target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a87b8f8018f6f42bf1bdbe94e06e8c5f17115e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->