### PR TITLE
providers: add Claude Sonnet 4.6 to model catalog + pricing

### DIFF
--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -557,6 +557,13 @@ fn default_providers_config() -> ProvidersConfig {
                         ),
                     },
                     ProviderModel {
+                        id: "claude-sonnet-4-6".to_string(),
+                        name: "Claude Sonnet 4.6".to_string(),
+                        description: Some(
+                            "Latest Sonnet, balanced speed and capability".to_string(),
+                        ),
+                    },
+                    ProviderModel {
                         id: "claude-sonnet-4-5-20250929".to_string(),
                         name: "Claude Sonnet 4.5".to_string(),
                         description: Some("Balanced speed and capability".to_string()),

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -57,6 +57,11 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(1_000, 5_000, Some(1_250), Some(100)),
     },
     PricingEntry {
+        canonical: "claude-sonnet-4-6",
+        aliases: &["claude-sonnet-4-6", "claude-4-6-sonnet"],
+        pricing: pricing(3_000, 15_000, Some(3_750), Some(300)),
+    },
+    PricingEntry {
         canonical: "claude-sonnet-4-5",
         aliases: &["claude-sonnet-4-5", "claude-4-5-sonnet"],
         pricing: pricing(3_000, 15_000, Some(3_750), Some(300)),


### PR DESCRIPTION
## Problem

Claude Sonnet 4.6 (the latest Sonnet) was missing from the model-routing UI and from every other model picker.

The model-routing page populates its dropdowns from `GET /api/providers?include_all=true`, which returns the **hardcoded default catalog** in `src/api/providers.rs` → `default_providers_config()`, merged with a *dynamic* catalog that's only fetched when an Anthropic **API key** is configured. Claude Max / OAuth subscription accounts have no API key, so they fall back entirely to the hardcoded list — which had Opus 4.8/4.7/4.6/4.5, Sonnet 5, Sonnet 4.5, and Sonnet 4, but **no `claude-sonnet-4-6`**.

## Changes

- **`src/api/providers.rs`** — add `claude-sonnet-4-6` ("Claude Sonnet 4.6") to the Anthropic default model list, as the newest Sonnet (above Sonnet 4.5). This is what makes it appear in the routing UI and other pickers.
- **`src/cost.rs`** — add a matching pricing entry (`claude-sonnet-4-6`, same Sonnet rates: $3 / $15 per 1M in/out, with cache pricing). Without it, cost tracking returns `None` and mis-prices Sonnet 4.6 runs.

## Keeping it current

The hardcoded list in `default_providers_config()` is the single source of truth for subscription/OAuth accounts. When a new Claude model ships it needs two edits to be fully wired: the `ProviderModel` in `src/api/providers.rs` and the `PricingEntry` in `src/cost.rs`. API-key accounts pick up new models automatically via `fetch_anthropic_models`.

## Validation

`cargo fmt --all` + `cargo check --lib` pass.