### PR TITLE
codex: stop falling back to retired gpt-5.3-codex; prune dead models

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3570,13 +3570,17 @@ async fn run_mission_turn(
                         tracing::warn!(
                             mission_id = %mission_id,
                             requested_model = ?requested_model,
-                            "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use"
+                            "Retrying Codex turn on the requested model (not the stale Codex CLI default) after it stopped before tool use"
                         );
                         result = run_codex_turn(
                             &workspace,
                             &mission_work_dir,
                             codex_message,
-                            None,
+                            // Was `None`, which made the Codex CLI fall back to
+                            // its built-in default — currently the retired
+                            // `gpt-5.3-codex`, rejected by ChatGPT-account auth
+                            // with a 400. Retry on the requested (latest) model.
+                            requested_model,
                             model_effort.as_deref(),
                             effective_agent.as_deref(),
                             mission_id,
@@ -3707,13 +3711,16 @@ async fn run_mission_turn(
                                 attempt = attempt_idx,
                                 requested_model = ?requested_model,
                                 credential = %credential_label,
-                                "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use"
+                                "Retrying Codex turn on the requested model (not the stale Codex CLI default) after it stopped before tool use"
                             );
                             result = run_codex_turn(
                                 &workspace,
                                 &mission_work_dir,
                                 codex_message,
-                                None,
+                                // Was `None` (stale CLI default gpt-5.3-codex,
+                                // 400 on ChatGPT auth). Retry on the requested
+                                // (latest) model instead.
+                                requested_model,
                                 model_effort.as_deref(),
                                 effective_agent.as_deref(),
                                 mission_id,

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -591,46 +591,12 @@ fn default_providers_config() -> ProvidersConfig {
                 billing: "subscription".to_string(),
                 description: "ChatGPT Plus/Pro via OAuth".to_string(),
                 models: vec![
-                    // Keep this fallback list aligned with Codex upstream model IDs:
-                    // https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/models.json
-                    // (authoritative source for Codex CLI model catalog).
-                    // Codex-optimized models (for Codex CLI)
-                    ProviderModel {
-                        id: "gpt-5-codex".to_string(),
-                        name: "GPT-5 Codex".to_string(),
-                        description: Some("Purpose-built for agentic coding".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5-codex-mini".to_string(),
-                        name: "GPT-5 Codex Mini".to_string(),
-                        description: Some("Smaller, cost-effective variant".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.1-codex".to_string(),
-                        name: "GPT-5.1 Codex".to_string(),
-                        description: Some("Balanced capability and speed".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.1-codex-max".to_string(),
-                        name: "GPT-5.1 Codex Max".to_string(),
-                        description: Some("Highest reasoning capacity".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.1-codex-mini".to_string(),
-                        name: "GPT-5.1 Codex Mini".to_string(),
-                        description: Some("Fast and economical".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.2-codex".to_string(),
-                        name: "GPT-5.2 Codex".to_string(),
-                        description: Some("Smart and precise coding agent".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.3-codex".to_string(),
-                        name: "GPT-5.3 Codex".to_string(),
-                        description: Some("Newest Codex coding model".to_string()),
-                    },
-                    // Additional OpenAI models
+                    // Only current models. OpenAI's ChatGPT-account Codex keeps
+                    // a small recent set, so the older codex variants (gpt-5-codex
+                    // … gpt-5.3-codex) and stale generics (gpt-5.1/5.2/5.3) were
+                    // removed — gpt-5.3-codex now 404s ("model not supported when
+                    // using Codex with a ChatGPT account"), and everything older
+                    // than it is dead too. Newest first.
                     ProviderModel {
                         id: "gpt-5.5".to_string(),
                         name: "GPT-5.5".to_string(),
@@ -639,24 +605,14 @@ fn default_providers_config() -> ProvidersConfig {
                         ),
                     },
                     ProviderModel {
+                        id: "gpt-5.5-codex".to_string(),
+                        name: "GPT-5.5 Codex".to_string(),
+                        description: Some("Latest Codex-optimized coding model".to_string()),
+                    },
+                    ProviderModel {
                         id: "gpt-5.4".to_string(),
                         name: "GPT-5.4".to_string(),
                         description: Some("Previous frontier coding model in Codex".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.3".to_string(),
-                        name: "GPT-5.3".to_string(),
-                        description: Some("General-purpose GPT-5.3".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.2".to_string(),
-                        name: "GPT-5.2".to_string(),
-                        description: Some("General-purpose GPT-5.2".to_string()),
-                    },
-                    ProviderModel {
-                        id: "gpt-5.1".to_string(),
-                        name: "GPT-5.1".to_string(),
-                        description: Some("General-purpose GPT-5.1".to_string()),
                     },
                 ],
             },


### PR DESCRIPTION
## Problem

Two missions explicitly set to **gpt-5.5** (`8fd3c4f4`, `0a5ef19b`) failed with:

```
400 invalid_request_error: The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.
```

The user never selected gpt-5.3-codex. Journal trace on both:

```
WARN Retrying Codex turn with CLI default model ... requested_model=Some("gpt-5.5")
     requested_model=None resolved_model=None model=None
ERROR 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account
```

## Cause

The tool-stall retry path (`codex_tool_stall_should_retry_with_default_model`) fires when a *generic* GPT model (e.g. gpt-5.5) stops before using a required tool. It re-ran the turn with `model=None`, which makes the Codex CLI fall back to its **built-in default** — the now-retired **gpt-5.3-codex** — which ChatGPT-account auth rejects.

## Fix

- **mission_runner.rs**: both tool-stall retry sites now re-run on the *requested* (latest) model instead of `None`, so we never hit the stale CLI default.
- **providers.rs**: prune the no-longer-supported OpenAI Codex models. Every codex variant <= the dead gpt-5.3-codex is also dead, and the old generics (5.1/5.2/5.3) are superseded. Keep **gpt-5.5**, add **gpt-5.5-codex** (current), keep **gpt-5.4**.

## Verification

Built + deployed to prod. `/api/providers` now serves exactly: `gpt-5.4 gpt-5.5 gpt-5.5-codex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission execution retry behavior for Codex stalls; wrong model handling could still affect live missions, but the fix aligns retries with explicit user model choice.
> 
> **Overview**
> Fixes Codex missions that failed with **400** on **gpt-5.3-codex** even when the user chose **gpt-5.5**. When a generic GPT model stalled before required tool use, the retry path called `run_codex_turn` with **`model=None`**, so the Codex CLI fell back to its built-in default (**gpt-5.3-codex**), which ChatGPT-account auth rejects. **Both** tool-stall retry sites now pass **`requested_model`** so the retry stays on the user’s model.
> 
> The OpenAI (subscription) default catalog is trimmed to **gpt-5.5**, **gpt-5.5-codex**, and **gpt-5.4**, dropping retired codex variants and superseded generics that no longer work with ChatGPT-account Codex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0975245594e451d06237bf87aab33c28a3094bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->