### PR TITLE
Model routing debug panel

### DIFF
--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -16,6 +16,7 @@ import { Save, Loader, Check, Gauge, Bot } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getRuntimeApiBase, writeSavedSettings } from '@/lib/settings';
 import { ServerConnectionCard } from '@/components/server-connection-card';
+import { ModelRoutingDebug } from '@/components/model-routing-debug';
 import { useBackendConfigs } from '@/lib/use-backend-configs';
 
 const SETTINGS_BACKEND_IDS = ['opencode', 'claudecode', 'grok'] as const;
@@ -610,6 +611,8 @@ export default function BackendsPage() {
             </div>
           ) : null}
         </section>
+
+        <ModelRoutingDebug />
       </div>
     </div>
   );

--- a/dashboard/src/components/model-routing-debug.tsx
+++ b/dashboard/src/components/model-routing-debug.tsx
@@ -28,7 +28,7 @@ function ChainRow({ chain }: { chain: ModelChain }) {
     () => resolveModelChain(chain.id),
     { revalidateOnFocus: false }
   );
-  const { data: health } = useSWR('routing-health', listAccountHealth, {
+  const { data: health, mutate: mutateHealth } = useSWR('routing-health', listAccountHealth, {
     refreshInterval: 5000,
   });
   const [testing, setTesting] = useState(false);
@@ -90,7 +90,9 @@ function ChainRow({ chain }: { chain: ModelChain }) {
           const h = r ? healthByAccount.get(r.account_id) : undefined;
           const skipped = !r;
           const inCooldown = h?.cooldown_remaining_secs != null;
-          const ok = r && !inCooldown;
+          const noCredentials = r != null && !r.has_credentials;
+          const degraded = h?.is_degraded === true;
+          const ok = r != null && r.has_credentials && !inCooldown && !degraded;
           return (
             <div
               key={idx}
@@ -109,6 +111,18 @@ function ChainRow({ chain }: { chain: ModelChain }) {
                     unresolved
                   </span>
                 )}
+                {noCredentials && (
+                  <span className="flex items-center gap-1 text-amber-400">
+                    <AlertCircle className="h-3 w-3" />
+                    no credentials
+                  </span>
+                )}
+                {degraded && !inCooldown && (
+                  <span className="flex items-center gap-1 text-amber-400">
+                    <AlertCircle className="h-3 w-3" />
+                    degraded
+                  </span>
+                )}
                 {inCooldown && (
                   <>
                     <span className="text-red-400">
@@ -118,6 +132,7 @@ function ChainRow({ chain }: { chain: ModelChain }) {
                       onClick={async () => {
                         try {
                           await clearAccountCooldown(r!.account_id);
+                          await mutateHealth();
                           toast.success('Cooldown cleared');
                         } catch (e) {
                           toast.error((e as Error).message);

--- a/dashboard/src/components/model-routing-debug.tsx
+++ b/dashboard/src/components/model-routing-debug.tsx
@@ -10,10 +10,10 @@ import {
   listAccountHealth,
   clearAccountCooldown,
   listFallbackEvents,
+  testModelChain,
   ModelChain,
   ResolvedEntry,
 } from '@/lib/api/model-routing';
-import { apiPost } from '@/lib/api/core';
 
 function fmtAgo(iso: string): string {
   const secs = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
@@ -40,17 +40,16 @@ function ChainRow({ chain }: { chain: ModelChain }) {
     setTesting(true);
     setTestResult(null);
     try {
-      const res = await apiPost<{ choices?: { message: { content: string } }[] }>(
-        `/v1/chat/completions`,
-        {
-          model: chain.id,
-          messages: [{ role: 'user', content: 'ping' }],
-          max_tokens: 1,
-        },
-        'Test request failed'
-      );
-      const msg = res.choices?.[0]?.message.content ?? '(no content)';
-      setTestResult(`✅ ${msg.slice(0, 80)}`);
+      // Goes through the JWT-authed test endpoint — the dashboard does not
+      // hold a proxy bearer for /v1/chat/completions.
+      const res = await testModelChain(chain.id);
+      if (res.ok) {
+        const msg = res.response.choices?.[0]?.message.content ?? '(no content)';
+        setTestResult(`✅ ${(msg ?? '(no content)').slice(0, 80)}`);
+      } else {
+        const err = res.response.error?.message ?? `HTTP ${res.status}`;
+        setTestResult(`❌ ${err.slice(0, 160)}`);
+      }
       mutateResolved();
     } catch (e) {
       setTestResult(`❌ ${(e as Error).message}`);

--- a/dashboard/src/components/model-routing-debug.tsx
+++ b/dashboard/src/components/model-routing-debug.tsx
@@ -88,16 +88,19 @@ function ChainRow({ chain }: { chain: ModelChain }) {
           );
           // /resolve omits accounts in cooldown, so fall back to matching
           // health by provider — otherwise cooled-down entries read as
-          // "unresolved" with no way to clear the cooldown.
-          const cooledFallback = !r
-            ? (health ?? []).find(
+          // "unresolved" with no way to clear the cooldown.  With several
+          // accounts on the same provider we can't attribute the cooldown to
+          // one of them, so "clear" targets every cooled account explicitly.
+          const cooledMatches = !r
+            ? (health ?? []).filter(
                 (x) =>
                   x.provider_id === entry.provider_id &&
                   x.cooldown_remaining_secs != null
               )
-            : undefined;
+            : [];
+          const cooledFallback = cooledMatches[0];
           const h = r ? healthByAccount.get(r.account_id) : cooledFallback;
-          const accountId = r?.account_id ?? cooledFallback?.account_id;
+          const clearTargets = r ? (h ? [h.account_id] : []) : cooledMatches.map((x) => x.account_id);
           const skipped = !r && !cooledFallback;
           const inCooldown = h?.cooldown_remaining_secs != null;
           const noCredentials = r != null && !r.has_credentials;
@@ -133,24 +136,34 @@ function ChainRow({ chain }: { chain: ModelChain }) {
                     degraded
                   </span>
                 )}
-                {inCooldown && accountId && (
+                {inCooldown && clearTargets.length > 0 && (
                   <>
                     <span className="text-red-400">
                       cooldown {Math.round(h!.cooldown_remaining_secs!)}s
+                      {cooledMatches.length > 1 && ` (${cooledMatches.length} accounts)`}
                     </span>
                     <button
                       onClick={async () => {
                         try {
-                          await clearAccountCooldown(accountId);
+                          await Promise.all(clearTargets.map((id) => clearAccountCooldown(id)));
                           await mutateHealth();
-                          toast.success('Cooldown cleared');
+                          toast.success(
+                            clearTargets.length > 1
+                              ? `Cleared ${clearTargets.length} cooldowns`
+                              : 'Cooldown cleared'
+                          );
                         } catch (e) {
                           toast.error((e as Error).message);
                         }
                       }}
+                      title={
+                        cooledMatches.length > 1
+                          ? `Clears all ${cooledMatches.length} cooled ${entry.provider_id} accounts`
+                          : undefined
+                      }
                       className="rounded bg-white/5 px-1.5 py-0.5 text-white/70 hover:bg-white/10"
                     >
-                      clear
+                      {cooledMatches.length > 1 ? 'clear all' : 'clear'}
                     </button>
                   </>
                 )}

--- a/dashboard/src/components/model-routing-debug.tsx
+++ b/dashboard/src/components/model-routing-debug.tsx
@@ -146,7 +146,9 @@ function ChainRow({ chain }: { chain: ModelChain }) {
                       onClick={async () => {
                         try {
                           await Promise.all(clearTargets.map((id) => clearAccountCooldown(id)));
-                          await mutateHealth();
+                          // /resolve omits cooled accounts, so refresh it too —
+                          // otherwise the entry keeps reading "unresolved".
+                          await Promise.all([mutateHealth(), mutateResolved()]);
                           toast.success(
                             clearTargets.length > 1
                               ? `Cleared ${clearTargets.length} cooldowns`

--- a/dashboard/src/components/model-routing-debug.tsx
+++ b/dashboard/src/components/model-routing-debug.tsx
@@ -87,8 +87,19 @@ function ChainRow({ chain }: { chain: ModelChain }) {
           const r = resolved?.find(
             (x) => x.provider_id === entry.provider_id && x.model_id === entry.model_id
           );
-          const h = r ? healthByAccount.get(r.account_id) : undefined;
-          const skipped = !r;
+          // /resolve omits accounts in cooldown, so fall back to matching
+          // health by provider — otherwise cooled-down entries read as
+          // "unresolved" with no way to clear the cooldown.
+          const cooledFallback = !r
+            ? (health ?? []).find(
+                (x) =>
+                  x.provider_id === entry.provider_id &&
+                  x.cooldown_remaining_secs != null
+              )
+            : undefined;
+          const h = r ? healthByAccount.get(r.account_id) : cooledFallback;
+          const accountId = r?.account_id ?? cooledFallback?.account_id;
+          const skipped = !r && !cooledFallback;
           const inCooldown = h?.cooldown_remaining_secs != null;
           const noCredentials = r != null && !r.has_credentials;
           const degraded = h?.is_degraded === true;
@@ -123,7 +134,7 @@ function ChainRow({ chain }: { chain: ModelChain }) {
                     degraded
                   </span>
                 )}
-                {inCooldown && (
+                {inCooldown && accountId && (
                   <>
                     <span className="text-red-400">
                       cooldown {Math.round(h!.cooldown_remaining_secs!)}s
@@ -131,7 +142,7 @@ function ChainRow({ chain }: { chain: ModelChain }) {
                     <button
                       onClick={async () => {
                         try {
-                          await clearAccountCooldown(r!.account_id);
+                          await clearAccountCooldown(accountId);
                           await mutateHealth();
                           toast.success('Cooldown cleared');
                         } catch (e) {

--- a/dashboard/src/components/model-routing-debug.tsx
+++ b/dashboard/src/components/model-routing-debug.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useState } from 'react';
+import useSWR from 'swr';
+import { Activity, RefreshCw, Zap, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { toast } from '@/components/toast';
+import {
+  listModelChains,
+  resolveModelChain,
+  listAccountHealth,
+  clearAccountCooldown,
+  listFallbackEvents,
+  ModelChain,
+  ResolvedEntry,
+} from '@/lib/api/model-routing';
+import { apiPost } from '@/lib/api/core';
+
+function fmtAgo(iso: string): string {
+  const secs = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+  if (secs < 60) return `${Math.round(secs)}s ago`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  return `${Math.round(secs / 3600)}h ago`;
+}
+
+function ChainRow({ chain }: { chain: ModelChain }) {
+  const { data: resolved, mutate: mutateResolved } = useSWR<ResolvedEntry[]>(
+    `resolve:${chain.id}`,
+    () => resolveModelChain(chain.id),
+    { revalidateOnFocus: false }
+  );
+  const { data: health } = useSWR('routing-health', listAccountHealth, {
+    refreshInterval: 5000,
+  });
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<string | null>(null);
+
+  const healthByAccount = new Map((health ?? []).map((h) => [h.account_id, h]));
+
+  const runTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await apiPost<{ choices?: { message: { content: string } }[] }>(
+        `/v1/chat/completions`,
+        {
+          model: chain.id,
+          messages: [{ role: 'user', content: 'ping' }],
+          max_tokens: 1,
+        },
+        'Test request failed'
+      );
+      const msg = res.choices?.[0]?.message.content ?? '(no content)';
+      setTestResult(`✅ ${msg.slice(0, 80)}`);
+      mutateResolved();
+    } catch (e) {
+      setTestResult(`❌ ${(e as Error).message}`);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div>
+          <div className="text-sm font-medium text-white">
+            {chain.name}{' '}
+            <span className="text-white/30 font-normal text-xs">({chain.id})</span>
+          </div>
+          <div className="text-xs text-white/40">
+            {chain.entries.length} entries
+          </div>
+        </div>
+        <button
+          onClick={runTest}
+          disabled={testing}
+          className="flex items-center gap-1.5 rounded-md bg-indigo-500/15 px-2.5 py-1 text-xs text-indigo-300 hover:bg-indigo-500/25 transition-colors disabled:opacity-50"
+          title="Send a 1-token test request through this chain"
+        >
+          <Zap className="h-3 w-3" />
+          {testing ? 'Testing…' : 'Test chain'}
+        </button>
+      </div>
+
+      <div className="space-y-1">
+        {chain.entries.map((entry, idx) => {
+          const r = resolved?.find(
+            (x) => x.provider_id === entry.provider_id && x.model_id === entry.model_id
+          );
+          const h = r ? healthByAccount.get(r.account_id) : undefined;
+          const skipped = !r;
+          const inCooldown = h?.cooldown_remaining_secs != null;
+          const ok = r && !inCooldown;
+          return (
+            <div
+              key={idx}
+              className="flex items-center justify-between gap-2 rounded border border-white/[0.04] bg-black/20 px-2.5 py-1.5 text-xs"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-white/30 tabular-nums">{idx + 1}.</span>
+                <span className="text-white/80 truncate">
+                  {entry.provider_id} / {entry.model_id}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {skipped && (
+                  <span className="flex items-center gap-1 text-amber-400">
+                    <AlertCircle className="h-3 w-3" />
+                    unresolved
+                  </span>
+                )}
+                {inCooldown && (
+                  <>
+                    <span className="text-red-400">
+                      cooldown {Math.round(h!.cooldown_remaining_secs!)}s
+                    </span>
+                    <button
+                      onClick={async () => {
+                        try {
+                          await clearAccountCooldown(r!.account_id);
+                          toast.success('Cooldown cleared');
+                        } catch (e) {
+                          toast.error((e as Error).message);
+                        }
+                      }}
+                      className="rounded bg-white/5 px-1.5 py-0.5 text-white/70 hover:bg-white/10"
+                    >
+                      clear
+                    </button>
+                  </>
+                )}
+                {ok && (
+                  <span className="flex items-center gap-1 text-emerald-400">
+                    <CheckCircle2 className="h-3 w-3" />
+                    healthy
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {testResult && (
+        <div className="mt-2 rounded bg-black/30 px-2 py-1 text-xs font-mono text-white/70">
+          {testResult}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ModelRoutingDebug() {
+  const { data: chains, isLoading, mutate } = useSWR('routing-chains', listModelChains, {
+    revalidateOnFocus: false,
+  });
+  const { data: events } = useSWR('routing-events', listFallbackEvents, {
+    refreshInterval: 10000,
+  });
+
+  return (
+    <section className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 flex-shrink-0">
+          <Activity className="h-5 w-5 text-emerald-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-sm font-medium text-white">Model Routing Debug</h2>
+          <p className="text-xs text-white/40 truncate">
+            Resolve chains, inspect cooldowns, replay test requests
+          </p>
+        </div>
+        <button
+          onClick={() => mutate()}
+          className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/5 text-white/60 hover:bg-white/10"
+          title="Refresh"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {isLoading && <div className="text-xs text-white/40">Loading chains…</div>}
+
+      <div className="space-y-2">
+        {chains?.map((c) => (
+          <ChainRow key={c.id} chain={c} />
+        ))}
+      </div>
+
+      <div className="mt-5">
+        <h3 className="text-xs font-medium text-white/60 mb-2">
+          Recent fallback events
+        </h3>
+        {!events || events.length === 0 ? (
+          <div className="text-xs text-white/30">
+            No fallback events recorded.
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {events.slice(-20).reverse().map((e, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between gap-2 rounded border border-white/[0.04] bg-black/20 px-2.5 py-1.5 text-xs"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-white/40 tabular-nums flex-shrink-0">
+                    {fmtAgo(e.timestamp)}
+                  </span>
+                  <span className="text-white/30">{e.chain_id}</span>
+                  <span className="text-white/70 truncate">
+                    {e.from_provider}/{e.from_model}
+                    {e.to_provider && ` → ${e.to_provider}`}
+                  </span>
+                </div>
+                <span className="text-amber-400 flex-shrink-0">{e.reason}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -176,10 +176,22 @@ export function NewMissionDialog({
     return backends?.filter((b) => isBackendAvailable(backendConfigs[b.id])) || [];
   }, [backends, backendConfigs]);
 
-  // SWR: fetch agents for each enabled backend
+  const workspaceProfile = useMemo(() => {
+    const targetWorkspace = newMissionWorkspace
+      ? workspaces.find((workspace) => workspace.id === newMissionWorkspace)
+      : workspaces.find((workspace) => workspace.id === '00000000-0000-0000-0000-000000000000')
+        || workspaces.find((workspace) => workspace.workspace_type === 'host');
+    return targetWorkspace?.config_profile || null;
+  }, [newMissionWorkspace, workspaces]);
+
+  // SWR: fetch agents for each enabled backend.  OpenCode agents are
+  // profile-aware: native `.opencode/agents/*.md` files live under the
+  // selected workspace's library config profile.
   const { data: opencodeAgents, mutate: mutateOpencodeAgents } = useSWR<BackendAgent[]>(
-    open && enabledBackends.some(b => b.id === 'opencode') ? 'backend-opencode-agents' : null,
-    () => listBackendAgents('opencode'),
+    open && enabledBackends.some(b => b.id === 'opencode')
+      ? `backend-opencode-agents:${workspaceProfile ?? 'default'}`
+      : null,
+    () => listBackendAgents('opencode', workspaceProfile),
     { revalidateOnFocus: true, dedupingInterval: 5000 }
   );
   const { data: claudecodeAgents, mutate: mutateClaudecodeAgents } = useSWR<BackendAgent[]>(
@@ -219,14 +231,6 @@ export function NewMissionDialog({
     getClaudeCodeConfig,
     { revalidateOnFocus: false, dedupingInterval: 30000 }
   );
-
-  const workspaceProfile = useMemo(() => {
-    const targetWorkspace = newMissionWorkspace
-      ? workspaces.find((workspace) => workspace.id === newMissionWorkspace)
-      : workspaces.find((workspace) => workspace.id === '00000000-0000-0000-0000-000000000000')
-        || workspaces.find((workspace) => workspace.workspace_type === 'host');
-    return targetWorkspace?.config_profile || null;
-  }, [newMissionWorkspace, workspaces]);
 
   // Combine all agents from enabled backends
   const allAgents = useMemo((): CombinedAgent[] => {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3156,9 +3156,11 @@ export async function getBackend(id: string): Promise<Backend> {
 // List agents for a specific backend
 export async function listBackendAgents(
   backendId: string,
+  profile?: string | null,
 ): Promise<BackendAgent[]> {
+  const query = profile ? `?profile=${encodeURIComponent(profile)}` : "";
   return apiGet(
-    `/api/backends/${encodeURIComponent(backendId)}/agents`,
+    `/api/backends/${encodeURIComponent(backendId)}/agents${query}`,
     "Failed to list backend agents",
   );
 }

--- a/dashboard/src/lib/api/model-routing.ts
+++ b/dashboard/src/lib/api/model-routing.ts
@@ -125,6 +125,24 @@ export async function resolveModelChain(id: string): Promise<ResolvedEntry[]> {
   );
 }
 
+export interface ChainTestResult {
+  ok: boolean;
+  status: number;
+  response: {
+    choices?: { message: { content: string | null } }[];
+    error?: { message?: string };
+    [key: string]: unknown;
+  };
+}
+
+export async function testModelChain(id: string): Promise<ChainTestResult> {
+  return apiPost(
+    `/api/model-routing/chains/${encodeURIComponent(id)}/test`,
+    undefined,
+    "Failed to test model chain"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Health Tracking
 // ---------------------------------------------------------------------------

--- a/dashboard/tests/mission-backends.spec.ts
+++ b/dashboard/tests/mission-backends.spec.ts
@@ -55,7 +55,11 @@ test.describe('Mission backend configs', () => {
     });
     expect(updateRes.ok()).toBeTruthy();
 
-    const agentsRes = await request.get(`${API_BASE}/api/opencode/agents`);
+    // Use the same profile-aware endpoint the dialog uses, so the test fails
+    // if profile-specific agents stop appearing in the UI.
+    const agentsRes = await request.get(
+      `${API_BASE}/api/backends/opencode/agents?profile=spark-local`,
+    );
     expect(agentsRes.ok()).toBeTruthy();
     const agents = (await agentsRes.json()) as unknown[];
     const agentNames = agents

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Extension, Path, State},
+    extract::{Extension, Path, Query, State},
     http::StatusCode,
     Json,
 };
@@ -63,21 +63,30 @@ pub async fn get_backend(
     }
 }
 
+/// Query parameters for listing backend agents.
+#[derive(Debug, Deserialize)]
+pub struct ListBackendAgentsQuery {
+    /// Library config profile to resolve native agents from (OpenCode only).
+    pub profile: Option<String>,
+}
+
 /// List agents for a specific backend
 pub async fn list_backend_agents(
     State(state): State<Arc<AppState>>,
     Extension(_user): Extension<AuthUser>,
     Path(id): Path<String>,
+    Query(query): Query<ListBackendAgentsQuery>,
 ) -> Result<Json<Vec<AgentResponse>>, (StatusCode, String)> {
     if id == "opencode" {
-        let payload = super::opencode::fetch_opencode_agents(&state)
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to list agents: {}", e),
-                )
-            })?;
+        let payload =
+            super::opencode::fetch_opencode_agents_for_profile(&state, query.profile.as_deref())
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to list agents: {}", e),
+                    )
+                })?;
         let agents = payload
             .as_array()
             .cloned()

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11354,7 +11354,11 @@ pub async fn run_opencode_turn(
                                     tool_call_steps = tool_call_step_count,
                                     "OpenCode JSON step_finish event"
                                 );
-                                if reason == "stop" {
+                                // Match the shared SSE parser: an empty reason
+                                // also marks the final step (some providers omit
+                                // it); otherwise completion waits on idle
+                                // timeouts or process exit.
+                                if reason == "stop" || reason.is_empty() {
                                     let _ = sse_complete_tx.send(true);
                                 } else {
                                     // Track consecutive tool-call steps to detect runaway loops

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11300,17 +11300,14 @@ pub async fn run_opencode_turn(
                                 }
                             }
 
-                            // Track tool depth for plain opencode JSON mode so that
-                            // the text-output idle timeout doesn't kill the process
-                            // while MCP tools (web fetch, etc.) are actively running.
+                            // Reset tool depth at step boundaries for plain opencode
+                            // JSON mode.  Per-tool increments/decrements happen below
+                            // on the ToolCall/ToolResult events emitted by the shared
+                            // parser (which also covers message.part.updated tool
+                            // parts), so the resets here are a safety net against a
+                            // missed ToolResult pinning depth above zero forever.
                             if let Some(ref tx) = json_tool_depth_tx {
-                                if event_type == "tool_use" {
-                                    tx.send_modify(|v| *v = v.saturating_add(1));
-                                } else if event_type == "step_finish" {
-                                    // All tools for this step completed — reset depth.
-                                    tx.send_modify(|v| *v = 0);
-                                } else if event_type == "step_start" {
-                                    // New step starting — ensure depth is clean.
+                                if event_type == "step_finish" || event_type == "step_start" {
                                     tx.send_modify(|v| *v = 0);
                                 }
                             }
@@ -11466,10 +11463,35 @@ pub async fn run_opencode_turn(
                                         let _ = text_output_tx.send(true);
                                         sse_emitted_text.store(true, std::sync::atomic::Ordering::SeqCst);
                                     }
+                                    // Track active tool depth so inactivity timeouts
+                                    // don't kill the process mid-tool-run (builds,
+                                    // web fetches, etc.).
+                                    if let Some(ref tx) = json_tool_depth_tx {
+                                        match event {
+                                            AgentEvent::ToolCall { .. } => {
+                                                tx.send_modify(|v| *v = v.saturating_add(1));
+                                            }
+                                            AgentEvent::ToolResult { .. } => {
+                                                tx.send_modify(|v| *v = v.saturating_sub(1));
+                                            }
+                                            _ => {}
+                                        }
+                                    }
                                     remember_tool_result_text(&event, &latest_tool_result_text);
                                     let _ = events_tx.send(event);
                                 }
                                 for event in parsed.extra_events {
+                                    if let Some(ref tx) = json_tool_depth_tx {
+                                        match event {
+                                            AgentEvent::ToolCall { .. } => {
+                                                tx.send_modify(|v| *v = v.saturating_add(1));
+                                            }
+                                            AgentEvent::ToolResult { .. } => {
+                                                tx.send_modify(|v| *v = v.saturating_sub(1));
+                                            }
+                                            _ => {}
+                                        }
+                                    }
                                     remember_tool_result_text(&event, &latest_tool_result_text);
                                     let _ = events_tx.send(event);
                                 }

--- a/src/api/model_routing.rs
+++ b/src/api/model_routing.rs
@@ -28,6 +28,7 @@ pub fn routes() -> Router<Arc<super::routes::AppState>> {
         .route("/chains/:id", put(update_chain))
         .route("/chains/:id", delete(delete_chain))
         .route("/chains/:id/resolve", get(resolve_chain))
+        .route("/chains/:id/test", post(test_chain))
         // Health tracking
         .route("/health", get(list_health))
         .route("/health/:account_id", get(get_account_health))
@@ -315,6 +316,53 @@ async fn resolve_chain(
             })
             .collect(),
     ))
+}
+
+/// POST /api/model-routing/chains/:id/test - Send a 1-token test request
+/// through a chain.
+///
+/// Runs behind the dashboard JWT (unlike `/v1/chat/completions`, which
+/// requires a proxy bearer), so the debug panel can exercise a chain without
+/// holding a proxy key.
+async fn test_chain(
+    State(state): State<Arc<super::routes::AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if state.chain_store.get(&id).await.is_none() {
+        return Err((StatusCode::NOT_FOUND, format!("Chain '{}' not found", id)));
+    }
+
+    let body = serde_json::json!({
+        "model": id,
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+    });
+    let body_bytes = bytes::Bytes::from(serde_json::to_vec(&body).expect("test body serializes"));
+    let response = super::proxy::chat_completions_inner(
+        state.clone(),
+        axum::http::HeaderMap::new(),
+        body_bytes,
+    )
+    .await;
+
+    let status = response.status();
+    let collected = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to read test response: {}", e),
+            )
+        })?;
+    let payload: serde_json::Value = serde_json::from_slice(&collected).unwrap_or_else(
+        |_| serde_json::json!({ "raw": String::from_utf8_lossy(&collected).to_string() }),
+    );
+
+    Ok(Json(serde_json::json!({
+        "ok": status.is_success(),
+        "status": status.as_u16(),
+        "response": payload,
+    })))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -445,7 +445,16 @@ async fn chat_completions(
     if let Err(resp) = verify_proxy_auth(&headers, &state).await {
         return resp;
     }
+    chat_completions_inner(state, headers, body).await
+}
 
+/// Chain-routed chat completion without proxy auth.  Callers must enforce
+/// their own authentication (e.g. the JWT-protected chain test endpoint).
+pub(crate) async fn chat_completions_inner(
+    state: Arc<super::routes::AppState>,
+    headers: HeaderMap,
+    body: bytes::Bytes,
+) -> Response {
     // 1. Parse the request to extract the model name
     let req: ChatCompletionRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes mission completion and inactivity-timeout behavior for OpenCode JSON runs, and adds a JWT-only path into chain-routed chat completions; profile-scoped agents alter what the UI offers per workspace.
> 
> **Overview**
> Adds a **Model Routing Debug** section on the Backends settings page to inspect chains, resolved accounts, cooldowns, recent fallbacks, and run JWT-authenticated **Test chain** requests (1-token ping) without a proxy bearer.
> 
> Backend support includes `POST /api/model-routing/chains/:id/test`, which reuses a new **`chat_completions_inner`** helper that skips proxy auth while the route stays dashboard-authenticated.
> 
> **OpenCode agent listing** is now **config-profile aware**: `GET /api/backends/opencode/agents?profile=…` and the new-mission dialog refetch agents when the selected workspace’s profile changes. The Playwright test was updated to hit the same endpoint.
> 
> **OpenCode JSON mission runner** fixes treat an empty `step_finish` reason as completion (aligned with the SSE parser), track active tools via shared `ToolCall`/`ToolResult` events for idle timeouts, and only reset tool depth on step boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f870e534aaa6227a0c70b33e6380e41cef86273f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->