### PR TITLE
Codex rotation + Ask panel fold + freshness-aware Ask copilot with secrets bridge

### DIFF
--- a/dashboard/src/app/settings/llm/page.tsx
+++ b/dashboard/src/app/settings/llm/page.tsx
@@ -8,8 +8,10 @@ import {
   getLlmRoles,
   getSettings,
   updateSettings,
+  listProviders,
   type LlmRoleStatus,
 } from '@/lib/api';
+import { listModelChains, type ModelChain } from '@/lib/api/model-routing';
 import {
   ArrowUpRight,
   Check,
@@ -71,13 +73,42 @@ export default function LLMSettingsPage() {
     isLoading: rolesLoading,
     mutate: mutateRoles,
   } = useSWR('llm-roles', getLlmRoles, { revalidateOnFocus: false });
+  const { data: chains = [] } = useSWR<ModelChain[]>('model-chains', listModelChains, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60000,
+  });
+  const { data: providersData } = useSWR(
+    'providers-all',
+    () => listProviders({ includeAll: true }),
+    { revalidateOnFocus: false, dedupingInterval: 60000 }
+  );
+  const providers = providersData?.providers ?? [];
 
   const [askModelValue, setAskModelValue] = useState<string | null>(null);
+  const [customMode, setCustomMode] = useState(false);
   const [savingAskModel, setSavingAskModel] = useState(false);
 
   const savedModel = serverSettings?.ask_assistant_model ?? '';
   const effectiveValue = askModelValue ?? savedModel;
   const dirty = askModelValue !== null && askModelValue.trim() !== savedModel;
+
+  // Options the picker knows about: routing chains + provider/model
+  // passthroughs (both served via the local /v1 router) + the Cerebras
+  // default shortcuts. Anything else is "Custom".
+  const chainIds = chains.map((c) => c.id);
+  const providerModelIds = providers.flatMap((p) =>
+    p.models.map((m) => `${p.id}/${m.id}`)
+  );
+  const knownValues = new Set<string>([
+    '',
+    'gpt-oss-120b',
+    'zai-glm-4.7',
+    ...chainIds,
+    ...providerModelIds,
+  ]);
+  const selectValue = customMode || !knownValues.has(effectiveValue)
+    ? '__custom__'
+    : effectiveValue;
 
   const saveAskModel = async (value: string) => {
     setSavingAskModel(true);
@@ -87,6 +118,7 @@ export default function LLMSettingsPage() {
       // None server-side, whereas JSON null is treated as "no change".
       await updateSettings({ ask_assistant_model: trimmed });
       setAskModelValue(null);
+      setCustomMode(false);
       mutateSettings();
       mutateRoles();
       toast.success(
@@ -154,16 +186,57 @@ export default function LLMSettingsPage() {
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    <input
-                      type="text"
-                      value={effectiveValue}
-                      onChange={(e) => setAskModelValue(e.target.value)}
-                      placeholder="gpt-oss-120b"
-                      className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white font-mono placeholder:text-white/20 focus:outline-none focus:border-sky-500/50"
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') saveAskModel(effectiveValue);
+                    <select
+                      value={selectValue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v === '__custom__') {
+                          setCustomMode(true);
+                          setAskModelValue(effectiveValue);
+                        } else {
+                          setCustomMode(false);
+                          setAskModelValue(v);
+                        }
                       }}
-                    />
+                      className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-sky-500/50 [&>option]:bg-slate-800 [&>optgroup]:bg-slate-900 [&>option]:text-white [&>optgroup]:text-white/70"
+                    >
+                      <option value="">Default — Cerebras · gpt-oss-120b</option>
+                      <option value="zai-glm-4.7">Cerebras · zai-glm-4.7 (larger, slower)</option>
+                      {chainIds.length > 0 && (
+                        <optgroup label="Routing chains (with fallbacks)">
+                          {chainIds.map((id) => (
+                            <option key={id} value={id}>
+                              {id}
+                            </option>
+                          ))}
+                        </optgroup>
+                      )}
+                      {providers.map(
+                        (p) =>
+                          p.models.length > 0 && (
+                            <optgroup key={p.id} label={p.name}>
+                              {p.models.map((m) => (
+                                <option key={`${p.id}/${m.id}`} value={`${p.id}/${m.id}`}>
+                                  {p.id}/{m.id}
+                                </option>
+                              ))}
+                            </optgroup>
+                          )
+                      )}
+                      <option value="__custom__">Custom…</option>
+                    </select>
+                    {selectValue === '__custom__' && (
+                      <input
+                        type="text"
+                        value={effectiveValue}
+                        onChange={(e) => setAskModelValue(e.target.value)}
+                        placeholder="provider/model, chain id, or bare Cerebras model"
+                        className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white font-mono placeholder:text-white/20 focus:outline-none focus:border-sky-500/50"
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') saveAskModel(effectiveValue);
+                        }}
+                      />
+                    )}
                     <div className="flex items-center gap-2">
                       <button
                         onClick={() => saveAskModel(effectiveValue)}
@@ -189,9 +262,11 @@ export default function LLMSettingsPage() {
                       )}
                     </div>
                     <p className="text-xs text-white/30">
-                      Leave blank for the default (gpt-oss-120b). Served via
-                      Cerebras when configured, e.g. zai-glm-4.7 for a larger,
-                      slower model.
+                      Routing chains and provider/model picks (e.g.{' '}
+                      <code className="font-mono">builtin/assistant</code>,{' '}
+                      <code className="font-mono">xai/grok-code-fast-1</code>) are
+                      served through the /v1 router with fallbacks and usage
+                      accounting. Bare model ids stay on direct Cerebras.
                     </p>
                   </div>
                 )}
