### PR TITLE
monitoring: memory-health endpoint (host pressure + top consumers)

### DIFF
--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -18,6 +18,7 @@ use axum::{
     },
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
+    Json,
 };
 use futures::{FutureExt, SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -125,6 +126,15 @@ impl MemoryHealthLevel {
     }
 }
 
+/// Percentage of `used` over `total` (0 when `total` is 0).
+fn pct(used: u64, total: u64) -> f32 {
+    if total > 0 {
+        (used as f64 / total as f64 * 100.0) as f32
+    } else {
+        0.0
+    }
+}
+
 /// Container metrics update sent over WebSocket
 #[derive(Debug, Clone, Serialize)]
 struct ContainerMetricsMessage {
@@ -193,6 +203,52 @@ impl MonitoringState {
     pub async fn set_workspaces(&self, ws: SharedWorkspaceStore) {
         let mut guard = self.workspaces.write().await;
         *guard = Some(ws);
+    }
+
+    /// Snapshot of host memory pressure + the top memory-consuming container
+    /// workspaces. Backs the in-app memory-pressure banner and (later) mission
+    /// admission control. Host figures come from a fresh `sysinfo` read; the
+    /// per-container figures reuse the latest sample the background collector
+    /// already keeps, so this is cheap to call on a poll.
+    pub async fn memory_health(&self) -> MemoryHealth {
+        let mut sys = System::new();
+        sys.refresh_memory();
+        let memory_total = sys.total_memory();
+        let memory_used = sys.used_memory();
+        let swap_total = sys.total_swap();
+        let swap_used = sys.used_swap();
+        let memory_percent = pct(memory_used, memory_total);
+        let swap_percent = pct(swap_used, swap_total);
+
+        let mut top_consumers: Vec<MemoryConsumer> = {
+            let ch = self.container_history.read().await;
+            ch.values()
+                .filter_map(|h| h.back())
+                .map(|cm| MemoryConsumer {
+                    workspace_id: cm.workspace_id.clone(),
+                    workspace_name: cm.workspace_name.clone(),
+                    memory_used: cm.memory_used,
+                    memory_percent: cm.memory_percent,
+                })
+                .collect()
+        };
+        top_consumers.sort_by_key(|c| std::cmp::Reverse(c.memory_used));
+        top_consumers.truncate(5);
+
+        MemoryHealth {
+            level: MemoryHealthLevel::from_usage(memory_percent, swap_percent),
+            memory_used,
+            memory_total,
+            memory_percent,
+            swap_used,
+            swap_total,
+            swap_percent,
+            top_consumers,
+            timestamp_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        }
     }
 
     /// Background task that continuously collects metrics
@@ -497,6 +553,14 @@ static MONITORING_STATE: std::sync::OnceLock<Arc<MonitoringState>> = std::sync::
 
 fn get_monitoring_state() -> Arc<MonitoringState> {
     MONITORING_STATE.get_or_init(MonitoringState::new).clone()
+}
+
+/// `GET /api/monitoring/memory-health` — current host memory pressure level
+/// (ok / warn / critical) plus the top container memory consumers, for the
+/// in-app memory-pressure banner. Auth is enforced by the protected-routes
+/// middleware.
+pub async fn memory_health_handler() -> Json<MemoryHealth> {
+    Json(get_monitoring_state().memory_health().await)
 }
 
 /// Initialize the monitoring background collector at server startup.

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -70,6 +70,61 @@ pub struct ContainerMetrics {
     pub memory_percent: f64,
 }
 
+/// Severity of host memory pressure, used by the dashboard banner and by
+/// mission admission control. Thresholds: warn at >=80% RAM (or >=20% swap),
+/// critical at >=90% RAM (or >=50% swap).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryHealthLevel {
+    Ok,
+    Warn,
+    Critical,
+}
+
+/// A single workspace/mission's memory footprint, for "who's the culprit"
+/// diagnostics in the warning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryConsumer {
+    pub workspace_id: String,
+    pub workspace_name: String,
+    pub memory_used: u64,
+    pub memory_percent: f64,
+}
+
+/// Host memory-health snapshot: overall level + top consuming workspaces.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryHealth {
+    pub level: MemoryHealthLevel,
+    pub memory_used: u64,
+    pub memory_total: u64,
+    pub memory_percent: f32,
+    pub swap_used: u64,
+    pub swap_total: u64,
+    pub swap_percent: f32,
+    /// Top memory-consuming container workspaces, largest first (max 5).
+    pub top_consumers: Vec<MemoryConsumer>,
+    pub timestamp_ms: u64,
+}
+
+/// Warn when RAM or swap usage reaches these percentages.
+const MEM_WARN_PCT: f32 = 80.0;
+const SWAP_WARN_PCT: f32 = 20.0;
+/// Escalate to critical at these percentages.
+const MEM_CRITICAL_PCT: f32 = 90.0;
+const SWAP_CRITICAL_PCT: f32 = 50.0;
+
+impl MemoryHealthLevel {
+    fn from_usage(memory_percent: f32, swap_percent: f32) -> Self {
+        if memory_percent >= MEM_CRITICAL_PCT || swap_percent >= SWAP_CRITICAL_PCT {
+            MemoryHealthLevel::Critical
+        } else if memory_percent >= MEM_WARN_PCT || swap_percent >= SWAP_WARN_PCT {
+            MemoryHealthLevel::Warn
+        } else {
+            MemoryHealthLevel::Ok
+        }
+    }
+}
+
 /// Container metrics update sent over WebSocket
 #[derive(Debug, Clone, Serialize)]
 struct ContainerMetricsMessage {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -998,6 +998,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             "/api/providers/catalog",
             get(super::providers::list_full_model_catalog),
         )
