### PR TITLE
Copilot steering: stop_agent + send_to_agent tools

### DIFF
--- a/ASK_ASSISTANT_DESIGN.md
+++ b/ASK_ASSISTANT_DESIGN.md
@@ -34,7 +34,13 @@ Cerebras title fix (#489), `metadata_llm.rs` provider ladder.
 - No worktree / sandbox-copy mode (usage is read-dominant).
 - No destructive-write confirmation gate. Full bash, no friction; a visual
   "agent idle/working" indicator is informational only.
-- Ask never **starts** a main-agent turn. Strictly non-interrupting.
+- ~~Ask never **starts** a main-agent turn. Strictly non-interrupting.~~
+  **Superseded (v1.1):** the Copilot now has explicit steering tools —
+  `stop_agent` (CancelMission, same as the Stop button) and `send_to_agent`
+  (a real composer-equivalent UserMessage, optionally interrupting the
+  current turn first). The system prompt frames these as interventions to
+  use when the operator asks to stop/steer, or in clearly harmful loops;
+  the default posture stays read-mostly.
 - Not every harness *heeds* the operator-note identically — delivery is
   harness-agnostic, faithfulness is best-effort (§9).
 

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -196,6 +196,7 @@ pub async fn ask_send(
         workspaces: Arc::clone(&state.workspaces),
         workspace_id,
         proxy_keys: Arc::clone(&state.proxy_api_keys),
+        control_cmd_tx: control.cmd_tx.clone(),
     };
 
     let answer_result = run_ask_turn(&turn, &req.content).await;
@@ -320,6 +321,7 @@ pub async fn ask_send_stream(
         workspaces: Arc::clone(&state.workspaces),
         workspace_id,
         proxy_keys: Arc::clone(&state.proxy_api_keys),
+        control_cmd_tx: control.cmd_tx.clone(),
     };
 
     let content = req.content.clone();

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -197,6 +197,7 @@ pub async fn ask_send(
         workspace_id,
         proxy_keys: Arc::clone(&state.proxy_api_keys),
         control_cmd_tx: control.cmd_tx.clone(),
+        events_tx: control.events_tx.clone(),
     };
 
     let answer_result = run_ask_turn(&turn, &req.content).await;
@@ -322,6 +323,7 @@ pub async fn ask_send_stream(
         workspace_id,
         proxy_keys: Arc::clone(&state.proxy_api_keys),
         control_cmd_tx: control.cmd_tx.clone(),
+        events_tx: control.events_tx.clone(),
     };
 
     let content = req.content.clone();

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -83,6 +83,10 @@ pub struct AskTurn {
     /// Proxy API key store, for answering "is the key the operator issued
     /// actually being used?" with `last_used_at` facts.
     pub proxy_keys: SharedProxyApiKeyStore,
+    /// Command channel into the user's control session, for the steering tools
+    /// (`stop_agent` / `send_to_agent`). Same channel the dashboard's Stop
+    /// button and composer use.
+    pub control_cmd_tx: tokio::sync::mpsc::Sender<crate::api::control::ControlCommand>,
 }
 
 /// Run one Ask turn: persist the operator message, drive the tool loop, persist
@@ -489,6 +493,14 @@ async fn build_system_prompt(turn: &AskTurn, user_content: &str) -> String {
          name and never repeat the value. Use list_workspace_env and \
          proxy_key_status to answer \"is the key set / is it being used?\" with \
          facts instead of guesses.\n\n\
+         Steering authority: you can stop the working agent (stop_agent) and send \
+         it steering messages (send_to_agent) — the same controls the operator has. \
+         These are interventions, not observations: use them when the operator asks \
+         you to stop/steer/redirect the agent, or when it is burning resources in a \
+         clearly harmful loop. Otherwise, propose the steering message and let the \
+         operator decide. When you do steer, make the message self-contained and \
+         bounded (what to stop, what to do instead, when to stop doing it) — the \
+         working agent has no access to this conversation.\n\n\
          Be concise and concrete. Cite event sequence numbers or file paths when \
          relevant. When you identify a blocker the operator could fix through \
          configuration (missing env var, unused key), propose the concrete fix — \
@@ -571,6 +583,35 @@ fn tool_definitions() -> Vec<Value> {
                 "name": "proxy_key_status",
                 "description": "List the gateway's proxy API keys (name, prefix, created_at, last_used_at). Use to answer whether a key the operator issued is valid/actually being used.",
                 "parameters": { "type": "object", "properties": {} }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "stop_agent",
+                "description": "Interrupt the working agent's current turn (same as the operator's Stop button). The mission becomes interrupted/awaiting until resumed or steered. Use only when the operator asked you to stop it, or when it is clearly stuck in a harmful loop.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "reason": { "type": "string", "description": "One-line reason, recorded for the operator." }
+                    },
+                    "required": ["reason"]
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "send_to_agent",
+                "description": "Send a steering message to the working agent, exactly as if the operator typed it in the mission composer. If the agent is mid-turn the message is queued and picked up at the next turn boundary — set interrupt=true to cancel the current turn first so it takes effect immediately. If the agent is idle this STARTS a new turn. Use only when the operator asked you to steer/redirect the agent.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "message": { "type": "string", "description": "The steering instructions for the working agent. Be specific: what to stop doing, what to do instead, and any bounds." },
+                        "interrupt": { "type": "boolean", "description": "Cancel the agent's current turn before delivering, so the steer applies now instead of after the turn ends. Default false." }
+                    },
+                    "required": ["message"]
+                }
             }
         }),
     ]
