### PR TITLE
missions: memory isolation v2 — missions.slice, PTY scope fix, live caps

### DIFF
--- a/dashboard/src/app/workspaces/page.tsx
+++ b/dashboard/src/app/workspaces/page.tsx
@@ -45,6 +45,7 @@ import { cn } from '@/lib/utils';
 import { useToast } from '@/components/toast';
 import { ConfigCodeEditor } from '@/components/config-code-editor';
 import { EnvVarsEditor, type EnvRow, toEnvRows, envRowsToMap, getEncryptedKeys } from '@/components/env-vars-editor';
+import { WorkspaceResources } from '@/components/workspace-resources';
 
 // The nil UUID represents the default "host" workspace which cannot be deleted
 const DEFAULT_WORKSPACE_ID = '00000000-0000-0000-0000-000000000000';
@@ -684,6 +685,11 @@ export default function WorkspacesPage() {
                         <p className="text-sm text-red-300">{extractErrorSummary(selectedWorkspace.error_message)}</p>
                       </div>
                     </div>
+                  )}
+
+                  {/* Live memory usage + caps for container workspaces */}
+                  {selectedWorkspace.workspace_type === 'container' && (
+                    <WorkspaceResources workspaceId={selectedWorkspace.id} />
                   )}
 
                   {/* Network settings for container workspaces */}

--- a/dashboard/src/components/workspace-resources.tsx
+++ b/dashboard/src/components/workspace-resources.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+/**
+ * WorkspaceResources — live memory usage + caps for a container workspace.
+ *
+ * Shows the aggregated memory consumption of the workspace's transient
+ * mission scopes (boot + exec) and lets the operator retune the caps:
+ * applied live to running scopes via `systemctl set-property --runtime`
+ * and persisted as workspace env overrides (MISSION_MEMORY_*).
+ */
+
+import { useState } from 'react';
+import useSWR from 'swr';
+import { Gauge, Zap } from 'lucide-react';
+import {
+  getWorkspaceMemory,
+  updateWorkspaceResources,
+} from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || bytes === undefined) return '—';
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)}G`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(0)}M`;
+  return `${bytes}B`;
+}
+
+const MEM_VALUE_RE = /^(\d+(\.\d+)?[KMGTkmgt]?|\d+(\.\d+)?%|infinity)?$/;
+
+export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
+  const { data: stats, mutate } = useSWR(
+    `workspace-memory-${workspaceId}`,
+    () => getWorkspaceMemory(workspaceId),
+    { refreshInterval: 5000, revalidateOnFocus: false }
+  );
+
+  const [memoryHigh, setMemoryHigh] = useState('');
+  const [memoryMax, setMemoryMax] = useState('');
+  const [applying, setApplying] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const current = stats?.memory_current_bytes ?? null;
+  const limit = stats?.memory_limit_bytes ?? null;
+  const pct =
+    current !== null && limit !== null && limit > 0
+      ? Math.min(100, (current / limit) * 100)
+      : null;
+
+  const inputsValid =
+    MEM_VALUE_RE.test(memoryHigh.trim()) && MEM_VALUE_RE.test(memoryMax.trim());
+  const hasInput = memoryHigh.trim() !== '' || memoryMax.trim() !== '';
+
+  const apply = async () => {
+    if (!hasInput || !inputsValid) return;
+    setApplying(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await updateWorkspaceResources(workspaceId, {
+        ...(memoryHigh.trim() !== '' ? { memory_high: memoryHigh.trim() } : {}),
+        ...(memoryMax.trim() !== '' ? { memory_max: memoryMax.trim() } : {}),
+        persist: true,
+        apply_live: true,
+      });
+      setResult(
+        res.applied_units.length > 0
+          ? `Applied live to ${res.applied_units.length} scope(s); persisted for future boots.`
+          : 'Persisted; no running scopes to retune (applies at next boot).'
+      );
+      setMemoryHigh('');
+      setMemoryMax('');
+      mutate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update resources');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg bg-white/[0.02] border border-white/[0.05] p-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs text-white/60 font-medium flex items-center gap-1.5">
+            <Gauge className="h-3.5 w-3.5 text-white/40" />
+            Resources
+          </p>
+          <p className="text-[10px] text-white/30 mt-0.5">
+            Memory caps for this workspace&apos;s mission scopes. Changes apply live —
+            no restart needed.
+          </p>
+        </div>
+        <span className="text-xs font-mono text-white/70">
+          {formatBytes(current)}
+          {limit !== null && (
+            <span className="text-white/35"> / {formatBytes(limit)}</span>
+          )}
+        </span>
+      </div>
+
+      {pct !== null && (
+        <div className="mt-2 h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden">
+          <div
+            className={cn(
+              'h-full rounded-full transition-all',
+              pct > 90 ? 'bg-red-400/80' : pct > 75 ? 'bg-amber-400/70' : 'bg-emerald-400/60'
+            )}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+
+      {stats?.memory_peak_bytes !== null && stats?.memory_peak_bytes !== undefined && (
+        <p className="text-[10px] text-white/25 mt-1">
+          Peak: {formatBytes(stats.memory_peak_bytes)}
+        </p>
+      )}
+
+      {stats?.error && (
+        <p className="text-[10px] text-white/30 mt-1.5">{stats.error}</p>
+      )}
+
+      <div className="mt-3 flex items-end gap-2">
+        <div className="flex-1">
+          <label className="text-[10px] text-white/40 block mb-1">
+            MemoryHigh (throttle)
+          </label>
+          <input
+            type="text"
+            value={memoryHigh}
+            onChange={(e) => setMemoryHigh(e.target.value)}
+            placeholder="e.g. 20G"
+            className="w-full rounded-lg border border-white/[0.06] bg-black/20 px-2.5 py-1.5 text-xs text-white font-mono placeholder:text-white/20 focus:border-indigo-500/50 focus:outline-none"
+          />
+        </div>
+        <div className="flex-1">
+          <label className="text-[10px] text-white/40 block mb-1">
+            MemoryMax (OOM kill)
+          </label>
+          <input
+            type="text"
+            value={memoryMax}
+            onChange={(e) => setMemoryMax(e.target.value)}
+            placeholder="e.g. 24G"
+            className="w-full rounded-lg border border-white/[0.06] bg-black/20 px-2.5 py-1.5 text-xs text-white font-mono placeholder:text-white/20 focus:border-indigo-500/50 focus:outline-none"
+          />
+        </div>
+        <button
+          onClick={apply}
+          disabled={!hasInput || !inputsValid || applying}
+          className={cn(
+            'shrink-0 flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+            hasInput && inputsValid && !applying
+              ? 'bg-indigo-500/20 border border-indigo-500/30 text-indigo-200 hover:bg-indigo-500/30'
+              : 'bg-white/[0.04] border border-white/[0.06] text-white/30 cursor-not-allowed'
+          )}
+        >
+          <Zap className="h-3 w-3" />
+          {applying ? 'Applying…' : 'Apply'}
+        </button>
+      </div>
+
+      {!inputsValid && hasInput && (
+        <p className="text-[10px] text-red-300/80 mt-1.5">
+          Values: bytes with K/M/G/T suffix, %, or &quot;infinity&quot;.
+        </p>
+      )}
+      {result && <p className="text-[10px] text-emerald-300/80 mt-1.5">{result}</p>}
+      {error && <p className="text-[10px] text-red-300/80 mt-1.5">{error}</p>}
+    </div>
+  );
+}

--- a/dashboard/src/components/workspace-resources.tsx
+++ b/dashboard/src/components/workspace-resources.tsx
@@ -63,11 +63,21 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
         persist: true,
         apply_live: true,
       });
-      setResult(
-        res.applied_units.length > 0
-          ? `Applied live to ${res.applied_units.length} scope(s); persisted for future boots.`
-          : 'Persisted; no running scopes to retune (applies at next boot).'
-      );
+      if (res.failed_units.length > 0 && res.applied_units.length === 0) {
+        setError(
+          `Persisted, but live retune failed on ${res.failed_units.length} running scope(s) — caps apply at next boot. Check server logs.`
+        );
+      } else {
+        setResult(
+          res.applied_units.length > 0
+            ? `Applied live to ${res.applied_units.length} scope(s)${
+                res.failed_units.length > 0
+                  ? ` (${res.failed_units.length} failed)`
+                  : ''
+              }; persisted for future boots.`
+            : 'Persisted; no running scopes to retune (applies at next boot).'
+        );
+      }
       setMemoryHigh('');
       setMemoryMax('');
       mutate();
