### PR TITLE
Ask Assistant — non-interrupting sidecar co-pilot (M1–M4)

### DIFF
--- a/ASK_ASSISTANT_DESIGN.md
+++ b/ASK_ASSISTANT_DESIGN.md
@@ -1,0 +1,188 @@
+# Ask Assistant — Design
+
+> A fast, read-mostly **sidecar assistant** that rides alongside a running
+> mission. It can read the full mission history, run bash in the live workspace,
+> and answer questions — **without interrupting the main agent's turn loop or
+> queue**. Powered by a configurable fast model (default: Cerebras
+> `gpt-oss-120b`).
+
+Status: **M1 backend implemented** (store + client + loop + HTTP routes,
+compiles, storage unit-tested). M2–M5 pending.
+Owner: Thomas
+Related: conversation-anchored snapshot (#477, #482), thinking capture (#481),
+Cerebras title fix (#489), `metadata_llm.rs` provider ladder.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+- Let the operator **chat about what a mission is doing** at any time, in a
+  separate lane that never touches the harness lock, the message queue, or the
+  mission transcript fed back to the working agent.
+- Give the assistant **real capability**: full read+write `bash` in the live
+  workspace plus history retrieval.
+- **Persistent, browsable Ask threads** per mission, clearable, **never merged
+  into mission history** (the working agent cannot see the Ask conversation).
+- A **dedicated, configurable Ask model** (separate from the metadata model),
+  optimized for *smart + fast + large context*.
+- One **quiet "operator-note"** bridge: when Ask **writes** to the workspace, the
+  working agent gets a passive heads-up on its next turn.
+- Works across web, iOS, and Android (shared API).
+
+### Non-goals (v1)
+- No worktree / sandbox-copy mode (usage is read-dominant).
+- No destructive-write confirmation gate. Full bash, no friction; a visual
+  "agent idle/working" indicator is informational only.
+- Ask never **starts** a main-agent turn. Strictly non-interrupting.
+- Not every harness *heeds* the operator-note identically — delivery is
+  harness-agnostic, faithfulness is best-effort (§9).
+
+---
+
+## 2. Concept & lanes
+
+Two lanes share one workspace and one mission identity, otherwise isolated:
+
+- **Driver lane** — the working agent: `mission_events`, history, harness lock,
+  message queue.
+- **Co-pilot lane** — the Ask assistant: `ask_threads` / `ask_messages` (separate
+  `ask.db`), no lock, no queue, its own response path.
+
+Hard rule: **nothing ever reads `ask_*` rows into the working agent's prompt.**
+The only cross-lane bridges are the operator-note (Ask write → working agent,
+passive) and "Send to agent" (manual: Ask answer → real composer).
+
+---
+
+## 3. Data model (implemented)
+
+Separate `ask.db` (rusqlite), keyed by `mission_id` (ownership enforced at the
+HTTP layer via the user's per-user mission store).
+
+- `ask_threads(id, mission_id, title, model, created_at, updated_at)`
+- `ask_messages(id, thread_id, seq, role, content, tool_name, tool_call_id,
+  metadata, created_at)` — `role ∈ {user, assistant, tool_call, tool_result}`,
+  FK → `ask_threads ON DELETE CASCADE`
+- `operator_notes(id, mission_id, body, source_thread_id, created_at,
+  flushed_at)` — the M2 bridge buffer
+
+Store: `src/api/ask/store.rs` (`AskStore`). Global singleton via tokio
+`OnceCell` at `<working_dir>/.sandboxed-sh/missions/ask.db`.
+
+---
+
+## 4. Backend: the Ask agentic loop (implemented)
+
+`src/api/ask/` — net-new, small, in-process:
+- `store.rs` — persistence (above).
+- `client.rs` — OpenAI-compatible chat client **with tool-calling** (reuses
+  `MetadataLlmConfig`; forwards `reasoning_effort` so reasoning models return
+  visible content).
+- `mod.rs` — `run_ask_turn`: persist user msg → seed system prompt (recent
+  events + summary) → tool loop (≤6 iterations) → persist assistant answer.
+- `http.rs` — handlers.
+
+Tools (read-on-demand so the 128K context ceiling never bites):
+- `bash(command)` → `WorkspaceExec::output(work_dir, "/bin/bash", ["-lc", cmd])`
+  — **full** read+write, live workspace, host or nspawn. No gate.
+- `read_history(limit)` → `MissionStore::get_latest_events`.
+- `read_file(path)` → bash `cat`.
+
+---
+
+## 5. Model configuration (implemented)
+
+`metadata_llm.rs`:
+- Lifted `resolve_provider_api_key` to module scope.
+- Added `build_assistant_llm_config()` → prefers Cerebras `gpt-oss-120b`
+  (`reasoning_effort=low`), overridable via `ASK_ASSISTANT_MODEL` env; falls back
+  to the metadata provider ladder.
+
+Cerebras caps context at ~128K regardless of model — seed recent window +
+summary, let the model pull more via grep/`read_history`. (M3 adds a Settings
+picker with a `supports_tools` capability flag.)
+
+---
+
+## 6. HTTP API (implemented)
+
+Routes (protected) in `routes.rs`, handlers in `src/api/ask/http.rs`:
+
+```
+POST   /api/control/missions/:id/ask                 send (returns final answer + messages)
+GET    /api/control/missions/:id/ask/threads         list threads
+GET    /api/control/missions/:id/ask/threads/:tid    thread + messages
+DELETE /api/control/missions/:id/ask/threads/:tid    clear/delete thread
+```
+
+These never call `queue_message` or acquire the harness lock.
+
+> M1 returns the final answer synchronously (JSON). Token-level **SSE streaming**
+> (`AgentEvent::Ask*` variants on a separate lane) is folded into M3 when the web
+> panel needs it.
+
+---
+
+## 7. Context strategy (the 128K ceiling)
+
+Seed: recent mission events + summary + the thread's prior messages. Then the
+model pulls more via `read_history` / `bash grep`. Keeps every request under
+128K and scales to arbitrarily long missions.
+
+---
+
+## 8. The quiet operator-note (M2)
+
+Delivery is harness-agnostic; faithfulness is best-effort.
+
+- **Detect** an Ask write by wrapping `bash`: `git status --porcelain` snapshot
+  before/after (non-git fallback deferred to M5). On change →
+  `enqueue_operator_note`.
+- **Deliver** by prepending a `<operator-note>` block into the working agent's
+  **next** `user_message` (all backends take the next turn as a single string:
+  Claude Code `--` arg, OpenCode prompt file, Codex `send_message_streaming`).
+  Centralized helper `prepend_pending_operator_notes(mission_id, user_message)`.
+- **Invariant:** notes are passive — flushed only when a turn is already about to
+  run. Ask can never wake the working agent.
+- **Audit:** a flushed note records an `operator_note` mission event (the *fact*
+  of a write touches the mission; the *chat* does not).
+
+Compatibility: all backends *see* the note; Claude Code *heeds* `<…>`-tagged
+blocks best.
+
+---
+
+## 9. Frontend — web (M3)
+
+Right-side collapsible **Ask panel**: thread switcher, co-pilot styling (distinct
+from the indigo Bot), tool-call rendering, slim composer, informational
+"agent idle/working" banner, per-item "ask about this" spark, "Send to agent"
+bridge. `Ask` button beside Queue/Stop + a keyboard toggle (not a Cmd+W variant).
+
+## 10. Frontend — iOS / Android (M4)
+
+Same endpoints. iOS: `.sheet` with medium/large detents. Android: bottom sheet.
+
+---
+
+## 11. Milestones
+
+- **M1 — Backend core** ✅ tables + store (unit-tested), Ask loop + tools,
+  `build_assistant_llm_config`, routes. Synchronous JSON responses.
+- **M2 — Operator-note bridge** — git-porcelain detection +
+  `prepend_pending_operator_notes` in all backend turn-prep + audit event.
+- **M3 — Web panel** — Ask store + (optional SSE), drawer, picker, spark, bridge.
+- **M4 — Mobile** — iOS sheet + Android bottom sheet.
+- **M5 — Polish** — per-thread cost, auto-titling, non-git write detection,
+  sandbox-copy mode.
+
+---
+
+## 12. Verification
+
+- M1 storage: `cargo test --lib ask::store` (thread/message roundtrip, cascade
+  delete, operator-note take-once) — passing.
+- M1 end-to-end: deploy to **dev**, then
+  `curl -X POST /api/control/missions/<id>/ask -d '{"content":"what is the agent doing?"}'`
+  with a Cerebras key configured. (Pending live run.)

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -47,6 +47,8 @@ import {
   useControlStreamingDiagnosticsStore,
   useControlThinkingStore,
   useControlViewingMissionStore,
+  useControlAskStore,
+  controlAskStore,
   type StreamDiagnosticsState,
 } from "./control-stores";
 import { NowTickProvider, useNow } from "@/lib/now-tick";
@@ -3921,7 +3923,19 @@ const ChatItemRow = memo(function ChatItemRow({
             </div>
           )}
         </div>
-        <CopyButton text={item.content} className="self-start mt-8" />
+        <div className="flex flex-col items-center gap-1 self-start mt-8">
+          <CopyButton text={item.content} />
+          <button
+            type="button"
+            onClick={() =>
+              controlAskStore.set({ open: true, seed: item.content })
+            }
+            title="Ask the co-pilot about this"
+            className="opacity-0 group-hover:opacity-100 transition-opacity text-white/30 hover:text-sky-300"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
     );
   }
@@ -4468,7 +4482,16 @@ export default function ControlClient() {
   const [showWorkbenchPanel, setShowWorkbenchPanel] = useState(
     () => searchParams.get("workbench") === "1",
   );
-  const [showAskPanel, setShowAskPanel] = useState(false);
+  const [askSlice, setAskSlice] = useControlAskStore();
+  const showAskPanel = askSlice.open;
+  const setShowAskPanel = useCallback(
+    (next: boolean | ((v: boolean) => boolean)) =>
+      setAskSlice((s) => ({
+        ...s,
+        open: typeof next === "function" ? next(s.open) : next,
+      })),
+    [setAskSlice],
+  );
   // ⌘/ (or Ctrl+/) toggles the Ask co-pilot panel.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -4479,7 +4502,7 @@ export default function ControlClient() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [setShowAskPanel]);
   const handleToggleThinkingPanel = useCallback(() => {
     setShowThinkingPanel((prev) => {
       const next = !prev;
@@ -11079,6 +11102,10 @@ export default function ControlClient() {
           {showAskPanel && viewingMissionId && (
             <AskPanel
               missionId={viewingMissionId}
+              seed={askSlice.seed}
+              onSeedConsumed={() =>
+                setAskSlice((s) => ({ ...s, seed: null }))
+              }
               onClose={() => setShowAskPanel(false)}
               onSendToAgent={(text) => {
                 setInput((prev) => (prev ? `${prev}\n\n${text}` : text));

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3931,7 +3931,7 @@ const ChatItemRow = memo(function ChatItemRow({
               controlAskStore.set({ open: true, seed: item.content })
             }
             title="Ask the co-pilot about this"
-            className="opacity-0 group-hover:opacity-100 transition-opacity text-white/30 hover:text-sky-300"
+            className="opacity-0 group-hover:opacity-100 transition-opacity text-[rgb(var(--foreground)/0.4)] hover:text-[rgb(var(--copilot))]"
           >
             <Sparkles className="h-3.5 w-3.5" />
           </button>
@@ -10111,8 +10111,8 @@ export default function ControlClient() {
               className={cn(
                 "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
                 showAskPanel
-                  ? "border-sky-500/30 bg-sky-500/10 text-sky-300"
-                  : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]",
+                  ? "border-[rgb(var(--copilot)/0.4)] bg-[rgb(var(--copilot)/0.12)] text-[rgb(var(--copilot))]"
+                  : "border-white/[0.06] bg-white/[0.02] text-[rgb(var(--foreground)/0.7)] hover:bg-white/[0.04]",
               )}
               title={
                 showAskPanel

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -4469,6 +4469,17 @@ export default function ControlClient() {
     () => searchParams.get("workbench") === "1",
   );
   const [showAskPanel, setShowAskPanel] = useState(false);
+  // ⌘/ (or Ctrl+/) toggles the Ask co-pilot panel.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "/") {
+        e.preventDefault();
+        setShowAskPanel((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
   const handleToggleThinkingPanel = useCallback(() => {
     setShowThinkingPanel((prev) => {
       const next = !prev;

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -27,6 +27,7 @@ import {
   type EnhancedInputHandle,
   type FilePasteContext,
 } from "@/components/enhanced-input";
+import { AskPanel } from "@/components/ask-panel";
 import { deriveAssistantTurnStatus } from "@/lib/assistant-turn-status";
 import { perfBus } from "@/lib/perf-bus";
 import {
@@ -169,6 +170,7 @@ import {
   Flag,
   Pencil,
   MoreVertical,
+  Sparkles,
 } from "lucide-react";
 import { IMAGE_PATH_PATTERN } from "@/lib/file-extensions";
 import {
@@ -4466,6 +4468,7 @@ export default function ControlClient() {
   const [showWorkbenchPanel, setShowWorkbenchPanel] = useState(
     () => searchParams.get("workbench") === "1",
   );
+  const [showAskPanel, setShowAskPanel] = useState(false);
   const handleToggleThinkingPanel = useCallback(() => {
     setShowThinkingPanel((prev) => {
       const next = !prev;
@@ -10067,6 +10070,26 @@ export default function ControlClient() {
               <span className="hidden sm:inline">Workbench</span>
             </button>
 
+            {/* Ask co-pilot toggle */}
+            <button
+              type="button"
+              onClick={() => setShowAskPanel((prev) => !prev)}
+              className={cn(
+                "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
+                showAskPanel
+                  ? "border-sky-500/30 bg-sky-500/10 text-sky-300"
+                  : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:bg-white/[0.04]",
+              )}
+              title={
+                showAskPanel
+                  ? "Hide Ask co-pilot"
+                  : "Ask about this mission (non-interrupting)"
+              }
+            >
+              <Sparkles className="h-4 w-4" />
+              <span className="hidden sm:inline">Ask</span>
+            </button>
+
             {/* Thinking panel toggle */}
             <button
               onClick={handleToggleThinkingPanel}
@@ -11039,6 +11062,18 @@ export default function ControlClient() {
                 </div>
               )}
             </div>
+          )}
+
+          {/* Ask co-pilot panel (separate lane — never interrupts the agent) */}
+          {showAskPanel && viewingMissionId && (
+            <AskPanel
+              missionId={viewingMissionId}
+              onClose={() => setShowAskPanel(false)}
+              onSendToAgent={(text) => {
+                setInput((prev) => (prev ? `${prev}\n\n${text}` : text));
+                setShowAskPanel(false);
+              }}
+            />
           )}
         </div>
       </div>

--- a/dashboard/src/app/control/control-stores.ts
+++ b/dashboard/src/app/control/control-stores.ts
@@ -95,3 +95,14 @@ export function useControlStreamingDiagnosticsStore() {
 export function useControlViewingMissionStore() {
   return useSliceStore(controlViewingMissionStore);
 }
+
+/** Ask co-pilot panel: open state + an optional seed to prefill the composer
+ * (set by the "ask about this" spark on a chat item). */
+export const controlAskStore = createSliceStore<{
+  open: boolean;
+  seed: string | null;
+}>({ open: false, seed: null });
+
+export function useControlAskStore() {
+  return useSliceStore(controlAskStore);
+}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -40,6 +40,10 @@
   /* Accent (single accent color - Indigo) */
   --accent: 99 102 241; /* Indigo-500 (#6366F1) */
 
+  /* Ask co-pilot identity (sky) - distinct from the indigo agent accent.
+     Lighter on dark surfaces, darker on light surfaces for readable contrast. */
+  --copilot: 56 189 248; /* Sky-400 (#38BDF8) - dark mode */
+
   /* Semantic Colors */
   --success: 34 197 94; /* #22C55E - emerald/green */
   --warning: 234 179 8; /* #EAB308 - amber */
@@ -93,6 +97,9 @@
   --foreground-secondary: 75 85 99; /* #4B5563 */
   --foreground-tertiary: 107 114 128; /* #6B7280 */
   --foreground-muted: 156 163 175; /* #9CA3AF */
+
+  /* Ask co-pilot identity (sky) - darker on light surfaces for contrast. */
+  --copilot: 2 132 199; /* Sky-600 (#0284C7) - light mode */
 
   /* Borders */
   --border: 17 24 39;

--- a/dashboard/src/app/settings/data/page.tsx
+++ b/dashboard/src/app/settings/data/page.tsx
@@ -55,7 +55,9 @@ export default function DataSettingsPage() {
     setSavingAskModel(true);
     try {
       const trimmed = (askModelValue ?? '').trim();
-      await updateSettings({ ask_assistant_model: trimmed || null });
+      // Send "" (not null) to clear: a present empty string is normalized to
+      // None server-side, whereas JSON null is treated as "no change".
+      await updateSettings({ ask_assistant_model: trimmed });
       mutateSettings();
       toast.success(
         trimmed ? 'Assistant model updated' : 'Assistant model reset to default'

--- a/dashboard/src/app/settings/data/page.tsx
+++ b/dashboard/src/app/settings/data/page.tsx
@@ -18,6 +18,7 @@ import {
   Download,
   Upload,
   Archive,
+  Sparkles,
   Trash2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -47,6 +48,26 @@ export default function DataSettingsPage() {
     getSettings,
     { revalidateOnFocus: false }
   );
+
+  const [askModelValue, setAskModelValue] = useState<string | null>(null);
+  const [savingAskModel, setSavingAskModel] = useState(false);
+  const handleSaveAskModel = async () => {
+    setSavingAskModel(true);
+    try {
+      const trimmed = (askModelValue ?? '').trim();
+      await updateSettings({ ask_assistant_model: trimmed || null });
+      mutateSettings();
+      toast.success(
+        trimmed ? 'Assistant model updated' : 'Assistant model reset to default'
+      );
+    } catch (err) {
+      toast.error(
+        `Failed to save: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    } finally {
+      setSavingAskModel(false);
+    }
+  };
 
   const handleStartEditLibraryRemote = () => {
     setLibraryRemoteValue(serverSettings?.library_remote || '');
@@ -298,6 +319,64 @@ export default function DataSettingsPage() {
               <p className="mt-1.5 text-xs text-white/30">
                 Git remote URL for skills, tools, agents, and rules. Click to edit.
               </p>
+            </div>
+          </div>
+
+          {/* Ask Assistant Model */}
+          <div className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5 flex flex-col">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/10 flex-shrink-0">
+                <Sparkles className="h-5 w-5 text-sky-400" />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-sm font-medium text-white">Ask Assistant Model</h2>
+                <p className="text-xs text-white/40">
+                  Model for the non-interrupting Ask co-pilot. Blank = default
+                  (gpt-oss-120b).
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-white/60 mb-1.5">
+                Model ID
+              </label>
+              {settingsLoading ? (
+                <div className="flex items-center gap-2 py-2.5">
+                  <Loader className="h-4 w-4 animate-spin text-white/40" />
+                  <span className="text-sm text-white/40">Loading...</span>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <input
+                    type="text"
+                    value={askModelValue ?? serverSettings?.ask_assistant_model ?? ''}
+                    onChange={(e) => setAskModelValue(e.target.value)}
+                    placeholder="gpt-oss-120b"
+                    className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white font-mono focus:outline-none focus:border-sky-500/50"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleSaveAskModel();
+                    }}
+                  />
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={handleSaveAskModel}
+                      disabled={savingAskModel}
+                      className="flex items-center gap-1.5 rounded-lg bg-sky-500 px-3 py-1.5 text-xs text-white hover:bg-sky-600 transition-colors cursor-pointer disabled:opacity-50"
+                    >
+                      {savingAskModel ? (
+                        <Loader className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Check className="h-3 w-3" />
+                      )}
+                      Save
+                    </button>
+                    <span className="text-xs text-white/30">
+                      e.g. gpt-oss-120b, qwen-3-235b-a22b-instruct-2507
+                    </span>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -190,16 +190,23 @@ export function AskPanel({
     newThread();
   }, [missionId, threadId, refreshThreads, newThread]);
 
+  // Theme-aware tokens (the app theme is driven by data-theme, so we key off the
+  // CSS variables rather than Tailwind's media-based dark: variant, which can
+  // diverge from a manually-stored theme).
+  const copilot = "text-[rgb(var(--copilot))]";
+  const ctrl =
+    "border border-[rgb(var(--foreground)/0.1)] bg-[rgb(var(--foreground)/0.04)] text-[rgb(var(--foreground)/0.6)] hover:bg-[rgb(var(--foreground)/0.07)] hover:text-[rgb(var(--foreground)/0.85)]";
+
   return (
-    <div className="flex h-full w-[380px] shrink-0 flex-col rounded-2xl border border-sky-500/15 bg-sky-500/[0.03] backdrop-blur-sm">
+    <div className="flex h-full w-[380px] shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 border-b border-white/[0.06] px-3 py-2.5">
+      <div className="flex items-center justify-between gap-2 border-b border-[rgb(var(--foreground)/0.1)] px-3 py-2.5">
         <div className="flex items-center gap-2">
-          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-sky-500/15">
-            <Sparkles className="h-3.5 w-3.5 text-sky-300" />
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[rgb(var(--copilot)/0.15)]">
+            <Sparkles className={cn("h-3.5 w-3.5", copilot)} />
           </div>
-          <span className="text-sm font-medium text-sky-100">Ask</span>
-          <span className="rounded bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-white/40">
+          <span className={cn("text-sm font-semibold", copilot)}>Ask</span>
+          <span className="rounded bg-[rgb(var(--foreground)/0.06)] px-1.5 py-0.5 text-[10px] text-[rgb(var(--foreground)/0.45)]">
             co-pilot
           </span>
         </div>
@@ -215,8 +222,8 @@ export function AskPanel({
             className={cn(
               "rounded-lg border p-1.5 transition-all active:scale-95",
               sandbox
-                ? "border-amber-500/30 bg-amber-500/10 text-amber-300"
-                : "border-white/[0.06] bg-white/[0.02] text-white/40 hover:bg-white/[0.05] hover:text-white/70",
+                ? "border-amber-500/40 bg-amber-500/15 text-amber-600 dark:text-amber-300"
+                : ctrl,
             )}
           >
             <FlaskConical className="h-3.5 w-3.5" />
@@ -228,8 +235,11 @@ export function AskPanel({
             className={cn(
               "flex items-center gap-1 rounded-lg border px-2 py-1 text-[11px] tabular-nums transition-all active:scale-95",
               showThreadList
-                ? "border-sky-500/30 bg-sky-500/10 text-sky-200"
-                : "border-white/[0.06] bg-white/[0.02] text-white/60 hover:bg-white/[0.05]",
+                ? cn(
+                    "border-[rgb(var(--copilot)/0.4)] bg-[rgb(var(--copilot)/0.12)]",
+                    copilot,
+                  )
+                : ctrl,
             )}
           >
             {threads.length}
@@ -244,7 +254,7 @@ export function AskPanel({
             type="button"
             onClick={newThread}
             title="New thread"
-            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-1.5 text-white/60 transition-all hover:bg-white/[0.05] hover:text-white/80 active:scale-95"
+            className={cn("rounded-lg p-1.5 transition-all active:scale-95", ctrl)}
           >
             <Plus className="h-3.5 w-3.5" />
           </button>
@@ -252,7 +262,7 @@ export function AskPanel({
             type="button"
             onClick={clearActive}
             title="Clear / delete thread"
-            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-1.5 text-white/60 transition-all hover:bg-red-500/10 hover:text-red-300 active:scale-95"
+            className="rounded-lg border border-[rgb(var(--foreground)/0.1)] bg-[rgb(var(--foreground)/0.04)] p-1.5 text-[rgb(var(--foreground)/0.6)] transition-all hover:bg-red-500/10 hover:text-[rgb(var(--error))] active:scale-95"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </button>
@@ -260,7 +270,7 @@ export function AskPanel({
             type="button"
             onClick={onClose}
             title="Close"
-            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-1.5 text-white/60 transition-all hover:bg-white/[0.05] hover:text-white/80 active:scale-95"
+            className={cn("rounded-lg p-1.5 transition-all active:scale-95", ctrl)}
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -269,9 +279,11 @@ export function AskPanel({
 
       {/* Thread switcher */}
       {showThreadList && (
-        <div className="max-h-48 overflow-y-auto border-b border-white/[0.06] bg-black/20 p-1.5">
+        <div className="max-h-48 overflow-y-auto border-b border-[rgb(var(--foreground)/0.1)] bg-[rgb(var(--foreground)/0.03)] p-1.5">
           {threads.length === 0 && (
-            <p className="px-2 py-1.5 text-[11px] text-white/30">No threads yet.</p>
+            <p className="px-2 py-1.5 text-[11px] text-[rgb(var(--foreground)/0.4)]">
+              No threads yet.
+            </p>
           )}
           {threads.map((t) => (
             <button
@@ -281,12 +293,12 @@ export function AskPanel({
               className={cn(
                 "block w-full truncate rounded-md px-2 py-1.5 text-left text-[11px] transition-colors",
                 t.id === threadId
-                  ? "bg-sky-500/10 text-sky-200"
-                  : "text-white/60 hover:bg-white/[0.04]",
+                  ? cn("bg-[rgb(var(--copilot)/0.12)]", copilot)
+                  : "text-[rgb(var(--foreground)/0.6)] hover:bg-[rgb(var(--foreground)/0.05)]",
               )}
             >
               {t.title || "Untitled thread"}
-              <span className="ml-1 text-white/25">
+              <span className="ml-1 text-[rgb(var(--foreground)/0.35)]">
                 {new Date(t.updated_at).toLocaleTimeString()}
               </span>
             </button>
@@ -298,13 +310,13 @@ export function AskPanel({
       <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto p-3">
         {messages.length === 0 && !loading && (
           <div className="mx-auto mt-10 flex max-w-[15rem] flex-col items-center text-center">
-            <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/10 ring-1 ring-inset ring-sky-400/20">
-              <Sparkles className="h-4 w-4 text-sky-300/70" />
+            <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-xl bg-[rgb(var(--copilot)/0.12)] ring-1 ring-inset ring-[rgb(var(--copilot)/0.25)]">
+              <Sparkles className={cn("h-4 w-4", copilot)} />
             </div>
-            <p className="text-[13px] font-medium text-white/70">
+            <p className="text-[13px] font-medium text-[rgb(var(--foreground)/0.75)]">
               Ask about this mission
             </p>
-            <p className="mt-1 text-[11.5px] leading-relaxed text-white/35">
+            <p className="mt-1 text-[11.5px] leading-relaxed text-[rgb(var(--foreground)/0.45)]">
               What it&apos;s doing, why, or inspect the workspace. The working
               agent is never interrupted.
             </p>
@@ -314,12 +326,17 @@ export function AskPanel({
           <AskBubble key={m.id} message={m} onSendToAgent={onSendToAgent} />
         ))}
         {loading && (
-          <div className="flex items-center gap-2 pl-1 text-[12px] text-sky-300/70">
+          <div
+            className={cn(
+              "flex items-center gap-2 pl-1 text-[12px]",
+              "text-[rgb(var(--copilot)/0.85)]",
+            )}
+          >
             <span className="flex gap-1" aria-hidden>
               {[0, 150, 300].map((delay) => (
                 <span
                   key={delay}
-                  className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-300/70"
+                  className="h-1.5 w-1.5 animate-pulse rounded-full bg-[rgb(var(--copilot)/0.85)]"
                   style={{ animationDelay: `${delay}ms` }}
                 />
               ))}
@@ -328,15 +345,15 @@ export function AskPanel({
           </div>
         )}
         {error && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-2.5 py-1.5 text-[11px] text-red-300">
+          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-2.5 py-1.5 text-[11px] text-[rgb(var(--error))]">
             {error}
           </div>
         )}
       </div>
 
       {/* Composer */}
-      <div className="border-t border-white/[0.06] p-2.5">
-        <div className="flex items-end gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-2.5 py-1.5 focus-within:border-sky-500/30">
+      <div className="border-t border-[rgb(var(--foreground)/0.1)] p-2.5">
+        <div className="flex items-end gap-2 rounded-xl border border-[rgb(var(--foreground)/0.12)] bg-[rgb(var(--foreground)/0.04)] px-2.5 py-1.5 focus-within:border-[rgb(var(--copilot)/0.4)]">
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -348,13 +365,16 @@ export function AskPanel({
             }}
             rows={1}
             placeholder="Ask the co-pilot…"
-            className="max-h-32 min-h-[24px] flex-1 resize-none bg-transparent text-sm text-white/90 placeholder:text-white/30 focus:outline-none"
+            className="max-h-32 min-h-[24px] flex-1 resize-none bg-transparent text-sm text-[rgb(var(--foreground)/0.9)] placeholder:text-[rgb(var(--foreground)/0.4)] focus:outline-none"
           />
           <button
             type="button"
             onClick={() => void send()}
             disabled={loading || !input.trim()}
-            className="rounded-lg bg-sky-500/15 p-1.5 text-sky-300 transition-all hover:bg-sky-500/25 active:scale-95 disabled:opacity-30 disabled:active:scale-100"
+            className={cn(
+              "rounded-lg bg-[rgb(var(--copilot)/0.15)] p-1.5 transition-all hover:bg-[rgb(var(--copilot)/0.25)] active:scale-95 disabled:opacity-30 disabled:active:scale-100",
+              copilot,
+            )}
           >
             <Send className="h-4 w-4" />
           </button>
@@ -376,13 +396,13 @@ function AskBubble({
   if (role === "user") {
     return (
       <div className="flex justify-end gap-2">
-        <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-white/[0.06] px-3 py-2">
-          <p className="whitespace-pre-wrap break-words text-sm text-white/90">
+        <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-[rgb(var(--foreground)/0.07)] px-3 py-2">
+          <p className="whitespace-pre-wrap break-words text-sm text-[rgb(var(--foreground)/0.9)]">
             {content}
           </p>
         </div>
-        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/[0.06]">
-          <User className="h-3.5 w-3.5 text-white/50" />
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--foreground)/0.07)]">
+          <User className="h-3.5 w-3.5 text-[rgb(var(--foreground)/0.5)]" />
         </div>
       </div>
     );
@@ -391,10 +411,10 @@ function AskBubble({
   if (role === "tool_call" || role === "tool_result") {
     const isCall = role === "tool_call";
     return (
-      <div className="ml-8 flex items-start gap-1.5 text-[11px] text-white/40">
-        <Terminal className="mt-0.5 h-3 w-3 shrink-0 text-white/30" />
+      <div className="ml-8 flex items-start gap-1.5 text-[11px] text-[rgb(var(--foreground)/0.45)]">
+        <Terminal className="mt-0.5 h-3 w-3 shrink-0 text-[rgb(var(--foreground)/0.35)]" />
         <div className="min-w-0 flex-1">
-          <span className="text-white/30">
+          <span className="text-[rgb(var(--foreground)/0.35)]">
             {isCall ? `${message.tool_name ?? "tool"} →` : "↳"}
           </span>{" "}
           <span className="break-words font-mono">
@@ -408,17 +428,17 @@ function AskBubble({
   // assistant
   return (
     <div className="flex justify-start gap-2">
-      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-500/15 ring-1 ring-inset ring-sky-400/20">
-        <Sparkles className="h-3.5 w-3.5 text-sky-300" />
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--copilot)/0.15)] ring-1 ring-inset ring-[rgb(var(--copilot)/0.25)]">
+        <Sparkles className="h-3.5 w-3.5 text-[rgb(var(--copilot))]" />
       </div>
-      <div className="group max-w-[85%] rounded-2xl rounded-tl-md border border-sky-500/10 bg-sky-500/[0.04] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+      <div className="group max-w-[85%] rounded-2xl rounded-tl-md border border-[rgb(var(--copilot)/0.18)] bg-[rgb(var(--copilot)/0.07)] px-3 py-2">
         <LazyMarkdownContent content={content} className="text-sm" />
         {onSendToAgent && (
           <button
             type="button"
             onClick={() => onSendToAgent(content)}
             title="Send to the working agent's composer"
-            className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-white/30 opacity-0 transition-all hover:text-sky-300 active:scale-95 group-hover:opacity-100"
+            className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-[rgb(var(--foreground)/0.4)] opacity-0 transition-all hover:text-[rgb(var(--copilot))] active:scale-95 group-hover:opacity-100"
           >
             <CornerUpLeft className="h-3 w-3" /> Send to agent
           </button>

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -30,6 +30,10 @@ interface AskPanelProps {
   onClose: () => void;
   /** Drop a piece of an Ask answer into the real mission composer. */
   onSendToAgent?: (text: string) => void;
+  /** Optional text to prefill the composer with (from the "ask about this" spark). */
+  seed?: string | null;
+  /** Called once the seed has been consumed into the composer. */
+  onSeedConsumed?: () => void;
 }
 
 /**
@@ -40,7 +44,13 @@ interface AskPanelProps {
  * and is rendered here with a distinct "co-pilot" identity (cyan/sky), separate
  * from the mission's indigo agent bubbles.
  */
-export function AskPanel({ missionId, onClose, onSendToAgent }: AskPanelProps) {
+export function AskPanel({
+  missionId,
+  onClose,
+  onSendToAgent,
+  seed,
+  onSeedConsumed,
+}: AskPanelProps) {
   const [threads, setThreads] = useState<AskThread[]>([]);
   const [threadId, setThreadId] = useState<string | null>(null);
   const [messages, setMessages] = useState<AskMessage[]>([]);
@@ -90,6 +100,17 @@ export function AskPanel({ missionId, onClose, onSendToAgent }: AskPanelProps) {
     const node = scrollRef.current;
     if (node) node.scrollTop = node.scrollHeight;
   }, [messages, loading]);
+
+  // "Ask about this" spark: prefill the composer with the quoted item.
+  useEffect(() => {
+    if (seed && seed.trim()) {
+      const snippet = seed.length > 280 ? `${seed.slice(0, 280)}…` : seed;
+      setInput(`About this:\n"""\n${snippet}\n"""\n\n`);
+      onSeedConsumed?.();
+    }
+    // Only react to a new seed; onSeedConsumed clears it so this won't loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seed]);
 
   const selectThread = useCallback(
     async (id: string) => {

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Sparkles,
+  X,
+  Plus,
+  Trash2,
+  Send,
+  Loader,
+  ChevronDown,
+  CornerUpLeft,
+  Terminal,
+  User,
+} from "lucide-react";
+
+import {
+  askSend,
+  listAskThreads,
+  getAskThread,
+  deleteAskThread,
+  type AskThread,
+  type AskMessage,
+} from "@/lib/api";
+import { LazyMarkdownContent } from "@/components/markdown-content";
+import { cn } from "@/lib/utils";
+
+interface AskPanelProps {
+  missionId: string;
+  onClose: () => void;
+  /** Drop a piece of an Ask answer into the real mission composer. */
+  onSendToAgent?: (text: string) => void;
+}
+
+/**
+ * Ask panel — the web surface for the non-interrupting sidecar co-pilot.
+ *
+ * Runs in its own lane: it never touches the mission's queue or the working
+ * agent. Its conversation lives in a separate store (`ask_threads`/`ask_messages`)
+ * and is rendered here with a distinct "co-pilot" identity (cyan/sky), separate
+ * from the mission's indigo agent bubbles.
+ */
+export function AskPanel({ missionId, onClose, onSendToAgent }: AskPanelProps) {
+  const [threads, setThreads] = useState<AskThread[]>([]);
+  const [threadId, setThreadId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<AskMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showThreadList, setShowThreadList] = useState(false);
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const refreshThreads = useCallback(async () => {
+    try {
+      const t = await listAskThreads(missionId);
+      setThreads(t);
+      return t;
+    } catch {
+      return [];
+    }
+  }, [missionId]);
+
+  // On mission change: load threads and open the most recent (if any).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const t = await refreshThreads();
+      if (cancelled) return;
+      if (t.length > 0) {
+        setThreadId(t[0].id);
+        try {
+          const detail = await getAskThread(missionId, t[0].id);
+          if (!cancelled) setMessages(detail.messages ?? []);
+        } catch {
+          /* ignore */
+        }
+      } else {
+        setThreadId(null);
+        setMessages([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [missionId, refreshThreads]);
+
+  // Auto-scroll on new messages.
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (node) node.scrollTop = node.scrollHeight;
+  }, [messages, loading]);
+
+  const selectThread = useCallback(
+    async (id: string) => {
+      setShowThreadList(false);
+      setThreadId(id);
+      setMessages([]);
+      try {
+        const detail = await getAskThread(missionId, id);
+        setMessages(detail.messages ?? []);
+      } catch {
+        setMessages([]);
+      }
+    },
+    [missionId],
+  );
+
+  const newThread = useCallback(() => {
+    setShowThreadList(false);
+    setThreadId(null);
+    setMessages([]);
+    setInput("");
+  }, []);
+
+  const send = useCallback(async () => {
+    const content = input.trim();
+    if (!content || loading) return;
+    setInput("");
+    setError(null);
+    setLoading(true);
+
+    // Optimistic user bubble.
+    const tempId = `temp-${Date.now()}`;
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: tempId,
+        thread_id: threadId ?? "",
+        seq: prev.length + 1,
+        role: "user",
+        content,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    try {
+      const res = await askSend(missionId, content, threadId ?? undefined);
+      setThreadId(res.thread_id);
+      setMessages(res.messages);
+      void refreshThreads();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ask failed");
+      // Roll back the optimistic bubble.
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      setInput(content);
+    } finally {
+      setLoading(false);
+    }
+  }, [input, loading, missionId, threadId, refreshThreads]);
+
+  const clearActive = useCallback(async () => {
+    if (!threadId) {
+      newThread();
+      return;
+    }
+    try {
+      await deleteAskThread(missionId, threadId);
+    } catch {
+      /* ignore */
+    }
+    await refreshThreads();
+    newThread();
+  }, [missionId, threadId, refreshThreads, newThread]);
+
+  return (
+    <div className="flex h-full w-[380px] shrink-0 flex-col rounded-2xl border border-sky-500/15 bg-sky-500/[0.03] backdrop-blur-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 border-b border-white/[0.06] px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-sky-500/15">
+            <Sparkles className="h-3.5 w-3.5 text-sky-300" />
+          </div>
+          <span className="text-sm font-medium text-sky-100">Ask</span>
+          <span className="rounded bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-white/40">
+            co-pilot
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setShowThreadList((v) => !v)}
+            title="Threads"
+            className="flex items-center gap-1 rounded-md border border-white/[0.06] bg-white/[0.02] px-2 py-1 text-[11px] text-white/60 hover:bg-white/[0.04]"
+          >
+            {threads.length} <ChevronDown className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={newThread}
+            title="New thread"
+            className="rounded-md border border-white/[0.06] bg-white/[0.02] p-1 text-white/60 hover:bg-white/[0.04]"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={clearActive}
+            title="Clear / delete thread"
+            className="rounded-md border border-white/[0.06] bg-white/[0.02] p-1 text-white/60 hover:bg-red-500/10 hover:text-red-300"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close"
+            className="rounded-md border border-white/[0.06] bg-white/[0.02] p-1 text-white/60 hover:bg-white/[0.04]"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Thread switcher */}
+      {showThreadList && (
+        <div className="max-h-48 overflow-y-auto border-b border-white/[0.06] bg-black/20 p-1.5">
+          {threads.length === 0 && (
+            <p className="px-2 py-1.5 text-[11px] text-white/30">No threads yet.</p>
+          )}
+          {threads.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => selectThread(t.id)}
+              className={cn(
+                "block w-full truncate rounded-md px-2 py-1.5 text-left text-[11px] transition-colors",
+                t.id === threadId
+                  ? "bg-sky-500/10 text-sky-200"
+                  : "text-white/60 hover:bg-white/[0.04]",
+              )}
+            >
+              {t.title || "Untitled thread"}
+              <span className="ml-1 text-white/25">
+                {new Date(t.updated_at).toLocaleTimeString()}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto p-3">
+        {messages.length === 0 && !loading && (
+          <div className="mt-8 text-center text-[12px] text-white/30">
+            <Sparkles className="mx-auto mb-2 h-5 w-5 text-sky-400/40" />
+            Ask about this mission — what it&apos;s doing, why, or inspect the
+            workspace. The working agent is never interrupted.
+          </div>
+        )}
+        {messages.map((m) => (
+          <AskBubble key={m.id} message={m} onSendToAgent={onSendToAgent} />
+        ))}
+        {loading && (
+          <div className="flex items-center gap-2 text-[12px] text-sky-300/70">
+            <Loader className="h-3.5 w-3.5 animate-spin" /> thinking…
+          </div>
+        )}
+        {error && (
+          <div className="rounded-md border border-red-500/20 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-300">
+            {error}
+          </div>
+        )}
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-white/[0.06] p-2.5">
+        <div className="flex items-end gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-2.5 py-1.5 focus-within:border-sky-500/30">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void send();
+              }
+            }}
+            rows={1}
+            placeholder="Ask the co-pilot…"
+            className="max-h-32 min-h-[24px] flex-1 resize-none bg-transparent text-sm text-white/90 placeholder:text-white/30 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => void send()}
+            disabled={loading || !input.trim()}
+            className="rounded-lg bg-sky-500/15 p-1.5 text-sky-300 transition-colors hover:bg-sky-500/25 disabled:opacity-30"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AskBubble({
+  message,
+  onSendToAgent,
+}: {
+  message: AskMessage;
+  onSendToAgent?: (text: string) => void;
+}) {
+  const { role, content } = message;
+
+  if (role === "user") {
+    return (
+      <div className="flex justify-end gap-2">
+        <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-white/[0.06] px-3 py-2">
+          <p className="whitespace-pre-wrap break-words text-sm text-white/90">
+            {content}
+          </p>
+        </div>
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/[0.06]">
+          <User className="h-3.5 w-3.5 text-white/50" />
+        </div>
+      </div>
+    );
+  }
+
+  if (role === "tool_call" || role === "tool_result") {
+    const isCall = role === "tool_call";
+    return (
+      <div className="ml-8 flex items-start gap-1.5 text-[11px] text-white/40">
+        <Terminal className="mt-0.5 h-3 w-3 shrink-0 text-white/30" />
+        <div className="min-w-0 flex-1">
+          <span className="text-white/30">
+            {isCall ? `${message.tool_name ?? "tool"} →` : "↳"}
+          </span>{" "}
+          <span className="break-words font-mono">
+            {truncate(isCall ? extractCommand(content) : content, 240)}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // assistant
+  return (
+    <div className="flex justify-start gap-2">
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-500/15">
+        <Sparkles className="h-3.5 w-3.5 text-sky-300" />
+      </div>
+      <div className="group max-w-[85%] rounded-2xl rounded-tl-md border border-sky-500/10 bg-sky-500/[0.04] px-3 py-2">
+        <LazyMarkdownContent content={content} className="text-sm" />
+        {onSendToAgent && (
+          <button
+            type="button"
+            onClick={() => onSendToAgent(content)}
+            title="Send to the working agent's composer"
+            className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-white/30 opacity-0 transition-opacity hover:text-sky-300 group-hover:opacity-100"
+          >
+            <CornerUpLeft className="h-3 w-3" /> Send to agent
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function extractCommand(toolCallJson: string): string {
+  try {
+    const parsed = JSON.parse(toolCallJson);
+    return parsed.command ?? parsed.path ?? toolCallJson;
+  } catch {
+    return toolCallJson;
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -12,6 +12,7 @@ import {
   CornerUpLeft,
   Terminal,
   User,
+  FlaskConical,
 } from "lucide-react";
 
 import {
@@ -58,6 +59,7 @@ export function AskPanel({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showThreadList, setShowThreadList] = useState(false);
+  const [sandbox, setSandbox] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -156,7 +158,12 @@ export function AskPanel({
     ]);
 
     try {
-      const res = await askSend(missionId, content, threadId ?? undefined);
+      const res = await askSend(
+        missionId,
+        content,
+        threadId ?? undefined,
+        sandbox,
+      );
       setThreadId(res.thread_id);
       setMessages(res.messages);
       void refreshThreads();
@@ -168,7 +175,7 @@ export function AskPanel({
     } finally {
       setLoading(false);
     }
-  }, [input, loading, missionId, threadId, refreshThreads]);
+  }, [input, loading, missionId, threadId, sandbox, refreshThreads]);
 
   const clearActive = useCallback(async () => {
     if (!threadId) {
@@ -198,6 +205,23 @@ export function AskPanel({
           </span>
         </div>
         <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setSandbox((v) => !v)}
+            title={
+              sandbox
+                ? "Isolated copy: writes go to a throwaway git worktree"
+                : "Run in an isolated copy of the workspace (git only)"
+            }
+            className={cn(
+              "rounded-md border p-1 transition-colors",
+              sandbox
+                ? "border-amber-500/30 bg-amber-500/10 text-amber-300"
+                : "border-white/[0.06] bg-white/[0.02] text-white/40 hover:bg-white/[0.04]",
+            )}
+          >
+            <FlaskConical className="h-3.5 w-3.5" />
+          </button>
           <button
             type="button"
             onClick={() => setShowThreadList((v) => !v)}

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -7,7 +7,6 @@ import {
   Plus,
   Trash2,
   Send,
-  Loader,
   ChevronDown,
   CornerUpLeft,
   Terminal,
@@ -214,10 +213,10 @@ export function AskPanel({
                 : "Run in an isolated copy of the workspace (git only)"
             }
             className={cn(
-              "rounded-md border p-1 transition-colors",
+              "rounded-lg border p-1.5 transition-all active:scale-95",
               sandbox
                 ? "border-amber-500/30 bg-amber-500/10 text-amber-300"
-                : "border-white/[0.06] bg-white/[0.02] text-white/40 hover:bg-white/[0.04]",
+                : "border-white/[0.06] bg-white/[0.02] text-white/40 hover:bg-white/[0.05] hover:text-white/70",
             )}
           >
             <FlaskConical className="h-3.5 w-3.5" />
@@ -226,15 +225,26 @@ export function AskPanel({
             type="button"
             onClick={() => setShowThreadList((v) => !v)}
             title="Threads"
-            className="flex items-center gap-1 rounded-md border border-white/[0.06] bg-white/[0.02] px-2 py-1 text-[11px] text-white/60 hover:bg-white/[0.04]"
+            className={cn(
+              "flex items-center gap-1 rounded-lg border px-2 py-1 text-[11px] tabular-nums transition-all active:scale-95",
+              showThreadList
+                ? "border-sky-500/30 bg-sky-500/10 text-sky-200"
+                : "border-white/[0.06] bg-white/[0.02] text-white/60 hover:bg-white/[0.05]",
+            )}
           >
-            {threads.length} <ChevronDown className="h-3 w-3" />
+            {threads.length}
+            <ChevronDown
+              className={cn(
+                "h-3 w-3 transition-transform",
+                showThreadList && "rotate-180",
+              )}
+            />
           </button>
           <button
             type="button"
             onClick={newThread}
             title="New thread"
-            className="rounded-md border border-white/[0.06] bg-white/[0.02] p-1 text-white/60 hover:bg-white/[0.04]"
+            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-1.5 text-white/60 transition-all hover:bg-white/[0.05] hover:text-white/80 active:scale-95"
           >
             <Plus className="h-3.5 w-3.5" />
           </button>
@@ -242,7 +252,7 @@ export function AskPanel({
             type="button"
             onClick={clearActive}
             title="Clear / delete thread"
-            className="rounded-md border border-white/[0.06] bg-white/[0.02] p-1 text-white/60 hover:bg-red-500/10 hover:text-red-300"
+            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-1.5 text-white/60 transition-all hover:bg-red-500/10 hover:text-red-300 active:scale-95"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </button>
@@ -250,7 +260,7 @@ export function AskPanel({
             type="button"
             onClick={onClose}
             title="Close"
-            className="rounded-md border border-white/[0.06] bg-white/[0.02] p-1 text-white/60 hover:bg-white/[0.04]"
+            className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-1.5 text-white/60 transition-all hover:bg-white/[0.05] hover:text-white/80 active:scale-95"
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -287,22 +297,38 @@ export function AskPanel({
       {/* Messages */}
       <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto p-3">
         {messages.length === 0 && !loading && (
-          <div className="mt-8 text-center text-[12px] text-white/30">
-            <Sparkles className="mx-auto mb-2 h-5 w-5 text-sky-400/40" />
-            Ask about this mission — what it&apos;s doing, why, or inspect the
-            workspace. The working agent is never interrupted.
+          <div className="mx-auto mt-10 flex max-w-[15rem] flex-col items-center text-center">
+            <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/10 ring-1 ring-inset ring-sky-400/20">
+              <Sparkles className="h-4 w-4 text-sky-300/70" />
+            </div>
+            <p className="text-[13px] font-medium text-white/70">
+              Ask about this mission
+            </p>
+            <p className="mt-1 text-[11.5px] leading-relaxed text-white/35">
+              What it&apos;s doing, why, or inspect the workspace. The working
+              agent is never interrupted.
+            </p>
           </div>
         )}
         {messages.map((m) => (
           <AskBubble key={m.id} message={m} onSendToAgent={onSendToAgent} />
         ))}
         {loading && (
-          <div className="flex items-center gap-2 text-[12px] text-sky-300/70">
-            <Loader className="h-3.5 w-3.5 animate-spin" /> thinking…
+          <div className="flex items-center gap-2 pl-1 text-[12px] text-sky-300/70">
+            <span className="flex gap-1" aria-hidden>
+              {[0, 150, 300].map((delay) => (
+                <span
+                  key={delay}
+                  className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-300/70"
+                  style={{ animationDelay: `${delay}ms` }}
+                />
+              ))}
+            </span>
+            thinking
           </div>
         )}
         {error && (
-          <div className="rounded-md border border-red-500/20 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-300">
+          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-2.5 py-1.5 text-[11px] text-red-300">
             {error}
           </div>
         )}
@@ -328,7 +354,7 @@ export function AskPanel({
             type="button"
             onClick={() => void send()}
             disabled={loading || !input.trim()}
-            className="rounded-lg bg-sky-500/15 p-1.5 text-sky-300 transition-colors hover:bg-sky-500/25 disabled:opacity-30"
+            className="rounded-lg bg-sky-500/15 p-1.5 text-sky-300 transition-all hover:bg-sky-500/25 active:scale-95 disabled:opacity-30 disabled:active:scale-100"
           >
             <Send className="h-4 w-4" />
           </button>
@@ -382,17 +408,17 @@ function AskBubble({
   // assistant
   return (
     <div className="flex justify-start gap-2">
-      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-500/15">
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-500/15 ring-1 ring-inset ring-sky-400/20">
         <Sparkles className="h-3.5 w-3.5 text-sky-300" />
       </div>
-      <div className="group max-w-[85%] rounded-2xl rounded-tl-md border border-sky-500/10 bg-sky-500/[0.04] px-3 py-2">
+      <div className="group max-w-[85%] rounded-2xl rounded-tl-md border border-sky-500/10 bg-sky-500/[0.04] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
         <LazyMarkdownContent content={content} className="text-sm" />
         {onSendToAgent && (
           <button
             type="button"
             onClick={() => onSendToAgent(content)}
             title="Send to the working agent's composer"
-            className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-white/30 opacity-0 transition-opacity hover:text-sky-300 group-hover:opacity-100"
+            className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-white/30 opacity-0 transition-all hover:text-sky-300 active:scale-95 group-hover:opacity-100"
           >
             <CornerUpLeft className="h-3 w-3" /> Send to agent
           </button>

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -61,6 +61,16 @@ export function AskPanel({
   const [sandbox, setSandbox] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Auto-grow the composer with input, capped (lighter than the main composer's
+  // 10-line cap). Runs on every input change, including seed prefill and reset.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 120)}px`;
+  }, [input]);
 
   const refreshThreads = useCallback(async () => {
     try {
@@ -355,6 +365,7 @@ export function AskPanel({
       <div className="border-t border-[rgb(var(--foreground)/0.1)] p-2.5">
         <div className="flex items-end gap-2 rounded-xl border border-[rgb(var(--foreground)/0.12)] bg-[rgb(var(--foreground)/0.04)] px-2.5 py-1.5 focus-within:border-[rgb(var(--copilot)/0.4)]">
           <textarea
+            ref={textareaRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
@@ -365,7 +376,7 @@ export function AskPanel({
             }}
             rows={1}
             placeholder="Ask the co-pilot…"
-            className="max-h-32 min-h-[24px] flex-1 resize-none bg-transparent text-sm text-[rgb(var(--foreground)/0.9)] placeholder:text-[rgb(var(--foreground)/0.4)] focus:outline-none"
+            className="min-h-[24px] flex-1 resize-none overflow-y-auto bg-transparent text-sm leading-5 text-[rgb(var(--foreground)/0.9)] placeholder:text-[rgb(var(--foreground)/0.4)] focus:outline-none"
           />
           <button
             type="button"

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -492,6 +492,76 @@ export async function clearQueue(): Promise<{ cleared: number }> {
   return apiDel("/api/control/queue", "Failed to clear queue");
 }
 
+// ── Ask assistant (non-interrupting sidecar co-pilot) ──────────────────────
+
+export interface AskThread {
+  id: string;
+  mission_id: string;
+  title: string | null;
+  model: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AskMessage {
+  id: string;
+  thread_id: string;
+  seq: number;
+  /** "user" | "assistant" | "tool_call" | "tool_result" */
+  role: string;
+  content: string;
+  tool_name?: string | null;
+  tool_call_id?: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AskSendResponse {
+  thread_id: string;
+  answer: string;
+  messages: AskMessage[];
+}
+
+/** Send a question to the Ask assistant for a mission (creates a thread if none). */
+export async function askSend(
+  missionId: string,
+  content: string,
+  threadId?: string,
+): Promise<AskSendResponse> {
+  return apiPost<AskSendResponse>(
+    `/api/control/missions/${missionId}/ask`,
+    threadId ? { content, thread_id: threadId } : { content },
+    "Failed to ask the assistant",
+  );
+}
+
+export async function listAskThreads(missionId: string): Promise<AskThread[]> {
+  return apiGet<AskThread[]>(
+    `/api/control/missions/${missionId}/ask/threads`,
+    "Failed to list Ask threads",
+  );
+}
+
+export async function getAskThread(
+  missionId: string,
+  threadId: string,
+): Promise<{ messages: AskMessage[] } & AskThread> {
+  return apiGet(
+    `/api/control/missions/${missionId}/ask/threads/${threadId}`,
+    "Failed to load Ask thread",
+  );
+}
+
+export async function deleteAskThread(
+  missionId: string,
+  threadId: string,
+): Promise<void> {
+  return apiDel(
+    `/api/control/missions/${missionId}/ask/threads/${threadId}`,
+    "Failed to delete Ask thread",
+  );
+}
+
 // Agent tree snapshot (for refresh resilience)
 export interface AgentTreeNode {
   id: string;

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -2941,6 +2941,7 @@ export interface SettingsResponse {
   max_concurrent_tasks: number | null;
   auto_cleanup_enabled: boolean | null;
   auto_cleanup_days: number | null;
+  ask_assistant_model: string | null;
 }
 
 export interface UpdateLibraryRemoteResponse {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -522,15 +522,23 @@ export interface AskSendResponse {
   messages: AskMessage[];
 }
 
-/** Send a question to the Ask assistant for a mission (creates a thread if none). */
+/** Send a question to the Ask assistant for a mission (creates a thread if none).
+ * When `sandbox` is true, the Ask bash tool runs in an isolated git worktree so
+ * its writes never touch the live workspace. */
 export async function askSend(
   missionId: string,
   content: string,
   threadId?: string,
+  sandbox?: boolean,
 ): Promise<AskSendResponse> {
+  const body: { content: string; thread_id?: string; sandbox?: boolean } = {
+    content,
+  };
+  if (threadId) body.thread_id = threadId;
+  if (sandbox) body.sandbox = true;
   return apiPost<AskSendResponse>(
     `/api/control/missions/${missionId}/ask`,
-    threadId ? { content, thread_id: threadId } : { content },
+    body,
     "Failed to ask the assistant",
   );
 }

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		B3680EB29951C459A8C8A35A /* DesktopStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */; };
 		B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370F364BA05D1236D9B630AB /* ChatMessage.swift */; };
 		BAA09895377937393FF864A7 /* Mission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6DBBABC4AE0FD4368A185C /* Mission.swift */; };
+		A5A5A5A5A5A5A5A5A5A5A502 /* Ask.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5A5A5A5A5A5A5A5A5A501 /* Ask.swift */; };
+		A5A5A5A5A5A5A5A5A5A5A504 /* AskSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5A5A5A5A5A5A5A5A5A503 /* AskSheet.swift */; };
 		BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6993AD59CA0D7392AAACDC2 /* BackendAgentService.swift */; };
 		C159E476E057E6691D1E0E85 /* GlassCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F5D3EB21B6FF298AF5CD32 /* GlassCard.swift */; };
 		C7C23F6559C34034D1680FC2 /* FileEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */; };
@@ -78,6 +80,7 @@
 		081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerSheetView.swift; sourceTree = "<group>"; };
 		0C2AB7D53F29AB97345FA4DA /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		0C6DBBABC4AE0FD4368A185C /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
+		A5A5A5A5A5A5A5A5A5A5A501 /* Ask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ask.swift; sourceTree = "<group>"; };
 		1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResilienceTests.swift; sourceTree = "<group>"; };
 		1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMissionSheet.swift; sourceTree = "<group>"; };
 		1C19E1741AE5E4A19BDAAB98 /* SandboxedDashboard.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SandboxedDashboard.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -109,6 +112,7 @@
 		880FCB82E3B58C3C3C6DABD6 /* DesktopStreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamView.swift; sourceTree = "<group>"; };
 		8D9C3868787C973C5B65DFCD /* FilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesView.swift; sourceTree = "<group>"; };
 		8EAAE29E81F160F8E8409B7D /* QueueSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueSheet.swift; sourceTree = "<group>"; };
+		A5A5A5A5A5A5A5A5A5A5A503 /* AskSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskSheet.swift; sourceTree = "<group>"; };
 		8EB13B92B70F6884D323E5FF /* FidoApprovalState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FidoApprovalState.swift; sourceTree = "<group>"; };
 		97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A636998B83DD23C5D2688C2D /* RunningMissionsBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningMissionsBar.swift; sourceTree = "<group>"; };
@@ -270,6 +274,7 @@
 				D2E4AC8C92D9F496B8152B8F /* ControlView.swift */,
 				1834CB7B575220FDE7679F7B /* NewMissionSheet.swift */,
 				8EAAE29E81F160F8E8409B7D /* QueueSheet.swift */,
+				A5A5A5A5A5A5A5A5A5A5A503 /* AskSheet.swift */,
 			);
 			path = Control;
 			sourceTree = "<group>";
@@ -303,6 +308,7 @@
 				CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */,
 				492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */,
 				0C6DBBABC4AE0FD4368A185C /* Mission.swift */,
+				A5A5A5A5A5A5A5A5A5A5A501 /* Ask.swift */,
 				97D6534BE4C1B5E0BEA90A5A /* Workspace.swift */,
 			);
 			path = Models;
@@ -454,11 +460,13 @@
 				48ADF499E7EE67D254FBE45A /* LoadingView.swift in Sources */,
 				F14B1635CFA8338A1C733CAD /* MarkdownView.swift in Sources */,
 				BAA09895377937393FF864A7 /* Mission.swift in Sources */,
+				A5A5A5A5A5A5A5A5A5A5A502 /* Ask.swift in Sources */,
 				9380357DC269257F9E693388 /* NavigationState.swift in Sources */,
 				110C67FF7A62B86FB7AD4CD0 /* NetworkMonitor.swift in Sources */,
 				D0646F9EE2D2E984F0446C57 /* NewMissionSheet.swift in Sources */,
 				B2C28CDD378203A229D62B9B /* PhosphorIcon.swift in Sources */,
 				51E9D9F51934DFC8EAD58CDC /* QueueSheet.swift in Sources */,
+				A5A5A5A5A5A5A5A5A5A5A504 /* AskSheet.swift in Sources */,
 				95B7AB5DBEB42E107EBE06FB /* RunningMissionsBar.swift in Sources */,
 				6846AB79778CDF4CC216B7D1 /* SandboxedDashboardApp.swift in Sources */,
 				A9B4F30DDAD9DBAEB009F77B /* SettingsView.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard/Models/Ask.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Ask.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+// Models for the Ask assistant — the non-interrupting sidecar co-pilot.
+// These mirror the backend `ask_threads` / `ask_messages` payloads exactly.
+// (The decoder uses plain JSONDecoder with no key strategy, so every snake_case
+// field needs an explicit CodingKey.)
+
+// MARK: - Thread
+
+struct AskThread: Codable, Identifiable {
+    let id: String
+    let missionId: String
+    let title: String?
+    let model: String?
+    let createdAt: String
+    let updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, model
+        case missionId = "mission_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    var displayTitle: String { title ?? "Untitled thread" }
+}
+
+// MARK: - Message
+
+struct AskMessage: Codable, Identifiable {
+    let id: String
+    let threadId: String
+    let seq: Int
+    /// "user" | "assistant" | "tool_call" | "tool_result"
+    let role: String
+    let content: String
+    let toolName: String?
+    let toolCallId: String?
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, seq, role, content
+        case threadId = "thread_id"
+        case toolName = "tool_name"
+        case toolCallId = "tool_call_id"
+        case createdAt = "created_at"
+        // `metadata` is intentionally omitted — arbitrary JSON we don't render.
+    }
+
+    var isUser: Bool { role == "user" }
+    var isAssistant: Bool { role == "assistant" }
+    var isToolCall: Bool { role == "tool_call" }
+    var isToolResult: Bool { role == "tool_result" }
+    var isTool: Bool { isToolCall || isToolResult }
+}
+
+// MARK: - API responses
+
+/// Response of `POST /api/control/missions/:id/ask`.
+struct AskSendResponse: Codable {
+    let threadId: String
+    let answer: String
+    let messages: [AskMessage]
+
+    enum CodingKeys: String, CodingKey {
+        case answer, messages
+        case threadId = "thread_id"
+    }
+}
+
+/// Response of `GET /api/control/missions/:id/ask/threads/:tid`
+/// (thread fields flattened alongside `messages`).
+struct AskThreadDetail: Codable {
+    let id: String
+    let missionId: String
+    let title: String?
+    let model: String?
+    let createdAt: String
+    let updatedAt: String
+    let messages: [AskMessage]
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, model, messages
+        case missionId = "mission_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -82,6 +82,20 @@ final class APIService {
         return URLSession(configuration: config)
     }()
 
+    /// Session for the Ask assistant. Its synchronous backend runs an agentic
+    /// loop (up to 6 LLM iterations × ~60s each, plus tool execution) and emits
+    /// no bytes until the whole turn finishes, so the 10s/25s JSON timeouts
+    /// would abort nearly every Ask request. Generous bounds instead.
+    nonisolated private static let askSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 200
+        config.timeoutIntervalForResource = 420
+        config.waitsForConnectivity = false
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.httpAdditionalHeaders = ["Accept": "application/json"]
+        return URLSession(configuration: config)
+    }()
+
     // Configuration
     var baseURL: String {
         get {
@@ -530,7 +544,8 @@ final class APIService {
         }
         return try await post(
             "/api/control/missions/\(missionId)/ask",
-            body: AskRequest(content: content, thread_id: threadId)
+            body: AskRequest(content: content, thread_id: threadId),
+            session: Self.askSession
         )
     }
 
@@ -1063,7 +1078,12 @@ final class APIService {
         return try await executeWithResponse(request)
     }
     
-    private func post<T: Decodable, B: Encodable>(_ path: String, body: B, authenticated: Bool = true) async throws -> T {
+    private func post<T: Decodable, B: Encodable>(
+        _ path: String,
+        body: B,
+        authenticated: Bool = true,
+        session: URLSession? = nil
+    ) async throws -> T {
         guard let url = makeURL(path) else {
             throw APIError.invalidURL
         }
@@ -1078,7 +1098,7 @@ final class APIService {
 
         request.httpBody = try JSONEncoder().encode(body)
 
-        return try await execute(request)
+        return try await execute(request, session: session)
     }
 
     private func delete<T: Decodable>(_ path: String, authenticated: Bool = true) async throws -> T {
@@ -1173,17 +1193,18 @@ final class APIService {
         ))
     }
     
-    private func execute<T: Decodable>(_ request: URLRequest) async throws -> T {
-        try await executeWithResponse(request).0
+    private func execute<T: Decodable>(_ request: URLRequest, session: URLSession? = nil) async throws -> T {
+        try await executeWithResponse(request, session: session).0
     }
 
-    private func executeWithResponse<T: Decodable>(_ request: URLRequest) async throws -> (T, HTTPURLResponse) {
+    private func executeWithResponse<T: Decodable>(_ request: URLRequest, session: URLSession? = nil) async throws -> (T, HTTPURLResponse) {
         let requestLabel = "\(request.httpMethod ?? "GET") \(request.url?.path ?? "?")"
+        let urlSession = session ?? Self.jsonSession
         let (data, response) = try await ControlPerformanceDiagnostics.shared.measureAsync(
             "api.request",
             detail: requestLabel
         ) {
-            try await Self.jsonSession.data(for: request)
+            try await urlSession.data(for: request)
         }
 
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -517,6 +517,37 @@ final class APIService {
         let _: EmptyResponse = try await post("/api/control/cancel", body: EmptyBody())
     }
 
+    // MARK: - Ask Assistant (non-interrupting sidecar co-pilot)
+
+    func postAsk(
+        missionId: String,
+        content: String,
+        threadId: String? = nil
+    ) async throws -> AskSendResponse {
+        struct AskRequest: Encodable {
+            let content: String
+            let thread_id: String?
+        }
+        return try await post(
+            "/api/control/missions/\(missionId)/ask",
+            body: AskRequest(content: content, thread_id: threadId)
+        )
+    }
+
+    func listAskThreads(missionId: String) async throws -> [AskThread] {
+        try await get("/api/control/missions/\(missionId)/ask/threads")
+    }
+
+    func getAskThread(missionId: String, threadId: String) async throws -> AskThreadDetail {
+        try await get("/api/control/missions/\(missionId)/ask/threads/\(threadId)")
+    }
+
+    func deleteAskThread(missionId: String, threadId: String) async throws {
+        let _: EmptyResponse = try await delete(
+            "/api/control/missions/\(missionId)/ask/threads/\(threadId)"
+        )
+    }
+
     // MARK: - Queue Management
 
     func getQueue() async throws -> [QueuedMessage] {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/AskSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/AskSheet.swift
@@ -1,0 +1,313 @@
+import SwiftUI
+
+/// Ask — the iOS surface for the non-interrupting sidecar co-pilot.
+///
+/// Presented as a bottom sheet (medium/large detents) over the mission. It runs
+/// in its own lane: it never touches the mission's queue or the working agent.
+/// Threads/messages live in a separate backend store and are rendered here with
+/// a distinct cyan "co-pilot" identity.
+struct AskSheet: View {
+    let missionId: String
+    /// Drop an Ask answer into the real mission composer (optional bridge).
+    var onSendToAgent: ((String) -> Void)? = nil
+    let onDismiss: () -> Void
+
+    @State private var threads: [AskThread] = []
+    @State private var threadId: String?
+    @State private var messages: [AskMessage] = []
+    @State private var input: String = ""
+    @State private var isLoading = false
+    @State private var errorText: String?
+
+    private let api = APIService.shared
+    private let copilot = Color.cyan
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                conversation
+                composer
+            }
+            .background(Theme.backgroundSecondary)
+            .navigationTitle("Ask")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+            .task { await loadThreads() }
+        }
+    }
+
+    // MARK: - Conversation
+
+    private var conversation: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    if messages.isEmpty && !isLoading {
+                        emptyState
+                    }
+                    ForEach(messages) { message in
+                        AskBubble(message: message, copilot: copilot, onSendToAgent: onSendToAgent)
+                            .id(message.id)
+                    }
+                    if isLoading {
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.small)
+                            Text("thinking…")
+                                .font(.caption)
+                                .foregroundStyle(copilot.opacity(0.8))
+                        }
+                        .id("loading")
+                    }
+                    if let errorText {
+                        Text(errorText)
+                            .font(.caption)
+                            .foregroundStyle(Theme.error)
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Theme.error.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                }
+                .padding(16)
+            }
+            .onChange(of: messages.count) { _, _ in
+                if let last = messages.last {
+                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                }
+            }
+            .onChange(of: isLoading) { _, loading in
+                if loading { withAnimation { proxy.scrollTo("loading", anchor: .bottom) } }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 22))
+                .foregroundStyle(copilot.opacity(0.5))
+            Text("Ask about this mission — what it's doing, why, or inspect the workspace. The working agent is never interrupted.")
+                .font(.footnote)
+                .foregroundStyle(Theme.textMuted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    // MARK: - Composer
+
+    private var composer: some View {
+        HStack(spacing: 8) {
+            TextField("Ask the co-pilot…", text: $input, axis: .vertical)
+                .lineLimit(1...4)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Theme.card)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .onSubmit { Task { await send() } }
+
+            Button {
+                Task { await send() }
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isLoading ? Theme.textMuted : copilot)
+            }
+            .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isLoading)
+        }
+        .padding(12)
+        .background(.ultraThinMaterial)
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            Button("Done") { onDismiss() }
+                .foregroundStyle(copilot)
+        }
+        ToolbarItem(placement: .topBarTrailing) {
+            HStack(spacing: 14) {
+                Menu {
+                    Button {
+                        newThread()
+                    } label: {
+                        Label("New thread", systemImage: "plus")
+                    }
+                    if !threads.isEmpty {
+                        Divider()
+                        ForEach(threads) { thread in
+                            Button {
+                                Task { await selectThread(thread.id) }
+                            } label: {
+                                Label(thread.displayTitle, systemImage: thread.id == threadId ? "checkmark" : "bubble.left")
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "bubble.left.and.bubble.right")
+                }
+
+                Button(role: .destructive) {
+                    Task { await clearThread() }
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .disabled(threadId == nil)
+            }
+            .foregroundStyle(copilot)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadThreads() async {
+        do {
+            let fetched = try await api.listAskThreads(missionId: missionId)
+            threads = fetched
+            if let first = fetched.first {
+                await selectThread(first.id)
+            }
+        } catch {
+            // Non-fatal — just start with an empty thread.
+        }
+    }
+
+    private func selectThread(_ id: String) async {
+        threadId = id
+        do {
+            let detail = try await api.getAskThread(missionId: missionId, threadId: id)
+            messages = detail.messages
+        } catch {
+            messages = []
+        }
+    }
+
+    private func newThread() {
+        threadId = nil
+        messages = []
+        input = ""
+        errorText = nil
+    }
+
+    private func send() async {
+        let content = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, !isLoading else { return }
+        input = ""
+        errorText = nil
+        isLoading = true
+
+        // Optimistic user bubble.
+        let optimistic = AskMessage(
+            id: "temp-\(UUID().uuidString)",
+            threadId: threadId ?? "",
+            seq: messages.count + 1,
+            role: "user",
+            content: content,
+            toolName: nil,
+            toolCallId: nil,
+            createdAt: ISO8601DateFormatter().string(from: Date())
+        )
+        messages.append(optimistic)
+
+        do {
+            let response = try await api.postAsk(missionId: missionId, content: content, threadId: threadId)
+            threadId = response.threadId
+            messages = response.messages
+            if let refreshed = try? await api.listAskThreads(missionId: missionId) {
+                threads = refreshed
+            }
+        } catch {
+            errorText = error.localizedDescription
+            messages.removeAll { $0.id == optimistic.id }
+            input = content
+        }
+        isLoading = false
+    }
+
+    private func clearThread() async {
+        guard let id = threadId else { return }
+        try? await api.deleteAskThread(missionId: missionId, threadId: id)
+        if let refreshed = try? await api.listAskThreads(missionId: missionId) {
+            threads = refreshed
+        }
+        newThread()
+    }
+}
+
+// MARK: - Bubble
+
+private struct AskBubble: View {
+    let message: AskMessage
+    let copilot: Color
+    var onSendToAgent: ((String) -> Void)?
+
+    var body: some View {
+        if message.isUser {
+            HStack {
+                Spacer(minLength: 40)
+                Text(message.content)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textPrimary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Theme.card)
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+        } else if message.isTool {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.textMuted)
+                Text(toolSummary)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(Theme.textMuted)
+                    .lineLimit(3)
+            }
+            .padding(.leading, 24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            // assistant
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 13))
+                    .foregroundStyle(copilot)
+                    .padding(.top, 2)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(message.content)
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.textPrimary)
+                        .textSelection(.enabled)
+                    if let onSendToAgent {
+                        Button {
+                            onSendToAgent(message.content)
+                        } label: {
+                            Label("Send to agent", systemImage: "arrow.uturn.left")
+                                .font(.caption2)
+                                .foregroundStyle(copilot.opacity(0.8))
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(copilot.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+        }
+    }
+
+    private var toolSummary: String {
+        let label = message.toolName.map { "\($0) → " } ?? "↳ "
+        let body: String
+        if message.isToolCall, let data = message.content.data(using: .utf8),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            body = (obj["command"] as? String) ?? (obj["path"] as? String) ?? message.content
+        } else {
+            body = message.content
+        }
+        let trimmed = body.count > 200 ? String(body.prefix(200)) + "…" : body
+        return label + trimmed
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -222,6 +222,7 @@ struct ControlView: View {
 
     // Thoughts panel state
     @State private var showThoughts = false
+    @State private var showAskSheet = false
     @State private var textOpBuffers: [String: String] = [:]
 
     // Tool grouping state - track which groups are expanded
@@ -311,6 +312,21 @@ struct ControlView: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
                 .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+        }
+        .sheet(isPresented: $showAskSheet) {
+            if let missionId = viewingMission?.id ?? currentMission?.id {
+                AskSheet(
+                    missionId: missionId,
+                    onSendToAgent: { text in
+                        inputText = inputText.isEmpty ? text : inputText + "\n\n" + text
+                        showAskSheet = false
+                    },
+                    onDismiss: { showAskSheet = false }
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+                .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+            }
         }
         .sheet(isPresented: $showWorkerSheet) {
             WorkerSheetView(workers: childMissions, runningWorkers: runningMissions)
@@ -500,6 +516,14 @@ struct ControlView: View {
                     .foregroundStyle(
                         messages.contains(where: { $0.isThinking }) ? Theme.accent : Theme.textSecondary
                     )
+            }
+            Button {
+                showAskSheet = true
+                HapticService.lightTap()
+            } label: {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.cyan)
             }
             if !childMissions.isEmpty {
                 Button {

--- a/src/api/ask/client.rs
+++ b/src/api/ask/client.rs
@@ -30,6 +30,8 @@ pub struct ToolCall {
 pub struct AskCompletion {
     pub content: Option<String>,
     pub tool_calls: Vec<ToolCall>,
+    /// Total tokens reported by the provider for this call (prompt + completion).
+    pub total_tokens: Option<u64>,
 }
 
 /// Thin chat client bound to a resolved LLM config.
@@ -134,9 +136,12 @@ impl AskClient {
             }
         }
 
+        let total_tokens = json["usage"]["total_tokens"].as_u64();
+
         Ok(AskCompletion {
             content,
             tool_calls,
+            total_tokens,
         })
     }
 }

--- a/src/api/ask/client.rs
+++ b/src/api/ask/client.rs
@@ -1,0 +1,142 @@
+//! Minimal OpenAI-compatible chat client with tool-calling support for the Ask
+//! assistant loop. Reuses the metadata LLM config (base URL / key / model) but
+//! adds function/tool calling, which the metadata summarizer does not need.
+//!
+//! Cerebras (and most fast providers) expose the OpenAI `/chat/completions`
+//! shape, so this client targets that format only.
+
+use serde_json::{json, Value};
+
+use crate::api::metadata_llm::{ApiFormat, MetadataLlmConfig};
+
+/// Whether a model is a reasoning model that needs an explicit `reasoning_effort`
+/// (and token headroom) to return visible content on the OpenAI-compatible API.
+fn model_is_reasoning(model: &str) -> bool {
+    let m = model.to_lowercase();
+    m.contains("gpt-oss") || m.contains("qwen") || m.contains("thinking") || m.contains("reasoning")
+}
+
+/// A tool call requested by the model.
+#[derive(Debug, Clone)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    /// Raw JSON arguments string (as returned by the model).
+    pub arguments: String,
+}
+
+/// One assistant turn returned by the model.
+#[derive(Debug, Clone, Default)]
+pub struct AskCompletion {
+    pub content: Option<String>,
+    pub tool_calls: Vec<ToolCall>,
+}
+
+/// Thin chat client bound to a resolved LLM config.
+pub struct AskClient {
+    http: reqwest::Client,
+    config: MetadataLlmConfig,
+}
+
+impl AskClient {
+    pub fn new(http: reqwest::Client, config: MetadataLlmConfig) -> Self {
+        Self { http, config }
+    }
+
+    pub fn model(&self) -> &str {
+        &self.config.model
+    }
+
+    /// Run one chat completion.
+    ///
+    /// `messages` is an OpenAI-style message array (already including system,
+    /// prior turns, and tool results). `tools` is an OpenAI-style tool array; an
+    /// empty slice disables tool calling.
+    pub async fn complete(
+        &self,
+        messages: &[Value],
+        tools: &[Value],
+    ) -> Result<AskCompletion, String> {
+        if self.config.api_format != ApiFormat::OpenAI {
+            return Err("Ask assistant requires an OpenAI-compatible provider".to_string());
+        }
+
+        let url = format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        );
+
+        let mut body = json!({
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": 0.3,
+            "max_tokens": 2048,
+        });
+        if !tools.is_empty() {
+            body["tools"] = json!(tools);
+            body["tool_choice"] = json!("auto");
+        }
+        // gpt-oss / qwen3 on Cerebras are reasoning models: without an explicit
+        // effort (and token headroom) they spend the budget on hidden reasoning
+        // and return empty content. "low" keeps the sidecar snappy.
+        if model_is_reasoning(&self.config.model) {
+            body["reasoning_effort"] = json!("low");
+        }
+
+        let resp = self
+            .http
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .timeout(std::time::Duration::from_secs(60))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Ask LLM request error: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(format!("Ask LLM returned {status}: {text}"));
+        }
+
+        let json: Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Ask LLM parse error: {e}"))?;
+
+        let message = &json["choices"][0]["message"];
+        let content = message["content"].as_str().and_then(|s| {
+            let t = s.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        });
+
+        let mut tool_calls = Vec::new();
+        if let Some(calls) = message["tool_calls"].as_array() {
+            for call in calls {
+                let id = call["id"].as_str().unwrap_or("").to_string();
+                let name = call["function"]["name"].as_str().unwrap_or("").to_string();
+                let arguments = call["function"]["arguments"]
+                    .as_str()
+                    .unwrap_or("{}")
+                    .to_string();
+                if !name.is_empty() {
+                    tool_calls.push(ToolCall {
+                        id,
+                        name,
+                        arguments,
+                    });
+                }
+            }
+        }
+
+        Ok(AskCompletion {
+            content,
+            tool_calls,
+        })
+    }
+}

--- a/src/api/ask/client.rs
+++ b/src/api/ask/client.rs
@@ -13,7 +13,13 @@ use crate::api::metadata_llm::{ApiFormat, MetadataLlmConfig};
 /// (and token headroom) to return visible content on the OpenAI-compatible API.
 fn model_is_reasoning(model: &str) -> bool {
     let m = model.to_lowercase();
-    m.contains("gpt-oss") || m.contains("qwen") || m.contains("thinking") || m.contains("reasoning")
+    // Match only actual reasoning variants — not every Qwen model (e.g.
+    // qwen2.5-coder is NOT a reasoning model and rejects `reasoning_effort`).
+    m.contains("gpt-oss")
+        || m.contains("qwen3")
+        || m.contains("qwq")
+        || m.contains("thinking")
+        || m.contains("reasoning")
 }
 
 /// A tool call requested by the model.

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -42,6 +42,10 @@ pub struct AskSendRequest {
     #[serde(default)]
     pub thread_id: Option<Uuid>,
     pub content: String,
+    /// Run the Ask bash tool in an isolated copy of the workspace (git worktree
+    /// or temp copy) so writes never touch the live tree. Opt-in.
+    #[serde(default)]
+    pub sandbox: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -120,11 +124,28 @@ pub async fn ask_send(
         Some(mission.workspace_id),
     )
     .await;
-    let work_dir = mission
+    let base_work_dir = mission
         .working_directory
         .as_ref()
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| workspace.path.clone());
+
+    // Optional sandbox-copy isolation: writes go to a throwaway worktree/copy.
+    let setup_exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
+    let sandbox_dir = if req.sandbox {
+        super::prepare_sandbox(&setup_exec, &base_work_dir).await
+    } else {
+        None
+    };
+    if req.sandbox && sandbox_dir.is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Sandbox mode requires a git workspace (no isolated worktree could be created)"
+                .to_string(),
+        ));
+    }
+    let used_sandbox = sandbox_dir.is_some();
+    let work_dir = sandbox_dir.clone().unwrap_or_else(|| base_work_dir.clone());
 
     let turn = AskTurn {
         ask_store: Arc::clone(&ask_store),
@@ -134,9 +155,16 @@ pub async fn ask_send(
         llm: AskClient::new(state.http_client.clone(), cfg),
         mission_id,
         thread_id: thread.id,
+        sandbox: used_sandbox,
     };
 
-    let answer = run_ask_turn(&turn, &req.content).await.map_err(internal)?;
+    let answer_result = run_ask_turn(&turn, &req.content).await;
+
+    // Tear down the sandbox regardless of how the turn ended.
+    if let Some(dir) = &sandbox_dir {
+        super::cleanup_sandbox(&setup_exec, &base_work_dir, dir).await;
+    }
+    let answer = answer_result.map_err(internal)?;
 
     // Auto-title a freshly created thread from the operator's first message.
     if is_new_thread {

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -1,0 +1,198 @@
+//! HTTP handlers for the Ask assistant.
+//!
+//! All routes are mission-scoped and live under `/api/control/missions/:id/ask`.
+//! They run in the Ask lane: never acquiring the harness lock, never enqueuing
+//! into the mission's message queue, and never writing to `mission_events`.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::store::{AskMessage, AskThread};
+use super::{run_ask_turn, AskClient, AskTurn};
+use crate::api::auth::AuthUser;
+use crate::api::routes::AppState;
+
+fn internal(e: impl std::fmt::Display) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AskSendRequest {
+    /// Existing thread to continue. When absent, a new thread is created.
+    #[serde(default)]
+    pub thread_id: Option<Uuid>,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AskSendResponse {
+    pub thread_id: Uuid,
+    pub answer: String,
+    pub messages: Vec<AskMessage>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AskThreadDetail {
+    #[serde(flatten)]
+    pub thread: AskThread,
+    pub messages: Vec<AskMessage>,
+}
+
+/// POST /api/control/missions/:id/ask — send a question to the Ask assistant.
+pub async fn ask_send(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(mission_id): Path<Uuid>,
+    Json(req): Json<AskSendRequest>,
+) -> Result<Json<AskSendResponse>, (StatusCode, String)> {
+    if req.content.trim().is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "content is empty".to_string()));
+    }
+
+    let control = crate::api::control::control_for_user(&state, &user).await;
+    let mission = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal)?
+        .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
+
+    // Resolve the assistant model/config (Cerebras gpt-oss-120b by default).
+    let cfg = crate::api::metadata_llm::build_assistant_llm_config(&state.ai_providers)
+        .await
+        .ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "No assistant LLM configured (set a Cerebras key or ASK_ASSISTANT_MODEL)".to_string(),
+        ))?;
+
+    let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
+
+    // Resolve or create the thread.
+    let thread = match req.thread_id {
+        Some(tid) => {
+            let t = ask_store
+                .get_thread(tid)
+                .await
+                .map_err(internal)?
+                .ok_or((StatusCode::NOT_FOUND, "Thread not found".to_string()))?;
+            if t.mission_id != mission_id {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "Thread does not belong to this mission".to_string(),
+                ));
+            }
+            t
+        }
+        None => ask_store
+            .create_thread(mission_id, Some(cfg.model.clone()))
+            .await
+            .map_err(internal)?,
+    };
+
+    // Resolve the live workspace + working directory for the bash tool.
+    let workspace = crate::workspace::resolve_workspace(
+        &state.workspaces,
+        &state.config,
+        Some(mission.workspace_id),
+    )
+    .await;
+    let work_dir = mission
+        .working_directory
+        .as_ref()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| workspace.path.clone());
+
+    let turn = AskTurn {
+        ask_store: Arc::clone(&ask_store),
+        mission_store: Arc::clone(&control.mission_store),
+        workspace_exec: crate::workspace_exec::WorkspaceExec::new(workspace),
+        work_dir,
+        llm: AskClient::new(state.http_client.clone(), cfg),
+        mission_id,
+        thread_id: thread.id,
+    };
+
+    let answer = run_ask_turn(&turn, &req.content).await.map_err(internal)?;
+    let messages = ask_store.list_messages(thread.id).await.map_err(internal)?;
+
+    Ok(Json(AskSendResponse {
+        thread_id: thread.id,
+        answer,
+        messages,
+    }))
+}
+
+/// GET /api/control/missions/:id/ask/threads — list Ask threads for a mission.
+pub async fn list_ask_threads(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(mission_id): Path<Uuid>,
+) -> Result<Json<Vec<AskThread>>, (StatusCode, String)> {
+    let control = crate::api::control::control_for_user(&state, &user).await;
+    control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal)?
+        .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
+
+    let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
+    let threads = ask_store.list_threads(mission_id).await.map_err(internal)?;
+    Ok(Json(threads))
+}
+
+/// GET /api/control/missions/:id/ask/threads/:tid — thread + messages.
+pub async fn get_ask_thread(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path((mission_id, thread_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<AskThreadDetail>, (StatusCode, String)> {
+    let control = crate::api::control::control_for_user(&state, &user).await;
+    control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal)?
+        .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
+
+    let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
+    let thread = ask_store
+        .get_thread(thread_id)
+        .await
+        .map_err(internal)?
+        .filter(|t| t.mission_id == mission_id)
+        .ok_or((StatusCode::NOT_FOUND, "Thread not found".to_string()))?;
+    let messages = ask_store.list_messages(thread_id).await.map_err(internal)?;
+    Ok(Json(AskThreadDetail { thread, messages }))
+}
+
+/// DELETE /api/control/missions/:id/ask/threads/:tid — clear/delete a thread.
+pub async fn delete_ask_thread(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path((mission_id, thread_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let control = crate::api::control::control_for_user(&state, &user).await;
+    control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal)?
+        .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
+
+    let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
+    // Only delete if the thread belongs to this mission.
+    if let Some(thread) = ask_store.get_thread(thread_id).await.map_err(internal)? {
+        if thread.mission_id == mission_id {
+            ask_store.delete_thread(thread_id).await.map_err(internal)?;
+        }
+    }
+    Ok(Json(
+        serde_json::json!({ "ok": true, "deleted": thread_id }),
+    ))
+}

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -21,6 +21,21 @@ fn internal(e: impl std::fmt::Display) -> (StatusCode, String) {
     (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
 }
 
+/// Derive a short thread title from the operator's first message (first line,
+/// trimmed to ~48 chars). Cheap and synchronous — no extra LLM call.
+fn derive_title(content: &str) -> String {
+    let first_line = content.lines().next().unwrap_or("").trim();
+    let mut title: String = first_line.chars().take(48).collect();
+    if first_line.chars().count() > 48 {
+        title.push('…');
+    }
+    if title.is_empty() {
+        "Ask".to_string()
+    } else {
+        title
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct AskSendRequest {
     /// Existing thread to continue. When absent, a new thread is created.
@@ -73,6 +88,7 @@ pub async fn ask_send(
     let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
 
     // Resolve or create the thread.
+    let is_new_thread = req.thread_id.is_none();
     let thread = match req.thread_id {
         Some(tid) => {
             let t = ask_store
@@ -118,6 +134,14 @@ pub async fn ask_send(
     };
 
     let answer = run_ask_turn(&turn, &req.content).await.map_err(internal)?;
+
+    // Auto-title a freshly created thread from the operator's first message.
+    if is_new_thread {
+        let _ = ask_store
+            .set_thread_title(thread.id, &derive_title(&req.content))
+            .await;
+    }
+
     let messages = ask_store.list_messages(thread.id).await.map_err(internal)?;
 
     Ok(Json(AskSendResponse {

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -77,13 +77,16 @@ pub async fn ask_send(
         .map_err(internal)?
         .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
 
-    // Resolve the assistant model/config (Cerebras gpt-oss-120b by default).
-    let cfg = crate::api::metadata_llm::build_assistant_llm_config(&state.ai_providers)
-        .await
-        .ok_or((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "No assistant LLM configured (set a Cerebras key or ASK_ASSISTANT_MODEL)".to_string(),
-        ))?;
+    // Resolve the assistant model/config (Settings override → env → default).
+    let model_override = state.settings.get().await.ask_assistant_model;
+    let cfg =
+        crate::api::metadata_llm::build_assistant_llm_config(&state.ai_providers, model_override)
+            .await
+            .ok_or((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "No assistant LLM configured (set a Cerebras key or ASK_ASSISTANT_MODEL)"
+                    .to_string(),
+            ))?;
 
     let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
 

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -504,7 +504,7 @@ pub async fn prepend_pending_operator_notes(
     let mut block = String::from("<operator-note>\n");
     for note in &notes {
         block.push_str(&note.body);
-        block.push_str("\n");
+        block.push('\n');
     }
     block.push_str("</operator-note>\n\n");
     block.push_str(&user_message);

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -17,7 +17,7 @@ pub mod http;
 pub mod store;
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde_json::{json, Value};
@@ -63,6 +63,9 @@ pub struct AskTurn {
     pub llm: AskClient,
     pub mission_id: Uuid,
     pub thread_id: Uuid,
+    /// When true, `work_dir` is an isolated sandbox copy of the workspace, so
+    /// writes are throwaway and we skip the operator-note bridge entirely.
+    pub sandbox: bool,
 }
 
 /// Run one Ask turn: persist the operator message, drive the tool loop, persist
@@ -277,8 +280,12 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
             if cmd.trim().is_empty() {
                 return "Error: empty command".to_string();
             }
-            // Snapshot the working tree before/after so we can report any
-            // out-of-band writes to the working agent (the operator-note bridge).
+            // In sandbox mode the writes land in a throwaway copy, so there's
+            // nothing to report to the working agent. Otherwise snapshot the
+            // working tree before/after for the operator-note bridge.
+            if turn.sandbox {
+                return run_bash(turn, &cmd).await;
+            }
             let baseline = capture_write_baseline(turn).await;
             let result = run_bash(turn, &cmd).await;
             record_writes(turn, &cmd, baseline).await;
@@ -502,6 +509,54 @@ pub async fn prepend_pending_operator_notes(
     block.push_str("</operator-note>\n\n");
     block.push_str(&user_message);
     (block, count)
+}
+
+/// Prepare an isolated sandbox copy of the workspace for "Ask in isolated copy"
+/// mode, using a detached git worktree (cheap, shares history, no full copy).
+/// Returns the sandbox path, or `None` if the workspace isn't a git repo (we
+/// deliberately do NOT `cp -a` a possibly-huge non-git tree). The caller treats
+/// `None` for an explicit sandbox request as an error rather than silently
+/// running against the live tree.
+pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Option<PathBuf> {
+    let sandbox = PathBuf::from(format!("/tmp/ask-sandbox-{}", Uuid::new_v4()));
+    let base_str = base_work_dir.to_string_lossy().to_string();
+    let sandbox_str = sandbox.to_string_lossy().to_string();
+    let cmd = format!(
+        "git -C {b} rev-parse --git-dir >/dev/null 2>&1 && \
+         git -C {b} worktree add --detach {s} HEAD >/dev/null 2>&1 && \
+         echo SANDBOX_OK",
+        b = single_quote(&base_str),
+        s = single_quote(&sandbox_str)
+    );
+    let args = vec!["-lc".to_string(), cmd];
+    match exec
+        .output(base_work_dir, "/bin/bash", &args, HashMap::new())
+        .await
+    {
+        Ok(out)
+            if out.status.success()
+                && String::from_utf8_lossy(&out.stdout).contains("SANDBOX_OK") =>
+        {
+            Some(sandbox)
+        }
+        _ => None,
+    }
+}
+
+/// Tear down a sandbox created by [`prepare_sandbox`]. Best-effort: removes the
+/// git worktree if it is one, otherwise `rm -rf`s the copy.
+pub async fn cleanup_sandbox(exec: &WorkspaceExec, base_work_dir: &Path, sandbox: &Path) {
+    let base_str = base_work_dir.to_string_lossy().to_string();
+    let sandbox_str = sandbox.to_string_lossy().to_string();
+    let cmd = format!(
+        "git -C {b} worktree remove --force {s} 2>/dev/null || rm -rf {s}",
+        b = single_quote(&base_str),
+        s = single_quote(&sandbox_str)
+    );
+    let args = vec!["-lc".to_string(), cmd];
+    let _ = exec
+        .output(base_work_dir, "/bin/bash", &args, HashMap::new())
+        .await;
 }
 
 fn single_quote(s: &str) -> String {

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1,0 +1,501 @@
+//! Ask assistant — a fast, read-mostly sidecar co-pilot that rides alongside a
+//! running mission. It can read the mission history and run bash in the live
+//! workspace, answering operator questions **without** touching the working
+//! agent's turn loop, queue, or harness lock.
+//!
+//! This module hosts:
+//! - the persistent [`store`] (separate `ask.db`, never merged into mission
+//!   history),
+//! - the OpenAI-compatible tool-calling [`client`],
+//! - the in-process agentic [`run_ask_turn`] loop, and
+//! - the global [`ask_store`] accessor.
+//!
+//! See `ASK_ASSISTANT_DESIGN.md` for the full design.
+
+pub mod client;
+pub mod http;
+pub mod store;
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use tokio::sync::OnceCell;
+use uuid::Uuid;
+
+use crate::api::mission_store::MissionStore;
+use crate::workspace_exec::WorkspaceExec;
+
+pub use client::AskClient;
+pub use store::{AskMessage, AskStore, AskThread, OperatorNote};
+
+/// Hard cap on tool-calling iterations per turn — keeps cost/latency bounded.
+const MAX_ITERATIONS: usize = 6;
+/// Max bytes of any single tool result fed back to the model.
+const MAX_TOOL_RESULT_BYTES: usize = 8_000;
+/// Number of recent mission events seeded into the system prompt.
+const SEED_EVENT_COUNT: usize = 40;
+
+static ASK_STORE: OnceCell<Arc<AskStore>> = OnceCell::const_new();
+
+/// Get (lazily initializing) the global Ask store, placed next to the mission
+/// databases under the working directory.
+pub async fn ask_store(config: &crate::config::Config) -> Result<Arc<AskStore>, String> {
+    ASK_STORE
+        .get_or_try_init(|| async {
+            let base = config.working_dir.join(".sandboxed-sh").join("missions");
+            tokio::fs::create_dir_all(&base)
+                .await
+                .map_err(|e| e.to_string())?;
+            AskStore::open(base.join("ask.db")).await.map(Arc::new)
+        })
+        .await
+        .map(Arc::clone)
+}
+
+/// Everything the Ask loop needs for one turn.
+pub struct AskTurn {
+    pub ask_store: Arc<AskStore>,
+    pub mission_store: Arc<dyn MissionStore>,
+    pub workspace_exec: WorkspaceExec,
+    pub work_dir: PathBuf,
+    pub llm: AskClient,
+    pub mission_id: Uuid,
+    pub thread_id: Uuid,
+}
+
+/// Run one Ask turn: persist the operator message, drive the tool loop, persist
+/// the assistant answer, and return the final text.
+pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, String> {
+    // Persist the operator's message first.
+    turn.ask_store
+        .append_message(turn.thread_id, "user", user_content, None, None, None)
+        .await?;
+
+    // Assemble the OpenAI message array: system + prior turns + this message.
+    let system = build_system_prompt(turn).await;
+    let mut messages: Vec<Value> = vec![json!({ "role": "system", "content": system })];
+
+    // Replay prior user/assistant turns for continuity (tool details are kept in
+    // the store for the UI but not replayed to the model — the final answers
+    // carry what matters). `prior` already includes the message just appended.
+    let prior = turn.ask_store.list_messages(turn.thread_id).await?;
+    for m in &prior {
+        match m.role.as_str() {
+            "user" => messages.push(json!({ "role": "user", "content": m.content })),
+            "assistant" => messages.push(json!({ "role": "assistant", "content": m.content })),
+            _ => {}
+        }
+    }
+
+    let tools = tool_definitions();
+    let mut final_answer = String::new();
+
+    for _ in 0..MAX_ITERATIONS {
+        let completion = turn.llm.complete(&messages, &tools).await?;
+
+        if completion.tool_calls.is_empty() {
+            final_answer = completion.content.unwrap_or_default();
+            break;
+        }
+
+        // Reflect the assistant's tool-calling turn into the live context.
+        let assistant_tool_calls: Vec<Value> = completion
+            .tool_calls
+            .iter()
+            .map(|tc| {
+                json!({
+                    "id": tc.id,
+                    "type": "function",
+                    "function": { "name": tc.name, "arguments": tc.arguments },
+                })
+            })
+            .collect();
+        messages.push(json!({
+            "role": "assistant",
+            "content": completion.content.clone().unwrap_or_default(),
+            "tool_calls": assistant_tool_calls,
+        }));
+
+        for tc in &completion.tool_calls {
+            turn.ask_store
+                .append_message(
+                    turn.thread_id,
+                    "tool_call",
+                    &tc.arguments,
+                    Some(tc.name.clone()),
+                    Some(tc.id.clone()),
+                    None,
+                )
+                .await?;
+
+            let result = execute_tool(turn, &tc.name, &tc.arguments).await;
+            let result = truncate(&result, MAX_TOOL_RESULT_BYTES);
+
+            turn.ask_store
+                .append_message(
+                    turn.thread_id,
+                    "tool_result",
+                    &result,
+                    Some(tc.name.clone()),
+                    Some(tc.id.clone()),
+                    None,
+                )
+                .await?;
+
+            messages.push(json!({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result,
+            }));
+        }
+    }
+
+    if final_answer.is_empty() {
+        final_answer =
+            "(The assistant reached the tool-call limit without a final answer.)".to_string();
+    }
+
+    turn.ask_store
+        .append_message(
+            turn.thread_id,
+            "assistant",
+            &final_answer,
+            None,
+            None,
+            Some(json!({ "model": turn.llm.model() })),
+        )
+        .await?;
+
+    Ok(final_answer)
+}
+
+async fn build_system_prompt(turn: &AskTurn) -> String {
+    let mut seed = String::new();
+    if let Ok(Some(mission)) = turn.mission_store.get_mission(turn.mission_id).await {
+        if let Some(title) = &mission.title {
+            seed.push_str(&format!("Mission title: {title}\n"));
+        }
+        if let Some(desc) = &mission.short_description {
+            seed.push_str(&format!("Mission status: {desc}\n"));
+        }
+        seed.push_str(&format!("Mission backend: {}\n", mission.backend));
+    }
+
+    if let Ok(events) = turn
+        .mission_store
+        .get_latest_events(turn.mission_id, SEED_EVENT_COUNT)
+        .await
+    {
+        seed.push_str("\nRecent mission events (newest last):\n");
+        for ev in &events {
+            let tool = ev
+                .tool_name
+                .as_deref()
+                .map(|t| format!(" {t}"))
+                .unwrap_or_default();
+            seed.push_str(&format!(
+                "[{}] {}{}: {}\n",
+                ev.sequence,
+                ev.event_type,
+                tool,
+                truncate(&ev.content, 240)
+            ));
+        }
+    }
+
+    format!(
+        "You are the Ask co-pilot for an autonomous coding mission. A separate \
+         \"working agent\" is doing the real work in this same workspace; you are a \
+         read-mostly assistant helping the operator understand and occasionally nudge \
+         what's happening.\n\n\
+         Prefer reading (history, files, logs) over writing. You MAY write to the \
+         workspace with the bash tool, but anything you change is reported to the \
+         working agent, so keep writes minimal and intentional. The full mission \
+         history may be large — retrieve what you need with read_history / bash \
+         (grep, rg, cat) rather than assuming it is all provided.\n\n\
+         Be concise and concrete. Cite event sequence numbers or file paths when \
+         relevant.\n\n\
+         === Mission context ===\n{seed}"
+    )
+}
+
+fn tool_definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Run a bash command in the mission's live workspace. Full read+write. Use for grep/rg/cat/ls/git status/git log to inspect the current state.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": { "type": "string", "description": "The bash command to run." }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "read_history",
+                "description": "Fetch the most recent mission events (the working agent's transcript: messages, tool calls/results, errors).",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "limit": { "type": "integer", "description": "How many recent events (default 60, max 300)." }
+                    }
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file from the mission workspace by path.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Path to the file (absolute or relative to the workspace root)." }
+                    },
+                    "required": ["path"]
+                }
+            }
+        }),
+    ]
+}
+
+async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
+    let args: Value = serde_json::from_str(arguments).unwrap_or_else(|_| json!({}));
+    match name {
+        "bash" => {
+            let cmd = args["command"].as_str().unwrap_or("").to_string();
+            if cmd.trim().is_empty() {
+                return "Error: empty command".to_string();
+            }
+            // Snapshot the working tree before/after so we can report any
+            // out-of-band writes to the working agent (the operator-note bridge).
+            let before = git_status_set(turn).await;
+            let result = run_bash(turn, &cmd).await;
+            record_writes(turn, &cmd, before).await;
+            result
+        }
+        "read_file" => {
+            let path = args["path"].as_str().unwrap_or("");
+            if path.trim().is_empty() {
+                return "Error: empty path".to_string();
+            }
+            run_bash(turn, &format!("cat -- {}", single_quote(path))).await
+        }
+        "read_history" => {
+            let limit = args["limit"].as_u64().unwrap_or(60).clamp(1, 300) as usize;
+            match turn
+                .mission_store
+                .get_latest_events(turn.mission_id, limit)
+                .await
+            {
+                Ok(events) => {
+                    let mut out = String::new();
+                    for ev in &events {
+                        let tool = ev
+                            .tool_name
+                            .as_deref()
+                            .map(|t| format!(" {t}"))
+                            .unwrap_or_default();
+                        out.push_str(&format!(
+                            "[{}] {}{}: {}\n",
+                            ev.sequence,
+                            ev.event_type,
+                            tool,
+                            truncate(&ev.content, 400)
+                        ));
+                    }
+                    if out.is_empty() {
+                        "(no events)".to_string()
+                    } else {
+                        out
+                    }
+                }
+                Err(e) => format!("Error reading history: {e}"),
+            }
+        }
+        other => format!("Error: unknown tool '{other}'"),
+    }
+}
+
+async fn run_bash(turn: &AskTurn, command: &str) -> String {
+    let args = vec!["-lc".to_string(), command.to_string()];
+    match turn
+        .workspace_exec
+        .output(&turn.work_dir, "/bin/bash", &args, HashMap::new())
+        .await
+    {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let mut out = String::new();
+            if !stdout.trim().is_empty() {
+                out.push_str(stdout.trim_end());
+            }
+            if !stderr.trim().is_empty() {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str("[stderr] ");
+                out.push_str(stderr.trim_end());
+            }
+            let code = output.status.code().unwrap_or(-1);
+            if code != 0 {
+                out.push_str(&format!("\n[exit code {code}]"));
+            }
+            if out.is_empty() {
+                "(no output)".to_string()
+            } else {
+                out
+            }
+        }
+        Err(e) => format!("Error running command: {e}"),
+    }
+}
+
+/// Snapshot `git status --porcelain` (tracked + untracked) as a set of lines.
+/// Returns `None` when the workspace is not a git repo (no detection possible).
+async fn git_status_set(turn: &AskTurn) -> Option<HashSet<String>> {
+    let args = vec![
+        "-lc".to_string(),
+        "git status --porcelain=v1 --untracked-files=all 2>/dev/null".to_string(),
+    ];
+    let output = turn
+        .workspace_exec
+        .output(&turn.work_dir, "/bin/bash", &args, HashMap::new())
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None; // not a git repo (or git unavailable)
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    Some(text.lines().map(|l| l.to_string()).collect())
+}
+
+/// After an Ask bash command, diff the working tree against the `before`
+/// snapshot and enqueue an operator-note describing any new/changed paths so the
+/// working agent learns about edits it didn't make.
+async fn record_writes(turn: &AskTurn, command: &str, before: Option<HashSet<String>>) {
+    let Some(before) = before else { return };
+    let Some(after) = git_status_set(turn).await else {
+        return;
+    };
+
+    // New porcelain lines that weren't present before — predominantly this
+    // command's writes (the window is a single command).
+    let mut changed: Vec<String> = after
+        .difference(&before)
+        .map(|l| l.trim().to_string())
+        .collect();
+    if changed.is_empty() {
+        return;
+    }
+    changed.sort();
+
+    let body = format!(
+        "While you were working, the operator made out-of-band changes to this \
+         workspace via the Ask assistant (not by you), running `{}`:\n{}\n\
+         If relevant, re-read these files before continuing; do not assume your \
+         previous view of them is current.",
+        truncate(command, 200),
+        changed
+            .iter()
+            .map(|l| format!("- {l}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    if let Err(e) = turn
+        .ask_store
+        .enqueue_operator_note(turn.mission_id, &body, Some(turn.thread_id))
+        .await
+    {
+        tracing::warn!("[Ask] failed to enqueue operator note: {e}");
+    }
+}
+
+/// Flush any pending operator-notes for a mission into the working agent's next
+/// turn by prepending a tagged block to its `user_message`. Returns the message
+/// unchanged when there are no pending notes.
+///
+/// This is the **delivery** half of the operator-note bridge, called from each
+/// backend's turn-prep (see `mission_runner`). Notes are passive: this only ever
+/// runs when a turn is already about to execute — it never starts one.
+pub async fn prepend_pending_operator_notes(
+    store: &AskStore,
+    mission_id: Uuid,
+    user_message: String,
+) -> (String, usize) {
+    let notes = match store.take_pending_operator_notes(mission_id).await {
+        Ok(n) if !n.is_empty() => n,
+        _ => return (user_message, 0),
+    };
+    let count = notes.len();
+    let mut block = String::from("<operator-note>\n");
+    for note in &notes {
+        block.push_str(&note.body);
+        block.push_str("\n");
+    }
+    block.push_str("</operator-note>\n\n");
+    block.push_str(&user_message);
+    (block, count)
+}
+
+fn single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+fn truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}… (truncated)", &s[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn temp_store() -> Arc<AskStore> {
+        let path = std::env::temp_dir().join(format!("ask-bridge-{}.db", Uuid::new_v4()));
+        Arc::new(AskStore::open(path).await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn operator_notes_prepend_then_drain() {
+        let store = temp_store().await;
+        let mission = Uuid::new_v4();
+
+        // No pending notes → message is returned unchanged.
+        let (msg, n) = prepend_pending_operator_notes(&store, mission, "Continue.".into()).await;
+        assert_eq!(n, 0);
+        assert_eq!(msg, "Continue.");
+
+        store
+            .enqueue_operator_note(mission, "Added scripts/probe.sh", None)
+            .await
+            .unwrap();
+
+        let (msg, n) = prepend_pending_operator_notes(&store, mission, "Continue.".into()).await;
+        assert_eq!(n, 1);
+        assert!(msg.starts_with("<operator-note>"));
+        assert!(msg.contains("Added scripts/probe.sh"));
+        assert!(msg.trim_end().ends_with("Continue."));
+
+        // Flushed exactly once — the next turn sees no note.
+        let (msg, n) = prepend_pending_operator_notes(&store, mission, "Continue.".into()).await;
+        assert_eq!(n, 0);
+        assert_eq!(msg, "Continue.");
+    }
+}

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -91,9 +91,11 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
 
     let tools = tool_definitions();
     let mut final_answer = String::new();
+    let mut total_tokens: u64 = 0;
 
     for _ in 0..MAX_ITERATIONS {
         let completion = turn.llm.complete(&messages, &tools).await?;
+        total_tokens += completion.total_tokens.unwrap_or(0);
 
         if completion.tool_calls.is_empty() {
             final_answer = completion.content.unwrap_or_default();
@@ -164,7 +166,7 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
             &final_answer,
             None,
             None,
-            Some(json!({ "model": turn.llm.model() })),
+            Some(json!({ "model": turn.llm.model(), "total_tokens": total_tokens })),
         )
         .await?;
 
@@ -277,9 +279,9 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
             }
             // Snapshot the working tree before/after so we can report any
             // out-of-band writes to the working agent (the operator-note bridge).
-            let before = git_status_set(turn).await;
+            let baseline = capture_write_baseline(turn).await;
             let result = run_bash(turn, &cmd).await;
-            record_writes(turn, &cmd, before).await;
+            record_writes(turn, &cmd, baseline).await;
             result
         }
         "read_file" => {
@@ -379,25 +381,79 @@ async fn git_status_set(turn: &AskTurn) -> Option<HashSet<String>> {
     Some(text.lines().map(|l| l.to_string()).collect())
 }
 
-/// After an Ask bash command, diff the working tree against the `before`
-/// snapshot and enqueue an operator-note describing any new/changed paths so the
-/// working agent learns about edits it didn't make.
-async fn record_writes(turn: &AskTurn, command: &str, before: Option<HashSet<String>>) {
-    let Some(before) = before else { return };
-    let Some(after) = git_status_set(turn).await else {
-        return;
+/// Baseline of the working tree captured before an Ask bash command, used to
+/// detect writes afterwards. Git workspaces use a porcelain snapshot; non-git
+/// workspaces fall back to an mtime cutoff.
+enum WriteBaseline {
+    Git(HashSet<String>),
+    /// Epoch seconds, for `find -newermt @epoch` detection.
+    Mtime(String),
+    None,
+}
+
+async fn capture_write_baseline(turn: &AskTurn) -> WriteBaseline {
+    if let Some(set) = git_status_set(turn).await {
+        return WriteBaseline::Git(set);
+    }
+    // Non-git fallback: capture an epoch marker for mtime-based detection.
+    let args = vec!["-lc".to_string(), "date +%s".to_string()];
+    if let Ok(out) = turn
+        .workspace_exec
+        .output(&turn.work_dir, "/bin/bash", &args, HashMap::new())
+        .await
+    {
+        let epoch = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !epoch.is_empty() && epoch.chars().all(|c| c.is_ascii_digit()) {
+            return WriteBaseline::Mtime(epoch);
+        }
+    }
+    WriteBaseline::None
+}
+
+/// After an Ask bash command, diff the working tree against the `baseline` and
+/// enqueue an operator-note describing any new/changed paths so the working
+/// agent learns about edits it didn't make.
+async fn record_writes(turn: &AskTurn, command: &str, baseline: WriteBaseline) {
+    let mut changed: Vec<String> = match baseline {
+        WriteBaseline::Git(before) => {
+            let Some(after) = git_status_set(turn).await else {
+                return;
+            };
+            // New porcelain lines that weren't present before — predominantly
+            // this command's writes (the window is a single command).
+            after
+                .difference(&before)
+                .map(|l| l.trim().to_string())
+                .collect()
+        }
+        WriteBaseline::Mtime(epoch) => {
+            let cmd = format!(
+                "find . -type f -newermt @{epoch} \
+                 -not -path './.git/*' -not -path './node_modules/*' \
+                 -not -path './target/*' 2>/dev/null | head -50"
+            );
+            let args = vec!["-lc".to_string(), cmd];
+            match turn
+                .workspace_exec
+                .output(&turn.work_dir, "/bin/bash", &args, HashMap::new())
+                .await
+            {
+                Ok(out) => String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .map(|l| l.trim().to_string())
+                    .filter(|l| !l.is_empty())
+                    .collect(),
+                Err(_) => return,
+            }
+        }
+        WriteBaseline::None => return,
     };
 
-    // New porcelain lines that weren't present before — predominantly this
-    // command's writes (the window is a single command).
-    let mut changed: Vec<String> = after
-        .difference(&before)
-        .map(|l| l.trim().to_string())
-        .collect();
     if changed.is_empty() {
         return;
     }
     changed.sort();
+    changed.dedup();
 
     let body = format!(
         "While you were working, the operator made out-of-band changes to this \

--- a/src/api/ask/store.rs
+++ b/src/api/ask/store.rs
@@ -1,0 +1,517 @@
+//! Persistent storage for the Ask assistant (the non-interrupting sidecar
+//! co-pilot). Deliberately separate from the mission store / `mission_events`
+//! so Ask conversations never enter the working agent's prompt context.
+//!
+//! Backed by its own SQLite database (`ask.db`) alongside the mission stores.
+//! Mission ownership / access control is enforced at the HTTP layer (the caller
+//! verifies the user owns the mission via their per-user mission store), so this
+//! store is keyed purely by `mission_id` and shared across users.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Utc;
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+/// A conversation thread between the operator and the Ask assistant, scoped to
+/// one mission. A mission may have many threads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AskThread {
+    pub id: Uuid,
+    pub mission_id: Uuid,
+    pub title: Option<String>,
+    /// Model used for this thread (snapshot of the picker at create time).
+    pub model: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// One message in an Ask thread: an operator prompt, an assistant reply, or a
+/// tool call / result emitted during the agentic loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AskMessage {
+    pub id: Uuid,
+    pub thread_id: Uuid,
+    pub seq: i64,
+    /// `user` | `assistant` | `tool_call` | `tool_result`
+    pub role: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
+}
+
+/// A passive note queued by the Ask lane to be flushed into the working agent's
+/// next turn (the operator-note bridge — see M2). Lives at mission scope, not
+/// inside an Ask thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorNote {
+    pub id: Uuid,
+    pub mission_id: Uuid,
+    pub body: String,
+    pub source_thread_id: Option<Uuid>,
+    pub created_at: String,
+}
+
+/// SQLite-backed Ask store.
+pub struct AskStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl std::fmt::Debug for AskStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AskStore").finish()
+    }
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339()
+}
+
+impl AskStore {
+    /// Open (and create/migrate) the Ask database at `db_path`.
+    pub async fn open(db_path: PathBuf) -> Result<Self, String> {
+        let conn = tokio::task::spawn_blocking(move || -> Result<Connection, String> {
+            let conn = Connection::open(&db_path).map_err(|e| e.to_string())?;
+            conn.pragma_update(None, "journal_mode", "WAL")
+                .map_err(|e| e.to_string())?;
+            conn.pragma_update(None, "foreign_keys", "ON")
+                .map_err(|e| e.to_string())?;
+            conn.execute_batch(SCHEMA).map_err(|e| e.to_string())?;
+            Ok(conn)
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    // ── Threads ──────────────────────────────────────────────────────────────
+
+    pub async fn create_thread(
+        &self,
+        mission_id: Uuid,
+        model: Option<String>,
+    ) -> Result<AskThread, String> {
+        let conn = self.conn.clone();
+        let thread = AskThread {
+            id: Uuid::new_v4(),
+            mission_id,
+            title: None,
+            model,
+            created_at: now(),
+            updated_at: now(),
+        };
+        let t = thread.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), String> {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO ask_threads (id, mission_id, title, model, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    t.id.to_string(),
+                    t.mission_id.to_string(),
+                    t.title,
+                    t.model,
+                    t.created_at,
+                    t.updated_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+        Ok(thread)
+    }
+
+    pub async fn list_threads(&self, mission_id: Uuid) -> Result<Vec<AskThread>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || -> Result<Vec<AskThread>, String> {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, mission_id, title, model, created_at, updated_at \
+                     FROM ask_threads WHERE mission_id = ?1 ORDER BY updated_at DESC",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![mission_id.to_string()], row_to_thread)
+                .map_err(|e| e.to_string())?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| e.to_string())?);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    pub async fn get_thread(&self, thread_id: Uuid) -> Result<Option<AskThread>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || -> Result<Option<AskThread>, String> {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                "SELECT id, mission_id, title, model, created_at, updated_at \
+                 FROM ask_threads WHERE id = ?1",
+                params![thread_id.to_string()],
+                row_to_thread,
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    pub async fn delete_thread(&self, thread_id: Uuid) -> Result<(), String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), String> {
+            let conn = conn.blocking_lock();
+            // Messages cascade via FK; delete the thread row.
+            conn.execute(
+                "DELETE FROM ask_threads WHERE id = ?1",
+                params![thread_id.to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    pub async fn set_thread_title(&self, thread_id: Uuid, title: &str) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let title = title.to_string();
+        tokio::task::spawn_blocking(move || -> Result<(), String> {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE ask_threads SET title = ?2, updated_at = ?3 WHERE id = ?1",
+                params![thread_id.to_string(), title, now()],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    // ── Messages ─────────────────────────────────────────────────────────────
+
+    pub async fn append_message(
+        &self,
+        thread_id: Uuid,
+        role: &str,
+        content: &str,
+        tool_name: Option<String>,
+        tool_call_id: Option<String>,
+        metadata: Option<serde_json::Value>,
+    ) -> Result<AskMessage, String> {
+        let conn = self.conn.clone();
+        let role = role.to_string();
+        let content = content.to_string();
+        tokio::task::spawn_blocking(move || -> Result<AskMessage, String> {
+            let conn = conn.blocking_lock();
+            let seq: i64 = conn
+                .query_row(
+                    "SELECT COALESCE(MAX(seq), 0) + 1 FROM ask_messages WHERE thread_id = ?1",
+                    params![thread_id.to_string()],
+                    |row| row.get(0),
+                )
+                .map_err(|e| e.to_string())?;
+            let msg = AskMessage {
+                id: Uuid::new_v4(),
+                thread_id,
+                seq,
+                role,
+                content,
+                tool_name,
+                tool_call_id,
+                metadata,
+                created_at: now(),
+            };
+            let metadata_str = msg
+                .metadata
+                .as_ref()
+                .map(|m| m.to_string())
+                .unwrap_or_default();
+            conn.execute(
+                "INSERT INTO ask_messages \
+                 (id, thread_id, seq, role, content, tool_name, tool_call_id, metadata, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    msg.id.to_string(),
+                    msg.thread_id.to_string(),
+                    msg.seq,
+                    msg.role,
+                    msg.content,
+                    msg.tool_name,
+                    msg.tool_call_id,
+                    metadata_str,
+                    msg.created_at,
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            conn.execute(
+                "UPDATE ask_threads SET updated_at = ?2 WHERE id = ?1",
+                params![msg.thread_id.to_string(), msg.created_at],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(msg)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    pub async fn list_messages(&self, thread_id: Uuid) -> Result<Vec<AskMessage>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || -> Result<Vec<AskMessage>, String> {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, thread_id, seq, role, content, tool_name, tool_call_id, metadata, created_at \
+                     FROM ask_messages WHERE thread_id = ?1 ORDER BY seq ASC",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![thread_id.to_string()], row_to_message)
+                .map_err(|e| e.to_string())?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| e.to_string())?);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    // ── Operator notes (M2 bridge) ───────────────────────────────────────────
+
+    pub async fn enqueue_operator_note(
+        &self,
+        mission_id: Uuid,
+        body: &str,
+        source_thread_id: Option<Uuid>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let body = body.to_string();
+        tokio::task::spawn_blocking(move || -> Result<(), String> {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO operator_notes (id, mission_id, body, source_thread_id, created_at, flushed_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, NULL)",
+                params![
+                    Uuid::new_v4().to_string(),
+                    mission_id.to_string(),
+                    body,
+                    source_thread_id.map(|i| i.to_string()),
+                    now(),
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    /// Atomically return all pending (un-flushed) operator notes for a mission
+    /// and mark them flushed. Used by the working-agent turn-prep path.
+    pub async fn take_pending_operator_notes(
+        &self,
+        mission_id: Uuid,
+    ) -> Result<Vec<OperatorNote>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || -> Result<Vec<OperatorNote>, String> {
+            let conn = conn.blocking_lock();
+            let notes = {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, mission_id, body, source_thread_id, created_at \
+                         FROM operator_notes WHERE mission_id = ?1 AND flushed_at IS NULL \
+                         ORDER BY created_at ASC",
+                    )
+                    .map_err(|e| e.to_string())?;
+                let rows = stmt
+                    .query_map(params![mission_id.to_string()], row_to_note)
+                    .map_err(|e| e.to_string())?;
+                let mut out = Vec::new();
+                for r in rows {
+                    out.push(r.map_err(|e| e.to_string())?);
+                }
+                out
+            };
+            if !notes.is_empty() {
+                conn.execute(
+                    "UPDATE operator_notes SET flushed_at = ?2 \
+                     WHERE mission_id = ?1 AND flushed_at IS NULL",
+                    params![mission_id.to_string(), now()],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+            Ok(notes)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+}
+
+fn row_to_thread(row: &rusqlite::Row<'_>) -> rusqlite::Result<AskThread> {
+    let id: String = row.get(0)?;
+    let mission_id: String = row.get(1)?;
+    Ok(AskThread {
+        id: Uuid::parse_str(&id).unwrap_or_default(),
+        mission_id: Uuid::parse_str(&mission_id).unwrap_or_default(),
+        title: row.get(2)?,
+        model: row.get(3)?,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+fn row_to_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<AskMessage> {
+    let id: String = row.get(0)?;
+    let thread_id: String = row.get(1)?;
+    let metadata_str: Option<String> = row.get(7)?;
+    let metadata = metadata_str
+        .filter(|s| !s.is_empty())
+        .and_then(|s| serde_json::from_str(&s).ok());
+    Ok(AskMessage {
+        id: Uuid::parse_str(&id).unwrap_or_default(),
+        thread_id: Uuid::parse_str(&thread_id).unwrap_or_default(),
+        seq: row.get(2)?,
+        role: row.get(3)?,
+        content: row.get(4)?,
+        tool_name: row.get(5)?,
+        tool_call_id: row.get(6)?,
+        metadata,
+        created_at: row.get(8)?,
+    })
+}
+
+fn row_to_note(row: &rusqlite::Row<'_>) -> rusqlite::Result<OperatorNote> {
+    let id: String = row.get(0)?;
+    let mission_id: String = row.get(1)?;
+    let source: Option<String> = row.get(3)?;
+    Ok(OperatorNote {
+        id: Uuid::parse_str(&id).unwrap_or_default(),
+        mission_id: Uuid::parse_str(&mission_id).unwrap_or_default(),
+        body: row.get(2)?,
+        source_thread_id: source.and_then(|s| Uuid::parse_str(&s).ok()),
+        created_at: row.get(4)?,
+    })
+}
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS ask_threads (
+    id          TEXT PRIMARY KEY,
+    mission_id  TEXT NOT NULL,
+    title       TEXT,
+    model       TEXT,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ask_threads_mission ON ask_threads(mission_id, updated_at);
+
+CREATE TABLE IF NOT EXISTS ask_messages (
+    id           TEXT PRIMARY KEY,
+    thread_id    TEXT NOT NULL,
+    seq          INTEGER NOT NULL,
+    role         TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    tool_name    TEXT,
+    tool_call_id TEXT,
+    metadata     TEXT,
+    created_at   TEXT NOT NULL,
+    FOREIGN KEY (thread_id) REFERENCES ask_threads(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_ask_messages_thread ON ask_messages(thread_id, seq);
+
+CREATE TABLE IF NOT EXISTS operator_notes (
+    id               TEXT PRIMARY KEY,
+    mission_id       TEXT NOT NULL,
+    body             TEXT NOT NULL,
+    source_thread_id TEXT,
+    created_at       TEXT NOT NULL,
+    flushed_at       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_operator_notes_pending ON operator_notes(mission_id, flushed_at);
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn temp_store() -> AskStore {
+        let path = std::env::temp_dir().join(format!("ask-test-{}.db", Uuid::new_v4()));
+        AskStore::open(path).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn thread_and_message_roundtrip() {
+        let store = temp_store().await;
+        let mission = Uuid::new_v4();
+
+        let thread = store
+            .create_thread(mission, Some("gpt-oss-120b".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(thread.mission_id, mission);
+
+        store
+            .append_message(thread.id, "user", "what's happening?", None, None, None)
+            .await
+            .unwrap();
+        store
+            .append_message(thread.id, "assistant", "reading logs", None, None, None)
+            .await
+            .unwrap();
+
+        let msgs = store.list_messages(thread.id).await.unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].seq, 1);
+        assert_eq!(msgs[1].seq, 2);
+        assert_eq!(msgs[0].role, "user");
+
+        let threads = store.list_threads(mission).await.unwrap();
+        assert_eq!(threads.len(), 1);
+
+        // Delete cascades messages.
+        store.delete_thread(thread.id).await.unwrap();
+        assert!(store.get_thread(thread.id).await.unwrap().is_none());
+        assert!(store.list_messages(thread.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn operator_notes_are_taken_once() {
+        let store = temp_store().await;
+        let mission = Uuid::new_v4();
+
+        store
+            .enqueue_operator_note(mission, "Added scripts/probe.sh", None)
+            .await
+            .unwrap();
+        store
+            .enqueue_operator_note(mission, "Edited src/foo.rs", None)
+            .await
+            .unwrap();
+
+        let first = store.take_pending_operator_notes(mission).await.unwrap();
+        assert_eq!(first.len(), 2);
+
+        // Second take returns nothing — notes flush exactly once.
+        let second = store.take_pending_operator_notes(mission).await.unwrap();
+        assert!(second.is_empty());
+    }
+}

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3501,7 +3501,7 @@ async fn set_and_emit_status(
     });
 }
 
-async fn control_for_user(state: &Arc<AppState>, user: &AuthUser) -> ControlState {
+pub(crate) async fn control_for_user(state: &Arc<AppState>, user: &AuthUser) -> ControlState {
     state.control.get_or_spawn(user).await
 }
 

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -303,11 +303,16 @@ pub(crate) fn resolve_provider_api_key(
 /// independent of the metadata config's reasoning fields.
 pub async fn build_assistant_llm_config(
     ai_providers: &crate::ai_providers::AIProviderStore,
+    model_override: Option<String>,
 ) -> Option<MetadataLlmConfig> {
     use crate::ai_providers::ProviderType;
 
-    let assistant_model =
-        std::env::var("ASK_ASSISTANT_MODEL").unwrap_or_else(|_| "gpt-oss-120b".to_string());
+    // Precedence: explicit Settings override → ASK_ASSISTANT_MODEL env → default.
+    let assistant_model = model_override
+        .filter(|m| !m.trim().is_empty())
+        .or_else(|| std::env::var("ASK_ASSISTANT_MODEL").ok())
+        .filter(|m| !m.trim().is_empty())
+        .unwrap_or_else(|| "gpt-oss-120b".to_string());
 
     // Prefer Cerebras (fast + large context) for the assistant role.
     if let Some(provider) = ai_providers.get_by_type(ProviderType::Cerebras).await {

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -308,10 +308,14 @@ pub async fn build_assistant_llm_config(
     use crate::ai_providers::ProviderType;
 
     // Precedence: explicit Settings override → ASK_ASSISTANT_MODEL env → default.
-    let assistant_model = model_override
-        .filter(|m| !m.trim().is_empty())
-        .or_else(|| std::env::var("ASK_ASSISTANT_MODEL").ok())
-        .filter(|m| !m.trim().is_empty())
+    // An explicit choice (Settings override → env) vs the built-in default.
+    let explicit_model = model_override.filter(|m| !m.trim().is_empty()).or_else(|| {
+        std::env::var("ASK_ASSISTANT_MODEL")
+            .ok()
+            .filter(|m| !m.trim().is_empty())
+    });
+    let assistant_model = explicit_model
+        .clone()
         .unwrap_or_else(|| "gpt-oss-120b".to_string());
 
     // Prefer Cerebras (fast + large context) for the assistant role.
@@ -348,9 +352,32 @@ pub async fn build_assistant_llm_config(
         }
     }
 
-    // Fallback: reuse the metadata ladder so Ask works with any provider.
+    // Fallback: reuse the metadata ladder so Ask still works without Cerebras.
     tracing::info!("[AskLLM] Cerebras unavailable; falling back to metadata provider ladder");
-    try_build_config_from_providers(ai_providers).await
+    let cfg = try_build_config_from_providers(ai_providers).await?;
+    // AskClient only speaks the OpenAI `/chat/completions` shape, so an
+    // Anthropic-format fallback would always fail at call time — treat it as
+    // "no assistant available" instead.
+    if cfg.api_format != ApiFormat::OpenAI {
+        tracing::warn!(
+            "[AskLLM] only an Anthropic-format provider is configured; Ask assistant is \
+             unavailable (needs an OpenAI-compatible provider such as Cerebras/OpenRouter/Groq)"
+        );
+        return None;
+    }
+    // The fallback provider serves its own model namespace, so we can't honor a
+    // Cerebras-specific override here — surface that rather than silently dropping it.
+    if let Some(model) = explicit_model {
+        if model != cfg.model {
+            tracing::warn!(
+                "[AskLLM] ignoring assistant model override '{}' — Cerebras unavailable; using \
+                 fallback provider's model '{}'",
+                model,
+                cfg.model
+            );
+        }
+    }
+    Some(cfg)
 }
 
 async fn try_build_config_from_providers(

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -268,37 +268,94 @@ pub async fn refresh_metadata_llm_config(ai_providers: &crate::ai_providers::AIP
     client.set_config(config).await;
 }
 
+/// Resolve the API key/token for a provider: use the stored key first, then
+/// OAuth credentials from disk, then the provider type's env var.
+pub(crate) fn resolve_provider_api_key(
+    provider: &crate::ai_providers::AIProvider,
+) -> Option<String> {
+    if let Some(ref key) = provider.api_key {
+        return Some(key.clone());
+    }
+    // Check OAuth credentials from disk (source of truth, updated by background
+    // refresh). The store's oauth.access_token can be stale.
+    if let Some(entry) = crate::api::ai_providers::read_oauth_token_entry(provider.provider_type) {
+        if !entry.access_token.is_empty()
+            && !crate::api::ai_providers::oauth_token_expired(entry.expires_at)
+        {
+            return Some(entry.access_token);
+        }
+    }
+    if let Some(env_var) = provider.provider_type.env_var_name() {
+        if let Ok(key) = std::env::var(env_var) {
+            if !key.trim().is_empty() {
+                return Some(key);
+            }
+        }
+    }
+    None
+}
+
+/// Build the config for the **Assistant** role (the Ask sidecar). Prefers a
+/// fast, smart, large-context model: Cerebras `gpt-oss-120b` by default
+/// (overridable via `ASK_ASSISTANT_MODEL`). Falls back to the metadata provider
+/// ladder so Ask still works with whatever provider is configured. The Ask
+/// client derives `reasoning_effort` from the model name itself, so this stays
+/// independent of the metadata config's reasoning fields.
+pub async fn build_assistant_llm_config(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+) -> Option<MetadataLlmConfig> {
+    use crate::ai_providers::ProviderType;
+
+    let assistant_model =
+        std::env::var("ASK_ASSISTANT_MODEL").unwrap_or_else(|_| "gpt-oss-120b".to_string());
+
+    // Prefer Cerebras (fast + large context) for the assistant role.
+    if let Some(provider) = ai_providers.get_by_type(ProviderType::Cerebras).await {
+        if let Some(api_key) = resolve_provider_api_key(&provider) {
+            tracing::info!(
+                "[AskLLM] Using Cerebras assistant model {}",
+                assistant_model
+            );
+            return Some(MetadataLlmConfig {
+                base_url: provider
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.cerebras.ai/v1".to_string()),
+                api_key,
+                model: assistant_model,
+                api_format: ApiFormat::OpenAI,
+            });
+        }
+    }
+    // Env-only Cerebras key (provider not in the store).
+    if let Ok(api_key) = std::env::var("CEREBRAS_API_KEY") {
+        if !api_key.trim().is_empty() {
+            tracing::info!(
+                "[AskLLM] Using Cerebras (env) assistant model {}",
+                assistant_model
+            );
+            return Some(MetadataLlmConfig {
+                base_url: "https://api.cerebras.ai/v1".to_string(),
+                api_key,
+                model: assistant_model,
+                api_format: ApiFormat::OpenAI,
+            });
+        }
+    }
+
+    // Fallback: reuse the metadata ladder so Ask works with any provider.
+    tracing::info!("[AskLLM] Cerebras unavailable; falling back to metadata provider ladder");
+    try_build_config_from_providers(ai_providers).await
+}
+
 async fn try_build_config_from_providers(
     ai_providers: &crate::ai_providers::AIProviderStore,
 ) -> Option<MetadataLlmConfig> {
     use crate::ai_providers::ProviderType;
 
-    /// Resolve the API key/token for a provider: use the stored key first,
-    /// then OAuth credentials from disk, then the provider type's env var.
-    fn resolve_api_key(provider: &crate::ai_providers::AIProvider) -> Option<String> {
-        if let Some(ref key) = provider.api_key {
-            return Some(key.clone());
-        }
-        // Check OAuth credentials from disk (source of truth, updated by
-        // background refresh). The store's oauth.access_token can be stale.
-        if let Some(entry) =
-            crate::api::ai_providers::read_oauth_token_entry(provider.provider_type)
-        {
-            if !entry.access_token.is_empty()
-                && !crate::api::ai_providers::oauth_token_expired(entry.expires_at)
-            {
-                return Some(entry.access_token);
-            }
-        }
-        if let Some(env_var) = provider.provider_type.env_var_name() {
-            if let Ok(key) = std::env::var(env_var) {
-                if !key.trim().is_empty() {
-                    return Some(key);
-                }
-            }
-        }
-        None
-    }
+    // Use the lifted resolver under the original local name so the call sites
+    // below stay unchanged.
+    let resolve_api_key = resolve_provider_api_key;
 
     // Provider candidates in priority order (cheapest/fastest first).
     // Each entry: (provider_type, default_base_url, model, api_format)

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -350,6 +350,9 @@ pub async fn build_assistant_llm_config(
                 api_key,
                 model: assistant_model,
                 api_format: ApiFormat::OpenAI,
+                // AskClient derives reasoning_effort from the model name itself,
+                // so the assistant config leaves this unset.
+                reasoning_effort: None,
             });
         }
     }
@@ -365,6 +368,9 @@ pub async fn build_assistant_llm_config(
                 api_key,
                 model: assistant_model,
                 api_format: ApiFormat::OpenAI,
+                // AskClient derives reasoning_effort from the model name itself,
+                // so the assistant config leaves this unset.
+                reasoning_effort: None,
             });
         }
     }

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2863,6 +2863,25 @@ async fn run_mission_turn(
     boss_user_id: Option<String>,
 ) -> AgentResult {
     let mut config = config;
+    // Operator-note bridge: flush any pending Ask-assistant writes into this
+    // turn's message so the working agent learns about out-of-band edits it
+    // didn't make. Passive by construction — this only runs because a turn is
+    // already executing, so it can never wake an idle agent. Delivery is
+    // harness-agnostic (every backend receives `user_message` as a string); the
+    // note also becomes part of the logged turn, giving an inherent audit trail.
+    let mut user_message = user_message;
+    if let Ok(ask_store) = crate::api::ask::ask_store(&config).await {
+        let (msg, flushed) =
+            crate::api::ask::prepend_pending_operator_notes(&ask_store, mission_id, user_message)
+                .await;
+        user_message = msg;
+        if flushed > 0 {
+            tracing::info!(
+                mission_id = %mission_id,
+                "[Ask] flushed {flushed} operator note(s) into working-agent turn"
+            );
+        }
+    }
     let effective_agent = agent_override.clone();
     if let Some(ref agent) = effective_agent {
         config.opencode_agent = Some(agent.clone());

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,6 +16,7 @@
 //! - `POST /api/tools/{name}/toggle` - Enable/disable a tool
 
 pub mod ai_providers;
+pub mod ask;
 mod auth;
 pub mod automation_variables;
 pub mod backends;

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -722,6 +722,20 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             "/api/control/missions/:id/parallel",
             post(control::start_mission_parallel),
         )
+        // Ask assistant (non-interrupting sidecar co-pilot)
+        .route(
+            "/api/control/missions/:id/ask",
+            post(crate::api::ask::http::ask_send),
+        )
+        .route(
+            "/api/control/missions/:id/ask/threads",
+            get(crate::api::ask::http::list_ask_threads),
+        )
+        .route(
+            "/api/control/missions/:id/ask/threads/:tid",
+            get(crate::api::ask::http::get_ask_thread)
+                .delete(crate::api::ask::http::delete_ask_thread),
+        )
         .route(
             "/api/control/missions/:id",
             axum::routing::delete(control::delete_mission),

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -37,6 +37,7 @@ pub struct SettingsResponse {
     pub max_concurrent_tasks: Option<usize>,
     pub auto_cleanup_enabled: Option<bool>,
     pub auto_cleanup_days: Option<u32>,
+    pub ask_assistant_model: Option<String>,
 }
 
 impl From<Settings> for SettingsResponse {
@@ -48,6 +49,7 @@ impl From<Settings> for SettingsResponse {
             max_concurrent_tasks: settings.max_concurrent_tasks,
             auto_cleanup_enabled: settings.auto_cleanup_enabled,
             auto_cleanup_days: settings.auto_cleanup_days,
+            ask_assistant_model: settings.ask_assistant_model,
         }
     }
 }
@@ -67,6 +69,9 @@ pub struct UpdateSettingsRequest {
     pub auto_cleanup_enabled: Option<bool>,
     #[serde(default)]
     pub auto_cleanup_days: Option<u32>,
+    /// Double-Option so a present `null` clears it (back to env/default).
+    #[serde(default)]
+    pub ask_assistant_model: Option<Option<String>>,
 }
 
 /// Request to update library remote specifically.
@@ -140,6 +145,10 @@ async fn update_settings(
             ));
         }
         new_settings.auto_cleanup_days = Some(value);
+    }
+    if let Some(value) = req.ask_assistant_model {
+        // Normalize empty string to None (fall back to env/default).
+        new_settings.ask_assistant_model = value.filter(|s| !s.trim().is_empty());
     }
 
     state

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -59,6 +59,11 @@ pub struct Settings {
     /// older than this becomes eligible for GC. When None, defaults to 7.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_cleanup_days: Option<u32>,
+    /// Model for the Ask assistant (sidecar co-pilot). When None, falls back to
+    /// the `ASK_ASSISTANT_MODEL` env var, then the built-in default
+    /// (`gpt-oss-120b`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ask_assistant_model: Option<String>,
 }
 
 /// In-memory store for global settings with disk persistence.
@@ -129,6 +134,7 @@ impl SettingsStore {
             max_concurrent_tasks,
             auto_cleanup_enabled: None,
             auto_cleanup_days: None,
+            ask_assistant_model: std::env::var("ASK_ASSISTANT_MODEL").ok(),
         }
     }
 


### PR DESCRIPTION
## Ask Assistant — non-interrupting sidecar co-pilot for missions

A fast, read-mostly **co-pilot** that rides alongside a running mission. You can chat about what the agent is doing, why, and inspect the live workspace — **without ever interrupting the working agent** (separate lane: no harness lock, no message queue, never written into the agent's prompt). Powered by Cerebras `gpt-oss-120b` by default.

Full design: `ASK_ASSISTANT_DESIGN.md`.

### What's included

**M1 — Backend core** (`src/api/ask/`)
- `AskStore` — separate `ask.db` (threads / messages / operator_notes), never merged into `mission_events`
- Tool-calling `AskClient` + `run_ask_turn` agentic loop with **full bash** + `read_history` + `read_file`
- `build_assistant_llm_config` — Cerebras `gpt-oss-120b` default, `ASK_ASSISTANT_MODEL` override (derives `reasoning_effort` from the model name, so this is independent of #489)
- Routes: `POST /api/control/missions/:id/ask`, `GET/DELETE .../ask/threads[/:tid]`
- **Verified live on dev**: real curl → the model read mission context, called `bash` (`pwd`), answered in ~700ms; thread list + continuity work; **0 Ask content leaked into the mission event stream**

**M2 — Operator-note bridge**
- The Ask `bash` tool does a `git status` before/after diff and enqueues a note on any write
- `run_mission_turn` flushes pending notes as a `<operator-note>` block into the working agent's **next** message (one injection point covers all backends). Passive — it only rides an already-running turn, so it can never wake an idle agent.

**M3 — Web Ask panel** (`dashboard/`)
- `AskPanel` right-side drawer with a sky "co-pilot" identity, thread switcher, tool-call rendering, composer, new/clear, and a "Send to agent" bridge
- `lib/api.ts` client functions; "Ask" header button beside Workbench
- `tsc` + `eslint` clean

**M4 — iOS** (`ios_dashboard/`)
- `AskSheet` bottom sheet (medium/large detents), thread menu, cyan co-pilot bubbles, tool-call rendering, composer, Send-to-agent
- `APIService` methods + `Ask.swift` models (registered in the Xcode project)
- `xcodebuild` **BUILD SUCCEEDED**

### Verification
- `cargo build` clean; `cargo test --lib ask::` green (storage + bridge unit tests)
- Backend verified end-to-end on the dev deployment
- Dashboard: type-check + lint clean
- iOS: builds in Xcode

### Notes
- Branch is based on `master` (decoupled from #489).
- **Not yet done (M5 / follow-ups):** SSE token streaming, Settings assistant-model picker, "ask about this" per-item spark, thread auto-titling, non-git write detection, Android client.
- Operator-note write-detection only fires in **git** workspaces (non-git fallback is M5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Ask runs full read/write bash in the live workspace (with optional sandbox); operator notes mutate the working agent's next user message, so incorrect write detection or note content could mislead an in-flight mission.
> 
> **Overview**
> Introduces a **non-interrupting Ask co-pilot** on its own lane: mission-scoped HTTP APIs, a dedicated `ask.db` for threads/messages, and an in-process tool-calling loop (`bash`, `read_history`, `read_file`) that never acquires the harness lock or enqueues mission messages.
> 
> **Backend:** `build_assistant_llm_config` (Cerebras default, Settings/`ASK_ASSISTANT_MODEL` override), optional **git worktree sandbox** for isolated Ask writes, write detection (git porcelain + non-git mtime fallback) that enqueues **operator notes**, and **`prepend_pending_operator_notes`** in `run_mission_turn` so the working agent gets a passive `<operator-note>` block on its next turn only.
> 
> **Web:** Sky-themed **`AskPanel`** (threads, composer, sandbox toggle, Send to agent), header **Ask** toggle and **⌘/** shortcut, per-message **spark** to seed the panel, **`controlAskStore`**, and Data settings field for the assistant model.
> 
> **iOS:** **`AskSheet`** with the same API surface, extended **`APIService`** (long-timeout session for synchronous Ask turns), and Xcode project wiring.
> 
> Also adds **`ASK_ASSISTANT_DESIGN.md`** and exposes **`control_for_user`** to Ask HTTP handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6830d518bd84814084157859f7f81f1ccd0e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->