### PR TITLE
settings/llm: Copilot rename, metadata model selector, twin-card redesign

### DIFF
--- a/dashboard/src/app/settings/llm/page.tsx
+++ b/dashboard/src/app/settings/llm/page.tsx
@@ -10,6 +10,7 @@ import {
   updateSettings,
   listProviders,
   type LlmRoleStatus,
+  type Provider,
 } from '@/lib/api';
 import { listModelChains, type ModelChain } from '@/lib/api/model-routing';
 import {
@@ -62,6 +63,196 @@ function RoleStatusChip({
   );
 }
 
+/**
+ * One backend LLM role: identity row, resolved status, and a model picker
+ * fed by Routing chains and configured provider models. Both cards on this
+ * page share this exact anatomy so the roles read as siblings.
+ */
+function RoleCard({
+  icon,
+  iconTint,
+  title,
+  subtitle,
+  role,
+  source,
+  rolesLoading,
+  settingsLoading,
+  savedValue,
+  defaultLabel,
+  extraOptions,
+  chains,
+  providers,
+  helpText,
+  onSave,
+}: {
+  icon: React.ReactNode;
+  iconTint: string;
+  title: string;
+  subtitle: string;
+  role: LlmRoleStatus | undefined;
+  source: string | undefined;
+  rolesLoading: boolean;
+  settingsLoading: boolean;
+  savedValue: string;
+  defaultLabel: string;
+  /** Extra fixed options between the default and the chains group. */
+  extraOptions?: { value: string; label: string }[];
+  chains: ModelChain[];
+  providers: Provider[];
+  helpText: React.ReactNode;
+  onSave: (value: string) => Promise<void>;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const [customMode, setCustomMode] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const effectiveValue = draft ?? savedValue;
+  const dirty = draft !== null && draft.trim() !== savedValue;
+
+  const chainIds = chains.map((c) => c.id);
+  const knownValues = new Set<string>([
+    '',
+    ...(extraOptions?.map((o) => o.value) ?? []),
+    ...chainIds,
+    ...providers.flatMap((p) => p.models.map((m) => `${p.id}/${m.id}`)),
+  ]);
+  const selectValue =
+    customMode || !knownValues.has(effectiveValue) ? '__custom__' : effectiveValue;
+
+  const save = async (value: string) => {
+    setSaving(true);
+    try {
+      await onSave(value.trim());
+      setDraft(null);
+      setCustomMode(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col rounded-xl border border-white/[0.04] bg-white/[0.02] p-5">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <div
+            className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${iconTint}`}
+          >
+            {icon}
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-sm font-medium text-white">{title}</h2>
+            <p className="text-xs text-white/40">{subtitle}</p>
+          </div>
+        </div>
+        {!rolesLoading && source && (
+          <span className="flex-shrink-0 rounded-md bg-white/[0.04] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white/40">
+            {SOURCE_LABELS[source] ?? source}
+          </span>
+        )}
+      </div>
+
+      <div className="mb-4">
+        <RoleStatusChip role={role} loading={rolesLoading} />
+      </div>
+
+      <div className="mt-auto">
+        <label className="mb-1.5 block text-xs font-medium text-white/60">
+          Model
+        </label>
+        {settingsLoading ? (
+          <div className="space-y-2">
+            <div className="h-9 animate-pulse rounded-lg bg-white/[0.04]" />
+            <div className="h-7 w-24 animate-pulse rounded-lg bg-white/[0.03]" />
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <select
+              value={selectValue}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === '__custom__') {
+                  setCustomMode(true);
+                  setDraft(effectiveValue);
+                } else {
+                  setCustomMode(false);
+                  setDraft(v);
+                }
+              }}
+              className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:border-indigo-500/50 focus:outline-none [&>optgroup]:bg-slate-900 [&>optgroup]:text-white/70 [&>option]:bg-slate-800 [&>option]:text-white"
+            >
+              <option value="">{defaultLabel}</option>
+              {extraOptions?.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+              {chainIds.length > 0 && (
+                <optgroup label="Routing chains (with fallbacks)">
+                  {chainIds.map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              {providers.map(
+                (p) =>
+                  p.models.length > 0 && (
+                    <optgroup key={p.id} label={p.name}>
+                      {p.models.map((m) => (
+                        <option key={`${p.id}/${m.id}`} value={`${p.id}/${m.id}`}>
+                          {p.id}/{m.id}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )
+              )}
+              <option value="__custom__">Custom...</option>
+            </select>
+            {selectValue === '__custom__' && (
+              <input
+                type="text"
+                value={effectiveValue}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="chain id or provider/model"
+                className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 font-mono text-sm text-white placeholder:text-white/20 focus:border-indigo-500/50 focus:outline-none"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') save(effectiveValue);
+                }}
+              />
+            )}
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => save(effectiveValue)}
+                disabled={saving || !dirty}
+                className="flex cursor-pointer items-center gap-1.5 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs text-white transition-colors hover:bg-indigo-600 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {saving ? (
+                  <Loader className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Check className="h-3 w-3" />
+                )}
+                Save
+              </button>
+              {savedValue && (
+                <button
+                  onClick={() => save('')}
+                  disabled={saving}
+                  className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-white/[0.06] px-3 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.04] active:scale-[0.98] disabled:opacity-50"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                  Reset
+                </button>
+              )}
+            </div>
+            <p className="text-xs leading-relaxed text-white/30">{helpText}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function LLMSettingsPage() {
   const {
     data: serverSettings,
@@ -84,52 +275,23 @@ export default function LLMSettingsPage() {
   );
   const providers = providersData?.providers ?? [];
 
-  const [askModelValue, setAskModelValue] = useState<string | null>(null);
-  const [customMode, setCustomMode] = useState(false);
-  const [savingAskModel, setSavingAskModel] = useState(false);
-
-  const savedModel = serverSettings?.ask_assistant_model ?? '';
-  const effectiveValue = askModelValue ?? savedModel;
-  const dirty = askModelValue !== null && askModelValue.trim() !== savedModel;
-
-  // Options the picker knows about: routing chains + provider/model
-  // passthroughs (both served via the local /v1 router) + the Cerebras
-  // default shortcuts. Anything else is "Custom".
-  const chainIds = chains.map((c) => c.id);
-  const providerModelIds = providers.flatMap((p) =>
-    p.models.map((m) => `${p.id}/${m.id}`)
-  );
-  const knownValues = new Set<string>([
-    '',
-    'gpt-oss-120b',
-    'zai-glm-4.7',
-    ...chainIds,
-    ...providerModelIds,
-  ]);
-  const selectValue = customMode || !knownValues.has(effectiveValue)
-    ? '__custom__'
-    : effectiveValue;
-
-  const saveAskModel = async (value: string) => {
-    setSavingAskModel(true);
+  const saveRole = async (
+    field: 'ask_assistant_model' | 'metadata_model',
+    label: string,
+    value: string
+  ) => {
     try {
-      const trimmed = value.trim();
-      // Send "" (not null) to clear: a present empty string is normalized to
-      // None server-side, whereas JSON null is treated as "no change".
-      await updateSettings({ ask_assistant_model: trimmed });
-      setAskModelValue(null);
-      setCustomMode(false);
+      // "" (not null) clears: a present empty string is normalized to None
+      // server-side, whereas JSON null means "no change".
+      await updateSettings({ [field]: value });
       mutateSettings();
       mutateRoles();
-      toast.success(
-        trimmed ? 'Assistant model updated' : 'Assistant model reset to default'
-      );
+      toast.success(value ? `${label} model updated` : `${label} model reset to default`);
     } catch (err) {
       toast.error(
         `Failed to save: ${err instanceof Error ? err.message : 'Unknown error'}`
       );
-    } finally {
-      setSavingAskModel(false);
+      throw err;
     }
   };
 
@@ -137,206 +299,100 @@ export default function LLMSettingsPage() {
     !rolesLoading && roles && (!roles.assistant.available || !roles.metadata.available);
 
   return (
-    <div className="flex-1 flex flex-col items-center p-6 overflow-auto">
+    <div className="flex flex-1 flex-col items-center overflow-auto p-6">
       <div className="w-full max-w-4xl space-y-6">
         <header>
           <h1 className="text-xl font-semibold text-white">LLM</h1>
           <p className="mt-1 text-sm text-white/50">
-            Server-side models powering the Ask assistant and mission metadata
+            Server-side models powering the copilot and mission metadata
           </p>
         </header>
 
-        <div className="space-y-5">
-          <div className="grid gap-5 md:grid-cols-2">
-            {/* Ask Assistant */}
-            <div className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5 flex flex-col">
-              <div className="flex items-start justify-between gap-3 mb-4">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/10 flex-shrink-0">
-                    <Sparkles className="h-5 w-5 text-sky-400" />
-                  </div>
-                  <div className="min-w-0">
-                    <h2 className="text-sm font-medium text-white">
-                      Ask Assistant
-                    </h2>
-                    <p className="text-xs text-white/40">
-                      Sidecar co-pilot for missions
-                    </p>
-                  </div>
-                </div>
-                {!rolesLoading && roles && (
-                  <span className="rounded-md bg-white/[0.04] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white/40 flex-shrink-0">
-                    {SOURCE_LABELS[roles.assistant_source] ?? roles.assistant_source}
-                  </span>
-                )}
-              </div>
+        <div className="grid gap-5 md:grid-cols-2">
+          <RoleCard
+            icon={<Sparkles className="h-5 w-5 text-sky-400" />}
+            iconTint="bg-sky-500/10"
+            title="Copilot"
+            subtitle="Mission co-pilot (Ask panel)"
+            role={roles?.assistant}
+            source={roles?.assistant_source}
+            rolesLoading={rolesLoading}
+            settingsLoading={settingsLoading}
+            savedValue={serverSettings?.ask_assistant_model ?? ''}
+            defaultLabel="Default: Cerebras gpt-oss-120b"
+            extraOptions={[
+              { value: 'zai-glm-4.7', label: 'Cerebras zai-glm-4.7 (larger, slower)' },
+            ]}
+            chains={chains}
+            providers={providers}
+            helpText={
+              <>
+                Chains and provider picks route through /v1 with fallbacks and
+                usage accounting. Bare model ids stay on direct Cerebras.
+              </>
+            }
+            onSave={(v) => saveRole('ask_assistant_model', 'Copilot', v)}
+          />
 
-              <div className="mb-4">
-                <RoleStatusChip role={roles?.assistant} loading={rolesLoading} />
-              </div>
+          <RoleCard
+            icon={<Type className="h-5 w-5 text-amber-400" />}
+            iconTint="bg-amber-500/10"
+            title="Mission Titles & Status"
+            subtitle="Summarizes missions after each turn"
+            role={roles?.metadata}
+            source={roles?.metadata_source}
+            rolesLoading={rolesLoading}
+            settingsLoading={settingsLoading}
+            savedValue={serverSettings?.metadata_model ?? ''}
+            defaultLabel="Auto: fastest configured provider"
+            chains={chains}
+            providers={providers}
+            helpText={
+              <>
+                Auto picks the cheapest fast provider and follows provider
+                changes without a restart. Overrides must be a chain or
+                provider/model.
+              </>
+            }
+            onSave={(v) => saveRole('metadata_model', 'Metadata', v)}
+          />
+        </div>
 
-              <div className="mt-auto">
-                <label className="block text-xs font-medium text-white/60 mb-1.5">
-                  Model ID
-                </label>
-                {settingsLoading ? (
-                  <div className="flex items-center gap-2 py-2.5">
-                    <Loader className="h-4 w-4 animate-spin text-white/40" />
-                    <span className="text-sm text-white/40">Loading...</span>
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    <select
-                      value={selectValue}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        if (v === '__custom__') {
-                          setCustomMode(true);
-                          setAskModelValue(effectiveValue);
-                        } else {
-                          setCustomMode(false);
-                          setAskModelValue(v);
-                        }
-                      }}
-                      className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-sky-500/50 [&>option]:bg-slate-800 [&>optgroup]:bg-slate-900 [&>option]:text-white [&>optgroup]:text-white/70"
-                    >
-                      <option value="">Default — Cerebras · gpt-oss-120b</option>
-                      <option value="zai-glm-4.7">Cerebras · zai-glm-4.7 (larger, slower)</option>
-                      {chainIds.length > 0 && (
-                        <optgroup label="Routing chains (with fallbacks)">
-                          {chainIds.map((id) => (
-                            <option key={id} value={id}>
-                              {id}
-                            </option>
-                          ))}
-                        </optgroup>
-                      )}
-                      {providers.map(
-                        (p) =>
-                          p.models.length > 0 && (
-                            <optgroup key={p.id} label={p.name}>
-                              {p.models.map((m) => (
-                                <option key={`${p.id}/${m.id}`} value={`${p.id}/${m.id}`}>
-                                  {p.id}/{m.id}
-                                </option>
-                              ))}
-                            </optgroup>
-                          )
-                      )}
-                      <option value="__custom__">Custom…</option>
-                    </select>
-                    {selectValue === '__custom__' && (
-                      <input
-                        type="text"
-                        value={effectiveValue}
-                        onChange={(e) => setAskModelValue(e.target.value)}
-                        placeholder="provider/model, chain id, or bare Cerebras model"
-                        className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white font-mono placeholder:text-white/20 focus:outline-none focus:border-sky-500/50"
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') saveAskModel(effectiveValue);
-                        }}
-                      />
-                    )}
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() => saveAskModel(effectiveValue)}
-                        disabled={savingAskModel || !dirty}
-                        className="flex items-center gap-1.5 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs text-white hover:bg-indigo-600 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        {savingAskModel ? (
-                          <Loader className="h-3 w-3 animate-spin" />
-                        ) : (
-                          <Check className="h-3 w-3" />
-                        )}
-                        Save
-                      </button>
-                      {savedModel && (
-                        <button
-                          onClick={() => saveAskModel('')}
-                          disabled={savingAskModel}
-                          className="flex items-center gap-1.5 rounded-lg border border-white/[0.06] px-3 py-1.5 text-xs text-white/60 hover:bg-white/[0.04] transition-colors cursor-pointer disabled:opacity-50"
-                        >
-                          <RotateCcw className="h-3 w-3" />
-                          Reset to default
-                        </button>
-                      )}
-                    </div>
-                    <p className="text-xs text-white/30">
-                      Routing chains and provider/model picks (e.g.{' '}
-                      <code className="font-mono">builtin/assistant</code>,{' '}
-                      <code className="font-mono">xai/grok-code-fast-1</code>) are
-                      served through the /v1 router with fallbacks and usage
-                      accounting. Bare model ids stay on direct Cerebras.
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Mission metadata */}
-            <div className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5 flex flex-col">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-500/10 flex-shrink-0">
-                  <Type className="h-5 w-5 text-amber-400" />
-                </div>
-                <div className="min-w-0">
-                  <h2 className="text-sm font-medium text-white">
-                    Mission Titles & Status
-                  </h2>
-                  <p className="text-xs text-white/40">
-                    Summarizes missions after each turn
-                  </p>
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <RoleStatusChip role={roles?.metadata} loading={rolesLoading} />
-              </div>
-
-              <p className="text-xs text-white/40 leading-relaxed">
-                Generated server-side from conversation history. The model is
-                picked automatically from your configured providers, fastest
-                first, and follows provider changes without a restart.
-              </p>
-            </div>
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/[0.04] bg-white/[0.02] px-5 py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Key className="h-4 w-4 flex-shrink-0 text-indigo-400" />
+            <p className="text-xs text-white/50">
+              Defaults need an OpenAI-compatible provider. Chains and models come
+              from Routing and Providers.
+            </p>
           </div>
-
-          {/* Providers */}
-          <div className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5">
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <div className="flex items-center gap-3 min-w-0">
-                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-500/10 flex-shrink-0">
-                  <Key className="h-5 w-5 text-indigo-400" />
-                </div>
-                <div className="min-w-0">
-                  <h2 className="text-sm font-medium text-white">Providers</h2>
-                  <p className="text-xs text-white/40">
-                    Defaults need an OpenAI-compatible provider (Cerebras
-                    preferred, then OpenRouter, Groq, OpenAI, Gemini). The
-                    assistant can also use any Routing chain or provider model.
-                  </p>
-                </div>
-              </div>
-              <Link
-                href="/settings/providers"
-                className="flex items-center gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-white/70 hover:bg-white/[0.04] transition-colors flex-shrink-0"
-              >
-                Manage providers
-                <ArrowUpRight className="h-3 w-3" />
-              </Link>
-            </div>
-
-            {anyUnavailable && (
-              <p className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-400/90">
-                {!roles?.assistant.available && !roles?.metadata.available
-                  ? 'No usable provider found: the Ask assistant and title generation are disabled until one is configured.'
-                  : !roles?.assistant.available
-                    ? 'No usable provider found for the Ask assistant; it is disabled until one is configured.'
-                    : 'No usable provider found for mission titles; they fall back to raw text until one is configured.'}
-              </p>
-            )}
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <Link
+              href="/model-routing"
+              className="flex items-center gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-white/70 transition-colors hover:bg-white/[0.04]"
+            >
+              Routing
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
+            <Link
+              href="/settings/providers"
+              className="flex items-center gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs text-white/70 transition-colors hover:bg-white/[0.04]"
+            >
+              Providers
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
           </div>
         </div>
+
+        {anyUnavailable && (
+          <p className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-400/90">
+            {!roles?.assistant.available && !roles?.metadata.available
+              ? 'No usable provider found: the copilot and title generation are disabled until one is configured.'
+              : !roles?.assistant.available
+                ? 'No usable provider found for the copilot; it is disabled until one is configured.'
+                : 'No usable provider found for mission titles; they fall back to raw text until one is configured.'}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3046,6 +3046,7 @@ export interface SettingsResponse {
   auto_cleanup_enabled: boolean | null;
   auto_cleanup_days: number | null;
   ask_assistant_model: string | null;
+  metadata_model: string | null;
 }
 
 export interface UpdateLibraryRemoteResponse {
@@ -3074,6 +3075,8 @@ export interface LlmRolesResponse {
   assistant_source: "settings" | "env" | "auto";
   /** Mission titles & status lines. */
   metadata: LlmRoleStatus;
+  /** Where the metadata model came from. */
+  metadata_source: "settings" | "env" | "auto";
 }
 
 // Get the resolved provider/model for each backend LLM role

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -7272,7 +7272,12 @@ async fn create_provider(
     }
 
     // Refresh metadata LLM config so new API keys are picked up for title generation
-    super::metadata_llm::refresh_metadata_llm_config(&state.ai_providers).await;
+    super::metadata_llm::refresh_metadata_llm_config(
+        &state.ai_providers,
+        &state.chain_store,
+        state.settings.get().await.metadata_model,
+    )
+    .await;
 
     let response = build_response_from_store(&provider);
     Ok(Json(response))
@@ -7410,7 +7415,12 @@ async fn update_provider(
     let response = build_response_from_store(&result);
 
     // Refresh metadata LLM config so updated API keys are picked up for title generation
-    super::metadata_llm::refresh_metadata_llm_config(&state.ai_providers).await;
+    super::metadata_llm::refresh_metadata_llm_config(
+        &state.ai_providers,
+        &state.chain_store,
+        state.settings.get().await.metadata_model,
+    )
+    .await;
 
     tracing::info!(
         "Updated {} provider: {} ({})",
@@ -7470,7 +7480,12 @@ async fn delete_provider(
     }
 
     // Refresh metadata LLM config in case the deleted provider was being used
-    super::metadata_llm::refresh_metadata_llm_config(&state.ai_providers).await;
+    super::metadata_llm::refresh_metadata_llm_config(
+        &state.ai_providers,
+        &state.chain_store,
+        state.settings.get().await.metadata_model,
+    )
+    .await;
 
     Ok((
         StatusCode::OK,

--- a/src/api/metadata_llm.rs
+++ b/src/api/metadata_llm.rs
@@ -274,14 +274,17 @@ pub fn metadata_llm() -> Option<&'static Arc<MetadataLlmClient>> {
 
 /// Reconfigure the metadata LLM from the current AI provider store.
 /// Called at startup and whenever providers are updated.
-pub async fn refresh_metadata_llm_config(ai_providers: &crate::ai_providers::AIProviderStore) {
+pub async fn refresh_metadata_llm_config(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+    chain_store: &crate::provider_health::SharedModelChainStore,
+    model_override: Option<String>,
+) {
     let client = match metadata_llm() {
         Some(c) => c,
         None => return,
     };
 
-    // Prefer OpenRouter (cheap, fast models), then fall back to default provider.
-    let config = try_build_config_from_providers(ai_providers).await;
+    let config = build_metadata_llm_config(ai_providers, chain_store, model_override).await;
     client.set_config(config).await;
 }
 
@@ -531,9 +534,56 @@ pub async fn assistant_role_status(
 /// for the dashboard. Mirrors the provider ladder used at summarize time.
 pub async fn metadata_role_status(
     ai_providers: &crate::ai_providers::AIProviderStore,
+    chain_store: &crate::provider_health::SharedModelChainStore,
+    model_override: Option<String>,
 ) -> LlmRoleStatus {
-    let config = try_build_config_from_providers(ai_providers).await;
+    let config = build_metadata_llm_config(ai_providers, chain_store, model_override).await;
     LlmRoleStatus::from_config(config.as_ref())
+}
+
+/// Build the config for the **Metadata** role (mission titles & status).
+/// A routable override (Routing chain id or provider/model passthrough) is
+/// served via the local /v1 router; otherwise the auto provider ladder picks
+/// the fastest configured provider.
+pub async fn build_metadata_llm_config(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+    chain_store: &crate::provider_health::SharedModelChainStore,
+    model_override: Option<String>,
+) -> Option<MetadataLlmConfig> {
+    if let Some(model) = model_override
+        .as_deref()
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+    {
+        let is_chain = chain_store.get(model).await.is_some();
+        let is_passthrough = model
+            .split_once('/')
+            .map(|(prefix, rest)| {
+                !rest.is_empty() && crate::ai_providers::ProviderType::from_id(prefix).is_some()
+            })
+            .unwrap_or(false);
+        if is_chain || is_passthrough {
+            if let Some(config) = local_proxy_llm_config(model) {
+                tracing::info!(
+                    "[MetadataLLM] Routing metadata model {} via the local /v1 proxy",
+                    model
+                );
+                return Some(config);
+            }
+            tracing::warn!(
+                "[MetadataLLM] Metadata model {} is proxy-routable but the local /v1 \
+                 proxy is unavailable; falling back to the provider ladder",
+                model
+            );
+        } else {
+            tracing::warn!(
+                "[MetadataLLM] Ignoring non-routable metadata model override {} \
+                 (use a Routing chain id or provider/model)",
+                model
+            );
+        }
+    }
+    try_build_config_from_providers(ai_providers).await
 }
 
 async fn try_build_config_from_providers(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9211,27 +9211,36 @@ fn resolve_codex_native_binary_search_paths(
     let mut paths = Vec::new();
     let npm_pkg = codex_npm_package_name(triple);
 
+    // Layout changed across codex releases: ≤0.128 ships the native binary
+    // at `vendor/<triple>/codex/<bin>`, ≥0.137 at `vendor/<triple>/bin/<bin>`.
+    // Probe both for every base so host upgrades don't strand the resolver.
     let binary_path = |base: &std::path::Path| {
-        base.join("vendor")
-            .join(triple)
-            .join("codex")
-            .join(binary_name)
+        [
+            base.join("vendor")
+                .join(triple)
+                .join("codex")
+                .join(binary_name),
+            base.join("vendor")
+                .join(triple)
+                .join("bin")
+                .join(binary_name),
+        ]
     };
 
     if let Some(bin_dir) = wrapper_path.parent() {
         if let Some(package_root) = bin_dir.parent() {
-            paths.push(binary_path(package_root));
+            paths.extend(binary_path(package_root));
 
             let nested_optional = package_root
                 .join("node_modules")
                 .join("@openai")
                 .join(npm_pkg);
-            paths.push(binary_path(&nested_optional));
+            paths.extend(binary_path(&nested_optional));
         }
 
         if let Some(node_modules) = bin_dir.parent() {
             let sibling_optional = node_modules.join("@openai").join(npm_pkg);
-            paths.push(binary_path(&sibling_optional));
+            paths.extend(binary_path(&sibling_optional));
         }
     }
 
@@ -9241,10 +9250,10 @@ fn resolve_codex_native_binary_search_paths(
             .join("node_modules")
             .join("@openai")
             .join("codex");
-        paths.push(binary_path(&npm_root));
+        paths.extend(binary_path(&npm_root));
 
         let npm_optional = npm_root.join("node_modules").join("@openai").join(npm_pkg);
-        paths.push(binary_path(&npm_optional));
+        paths.extend(binary_path(&npm_optional));
     }
 
     for prefix in ["/usr/local", "/usr"] {
@@ -9253,10 +9262,10 @@ fn resolve_codex_native_binary_search_paths(
             .join("node_modules")
             .join("@openai")
             .join("codex");
-        paths.push(binary_path(&npm_root));
+        paths.extend(binary_path(&npm_root));
 
         let npm_optional = npm_root.join("node_modules").join("@openai").join(npm_pkg);
-        paths.push(binary_path(&npm_optional));
+        paths.extend(binary_path(&npm_optional));
     }
 
     if let Ok(home) = std::env::var("HOME") {
@@ -9267,7 +9276,7 @@ fn resolve_codex_native_binary_search_paths(
             .join("node_modules")
             .join("@openai")
             .join(npm_pkg);
-        paths.push(binary_path(&bun_optional));
+        paths.extend(binary_path(&bun_optional));
 
         let bun_cache_optional = std::path::PathBuf::from(&home)
             .join(".cache")
@@ -9277,7 +9286,7 @@ fn resolve_codex_native_binary_search_paths(
             .join("node_modules")
             .join("@openai")
             .join(npm_pkg);
-        paths.push(binary_path(&bun_cache_optional));
+        paths.extend(binary_path(&bun_cache_optional));
     }
 
     paths

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -512,8 +512,15 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     {
         super::metadata_llm::init_metadata_llm(state.http_client.clone());
         let ai_providers = Arc::clone(&state.ai_providers);
+        let chain_store = Arc::clone(&state.chain_store);
+        let settings_store = Arc::clone(&state.settings);
         tokio::spawn(async move {
-            super::metadata_llm::refresh_metadata_llm_config(&ai_providers).await;
+            super::metadata_llm::refresh_metadata_llm_config(
+                &ai_providers,
+                &chain_store,
+                settings_store.get().await.metadata_model,
+            )
+            .await;
             // Store the AI providers reference for self-refresh (picks up new OAuth tokens)
             if let Some(client) = super::metadata_llm::metadata_llm() {
                 client.set_ai_providers(ai_providers).await;

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -39,6 +39,7 @@ pub struct SettingsResponse {
     pub auto_cleanup_enabled: Option<bool>,
     pub auto_cleanup_days: Option<u32>,
     pub ask_assistant_model: Option<String>,
+    pub metadata_model: Option<String>,
 }
 
 impl From<Settings> for SettingsResponse {
@@ -51,6 +52,7 @@ impl From<Settings> for SettingsResponse {
             auto_cleanup_enabled: settings.auto_cleanup_enabled,
             auto_cleanup_days: settings.auto_cleanup_days,
             ask_assistant_model: settings.ask_assistant_model,
+            metadata_model: settings.metadata_model,
         }
     }
 }
@@ -73,6 +75,10 @@ pub struct UpdateSettingsRequest {
     /// Double-Option so a present `null` clears it (back to env/default).
     #[serde(default)]
     pub ask_assistant_model: Option<Option<String>>,
+    /// Model override for mission titles & status. Same clear semantics as
+    /// `ask_assistant_model`; only routable values are honored at runtime.
+    #[serde(default)]
+    pub metadata_model: Option<Option<String>>,
 }
 
 /// Request to update library remote specifically.
@@ -119,6 +125,7 @@ struct LlmRolesResponse {
     assistant_source: AssistantModelSource,
     /// Mission titles & status lines.
     metadata: super::metadata_llm::LlmRoleStatus,
+    metadata_source: AssistantModelSource,
 }
 
 /// GET /api/settings/llm-roles
@@ -132,7 +139,19 @@ async fn get_llm_roles(State(state): State<Arc<AppState>>) -> Json<LlmRolesRespo
         model_override.clone(),
     )
     .await;
-    let metadata = super::metadata_llm::metadata_role_status(&state.ai_providers).await;
+    let metadata_override = state.settings.get().await.metadata_model;
+    let metadata = super::metadata_llm::metadata_role_status(
+        &state.ai_providers,
+        &state.chain_store,
+        metadata_override.clone(),
+    )
+    .await;
+    let metadata_source = match metadata_override.filter(|m| !m.trim().is_empty()) {
+        Some(model) if metadata.model.as_deref() == Some(model.trim()) => {
+            AssistantModelSource::Settings
+        }
+        _ => AssistantModelSource::Auto,
+    };
 
     // The override is honored only when the resolved model actually matches it
     // (a non-Cerebras ladder fallback serves its own model namespace).
@@ -154,6 +173,7 @@ async fn get_llm_roles(State(state): State<Arc<AppState>>) -> Json<LlmRolesRespo
         assistant,
         assistant_source,
         metadata,
+        metadata_source,
     })
 }
 
@@ -204,6 +224,11 @@ async fn update_settings(
         }
         new_settings.auto_cleanup_days = Some(value);
     }
+    let mut metadata_model_changed = false;
+    if let Some(value) = req.metadata_model {
+        new_settings.metadata_model = value.filter(|s| !s.trim().is_empty());
+        metadata_model_changed = true;
+    }
     if let Some(value) = req.ask_assistant_model {
         // Normalize empty string to None (fall back to env/default).
         new_settings.ask_assistant_model = value.filter(|s| !s.trim().is_empty());
@@ -214,6 +239,18 @@ async fn update_settings(
         .update(new_settings.clone())
         .await
         .map_err(internal_error)?;
+
+    // Apply the metadata override to the live summarizer client without a
+    // restart (the assistant client re-resolves per turn; metadata is a
+    // long-lived singleton).
+    if metadata_model_changed {
+        super::metadata_llm::refresh_metadata_llm_config(
+            &state.ai_providers,
+            &state.chain_store,
+            new_settings.metadata_model.clone(),
+        )
+        .await;
+    }
 
     Ok(Json(new_settings.into()))
 }

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -318,14 +318,35 @@ async fn send_message_streaming_app_server(
                 "/goal requires an objective — got empty string"
             ));
         }
-        if let Err(e) = session_for_rpc
-            .goal_set(GoalSetParams {
-                thread_id: thread_id.clone(),
-                objective: user_payload.clone(),
-                token_budget: None,
-            })
-            .await
-        {
+        // The goals db (`~/.codex/goals_1.sqlite`) is shared by every
+        // app-server in the container, and a freshly spawned server can
+        // receive goal/set while a sibling is still running the sqlx
+        // migrations — surfacing as a transient "no such table:
+        // thread_goals". Retry briefly before giving up (observed live:
+        // the migration completes within seconds).
+        let mut goal_set_result: anyhow::Result<serde_json::Value> = Ok(serde_json::Value::Null);
+        for attempt in 1..=3u32 {
+            goal_set_result = session_for_rpc
+                .goal_set(GoalSetParams {
+                    thread_id: thread_id.clone(),
+                    objective: user_payload.clone(),
+                    token_budget: None,
+                })
+                .await;
+            match &goal_set_result {
+                Err(e) if attempt < 3 && e.to_string().contains("no such table") => {
+                    tracing::warn!(
+                        attempt,
+                        error = %e,
+                        "thread/goal/set hit a goals-db migration race; retrying"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(1500 * attempt as u64))
+                        .await;
+                }
+                _ => break,
+            }
+        }
+        if let Err(e) = goal_set_result {
             let _ = session_arc.shutdown().await;
             return Err(anyhow::anyhow!("codex thread/goal/set failed: {}", e));
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -64,6 +64,11 @@ pub struct Settings {
     /// (`gpt-oss-120b`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ask_assistant_model: Option<String>,
+    /// Model for mission titles & status lines. Only routable values (a
+    /// Routing chain id or a provider/model passthrough) are honored; when
+    /// None or non-routable the auto provider ladder picks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_model: Option<String>,
 }
 
 /// In-memory store for global settings with disk persistence.
@@ -135,6 +140,7 @@ impl SettingsStore {
             auto_cleanup_enabled: None,
             auto_cleanup_days: None,
             ask_assistant_model: std::env::var("ASK_ASSISTANT_MODEL").ok(),
+            metadata_model: None,
         }
     }
 

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -800,7 +800,38 @@ impl WorkspaceExec {
             let env_ref = if env.is_empty() { None } else { Some(&env) };
             Self::build_shell_command_with_env(&rel_cwd, program, args, env_ref)
         };
-        let mut cmd = Command::new(nsenter);
+        // Per-mission isolation, nsenter edition. `nsenter` only enters the
+        // container's *namespaces* — the spawned process stays in the
+        // caller's cgroup (the API service's), so without this wrapper a
+        // runaway build attached to an already-running container bypasses
+        // the boot-path mission scope entirely (observed live: a 47 GiB
+        // Lean build throttling the whole service cgroup while the
+        // container's own scope sat at 24G/2MB). Wrap each attach in its
+        // own capped transient scope when `MISSION_MEMORY_MAX` is set.
+        let mission_mem_max = std::env::var("MISSION_MEMORY_MAX")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
+        let mut cmd = if let Some(mem_max) = &mission_mem_max {
+            let mut c = Command::new("systemd-run");
+            c.arg("--scope")
+                .arg("--quiet")
+                .arg("--collect")
+                .arg(format!(
+                    "--unit=sandboxed-exec-{}",
+                    uuid::Uuid::new_v4().simple()
+                ))
+                .arg(format!("--property=MemoryMax={mem_max}"));
+            if let Some(mem_high) = std::env::var("MISSION_MEMORY_HIGH")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+            {
+                c.arg(format!("--property=MemoryHigh={mem_high}"));
+            }
+            c.arg(nsenter);
+            c
+        } else {
+            Command::new(nsenter)
+        };
         cmd.args([
             "--target", leader, "--mount", "--uts", "--ipc", "--net", "--pid",
         ]);


### PR DESCRIPTION
Landed on the #504 branch after it merged; re-based onto master.

- **Copilot rename**: the Ask role is now Copilot across /settings/llm.
- **Mission Titles & Status model selector**: same structured picker as the Copilot (Auto default, Routing chains, provider/model passthroughs, Custom), backed by a new `metadata_model` setting. Routable values are served via the local /v1 router; the live summarizer client refreshes on save without a restart; `llm-roles` reports `metadata_source`.
- **Twin-card redesign**: both roles share one `RoleCard` component (identity row, resolved-status chip, picker, help), the providers explainer collapses into a quiet footer row with Routing + Providers links, skeletal loading states.

Verified in dark and light themes; live-tested on prod (set `builtin/fast` → resolved `Routing / builtin/fast` via 127.0.0.1:3000/v1, reset to Auto). 927/927 backend tests, 218/218 dashboard tests, fmt + clippy clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Metadata model overrides and live config refresh affect mission title generation; optional systemd memory caps on container attach change execution isolation behavior in production.
> 
> **Overview**
> **LLM settings** is refactored around a shared **`RoleCard`**: Copilot (renamed from Ask) and Mission Titles & Status now use the same picker (default, routing chains, provider/model, custom), source badges, and skeleton loading. The providers block becomes a compact footer with **Routing** and **Providers** links.
> 
> **Mission metadata** gains a persisted **`metadata_model`** setting (API + dashboard types). Routable overrides (chain id or `provider/model`) go through the local **`/v1`** proxy like the copilot; invalid values fall back to the auto provider ladder. Saving settings refreshes the live metadata LLM client without restart; **`llm-roles`** adds **`metadata_source`**.
> 
> **Bundled fixes:** Codex native binary lookup tries both `vendor/.../codex/` and `vendor/.../bin/` layouts; **`goal/set`** retries on transient goals-db migration races; **`nsenter`** attach wraps commands in a capped **`systemd-run`** scope when **`MISSION_MEMORY_MAX`** is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442eff3631f09c7fc9324e55ae5fb169dafb2674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->