### PR TITLE
control: trim dead space around the working/thinking indicators

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -504,7 +504,9 @@ const CONVERSATION_EVENT_TYPES = new Set([
 // cache path so a cache hit behaves like `getMissionSnapshot` — without it a
 // stale or oversized cached tail would be replayed in full (slow load) and the
 // recent-message anchoring would be bypassed.
-function anchorEventsToRecentConversation(events: StoredEvent[]): StoredEvent[] {
+function anchorEventsToRecentConversation(
+  events: StoredEvent[],
+): StoredEvent[] {
   // Anchor ONLY when at least N conversation messages exist, matching the
   // server: `nth_recent_event_sequence(N)` returns None below N, in which case
   // get_mission_snapshot falls back to the plain recent-events tail (no
@@ -6042,7 +6044,6 @@ export default function ControlClient() {
     [HISTORY_EVENT_TYPES, eventsToItems, computeHasMoreOlder, setItems],
   );
 
-
   // Load mission from URL param on mount (and retry on auth success)
   const [authRetryTrigger, setAuthRetryTrigger] = useState(0);
 
@@ -10411,7 +10412,7 @@ export default function ControlClient() {
             <div
               ref={containerRef}
               data-testid="chat-scroll-container"
-              className="flex-1 overflow-y-auto p-6"
+              className="flex-1 overflow-y-auto px-6 pt-6 pb-2"
             >
               {/* Backwards pagination — only when there's actually more older
               history to fetch and the chat isn't empty. Click prepends the
@@ -10594,7 +10595,7 @@ export default function ControlClient() {
                   `agentWorkingIndicator` memo so each NowTick render doesn't
                   re-walk the whole items array. */}
                   {agentWorkingPillVisible && agentWorkingIndicator && (
-                    <div className="flex justify-start animate-fade-in">
+                    <div className="flex justify-start animate-fade-in -mt-3">
                       <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
                         <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
                         <span className="text-xs font-medium text-indigo-300">

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -10595,7 +10595,7 @@ export default function ControlClient() {
                   `agentWorkingIndicator` memo so each NowTick render doesn't
                   re-walk the whole items array. */}
                   {agentWorkingPillVisible && agentWorkingIndicator && (
-                    <div className="flex justify-start animate-fade-in -mt-3">
+                    <div className="flex justify-start animate-fade-in pb-6">
                       <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
                         <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
                         <span className="text-xs font-medium text-indigo-300">

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -10595,7 +10595,7 @@ export default function ControlClient() {
                   `agentWorkingIndicator` memo so each NowTick render doesn't
                   re-walk the whole items array. */}
                   {agentWorkingPillVisible && agentWorkingIndicator && (
-                    <div className="flex justify-start animate-fade-in pb-6">
+                    <div className="flex justify-start animate-fade-in -mt-3">
                       <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/[0.08] px-3 py-1.5">
                         <Loader className="h-3.5 w-3.5 text-indigo-400 animate-spin" />
                         <span className="text-xs font-medium text-indigo-300">


### PR DESCRIPTION
Addresses feedback that the **Agent is working** pill (and the inline **is thinking** indicator) had too much padding below — you had to scroll to see the bottom — and a touch too much above.

- The chat scroll container was `p-6` (24px all sides). Its 24px **bottom** padding, stacked with the timeline's row spacing, pushed the bottom-most content below the fold. Reduced to `px-6 pt-6 pb-2` (8px bottom). Helps **both** indicators, since both render at the tail of the timeline.
- Pulled the working pill up with `-mt-3` so it sits ~12px under the last message instead of the full 24px `space-y` gap.

CSS-only, low risk. `tsc` + eslint clean. The local dev server watches this file, so it hot-reloads on localhost:3001 for a live look.

The two knobs if you want it tighter/looser: container `pb-2` and pill `-mt-3`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only padding and margin tweaks on the chat scroll area and working pill; no logic, auth, or data changes.
> 
> **Overview**
> Tightens vertical spacing at the bottom of the control chat so the **Agent is working** pill and tail-of-timeline indicators (including inline **is thinking**) sit closer to the last message and need less scrolling to see.
> 
> The chat scroll container padding changes from uniform `p-6` to **`px-6 pt-6 pb-2`**, cutting bottom padding from 24px to 8px. The working pill wrapper gets **`-mt-3`** so it sits ~12px under the previous row instead of the full timeline gap.
> 
> Also includes minor formatting in the same file (multi-line signature for `anchorEventsToRecentConversation`, removal of an extra blank line)—no behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd57a8c668f5e728a7e2606e0e7099044b8f7816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->