@@ -724,6 +765,76 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                 None => "Error: workspace not found".to_string(),
             }
         }
+        "stop_agent" => {
+            let reason = args["reason"].as_str().unwrap_or("").trim().to_string();
+            if reason.is_empty() {
+                return "Error: a reason is required".to_string();
+            }
+            match cancel_working_agent(turn).await {
+                Ok(()) => format!(
+                    "Interrupted the working agent's current turn (reason: {reason}). The \
+                     mission will settle as interrupted/awaiting; use send_to_agent to \
+                     redirect it, or the operator can resume it from the dashboard."
+                ),
+                Err(e) => format!("Error stopping the agent: {e}"),
+            }
+        }
+        "send_to_agent" => {
+            let message = args["message"].as_str().unwrap_or("").trim().to_string();
+            if message.is_empty() {
+                return "Error: message is empty".to_string();
+            }
+            let interrupt = args["interrupt"].as_bool().unwrap_or(false);
+            if interrupt {
+                if let Err(e) = cancel_working_agent(turn).await {
+                    // A failed cancel usually means nothing was running — the
+                    // steer below still applies, so report and continue.
+                    tracing::info!(
+                        mission_id = %turn.mission_id,
+                        "[Ask] interrupt before steer found nothing to cancel: {e}"
+                    );
+                }
+            }
+            let content = format_steer_message(&message);
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let send = turn
+                .control_cmd_tx
+                .send(crate::api::control::ControlCommand::UserMessage {
+                    id: Uuid::new_v4(),
+                    content,
+                    agent: None,
+                    target_mission_id: Some(turn.mission_id),
+                    respond: tx,
+                })
+                .await;
+            if send.is_err() {
+                return "Error: the control session is unavailable".to_string();
+            }
+            match tokio::time::timeout(std::time::Duration::from_secs(15), rx).await {
+                Ok(Ok(queued)) if queued => {
+                    if interrupt {
+                        "Steering message delivered after interrupting the current turn — \
+                         the agent will act on it as soon as the cancellation settles."
+                            .to_string()
+                    } else {
+                        "Steering message queued — the working agent is mid-turn and will \
+                         act on it at the next turn boundary. Pass interrupt=true if it \
+                         must take effect immediately."
+                            .to_string()
+                    }
+                }
+                Ok(Ok(_)) => "Steering message delivered — the agent was idle, so this \
+                              starts a new turn now."
+                    .to_string(),
+                Ok(Err(_)) | Err(_) => {
+                    // The control loop accepted the command but never confirmed —
+                    // the message is most likely in flight; don't claim failure.
+                    "Steering message submitted (no queue confirmation received). \
+                     Check read_history shortly to confirm the agent saw it."
+                        .to_string()
+                }
+            }
+        }
         "proxy_key_status" => {
             let keys = turn.proxy_keys.list().await;
             if keys.is_empty() {
@@ -748,6 +859,32 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
         }
         other => format!("Error: unknown tool '{other}'"),
     }
