### PR TITLE
queue: fix ghost rows after delete + scope clear-all per mission

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -117,6 +117,8 @@ import {
   type DesktopSessionDetail,
   type StoredEvent,
   type SharedFile,
+  type QueuedMessage,
+  isHttpStatusError,
 } from "@/lib/api";
 import { QueueStrip, type QueueItem } from "@/components/queue-strip";
 import { GoalBar } from "@/components/goal-bar";
@@ -570,6 +572,52 @@ const PerfOverlay = dynamic(() =>
 
 type ToolItem = Extract<ChatItem, { kind: "tool" }>;
 type SidePanelItem = Extract<ChatItem, { kind: "thinking" | "stream" }>;
+
+/**
+ * Merge a `getQueue()` snapshot into history items for one mission: mark
+ * existing user rows as queued and append rows for queue entries missing
+ * from history.
+ *
+ * `snapshotIsFresh` must be false when a local queue mutation (remove /
+ * clear) happened while the snapshot was in flight — such a snapshot may
+ * still contain a just-deleted message, and merging it would resurrect the
+ * message as a ghost row that the server can no longer delete (404). Stale
+ * snapshots are ignored entirely; the post-mutation queue sync reconciles
+ * flags with a fresh fetch.
+ */
+function mergeQueuedMessagesIntoItems(
+  historyItems: ChatItem[],
+  queuedMessages: QueuedMessage[],
+  missionId: string,
+  snapshotIsFresh: boolean,
+): ChatItem[] {
+  if (!snapshotIsFresh) return historyItems;
+  const missionQueuedMessages = queuedMessages.filter(
+    (qm) => qm.mission_id === missionId,
+  );
+  if (missionQueuedMessages.length === 0) return historyItems;
+  const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
+  // Mark existing items as queued
+  let next = historyItems.map((item) =>
+    item.kind === "user" && queuedIds.has(item.id)
+      ? { ...item, queued: true }
+      : item,
+  );
+  // Add any queued messages not already in history
+  const existingIds = new Set(next.map((item) => item.id));
+  const newQueuedItems: ChatItem[] = missionQueuedMessages
+    .filter((qm) => !existingIds.has(qm.id))
+    .map((qm) => ({
+      kind: "user" as const,
+      id: qm.id,
+      content: qm.content,
+      timestamp: Date.now(),
+      agent: qm.agent ?? undefined,
+      queued: true,
+    }));
+  if (newQueuedItems.length > 0) next = [...next, ...newQueuedItems];
+  return next;
+}
 
 // Mirror of the server's conversation-anchored snapshot (see
 // `get_mission_snapshot` in src/api/control.rs). Keep these in sync.
@@ -4486,6 +4534,12 @@ export default function ControlClient() {
   const [queueLen, setQueueLen] = useControlQueueStore();
   const lastQueueLenRef = useRef<number | null>(null);
   const syncingQueueRef = useRef(false);
+  // Bumped whenever the user locally mutates the queue (remove / clear all).
+  // getQueue() snapshots capture the generation *before* the fetch and compare
+  // it when applying — a snapshot taken while a deletion was in flight may
+  // still contain the deleted message, and merging it would resurrect the
+  // message as a ghost row (visible in the queue strip, 404 on re-delete).
+  const queueMutationGenRef = useRef(0);
 
   // Backwards-pagination state. Long missions can have 20k+ history events
   // and the initial load is capped at HISTORY_PAGE_SIZE for memory + render
@@ -6488,6 +6542,7 @@ export default function ControlClient() {
       fetchingMissionIdRef.current = id; // Track which mission we're loading
       try {
         // Load mission, events, and queue in parallel for faster load
+        const queueGenAtFetch = queueMutationGenRef.current;
         const [mission, events, queuedMessages] = await Promise.all([
           loadMission(id),
           loadHistoryEvents(id).catch(() => null), // Don't fail if events unavailable
@@ -6574,31 +6629,12 @@ export default function ControlClient() {
         // correctly (see `seedPaginationStateAfterInitialLoad`).
         const historicEventsLen = historyItems.length;
         // Merge queued messages that belong to this mission
-        const missionQueuedMessages = queuedMessages.filter(
-          (qm) => qm.mission_id === id,
+        historyItems = mergeQueuedMessagesIntoItems(
+          historyItems,
+          queuedMessages,
+          id,
+          queueGenAtFetch === queueMutationGenRef.current,
         );
-        if (missionQueuedMessages.length > 0) {
-          const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
-          // Mark existing items as queued
-          historyItems = historyItems.map((item) =>
-            item.kind === "user" && queuedIds.has(item.id)
-              ? { ...item, queued: true }
-              : item,
-          );
-          // Add any queued messages not already in history
-          const existingIds = new Set(historyItems.map((item) => item.id));
-          const newQueuedItems: ChatItem[] = missionQueuedMessages
-            .filter((qm) => !existingIds.has(qm.id))
-            .map((qm) => ({
-              kind: "user" as const,
-              id: qm.id,
-              content: qm.content,
-              timestamp: Date.now(),
-              agent: qm.agent ?? undefined,
-              queued: true,
-            }));
-          historyItems = [...historyItems, ...newQueuedItems];
-        }
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
         seedPaginationStateAfterInitialLoad(id, historicEventsLen);
@@ -6655,6 +6691,7 @@ export default function ControlClient() {
           applyDesktopSessionState(mission);
           router.replace(`/control?mission=${mission.id}`, { scroll: false });
           // Load full events and queue in background (including tool calls)
+          const queueGenAtFetch = queueMutationGenRef.current;
           Promise.all([
             loadHistoryEvents(mission.id),
             getQueue().catch(() => []),
@@ -6669,33 +6706,12 @@ export default function ControlClient() {
               // queued items (see `seedPaginationStateAfterInitialLoad`).
               const historicEventsLen = historyItems.length;
               // Merge queued messages that belong to this mission
-              const missionQueuedMessages = queuedMessages.filter(
-                (qm) => qm.mission_id === mission.id,
+              historyItems = mergeQueuedMessagesIntoItems(
+                historyItems,
+                queuedMessages,
+                mission.id,
+                queueGenAtFetch === queueMutationGenRef.current,
               );
-              if (missionQueuedMessages.length > 0) {
-                const queuedIds = new Set(
-                  missionQueuedMessages.map((qm) => qm.id),
-                );
-                historyItems = historyItems.map((item) =>
-                  item.kind === "user" && queuedIds.has(item.id)
-                    ? { ...item, queued: true }
-                    : item,
-                );
-                const existingIds = new Set(
-                  historyItems.map((item) => item.id),
-                );
-                const newQueuedItems: ChatItem[] = missionQueuedMessages
-                  .filter((qm) => !existingIds.has(qm.id))
-                  .map((qm) => ({
-                    kind: "user" as const,
-                    id: qm.id,
-                    content: qm.content,
-                    timestamp: Date.now(),
-                    agent: qm.agent ?? undefined,
-                    queued: true,
-                  }));
-                historyItems = [...historyItems, ...newQueuedItems];
-              }
               setItems(historyItems);
               adjustVisibleItemsLimit(historyItems);
               seedPaginationStateAfterInitialLoad(
@@ -7177,6 +7193,7 @@ export default function ControlClient() {
       // This ensures we don't show stale cached events
       try {
         // Load mission, events, and queue in parallel for faster load
+        const queueGenAtFetch = queueMutationGenRef.current;
         const [mission, events, queuedMessages] = await Promise.all([
           getMission(missionId),
           loadHistoryEvents(missionId).catch(() => null), // Don't fail if events unavailable
@@ -7200,29 +7217,12 @@ export default function ControlClient() {
         // (see `seedPaginationStateAfterInitialLoad`).
         const historicEventsLen = historyItems.length;
         // Merge queued messages that belong to this mission
-        const missionQueuedMessages = queuedMessages.filter(
-          (qm) => qm.mission_id === missionId,
+        historyItems = mergeQueuedMessagesIntoItems(
+          historyItems,
+          queuedMessages,
+          missionId,
+          queueGenAtFetch === queueMutationGenRef.current,
         );
-        if (missionQueuedMessages.length > 0) {
-          const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
-          historyItems = historyItems.map((item) =>
-            item.kind === "user" && queuedIds.has(item.id)
-              ? { ...item, queued: true }
-              : item,
-          );
-          const existingIds = new Set(historyItems.map((item) => item.id));
-          const newQueuedItems: ChatItem[] = missionQueuedMessages
-            .filter((qm) => !existingIds.has(qm.id))
-            .map((qm) => ({
-              kind: "user" as const,
-              id: qm.id,
-              content: qm.content,
-              timestamp: Date.now(),
-              agent: qm.agent ?? undefined,
-              queued: true,
-            }));
-          historyItems = [...historyItems, ...newQueuedItems];
-        }
 
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
@@ -8046,7 +8046,12 @@ export default function ControlClient() {
         }
 
         const nextQueueLen = typeof q === "number" ? q : 0;
-        setQueueLen(nextQueueLen);
+        // Only adopt the queue length when the status concerns the viewed
+        // mission — parallel missions emit their own per-mission Status
+        // events and must not clobber the viewed mission's badge.
+        if (shouldApplyStatus) {
+          setQueueLen(nextQueueLen);
+        }
         setRunStateMissionId(effectiveMissionId);
 
         if (shouldApplyStatus && effectiveMissionId) {
@@ -9834,7 +9839,12 @@ export default function ControlClient() {
       if (!missionId || syncingQueueRef.current) return;
       syncingQueueRef.current = true;
       try {
+        const queueGenAtFetch = queueMutationGenRef.current;
         const queuedMessages = await getQueue();
+        // A local remove/clear landed while this snapshot was in flight —
+        // it may still contain the deleted message. Discard it; the
+        // mutation handler triggers its own (fresh) sync.
+        if (queueGenAtFetch !== queueMutationGenRef.current) return;
         const queuedForMission = queuedMessages.filter(
           (qm) => qm.mission_id === missionId,
         );
@@ -9873,6 +9883,7 @@ export default function ControlClient() {
     async (missionId: string) => {
       try {
         const knownSeq = missionMaxSeqRef.current.get(missionId) ?? 0;
+        const queueGenAtFetch = queueMutationGenRef.current;
 
         if (knownSeq > 0) {
           const [mission, deltaEvents, queuedMessages] = await Promise.all([
@@ -9989,36 +10000,43 @@ export default function ControlClient() {
 
           // Queue reconciliation still needs every tick — a message
           // could move from "queued" to "processing" with no new events.
-          const missionQueuedMessages = queuedMessages.filter(
-            (qm) => qm.mission_id === missionId,
-          );
-          const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
-          setItems((prev) => {
-            let changed = false;
-            const next = prev.map((item) => {
-              if (item.kind !== "user") return item;
-              const shouldBeQueued = queuedIds.has(item.id);
-              if (!!item.queued === shouldBeQueued) return item;
-              changed = true;
-              return { ...item, queued: shouldBeQueued };
+          // Skip when a local remove/clear landed while the snapshot was
+          // in flight: the snapshot may still contain the deleted message
+          // and re-adding it would resurrect a ghost row.
+          if (queueGenAtFetch === queueMutationGenRef.current) {
+            const missionQueuedMessages = queuedMessages.filter(
+              (qm) => qm.mission_id === missionId,
+            );
+            const queuedIds = new Set(
+              missionQueuedMessages.map((qm) => qm.id),
+            );
+            setItems((prev) => {
+              let changed = false;
+              const next = prev.map((item) => {
+                if (item.kind !== "user") return item;
+                const shouldBeQueued = queuedIds.has(item.id);
+                if (!!item.queued === shouldBeQueued) return item;
+                changed = true;
+                return { ...item, queued: shouldBeQueued };
+              });
+              const existingIds = new Set(prev.map((it) => it.id));
+              const newQueued: ChatItem[] = missionQueuedMessages
+                .filter((qm) => !existingIds.has(qm.id))
+                .map((qm) => ({
+                  kind: "user" as const,
+                  id: qm.id,
+                  content: qm.content,
+                  timestamp: Date.now(),
+                  agent: qm.agent ?? undefined,
+                  queued: true,
+                }));
+              if (newQueued.length === 0 && !changed) return prev;
+              const merged =
+                newQueued.length > 0 ? [...next, ...newQueued] : next;
+              updateMissionItems(missionId, merged);
+              return merged;
             });
-            const existingIds = new Set(prev.map((it) => it.id));
-            const newQueued: ChatItem[] = missionQueuedMessages
-              .filter((qm) => !existingIds.has(qm.id))
-              .map((qm) => ({
-                kind: "user" as const,
-                id: qm.id,
-                content: qm.content,
-                timestamp: Date.now(),
-                agent: qm.agent ?? undefined,
-                queued: true,
-              }));
-            if (newQueued.length === 0 && !changed) return prev;
-            const merged =
-              newQueued.length > 0 ? [...next, ...newQueued] : next;
-            updateMissionItems(missionId, merged);
-            return merged;
-          });
+          }
           if (!needsFullReload) return;
           // Orphan delta — clear the cursor and fall through to the
           // full reload below so state reconstructs with full context.
@@ -10026,6 +10044,7 @@ export default function ControlClient() {
         }
 
         // Full reload fallback (first load or counter reset).
+        const fullQueueGenAtFetch = queueMutationGenRef.current;
         const [mission, events, queuedMessages] = await Promise.all([
           getMission(missionId),
           loadHistoryEvents(missionId).catch(() => null),
@@ -10047,29 +10066,12 @@ export default function ControlClient() {
         // Pre-queue length: pagination uses this to find the live tail
         // without clipping queued items (see `seedPaginationStateAfterInitialLoad`).
         const historicEventsLen = historyItems.length;
-        const missionQueuedMessages = queuedMessages.filter(
-          (qm) => qm.mission_id === missionId,
+        historyItems = mergeQueuedMessagesIntoItems(
+          historyItems,
+          queuedMessages,
+          missionId,
+          fullQueueGenAtFetch === queueMutationGenRef.current,
         );
-        if (missionQueuedMessages.length > 0) {
-          const queuedIds = new Set(missionQueuedMessages.map((qm) => qm.id));
-          historyItems = historyItems.map((item) =>
-            item.kind === "user" && queuedIds.has(item.id)
-              ? { ...item, queued: true }
-              : item,
-          );
-          const existingIds = new Set(historyItems.map((item) => item.id));
-          const newQueuedItems: ChatItem[] = missionQueuedMessages
-            .filter((qm) => !existingIds.has(qm.id))
-            .map((qm) => ({
-              kind: "user" as const,
-              id: qm.id,
-              content: qm.content,
-              timestamp: Date.now(),
-              agent: qm.agent ?? undefined,
-              queued: true,
-            }));
-          historyItems = [...historyItems, ...newQueuedItems];
-        }
 
         setItems(historyItems);
         adjustVisibleItemsLimit(historyItems);
@@ -10139,31 +10141,68 @@ export default function ControlClient() {
       .map((item) => ({
         id: item.id,
         content: item.content,
-        agent: null, // Agent info not stored in current item structure
+        agent: item.agent ?? null,
       }));
   }, [items]);
+
+  // Drop a message from the local timeline (and the viewed mission's cache,
+  // so the row doesn't come back from a cache restore).
+  const dropQueuedItemLocally = useCallback(
+    (messageId: string) => {
+      setItems((prev) => {
+        const next = prev.filter((item) => item.id !== messageId);
+        if (next.length === prev.length) return prev;
+        const missionId = viewingMissionIdRef.current;
+        if (missionId) updateMissionItems(missionId, next);
+        return next;
+      });
+    },
+    [setItems, updateMissionItems],
+  );
 
   // Handle removing a message from the queue
   const handleRemoveFromQueue = async (messageId: string) => {
     try {
       await removeFromQueue(messageId);
-      // Optimistically remove from local state
-      setItems((prev) => prev.filter((item) => item.id !== messageId));
+      // Invalidate in-flight getQueue() snapshots (they may predate the
+      // deletion and would resurrect the message), then drop it locally.
+      queueMutationGenRef.current += 1;
+      dropQueuedItemLocally(messageId);
       toast.success("Removed from queue");
+      // Belt-and-braces: reconcile against a fresh post-delete snapshot.
+      const missionId = viewingMissionIdRef.current;
+      if (missionId) void syncQueueForMission(missionId);
     } catch (err) {
+      if (isHttpStatusError(err, 404)) {
+        // The server no longer has this message (e.g. a stale snapshot
+        // resurrected an already-deleted row) — self-heal by dropping it.
+        queueMutationGenRef.current += 1;
+        dropQueuedItemLocally(messageId);
+        toast.success("Message already removed from queue");
+        return;
+      }
       console.error(err);
       toast.error("Failed to remove from queue");
     }
   };
 
-  // Handle clearing all queued messages
+  // Handle clearing all queued messages for the viewed mission
   const handleClearQueue = async () => {
     try {
-      const { cleared } = await clearQueue();
+      // Scope to the viewed mission so clearing here doesn't wipe other
+      // missions' queues.
+      const missionId = viewingMissionIdRef.current;
+      const { cleared } = await clearQueue(missionId ?? undefined);
+      queueMutationGenRef.current += 1;
       // Optimistically remove all queued items from local state
-      setItems((prev) =>
-        prev.filter((item) => !(item.kind === "user" && item.queued === true)),
-      );
+      setItems((prev) => {
+        const next = prev.filter(
+          (item) => !(item.kind === "user" && item.queued === true),
+        );
+        if (next.length === prev.length) return prev;
+        if (missionId) updateMissionItems(missionId, next);
+        return next;
+      });
       toast.success(
         `Cleared ${cleared} message${cleared !== 1 ? "s" : ""} from queue`,
       );

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -33,6 +33,7 @@ import {
   libPut,
   libDel,
   ensureLibraryResponse,
+  HttpStatusError,
 } from "./api/core";
 
 // Types that remain in this file (not yet migrated to modules)
@@ -482,14 +483,26 @@ export async function getQueue(): Promise<QueuedMessage[]> {
 }
 
 export async function removeFromQueue(messageId: string): Promise<void> {
-  return apiDel(
-    `/api/control/queue/${messageId}`,
-    "Failed to remove from queue",
-  );
+  const res = await apiFetch(`/api/control/queue/${messageId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    // Carry the status so callers can treat 404 ("message not in queue")
+    // as already-removed instead of a hard failure.
+    throw new HttpStatusError("Failed to remove from queue", res.status);
+  }
 }
 
-export async function clearQueue(): Promise<{ cleared: number }> {
-  return apiDel("/api/control/queue", "Failed to clear queue");
+/** Clear queued messages. When `missionId` is given, only messages targeting
+ * that mission are cleared — without it the backend wipes every mission's
+ * queue. */
+export async function clearQueue(
+  missionId?: string,
+): Promise<{ cleared: number }> {
+  const path = missionId
+    ? `/api/control/queue?mission_id=${encodeURIComponent(missionId)}`
+    : "/api/control/queue";
+  return apiDel(path, "Failed to clear queue");
 }
 
 // ── Ask assistant (non-interrupting sidecar co-pilot) ──────────────────────

--- a/dashboard/src/lib/api/core.ts
+++ b/dashboard/src/lib/api/core.ts
@@ -46,6 +46,25 @@ export class LibraryUnavailableError extends Error {
   }
 }
 
+/** Error carrying the HTTP status code, for callers that need to branch on it
+ * (e.g. treating a 404 on DELETE as "already gone" rather than a failure). */
+export class HttpStatusError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "HttpStatusError";
+    this.status = status;
+  }
+}
+
+export function isHttpStatusError(
+  error: unknown,
+  status: number,
+): error is HttpStatusError {
+  return error instanceof HttpStatusError && error.status === status;
+}
+
 // ---------------------------------------------------------------------------
 // Base Fetch with Auth
 // ---------------------------------------------------------------------------

--- a/ios_dashboard/SandboxedDashboard/Models/Mission.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/Mission.swift
@@ -234,6 +234,15 @@ struct QueuedMessage: Codable, Identifiable {
     let id: String
     let content: String
     let agent: String?
+    /// Mission this message targets. `GET /api/control/queue` returns every
+    /// mission's queued messages — the UI must filter on this to avoid
+    /// showing (and deleting) another mission's queue entries.
+    let missionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, content, agent
+        case missionId = "mission_id"
+    }
 
     /// Truncated content for display (max 100 chars)
     var displayContent: String {

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -646,11 +646,19 @@ final class APIService {
         let _: EmptyResponse = try await delete("/api/control/queue/\(messageId)")
     }
 
-    func clearQueue() async throws -> Int {
+    /// Clear queued messages. When `missionId` is given, only messages
+    /// targeting that mission are cleared — without it the backend wipes
+    /// every mission's queue.
+    func clearQueue(missionId: String? = nil) async throws -> Int {
         struct ClearResponse: Decodable {
             let cleared: Int
         }
-        let response: ClearResponse = try await delete("/api/control/queue")
+        var path = "/api/control/queue"
+        if let missionId,
+           let encoded = missionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+            path += "?mission_id=\(encoded)"
+        }
+        let response: ClearResponse = try await delete(path)
         return response.cleared
     }
 

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -131,6 +131,11 @@ struct ControlView: View {
     @State private var pendingSendCount = 0
     @State private var queuedItems: [QueuedMessage] = []
     @State private var showQueueSheet = false
+    /// Bumped on every local queue mutation (remove / clear). In-flight
+    /// `getQueue()` responses captured under an older generation are
+    /// discarded — they may still contain a just-deleted message and would
+    /// resurrect it as a ghost row.
+    @State private var queueMutationGeneration = 0
     @State private var currentMission: Mission?
     @State private var viewingMission: Mission?
     @State private var isLoading = true
@@ -3187,7 +3192,20 @@ struct ControlView: View {
 
     private func loadQueueItems() async {
         do {
-            queuedItems = try await api.getQueue()
+            let generation = queueMutationGeneration
+            let allQueued = try await api.getQueue()
+            // A local remove/clear landed while this fetch was in flight —
+            // the snapshot may still contain the deleted message. Discard it.
+            guard generation == queueMutationGeneration else { return }
+            // GET /api/control/queue returns every mission's queued messages;
+            // scope the sheet to the mission being viewed so we never show
+            // (or delete) another mission's queue entries.
+            let missionId = viewingMissionId ?? currentMission?.id
+            if let missionId {
+                queuedItems = allQueued.filter { $0.missionId == missionId }
+            } else {
+                queuedItems = allQueued
+            }
         } catch {
             print("Failed to load queue: \(error)")
         }
@@ -3205,9 +3223,14 @@ struct ControlView: View {
             queuedItems.removeAll { $0.id == messageId }
             queueLength = max(0, queueLength - 1)
         }
+        queueMutationGeneration += 1
         Task {
             do {
                 try await api.removeFromQueue(messageId: messageId)
+            } catch APIError.httpError(404, _) {
+                // Already gone server-side (e.g. a stale snapshot had
+                // resurrected an already-deleted row) — the optimistic
+                // removal was correct; nothing to roll back.
             } catch {
                 print("Failed to remove from queue: \(error)")
                 // Reconcile with the server on error so the row reappears
@@ -3220,16 +3243,19 @@ struct ControlView: View {
     }
 
     /// Synchronous optimistic clear — same rationale as
-    /// `removeFromQueueOptimistic`.
+    /// `removeFromQueueOptimistic`. Scoped to the viewed mission so clearing
+    /// here doesn't wipe other missions' queues.
     private func clearQueueOptimistic() {
         withAnimation(.easeOut(duration: 0.2)) {
             queuedItems = []
             queueLength = 0
         }
+        queueMutationGeneration += 1
         showQueueSheet = false
+        let missionId = viewingMissionId ?? currentMission?.id
         Task {
             do {
-                _ = try await api.clearQueue()
+                _ = try await api.clearQueue(missionId: missionId)
                 HapticService.success()
             } catch {
                 print("Failed to clear queue: \(error)")

--- a/ios_dashboard/SandboxedDashboard/Views/Control/QueueSheet.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/QueueSheet.swift
@@ -144,9 +144,9 @@ struct QueueItemRow: View {
 #Preview("With Items") {
     QueueSheet(
         items: [
-            QueuedMessage(id: "1", content: "Can you also fix the login bug?", agent: nil),
-            QueuedMessage(id: "2", content: "Run the tests after that", agent: "claude"),
-            QueuedMessage(id: "3", content: "This is a much longer message that should get truncated at some point to prevent it from taking up too much space in the queue list view", agent: nil)
+            QueuedMessage(id: "1", content: "Can you also fix the login bug?", agent: nil, missionId: nil),
+            QueuedMessage(id: "2", content: "Run the tests after that", agent: "claude", missionId: nil),
+            QueuedMessage(id: "3", content: "This is a much longer message that should get truncated at some point to prevent it from taking up too much space in the queue list view", agent: nil, missionId: nil)
         ],
         onRemove: { _ in },
         onClearAll: {},

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3118,8 +3118,11 @@ pub enum ControlCommand {
         message_id: Uuid,
         respond: oneshot::Sender<bool>, // true if removed, false if not found
     },
-    /// Clear all messages from the queue
+    /// Clear queued messages. When `mission_id` is set, only messages
+    /// targeting that mission are cleared (main queue entries targeting it +
+    /// that mission's parallel-runner queue); otherwise every queue is wiped.
     ClearQueue {
+        mission_id: Option<Uuid>,
         respond: oneshot::Sender<usize>, // number of messages cleared
     },
 }
@@ -3653,16 +3656,30 @@ pub async fn remove_from_queue(
     }
 }
 
-/// Clear all messages from the queue.
+/// Query parameters for `clear_queue`.
+#[derive(Debug, Default, Deserialize)]
+pub struct ClearQueueQuery {
+    /// When set, only clear messages targeting this mission instead of
+    /// wiping every mission's queue.
+    #[serde(default)]
+    pub mission_id: Option<Uuid>,
+}
+
+/// Clear queued messages (optionally scoped to a single mission via
+/// `?mission_id=`).
 pub async fn clear_queue(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
+    Query(query): Query<ClearQueueQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     let (tx, rx) = oneshot::channel();
     control
         .cmd_tx
-        .send(ControlCommand::ClearQueue { respond: tx })
+        .send(ControlCommand::ClearQueue {
+            mission_id: query.mission_id,
+            respond: tx,
+        })
         .await
         .map_err(session_unavailable)?;
     let cleared = rx.await.map_err(|_| {
@@ -9080,6 +9097,18 @@ async fn control_actor_loop(
                                         queued: was_running,
                                         mission_id: Some(tid),
                                     });
+                                    // Surface the parallel queue growth to all
+                                    // clients (Status events otherwise only
+                                    // carry the main queue length). Only when
+                                    // the message actually stays queued —
+                                    // otherwise start_next pops it right away.
+                                    if was_running {
+                                        let _ = events_tx.send(AgentEvent::Status {
+                                            state: ControlRunState::Running,
+                                            queue_len: runner.queue.len(),
+                                            mission_id: Some(tid),
+                                        });
+                                    }
                                     // Try to start if not already running
                                     if !runner.is_running() {
                                         runner.start_next(
@@ -10505,41 +10534,114 @@ async fn control_actor_loop(
                             });
                         }
 
-                        // Also try to remove from parallel runner queues
+                        // Also try to remove from parallel runner queues.
+                        // Emit a Status event for each affected mission so
+                        // every client (other tabs, iOS) learns the queue
+                        // changed — without this, only the deleting client
+                        // ever updates its UI.
                         for (mid, runner) in parallel_runners.iter_mut() {
                             if runner.remove_from_queue(message_id) {
                                 removed = true;
                                 tracing::info!("Removed message {} from parallel mission {}", message_id, mid);
+                                let _ = events_tx.send(AgentEvent::Status {
+                                    state: if runner.is_running() {
+                                        ControlRunState::Running
+                                    } else {
+                                        ControlRunState::Idle
+                                    },
+                                    queue_len: runner.queue.len(),
+                                    mission_id: Some(*mid),
+                                });
                             }
                         }
 
                         let _ = respond.send(removed);
                     }
-                    ControlCommand::ClearQueue { respond } => {
-                        let mut cleared = queue.len();
-                        queue.clear();
+                    ControlCommand::ClearQueue { mission_id, respond } => {
+                        let main_mission_id = if running.is_some() {
+                            running_mission_id
+                        } else {
+                            *current_mission.read().await
+                        };
 
-                        // Also clear parallel runner queues
-                        for (_mid, runner) in parallel_runners.iter_mut() {
-                            cleared += runner.clear_queue();
+                        let mut cleared = 0usize;
+                        match mission_id {
+                            Some(target) => {
+                                // Scoped clear: only drop messages targeting
+                                // this mission (main queue entries + that
+                                // mission's parallel-runner queue). Clearing
+                                // from one mission's view must not wipe other
+                                // missions' queues.
+                                let before_len = queue.len();
+                                queue.retain(|(_, _, _, target_mid)| *target_mid != Some(target));
+                                cleared += before_len - queue.len();
+                                if before_len != queue.len() {
+                                    let _ = events_tx.send(AgentEvent::Status {
+                                        state: if running.is_some() {
+                                            ControlRunState::Running
+                                        } else {
+                                            ControlRunState::Idle
+                                        },
+                                        queue_len: queue.len(),
+                                        mission_id: main_mission_id,
+                                    });
+                                }
+                                if let Some(runner) = parallel_runners.get_mut(&target) {
+                                    let runner_cleared = runner.clear_queue();
+                                    if runner_cleared > 0 {
+                                        cleared += runner_cleared;
+                                        let _ = events_tx.send(AgentEvent::Status {
+                                            state: if runner.is_running() {
+                                                ControlRunState::Running
+                                            } else {
+                                                ControlRunState::Idle
+                                            },
+                                            queue_len: 0,
+                                            mission_id: Some(target),
+                                        });
+                                    }
+                                }
+                                tracing::info!(
+                                    "Cleared {} queued messages for mission {}",
+                                    cleared, target
+                                );
+                            }
+                            None => {
+                                cleared = queue.len();
+                                queue.clear();
+
+                                // Also clear parallel runner queues, notifying
+                                // each affected mission's viewers.
+                                for (mid, runner) in parallel_runners.iter_mut() {
+                                    let runner_cleared = runner.clear_queue();
+                                    if runner_cleared > 0 {
+                                        cleared += runner_cleared;
+                                        let _ = events_tx.send(AgentEvent::Status {
+                                            state: if runner.is_running() {
+                                                ControlRunState::Running
+                                            } else {
+                                                ControlRunState::Idle
+                                            },
+                                            queue_len: 0,
+                                            mission_id: Some(*mid),
+                                        });
+                                    }
+                                }
+
+                                // Emit event to notify frontend (main queue)
+                                let _ = events_tx.send(AgentEvent::Status {
+                                    state: if running.is_some() {
+                                        ControlRunState::Running
+                                    } else {
+                                        ControlRunState::Idle
+                                    },
+                                    queue_len: 0,
+                                    mission_id: main_mission_id,
+                                });
+
+                                tracing::info!("Cleared {} total queued messages (main + parallel)", cleared);
+                            }
                         }
-
-                        // Emit event to notify frontend (main queue only)
-                        let _ = events_tx.send(AgentEvent::Status {
-                            state: if running.is_some() {
-                                ControlRunState::Running
-                            } else {
-                                ControlRunState::Idle
-                            },
-                            queue_len: 0,
-                            mission_id: if running.is_some() {
-                                running_mission_id
-                            } else {
-                                *current_mission.read().await
-                            },
-                        });
-
-                        tracing::info!("Cleared {} total queued messages (main + parallel)", cleared);
                         let _ = respond.send(cleared);
                     }
                 }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -10574,8 +10574,9 @@ async fn control_actor_loop(
                                 // missions' queues.
                                 let before_len = queue.len();
                                 queue.retain(|(_, _, _, target_mid)| *target_mid != Some(target));
-                                cleared += before_len - queue.len();
-                                if before_len != queue.len() {
+                                let main_removed = before_len - queue.len();
+                                cleared += main_removed;
+                                if main_removed > 0 {
                                     let _ = events_tx.send(AgentEvent::Status {
                                         state: if running.is_some() {
                                             ControlRunState::Running
@@ -10586,20 +10587,42 @@ async fn control_actor_loop(
                                         mission_id: main_mission_id,
                                     });
                                 }
+                                // Clients filter Status events by the mission
+                                // they are viewing, so the main-queue event
+                                // above is invisible to a client focused on
+                                // `target` (unless target IS the main
+                                // mission). Emit a target-scoped Status
+                                // whenever anything was cleared for it.
+                                let mut target_status_sent = false;
                                 if let Some(runner) = parallel_runners.get_mut(&target) {
                                     let runner_cleared = runner.clear_queue();
-                                    if runner_cleared > 0 {
-                                        cleared += runner_cleared;
+                                    cleared += runner_cleared;
+                                    if runner_cleared > 0 || main_removed > 0 {
                                         let _ = events_tx.send(AgentEvent::Status {
                                             state: if runner.is_running() {
                                                 ControlRunState::Running
                                             } else {
                                                 ControlRunState::Idle
                                             },
-                                            queue_len: 0,
+                                            queue_len: runner.queue.len(),
                                             mission_id: Some(target),
                                         });
+                                        target_status_sent = true;
                                     }
+                                }
+                                if main_removed > 0
+                                    && !target_status_sent
+                                    && main_mission_id != Some(target)
+                                {
+                                    // No parallel runner for `target` and it
+                                    // is not the main mission: it cannot be
+                                    // running, but its viewers still need a
+                                    // scoped event to refresh their queue.
+                                    let _ = events_tx.send(AgentEvent::Status {
+                                        state: ControlRunState::Idle,
+                                        queue_len: 0,
+                                        mission_id: Some(target),
+                                    });
                                 }
                                 tracing::info!(
                                     "Cleared {} queued messages for mission {}",


### PR DESCRIPTION
## Bug

Deleting a message from the queue strip sometimes left it displayed; re-deleting failed with **404 "message not in queue"** — the first DELETE had succeeded server-side, but the UI resurrected the row and nothing ever reconciled it.

**Root cause (dashboard):** the history-merge paths (`loadMission` / `handleViewMission` / `reloadMissionHistory`) fetch `getQueue()` in parallel with history. A snapshot fetched while a DELETE was in flight still contains the message; the merge then re-adds it (`queued: true`) *after* the optimistic removal. No self-healing existed: the queue sync only fires on SSE `queue_len` decreases, the 15s reload tick is skipped while SSE is healthy, and the 404 path only toasted an error.

## Fixes

### Dashboard
- **Anti-resurrection guard**: a queue-mutation generation ref is bumped on every local remove/clear; all `getQueue()` consumers capture it before fetching and discard snapshots invalidated mid-flight. The four duplicated merge blocks are deduped into `mergeQueuedMessagesIntoItems()`.
- **404 self-heal**: `removeFromQueue` now throws `HttpStatusError`; a 404 drops the row locally ("already removed") instead of erroring.
- Post-delete `syncQueueForMission` + per-mission items-cache update on removal.
- **Clear-all scoped to the viewed mission** (`DELETE /api/control/queue?mission_id=`) — it previously wiped every mission's queue, including parallel ones.
- Status events only update the queue badge when they concern the viewed mission; queue strip shows the queued agent.

### Backend
- `RemoveFromQueue` emits a `Status` event (mission_id + runner queue_len) when removing from a **parallel runner** queue — previously silent, so other clients (tabs/iOS) never learned the queue changed. Same on enqueue to a busy parallel runner.
- `ClearQueue` accepts an optional `mission_id` (scoped: main-queue entries targeting that mission + that mission's parallel queue). No param keeps the wipe-all behavior, now with per-mission Status events.

### iOS
- `QueuedMessage` decodes `mission_id` and the queue sheet **filters to the viewed mission** — it previously showed (and could swipe-delete!) other missions' queue entries, and reconciled the badge against the global count.
- Same stale-snapshot guard via a mutation generation in `loadQueueItems()`.
- 404 on delete = already removed (no row resurrection / error haptic); clear-all passes the viewed mission id.

## Testing
- `cargo test` ✅, `cargo fmt --check` ✅, clippy clean on touched code
- dashboard `tsc --noEmit` ✅, eslint on touched files: 0 errors
- iOS `xcodebuild` (simulator): **BUILD SUCCEEDED**
- **Deployed to the dev backend** and smoke-tested via curl: enqueue while busy → 2 queued with `mission_id`; DELETE one → 200; re-DELETE → 404; clear scoped to a *different* mission → `cleared: 0` and queue intact; clear scoped to the right mission → `cleared: 1`; invalid `mission_id` → 400.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control queue state, SSE Status handling, and backend queue mutation paths across dashboard, iOS, and Rust; behavior changes are targeted but multi-surface and race-sensitive.
> 
> **Overview**
> Fixes a race where **in-flight `getQueue()` snapshots** could re-merge deleted messages into the control timeline after a successful DELETE, leaving **ghost queue rows** and **404 on re-delete**.
> 
> The dashboard adds a **queue mutation generation** ref bumped on local remove/clear; every merge/sync path captures the generation before fetch and **skips stale snapshots**, with shared **`mergeQueuedMessagesIntoItems()`**. Removes treat **404 as already gone** via **`HttpStatusError`**, update the mission items cache, and trigger a fresh sync. **Clear-all** is scoped to the viewed mission (`?mission_id=`). **Status** queue badges update only for the **viewed mission**; the queue strip shows the queued **agent**.
> 
> The backend **`ClearQueue`** accepts optional **`mission_id`** (scoped retain on main queue + that mission’s parallel runner; global clear unchanged). **Remove/clear/enqueue** on parallel runners now emit **mission-scoped `Status` events** so other tabs/clients refresh.
> 
> iOS mirrors the same: **`mission_id`** on queued messages, **filter queue UI to viewed mission**, mutation generation on load, **404 self-heal**, and **scoped clear**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba42bf1d7de8244d413be557017b12c61618cbe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->