### PR TITLE
proxy: inject Claude Code identity for Anthropic OAuth requests (fixes Opus 429)

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -640,15 +640,19 @@ pub(crate) async fn chat_completions_inner(
                     continue;
                 }
             };
-            let upstream_body =
-                match build_anthropic_upstream_request(&body, &entry.model_id, is_stream) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        tracing::error!("Failed to build Anthropic upstream request: {}", e);
-                        server_error_count += 1;
-                        continue;
-                    }
-                };
+            let upstream_body = match build_anthropic_upstream_request(
+                &body,
+                &entry.model_id,
+                is_stream,
+                entry.has_oauth,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!("Failed to build Anthropic upstream request: {}", e);
+                    server_error_count += 1;
+                    continue;
+                }
+            };
             let headers = build_anthropic_proxy_headers(credential, entry.has_oauth);
             (
                 "https://api.anthropic.com/v1/messages".to_string(),
@@ -822,7 +826,12 @@ pub(crate) async fn chat_completions_inner(
                 let base = if use_anthropic_oauth_cli_proxy_adapter {
                     rewrite_model_for_anthropic_cli_proxy(&body, &entry.model_id)
                 } else {
-                    build_anthropic_upstream_request(&body, &entry.model_id, is_stream)
+                    build_anthropic_upstream_request(
+                        &body,
+                        &entry.model_id,
+                        is_stream,
+                        entry.has_oauth,
+                    )
                 };
                 base.and_then(|b| anthropic_body_drop_thinking_and_disable(&b))
                     .map_err(
@@ -2760,10 +2769,19 @@ fn build_anthropic_proxy_headers(credential: &str, has_oauth: bool) -> HeaderMap
     headers
 }
 
+/// First system block Anthropic requires on OAuth-subscription tokens. The
+/// `/v1/messages` endpoint rejects subscription (Claude Pro/Max) OAuth tokens
+/// with a misleading `429 rate_limit_error` unless the request identifies
+/// itself as Claude Code via this exact system line — even when the account
+/// has ample rate-limit budget. API-key requests don't need it. This mirrors
+/// what real Claude Code (and our own usage-probe in ai_providers.rs) sends.
+const CLAUDE_CODE_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
+
 fn build_anthropic_upstream_request(
     body: &[u8],
     model_id: &str,
     is_stream: bool,
+    force_claude_code_identity: bool,
 ) -> Result<bytes::Bytes, String> {
     let req: serde_json::Value =
         serde_json::from_slice(body).map_err(|e| format!("Invalid JSON: {}", e))?;
@@ -2813,6 +2831,19 @@ fn build_anthropic_upstream_request(
     if model_changed {
         strip_thinking_blocks(&mut messages);
     }
+    // OAuth-subscription tokens require the Claude Code identity as the first
+    // system block, else Anthropic returns a misleading 429. Prepend it unless
+    // the caller's own system prompt already leads with it (idempotent so a
+    // retry can't double it).
+    let system = if force_claude_code_identity && !system.starts_with(CLAUDE_CODE_IDENTITY) {
+        if system.is_empty() {
+            CLAUDE_CODE_IDENTITY.to_string()
+        } else {
+            format!("{CLAUDE_CODE_IDENTITY}\n\n{system}")
+        }
+    } else {
+        system
+    };
     if !system.is_empty() {
         out.insert("system".to_string(), serde_json::Value::String(system));
     }
@@ -4725,6 +4756,7 @@ mod tests {
             serde_json::to_vec(&body).unwrap().as_slice(),
             "claude-opus-4-7",
             false,
+            false,
         )
         .unwrap();
         let payload: serde_json::Value = serde_json::from_slice(payload_bytes.as_ref()).unwrap();
@@ -4742,6 +4774,86 @@ mod tests {
                 "name": "echo"
             })
         );
+    }
+
+    #[test]
+    fn anthropic_oauth_request_prepends_claude_code_identity() {
+        // OAuth path (force_claude_code_identity = true): the Claude Code
+        // identity must lead the system prompt, else Anthropic 429s the
+        // subscription token.
+        let body = serde_json::json!({
+            "model": "claude-opus-4-8",
+            "messages": [
+                { "role": "system", "content": "Be brief." },
+                { "role": "user", "content": "hi" }
+            ],
+            "max_tokens": 16,
+        });
+        let bytes = build_anthropic_upstream_request(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "claude-opus-4-8",
+            false,
+            true,
+        )
+        .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(bytes.as_ref()).unwrap();
+        assert_eq!(
+            payload["system"],
+            "You are Claude Code, Anthropic's official CLI for Claude.\n\nBe brief."
+        );
+
+        // Idempotent: a system prompt already leading with the identity is not
+        // doubled (covers the thinking-strip retry re-running the builder).
+        let body2 = serde_json::json!({
+            "model": "claude-opus-4-8",
+            "messages": [
+                { "role": "system", "content": "You are Claude Code, Anthropic's official CLI for Claude.\n\nBe brief." },
+                { "role": "user", "content": "hi" }
+            ],
+            "max_tokens": 16,
+        });
+        let bytes2 = build_anthropic_upstream_request(
+            serde_json::to_vec(&body2).unwrap().as_slice(),
+            "claude-opus-4-8",
+            false,
+            true,
+        )
+        .unwrap();
+        let payload2: serde_json::Value = serde_json::from_slice(bytes2.as_ref()).unwrap();
+        assert_eq!(
+            payload2["system"],
+            "You are Claude Code, Anthropic's official CLI for Claude.\n\nBe brief."
+        );
+
+        // Empty system + OAuth: identity becomes the whole system prompt.
+        let body3 = serde_json::json!({
+            "model": "claude-opus-4-8",
+            "messages": [ { "role": "user", "content": "hi" } ],
+            "max_tokens": 16,
+        });
+        let bytes3 = build_anthropic_upstream_request(
+            serde_json::to_vec(&body3).unwrap().as_slice(),
+            "claude-opus-4-8",
+            false,
+            true,
+        )
+        .unwrap();
+        let payload3: serde_json::Value = serde_json::from_slice(bytes3.as_ref()).unwrap();
+        assert_eq!(
+            payload3["system"],
+            "You are Claude Code, Anthropic's official CLI for Claude."
+        );
+
+        // API-key path (force = false): system is untouched.
+        let bytes4 = build_anthropic_upstream_request(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "claude-opus-4-8",
+            false,
+            false,
+        )
+        .unwrap();
+        let payload4: serde_json::Value = serde_json::from_slice(bytes4.as_ref()).unwrap();
+        assert_eq!(payload4["system"], "Be brief.");
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -2970,6 +2970,14 @@ fn anthropic_content_blocks_from_openai(
         return Vec::new();
     };
     if let Some(text) = content.as_str() {
+        // Anthropic rejects empty/whitespace-only text blocks ("text content
+        // blocks must be non-empty"). An OpenAI assistant message commonly
+        // carries content:"" alongside tool_calls (MiniMax/most OpenAI-style
+        // models do this); emitting an empty text block next to the tool_use
+        // blocks 400s the whole replay. Drop it.
+        if text.trim().is_empty() {
+            return Vec::new();
+        }
         return vec![serde_json::json!({ "type": "text", "text": text })];
     }
     let Some(parts) = content.as_array() else {
@@ -2980,7 +2988,10 @@ fn anthropic_content_blocks_from_openai(
         match part.get("type").and_then(|v| v.as_str()).unwrap_or("") {
             "text" => {
                 if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
-                    out.push(serde_json::json!({ "type": "text", "text": text }));
+                    // Skip empty/whitespace-only text blocks (see above).
+                    if !text.trim().is_empty() {
+                        out.push(serde_json::json!({ "type": "text", "text": text }));
+                    }
                 }
             }
             "image_url" => {
@@ -4315,6 +4326,50 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use futures::StreamExt;
+
+    #[test]
+    fn anthropic_conversion_drops_empty_text_block_beside_tool_use() {
+        // OpenAI assistant turns routinely carry content:"" alongside
+        // tool_calls. Anthropic rejects empty text blocks, so the converted
+        // assistant message must contain ONLY the tool_use block — else the
+        // whole replay 400s (observed: MiniMax history replayed on Opus).
+        let messages = serde_json::json!([
+            { "role": "user", "content": "List files." },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": { "name": "terminal", "arguments": "{\"cmd\":\"ls\"}" }
+                }]
+            },
+            { "role": "tool", "tool_call_id": "call_1", "content": "file1.txt" },
+            { "role": "user", "content": "Reply: pong" }
+        ]);
+        let (_system, out) =
+            anthropic_messages_from_openai(messages.as_array().unwrap().as_slice());
+        // The assistant message: exactly one block, the tool_use (no empty text).
+        let assistant = out
+            .iter()
+            .find(|m| m.get("role").and_then(|v| v.as_str()) == Some("assistant"))
+            .expect("assistant message present");
+        let blocks = assistant["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1, "empty text block must be dropped");
+        assert_eq!(blocks[0]["type"], "tool_use");
+        assert_eq!(blocks[0]["name"], "terminal");
+        // No message anywhere carries an empty text block.
+        for m in &out {
+            for b in m["content"].as_array().unwrap() {
+                if b.get("type").and_then(|v| v.as_str()) == Some("text") {
+                    assert!(
+                        !b["text"].as_str().unwrap().trim().is_empty(),
+                        "no empty text blocks may survive conversion"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn parse_direct_model_entry_accepts_known_provider_prefix() {


### PR DESCRIPTION
## Symptôme
La chain `opus` (et toute chain Anthropic routée sur un compte OAuth d'abonnement Claude Pro/Max) renvoyait systématiquement `429 rate_limit_error` — alors que le compte avait **tout son budget** (panneau Providers : `allowed, 6/100` sur la fenêtre 5h).

## Cause racine
`api.anthropic.com/v1/messages` rejette les tokens OAuth d'abonnement avec un **429 trompeur** sauf si la requête s'identifie comme Claude Code via un premier bloc system `You are Claude Code, Anthropic's official CLI for Claude.`. Vérifié au curl, même token / même modèle :

| requête | résultat |
|---|---|
| Opus 4.8 **avec** identité Claude Code | 200 ✅ |
| Opus 4.8 **sans** | 429 ❌ |

`build_anthropic_upstream_request` construisait le `system` uniquement depuis les messages OpenAI du client → jamais d'identité → 429. Notre propre sonde d'usage (ai_providers.rs:6500) envoie déjà cette identité, d'où le panneau Usage "allowed" pendant que l'inférence échouait — c'est cette divergence qui a révélé le bug.

## Fix
`build_anthropic_upstream_request` prend un `force_claude_code_identity` (= `entry.has_oauth` aux deux call sites) et préfixe l'identité au system, **idempotent** (le retry strip-thinking rejoue le builder). Les requêtes par clé API sont inchangées.

Test unitaire couvrant : prepend, idempotence, system vide, et chemin clé-API intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upstream Anthropic request shaping for all OAuth-routed traffic (system prompt mutation) and message conversion for every Anthropic adapter call; behavior is scoped and tested but affects a critical inference path.
> 
> **Overview**
> Fixes **Anthropic OAuth subscription routing** (e.g. Opus chains on Claude Pro/Max) that failed with misleading **429 rate_limit_error** despite available quota. `build_anthropic_upstream_request` now takes **`force_claude_code_identity`** (from `entry.has_oauth` on the initial upstream build and on the stale-thinking retry) and **prepends** the required Claude Code system line to the converted `system` prompt, **idempotently** so retries do not duplicate it. API-key paths leave the client system prompt unchanged.
> 
> Also hardens **OpenAI → Anthropic message conversion** by **omitting empty or whitespace-only text blocks**, including assistant turns with `content: ""` plus `tool_calls`, so replays are not rejected with 400 for non-empty text rules.
> 
> Unit tests cover OAuth system prepend/idempotence, API-key unchanged behavior, and assistant tool-call conversion without spurious text blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a7cff7adfd2acaad4fd8c503d34e64a37a7583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->