+}
+
+/// Cancel the working agent's current turn through the control session — the
+/// same `CancelMission` path the dashboard's Stop button uses.
+async fn cancel_working_agent(turn: &AskTurn) -> Result<(), String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    turn.control_cmd_tx
+        .send(crate::api::control::ControlCommand::CancelMission {
+            mission_id: turn.mission_id,
+            min_idle: None,
+            respond: tx,
+        })
+        .await
+        .map_err(|_| "the control session is unavailable".to_string())?;
+    match tokio::time::timeout(std::time::Duration::from_secs(15), rx).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err("the control session dropped the request".to_string()),
+        Err(_) => Err("timed out waiting for the cancellation to be acknowledged".to_string()),
+    }
+}
+
+/// Wrap a Copilot steering message so the working agent (and the mission
+/// transcript) can tell it came through the co-pilot acting on the operator's
+/// behalf, not from the operator typing directly.
+fn format_steer_message(message: &str) -> String {
+    format!("[Steering from the operator via the Copilot]\n{message}")
 }
 
 /// Mask an env var value for display: short prefix + length, never the value.
@@ -1105,6 +1242,13 @@ mod tests {
         assert!(!message_mentions_secret("what is the mission status?"));
         assert!(!message_mentions_secret("the sk-learn library"));
         assert!(!message_mentions_secret("commit 381a865f is on master"));
+    }
+
+    #[test]
+    fn steer_messages_carry_a_copilot_attribution() {
+        let msg = format_steer_message("Stop rewriting orchestrator-state.json.");
+        assert!(msg.starts_with("[Steering from the operator via the Copilot]"));
+        assert!(msg.ends_with("Stop rewriting orchestrator-state.json."));
     }
 
     #[test]

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -810,8 +810,9 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
             if send.is_err() {
                 return "Error: the control session is unavailable".to_string();
             }
+            use crate::api::control::UserMessageAck;
             match tokio::time::timeout(std::time::Duration::from_secs(15), rx).await {
-                Ok(Ok(queued)) if queued => {
+                Ok(Ok(UserMessageAck::Queued)) => {
                     if interrupt {
                         "Steering message delivered after interrupting the current turn — \
                          the agent will act on it as soon as the cancellation settles."
@@ -823,13 +824,20 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                             .to_string()
                     }
                 }
-                Ok(Ok(_)) => "Steering message delivered — the agent was idle, so this \
-                              starts a new turn now."
-                    .to_string(),
+                Ok(Ok(UserMessageAck::Delivered)) => {
+                    "Steering message delivered — a turn is starting on it now.".to_string()
+                }
+                Ok(Ok(UserMessageAck::Dropped)) => {
+                    "Error: the steering message was DROPPED — it never reached the \
+                     working agent (parallel mission cap, mission load failure, or a \
+                     rejected goal kickoff). Check read_history for the error event, \
+                     resolve the cause, then retry."
+                        .to_string()
+                }
                 Ok(Err(_)) | Err(_) => {
                     // The control loop accepted the command but never confirmed —
                     // the message is most likely in flight; don't claim failure.
-                    "Steering message submitted (no queue confirmation received). \
+                    "Steering message submitted (no delivery confirmation received). \
                      Check read_history shortly to confirm the agent saw it."
                         .to_string()
                 }

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -87,6 +87,10 @@ pub struct AskTurn {
     /// (`stop_agent` / `send_to_agent`). Same channel the dashboard's Stop
     /// button and composer use.
     pub control_cmd_tx: tokio::sync::mpsc::Sender<crate::api::control::ControlCommand>,
+    /// Event broadcast for the control session. Events sent here reach live
+    /// viewers AND the persistent event logger — used to leave a durable audit
+    /// record when the Copilot stops the working agent.
+    pub events_tx: tokio::sync::broadcast::Sender<crate::api::control::AgentEvent>,
 }
 
 /// Run one Ask turn: persist the operator message, drive the tool loop, persist
@@ -771,11 +775,15 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                 return "Error: a reason is required".to_string();
             }
             match cancel_working_agent(turn).await {
-                Ok(()) => format!(
-                    "Interrupted the working agent's current turn (reason: {reason}). The \
-                     mission will settle as interrupted/awaiting; use send_to_agent to \
-                     redirect it, or the operator can resume it from the dashboard."
-                ),
+                Ok(()) => {
+                    record_copilot_stop(turn, &reason).await;
+                    format!(
+                        "Interrupted the working agent's current turn (reason: {reason}). \
+                         The reason was recorded in the mission transcript. The mission \
+                         will settle as interrupted/awaiting; use send_to_agent to \
+                         redirect it, or the operator can resume it from the dashboard."
+                    )
+                }
                 Err(e) => format!("Error stopping the agent: {e}"),
             }
         }