@@ -92,11 +102,21 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
         persist: true,
         apply_live: true,
       });
-      setResult(
-        res.applied_units.length > 0
-          ? `Reset to defaults on ${res.applied_units.length} scope(s); cleared persisted overrides.`
-          : 'Cleared persisted overrides (applies at next boot).'
-      );
+      if (res.failed_units.length > 0 && res.applied_units.length === 0) {
+        setError(
+          `Cleared overrides, but live retune failed on ${res.failed_units.length} running scope(s) — defaults apply at next boot. Check server logs.`
+        );
+      } else {
+        setResult(
+          res.applied_units.length > 0
+            ? `Reset to defaults on ${res.applied_units.length} scope(s)${
+                res.failed_units.length > 0
+                  ? ` (${res.failed_units.length} failed)`
+                  : ''
+              }; cleared persisted overrides.`
+            : 'Cleared persisted overrides (applies at next boot).'
+        );
+      }
       setMemoryHigh('');
       setMemoryMax('');
       mutate();

--- a/dashboard/src/components/workspace-resources.tsx
+++ b/dashboard/src/components/workspace-resources.tsx
@@ -78,6 +78,35 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
     }
   };
 
+  // Revert both overrides to the global MISSION_MEMORY_* defaults. The API
+  // treats an empty string as "clear this override" (vs. an absent field,
+  // which leaves it unchanged), so we send explicit empties here.
+  const resetDefaults = async () => {
+    setApplying(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await updateWorkspaceResources(workspaceId, {
+        memory_high: '',
+        memory_max: '',
+        persist: true,
+        apply_live: true,
+      });
+      setResult(
+        res.applied_units.length > 0
+          ? `Reset to defaults on ${res.applied_units.length} scope(s); cleared persisted overrides.`
+          : 'Cleared persisted overrides (applies at next boot).'
+      );
+      setMemoryHigh('');
+      setMemoryMax('');
+      mutate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to reset resources');
+    } finally {
+      setApplying(false);
+    }
+  };
+
   return (
     <div className="rounded-lg bg-white/[0.02] border border-white/[0.05] p-3">
       <div className="flex items-center justify-between">
@@ -160,6 +189,14 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
           {applying ? 'Applying…' : 'Apply'}
         </button>
       </div>
+
+      <button
+        onClick={resetDefaults}
+        disabled={applying}
+        className="text-[10px] text-white/35 hover:text-white/60 mt-1.5 transition-colors disabled:cursor-not-allowed disabled:hover:text-white/35"
+      >
+        Reset to defaults
+      </button>
 
       {!inputsValid && hasInput && (
         <p className="text-[10px] text-red-300/80 mt-1.5">

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -83,6 +83,11 @@ export {
   buildWorkspace,
   getWorkspaceDebug,
   getWorkspaceInitLog,
+  type WorkspaceMemoryStats,
+  getWorkspaceMemory,
+  type UpdateWorkspaceResourcesRequest,
+  type UpdateWorkspaceResourcesResponse,
+  updateWorkspaceResources,
 } from "./workspaces";
 
 // Providers

--- a/dashboard/src/lib/api/workspaces.ts
+++ b/dashboard/src/lib/api/workspaces.ts
@@ -155,3 +155,56 @@ export async function getWorkspaceInitLog(id: string): Promise<InitLogResponse> 
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Memory / resources
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceMemoryStats {
+  workspace_id: string;
+  workspace_name: string;
+  workspace_type: string;
+  memory_current_bytes: number | null;
+  memory_peak_bytes: number | null;
+  memory_limit_bytes: number | null;
+  memory_available_bytes: number | null;
+  memory_current_mb: number | null;
+  memory_peak_mb: number | null;
+  memory_limit_mb: string | null;
+  container_name: string | null;
+  error: string | null;
+}
+
+export async function getWorkspaceMemory(id: string): Promise<WorkspaceMemoryStats> {
+  return apiGet(`/api/workspaces/${id}/memory`, "Failed to fetch workspace memory");
+}
+
+export interface UpdateWorkspaceResourcesRequest {
+  /** e.g. "24G", "infinity"; "" clears the override (global default). */
+  memory_max?: string;
+  memory_high?: string;
+  memory_swap_max?: string;
+  /** Persist as a workspace env override (default true). */
+  persist?: boolean;
+  /** Retune currently-running scopes live (default true). */
+  apply_live?: boolean;
+}
+
+export interface UpdateWorkspaceResourcesResponse {
+  applied_units: string[];
+  persisted: boolean;
+  memory_max: string | null;
+  memory_high: string | null;
+  memory_swap_max: string | null;
+}
+
+export async function updateWorkspaceResources(
+  id: string,
+  data: UpdateWorkspaceResourcesRequest
+): Promise<UpdateWorkspaceResourcesResponse> {
+  return apiPost(
+    `/api/workspaces/${id}/resources`,
+    data,
+    "Failed to update workspace resources"
+  );
+}

--- a/dashboard/src/lib/api/workspaces.ts
+++ b/dashboard/src/lib/api/workspaces.ts
@@ -192,6 +192,7 @@ export interface UpdateWorkspaceResourcesRequest {
 
 export interface UpdateWorkspaceResourcesResponse {
   applied_units: string[];
+  failed_units: string[];
   persisted: boolean;
   memory_max: string | null;
   memory_high: string | null;

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -7176,27 +7176,29 @@ async fn check_mission_oom_kills(
                 continue;
             };
             live_units.insert(unit.clone());
-            match oom_seen.get(&unit) {
-                Some(prev) if count > *prev => {
-                    let killed = count - prev;
-                    tracing::warn!(
-                        "Memory watchdog: {} OOM kill(s) in {} (mission {}, workspace {})",
-                        killed,
-                        unit,
-                        mission.id,
-                        workspace.name
-                    );
-                    let _ = events_tx.send(AgentEvent::MissionActivity {
-                        label: format!(
-                            "⚠ Memory limit hit: kernel OOM-killed {killed} process(es) in this \
-                             mission's cgroup. Builds should lower parallelism, or raise the \
-                             workspace memory cap (Resources panel / MISSION_MEMORY_MAX)."
-                        ),
-                        tool_name: "memory_watchdog".to_string(),
-                        mission_id: Some(mission.id),
-                    });
-                }
-                _ => {}
+            // Treat a never-seen scope as a baseline of 0 so the first kernel
+            // OOM in a freshly-discovered cgroup is reported rather than
+            // silently absorbed into the baseline (e.g. when the watchdog
+            // starts after a scope already accumulated kills).
+            let prev = oom_seen.get(&unit).copied().unwrap_or(0);
+            if count > prev {
+                let killed = count - prev;
+                tracing::warn!(
+                    "Memory watchdog: {} OOM kill(s) in {} (mission {}, workspace {})",
+                    killed,
+                    unit,
+                    mission.id,
+                    workspace.name
+                );
+                let _ = events_tx.send(AgentEvent::MissionActivity {
+                    label: format!(
+                        "⚠ Memory limit hit: kernel OOM-killed {killed} process(es) in this \
+                         mission's cgroup. Builds should lower parallelism, or raise the \
+                         workspace memory cap (Resources panel / MISSION_MEMORY_MAX)."
+                    ),
+                    tool_name: "memory_watchdog".to_string(),
+                    mission_id: Some(mission.id),
+                });
             }
             oom_seen.insert(unit, count);
         }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -7185,7 +7185,17 @@ async fn check_mission_oom_kills(
         let Some(workspace) = workspaces.get(*workspace_id).await else {
             continue;
         };
-        let units = crate::api::workspaces::list_workspace_scope_units(&workspace).await;
+        let units = match crate::api::workspaces::list_workspace_scope_units(&workspace).await {
+            Ok(units) => units,
+            Err(e) => {
+                tracing::warn!(
+                    "OOM watchdog: could not list scopes for {}: {}",
+                    workspace.name,
+                    e
+                );
+                continue;
+            }
+        };
         for unit in units {
             let Some(count) = read_scope_oom_kills(&unit).await else {
                 continue;

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6645,6 +6645,7 @@ fn spawn_control_session(
             Arc::clone(&state.mission_store),
             state.cmd_tx.clone(),
             events_tx.clone(),
+            workspaces.clone(),
         ));
         tokio::spawn(ack_promotion_loop(
             Arc::clone(&state.mission_store),
@@ -6977,6 +6978,7 @@ async fn stuck_mission_watchdog_loop(
     mission_store: Arc<dyn MissionStore>,
     cmd_tx: mpsc::Sender<ControlCommand>,
     events_tx: broadcast::Sender<AgentEvent>,
+    workspaces: workspace::SharedWorkspaceStore,
 ) {
     use std::collections::HashSet;
 
@@ -6987,6 +6989,11 @@ async fn stuck_mission_watchdog_loop(
         STUCK_SECONDS,
         CHECK_INTERVAL.as_secs()
     );
+
+    // Last seen `oom_kill` counter per scope unit; an increase means the
+    // kernel killed something inside a mission's memory cgroup since the
+    // previous tick. Entries for dead scopes are pruned each pass.
+    let mut oom_seen: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
 
     loop {
         tokio::time::sleep(CHECK_INTERVAL).await;
@@ -7018,6 +7025,20 @@ async fn stuck_mission_watchdog_loop(
         };
 
         let running_ids: HashSet<Uuid> = running_list.iter().map(|info| info.mission_id).collect();
+
+        // OOM surveillance: surface kernel `oom_kill` events from mission
+        // memory cgroups as mission activity. Without this, a build killed
+        // by its memory cap looks like a silent tool failure and agents
+        // retry it in a loop instead of adapting (lower parallelism) or
+        // requesting a cap boost.
+        check_mission_oom_kills(
+            &workspaces,
+            &active_missions,
+            &running_ids,
+            &mut oom_seen,
+            &events_tx,
+        )
+        .await;
 
         // Case 1 — actor reports the mission running but stalled past
         // threshold. Cancel via the actor (clean shutdown) and mark
@@ -7109,6 +7130,81 @@ async fn stuck_mission_watchdog_loop(
             });
         }
     }
+}
+
+/// Read the kernel `oom_kill` counter from a scope unit's `memory.events`.
+/// Returns `None` when the unit/cgroup is gone or unreadable.
+async fn read_scope_oom_kills(unit: &str) -> Option<u64> {
+    let output = tokio::process::Command::new("systemctl")
+        .args(["show", unit, "-p", "ControlGroup", "--value"])
+        .output()
+        .await
+        .ok()?;
+    let cgroup = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if cgroup.is_empty() {
+        return None;
+    }
+    let path = format!("/sys/fs/cgroup{cgroup}/memory.events");
+    let content = tokio::fs::read_to_string(path).await.ok()?;
+    content.lines().find_map(|line| {
+        line.strip_prefix("oom_kill ")
+            .and_then(|v| v.trim().parse::<u64>().ok())
+    })
+}
+
+/// Detect `oom_kill` increases in running missions' memory cgroups and
+/// surface them on the mission event stream. One pass per watchdog tick.
+async fn check_mission_oom_kills(
+    workspaces: &workspace::SharedWorkspaceStore,
+    active_missions: &[crate::api::mission_store::Mission],
+    running_ids: &std::collections::HashSet<Uuid>,
+    oom_seen: &mut std::collections::HashMap<String, u64>,
+    events_tx: &broadcast::Sender<AgentEvent>,
+) {
+    let mut live_units: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for mission in active_missions
+        .iter()
+        .filter(|m| running_ids.contains(&m.id))
+    {
+        let Some(workspace) = workspaces.get(mission.workspace_id).await else {
+            continue;
+        };
+        let units = crate::api::workspaces::list_workspace_scope_units(&workspace).await;
+        for unit in units {
+            let Some(count) = read_scope_oom_kills(&unit).await else {
+                continue;
+            };
+            live_units.insert(unit.clone());
+            match oom_seen.get(&unit) {
+                Some(prev) if count > *prev => {
+                    let killed = count - prev;
+                    tracing::warn!(
+                        "Memory watchdog: {} OOM kill(s) in {} (mission {}, workspace {})",
+                        killed,
+                        unit,
+                        mission.id,
+                        workspace.name
+                    );
+                    let _ = events_tx.send(AgentEvent::MissionActivity {
+                        label: format!(
+                            "⚠ Memory limit hit: kernel OOM-killed {killed} process(es) in this \
+                             mission's cgroup. Builds should lower parallelism, or raise the \
+                             workspace memory cap (Resources panel / MISSION_MEMORY_MAX)."
+                        ),
+                        tool_name: "memory_watchdog".to_string(),
+                        mission_id: Some(mission.id),
+                    });
+                }
+                _ => {}
+            }
+            oom_seen.insert(unit, count);
+        }
+    }
+
+    // Drop counters for scopes that no longer exist so the map can't grow
+    // unboundedly across weeks of uptime.
+    oom_seen.retain(|unit, _| live_units.contains(unit));
 }
 
 async fn stale_mission_cleanup_loop(

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -7163,11 +7163,26 @@ async fn check_mission_oom_kills(
 ) {
     let mut live_units: std::collections::HashSet<String> = std::collections::HashSet::new();
 
+    // Scopes are workspace-level and shared by every mission running in the
+    // same container, while `oom_seen` is keyed by unit. Group missions by
+    // workspace so each unit's OOM delta is consumed once per tick and the
+    // alert fans out to *all* missions on that workspace — otherwise the
+    // first mission would absorb the delta and its siblings would never see
+    // the OOM signal.
+    let mut missions_by_workspace: std::collections::HashMap<Uuid, Vec<Uuid>> =
+        std::collections::HashMap::new();
     for mission in active_missions
         .iter()
         .filter(|m| running_ids.contains(&m.id))
     {
-        let Some(workspace) = workspaces.get(mission.workspace_id).await else {
+        missions_by_workspace
+            .entry(mission.workspace_id)
+            .or_default()
+            .push(mission.id);
+    }
+
+    for (workspace_id, mission_ids) in &missions_by_workspace {
+        let Some(workspace) = workspaces.get(*workspace_id).await else {
             continue;
         };
         let units = crate::api::workspaces::list_workspace_scope_units(&workspace).await;
@@ -7184,21 +7199,23 @@ async fn check_mission_oom_kills(
             if count > prev {
                 let killed = count - prev;
                 tracing::warn!(
-                    "Memory watchdog: {} OOM kill(s) in {} (mission {}, workspace {})",
+                    "Memory watchdog: {} OOM kill(s) in {} (workspace {}, {} mission(s))",
                     killed,
                     unit,
-                    mission.id,
-                    workspace.name
+                    workspace.name,
+                    mission_ids.len()
                 );
-                let _ = events_tx.send(AgentEvent::MissionActivity {
-                    label: format!(
-                        "⚠ Memory limit hit: kernel OOM-killed {killed} process(es) in this \
-                         mission's cgroup. Builds should lower parallelism, or raise the \
-                         workspace memory cap (Resources panel / MISSION_MEMORY_MAX)."
-                    ),
-                    tool_name: "memory_watchdog".to_string(),
-                    mission_id: Some(mission.id),
-                });
+                for mission_id in mission_ids {
+                    let _ = events_tx.send(AgentEvent::MissionActivity {
+                        label: format!(
+                            "⚠ Memory limit hit: kernel OOM-killed {killed} process(es) in this \
+                             mission's cgroup. Builds should lower parallelism, or raise the \
+                             workspace memory cap (Resources panel / MISSION_MEMORY_MAX)."
+                        ),
+                        tool_name: "memory_watchdog".to_string(),
+                        mission_id: Some(*mission_id),
+                    });
+                }
             }
             oom_seen.insert(unit, count);
         }

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -7162,6 +7162,10 @@ async fn check_mission_oom_kills(
     events_tx: &broadcast::Sender<AgentEvent>,
 ) {
     let mut live_units: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Whether we got a complete picture of live scopes this tick. A failed
+    // workspace lookup or `list-units` means some scopes couldn't be
+    // enumerated, so we must not prune `oom_seen` (see the retain below).
+    let mut enumeration_complete = true;
 
     // Scopes are workspace-level and shared by every mission running in the
     // same container, while `oom_seen` is keyed by unit. Group missions by
@@ -7183,6 +7187,7 @@ async fn check_mission_oom_kills(
 
     for (workspace_id, mission_ids) in &missions_by_workspace {
         let Some(workspace) = workspaces.get(*workspace_id).await else {
+            enumeration_complete = false;
             continue;
         };
         let units = match crate::api::workspaces::list_workspace_scope_units(&workspace).await {
@@ -7193,14 +7198,18 @@ async fn check_mission_oom_kills(
                     workspace.name,
                     e
                 );
+                enumeration_complete = false;
                 continue;
             }
         };
         for unit in units {
+            // The unit was listed, so it's alive: record it now so a transient
+            // `memory.events` read failure below doesn't drop its baseline and
+            // cause the cumulative oom_kill total to be re-reported as new.
+            live_units.insert(unit.clone());
             let Some(count) = read_scope_oom_kills(&unit).await else {
                 continue;
             };
-            live_units.insert(unit.clone());
             // Treat a never-seen scope as a baseline of 0 so the first kernel
             // OOM in a freshly-discovered cgroup is reported rather than
             // silently absorbed into the baseline (e.g. when the watchdog
@@ -7232,8 +7241,14 @@ async fn check_mission_oom_kills(
     }
 
     // Drop counters for scopes that no longer exist so the map can't grow
-    // unboundedly across weeks of uptime.
-    oom_seen.retain(|unit, _| live_units.contains(unit));
+    // unboundedly across weeks of uptime — but only when we fully enumerated
+    // live scopes this tick. If any workspace failed to enumerate, pruning
+    // would drop a still-live scope's baseline and re-emit its cumulative
+    // oom_kill total as new kills on the next successful read. Skip pruning
+    // for this tick; it self-heals on the next clean pass.
+    if enumeration_complete {
+        oom_seen.retain(|unit, _| live_units.contains(unit));
+    }
 }
 
 async fn stale_mission_cleanup_loop(

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1641,7 +1641,25 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
     // `--register=no`, so machined scopes don't exist.
     let exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
     let container_name = exec.mission_scope_match_token();
-    let units = list_workspace_scope_units(workspace).await;
+    let units = match list_workspace_scope_units(workspace).await {
+        Ok(units) => units,
+        Err(e) => {
+            return WorkspaceMemoryStats {
+                workspace_id: workspace.id,
+                workspace_name: workspace.name.clone(),
+                workspace_type: workspace_type_str.to_string(),
+                memory_current_bytes: None,
+                memory_peak_bytes: None,
+                memory_limit_bytes: None,
+                memory_available_bytes: None,
+                memory_current_mb: None,
+                memory_peak_mb: None,
+                memory_limit_mb: None,
+                container_name,
+                error: Some(format!("Could not query mission scopes: {e}")),
+            };
+        }
+    };
 
     if units.is_empty() {
         return WorkspaceMemoryStats {
@@ -1746,10 +1764,17 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
 
 /// Every transient scope unit currently alive that belongs to this
 /// workspace's container: the boot scope plus per-exec attach scopes.
-pub(crate) async fn list_workspace_scope_units(workspace: &Workspace) -> Vec<String> {
+///
+/// `Ok(vec![])` means the query ran and the workspace genuinely has no live
+/// scopes; `Err` means the `systemctl list-units` query itself failed, so
+/// callers must not interpret the result as "no scopes" (the container may
+/// still be running and capped).
+pub(crate) async fn list_workspace_scope_units(
+    workspace: &Workspace,
+) -> Result<Vec<String>, String> {
     let exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
     let Some(token) = exec.mission_scope_match_token() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let output = tokio::process::Command::new("systemctl")
         .args([
@@ -1761,16 +1786,20 @@ pub(crate) async fn list_workspace_scope_units(workspace: &Workspace) -> Vec<Str
             "sandboxed-exec-*.scope",
         ])
         .output()
-        .await;
-    let Ok(output) = output else {
-        return Vec::new();
-    };
-    String::from_utf8_lossy(&output.stdout)
+        .await
+        .map_err(|e| format!("failed to run systemctl list-units: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "systemctl list-units failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter_map(|line| line.split_whitespace().next())
         .filter(|unit| unit.contains(&token))
         .map(|s| s.to_string())
-        .collect()
+        .collect())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1877,7 +1906,19 @@ async fn update_workspace_resources(
     let mut applied_units = Vec::new();
     let mut failed_units = Vec::new();
     if req.apply_live {
-        let units = list_workspace_scope_units(&workspace).await;
+        let units = match list_workspace_scope_units(&workspace).await {
+            Ok(units) => units,
+            Err(e) => {
+                // Persist still applies (caps take at next boot); record why
+                // the live retune found nothing instead of silently skipping.
+                tracing::warn!(
+                    "apply_live: could not list scopes for {}: {}",
+                    workspace.name,
+                    e
+                );
+                Vec::new()
+            }
+        };
         for unit in units {
             let mut cmd = tokio::process::Command::new("systemctl");
             cmd.args(["set-property", "--runtime", &unit]);

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1667,6 +1667,8 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
     let mut memory_peak: Option<u64> = None;
     let mut memory_limit: Option<u64> = None;
     let mut memory_available: Option<u64> = None;
+    let mut read_ok = false;
+    let mut last_error: Option<String> = None;
 
     for unit in &units {
         let output = tokio::process::Command::new("systemctl")
@@ -1678,8 +1680,21 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
             ])
             .output()
             .await;
+        match &output {
+            Ok(o) if !o.status.success() => {
+                last_error = Some(format!(
+                    "systemctl show {unit} failed: {}",
+                    String::from_utf8_lossy(&o.stderr).trim()
+                ));
+            }
+            Err(e) => {
+                last_error = Some(format!("systemctl show {unit} errored: {e}"));
+            }
+            _ => {}
+        }
         if let Ok(output) = output {
             if output.status.success() {
+                read_ok = true;
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let (cur, peak, max, avail, _) = parse_systemd_memory_stats(&stdout);
                 if let Some(c) = cur {
@@ -1717,7 +1732,15 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
             .map(|b| format!("{:.2}", b as f64 / 1024.0 / 1024.0))
             .or(Some("unlimited".to_string())),
         container_name,
-        error: None,
+        // Scopes exist but not one `systemctl show` succeeded — surface it
+        // instead of returning blank stats with no explanation.
+        error: if read_ok {
+            None
+        } else {
+            Some(last_error.unwrap_or_else(|| {
+                "Found mission scopes but could not read their memory stats".to_string()
+            }))
+        },
     }
 }
 

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1802,6 +1802,9 @@ fn default_true() -> bool {
 pub struct UpdateWorkspaceResourcesResponse {
     /// Units the new caps were applied to live (empty when none running).
     pub applied_units: Vec<String>,
+    /// Running scopes whose live retune failed (e.g. `systemctl set-property`
+    /// errored). Non-empty here means scopes exist but caps did not take live.
+    pub failed_units: Vec<String>,
     pub persisted: bool,
     /// Effective caps after this call (override merged with global defaults).
     pub memory_max: Option<String>,
@@ -1872,6 +1875,7 @@ async fn update_workspace_resources(
     let caps = exec.mission_memory_caps();
 
     let mut applied_units = Vec::new();
+    let mut failed_units = Vec::new();
     if req.apply_live {
         let units = list_workspace_scope_units(&workspace).await;
         for unit in units {
@@ -1894,9 +1898,11 @@ async fn update_workspace_resources(
                 Ok(out) => {
                     let stderr = String::from_utf8_lossy(&out.stderr);
                     tracing::warn!("set-property failed for {}: {}", unit, stderr.trim());
+                    failed_units.push(unit);
                 }
                 Err(e) => {
                     tracing::warn!("set-property spawn failed for {}: {}", unit, e);
+                    failed_units.push(unit);
                 }
             }
         }
@@ -1918,6 +1924,7 @@ async fn update_workspace_resources(
 
     Ok(Json(UpdateWorkspaceResourcesResponse {
         applied_units,
+        failed_units,
         persisted: req.persist,
         memory_max: caps.max,
         memory_high: caps.high,

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -41,6 +41,10 @@ pub fn routes() -> Router<Arc<super::routes::AppState>> {
         // Memory monitoring
         .route("/:id/memory", get(get_workspace_memory))
         .route("/memory/all", get(get_all_workspaces_memory))
+        // Live + persisted memory caps (per-workspace override of the
+        // MISSION_MEMORY_* defaults; applies to running scopes via
+        // `systemctl set-property --runtime`)
+        .route("/:id/resources", post(update_workspace_resources))
         // Backend preflight checks
         .route(
             "/:id/backends/:backend_id/preflight",
@@ -1630,51 +1634,70 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
         };
     }
 
-    // Get container name from workspace ID
-    let container_name = format!(
-        "mission-{}",
-        workspace
-            .id
-            .to_string()
-            .split('-')
-            .next()
-            .unwrap_or("unknown")
-    );
+    // Aggregate over every transient scope this workspace owns: the boot
+    // scope (`sandboxed-mission-<machine>.scope`) plus per-exec attach
+    // scopes (`sandboxed-exec-<machine>-*.scope`). The previous
+    // `machine-*.scope` lookup never matched: containers boot with
+    // `--register=no`, so machined scopes don't exist.
+    let exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
+    let container_name = exec.mission_scope_match_token();
+    let units = list_workspace_scope_units(workspace).await;
 
-    // Get systemd scope name for the container
-    let scope_name = format!("machine-{}.scope", container_name);
+    if units.is_empty() {
+        return WorkspaceMemoryStats {
+            workspace_id: workspace.id,
+            workspace_name: workspace.name.clone(),
+            workspace_type: workspace_type_str.to_string(),
+            memory_current_bytes: None,
+            memory_peak_bytes: None,
+            memory_limit_bytes: None,
+            memory_available_bytes: None,
+            memory_current_mb: None,
+            memory_peak_mb: None,
+            memory_limit_mb: None,
+            container_name,
+            error: Some(
+                "No active mission scopes (container not running, or memory caps disabled)"
+                    .to_string(),
+            ),
+        };
+    }
 
-    // Query systemd for memory stats
-    let output = tokio::process::Command::new("systemctl")
-        .args(["show", &scope_name])
-        .output()
-        .await;
+    let mut memory_current: Option<u64> = None;
+    let mut memory_peak: Option<u64> = None;
+    let mut memory_limit: Option<u64> = None;
+    let mut memory_available: Option<u64> = None;
 
-    let stats = match output {
-        Ok(output) if output.status.success() => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            parse_systemd_memory_stats(&stdout)
+    for unit in &units {
+        let output = tokio::process::Command::new("systemctl")
+            .args([
+                "show",
+                unit,
+                "-p",
+                "MemoryCurrent,MemoryPeak,MemoryMax,MemoryAvailable",
+            ])
+            .output()
+            .await;
+        if let Ok(output) = output {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let (cur, peak, max, avail, _) = parse_systemd_memory_stats(&stdout);
+                if let Some(c) = cur {
+                    memory_current = Some(memory_current.unwrap_or(0) + c);
+                }
+                if let Some(p) = peak {
+                    memory_peak = Some(memory_peak.unwrap_or(0).max(p));
+                }
+                if let Some(m) = max.filter(|m| *m != u64::MAX) {
+                    // Tightest configured cap across the workspace's scopes.
+                    memory_limit = Some(memory_limit.map_or(m, |cur: u64| cur.min(m)));
+                }
+                if let Some(a) = avail {
+                    memory_available = Some(memory_available.unwrap_or(0).max(a));
+                }
+            }
         }
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            (
-                None,
-                None,
-                None,
-                None,
-                Some(format!("Container not running: {}", stderr.trim())),
-            )
-        }
-        Err(e) => (
-            None,
-            None,
-            None,
-            None,
-            Some(format!("Failed to query systemctl: {}", e)),
-        ),
-    };
-
-    let (memory_current, memory_peak, memory_limit, memory_available, error) = stats;
+    }
 
     WorkspaceMemoryStats {
         workspace_id: workspace.id,
@@ -1687,17 +1710,192 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
         memory_current_mb: memory_current.map(|b| b as f64 / 1024.0 / 1024.0),
         memory_peak_mb: memory_peak.map(|b| b as f64 / 1024.0 / 1024.0),
         memory_limit_mb: memory_limit
-            .map(|b| {
-                if b == u64::MAX {
-                    "unlimited".to_string()
-                } else {
-                    format!("{:.2}", b as f64 / 1024.0 / 1024.0)
-                }
-            })
+            .map(|b| format!("{:.2}", b as f64 / 1024.0 / 1024.0))
             .or(Some("unlimited".to_string())),
-        container_name: Some(container_name),
-        error,
+        container_name,
+        error: None,
     }
+}
+
+/// Every transient scope unit currently alive that belongs to this
+/// workspace's container: the boot scope plus per-exec attach scopes.
+pub(crate) async fn list_workspace_scope_units(workspace: &Workspace) -> Vec<String> {
+    let exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
+    let Some(token) = exec.mission_scope_match_token() else {
+        return Vec::new();
+    };
+    let output = tokio::process::Command::new("systemctl")
+        .args([
+            "list-units",
+            "--plain",
+            "--no-legend",
+            "--all",
+            "sandboxed-mission-*.scope",
+            "sandboxed-exec-*.scope",
+        ])
+        .output()
+        .await;
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|unit| unit.contains(&token))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live memory-cap adjustment
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateWorkspaceResourcesRequest {
+    /// e.g. "24G", "infinity", "50%". `Some("")` clears the workspace
+    /// override (falls back to the global MISSION_MEMORY_MAX default).
+    pub memory_max: Option<String>,
+    pub memory_high: Option<String>,
+    pub memory_swap_max: Option<String>,
+    /// Persist into the workspace env-var overrides (default true). When
+    /// false the change is runtime-only: it survives until the scopes die.
+    #[serde(default = "default_true")]
+    pub persist: bool,
+    /// Apply to currently-running scopes via `systemctl set-property
+    /// --runtime` (default true).
+    #[serde(default = "default_true")]
+    pub apply_live: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateWorkspaceResourcesResponse {
+    /// Units the new caps were applied to live (empty when none running).
+    pub applied_units: Vec<String>,
+    pub persisted: bool,
+    /// Effective caps after this call (override merged with global defaults).
+    pub memory_max: Option<String>,
+    pub memory_high: Option<String>,
+    pub memory_swap_max: Option<String>,
+}
+
+/// Validate a systemd memory size: bytes, suffixed (K/M/G/T), percentage,
+/// or "infinity".
+fn valid_memory_size(value: &str) -> bool {
+    let v = value.trim();
+    if v.eq_ignore_ascii_case("infinity") {
+        return true;
+    }
+    let v = v.strip_suffix('%').unwrap_or(v);
+    let v = v
+        .strip_suffix(['K', 'M', 'G', 'T', 'k', 'm', 'g', 't'])
+        .unwrap_or(v);
+    !v.is_empty() && v.parse::<f64>().map(|n| n >= 0.0).unwrap_or(false)
+}
+
+/// POST /api/workspaces/:id/resources — adjust a workspace's memory caps.
+///
+/// This is the "boost" path: raise (or clear) one workspace's memory limits
+/// without touching the global env file and without restarting anything.
+/// Running scopes are retuned in place; the persisted override applies to
+/// every scope the workspace boots afterwards.
+async fn update_workspace_resources(
+    AxumPath(id): AxumPath<Uuid>,
+    State(state): State<Arc<super::routes::AppState>>,
+    Json(req): Json<UpdateWorkspaceResourcesRequest>,
+) -> Result<Json<UpdateWorkspaceResourcesResponse>, (StatusCode, String)> {
+    let mut workspace = require_workspace(&state.workspaces, id).await?;
+
+    let updates: [(&str, &Option<String>); 3] = [
+        ("MISSION_MEMORY_MAX", &req.memory_max),
+        ("MISSION_MEMORY_HIGH", &req.memory_high),
+        ("MISSION_MEMORY_SWAP_MAX", &req.memory_swap_max),
+    ];
+
+    for (key, value) in &updates {
+        if let Some(v) = value {
+            if !v.trim().is_empty() && !valid_memory_size(v) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "Invalid {key} value '{v}': expected bytes, K/M/G/T suffix, %, or 'infinity'"
+                    ),
+                ));
+            }
+        }
+    }
+
+    // Merge the requested values into the workspace env overrides (empty
+    // string = clear the override).
+    for (key, value) in &updates {
+        if let Some(v) = value {
+            let v = v.trim();
+            if v.is_empty() {
+                workspace.env_vars.remove(*key);
+            } else {
+                workspace.env_vars.insert(key.to_string(), v.to_string());
+            }
+        }
+    }
+
+    let exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
+    let caps = exec.mission_memory_caps();
+
+    let mut applied_units = Vec::new();
+    if req.apply_live {
+        let units = list_workspace_scope_units(&workspace).await;
+        for unit in units {
+            let mut cmd = tokio::process::Command::new("systemctl");
+            cmd.args(["set-property", "--runtime", &unit]);
+            cmd.arg(format!(
+                "MemoryMax={}",
+                caps.max.as_deref().unwrap_or("infinity")
+            ));
+            cmd.arg(format!(
+                "MemoryHigh={}",
+                caps.high.as_deref().unwrap_or("infinity")
+            ));
+            cmd.arg(format!(
+                "MemorySwapMax={}",
+                caps.swap_max.as_deref().unwrap_or("infinity")
+            ));
+            match cmd.output().await {
+                Ok(out) if out.status.success() => applied_units.push(unit),
+                Ok(out) => {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    tracing::warn!("set-property failed for {}: {}", unit, stderr.trim());
+                }
+                Err(e) => {
+                    tracing::warn!("set-property spawn failed for {}: {}", unit, e);
+                }
+            }
+        }
+    }
+
+    if req.persist {
+        state.workspaces.update(workspace.clone()).await;
+    }
+
+    tracing::info!(
+        "Workspace {} memory caps updated: max={:?} high={:?} swap_max={:?} (live: {} unit(s), persisted: {})",
+        workspace.name,
+        caps.max,
+        caps.high,
+        caps.swap_max,
+        applied_units.len(),
+        req.persist
+    );
+
+    Ok(Json(UpdateWorkspaceResourcesResponse {
+        applied_units,
+        persisted: req.persist,
+        memory_max: caps.max,
+        memory_high: caps.high,
+        memory_swap_max: caps.swap_max,
+    }))
 }
 
 /// Parse systemd cgroup memory statistics from `systemctl show` output.

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1689,11 +1689,15 @@ async fn get_container_memory_stats(workspace: &Workspace) -> WorkspaceMemorySta
                     memory_peak = Some(memory_peak.unwrap_or(0).max(p));
                 }
                 if let Some(m) = max.filter(|m| *m != u64::MAX) {
-                    // Tightest configured cap across the workspace's scopes.
-                    memory_limit = Some(memory_limit.map_or(m, |cur: u64| cur.min(m)));
+                    // Each scope is independently capped, so the workspace's
+                    // ceiling is the sum across scopes — matching the summed
+                    // `MemoryCurrent` numerator. Taking the min here would let
+                    // summed usage exceed the displayed limit and peg the
+                    // gauge at 100% while still climbing.
+                    memory_limit = Some(memory_limit.unwrap_or(0) + m);
                 }
                 if let Some(a) = avail {
-                    memory_available = Some(memory_available.unwrap_or(0).max(a));
+                    memory_available = Some(memory_available.unwrap_or(0) + a);
                 }
             }
         }

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -540,6 +540,44 @@ async fn unmount_if_present(root: &Path, target: &str) -> NspawnResult<()> {
     Ok(())
 }
 
+/// Build the `systemd-nspawn` command for a one-shot container execution,
+/// wrapped in a capped transient scope under `missions.slice` when
+/// `MISSION_MEMORY_MAX` is configured (config env override → process env).
+///
+/// One-shot executions (workspace init scripts, template builds) can compile
+/// arbitrarily large projects; without this wrapper they run in the API
+/// service's cgroup and can throttle the whole service — same failure mode
+/// as the mission boot/attach paths in `workspace_exec.rs`.
+fn scope_wrapped_nspawn_command(path: &Path, env: &HashMap<String, String>) -> Command {
+    let caps = crate::workspace_exec::mission_memory_caps_from_env(env);
+    let dir_token: String = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, ':' | '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let unit = format!(
+        "sandboxed-exec-{}-{}",
+        dir_token,
+        uuid::Uuid::new_v4().simple()
+    );
+    if let Some(scope_args) = caps.scope_run_args(&unit) {
+        let mut c = Command::new("systemd-run");
+        c.args(&scope_args);
+        c.arg("systemd-nspawn");
+        c
+    } else {
+        Command::new("systemd-nspawn")
+    }
+}
+
 /// Execute a command inside a container using systemd-nspawn.
 pub async fn execute_in_container(
     path: &Path,
@@ -550,7 +588,7 @@ pub async fn execute_in_container(
         return Err(NspawnError::NspawnExecution("Empty command".to_string()));
     }
 
-    let mut cmd = tokio::process::Command::new("systemd-nspawn");
+    let mut cmd = scope_wrapped_nspawn_command(path, &config.env);
     cmd.arg("-D").arg(path);
     cmd.arg("--quiet");
     // Disable timezone bind-mount (minbase containers lack /usr/share/zoneinfo)
@@ -643,7 +681,7 @@ pub async fn execute_in_container_streaming(
         return Err(NspawnError::NspawnExecution("Empty command".to_string()));
     }
 
-    let mut cmd = Command::new("systemd-nspawn");
+    let mut cmd = scope_wrapped_nspawn_command(path, &config.env);
     cmd.arg("-D").arg(path);
     cmd.arg("--quiet");
     cmd.arg("--timezone=off");

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -550,24 +550,13 @@ async fn unmount_if_present(root: &Path, target: &str) -> NspawnResult<()> {
 /// as the mission boot/attach paths in `workspace_exec.rs`.
 fn scope_wrapped_nspawn_command(path: &Path, env: &HashMap<String, String>) -> Command {
     let caps = crate::workspace_exec::mission_memory_caps_from_env(env);
-    let dir_token: String = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, ':' | '.' | '_' | '-') {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let unit = format!(
-        "sandboxed-exec-{}-{}",
-        dir_token,
-        uuid::Uuid::new_v4().simple()
-    );
+    // Embed the same machine-name token the mission boot/attach scopes use so
+    // this one-shot scope is discoverable by `list_workspace_scope_units`
+    // (live stats, retune, OOM watchdog). A divergent token would make the
+    // scope get caps yet stay invisible to the workspace memory plumbing.
+    let token =
+        crate::workspace_exec::machine_name_for_path(path).unwrap_or_else(|| "unknown".to_string());
+    let unit = format!("sandboxed-exec-{}-{}", token, uuid::Uuid::new_v4().simple());
     if let Some(scope_args) = caps.scope_run_args(&unit) {
         let mut c = Command::new("systemd-run");
         c.args(&scope_args);

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -85,6 +85,101 @@ fn mission_scope_unit(machine_name: &str) -> String {
     format!("sandboxed-mission-{sanitized}.scope")
 }
 
+/// systemd slice that hosts every mission scope. Putting all mission scopes
+/// under one slice makes them cgroup *siblings* of the API service instead of
+/// children, and lets ops pin an **aggregate** memory cap on the slice so the
+/// sum of missions can never starve the host or the API — the per-mission cap
+/// alone doesn't protect against N missions × cap > RAM.
+///
+/// Override with `MISSION_SLICE` (empty / `none` / `off` disables the slice
+/// assignment for rollback). systemd auto-creates the slice on first use; a
+/// unit file or `systemctl set-property missions.slice MemoryHigh=…` pins the
+/// aggregate limits.
+fn missions_slice() -> Option<String> {
+    match std::env::var("MISSION_SLICE") {
+        Ok(v) => {
+            let v = v.trim().to_string();
+            if v.is_empty() || v.eq_ignore_ascii_case("none") || v.eq_ignore_ascii_case("off") {
+                None
+            } else {
+                Some(v)
+            }
+        }
+        Err(_) => Some("missions.slice".to_string()),
+    }
+}
+
+/// Memory caps applied to a mission's transient scopes.
+///
+/// Resolution order (per key): workspace `env_vars` override → API process
+/// env. The workspace override is what makes "boost this one workspace"
+/// possible without touching the global env file or restarting anything.
+#[derive(Debug, Clone, Default)]
+pub struct MissionMemoryCaps {
+    pub max: Option<String>,
+    pub high: Option<String>,
+    pub swap_max: Option<String>,
+}
+
+impl MissionMemoryCaps {
+    /// `true` when no MemoryMax is configured — scope wrapping is skipped
+    /// entirely (Docker installs without systemd PID 1, dev hosts, …).
+    pub fn is_disabled(&self) -> bool {
+        self.max.is_none()
+    }
+
+    /// `systemd-run` arguments for a transient scope carrying these caps.
+    /// Returns `None` when caps are disabled.
+    pub(crate) fn scope_run_args(&self, unit: &str) -> Option<Vec<String>> {
+        let max = self.max.as_ref()?;
+        let mut args = vec![
+            "--scope".to_string(),
+            "--quiet".to_string(),
+            "--collect".to_string(),
+            format!("--unit={unit}"),
+        ];
+        if let Some(slice) = missions_slice() {
+            args.push(format!("--slice={slice}"));
+        }
+        args.push(format!("--property=MemoryMax={max}"));
+        if let Some(high) = &self.high {
+            args.push(format!("--property=MemoryHigh={high}"));
+        }
+        if let Some(swap) = &self.swap_max {
+            args.push(format!("--property=MemorySwapMax={swap}"));
+        }
+        Some(args)
+    }
+}
+
+/// Build [`MissionMemoryCaps`] from an arbitrary env map (workspace env vars,
+/// `NspawnConfig::env`, …) with process-env fallback.
+pub(crate) fn mission_memory_caps_from_env(env: &HashMap<String, String>) -> MissionMemoryCaps {
+    MissionMemoryCaps {
+        max: resolve_memory_var(env, "MISSION_MEMORY_MAX"),
+        high: resolve_memory_var(env, "MISSION_MEMORY_HIGH"),
+        swap_max: resolve_memory_var(env, "MISSION_MEMORY_SWAP_MAX"),
+    }
+}
+
+/// Resolve one memory-cap key: workspace env override first, then process env.
+/// Empty values mean "unset" at both levels, so a workspace can also *clear*
+/// a global default by setting the var to an empty string.
+fn resolve_memory_var(workspace_env: &HashMap<String, String>, key: &str) -> Option<String> {
+    if let Some(v) = workspace_env.get(key) {
+        let v = v.trim();
+        return if v.is_empty() {
+            None
+        } else {
+            Some(v.to_string())
+        };
+    }
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
 fn select_container_resolv_conf() -> Option<PathBuf> {
     let default_path = PathBuf::from("/etc/resolv.conf");
     let content = fs::read_to_string(&default_path).ok()?;
@@ -548,6 +643,26 @@ impl WorkspaceExec {
         Some(format!("sandboxed-{}-{}", sanitized, suffix))
     }
 
+    /// Memory caps for this workspace's mission scopes (workspace env
+    /// override → process env; see [`resolve_memory_var`]).
+    pub fn mission_memory_caps(&self) -> MissionMemoryCaps {
+        mission_memory_caps_from_env(&self.workspace.env_vars)
+    }
+
+    /// The boot scope unit name for this workspace's container, when one can
+    /// be derived. Public so the API layer (live cap adjustment, memory
+    /// stats, OOM watchdog) can address the same unit this module creates.
+    pub fn mission_boot_scope_unit(&self) -> Option<String> {
+        self.machine_name().map(|name| mission_scope_unit(&name))
+    }
+
+    /// Token shared by every transient scope this workspace spawns (boot +
+    /// per-exec attach scopes). Used by the API layer to `systemctl
+    /// set-property` all of a workspace's scopes at once.
+    pub fn mission_scope_match_token(&self) -> Option<String> {
+        self.machine_name()
+    }
+
     async fn running_container_leader(&self) -> Option<String> {
         // Patched: discover the leader via pgrep instead of machinectl.
         // Inside the docker entrypoint (Caddy as PID 1) machinectl refuses
@@ -617,29 +732,22 @@ impl WorkspaceExec {
             .filter(|name| !name.trim().is_empty())
             .context("Container workspace has no machine name")?;
 
-        // Per-mission isolation (Layer 1). When `MISSION_MEMORY_MAX` is set,
-        // boot the container inside its own transient systemd scope with a
-        // memory cap so one mission's runaway build (e.g. a 46G Lean
-        // compilation) can't starve the host or the API process, and so
-        // `systemctl stop <scope>` reliably kills the whole build tree on
-        // cancel/teardown. Unset (default) = unchanged direct nspawn boot, so
-        // shipping this binary is a no-op until the env is enabled (dev first).
-        let mission_mem_max = std::env::var("MISSION_MEMORY_MAX")
-            .ok()
-            .filter(|s| !s.trim().is_empty());
-        let mission_mem_high = std::env::var("MISSION_MEMORY_HIGH")
-            .ok()
-            .filter(|s| !s.trim().is_empty());
-        let mut cmd = if let Some(mem_max) = &mission_mem_max {
-            let scope_unit = mission_scope_unit(&name);
+        // Per-mission isolation (Layer 1). When `MISSION_MEMORY_MAX` is set
+        // (workspace env override → process env), boot the container inside
+        // its own transient systemd scope — under `missions.slice` so the
+        // aggregate of all missions is capped separately from the API
+        // service — with memory + swap caps so one mission's runaway build
+        // (e.g. a 46G Lean compilation) can't starve the host or the API
+        // process, and so `systemctl stop <scope>` reliably kills the whole
+        // build tree on cancel/teardown. Unset (default) = unchanged direct
+        // nspawn boot, so shipping this binary is a no-op until the env is
+        // enabled (Docker installs without systemd PID 1 stay on the direct
+        // path).
+        let caps = self.mission_memory_caps();
+        let scope_args = caps.scope_run_args(&mission_scope_unit(&name));
+        let mut cmd = if let Some(scope_args) = scope_args {
             let mut c = Command::new("systemd-run");
-            c.arg("--scope")
-                .arg(format!("--unit={scope_unit}"))
-                .arg("--collect")
-                .arg(format!("--property=MemoryMax={mem_max}"));
-            if let Some(mem_high) = &mission_mem_high {
-                c.arg(format!("--property=MemoryHigh={mem_high}"));
-            }
+            c.args(&scope_args);
             // systemd-nspawn's own scope-creation is disabled below via
             // --register=no/--keep-unit, so it joins this scope's cgroup.
             c.arg("systemd-nspawn");
@@ -808,25 +916,17 @@ impl WorkspaceExec {
         // Lean build throttling the whole service cgroup while the
         // container's own scope sat at 24G/2MB). Wrap each attach in its
         // own capped transient scope when `MISSION_MEMORY_MAX` is set.
-        let mission_mem_max = std::env::var("MISSION_MEMORY_MAX")
-            .ok()
-            .filter(|s| !s.trim().is_empty());
-        let mut cmd = if let Some(mem_max) = &mission_mem_max {
+        // The unit embeds the machine name so the API layer can find and
+        // retune every scope belonging to one workspace at runtime.
+        let caps = self.mission_memory_caps();
+        let exec_unit = format!(
+            "sandboxed-exec-{}-{}",
+            self.machine_name().unwrap_or_else(|| "unknown".to_string()),
+            uuid::Uuid::new_v4().simple()
+        );
+        let mut cmd = if let Some(scope_args) = caps.scope_run_args(&exec_unit) {
             let mut c = Command::new("systemd-run");
-            c.arg("--scope")
-                .arg("--quiet")
-                .arg("--collect")
-                .arg(format!(
-                    "--unit=sandboxed-exec-{}",
-                    uuid::Uuid::new_v4().simple()
-                ))
-                .arg(format!("--property=MemoryMax={mem_max}"));
-            if let Some(mem_high) = std::env::var("MISSION_MEMORY_HIGH")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-            {
-                c.arg(format!("--property=MemoryHigh={mem_high}"));
-            }
+            c.args(&scope_args);
             c.arg(nsenter);
             c
         } else {
@@ -1252,6 +1352,27 @@ impl WorkspaceExec {
             "-lc".to_string(),
             shell_cmd,
         ];
+
+        // Same cgroup-escape hatch as build_nsenter_command, PTY edition:
+        // this invocation is what launches harness CLIs (claude/codex/…) for
+        // missions, and without the scope wrapper the harness — and every
+        // build it spawns — lands in the API service's cgroup. That is
+        // exactly how a 45 GiB `lean` run throttled the whole prod service
+        // on 2026-06-07 despite boot-path caps being deployed. systemd-run
+        // --scope keeps the payload as its own foreground child, so PTY
+        // semantics and group-kill teardown are preserved.
+        let caps = self.mission_memory_caps();
+        let exec_unit = format!(
+            "sandboxed-exec-{}-{}",
+            self.machine_name().unwrap_or_else(|| "unknown".to_string()),
+            uuid::Uuid::new_v4().simple()
+        );
+        if let Some(scope_args) = caps.scope_run_args(&exec_unit) {
+            let mut args = scope_args;
+            args.push(nsenter);
+            args.extend(nsenter_args);
+            return Ok(("systemd-run".to_string(), args));
+        }
 
         Ok((nsenter, nsenter_args))
     }

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -69,6 +69,36 @@ fn environ_has_keepalive_marker(environ: &[u8]) -> bool {
         .any(|entry| entry == expected.as_bytes())
 }
 
+/// Stable container identity for a workspace, derived from its path. Every
+/// transient scope a workspace spawns (mission boot, per-exec attach, and the
+/// one-shot nspawn wrapper in `nspawn.rs`) embeds this token, so scope
+/// discovery (`list_workspace_scope_units`) can match them all by substring.
+/// Keep all scope-naming sites in sync with this — a divergent token makes a
+/// scope invisible to live stats, retune, and the OOM watchdog.
+pub fn machine_name_for_path(path: &Path) -> Option<String> {
+    let base = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())?;
+    let sanitized: String = base
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    let suffix = format!("{:08x}", hasher.finish() as u32);
+
+    Some(format!("sandboxed-{}-{}", sanitized, suffix))
+}
+
 /// Build a valid transient systemd scope unit name for a mission container.
 /// systemd unit names allow `[A-Za-z0-9:._-]`; replace anything else with `_`.
 fn mission_scope_unit(machine_name: &str) -> String {
@@ -618,29 +648,7 @@ impl WorkspaceExec {
     }
 
     fn machine_name(&self) -> Option<String> {
-        let base = self
-            .workspace
-            .path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())?;
-        let sanitized: String = base
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                    c
-                } else {
-                    '-'
-                }
-            })
-            .collect();
-
-        let mut hasher = DefaultHasher::new();
-        self.workspace.path.hash(&mut hasher);
-        let suffix = format!("{:08x}", hasher.finish() as u32);
-
-        Some(format!("sandboxed-{}-{}", sanitized, suffix))
+        machine_name_for_path(&self.workspace.path)
     }
 
     /// Memory caps for this workspace's mission scopes (workspace env

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -193,16 +193,18 @@ pub(crate) fn mission_memory_caps_from_env(env: &HashMap<String, String>) -> Mis
 }
 
 /// Resolve one memory-cap key: workspace env override first, then process env.
-/// Empty values mean "unset" at both levels, so a workspace can also *clear*
-/// a global default by setting the var to an empty string.
+/// An empty workspace value is treated as "no override" and falls back to the
+/// process default — same as removing the key — so clearing a cap via the raw
+/// env editor and via the Resources "Reset to defaults" button behave
+/// identically, and neither silently drops the mission out of its cgroup scope.
+/// To run a single workspace genuinely uncapped, set the value to `"infinity"`
+/// (which still wraps the mission in a discoverable scope).
 fn resolve_memory_var(workspace_env: &HashMap<String, String>, key: &str) -> Option<String> {
     if let Some(v) = workspace_env.get(key) {
         let v = v.trim();
-        return if v.is_empty() {
-            None
-        } else {
-            Some(v.to_string())
-        };
+        if !v.is_empty() {
+            return Some(v.to_string());
+        }
     }
     std::env::var(key)
         .ok()


### PR DESCRIPTION
## Contexte

Le 2026-06-07, un build Lean de 45 GiB lancé par une mission a mis prod à genoux pendant ~4h (swap saturé, /v1 et /model-routing en timeout, Hermes en APIConnectionError) **malgré** les caps par mission déployés le 6 juin. Cause : le chemin PTY du harness (`build_container_nsenter_invocation`) spawnait un nsenter brut — claude et tous ses descendants atterrissaient dans le cgroup du service API.

## Changements

**Étanchéité (le fix du jour)**
- Le chemin PTY harness wrappe désormais dans le même scope cappé que le chemin shell-exec
- Les exécutions one-shot nspawn (`execute_in_container[_streaming]` : init scripts, builds de template) sont wrappées aussi

**Architecture cgroup**
- Tous les scopes mission vont sous `missions.slice` → frères du service API, plafond **agrégé** possible sur la somme des missions (`MISSION_SLICE` pour override/rollback)
- `MISSION_MEMORY_SWAP_MAX` : cap swap par scope (un build qui swappe 30G ne finit jamais — mieux vaut OOM tôt)

**Boost par workspace, sans restart**
- Les `MISSION_MEMORY_*` se lisent d'abord dans les env vars du workspace (override persistant par workspace)
- `POST /api/workspaces/:id/resources` : validation, persistance, et retune **live** des scopes actifs via `systemctl set-property --runtime`
- `GET /api/workspaces/:id/memory` réparé : agrège les vrais scopes (`sandboxed-mission-*`/`sandboxed-exec-*`) — l'ancien lookup `machine-*.scope` ne matchait jamais (`--register=no`)

**Boucle agent**
- Le watchdog surveille `memory.events` des cgroups mission : un `oom_kill` émet un événement sur le stream de mission au lieu d'un échec silencieux que l'agent retente en boucle

**Dashboard**
- Panneau Resources sur les workspaces conteneur : jauge mémoire live (poll 5s), édition des caps, application à chaud

## Ops (fait au déploiement, pas dans ce diff)
- Unit `missions.slice` avec MemoryHigh/Max agrégés + baisse du cap du service API
- `MISSION_MEMORY_SWAP_MAX=4G` dans les env files
- Recyclage des conteneurs bootés avant la feature (ils échappent aux scopes)

## Suivi (hors scope)
- Scoper les missions host-workspace (toujours dans le cgroup du service)
- Injection de l'événement OOM dans la conversation de l'agent (operator-note)
- Garde-fou UI : boost ≤ plafond du slice

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cgroup/process spawning for all container missions and live systemd property updates; misconfiguration could OOM-kill workloads or still starve the API if scopes are skipped.
> 
> **Overview**
> **Mission memory isolation** is extended so harness PTY launches, nsenter attach/exec, and one-shot `systemd-nspawn` runs use the same capped transient scopes as container boot, with scopes placed under **`missions.slice`** and caps resolved from workspace **`MISSION_MEMORY_*`** env overrides (plus swap max).
> 
> **API & ops:** `GET …/memory` now aggregates **`sandboxed-mission-*` / `sandboxed-exec-*`** scopes instead of nonexistent `machine-*.scope` units. **`POST …/resources`** validates caps, persists overrides, and retunes running scopes via **`systemctl set-property --runtime`**. The stuck-mission watchdog watches **`memory.events` `oom_kill`** and emits **`MissionActivity`** for all missions on that workspace.
> 
> **Dashboard:** Container workspace overview adds a **Resources** panel (5s poll, usage bar, MemoryHigh/MemoryMax apply + reset) wired to the new API client helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcdf86234202d6de2c1546f974d02a6be29224ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->