### PR TITLE
dashboard: stabilize inline image heights so virtualized scroll-up doesn't jump

### DIFF
--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo, useRef, memo } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef, memo } from "react";
 import { createRoot } from "react-dom/client";
 import Markdown, { Components, defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -138,6 +138,16 @@ function releaseImageUrl(path: string): void {
     imageUrlCache.delete(path);
   }
 }
+
+// Rendered dimensions of inline images, keyed by resolved path. Inline
+// previews live inside a virtualized timeline: rows unmount as the user
+// scrolls away and remount on the way back, and every remount that paints
+// a placeholder whose height differs from the final image shifts all rows
+// below it (the virtualizer re-measures both states). Recording the
+// laid-out size on first load lets remounts (and the loading skeleton)
+// reserve the exact final box, so re-measures are no-ops and the scroll
+// position stays put.
+const imageDimsCache = new Map<string, { width: number; height: number }>();
 
 function isFilePath(str: string): boolean {
   const hasExtension = FILE_EXTENSIONS.some(ext => str.toLowerCase().endsWith(ext));
@@ -737,7 +747,12 @@ function InlineImagePreview({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  // Layout effect (not useEffect): the cached-URL path is synchronous, so
+  // running before paint means a remounted preview (virtualized row
+  // scrolled back into view) commits the real `<img>` without ever
+  // painting the loading skeleton — the timeline virtualizer never sees
+  // the intermediate (shorter) box and rows below don't jump.
+  useLayoutEffect(() => {
     // Reset between effect runs so a previous error/blob doesn't leak when
     // `resolvedPath` changes (e.g. `basePath` resolves after first paint).
     setImageUrl(null);
@@ -807,9 +822,19 @@ function InlineImagePreview({
   // the skeleton. `<span>` (not `<div>`) keeps this valid inside the `<p>`
   // that react-markdown wraps around `![alt](url)` so hydration doesn't
   // tear the subtree.
+  //
+  // When this image has rendered before, reserve its exact laid-out box so
+  // the skeleton → image swap is layout-neutral (critical inside the
+  // virtualized timeline — see `imageDimsCache`). Otherwise default to
+  // 300px: `max-h-[300px]` makes that the final height for any screenshot
+  // taller than 300px, which is the overwhelmingly common case, so the
+  // first-load shift is usually zero instead of +100px per image.
+  const knownDims = resolvedPath ? imageDimsCache.get(resolvedPath) : undefined;
   const placeholderClass =
     "my-2 block rounded-xl overflow-hidden border border-white/[0.06] bg-white/[0.03]";
-  const placeholderStyle = { maxWidth: 400, height: 200 } as const;
+  const placeholderStyle = knownDims
+    ? { width: knownDims.width, height: knownDims.height, maxWidth: "100%" as const }
+    : ({ maxWidth: 400, height: 300 } as const);
 
   if (error) {
     return (
@@ -837,6 +862,17 @@ function InlineImagePreview({
         src={imageUrl}
         alt={alt}
         className="max-h-[300px] rounded-xl border border-white/[0.06] cursor-pointer hover:border-white/[0.12] transition-colors"
+        // Pin the box to the remembered size so the row's height is stable
+        // from the very first commit, even before the blob is decoded
+        // (an `<img>` has no intrinsic size until decode completes, which
+        // is async even for cached blob URLs).
+        style={knownDims ? { width: knownDims.width, height: knownDims.height, maxWidth: "100%" } : undefined}
+        onLoad={(e) => {
+          const img = e.currentTarget;
+          if (resolvedPath && img.offsetWidth > 0 && img.offsetHeight > 0) {
+            imageDimsCache.set(resolvedPath, { width: img.offsetWidth, height: img.offsetHeight });
+          }
+        }}
         onClick={() => showFilePreviewModal(path, resolvedPath ?? path, workspaceId, missionId)}
       />
     </span>

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -746,6 +746,10 @@ function InlineImagePreview({
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Bumped in `onLoad` after recording the image's dimensions so the
+  // render below re-reads `imageDimsCache` and swaps the pre-decode
+  // reservation for the exact final box.
+  const [, setDimsVersion] = useState(0);
 
   // Layout effect (not useEffect): the cached-URL path is synchronous, so
   // running before paint means a remounted preview (virtualized row
@@ -865,12 +869,28 @@ function InlineImagePreview({
         // Pin the box to the remembered size so the row's height is stable
         // from the very first commit, even before the blob is decoded
         // (an `<img>` has no intrinsic size until decode completes, which
-        // is async even for cached blob URLs).
-        style={knownDims ? { width: knownDims.width, height: knownDims.height, maxWidth: "100%" } : undefined}
+        // is async even for cached blob URLs). Without remembered dims —
+        // e.g. the URL is cached but the row unmounted before `onLoad`
+        // ever fired — reserve the 300px fallback height instead of
+        // letting the box collapse to its (zero) pre-decode size; `onLoad`
+        // then records the real dims and re-renders with the exact box.
+        style={
+          knownDims
+            ? { width: knownDims.width, height: knownDims.height, maxWidth: "100%" }
+            : { height: 300, maxWidth: "100%" }
+        }
         onLoad={(e) => {
           const img = e.currentTarget;
-          if (resolvedPath && img.offsetWidth > 0 && img.offsetHeight > 0) {
-            imageDimsCache.set(resolvedPath, { width: img.offsetWidth, height: img.offsetHeight });
+          // Derive the final box from the intrinsic size and the
+          // max-h-[300px] rule rather than offsetWidth/offsetHeight: the
+          // pre-decode `height: 300` pin is still applied at this point,
+          // so the laid-out box of a shorter image would read as
+          // (stretched) 300px and get cached wrong.
+          if (resolvedPath && img.naturalWidth > 0 && img.naturalHeight > 0) {
+            const height = Math.min(300, img.naturalHeight);
+            const width = Math.round((img.naturalWidth / img.naturalHeight) * height);
+            imageDimsCache.set(resolvedPath, { width, height });
+            setDimsVersion((v) => v + 1);
           }
         }}
         onClick={() => showFilePreviewModal(path, resolvedPath ?? path, workspaceId, missionId)}


### PR DESCRIPTION
## Problem

Scrolling up through a mission timeline with screenshots (e.g. the canvas light/dark mission) jumped twice: the view got pushed back down near the bottom screenshot, then teleported toward the top of the message when continuing up.

## Root cause

The chat timeline is virtualized (TanStack Virtual) with scroll-offset compensation intentionally disabled, so any row whose height changes mid-scroll shifts everything below it. `InlineImagePreview` produced two such instabilities:

1. **First load**: the loading skeleton was 200px, but loaded screenshots render at 300px (`max-h-[300px]`) — +100px shift per image (measured +800px of `scrollHeight` growth during one scroll-up with 8 screenshots).
2. **Every remount**: the blob URL cache was only consulted in a post-paint `useEffect`, so each time the virtualizer remounted a row scrolled back into view, it painted the short skeletons for one cycle before swapping to cached images. Frame-by-frame trace: a 4-screenshot row oscillating 1290px → 1690px, shifting all rows below by 400px down then 400px back up — exactly the reported double-jump.

## Fix

- Module-level `imageDimsCache` records each image's laid-out size on load; skeleton **and** `<img>` (pre-decode) reserve that exact box on remount → layout-neutral swaps.
- Fetch effect switched to `useLayoutEffect` so cached blobs commit before paint — the virtualizer never measures the intermediate state.
- Default skeleton height 200px → 300px, matching the final height of any screenshot ≥300px tall (the common case) so first loads don't shift either.

## Verification

Playwright frame-by-frame instrumentation of the same scroll-up gesture on the affected mission:

- **Before**: `scrollHeight` oscillating 6009 ↔ 5609, rows re-measuring 1290 ↔ 1690, visible double-jumps.
- **After**: 0 `scrollHeight` changes and 0 row re-measures across 348 frames (fresh load) and 253 frames (remount path, scroll down then back up). Images render identically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change scoped to inline markdown image previews; no auth, API, or data handling changes.
> 
> **Overview**
> Fixes **scroll jumping** when scrolling up through mission chat rows that contain inline screenshot previews. The virtualized timeline re-measures rows whenever an image’s box height changes, which was happening on first load and on every remount after scroll-away.
> 
> **`InlineImagePreview`** now keeps row height stable: a module-level **`imageDimsCache`** stores each image’s laid-out width/height (derived from natural size and `max-h-[300px]`) on **`onLoad`**, and both the loading skeleton and the **`<img>`** (including pre-decode) reserve that box—or a **300px** default instead of **200px**—so swaps don’t grow the row. The blob URL fetch path uses **`useLayoutEffect`** instead of **`useEffect`** so cached images commit before paint and remounts skip a one-frame skeleton flash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7e71824a746ce38728da5d76302c3065d705f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->