@@ -785,14 +793,19 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                 return "Error: message is empty".to_string();
             }
             let interrupt = args["interrupt"].as_bool().unwrap_or(false);
+            // Track whether the requested interrupt actually landed — a failed
+            // cancel (timeout, control error) must not be reported as "delivered
+            // after interrupting" when the agent may still be mid-turn.
+            let mut interrupt_error: Option<String> = None;
             if interrupt {
                 if let Err(e) = cancel_working_agent(turn).await {
-                    // A failed cancel usually means nothing was running — the
-                    // steer below still applies, so report and continue.
                     tracing::info!(
                         mission_id = %turn.mission_id,
-                        "[Ask] interrupt before steer found nothing to cancel: {e}"
+                        "[Ask] interrupt before steer did not cancel anything: {e}"
                     );
+                    interrupt_error = Some(e);
+                } else {
+                    record_copilot_stop(turn, &format!("steering: {message}")).await;
                 }
             }
             let content = format_steer_message(&message);
@@ -812,18 +825,25 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
             }
             use crate::api::control::UserMessageAck;
             match tokio::time::timeout(std::time::Duration::from_secs(15), rx).await {
-                Ok(Ok(UserMessageAck::Queued)) => {
-                    if interrupt {
+                Ok(Ok(UserMessageAck::Queued)) => match (interrupt, &interrupt_error) {
+                    (true, None) => {
                         "Steering message delivered after interrupting the current turn — \
                          the agent will act on it as soon as the cancellation settles."
                             .to_string()
-                    } else {
+                    }
+                    (true, Some(err)) => format!(
+                        "Steering message queued, but the requested interrupt FAILED \
+                         ({err}) — the agent may still be mid-turn and will only act on \
+                         the message at the next turn boundary. Verify with read_history; \
+                         retry stop_agent if it must stop now."
+                    ),
+                    (false, _) => {
                         "Steering message queued — the working agent is mid-turn and will \
                          act on it at the next turn boundary. Pass interrupt=true if it \
                          must take effect immediately."
                             .to_string()
                     }
-                }
+                },
                 Ok(Ok(UserMessageAck::Delivered)) => {
                     "Steering message delivered — a turn is starting on it now.".to_string()
                 }
@@ -886,6 +906,21 @@ async fn cancel_working_agent(turn: &AskTurn) -> Result<(), String> {
         Ok(Err(_)) => Err("the control session dropped the request".to_string()),
         Err(_) => Err("timed out waiting for the cancellation to be acknowledged".to_string()),
     }
+}
+
+/// Leave a durable audit record of a Copilot-initiated stop in the mission
+/// transcript. Broadcast on `events_tx` so live viewers see it AND the
+/// persistent event logger writes it to mission events.
+async fn record_copilot_stop(turn: &AskTurn, reason: &str) {
+    let _ = turn.events_tx.send(crate::api::control::AgentEvent::Error {
+        message: format!(
+            "⏹ The Copilot stopped the working agent's turn (operator-authorized). \
+                 Reason: {}",
+            truncate(reason, 400)
+        ),
+        mission_id: Some(turn.mission_id),
+        resumable: true,
+    });
 }
 
 /// Wrap a Copilot steering message so the working agent (and the mission

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3008,6 +3008,23 @@ impl AgentEvent {
     }
 }
 
