### PR TITLE
control: successful turns supersede the interrupted status

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -8400,13 +8400,33 @@ async fn maybe_finalize_terminal_mission(
     match mission_store.get_mission(mission_id).await {
         Ok(Some(mission)) => {
             if mission.status == MissionStatus::Interrupted {
-                tracing::debug!(
+                // A turn that *succeeds* after the interruption marker was set
+                // (deploy restart mid-turn, then the drained turn completes)
+                // supersedes it: there is a fresh assistant answer, and leaving
+                // the mission "interrupted" makes the dashboard offer a resume
+                // that the still-registered runner rejects with "already
+                // running". Failure-shaped reasons keep the interrupted status
+                // (it is the more accurate cause).
+                let successful_turn = matches!(
+                    new_status,
+                    MissionStatus::AwaitingUser | MissionStatus::Completed
+                );
+                if !successful_turn {
+                    tracing::debug!(
+                        mission_id = %mission_id,
+                        reason = ?reason,
+                        context = log_context,
+                        "Skipping mission finalization because mission is already interrupted"
+                    );
+                    return;
+                }
+                tracing::info!(
                     mission_id = %mission_id,
                     reason = ?reason,
+                    new_status = ?new_status,
                     context = log_context,
-                    "Skipping mission finalization because mission is already interrupted"
+                    "Promoting interrupted mission: turn completed successfully after interruption"
                 );
-                return;
             }
 
             if !matches!(

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -8429,9 +8429,11 @@ async fn maybe_finalize_terminal_mission(
                 );
             }
 
+            // Interrupted is allowed through: the promotion check above already
+            // filtered it down to successful turns only.
             if !matches!(
                 mission.status,
-                MissionStatus::Active | MissionStatus::Pending
+                MissionStatus::Active | MissionStatus::Pending | MissionStatus::Interrupted
             ) {
                 tracing::debug!(
                     mission_id = %mission_id,


### PR DESCRIPTION
A deploy restart mid-turn marks the mission interrupted; when the drained turn then completes successfully, `maybe_finalize_terminal_mission` refused to update the status ("already interrupted"), leaving DB=interrupted while the runner stayed registered. The dashboard then auto-offered a resume which the runner rejected with "Mission ... is already running" (observed on mission 5aede562 after today's deploys).

AwaitingUser/Completed outcomes now override the stale interrupted marker (there's a fresh assistant answer); failure-shaped outcomes keep interrupted as the more accurate cause.

130/130 control tests, fmt + clippy clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission lifecycle finalization in control API; wrong branching could overwrite or skip status updates, but scope is narrow and success/failure cases are explicitly split.
> 
> **Overview**
> **`maybe_finalize_terminal_mission`** no longer treats **`Interrupted`** as a hard stop for every terminal turn. After a deploy restart marks a mission interrupted, a **drained turn that finishes successfully** can now update the DB to **`AwaitingUser`** or **`Completed`** instead of leaving **`Interrupted`** while the runner is still registered.
> 
> Failure-shaped terminal outcomes on an already-interrupted mission still skip finalization (interrupted remains the accurate state). **`Interrupted`** is also included in the set of statuses that may proceed to the normal finalization path, but only after the success check above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f488cedbabbaee87c6d792a9cab06c01a67a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->