### PR TITLE
missions: optional per-mission memory cap via systemd scope (env-gated)

### DIFF
--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -69,6 +69,22 @@ fn environ_has_keepalive_marker(environ: &[u8]) -> bool {
         .any(|entry| entry == expected.as_bytes())
 }
 
+/// Build a valid transient systemd scope unit name for a mission container.
+/// systemd unit names allow `[A-Za-z0-9:._-]`; replace anything else with `_`.
+fn mission_scope_unit(machine_name: &str) -> String {
+    let sanitized: String = machine_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, ':' | '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("sandboxed-mission-{sanitized}.scope")
+}
+
 fn select_container_resolv_conf() -> Option<PathBuf> {
     let default_path = PathBuf::from("/etc/resolv.conf");
     let content = fs::read_to_string(&default_path).ok()?;
@@ -601,7 +617,36 @@ impl WorkspaceExec {
             .filter(|name| !name.trim().is_empty())
             .context("Container workspace has no machine name")?;
 
-        let mut cmd = Command::new("systemd-nspawn");
+        // Per-mission isolation (Layer 1). When `MISSION_MEMORY_MAX` is set,
+        // boot the container inside its own transient systemd scope with a
+        // memory cap so one mission's runaway build (e.g. a 46G Lean
+        // compilation) can't starve the host or the API process, and so
+        // `systemctl stop <scope>` reliably kills the whole build tree on
+        // cancel/teardown. Unset (default) = unchanged direct nspawn boot, so
+        // shipping this binary is a no-op until the env is enabled (dev first).
+        let mission_mem_max = std::env::var("MISSION_MEMORY_MAX")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let mission_mem_high = std::env::var("MISSION_MEMORY_HIGH")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let mut cmd = if let Some(mem_max) = &mission_mem_max {
+            let scope_unit = mission_scope_unit(&name);
+            let mut c = Command::new("systemd-run");
+            c.arg("--scope")
+                .arg(format!("--unit={scope_unit}"))
+                .arg("--collect")
+                .arg(format!("--property=MemoryMax={mem_max}"));
+            if let Some(mem_high) = &mission_mem_high {
+                c.arg(format!("--property=MemoryHigh={mem_high}"));
+            }
+            // systemd-nspawn's own scope-creation is disabled below via
+            // --register=no/--keep-unit, so it joins this scope's cgroup.
+            c.arg("systemd-nspawn");
+            c
+        } else {
+            Command::new("systemd-nspawn")
+        };
         cmd.arg("-D").arg(root);
         cmd.arg(format!("--machine={}", name));
         cmd.arg("--quiet");


### PR DESCRIPTION
## Problem
Mission containers boot via `systemd-nspawn --register=no --keep-unit`, so they run **inside the service cgroup** with no per-mission memory limit. A single runaway build — e.g. a Lean compilation (`SegmentLayer3.lean`) that grew to ~46 GB — repeatedly filled host RAM + 31 GB of swap and took the prod backend unresponsive (3× in one day). The `max_parallel_missions` cap doesn't help a *single* heavyweight mission, and interrupting the mission doesn't kill the detached `lake`/`lean` build tree.

## Change
When `MISSION_MEMORY_MAX` is set, boot each mission's container inside its **own transient systemd scope** with `MemoryHigh`/`MemoryMax`:
- one mission can no longer starve the host or the API process (cgroup-OOMs just the runaway);
- `systemctl stop <scope>` reliably kills the whole build tree.

**Env-gated and opt-in:** unset (default) → unchanged direct `nspawn` boot, so deploying this binary is a **no-op until the env is enabled**. Configure with `MISSION_MEMORY_MAX` (+ optional `MISSION_MEMORY_HIGH`), e.g. `MemoryMax=16G`, `MemoryHigh=12G`.

## Status / follow-ups
- **Enable on dev first** (`sandboxed-sh-dev`) and validate the scope + cgroup cap + `systemctl stop` kill before enabling on prod.
- Follow-up (separate): wire mission cancel/interrupt to stop the scope, and bound Lean directly (`lake -j1` / `LEAN_NUM_THREADS`).

See incident context in the OOM notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how mission containers are spawned under systemd and applies cgroup memory limits when enabled; misconfigured limits or scope naming could affect mission boot or OOM behavior, though the env gate limits blast radius until explicitly turned on.
> 
> **Overview**
> Adds **opt-in per-mission memory isolation** when `MISSION_MEMORY_MAX` is set: persistent mission containers boot via `systemd-run --scope` (with optional `MISSION_MEMORY_HIGH`) instead of invoking `systemd-nspawn` directly, applying cgroup `MemoryMax`/`MemoryHigh` and `--collect` on a per-mission transient scope.
> 
> A new **`mission_scope_unit`** helper derives a valid scope name (`sandboxed-mission-{sanitized}.scope`) from the machine name. Existing **`--register=no` / `--keep-unit`** nspawn flags are unchanged so the container joins that scope’s cgroup rather than the service cgroup.
> 
> **Default behavior is unchanged** when the env vars are unset, so deploys stay a no-op until ops enable the cap (e.g. on dev first).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a324ee17eda91f8933bad012e83a29ced63091aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->