+/// Outcome of a [`ControlCommand::UserMessage`], acknowledged on its
+/// `respond` channel. Distinguishes "delivered, a turn is starting" from
+/// "dropped" — both used to be `false`, which made drops invisible to
+/// callers that need delivery guarantees (e.g. the Copilot's steering tool).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserMessageAck {
+    /// The target is busy mid-turn; the message was queued and will be
+    /// picked up at the next turn boundary.
+    Queued,
+    /// The message was delivered and a turn is starting now.
+    Delivered,
+    /// The message was dropped (parallel cap reached, mission load failure,
+    /// rejected goal kickoff, …). An `AgentEvent::Error` with details was
+    /// emitted on the event stream.
+    Dropped,
+}
+
 /// Internal control commands (queued and processed by the actor).
 #[derive(Debug)]
 pub enum ControlCommand {
@@ -3018,8 +3035,8 @@ pub enum ControlCommand {
         agent: Option<String>,
         /// Target mission ID - if provided and differs from running mission, start in parallel
         target_mission_id: Option<Uuid>,
-        /// Respond with whether the message was queued (true = waiting to be processed)
-        respond: oneshot::Sender<bool>,
+        /// Respond with the delivery outcome (queued / delivered / dropped).
+        respond: oneshot::Sender<UserMessageAck>,
     },
     ToolResult {
         tool_call_id: String,
@@ -3551,7 +3568,10 @@ pub async fn post_message(
         .await
         .map_err(session_unavailable)?;
     let queued = match queued_rx.await {
-        Ok(value) => value,
+        // The wire response keeps its historical bool shape: `queued` is true
+        // only when the message is waiting for the next turn boundary.
+        // Dropped messages surface as an `AgentEvent::Error` on the stream.
+        Ok(ack) => ack == UserMessageAck::Queued,
         Err(_) => {
             let status = control.status.read().await;
             status.state != ControlRunState::Idle
@@ -9035,7 +9055,11 @@ async fn control_actor_loop(
                     ControlCommand::UserMessage { id, content, agent: msg_agent, target_mission_id, respond } => {
                         if !accept_user_message_id(&mut accepted_user_message_ids, id) {
                             let status_snapshot = status.read().await;
-                            let _ = respond.send(status_snapshot.state != ControlRunState::Idle);
+                            let _ = respond.send(if status_snapshot.state != ControlRunState::Idle {
+                                UserMessageAck::Queued
+                            } else {
+                                UserMessageAck::Delivered
+                            });
                             continue;
                         }
 
@@ -9102,7 +9126,7 @@ async fn control_actor_loop(
                                     mission_id: goal_target_mission,
                                     resumable: true,
                                 });
-                                let _ = respond.send(false);
+                                let _ = respond.send(UserMessageAck::Dropped);
                                 continue;
                             }
                         }
@@ -9147,7 +9171,7 @@ async fn control_actor_loop(
                                             secrets.clone(),
                                         );
                                     }
-                                    let _ = respond.send(was_running);
+                                    let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
                                     continue;
                                 }
                             }
@@ -9180,7 +9204,7 @@ async fn control_actor_loop(
                                         mission_id: Some(tid),
                                         resumable: true,
                                     });