+        .route(
+            "/api/monitoring/memory-health",
+            get(super::monitoring::memory_health_handler),
+        )
         // Library management endpoints
         .nest("/api/library", library_api::routes())
         // Workspace management endpoints


### PR DESCRIPTION
Backend for an in-app **memory-pressure** signal (banner + future admission guard), so the recurring host-OOM is visible and preventable. Pairs with the per-mission memory cap (`MISSION_MEMORY_MAX`, merged in #495).

## This PR
- `MemoryHealthLevel` (`ok`/`warn`/`critical`), `MemoryConsumer`, `MemoryHealth`.
- Thresholds: **warn** ≥80% RAM or ≥20% swap; **critical** ≥90% RAM or ≥50% swap.
- `MonitoringState::memory_health()` — host RAM/swap via a fresh `sysinfo` read + the **top container consumers** from the collector's latest per-container sample (cheap to poll).
- Auth-gated **`GET /api/monitoring/memory-health`** returning the snapshot.
- `cargo check` / `clippy -D warnings` / `fmt` clean.

## Follow-ups (separate PRs)
- Dashboard: global warning banner (warn/critical) + top-consumer list with Pause/Stop.
- Mission **admission guard**: refuse to start/resume missions when critical.

Rebased on current `master`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only monitoring endpoint on existing collector data; no mission start/stop or cgroup policy changes in this PR.
> 
> **Overview**
> Adds a **poll-friendly host memory-health snapshot** for the dashboard banner and future mission admission checks.
> 
> **New API surface:** authenticated **`GET /api/monitoring/memory-health`** returns **`MemoryHealth`**: RAM/swap usage, a **`MemoryHealthLevel`** (`ok` / `warn` / `critical`), and up to five **top container workspaces** by memory (from the monitoring collector’s latest per-container samples). Host RAM/swap comes from a fresh **`sysinfo`** read; container rankings reuse existing **`container_history`** so polling stays cheap.
> 
> **Classification rules:** **warn** at ≥80% RAM or ≥20% swap; **critical** at ≥90% RAM or ≥50% swap. Shared types include **`MemoryConsumer`** for “who’s using memory” diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1456585db84bb32bbaadf3ee657a8f4b253e716d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->