@@ -236,8 +311,9 @@ export default function LLMSettingsPage() {
                 <div className="min-w-0">
                   <h2 className="text-sm font-medium text-white">Providers</h2>
                   <p className="text-xs text-white/40">
-                    Both roles need an OpenAI-compatible provider: Cerebras is
-                    preferred, then OpenRouter, Groq, OpenAI, or Gemini.
+                    Defaults need an OpenAI-compatible provider (Cerebras
+                    preferred, then OpenRouter, Groq, OpenAI, Gemini). The
+                    assistant can also use any Routing chain or provider model.
                   </p>
                 </div>
               </div>

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Sparkles,
   X,
@@ -564,15 +564,41 @@ function AskToolRun({ messages }: { messages: AskMessage[] }) {
   const [collapsed, setCollapsed] = useState(false);
   const callCount = messages.filter((m) => m.role === "tool_call").length;
 
+  // Keep the toggle pinned under the cursor across fold/unfold (mirrors the
+  // main chat's previous-tools fold): steps reveal *upward* into history and
+  // the content below the toggle never moves. The toggle's viewport position
+  // is captured on click and the scroller re-aligned pre-paint.
+  const toggleRef = useRef<HTMLButtonElement | null>(null);
+  const anchorTopRef = useRef<number | null>(null);
+
+  const setFolded = (next: boolean) => {
+    anchorTopRef.current =
+      toggleRef.current?.getBoundingClientRect().top ?? null;
+    setCollapsed(next);
+  };
+
+  useLayoutEffect(() => {
+    const anchorTop = anchorTopRef.current;
+    if (anchorTop == null) return;
+    anchorTopRef.current = null;
+    const el = toggleRef.current;
+    if (!el) return;
+    const scroller = el.closest(".overflow-y-auto");
+    if (!scroller) return;
+    const delta = el.getBoundingClientRect().top - anchorTop;
+    if (Math.abs(delta) > 0.5) scroller.scrollTop += delta;
+  }, [collapsed]);
+
   if (collapsed) {
     return (
       <button
+        ref={toggleRef}
         type="button"
-        onClick={() => setCollapsed(false)}
+        onClick={() => setFolded(false)}
         className="ml-8 flex items-center gap-1 text-[11px] text-[rgb(var(--foreground)/0.35)] transition-colors hover:text-[rgb(var(--foreground)/0.6)]"
-        title="Show tool steps"
+        title="Show tool steps (they reveal above)"
       >
-        <ChevronRight className="h-3 w-3" />
+        <ChevronUp className="h-3 w-3" />
         {callCount} tool step{callCount === 1 ? "" : "s"} hidden
       </button>
     );
@@ -584,12 +610,13 @@ function AskToolRun({ messages }: { messages: AskMessage[] }) {
         <AskBubble key={m.id} message={m} />
       ))}
       <button
+        ref={toggleRef}
         type="button"
-        onClick={() => setCollapsed(true)}
+        onClick={() => setFolded(true)}
         className="ml-8 flex items-center gap-1 text-[10px] text-[rgb(var(--foreground)/0.3)] transition-colors hover:text-[rgb(var(--foreground)/0.55)]"
         title="Hide tool steps"
       >
-        <ChevronUp className="h-3 w-3" />
+        <ChevronRight className="h-3 w-3" />
         Hide tool steps
       </button>
     </div>

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -245,7 +245,7 @@ pub async fn ask_send_stream(
     let cfg = crate::api::metadata_llm::build_assistant_llm_config(
         &state.ai_providers,
         &state.chain_store,
-        { state.settings.get().await.ask_assistant_model },
+        state.settings.get().await.ask_assistant_model,
     )
     .await
     .ok_or((

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -181,6 +181,7 @@ pub async fn ask_send(
     let used_sandbox = sandbox_dir.is_some();
     let work_dir = sandbox_dir.clone().unwrap_or_else(|| base_work_dir.clone());
 
+    let workspace_id = workspace.id;
     let turn = AskTurn {
         ask_store: Arc::clone(&ask_store),
         mission_store: Arc::clone(&control.mission_store),
@@ -190,6 +191,9 @@ pub async fn ask_send(
         mission_id,
         thread_id: thread.id,
         sandbox: used_sandbox,
+        workspaces: Arc::clone(&state.workspaces),
+        workspace_id,
+        proxy_keys: Arc::clone(&state.proxy_api_keys),
     };
 
     let answer_result = run_ask_turn(&turn, &req.content).await;
@@ -299,6 +303,7 @@ pub async fn ask_send_stream(
     let used_sandbox = sandbox_dir.is_some();
     let work_dir = sandbox_dir.clone().unwrap_or_else(|| base_work_dir.clone());
 
+    let workspace_id = workspace.id;
     let turn = AskTurn {
         ask_store: Arc::clone(&ask_store),
         mission_store: Arc::clone(&control.mission_store),
@@ -308,6 +313,9 @@ pub async fn ask_send_stream(
         mission_id,
         thread_id: thread.id,
         sandbox: used_sandbox,
+        workspaces: Arc::clone(&state.workspaces),
+        workspace_id,
+        proxy_keys: Arc::clone(&state.proxy_api_keys),
     };
 
     let content = req.content.clone();

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -117,14 +117,16 @@ pub async fn ask_send(
 
     // Resolve the assistant model/config (Settings override → env → default).
     let model_override = state.settings.get().await.ask_assistant_model;
-    let cfg =
-        crate::api::metadata_llm::build_assistant_llm_config(&state.ai_providers, model_override)
-            .await
-            .ok_or((
-                StatusCode::SERVICE_UNAVAILABLE,
-                "No assistant LLM configured (set a Cerebras key or ASK_ASSISTANT_MODEL)"
-                    .to_string(),
-            ))?;
+    let cfg = crate::api::metadata_llm::build_assistant_llm_config(
+        &state.ai_providers,
+        &state.chain_store,
+        model_override,
+    )
+    .await
+    .ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "No assistant LLM configured (set a Cerebras key or ASK_ASSISTANT_MODEL)".to_string(),
+    ))?;
 
     let ask_store = super::ask_store(&state.config).await.map_err(internal)?;
 
@@ -240,9 +242,11 @@ pub async fn ask_send_stream(
         .map_err(internal)?
         .ok_or((StatusCode::NOT_FOUND, "Mission not found".to_string()))?;
 
-    let cfg = crate::api::metadata_llm::build_assistant_llm_config(&state.ai_providers, {
-        state.settings.get().await.ask_assistant_model
-    })
+    let cfg = crate::api::metadata_llm::build_assistant_llm_config(
+        &state.ai_providers,
+        &state.chain_store,
+        { state.settings.get().await.ask_assistant_model },
+    )
     .await
     .ok_or((
         StatusCode::SERVICE_UNAVAILABLE,

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -27,6 +27,8 @@ use tokio::sync::OnceCell;
 use uuid::Uuid;
 
 use crate::api::mission_store::MissionStore;
+use crate::api::proxy_keys::SharedProxyApiKeyStore;
+use crate::workspace::SharedWorkspaceStore;
 use crate::workspace_exec::WorkspaceExec;
 
 pub use client::AskClient;
@@ -41,6 +43,9 @@ const MAX_ITERATIONS: usize = 10;
 const MAX_TOOL_RESULT_BYTES: usize = 8_000;
 /// Number of recent mission events seeded into the system prompt.
 const SEED_EVENT_COUNT: usize = 40;
+/// How far back to scan when looking for the latest goal_status event. One
+/// fetch serves both this scan and the [`SEED_EVENT_COUNT`] seed.
+const GOAL_SCAN_EVENT_COUNT: usize = 200;
 
 static ASK_STORE: OnceCell<Arc<AskStore>> = OnceCell::const_new();
 
@@ -71,6 +76,13 @@ pub struct AskTurn {
     /// When true, `work_dir` is an isolated sandbox copy of the workspace, so
     /// writes are throwaway and we skip the operator-note bridge entirely.
     pub sandbox: bool,
+    /// Workspace store + the mission's workspace id, for the workspace-env
+    /// tools (list/set env vars that get injected into the harness).
+    pub workspaces: SharedWorkspaceStore,
+    pub workspace_id: Uuid,
+    /// Proxy API key store, for answering "is the key the operator issued
+    /// actually being used?" with `last_used_at` facts.
+    pub proxy_keys: SharedProxyApiKeyStore,
 }
 
 /// Run one Ask turn: persist the operator message, drive the tool loop, persist
@@ -82,7 +94,7 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
         .await?;
 
     // Assemble the OpenAI message array: system + prior turns + this message.
-    let system = build_system_prompt(turn).await;
+    let system = build_system_prompt(turn, user_content).await;
     let mut messages: Vec<Value> = vec![json!({ "role": "system", "content": system })];
 
     // Replay prior user/assistant turns for continuity (tool details are kept in
@@ -141,7 +153,7 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
                 .await?;
 
             let result = execute_tool(turn, &tc.name, &tc.arguments).await;
-            let result = truncate(&result, MAX_TOOL_RESULT_BYTES);
+            let result = truncate_tool_result(&result);
 
             turn.ask_store
                 .append_message(
@@ -246,7 +258,7 @@ async fn run_ask_turn_streaming_inner(
         .append_message(turn.thread_id, "user", user_content, None, None, None)
         .await?;
 
-    let system = build_system_prompt(turn).await;
+    let system = build_system_prompt(turn, user_content).await;
     let mut messages: Vec<Value> = vec![json!({ "role": "system", "content": system })];
     let prior = turn.ask_store.list_messages(turn.thread_id).await?;
     for m in &prior {
@@ -313,7 +325,7 @@ async fn run_ask_turn_streaming_inner(
                 .await?;
 
             let result = execute_tool(turn, &tc.name, &tc.arguments).await;
-            let result = truncate(&result, MAX_TOOL_RESULT_BYTES);
+            let result = truncate_tool_result(&result);
             let _ = tx.send(AskStreamEvent::ToolResult {
                 tool_call_id: tc.id.clone(),
                 name: tc.name.clone(),
@@ -380,39 +392,69 @@ async fn run_ask_turn_streaming_inner(
     Ok(())
 }
 
-async fn build_system_prompt(turn: &AskTurn) -> String {
+async fn build_system_prompt(turn: &AskTurn, user_content: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let mut seed = String::new();
     if let Ok(Some(mission)) = turn.mission_store.get_mission(turn.mission_id).await {
         if let Some(title) = &mission.title {
             seed.push_str(&format!("Mission title: {title}\n"));
         }
+        seed.push_str(&format!(
+            "Mission status: {:?} (last updated {})\n",
+            mission.status, mission.updated_at
+        ));
         if let Some(desc) = &mission.short_description {
-            seed.push_str(&format!("Mission status: {desc}\n"));
+            seed.push_str(&format!("Mission summary: {desc}\n"));
         }
         seed.push_str(&format!("Mission backend: {}\n", mission.backend));
     }
 
+    // One slightly deeper fetch serves both the goal-status scan and the seed.
     if let Ok(events) = turn
         .mission_store
-        .get_latest_events(turn.mission_id, SEED_EVENT_COUNT)
+        .get_latest_events(turn.mission_id, GOAL_SCAN_EVENT_COUNT)
         .await
     {
+        if let Some(goal) = events
+            .iter()
+            .rev()
+            .find(|ev| ev.event_type == "goal_status")
+        {
+            seed.push_str(&format!(
+                "\nLatest goal status [{} {}]: {}\n",
+                goal.sequence,
+                goal.timestamp,
+                truncate(&goal.content, 600)
+            ));
+        }
+        let start = events.len().saturating_sub(SEED_EVENT_COUNT);
         seed.push_str("\nRecent mission events (newest last):\n");
-        for ev in &events {
+        for ev in &events[start..] {
             let tool = ev
                 .tool_name
                 .as_deref()
                 .map(|t| format!(" {t}"))
                 .unwrap_or_default();
             seed.push_str(&format!(
-                "[{}] {}{}: {}\n",
+                "[{} {}] {}{}: {}\n",
                 ev.sequence,
+                ev.timestamp,
                 ev.event_type,
                 tool,
-                truncate(&ev.content, 240)
+                truncate(&ev.content, 300)
             ));
         }
     }
+
+    let secret_note = if message_mentions_secret(user_content) {
+        "\n\n⚠ The operator's latest message contains what looks like a credential \
+         (API key / token). Persist it NOW with set_workspace_env under the variable \
+         name the mission's tooling expects (check its scripts/docs, or ask), then \
+         refer to it only by variable name. Never echo the full value back: chat \
+         context does not survive compaction, workspace env vars do."
+    } else {
+        ""
+    };
 
     let cwd = turn.work_dir.display();
     format!(
@@ -420,6 +462,17 @@ async fn build_system_prompt(turn: &AskTurn) -> String {
          \"working agent\" is doing the real work in this same workspace; you are a \
          read-mostly assistant helping the operator understand and occasionally nudge \
          what's happening.\n\n\
+         Current UTC time: {now}. Mission events and files carry timestamps — compare \
+         them against the current time and date your claims (\"as of 14:32Z\"); never \
+         present a snapshot from hours ago as the present state.\n\n\
+         Recency first: when asked where the mission stands, check the newest data \
+         before summarizing — `ls -lt` on results/output dirs, `tail` on logs and \
+         journals, `git log --oneline -10`, and read_history. Research logs and \
+         journals are append-only: the END of the file is the current state, the \
+         beginning is history.\n\n\
+         Tool results are capped at 8KB; a truncation notice reports the full size. \
+         For big files use read_file with offset/limit or tail/sed line ranges — \
+         never assume you saw the whole file.\n\n\
          Your bash tool runs in `{cwd}` — this is the mission's workspace and the \
          working agent's project root. Commands start there and relative paths \
          resolve against it, so you can `ls`, `cat`, or `git log` directly without \
@@ -429,8 +482,17 @@ async fn build_system_prompt(turn: &AskTurn) -> String {
          working agent, so keep writes minimal and intentional. The full mission \
          history may be large — retrieve what you need with read_history / bash \
          (grep, rg, cat) rather than assuming it is all provided.\n\n\
+         Secrets: if the operator shares a credential, persist it immediately with \
+         set_workspace_env — workspace env vars are injected into the working \
+         agent's process environment from its next turn onward and survive restarts \
+         and context compaction, unlike anything pasted in chat. Confirm by variable \
+         name and never repeat the value. Use list_workspace_env and \
+         proxy_key_status to answer \"is the key set / is it being used?\" with \
+         facts instead of guesses.\n\n\
          Be concise and concrete. Cite event sequence numbers or file paths when \
-         relevant.\n\n\
+         relevant. When you identify a blocker the operator could fix through \
+         configuration (missing env var, unused key), propose the concrete fix — \
+         and apply it with your tools when the operator asks.{secret_note}\n\n\
          === Mission context ===\n{seed}"
     )
 }
@@ -455,7 +517,7 @@ fn tool_definitions() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "read_history",
-                "description": "Fetch the most recent mission events (the working agent's transcript: messages, tool calls/results, errors).",
+                "description": "Fetch the most recent mission events (the working agent's transcript: messages, tool calls/results, errors). Each event carries its timestamp.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -468,14 +530,47 @@ fn tool_definitions() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "read_file",
-                "description": "Read a file from the mission workspace by path.",
+                "description": "Read a file from the mission workspace by path. Always reports total lines/bytes first. For big files pass offset/limit to read a line range (e.g. the tail of a long log).",
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "path": { "type": "string", "description": "Path to the file (absolute or relative to the workspace root)." }
+                        "path": { "type": "string", "description": "Path to the file (absolute or relative to the workspace root)." },
+                        "offset": { "type": "integer", "description": "1-based line number to start reading from (omit to start at the top)." },
+                        "limit": { "type": "integer", "description": "Number of lines to read (omit to read to the end)." }
                     },
                     "required": ["path"]
                 }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "list_workspace_env",
+                "description": "List the workspace environment variables injected into the working agent's process environment (names + masked values). Use to check whether a credential or config var is already set.",
+                "parameters": { "type": "object", "properties": {} }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "set_workspace_env",
+                "description": "Persist a workspace environment variable. It is injected into the working agent's environment from its next turn onward and survives restarts — the durable channel for credentials the operator shares in chat. The working agent is notified by name (never by value).",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "description": "POSIX env var name (e.g. DEFAULT_HARNESS_API_KEY)." },
+                        "value": { "type": "string", "description": "The value to store." }
+                    },
+                    "required": ["name", "value"]
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "proxy_key_status",
+                "description": "List the gateway's proxy API keys (name, prefix, created_at, last_used_at). Use to answer whether a key the operator issued is valid/actually being used.",
+                "parameters": { "type": "object", "properties": {} }
             }
         }),
     ]
@@ -505,7 +600,24 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
             if path.trim().is_empty() {
                 return "Error: empty path".to_string();
             }
-            run_bash(turn, &format!("cat -- {}", single_quote(path))).await
+            let offset = args["offset"].as_u64().map(|v| v.max(1));
+            let limit = args["limit"].as_u64().filter(|v| *v > 0);
+            let read_cmd = match (offset, limit) {
+                (Some(o), Some(l)) => {
+                    format!("sed -n '{o},{}p' -- \"$f\"", o.saturating_add(l - 1))
+                }
+                (Some(o), None) => format!("tail -n +{o} -- \"$f\""),
+                (None, Some(l)) => format!("head -n {l} -- \"$f\""),
+                (None, None) => "cat -- \"$f\"".to_string(),
+            };
+            // Lead with the file's true size so the model knows what fraction
+            // it is seeing (the 8KB tool-result cap truncates silently otherwise).
+            let cmd = format!(
+                "f={path}; if [ ! -f \"$f\" ]; then echo \"Error: no such file: $f\" >&2; exit 1; fi; \
+                 printf '[%s: %s lines, %s bytes total]\\n' \"$f\" \"$(wc -l < \"$f\")\" \"$(wc -c < \"$f\")\"; {read_cmd}",
+                path = single_quote(path),
+            );
+            run_bash(turn, &cmd).await
         }
         "read_history" => {
             let limit = args["limit"].as_u64().unwrap_or(60).clamp(1, 300) as usize;
@@ -523,8 +635,9 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                             .map(|t| format!(" {t}"))
                             .unwrap_or_default();
                         out.push_str(&format!(
-                            "[{}] {}{}: {}\n",
+                            "[{} {}] {}{}: {}\n",
                             ev.sequence,
+                            ev.timestamp,
                             ev.event_type,
                             tool,
                             truncate(&ev.content, 400)
@@ -539,8 +652,108 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                 Err(e) => format!("Error reading history: {e}"),
             }
         }
+        "list_workspace_env" => match turn.workspaces.get(turn.workspace_id).await {
+            Some(ws) => {
+                if ws.env_vars.is_empty() {
+                    "(no workspace env vars configured)".to_string()
+                } else {
+                    let mut entries: Vec<_> = ws.env_vars.iter().collect();
+                    entries.sort_by(|a, b| a.0.cmp(b.0));
+                    entries
+                        .into_iter()
+                        .map(|(k, v)| format!("{k} = {}", mask_value(v)))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                }
+            }
+            None => "Error: workspace not found".to_string(),
+        },
+        "set_workspace_env" => {
+            if turn.sandbox {
+                return "Error: set_workspace_env is disabled in sandbox mode (it would \
+                        change the live workspace configuration)."
+                    .to_string();
+            }
+            let env_name = args["name"].as_str().unwrap_or("").trim().to_string();
+            let value = args["value"].as_str().unwrap_or("").to_string();
+            if env_name.is_empty() || value.is_empty() {
+                return "Error: name and value are required".to_string();
+            }
+            if !crate::api::workspaces::is_valid_env_name(&env_name) {
+                return format!(
+                    "Error: '{env_name}' is not a valid POSIX env var name \
+                     (letters, digits, underscores; cannot start with a digit)"
+                );
+            }
+            if value.contains('\0') {
+                return "Error: value contains a NUL byte".to_string();
+            }
+            match turn.workspaces.get(turn.workspace_id).await {
+                Some(mut ws) => {
+                    let replaced = ws
+                        .env_vars
+                        .insert(env_name.clone(), value.clone())
+                        .is_some();
+                    if !turn.workspaces.update(ws).await {
+                        return "Error: failed to persist the workspace env var".to_string();
+                    }
+                    // Tell the working agent the variable exists — by name only,
+                    // so the value never lands in mission history.
+                    let note = format!(
+                        "The operator configured the workspace environment variable \
+                         `{env_name}` via the Ask assistant (value withheld). It is \
+                         injected into your process environment from your next turn \
+                         onward — read it from the environment by name instead of \
+                         asking for the value or inlining it in commands."
+                    );
+                    if let Err(e) = turn
+                        .ask_store
+                        .enqueue_operator_note(turn.mission_id, &note, Some(turn.thread_id))
+                        .await
+                    {
+                        tracing::warn!("[Ask] failed to enqueue env-var operator note: {e}");
+                    }
+                    format!(
+                        "{} workspace env var `{env_name}` ({} chars). It is injected into \
+                         the working agent's environment from its next turn onward; an \
+                         operator note was queued so the agent knows it is available.",
+                        if replaced { "Updated" } else { "Set" },
+                        value.chars().count()
+                    )
+                }
+                None => "Error: workspace not found".to_string(),
+            }
+        }
+        "proxy_key_status" => {
+            let keys = turn.proxy_keys.list().await;
+            if keys.is_empty() {
+                "(no proxy API keys)".to_string()
+            } else {
+                keys.iter()
+                    .map(|k| {
+                        format!(
+                            "{} ({}…) created {} — last used: {}",
+                            k.name,
+                            k.key_prefix,
+                            k.created_at
+                                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                            k.last_used_at
+                                .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+                                .unwrap_or_else(|| "never".to_string())
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
         other => format!("Error: unknown tool '{other}'"),
     }
+}
+
+/// Mask an env var value for display: short prefix + length, never the value.
+fn mask_value(v: &str) -> String {
+    let prefix: String = v.chars().take(4).collect();
+    format!("{prefix}… ({} chars)", v.chars().count())
 }
 
 async fn run_bash(turn: &AskTurn, command: &str) -> String {
@@ -783,6 +996,50 @@ fn truncate(s: &str, max_bytes: usize) -> String {
     format!("{}… (truncated)", &s[..end])
 }
 
+/// Truncate a tool result at [`MAX_TOOL_RESULT_BYTES`], appending an explicit
+/// notice with the full size so the model knows it saw a partial view and how
+/// to fetch the rest (instead of silently mistaking the prefix for the whole).
+fn truncate_tool_result(s: &str) -> String {
+    if s.len() <= MAX_TOOL_RESULT_BYTES {
+        return s.to_string();
+    }
+    let mut end = MAX_TOOL_RESULT_BYTES;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}\n… [truncated: showing first {} of {} bytes — use read_file with \
+         offset/limit, or tail/sed line ranges, to view the rest]",
+        &s[..end],
+        end,
+        s.len()
+    )
+}
+
+/// Heuristic detection of credential-shaped tokens in an operator message, used
+/// to nudge the model into persisting them via `set_workspace_env` instead of
+/// letting them live (and die) in chat context.
+fn message_mentions_secret(text: &str) -> bool {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?x)
+            \b(
+                sk-[A-Za-z0-9_-]{12,}                       # OpenAI / proxy-style keys
+              | (ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}      # GitHub tokens
+              | github_pat_[A-Za-z0-9_]{20,}
+              | AKIA[0-9A-Z]{16}                            # AWS access key id
+              | xox[abprs]-[A-Za-z0-9-]{10,}                # Slack tokens
+              | AIza[0-9A-Za-z_-]{30,}                      # Google API keys
+              | eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,} # JWT
+            )",
+        )
+        .expect("static secret-detection regex must compile")
+    });
+    re.is_match(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -817,5 +1074,43 @@ mod tests {
         let (msg, n) = prepend_pending_operator_notes(&store, mission, "Continue.".into()).await;
         assert_eq!(n, 0);
         assert_eq!(msg, "Continue.");
+    }
+
+    #[test]
+    fn tool_result_truncation_reports_full_size() {
+        let small = "ok";
+        assert_eq!(truncate_tool_result(small), "ok");
+
+        let big = "x".repeat(MAX_TOOL_RESULT_BYTES + 500);
+        let out = truncate_tool_result(&big);
+        assert!(out.contains(&format!(
+            "showing first {} of {} bytes",
+            MAX_TOOL_RESULT_BYTES,
+            big.len()
+        )));
+        assert!(out.contains("read_file with"));
+    }
+
+    #[test]
+    fn secret_detection_matches_common_token_shapes() {
+        // Synthetic values only — shaped like real tokens, never actual ones.
+        assert!(message_mentions_secret(
+            "try sk-proxy-0123456789abcdef0123456789abcdef and tell me"
+        ));
+        assert!(message_mentions_secret(
+            "token: ghp_0123456789abcdefghijABCDEFGHIJ0123"
+        ));
+        assert!(message_mentions_secret("AKIAIOSFODNN7EXAMPLE"));
+        // Plain prose, short ids, and tactic punctuation must not trip it.
+        assert!(!message_mentions_secret("what is the mission status?"));
+        assert!(!message_mentions_secret("the sk-learn library"));
+        assert!(!message_mentions_secret("commit 381a865f is on master"));
+    }
+
+    #[test]
+    fn env_value_masking_never_leaks() {
+        let masked = mask_value("sk-proxy-0123456789abcdef0123456789abcdef");
+        assert_eq!(masked, "sk-p… (41 chars)");
+        assert!(!masked.contains("0123456789"));
     }
 }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -12294,7 +12294,14 @@ async fn run_single_control_turn(
                 convo.clone()
             };
             let codex_message: &str = codex_message_owned.as_str();
-            let mut result = Box::pin(super::mission_runner::run_codex_turn(
+            // Shared rotation wrapper: identical account rotation + usage-cap
+            // cooldown behaviour to the initial mission dispatch. Previously
+            // this path ran a single bare run_codex_turn with no credential
+            // override, so a follow-up/retry on a usage-capped ChatGPT
+            // account kept re-hitting the same cap instead of rotating to
+            // the next account. Fallback-model and tool-stall retries are
+            // handled inside the wrapper per attempted credential.
+            Box::pin(super::mission_runner::run_codex_turn_with_rotation(
                 exec_workspace,
                 &ctx.working_dir,
                 codex_message,
@@ -12306,62 +12313,8 @@ async fn run_single_control_turn(
                 cancel.clone(),
                 &config.working_dir,
                 session_id.as_deref(),
-                None,
             ))
-            .await;
-
-            if let Some(fallback_model) = super::mission_runner::codex_chatgpt_fallback_for_result(
-                requested_codex_model,
-                &result,
-            ) {
-                tracing::warn!(
-                    mission_id = %mid,
-                    requested_model = ?requested_codex_model,
-                    fallback_model,
-                    "Retrying Codex turn with fallback model for ChatGPT account compatibility (control path)"
-                );
-                result = Box::pin(super::mission_runner::run_codex_turn(
-                    exec_workspace,
-                    &ctx.working_dir,
-                    codex_message,
-                    Some(fallback_model),
-                    requested_model_effort.as_deref(),
-                    config.opencode_agent.as_deref(),
-                    mid,
-                    events_tx.clone(),
-                    cancel,
-                    &config.working_dir,
-                    session_id.as_deref(),
-                    None,
-                ))
-                .await;
-            } else if super::mission_runner::codex_tool_stall_should_retry_with_default_model(
-                requested_codex_model,
-                &result,
-            ) {
-                tracing::warn!(
-                    mission_id = %mid,
-                    requested_model = ?requested_codex_model,
-                    "Retrying Codex turn with CLI default model after generic GPT model stopped before tool use (control path)"
-                );
-                result = Box::pin(super::mission_runner::run_codex_turn(
-                    exec_workspace,
-                    &ctx.working_dir,
-                    codex_message,
-                    None,
-                    requested_model_effort.as_deref(),
-                    config.opencode_agent.as_deref(),
-                    mid,
-                    events_tx.clone(),
-                    cancel,
-                    &config.working_dir,
-                    session_id.as_deref(),
-                    None,
-                ))
-                .await;
-            }
-
-            result
+            .await
         }
         Some("gemini") => {
             let mid = match require_mission_id(mission_id, "Gemini CLI", &events_tx) {

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -320,6 +320,7 @@ pub(crate) fn resolve_provider_api_key(
 /// independent of the metadata config's reasoning fields.
 pub async fn build_assistant_llm_config(
     ai_providers: &crate::ai_providers::AIProviderStore,
+    chain_store: &crate::provider_health::SharedModelChainStore,
     model_override: Option<String>,
 ) -> Option<MetadataLlmConfig> {
     use crate::ai_providers::ProviderType;
@@ -331,6 +332,38 @@ pub async fn build_assistant_llm_config(
             .ok()
             .filter(|m| !m.trim().is_empty())
     });
+
+    // A routable override — an existing Routing chain id ("builtin/assistant")
+    // or a provider/model passthrough ("xai/grok-code-fast-1",
+    // "cerebras/zai-glm-4.7") — goes through the local /v1 proxy: fallbacks,
+    // health tracking, and usage accounting come for free, and anything
+    // configured under Routing becomes usable for the assistant.
+    if let Some(model) = explicit_model.as_deref() {
+        let model = model.trim();
+        let is_chain = chain_store.get(model).await.is_some();
+        let is_passthrough = model
+            .split_once('/')
+            .map(|(prefix, rest)| !rest.is_empty() && ProviderType::from_id(prefix).is_some())
+            .unwrap_or(false);
+        if is_chain || is_passthrough {
+            match local_proxy_llm_config(model) {
+                Some(config) => {
+                    tracing::info!(
+                        "[AskLLM] Routing assistant model {} via the local /v1 proxy",
+                        model
+                    );
+                    return Some(config);
+                }
+                None => tracing::warn!(
+                    "[AskLLM] Assistant model {} is proxy-routable but the local \
+                     /v1 proxy is unavailable (missing PORT or proxy secret); \
+                     falling back to the direct provider ladder",
+                    model
+                ),
+            }
+        }
+    }
+
     let assistant_model = explicit_model
         .clone()
         .unwrap_or_else(|| "gpt-oss-120b".to_string());
@@ -439,9 +472,27 @@ impl LlmRoleStatus {
     }
 }
 
+/// Config pointing at the local /v1 router (chains + provider passthrough).
+fn local_proxy_llm_config(model: &str) -> Option<MetadataLlmConfig> {
+    let base = crate::api::mission_runner::localhost_api_base_url_from_env()?;
+    let secret = std::env::var("SANDBOXED_PROXY_SECRET")
+        .ok()
+        .filter(|s| !s.trim().is_empty())?;
+    Some(MetadataLlmConfig {
+        base_url: format!("{}/v1", base.trim_end_matches('/')),
+        api_key: secret,
+        model: model.to_string(),
+        api_format: ApiFormat::OpenAI,
+        // AskClient derives reasoning_effort from the model name itself.
+        reasoning_effort: None,
+    })
+}
+
 /// Map a base URL to a human-readable provider label for display purposes.
 fn provider_label_for_base_url(base_url: &str) -> String {
     let labels: &[(&str, &str)] = &[
+        ("127.0.0.1", "Routing"),
+        ("localhost", "Routing"),
         ("cerebras.ai", "Cerebras"),
         ("openrouter.ai", "OpenRouter"),
         ("groq.com", "Groq"),
@@ -469,9 +520,10 @@ fn provider_label_for_base_url(base_url: &str) -> String {
 /// dashboard. Mirrors `build_assistant_llm_config` without exposing the key.
 pub async fn assistant_role_status(
     ai_providers: &crate::ai_providers::AIProviderStore,
+    chain_store: &crate::provider_health::SharedModelChainStore,
     model_override: Option<String>,
 ) -> LlmRoleStatus {
-    let config = build_assistant_llm_config(ai_providers, model_override).await;
+    let config = build_assistant_llm_config(ai_providers, chain_store, model_override).await;
     LlmRoleStatus::from_config(config.as_ref())
 }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -718,6 +718,58 @@ const CODEX_ACCOUNT_LEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 static CODEX_ACCOUNT_POOL: LazyLock<StdMutex<HashMap<String, Arc<Semaphore>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
+/// Account-level cooldown memory: fingerprints of credentials that recently
+/// hit a usage/rate cap, mapped to when they may be tried again. Lets every
+/// codex path (initial dispatch, control-channel follow-ups) skip known-capped
+/// accounts instead of burning the first attempt on them. In-memory only —
+/// resets on restart, which is fine: the worst case is one wasted probe.
+static CODEX_ACCOUNT_COOLDOWNS: LazyLock<StdMutex<HashMap<String, std::time::Instant>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// OpenAI usage caps reset on long windows (often hours); 15 minutes keeps a
+/// capped account out of the hot path while re-probing often enough to catch
+/// an early reset.
+const CODEX_RATE_LIMIT_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+/// Capacity blips clear quickly; re-probe after 2 minutes.
+const CODEX_CAPACITY_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(2 * 60);
+/// Auth failures (refresh-token reuse) usually need a background token
+/// refresh to land; give it 10 minutes.
+const CODEX_AUTH_ERROR_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+fn codex_account_cooldown_remaining(fingerprint: &str) -> Option<std::time::Duration> {
+    let map = CODEX_ACCOUNT_COOLDOWNS
+        .lock()
+        .expect("Codex account cooldown mutex poisoned");
+    map.get(fingerprint)
+        .and_then(|until| until.checked_duration_since(std::time::Instant::now()))
+}
+
+fn set_codex_account_cooldown(fingerprint: &str, duration: std::time::Duration) {
+    let mut map = CODEX_ACCOUNT_COOLDOWNS
+        .lock()
+        .expect("Codex account cooldown mutex poisoned");
+    map.insert(
+        fingerprint.to_string(),
+        std::time::Instant::now() + duration,
+    );
+}
+
+fn clear_codex_account_cooldown(fingerprint: &str) {
+    let mut map = CODEX_ACCOUNT_COOLDOWNS
+        .lock()
+        .expect("Codex account cooldown mutex poisoned");
+    map.remove(fingerprint);
+}
+
+fn codex_cooldown_for_reason(reason: &TerminalReason) -> Option<std::time::Duration> {
+    match reason {
+        TerminalReason::RateLimited => Some(CODEX_RATE_LIMIT_COOLDOWN),
+        TerminalReason::CapacityLimited => Some(CODEX_CAPACITY_COOLDOWN),
+        TerminalReason::AuthError => Some(CODEX_AUTH_ERROR_COOLDOWN),
+        _ => None,
+    }
+}
+
 /// A codex auth credential — either a raw OpenAI API key (rotation slot keyed
 /// on the secret string) or a ChatGPT OAuth identity (rotation slot keyed on
 /// `chatgpt_account_id`, since that's what OpenAI's usage cap is keyed on).
@@ -1207,7 +1259,7 @@ async fn lease_codex_account(
         return None;
     }
 
-    let mut candidates: Vec<(CodexCredential, Arc<Semaphore>, usize)> = creds
+    let candidates: Vec<(CodexCredential, Arc<Semaphore>, usize)> = creds
         .into_iter()
         .filter(|cred| !tried_fingerprints.contains(&cred.fingerprint()))
         .map(|cred| {
@@ -1221,8 +1273,23 @@ async fn lease_codex_account(
         return None;
     }
 
-    // Prefer the currently least-loaded credential (highest available permits).
-    candidates.sort_by_key(|candidate| Reverse(candidate.2));
+    // Prefer credentials that aren't on a usage-cap cooldown; cooled ones stay
+    // in the list as a last resort so a single-account setup still retries
+    // instead of hard-failing. Within each group, prefer the least-loaded
+    // credential (highest available permits).
+    let (mut fresh, mut cooled): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|candidate| {
+        codex_account_cooldown_remaining(&candidate.0.fingerprint()).is_none()
+    });
+    fresh.sort_by_key(|candidate| Reverse(candidate.2));
+    cooled.sort_by_key(|candidate| Reverse(candidate.2));
+    for candidate in &cooled {
+        tracing::debug!(
+            credential = %candidate.0.label_for_logs(),
+            "Codex credential on usage-cap cooldown; deprioritized for lease"
+        );
+    }
+    let candidates: Vec<(CodexCredential, Arc<Semaphore>, usize)> =
+        fresh.into_iter().chain(cooled).collect();
 
     for (cred, sem, available) in &candidates {
         if let Ok(permit) = sem.clone().try_acquire_owned() {
@@ -3534,258 +3601,23 @@ async fn run_mission_turn(
                 convo.clone()
             };
             let codex_message: &str = codex_message_owned.as_str();
-            // Unified credential pool: API keys + ChatGPT-OAuth identities,
-            // de-duplicated by chatgpt_account_id. Empty only when neither
-            // an OpenAI API key nor a connected ChatGPT account is available.
-            //
-            // Defensive: if the pool was empty and the turn hits a rate
-            // limit, re-query once and rerun via rotation if credentials are
-            // now visible. The May 2026 incident showed the empty branch can
-            // be taken transiently even when accounts exist on disk, leaving
-            // the user with no rotation. The recheck guards against that
-            // without changing the happy-path behaviour.
-            'codex_arm: {
-                let mut all_creds = collect_codex_credentials(&config.working_dir);
-                let mut prior_empty_result: Option<AgentResult> = None;
-                if all_creds.is_empty() {
-                    let mut result = run_codex_turn(
-                        &workspace,
-                        &mission_work_dir,
-                        codex_message,
-                        requested_model,
-                        model_effort.as_deref(),
-                        effective_agent.as_deref(),
-                        mission_id,
-                        events_tx.clone(),
-                        cancel.clone(),
-                        &config.working_dir,
-                        session_id.as_deref(),
-                        None,
-                    )
-                    .await;
-
-                    if let Some(fallback_model) =
-                        codex_chatgpt_fallback_for_result(requested_model, &result)
-                    {
-                        tracing::warn!(
-                            mission_id = %mission_id,
-                            requested_model = ?requested_model,
-                            fallback_model,
-                            "Retrying Codex turn with fallback model for ChatGPT account compatibility"
-                        );
-                        result = run_codex_turn(
-                            &workspace,
-                            &mission_work_dir,
-                            codex_message,
-                            Some(fallback_model),
-                            model_effort.as_deref(),
-                            effective_agent.as_deref(),
-                            mission_id,
-                            events_tx.clone(),
-                            cancel.clone(),
-                            &config.working_dir,
-                            session_id.as_deref(),
-                            None,
-                        )
-                        .await;
-                    } else if codex_tool_stall_should_retry_with_default_model(
-                        requested_model,
-                        &result,
-                    ) {
-                        tracing::warn!(
-                            mission_id = %mission_id,
-                            requested_model = ?requested_model,
-                            "Retrying Codex turn on the requested model (not the stale Codex CLI default) after it stopped before tool use"
-                        );
-                        result = run_codex_turn(
-                            &workspace,
-                            &mission_work_dir,
-                            codex_message,
-                            // Was `None`, which made the Codex CLI fall back to
-                            // its built-in default — currently the retired
-                            // `gpt-5.3-codex`, rejected by ChatGPT-account auth
-                            // with a 400. Retry on the requested (latest) model.
-                            requested_model,
-                            model_effort.as_deref(),
-                            effective_agent.as_deref(),
-                            mission_id,
-                            events_tx.clone(),
-                            cancel.clone(),
-                            &config.working_dir,
-                            session_id.as_deref(),
-                            None,
-                        )
-                        .await;
-                    }
-
-                    // Defensive re-query: if this turn was rate/capacity limited
-                    // and a fresh enumeration now returns accounts, fall through
-                    // to the rotation loop instead of surfacing the failure.
-                    let constrained = matches!(
-                        result.terminal_reason,
-                        Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
-                    );
-                    if constrained {
-                        let recheck = collect_codex_credentials(&config.working_dir);
-                        if !recheck.is_empty() {
-                            tracing::warn!(
-                                mission_id = %mission_id,
-                                recovered_credentials = recheck.len(),
-                                "Codex credential pool was empty on first attempt but re-query found accounts after a rate-limited turn; retrying with rotation"
-                            );
-                            all_creds = recheck;
-                            prior_empty_result = Some(result);
-                            // fall through to rotation loop below
-                        } else {
-                            break 'codex_arm result;
-                        }
-                    } else {
-                        break 'codex_arm result;
-                    }
-                }
-                {
-                    let mut attempted_credentials: HashSet<String> = HashSet::new();
-                    let mut attempt_idx = 0usize;
-                    let mut last_constrained_result: Option<AgentResult> = prior_empty_result;
-
-                    loop {
-                        if cancel.is_cancelled() {
-                            break last_constrained_result
-                                .unwrap_or_else(cancel_or_shutdown_failure);
-                        }
-
-                        let lease = lease_codex_account(
-                            &config.working_dir,
-                            &attempted_credentials,
-                            &cancel,
-                        )
-                        .await;
-                        let Some(lease) = lease else {
-                            if let Some(prev) = last_constrained_result {
-                                break prev;
-                            }
-                            break AgentResult::failure(
-                            "All configured Codex accounts are currently at capacity. Try again shortly."
-                                .to_string(),
-                            0,
-                        )
-                        .with_terminal_reason(TerminalReason::CapacityLimited);
-                        };
-
-                        attempt_idx += 1;
-                        let credential_label = lease.credential.label_for_logs();
-                        attempted_credentials.insert(lease.credential.fingerprint());
-                        let credential_override = lease.credential.as_override();
-
-                        tracing::info!(
-                            mission_id = %mission_id,
-                            attempt = attempt_idx,
-                            credential = %credential_label,
-                            total_credentials = all_creds.len(),
-                            "Running Codex turn with leased account slot"
-                        );
-
-                        let mut result = run_codex_turn(
-                            &workspace,
-                            &mission_work_dir,
-                            codex_message,
-                            requested_model,
-                            model_effort.as_deref(),
-                            effective_agent.as_deref(),
-                            mission_id,
-                            events_tx.clone(),
-                            cancel.clone(),
-                            &config.working_dir,
-                            session_id.as_deref(),
-                            Some(&credential_override),
-                        )
-                        .await;
-
-                        if let Some(fallback_model) =
-                            codex_chatgpt_fallback_for_result(requested_model, &result)
-                        {
-                            tracing::warn!(
-                                mission_id = %mission_id,
-                                attempt = attempt_idx,
-                                requested_model = ?requested_model,
-                                fallback_model,
-                                credential = %credential_label,
-                                "Retrying Codex turn with fallback model for ChatGPT account compatibility"
-                            );
-                            result = run_codex_turn(
-                                &workspace,
-                                &mission_work_dir,
-                                codex_message,
-                                Some(fallback_model),
-                                model_effort.as_deref(),
-                                effective_agent.as_deref(),
-                                mission_id,
-                                events_tx.clone(),
-                                cancel.clone(),
-                                &config.working_dir,
-                                session_id.as_deref(),
-                                Some(&credential_override),
-                            )
-                            .await;
-                        } else if codex_tool_stall_should_retry_with_default_model(
-                            requested_model,
-                            &result,
-                        ) {
-                            tracing::warn!(
-                                mission_id = %mission_id,
-                                attempt = attempt_idx,
-                                requested_model = ?requested_model,
-                                credential = %credential_label,
-                                "Retrying Codex turn on the requested model (not the stale Codex CLI default) after it stopped before tool use"
-                            );
-                            result = run_codex_turn(
-                                &workspace,
-                                &mission_work_dir,
-                                codex_message,
-                                // Was `None` (stale CLI default gpt-5.3-codex,
-                                // 400 on ChatGPT auth). Retry on the requested
-                                // (latest) model instead.
-                                requested_model,
-                                model_effort.as_deref(),
-                                effective_agent.as_deref(),
-                                mission_id,
-                                events_tx.clone(),
-                                cancel.clone(),
-                                &config.working_dir,
-                                session_id.as_deref(),
-                                Some(&credential_override),
-                            )
-                            .await;
-                        }
-
-                        drop(lease);
-
-                        match result.terminal_reason {
-                            Some(
-                                TerminalReason::RateLimited
-                                | TerminalReason::CapacityLimited
-                                | TerminalReason::AuthError,
-                            ) if attempted_credentials.len() < all_creds.len() => {
-                                let reason = match result.terminal_reason {
-                                    Some(TerminalReason::CapacityLimited) => "capacity limited",
-                                    Some(TerminalReason::AuthError) => {
-                                        "auth failed (likely refresh-token reuse)"
-                                    }
-                                    _ => "rate limited",
-                                };
-                                tracing::info!(
-                                    mission_id = %mission_id,
-                                    attempt = attempt_idx,
-                                    reason,
-                                    "Codex account constrained; leasing next account"
-                                );
-                                last_constrained_result = Some(result);
-                            }
-                            _ => break result,
-                        }
-                    }
-                }
-            }
+            // Unified credential pool + rotation + cooldown handling lives in
+            // run_codex_turn_with_rotation so the control-channel follow-up
+            // path gets identical account-rotation behaviour.
+            run_codex_turn_with_rotation(
+                &workspace,
+                &mission_work_dir,
+                codex_message,
+                requested_model,
+                model_effort.as_deref(),
+                effective_agent.as_deref(),
+                mission_id,
+                events_tx.clone(),
+                cancel.clone(),
+                &config.working_dir,
+                session_id.as_deref(),
+            )
+            .await
         }
         "gemini" => {
             run_gemini_turn(
@@ -13266,6 +13098,272 @@ fn contains_ascii_word(haystack: &str, needle: &str) -> bool {
 }
 
 #[allow(clippy::too_many_arguments)]
+
+/// Run a codex turn through the unified credential pool with rotation and
+/// account-level cooldown handling. Shared by the initial mission dispatch
+/// and the control-channel follow-up path so a usage-capped ChatGPT account
+/// rotates to the next credential everywhere.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_codex_turn_with_rotation(
+    workspace: &Workspace,
+    mission_work_dir: &std::path::Path,
+    codex_message: &str,
+    requested_model: Option<&str>,
+    model_effort: Option<&str>,
+    agent: Option<&str>,
+    mission_id: Uuid,
+    events_tx: broadcast::Sender<AgentEvent>,
+    cancel: CancellationToken,
+    app_working_dir: &std::path::Path,
+    session_id: Option<&str>,
+) -> AgentResult {
+    'codex_arm: {
+        let mut all_creds = collect_codex_credentials(app_working_dir);
+        let mut prior_empty_result: Option<AgentResult> = None;
+        if all_creds.is_empty() {
+            let mut result = run_codex_turn(
+                workspace,
+                mission_work_dir,
+                codex_message,
+                requested_model,
+                model_effort,
+                agent,
+                mission_id,
+                events_tx.clone(),
+                cancel.clone(),
+                app_working_dir,
+                session_id,
+                None,
+            )
+            .await;
+
+            if let Some(fallback_model) =
+                codex_chatgpt_fallback_for_result(requested_model, &result)
+            {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    requested_model = ?requested_model,
+                    fallback_model,
+                    "Retrying Codex turn with fallback model for ChatGPT account compatibility"
+                );
+                result = run_codex_turn(
+                    workspace,
+                    mission_work_dir,
+                    codex_message,
+                    Some(fallback_model),
+                    model_effort,
+                    agent,
+                    mission_id,
+                    events_tx.clone(),
+                    cancel.clone(),
+                    app_working_dir,
+                    session_id,
+                    None,
+                )
+                .await;
+            } else if codex_tool_stall_should_retry_with_default_model(requested_model, &result) {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    requested_model = ?requested_model,
+                    "Retrying Codex turn on the requested model (not the stale Codex CLI default) after it stopped before tool use"
+                );
+                result = run_codex_turn(
+                    workspace,
+                    mission_work_dir,
+                    codex_message,
+                    // Was `None`, which made the Codex CLI fall back to
+                    // its built-in default — currently the retired
+                    // `gpt-5.3-codex`, rejected by ChatGPT-account auth
+                    // with a 400. Retry on the requested (latest) model.
+                    requested_model,
+                    model_effort,
+                    agent,
+                    mission_id,
+                    events_tx.clone(),
+                    cancel.clone(),
+                    app_working_dir,
+                    session_id,
+                    None,
+                )
+                .await;
+            }
+
+            // Defensive re-query: if this turn was rate/capacity limited
+            // and a fresh enumeration now returns accounts, fall through
+            // to the rotation loop instead of surfacing the failure.
+            let constrained = matches!(
+                result.terminal_reason,
+                Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
+            );
+            if constrained {
+                let recheck = collect_codex_credentials(app_working_dir);
+                if !recheck.is_empty() {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        recovered_credentials = recheck.len(),
+                        "Codex credential pool was empty on first attempt but re-query found accounts after a rate-limited turn; retrying with rotation"
+                    );
+                    all_creds = recheck;
+                    prior_empty_result = Some(result);
+                    // fall through to rotation loop below
+                } else {
+                    break 'codex_arm result;
+                }
+            } else {
+                break 'codex_arm result;
+            }
+        }
+        {
+            let mut attempted_credentials: HashSet<String> = HashSet::new();
+            let mut attempt_idx = 0usize;
+            let mut last_constrained_result: Option<AgentResult> = prior_empty_result;
+
+            loop {
+                if cancel.is_cancelled() {
+                    break last_constrained_result.unwrap_or_else(cancel_or_shutdown_failure);
+                }
+
+                let lease =
+                    lease_codex_account(app_working_dir, &attempted_credentials, &cancel).await;
+                let Some(lease) = lease else {
+                    if let Some(prev) = last_constrained_result {
+                        break prev;
+                    }
+                    break AgentResult::failure(
+                    "All configured Codex accounts are currently at capacity. Try again shortly."
+                        .to_string(),
+                    0,
+                )
+                .with_terminal_reason(TerminalReason::CapacityLimited);
+                };
+
+                attempt_idx += 1;
+                let credential_label = lease.credential.label_for_logs();
+                let credential_fingerprint = lease.credential.fingerprint();
+                attempted_credentials.insert(credential_fingerprint.clone());
+                let credential_override = lease.credential.as_override();
+
+                tracing::info!(
+                    mission_id = %mission_id,
+                    attempt = attempt_idx,
+                    credential = %credential_label,
+                    total_credentials = all_creds.len(),
+                    "Running Codex turn with leased account slot"
+                );
+
+                let mut result = run_codex_turn(
+                    workspace,
+                    mission_work_dir,
+                    codex_message,
+                    requested_model,
+                    model_effort,
+                    agent,
+                    mission_id,
+                    events_tx.clone(),
+                    cancel.clone(),
+                    app_working_dir,
+                    session_id,
+                    Some(&credential_override),
+                )
+                .await;
+
+                if let Some(fallback_model) =
+                    codex_chatgpt_fallback_for_result(requested_model, &result)
+                {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        attempt = attempt_idx,
+                        requested_model = ?requested_model,
+                        fallback_model,
+                        credential = %credential_label,
+                        "Retrying Codex turn with fallback model for ChatGPT account compatibility"
+                    );
+                    result = run_codex_turn(
+                        workspace,
+                        mission_work_dir,
+                        codex_message,
+                        Some(fallback_model),
+                        model_effort,
+                        agent,
+                        mission_id,
+                        events_tx.clone(),
+                        cancel.clone(),
+                        app_working_dir,
+                        session_id,
+                        Some(&credential_override),
+                    )
+                    .await;
+                } else if codex_tool_stall_should_retry_with_default_model(requested_model, &result)
+                {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        attempt = attempt_idx,
+                        requested_model = ?requested_model,
+                        credential = %credential_label,
+                        "Retrying Codex turn on the requested model (not the stale Codex CLI default) after it stopped before tool use"
+                    );
+                    result = run_codex_turn(
+                        workspace,
+                        mission_work_dir,
+                        codex_message,
+                        // Was `None` (stale CLI default gpt-5.3-codex,
+                        // 400 on ChatGPT auth). Retry on the requested
+                        // (latest) model instead.
+                        requested_model,
+                        model_effort,
+                        agent,
+                        mission_id,
+                        events_tx.clone(),
+                        cancel.clone(),
+                        app_working_dir,
+                        session_id,
+                        Some(&credential_override),
+                    )
+                    .await;
+                }
+
+                // Cooldown bookkeeping: a capped/constrained account is
+                // skipped by every future lease (this turn or any later
+                // path) until its cooldown lapses; a healthy turn clears
+                // any stale cooldown.
+                match result
+                    .terminal_reason
+                    .as_ref()
+                    .and_then(codex_cooldown_for_reason)
+                {
+                    Some(cooldown) => set_codex_account_cooldown(&credential_fingerprint, cooldown),
+                    None => clear_codex_account_cooldown(&credential_fingerprint),
+                }
+                drop(lease);
+
+                match result.terminal_reason {
+                    Some(
+                        TerminalReason::RateLimited
+                        | TerminalReason::CapacityLimited
+                        | TerminalReason::AuthError,
+                    ) if attempted_credentials.len() < all_creds.len() => {
+                        let reason = match result.terminal_reason {
+                            Some(TerminalReason::CapacityLimited) => "capacity limited",
+                            Some(TerminalReason::AuthError) => {
+                                "auth failed (likely refresh-token reuse)"
+                            }
+                            _ => "rate limited",
+                        };
+                        tracing::info!(
+                            mission_id = %mission_id,
+                            attempt = attempt_idx,
+                            reason,
+                            "Codex account constrained; leasing next account"
+                        );
+                        last_constrained_result = Some(result);
+                    }
+                    _ => break result,
+                }
+            }
+        }
+    }
+}
+
 pub async fn run_codex_turn(
     workspace: &Workspace,
     mission_work_dir: &std::path::Path,
@@ -14674,8 +14772,9 @@ mod tests {
         claudecode_malformed_startup_message, claudecode_pre_turn_transport_message,
         claudecode_resume_current_session_message, claudecode_transport_failure_data,
         claudecode_transport_failure_stage, claudecode_transport_failure_stage_for_incomplete_turn,
-        claudecode_transport_recovery_strategy, codex_chatgpt_fallback_for_result,
-        codex_chatgpt_fallback_model, codex_error_message_to_surface,
+        claudecode_transport_recovery_strategy, clear_codex_account_cooldown,
+        codex_account_cooldown_remaining, codex_chatgpt_fallback_for_result,
+        codex_chatgpt_fallback_model, codex_cooldown_for_reason, codex_error_message_to_surface,
         codex_final_message_looks_like_progress_update, codex_is_goal_request,
         codex_key_fingerprint, codex_missing_goal_final_response_message,
         codex_tool_stall_should_retry_with_default_model, codex_turn_requires_tool_activity,
@@ -14690,11 +14789,13 @@ mod tests {
         parse_opencode_goal_objective, parse_opencode_session_token, parse_opencode_sse_event,
         parse_opencode_stderr_text_part, preferred_model_for_cost, record_codex_error_message,
         replace_filepath_artifact_with_tool_output, resolve_cost_cents_and_source, running_health,
-        sanitized_opencode_stdout, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
-        strip_think_tags, summarize_recent_opencode_stderr, thinking_overlaps_visible_answer,
-        use_thinking_only_fallback, ClaudeIncompleteTurnContext, ClaudeTransportFailureStage,
-        ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState, MissionHealth, MissionRunState,
-        MissionStallSeverity, OpencodeSseState, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        sanitized_opencode_stdout, set_codex_account_cooldown, stall_severity, strip_ansi_codes,
+        strip_opencode_banner_lines, strip_think_tags, summarize_recent_opencode_stderr,
+        thinking_overlaps_visible_answer, use_thinking_only_fallback, ClaudeIncompleteTurnContext,
+        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
+        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState,
+        CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN, CODEX_RATE_LIMIT_COOLDOWN,
+        STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -15083,6 +15184,44 @@ mod tests {
         assert!(is_rate_limited_error(
             "see chatgpt.com/codex/settings/usage for details"
         ));
+    }
+
+    #[test]
+    fn codex_account_cooldown_set_query_clear() {
+        let fp = "test:cooldown-roundtrip";
+        assert!(codex_account_cooldown_remaining(fp).is_none());
+        set_codex_account_cooldown(fp, std::time::Duration::from_secs(60));
+        let remaining = codex_account_cooldown_remaining(fp).expect("cooldown set");
+        assert!(remaining <= std::time::Duration::from_secs(60));
+        assert!(remaining > std::time::Duration::from_secs(50));
+        clear_codex_account_cooldown(fp);
+        assert!(codex_account_cooldown_remaining(fp).is_none());
+    }
+
+    #[test]
+    fn codex_account_cooldown_expires() {
+        let fp = "test:cooldown-expiry";
+        set_codex_account_cooldown(fp, std::time::Duration::from_millis(0));
+        // A zero-duration cooldown is immediately lapsed.
+        assert!(codex_account_cooldown_remaining(fp).is_none());
+        clear_codex_account_cooldown(fp);
+    }
+
+    #[test]
+    fn codex_cooldown_reason_mapping() {
+        assert_eq!(
+            codex_cooldown_for_reason(&TerminalReason::RateLimited),
+            Some(CODEX_RATE_LIMIT_COOLDOWN)
+        );
+        assert_eq!(
+            codex_cooldown_for_reason(&TerminalReason::CapacityLimited),
+            Some(CODEX_CAPACITY_COOLDOWN)
+        );
+        assert_eq!(
+            codex_cooldown_for_reason(&TerminalReason::AuthError),
+            Some(CODEX_AUTH_ERROR_COOLDOWN)
+        );
+        assert_eq!(codex_cooldown_for_reason(&TerminalReason::Cancelled), None);
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -834,6 +834,21 @@ struct LeasedCodexAccount {
     _permit: OwnedSemaphorePermit,
 }
 
+/// Longest prefix of `s` that is at most `max_bytes` long without splitting
+/// a UTF-8 code point. A plain `&s[..n]` panics when byte `n` lands inside a
+/// multi-byte char (a user message with an em-dash at the boundary once took
+/// down the whole mission runner task before the turn started).
+fn utf8_safe_prefix(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 fn codex_key_fingerprint(key: &str) -> String {
     let suffix: String = key
         .chars()
@@ -2634,9 +2649,24 @@ impl MissionRunner {
                     Some(result)
                 }
                 Err(e) => {
+                    // A panicked turn used to vanish here (mission left
+                    // "active" forever with no event). Synthesize a failed
+                    // result so the normal finalization path marks the
+                    // mission failed and the UI surfaces the error.
                     tracing::error!("Mission runner task failed: {}", e);
                     self.state = MissionRunState::Finished;
-                    None
+                    Some((
+                        self.mission_id,
+                        String::new(),
+                        AgentResult::failure(
+                            format!(
+                                "Internal error: the agent turn crashed before completing ({e}). \
+                                 This is a bug in sandboxed.sh, not in your request — retry the \
+                                 message and report if it persists."
+                            ),
+                            0,
+                        ),
+                    ))
                 }
             }
         } else {
@@ -3150,7 +3180,7 @@ async fn run_mission_turn(
     } else {
         tracing::debug!(
             mission_id = %mission_id,
-            user_message_prefix = &user_message[..user_message.len().min(100)],
+            user_message_prefix = utf8_safe_prefix(&user_message, 100),
             "Not a Telegram message, skipping CLAUDE.md injection"
         );
     }
@@ -14791,11 +14821,11 @@ mod tests {
         replace_filepath_artifact_with_tool_output, resolve_cost_cents_and_source, running_health,
         sanitized_opencode_stdout, set_codex_account_cooldown, stall_severity, strip_ansi_codes,
         strip_opencode_banner_lines, strip_think_tags, summarize_recent_opencode_stderr,
-        thinking_overlaps_visible_answer, use_thinking_only_fallback, ClaudeIncompleteTurnContext,
-        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
-        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState,
-        CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN, CODEX_RATE_LIMIT_COOLDOWN,
-        STALL_SEVERE_SECS, STALL_WARN_SECS,
+        thinking_overlaps_visible_answer, use_thinking_only_fallback, utf8_safe_prefix,
+        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
+        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
+        OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
+        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -15205,6 +15235,19 @@ mod tests {
         // A zero-duration cooldown is immediately lapsed.
         assert!(codex_account_cooldown_remaining(fp).is_none());
         clear_codex_account_cooldown(fp);
+    }
+
+    #[test]
+    fn utf8_safe_prefix_respects_char_boundaries() {
+        // The exact production crash: em-dash (3 bytes) straddling byte 100.
+        let msg = format!("{}\u{2014}maybe using a few workflows", "a".repeat(98));
+        let prefix = utf8_safe_prefix(&msg, 100);
+        assert_eq!(prefix.len(), 98); // backs off to before the em-dash
+        assert!(prefix.chars().all(|c| c == 'a'));
+        // Boundary-exact and short inputs pass through untouched.
+        assert_eq!(utf8_safe_prefix("abc", 100), "abc");
+        assert_eq!(utf8_safe_prefix("abcd", 4), "abcd");
+        assert_eq!(utf8_safe_prefix("ab\u{2014}", 3), "ab");
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -13127,8 +13127,6 @@ fn contains_ascii_word(haystack: &str, needle: &str) -> bool {
     false
 }
 
-#[allow(clippy::too_many_arguments)]
-
 /// Run a codex turn through the unified credential pool with rotation and
 /// account-level cooldown handling. Shared by the initial mission dispatch
 /// and the control-channel follow-up path so a usage-capped ChatGPT account
@@ -13394,6 +13392,7 @@ pub(crate) async fn run_codex_turn_with_rotation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_codex_turn(
     workspace: &Workspace,
     mission_work_dir: &std::path::Path,

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -126,9 +126,12 @@ struct LlmRolesResponse {
 async fn get_llm_roles(State(state): State<Arc<AppState>>) -> Json<LlmRolesResponse> {
     let model_override = state.settings.get().await.ask_assistant_model;
 
-    let assistant =
-        super::metadata_llm::assistant_role_status(&state.ai_providers, model_override.clone())
-            .await;
+    let assistant = super::metadata_llm::assistant_role_status(
+        &state.ai_providers,
+        &state.chain_store,
+        model_override.clone(),
+    )
+    .await;
     let metadata = super::metadata_llm::metadata_role_status(&state.ai_providers).await;
 
     // The override is honored only when the resolved model actually matches it

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -868,7 +868,7 @@ fn sanitize_env_vars(env_vars: HashMap<String, String>) -> HashMap<String, Strin
         .collect()
 }
 
-fn is_valid_env_name(key: &str) -> bool {
+pub(crate) fn is_valid_env_name(key: &str) -> bool {
     let mut chars = key.chars();
     match chars.next() {
         Some(c) if c.is_ascii_alphabetic() || c == '_' => {}


### PR DESCRIPTION
Three commits that landed on `feat/assistant-workspace-bash` after #502 merged:

## codex: rotate accounts on control-path turns + usage-cap cooldown memory (`381a865f`)
Follow-up/retry turns (control path) ran a single bare `run_codex_turn` with no rotation, so a usage-capped ChatGPT account kept failing with the same limit error instead of rotating to the next credential. The rotation loop is extracted into `run_codex_turn_with_rotation` and shared by both the initial dispatch and the control path.

Adds account-level cooldown memory: `RateLimited` puts a credential on a 15-minute cooldown (`CapacityLimited` 2m, `AuthError` 10m); leases prefer non-cooled credentials and fall back to cooled ones only when nothing fresh exists.

**Already deployed to prod and verified live** (failed mission retried successfully through the rotation path).

## ask: cursor-anchored upward fold for tool-step runs (`d57bc22f`)
Mirrors the main chat's fold: the toggle's viewport position is captured on click and the scroller re-aligned pre-paint, so steps reveal upward into history while the toggle and everything below stay put. Verified 10 frames at 0px drift in both directions.

## ask: freshness-aware copilot + workspace-env secrets bridge (`1ff9f72b`)
The Ask copilot summarized a live mission ~10h stale and couldn't help when the working agent lost an API key pasted in chat (real incident on the Verity research mission: chat-pasted proxy key vanished at context compaction → HTTP 401). Root causes: no notion of current time, silent 8KB tool-result truncation on a 5000-line research log, and no durable channel for credentials shared in chat.

**System prompt:** current UTC time + real mission status/`updated_at` with a date-your-claims rule; recency-first investigation order (`ls -lt`, `tail`, `git log`, read_history); latest `goal_status` event surfaced (200-event scan); timestamps on every seeded/history event line; heuristic detection of credential-shaped tokens in the operator message (sk-/ghp_/AKIA/JWT/…) that nudges immediate persistence via `set_workspace_env`.

**Tools:** `read_file` gains offset/limit line ranges and always leads with total lines/bytes; tool-result truncation now appends an explicit notice with the full size; new `list_workspace_env` (masked values), `set_workspace_env` (persists to the mission's workspace, injected into the harness from its next turn, notifies the working agent by NAME only via operator note; disabled in sandbox mode), and `proxy_key_status` (`last_used_at` facts).

Tests: ask module 7/7 (incl. truncation notice, secret detection on synthetic tokens, value masking), fmt + clippy clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch mission Codex dispatch, workspace env mutation from Ask, and credential heuristics; mitigations include sandbox blocks on env writes, masked listing, and shared rotation logic, but mis-routed secrets or rotation edge cases could still affect live missions.
> 
> **Overview**
> **Codex** follow-up turns on the control path now use the same **`run_codex_turn_with_rotation`** path as initial dispatch, with in-memory **usage-cap cooldowns** (rate limit / capacity / auth) so leases prefer fresh credentials. Panicked mission-runner tasks are turned into **failed agent results** instead of leaving missions stuck active; **`utf8_safe_prefix`** avoids UTF-8 slice panics when logging user messages.
> 
> **Ask assistant** gets a **time- and recency-aware** system prompt (UTC clock, mission status/`updated_at`, latest `goal_status`, timestamps on seeded events), **explicit 8KB tool truncation notices**, **`read_file` offset/limit** with size headers, and new tools **`list_workspace_env`**, **`set_workspace_env`** (persist secrets to workspace env + operator note by name only; blocked in sandbox), and **`proxy_key_status`**. HTTP wiring passes **workspace store** and **proxy key store** into each turn. **`build_assistant_llm_config`** can route chain ids and `provider/model` overrides through the **local `/v1` proxy** when configured.
> 
> **Dashboard:** LLM settings replace the free-text Ask model field with a **select** (defaults, routing chains, provider models, custom). **Ask panel** tool-step fold uses **scroll anchoring** so expand/collapse does not jump the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60db248a0f6ea835b50e303b05b0ea463f5f271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->