### PR TITLE
codex: capture real reasoning summaries so thoughts persist and replay

### DIFF
--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -147,50 +147,30 @@ fn resolve_model(session_model: Option<&str>, default_model: Option<&str>) -> Op
         .or_else(|| default_model.map(|s| s.to_string()))
 }
 
-/// How a codex `delta` field should be combined with prior content of
-/// the same item.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DeltaSemantics {
-    /// Each delta is a new token to append (`item/agentMessage/delta`,
-    /// `item/reasoning/textDelta`). In practice, some app-server builds
-    /// occasionally send full snapshots through these methods, so the fold
-    /// still treats prefix-extension payloads as replacement snapshots.
-    Incremental,
-    /// Each delta is the full text-so-far. Atomic replacement
-    /// (`item/reasoning/summaryTextDelta` — observed empirically on prod
-    /// after the snowball regression). New streams (where the delta
-    /// doesn't extend the buffer) replace it too — codex sometimes
-    /// resets the summary draft mid-item without firing item/completed.
-    CumulativeSnapshot,
-}
-
-/// Fold a codex delta into a per-item buffer with explicit semantics.
+/// Fold a codex delta into a per-item buffer.
 ///
-/// `Incremental` appends true token deltas, but treats prefix-extension
-/// payloads as snapshots because some app-server builds send full text-so-far
-/// through delta-shaped events. `CumulativeSnapshot` replaces the buffer even
-/// when the new snapshot doesn't extend the prior one, because codex's summary
-/// stream can restart mid-item. The earlier prod bug ("The saved goalThe saved
-/// goal is active…" 36×) was our heuristic-only fold appending a fresh-start
-/// summary on top of the stable reasoning text.
-fn fold_delta_into(buffer: &mut String, delta: &str, semantics: DeltaSemantics) {
-    match semantics {
-        DeltaSemantics::Incremental => {
-            if !buffer.is_empty() && delta.starts_with(buffer.as_str()) {
-                buffer.clear();
-                buffer.push_str(delta);
-            } else if !buffer.starts_with(delta) {
-                buffer.push_str(delta);
-            }
-        }
-        DeltaSemantics::CumulativeSnapshot => {
-            // Drop pure echoes (delta is an earlier substring of the buffer).
-            if !buffer.is_empty() && buffer.starts_with(delta) && buffer.len() > delta.len() {
-                return;
-            }
-            buffer.clear();
-            buffer.push_str(delta);
-        }
+/// All codex `*/delta` notifications (`item/agentMessage/delta`,
+/// `item/reasoning/textDelta`, `item/reasoning/summaryTextDelta`) carry
+/// incremental token deltas on current CLI builds (verified on 0.128.0:
+/// a ~500-char summary arrives as ~94 token-sized deltas). Append by
+/// default, but absorb two snapshot-shaped payloads some builds emit
+/// through the same methods:
+/// - prefix-extension (delta starts with the buffer) → replace, so a full
+///   text-so-far resend doesn't duplicate;
+/// - echo (buffer starts with the delta) → drop, so a shorter resend
+///   doesn't shrink or duplicate.
+///
+/// `summaryTextDelta` was previously treated as a cumulative snapshot
+/// (wholesale replacement per delta). On 0.128.0 that collapsed every
+/// reasoning summary to whichever single token chunk was longest — the
+/// Thoughts panel showed/stored 35-char fragments (mission 2e8af5f7,
+/// 87 identical truncated thinking events).
+fn fold_delta_into(buffer: &mut String, delta: &str) {
+    if !buffer.is_empty() && delta.starts_with(buffer.as_str()) {
+        buffer.clear();
+        buffer.push_str(delta);
+    } else if !buffer.starts_with(delta) {
+        buffer.push_str(delta);
     }
 }
 
@@ -685,7 +665,7 @@ impl AppServerEventTranslator {
                         .to_string();
                     let entry = self.delta_buffers.entry(item_id).or_default();
                     // Agent-message deltas are incremental tokens.
-                    fold_delta_into(entry, delta, DeltaSemantics::Incremental);
+                    fold_delta_into(entry, delta);
                     events.push(ExecutionEvent::TextDelta {
                         content: entry.clone(),
                     });
@@ -698,20 +678,20 @@ impl AppServerEventTranslator {
                         .and_then(|v| v.as_str())
                         .unwrap_or("__anon_reasoning")
                         .to_string();
-                    // The two reasoning sub-streams have different
-                    // semantics, observed empirically (PR #403 prod
-                    // smoke): `textDelta` is incremental,
-                    // `summaryTextDelta` is cumulative snapshot. They
-                    // get separate buffer keys to avoid one stream
-                    // contaminating the other.
-                    let (kind, semantics) = if method == "item/reasoning/summaryTextDelta" {
-                        ("summary", DeltaSemantics::CumulativeSnapshot)
+                    // Both reasoning sub-streams carry incremental token
+                    // deltas on current CLI builds (0.128.0 verified for
+                    // `summaryTextDelta`; treating it as a cumulative
+                    // snapshot collapsed summaries to single token chunks).
+                    // They keep separate buffer keys so one stream can't
+                    // contaminate the other.
+                    let kind = if method == "item/reasoning/summaryTextDelta" {
+                        "summary"
                     } else {
-                        ("reasoning", DeltaSemantics::Incremental)
+                        "reasoning"
                     };
                     let key = format!("{}:{}", kind, item_id);
                     let entry = self.delta_buffers.entry(key.clone()).or_default();
-                    fold_delta_into(entry, delta, semantics);
+                    fold_delta_into(entry, delta);
                     events.push(ExecutionEvent::Thinking {
                         content: entry.clone(),
                         item_id: Some(key),
@@ -1011,14 +991,16 @@ mod tests {
     fn fold_delta_appends_incremental_tokens() {
         let mut buf = String::new();
         for tok in ["P", "O", "N", "G"] {
-            fold_delta_into(&mut buf, tok, DeltaSemantics::Incremental);
+            fold_delta_into(&mut buf, tok);
         }
         assert_eq!(buf, "PONG");
     }
 
     #[test]
     fn fold_delta_replaces_cumulative_snapshots() {
-        // Snapshot stream extending normally.
+        // Snapshot-shaped stream (each payload extends the previous one)
+        // must replace, not append — older app-server builds send full
+        // text-so-far through delta methods.
         let mut buf = String::new();
         for snapshot in [
             "The",
@@ -1026,64 +1008,56 @@ mod tests {
             "The targeted Lean",
             "The targeted Lean module",
         ] {
-            fold_delta_into(&mut buf, snapshot, DeltaSemantics::CumulativeSnapshot);
+            fold_delta_into(&mut buf, snapshot);
         }
         assert_eq!(buf, "The targeted Lean module");
     }
 
     #[test]
-    fn fold_delta_cumulative_handles_stream_restart() {
-        // Codex sometimes restarts a summary draft mid-item: the
-        // existing buffer "Done with first draft." is followed by a
-        // fresh sequence beginning with "The". The new delta does NOT
-        // extend the buffer, but cumulative-snapshot semantics replace
-        // wholesale anyway — this is the regression that produced the
-        // 36x snowball "The saved goalThe saved goal isThe saved goal
-        // is active…" on prod.
-        let mut buf = String::from("Done with first draft.");
-        fold_delta_into(&mut buf, "The", DeltaSemantics::CumulativeSnapshot);
-        assert_eq!(buf, "The");
-    }
-
-    #[test]
-    fn fold_delta_cumulative_drops_echo() {
-        // Pure echo of an earlier substring should not shrink the buffer.
+    fn fold_delta_drops_echo() {
+        // Pure echo of an earlier prefix should not shrink the buffer.
         let mut buf = String::from("The targeted Lean");
-        fold_delta_into(&mut buf, "The targeted", DeltaSemantics::CumulativeSnapshot);
+        fold_delta_into(&mut buf, "The targeted");
         assert_eq!(buf, "The targeted Lean");
     }
 
     #[test]
     fn fold_delta_idempotent_on_repeated_snapshot() {
         let mut buf = String::new();
-        fold_delta_into(&mut buf, "stable", DeltaSemantics::CumulativeSnapshot);
-        fold_delta_into(&mut buf, "stable", DeltaSemantics::CumulativeSnapshot);
+        fold_delta_into(&mut buf, "stable");
+        fold_delta_into(&mut buf, "stable");
         assert_eq!(buf, "stable");
     }
 
     #[test]
-    fn incremental_fold_accepts_cumulative_snapshots_without_snowballing() {
+    fn fold_delta_accumulates_summary_token_deltas() {
+        // Regression for the truncated-thoughts bug (mission 2e8af5f7):
+        // `item/reasoning/summaryTextDelta` on CLI 0.128.0 streams token
+        // deltas; cumulative-snapshot replacement collapsed the summary to
+        // its longest single chunk. Token deltas must accumulate.
         let mut buf = String::new();
-        fold_delta_into(&mut buf, "The fix makes", DeltaSemantics::Incremental);
-        fold_delta_into(
-            &mut buf,
-            "The fix makes a parity pack's fork count",
-            DeltaSemantics::Incremental,
+        for tok in [
+            "**Solving the riddle carefully**\n\nI",
+            "'m",
+            " working",
+            " through",
+            " the",
+            " sheep",
+            " puzzle.",
+        ] {
+            fold_delta_into(&mut buf, tok);
+        }
+        assert_eq!(
+            buf,
+            "**Solving the riddle carefully**\n\nI'm working through the sheep puzzle."
         );
-        fold_delta_into(
-            &mut buf,
-            "The fix makes a parity pack's fork count as selected.",
-            DeltaSemantics::Incremental,
-        );
-
-        assert_eq!(buf, "The fix makes a parity pack's fork count as selected.");
     }
 
     #[test]
-    fn incremental_fold_still_appends_true_token_deltas() {
+    fn fold_delta_still_appends_true_token_deltas() {
         let mut buf = String::new();
-        fold_delta_into(&mut buf, "Hello ", DeltaSemantics::Incremental);
-        fold_delta_into(&mut buf, "world", DeltaSemantics::Incremental);
+        fold_delta_into(&mut buf, "Hello ");
+        fold_delta_into(&mut buf, "world");
         assert_eq!(buf, "Hello world");
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1820,6 +1820,14 @@ async fn write_codex_config(
     }
 
     let config_payload = update_codex_mcp_config(&existing, &entries);
+    // Codex only streams reasoning summaries when the request asks for them.
+    // The CLI default (`model_reasoning_summary = "auto"`) yields zero
+    // summaries on ChatGPT-OAuth gpt-5.5 turns (verified 2026-06-04: 2770
+    // reasoning items across one day of rollouts, all `summary: []`), so no
+    // `item/reasoning/*` notifications stream, no Thinking events are
+    // emitted, and the Thoughts panel has nothing to persist or replay.
+    // Pin "detailed" unless the profile/operator already set a value.
+    let config_payload = ensure_codex_reasoning_summary(&config_payload);
     tokio::fs::write(&config_path, config_payload).await?;
 
     // Write skills to ~/.codex/skills using Codex's native skills format
@@ -1953,6 +1961,27 @@ fn codex_entry_from_mcp(
             })
         }
     }
+}
+
+/// Ensure the Codex config requests reasoning summaries. TOML top-level keys
+/// must precede the first `[section]`, so the key is prepended. A
+/// `model_reasoning_summary` already present in the top-level prelude (from a
+/// config profile or operator edit) wins — we only add the default when the
+/// key is absent.
+fn ensure_codex_reasoning_summary(config: &str) -> String {
+    let has_key = config
+        .lines()
+        .take_while(|line| !line.trim_start().starts_with('['))
+        .any(|line| {
+            line.split('=')
+                .next()
+                .map(|key| key.trim() == "model_reasoning_summary")
+                .unwrap_or(false)
+        });
+    if has_key {
+        return config.to_string();
+    }
+    format!("model_reasoning_summary = \"detailed\"\n\n{}", config)
 }
 
 fn update_codex_mcp_config(existing: &str, entries: &[CodexMcpEntry]) -> String {
@@ -4642,5 +4671,40 @@ mod tests {
         let result = update_codex_mcp_config("", &[]);
         assert!(!result.contains("[otel]"));
         assert!(!result.contains("[mcp_servers"));
+    }
+
+    #[test]
+    fn test_codex_reasoning_summary_added_before_sections() {
+        let config = "[mcp_servers.workspace]\ncommand = \"x\"\n";
+        let result = ensure_codex_reasoning_summary(config);
+        assert!(result.starts_with("model_reasoning_summary = \"detailed\"\n"));
+        // Top-level key must precede the first [section] header.
+        let key_pos = result.find("model_reasoning_summary").unwrap();
+        let section_pos = result.find('[').unwrap();
+        assert!(key_pos < section_pos);
+        assert!(result.contains("[mcp_servers.workspace]"));
+    }
+
+    #[test]
+    fn test_codex_reasoning_summary_respects_profile_override() {
+        let config =
+            "model_reasoning_summary = \"concise\"\n\n[mcp_servers.workspace]\ncommand = \"x\"\n";
+        let result = ensure_codex_reasoning_summary(config);
+        assert_eq!(result, config);
+        assert!(!result.contains("detailed"));
+    }
+
+    #[test]
+    fn test_codex_reasoning_summary_ignores_key_inside_sections() {
+        // A same-named key inside an MCP env table is not a top-level override.
+        let config = "[mcp_servers.workspace.env]\nmodel_reasoning_summary = \"none\"\n";
+        let result = ensure_codex_reasoning_summary(config);
+        assert!(result.starts_with("model_reasoning_summary = \"detailed\"\n"));
+    }
+
+    #[test]
+    fn test_codex_reasoning_summary_on_empty_config() {
+        let result = ensure_codex_reasoning_summary("");
+        assert!(result.starts_with("model_reasoning_summary = \"detailed\"\n"));
     }
 }


### PR DESCRIPTION
## Problem

On codex missions, "thoughts" appeared to stream live but were never stored — reloading a mission page showed no past thoughts (e.g. mission `3f05dc44`). DB audit: **zero `thinking` rows for every codex mission since 2026-05-28**.

## Analysis

The persistence pipeline (event logger → `mission_events` → `/events` endpoint → events-reducer → Thoughts panel) was intact end-to-end. The events simply never existed:

- What streamed live was the **answer draft** (`text_op`/`text_delta`) rendered in the Thoughts side panel as a stream row (see `docs/THOUGHT_STREAMING_BUG_REPORT.md` §6), which legitimately collapses into the assistant message on reload.
- The thinking rows older codex missions *did* have were **synthetic** (extracted from text deltas) and were intentionally removed in 8d76fb35 — real codex reasoning was never being captured.

Two root causes, both verified on the dev server:

1. **No reasoning summaries requested.** The generated `.codex/config.toml` never set `model_reasoning_summary`; the CLI default (`"auto"`) yields **zero** summaries on ChatGPT-OAuth gpt-5.5 turns — 2,770 reasoning items across one day of rollout JSONLs, all `summary: []` (encrypted content only). No summaries → no `item/reasoning/*` notifications → no `Thinking` events.
2. **Wrong delta semantics.** Once summaries flow, the translator folded `item/reasoning/summaryTextDelta` as a *cumulative snapshot*, but CLI 0.128.0 streams *incremental token deltas* — every thought collapsed to its longest single chunk (87 identical 35-char thinking rows on the repro mission).

## Fix

- `src/workspace.rs`: `ensure_codex_reasoning_summary()` prepends `model_reasoning_summary = "detailed"` to the generated `.codex/config.toml` (top-level key before any `[section]`; a profile/operator-set value wins). +4 tests.
- `src/backend/codex/mod.rs`: removed the `DeltaSemantics` split; `fold_delta_into` appends token deltas and still absorbs snapshot-shaped payloads from older app-server builds (prefix-extension → replace, echo → drop). Tests updated, +1 regression test reproducing the truncated-thought sequence.

## Verification

Deployed to `sandboxed-sh-dev` and ran a fresh codex mission (gpt-5.5, effort low):
- 87 `thinking` SSE events streamed with growing content
- 87 rows persisted with full content; final `done: true` thought is the complete summary
- `/events?view=history` returns them
- Dashboard renders the full "Thought for 1s" block after a hard reload (browser-verified)

`cargo fmt --check` clean; `backend::codex` (23) and `workspace::tests` (14) suites pass.

## Follow-ups (not in this PR)

- Every `done:false` thinking snapshot persists as its own row (87 rows for one thought) — could persist finals only or upsert the in-progress row.
- Seen during verification: the tool-stall retry path re-ran with the CLI default model and failed with "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account" despite 3508c177.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex event translation and workspace config generation; wrong delta semantics could still corrupt streamed text, but scope is limited to Codex backend and is well covered by tests.
> 
> **Overview**
> Fixes Codex missions where **thoughts streamed live but never persisted** after reload by addressing missing reasoning summaries and wrong delta folding.
> 
> **Workspace config:** Generated `.codex/config.toml` now prepends `model_reasoning_summary = "detailed"` when no top-level override exists, so the CLI actually emits `item/reasoning/*` notifications instead of empty summaries under the default `"auto"`.
> 
> **App-server translator:** Removes the `DeltaSemantics` split and treats **`summaryTextDelta` like other incremental token deltas** (append), while `fold_delta_into` still handles snapshot-shaped payloads (prefix-extension replaces; echo drops). This fixes summaries collapsing to single 35-char chunks on CLI 0.128.0.
> 
> Tests cover the new config helper and a regression for accumulating summary token deltas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090ab0f416f47e8be618d40087d04c458a7c2937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->