-                                    let _ = respond.send(false);
+                                    let _ = respond.send(UserMessageAck::Dropped);
                                     continue;
                                 } else {
                                     // Load mission and start in parallel
@@ -9252,7 +9276,7 @@ async fn control_actor_loop(
                                             );
                                             tracing::info!("Auto-started mission {} in parallel", tid);
                                             parallel_runners.insert(tid, runner);
-                                            let _ = respond.send(false);
+                                            let _ = respond.send(UserMessageAck::Delivered);
                                             continue;
                                         }
                                         Err(e) => {
@@ -9269,7 +9293,7 @@ async fn control_actor_loop(
                                                 mission_id: Some(tid),
                                                 resumable: true,
                                             });
-                                            let _ = respond.send(false);
+                                            let _ = respond.send(UserMessageAck::Dropped);
                                             continue;
                                         }
                                     }
@@ -9587,7 +9611,7 @@ async fn control_actor_loop(
                                 set_and_emit_status(&status, &events_tx, ControlRunState::Idle, 0, None).await;
                             }
                         }
-                        let _ = respond.send(was_running);
+                        let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
                     }
                     ControlCommand::ToolResult { tool_call_id, name, result } => {
                         // Deliver to the tool hub. resolve() caches the result if


### PR DESCRIPTION
## Problem

The Copilot (Ask sidecar) can watch a working agent loop on wasteful work but has no authority to intervene — it answers with *"I can't stop the agent or steer its tool calls from here — I'm a read-mostly co-pilot"* and can only draft a steering message for the operator to copy-paste.

## Change

Give the Copilot the operator's own controls, exposed as two new tools in the Ask loop:

- **`stop_agent(reason)`** — interrupts the working agent's current turn through the same `ControlCommand::CancelMission` path as the dashboard's Stop button.
- **`send_to_agent(message, interrupt?)`** — delivers a composer-equivalent `UserMessage` targeted at the mission. Mid-turn it queues for the next turn boundary; `interrupt=true` cancels the current turn first so the steer applies immediately; when the agent is idle it starts a new turn.

Steering messages are prefixed `[Steering from the operator via the Copilot]` so the mission transcript shows the source.

## Guardrails

The system prompt frames these as **interventions**: use them when the operator asks to stop/steer/redirect, or when the agent is burning resources in a clearly harmful loop — otherwise propose the steering message and let the operator decide. The default posture stays read-mostly.

`ASK_ASSISTANT_DESIGN.md`'s v1 'strictly non-interrupting' non-goal is marked superseded (v1.1).

## Plumbing

`AskTurn` now carries the control session's `cmd_tx` (wired in both the sync and streaming HTTP handlers); both tools time-bound their oneshot acks (15s) so a stuck control loop can't hang an Ask turn. Unit test covers the steer attribution prefix.

## Tests

- `cargo test --lib api::ask` — 8 passed (incl. new `steer_messages_carry_a_copilot_attribution`)
- `cargo fmt --all` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Copilot can cancel missions and inject user messages that start turns—same authority as the operator—on core control routing; mistakes or prompt misuse could interrupt or mis-steer live agents.
> 
> **Overview**
> The Ask Copilot gains **`stop_agent`** and **`send_to_agent`** tools wired to the same control paths as the dashboard Stop button and composer. `AskTurn` now carries `control_cmd_tx` and `events_tx` (sync and streaming HTTP handlers); stops emit a durable **`AgentEvent::Error`** audit line, and steering text is prefixed **`[Steering from the operator via the Copilot]`**.
> 
> **`send_to_agent`** supports optional **`interrupt`** (cancel current turn first), 15s ack timeouts, and honest tool feedback when interrupt fails or delivery is uncertain. The system prompt treats these as **interventions** (operator request or harmful loop), not default behavior.
> 
> **`UserMessageAck`** (`Queued` / `Delivered` / `Dropped`) replaces the old boolean on `ControlCommand::UserMessage` so drops are visible to the Copilot; the HTTP API still exposes the historical **`queued`** bool.
> 
> **`ASK_ASSISTANT_DESIGN.md`** marks the v1 “strictly non-interrupting” non-goal as superseded (v1.1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b07df58cf466984c6a9bba5f1d8237c0711a3cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->