### PR TITLE
Fence history in turn prompts so models answer the current request

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -12094,10 +12094,11 @@ async fn run_single_control_turn(
     let history_context =
         build_history_context(history_for_prompt, config.context.max_history_total_chars);
     let mut convo = String::new();
-    convo.push_str(&history_context);
-    convo.push_str("User:\n");
-    convo.push_str(&user_message);
-    convo.push_str("\n\nInstructions:\n- Continue the conversation helpfully.\n- Use available tools as needed.\n- For large data processing tasks (>10KB), prefer executing scripts rather than inline processing.\n");
+    convo.push_str(&crate::util::frame_turn_prompt(
+        &history_context,
+        &user_message,
+    ));
+    convo.push_str("\n\nInstructions:\n- Respond to the CURRENT user request. The conversation history is context only: do not resume or continue earlier tasks from it unless the current request asks you to.\n- Use available tools as needed.\n- For large data processing tasks (>10KB), prefer executing scripts rather than inline processing.\n");
     let _task = match crate::task::Task::new(convo.clone(), Some(1000)) {
         Ok(t) => t,
         Err(e) => {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3086,11 +3086,12 @@ async fn run_mission_turn(
     };
 
     let mut convo = String::new();
-    convo.push_str(&history_context);
-    convo.push_str("User:\n");
-    convo.push_str(&user_message);
+    convo.push_str(&crate::util::frame_turn_prompt(
+        &history_context,
+        &user_message,
+    ));
     convo.push_str(&deliverable_reminder);
-    convo.push_str("\n\nInstructions:\n- Continue the conversation helpfully.\n- Use available tools to gather information or make changes.\n- For large data processing tasks (>10KB), prefer executing scripts rather than inline processing.\n- USE information already provided in the message - do not ask for URLs, paths, or details that were already given.\n- When you have fully completed the user's goal or determined it cannot be completed, state that clearly in your final response.");
+    convo.push_str("\n\nInstructions:\n- Respond to the CURRENT user request. The conversation history is context only: do not resume or continue earlier tasks from it unless the current request asks you to.\n- Use available tools to gather information or make changes.\n- For large data processing tasks (>10KB), prefer executing scripts rather than inline processing.\n- USE information already provided in the message - do not ask for URLs, paths, or details that were already given.\n- When you have fully completed the user's goal or determined it cannot be completed, state that clearly in your final response.");
     convo.push_str(multi_step_instructions);
     convo.push('\n');
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -95,6 +95,22 @@ pub fn build_history_context(history: &[(String, String)], max_chars: usize) -> 
     result
 }
 
+/// Frame a turn prompt so the model cannot mistake replayed history for the
+/// live request. The bare `USER:`-style history followed by a near-identical
+/// `User:` label made models (observed: codex gpt-5.5) resume unfinished work
+/// from the history and conclude the turn without ever addressing the actual
+/// new message. History goes into an explicitly-fenced context block; the
+/// current message is labeled as this turn's task.
+pub fn frame_turn_prompt(history_context: &str, user_message: &str) -> String {
+    if history_context.trim().is_empty() {
+        return format!("User:\n{user_message}");
+    }
+    format!(
+        "## Conversation history (context only)\n\n{history_context}\
+         ## Current user request (your task for this turn)\n\n{user_message}"
+    )
+}
+
 /// Deduplicate and trim a list of skill names, preserving order.
 pub fn sanitize_skill_list(skills: Vec<String>) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
@@ -446,6 +462,27 @@ mod tests {
         let history: Vec<(String, String)> = vec![];
         let result = build_history_context(&history, 10000);
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn frame_turn_prompt_fences_history_and_labels_current_request() {
+        let history = "USER: Go ahead and update the issues\n\nASSISTANT: Done. Issue Cleanup\n\n";
+        let result = frame_turn_prompt(history, "what's the most important issue?");
+        assert!(result.starts_with("## Conversation history (context only)"));
+        assert!(result.contains("ASSISTANT: Done. Issue Cleanup"));
+        // The live request must be unambiguously separated from the replayed
+        // history (a bare "User:" label let models resume old work instead).
+        assert!(result.contains("## Current user request (your task for this turn)"));
+        assert!(result
+            .trim_end()
+            .ends_with("what's the most important issue?"));
+    }
+
+    #[test]
+    fn frame_turn_prompt_without_history_keeps_plain_label() {
+        let result = frame_turn_prompt("", "first message");
+        assert_eq!(result, "User:\nfirst message");
+        assert!(!result.contains("## Conversation history"));
     }
 
     #[test]


### PR DESCRIPTION
## Repro (prod, mission 8fd3c4f4, 2026-06-07)

```
11:56  user: "Go ahead and update the issues…"        → turn A
12:06  assistant: "Done. Issue Cleanup… #1961"         → turn A ends
12:07  user (queued, delivered into its own turn B):
       "what's the most important in the verity issues?"
12:08  turn B runs gh issue edit … ← finishes TURN A's leftover agenda
12:12  assistant: "Done. Issue Updates…"               ← question never answered
```

The queue worked; the prompt didn't. Codex turns start a fresh thread each time, so continuity comes from the replayed history — which used bare `USER:` / `ASSISTANT:` lines flowing straight into a near-identical `User:` label for the live message, under a *"Continue the conversation helpfully"* instruction. gpt-5.5 saw unfinished work in the history, finished it, said Done, and never addressed the actual request.

## Change

- `util::frame_turn_prompt()`: history goes into a fenced `## Conversation history (context only)` block; the live message is labeled `## Current user request (your task for this turn)`. No history → unchanged plain `User:` form.
- Both convo builders (mission_runner dispatch + run_single_control_turn) use it, and the instruction block now states: respond to the CURRENT request; do not resume earlier tasks from history unless asked.
- Mirrors the framing the session-reset retry paths already use (`## Prior conversation … ## Current message`).

## Tests

- 2 new unit tests on `frame_turn_prompt` (fenced history + current-request label; empty-history passthrough)
- `cargo test --lib util::tests` — 12 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change in two call sites with empty-history passthrough; low blast radius aside from possible model behavior shifts on edge cases.
> 
> **Overview**
> Fixes a prompt bug where replayed **USER:/ASSISTANT:** history flowed straight into a similar **User:** label, so models (e.g. Codex gpt-5.5) treated old unfinished work as the live task and ignored the new message.
> 
> Adds **`util::frame_turn_prompt`**: non-empty history is wrapped in **`## Conversation history (context only)`** and the live message under **`## Current user request (your task for this turn)`**; with no history the prompt stays **`User:\n…`**. **Mission runner** dispatch and **single control turn** convo builders now use this helper instead of concatenating history and the user line manually.
> 
> Instruction text in both paths drops “continue the conversation helpfully” in favor of **respond to the CURRENT user request** and **do not resume earlier tasks from history** unless asked. Two unit tests cover fenced vs empty history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674582e0a29ba60ca26de3486db47b54e0b01d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->