### PR TITLE
Codex (ChatGPT subscription) usage & limits panel + all-accounts-capped messaging

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1128,7 +1128,10 @@ function QuestionToolItem({
   onSubmit,
 }: {
   item: ToolItem;
-  onSubmit: (toolCallId: string, answers: string[][]) => Promise<void>;
+  onSubmit: (
+    toolCallId: string,
+    answers: string[][],
+  ) => Promise<{ ok: boolean; delivered: boolean }>;
 }) {
   const parsedQuestions = useMemo(
     () => parseQuestionArgs(item.args),
@@ -1159,10 +1162,14 @@ function QuestionToolItem({
   );
   const [otherText, setOtherText] = useState<Record<number, string>>({});
   const [submitting, setSubmitting] = useState(false);
+  // Set when the backend reports the answer reached no live mission (the
+  // mission ended before the answer arrived, e.g. the watchdog interrupted it).
+  const [deliveryFailed, setDeliveryFailed] = useState(false);
 
   useEffect(() => {
     setAnswers(questions.map(() => []));
     setOtherText({});
+    setDeliveryFailed(false);
   }, [item.toolCallId, questions]);
 
   const hasResult = item.result !== undefined;
@@ -1217,7 +1224,8 @@ function QuestionToolItem({
           return label;
         });
       });
-      await onSubmit(item.toolCallId, payload);
+      const outcome = await onSubmit(item.toolCallId, payload);
+      setDeliveryFailed(outcome?.delivered === false);
     } finally {
       setSubmitting(false);
     }
@@ -1381,7 +1389,12 @@ function QuestionToolItem({
                 </div>
               );
             })}
-            {hasResult ? (
+            {deliveryFailed ? (
+              <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 p-3 text-xs text-amber-400">
+                This mission is no longer running, so your answer wasn&apos;t
+                delivered. Resume the mission to continue.
+              </div>
+            ) : hasResult ? (
               <div className="text-xs text-green-400">Answer sent.</div>
             ) : (
               <button
@@ -3979,7 +3992,7 @@ type ChatItemRowProps = {
     toolCallId: string,
     name: string,
     result: unknown,
-  ) => Promise<void>;
+  ) => Promise<{ ok: boolean; delivered: boolean }>;
   onOptimisticToolResult: (toolCallId: string, result: unknown) => void;
   onRetryUserMessage: (msg: {
     id: string;
@@ -4268,7 +4281,7 @@ const ChatItemRow = memo(function ChatItemRow({
             item={item}
             onSubmit={async (toolCallId, answers) => {
               onOptimisticToolResult(toolCallId, { answers });
-              await onToolResult(toolCallId, item.name, { answers });
+              return onToolResult(toolCallId, item.name, { answers });
             }}
           />
         );
@@ -7823,7 +7836,7 @@ export default function ControlClient() {
 
   const handleToolResultCommit = useCallback(
     async (toolCallId: string, name: string, result: unknown) => {
-      await postControlToolResult({
+      return postControlToolResult({
         tool_call_id: toolCallId,
         name,
         result,

--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -50,6 +50,7 @@ import {
   Check,
   Pencil,
   Sparkles,
+  Eraser,
 } from 'lucide-react';
 import { cn, formatRelativeTime } from '@/lib/utils';
 
@@ -301,6 +302,41 @@ function EntryEditor({
 // Chain Card
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Minimal pill switch matching the dashboard's indigo accent + radius scale. */
+function Toggle({
+  checked,
+  onChange,
+  disabled,
+  label,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        'relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors cursor-pointer active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed',
+        checked ? 'bg-indigo-500' : 'bg-white/[0.12] hover:bg-white/[0.18]'
+      )}
+    >
+      <span
+        className={cn(
+          'inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform',
+          checked ? 'translate-x-[18px]' : 'translate-x-[3px]'
+        )}
+      />
+    </button>
+  );
+}
+
 function ChainCard({
   chain,
   onUpdate,
@@ -309,11 +345,23 @@ function ChainCard({
   providers,
 }: {
   chain: ModelChain;
-  onUpdate: (id: string, data: { name?: string; entries?: ChainEntry[]; is_default?: boolean }) => Promise<void>;
+  onUpdate: (id: string, data: { name?: string; entries?: ChainEntry[]; is_default?: boolean; strip_thinking?: boolean }) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
   onSetDefault: (id: string) => Promise<void>;
   providers: Provider[];
 }) {
+  const [savingStrip, setSavingStrip] = useState(false);
+
+  const handleToggleStrip = async (next: boolean) => {
+    setSavingStrip(true);
+    try {
+      await onUpdate(chain.id, { strip_thinking: next });
+    } catch {
+      // onUpdate surfaces the error toast.
+    } finally {
+      setSavingStrip(false);
+    }
+  };
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState(chain.name);
@@ -410,6 +458,22 @@ function ChainCard({
 
       {expanded && (
         <div className="border-t border-white/[0.04] px-3 py-3 space-y-3">
+          {/* Post-processing: strip reasoning tags */}
+          <div className="flex items-center gap-3 rounded-lg border border-white/[0.05] bg-white/[0.015] px-3 py-2">
+            <Eraser className="h-3.5 w-3.5 text-indigo-400/70 flex-shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="text-xs text-white/70">Strip reasoning tags</p>
+              <p className="mt-0.5 text-[10px] leading-snug text-white/35">
+                Removes <code className="rounded bg-white/[0.06] px-1 py-px font-mono text-white/55">&lt;think&gt;…&lt;/think&gt;</code> blocks and stray closing tags from replies. For models that leak reasoning into content (MiniMax, GLM).
+              </p>
+            </div>
+            <Toggle
+              checked={chain.strip_thinking}
+              onChange={handleToggleStrip}
+              disabled={savingStrip}
+              label="Strip reasoning tags"
+            />
+          </div>
           {editing ? (
             <>
               <div>
@@ -635,6 +699,7 @@ export default function ModelRoutingPage() {
     name: '',
     entries: [{ provider_id: '', model_id: '' }] as ChainEntry[],
     is_default: false,
+    strip_thinking: false,
   });
 
   const {
@@ -688,6 +753,7 @@ export default function ModelRoutingPage() {
         name: createForm.name.trim(),
         entries: validEntries,
         is_default: createForm.is_default,
+        strip_thinking: createForm.strip_thinking,
       });
       toast.success('Chain created');
       setShowCreate(false);
@@ -696,6 +762,7 @@ export default function ModelRoutingPage() {
         name: '',
         entries: [{ provider_id: '', model_id: '' }],
         is_default: false,
+        strip_thinking: false,
       });
       mutateChains();
     } catch (err) {
@@ -705,7 +772,7 @@ export default function ModelRoutingPage() {
 
   const handleUpdate = async (
     id: string,
-    data: { name?: string; entries?: ChainEntry[]; is_default?: boolean }
+    data: { name?: string; entries?: ChainEntry[]; is_default?: boolean; strip_thinking?: boolean }
   ) => {
     try {
       await updateModelChain(id, data);
@@ -937,22 +1004,34 @@ export default function ModelRoutingPage() {
                 providers={providers}
               />
               <div className="flex items-center justify-between pt-1">
-                <label className="flex items-center gap-2 text-xs text-white/60 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={createForm.is_default}
-                    onChange={(e) =>
-                      setCreateForm({ ...createForm, is_default: e.target.checked })
-                    }
-                    className="rounded border-white/20 cursor-pointer"
-                  />
-                  Set as default chain
-                </label>
+                <div className="flex items-center gap-4">
+                  <label className="flex items-center gap-2 text-xs text-white/60 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={createForm.is_default}
+                      onChange={(e) =>
+                        setCreateForm({ ...createForm, is_default: e.target.checked })
+                      }
+                      className="rounded border-white/20 cursor-pointer"
+                    />
+                    Set as default chain
+                  </label>
+                  <span className="flex items-center gap-2 text-xs text-white/60">
+                    <Toggle
+                      checked={createForm.strip_thinking}
+                      onChange={(next) =>
+                        setCreateForm({ ...createForm, strip_thinking: next })
+                      }
+                      label="Strip reasoning tags"
+                    />
+                    Strip reasoning tags
+                  </span>
+                </div>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => {
                       setShowCreate(false);
-                      setCreateForm({ id: '', name: '', entries: [{ provider_id: '', model_id: '' }], is_default: false });
+                      setCreateForm({ id: '', name: '', entries: [{ provider_id: '', model_id: '' }], is_default: false, strip_thinking: false });
                     }}
                     className="rounded-lg px-3 py-1.5 text-xs text-white/60 hover:text-white/80 transition-colors cursor-pointer"
                   >

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -99,6 +99,12 @@ function fmtReset(v: string | undefined | null): string {
   return v;
 }
 
+/** Format a unix epoch-seconds reset time as a relative "in Xh" string. */
+function fmtResetEpoch(secs: number | undefined | null): string {
+  if (secs == null) return '-';
+  return fmtReset(new Date(secs * 1000).toISOString());
+}
+
 /** Usage bar: shows used/limit with a mini progress bar */
 function UsageBar({ used, limit, label }: { used?: number | null; limit?: number | null; label: string }) {
   if (limit == null && used == null) return null;
@@ -241,10 +247,56 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
         </div>
       )}
 
-      {/* OpenAI connected without rate limits (OAuth without API key) */}
-      {type === 'openai' && usage.status === 'connected' && usage.requests_limit == null && (
-        <div className="text-[11px] text-emerald-400/70">Connected via OAuth</div>
+      {/* Codex (OpenAI ChatGPT subscription) usage & limits */}
+      {type === 'openai' && usage.codex_primary_used_percent != null && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-3 flex-wrap text-[11px] text-white/50">
+            {usage.codex_plan_type && (
+              <span><span className="text-white/30">Plan:</span> {usage.codex_plan_type}</span>
+            )}
+            {usage.codex_active_limit && (
+              <span><span className="text-white/30">Tier:</span> {usage.codex_active_limit}</span>
+            )}
+            {usage.codex_source === 'passive' && (
+              <span className="text-amber-400/60">(from recent traffic)</span>
+            )}
+          </div>
+          {usage.codex_primary_used_percent != null && (
+            <UsageBar
+              used={Math.round(100 - usage.codex_primary_used_percent)}
+              limit={100}
+              label="5h window"
+            />
+          )}
+          {usage.codex_secondary_used_percent != null && (
+            <UsageBar
+              used={Math.round(100 - usage.codex_secondary_used_percent)}
+              limit={100}
+              label="Weekly window"
+            />
+          )}
+          <div className="flex gap-4 text-[10px] text-white/30 flex-wrap">
+            {usage.codex_primary_reset_at != null && (
+              <span>5h reset: {fmtResetEpoch(usage.codex_primary_reset_at)}</span>
+            )}
+            {usage.codex_secondary_reset_at != null && (
+              <span>Weekly reset: {fmtResetEpoch(usage.codex_secondary_reset_at)}</span>
+            )}
+            {usage.codex_credits_unlimited === false && usage.codex_credits_balance != null && (
+              <span>Credits: {usage.codex_credits_balance}</span>
+            )}
+            {usage.codex_credits_unlimited === true && <span>Credits: unlimited</span>}
+          </div>
+        </div>
       )}
+
+      {/* OpenAI connected without rate limits (OAuth without API key, no Codex data) */}
+      {type === 'openai' &&
+        usage.status === 'connected' &&
+        usage.requests_limit == null &&
+        usage.codex_primary_used_percent == null && (
+          <div className="text-[11px] text-emerald-400/70">Connected via OAuth</div>
+        )}
 
       {/* Cerebras style rate limits */}
       {type === 'cerebras' && (

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -449,12 +449,15 @@ export async function postControlToolResult(payload: {
   tool_call_id: string;
   name: string;
   result: unknown;
-}): Promise<void> {
-  return apiPost(
+}): Promise<{ ok: boolean; delivered: boolean }> {
+  const res = await apiPost<{ ok?: boolean; delivered?: boolean } | undefined>(
     "/api/control/tool_result",
     payload,
     "Failed to post tool result",
   );
+  // Older backends returned a bare `{ ok: true }` with no delivery signal;
+  // treat a missing flag as delivered so we don't false-alarm against them.
+  return { ok: res?.ok ?? true, delivered: res?.delivered ?? true };
 }
 
 export async function cancelControl(): Promise<void> {

--- a/dashboard/src/lib/api/model-routing.ts
+++ b/dashboard/src/lib/api/model-routing.ts
@@ -18,6 +18,12 @@ export interface ModelChain {
   name: string;
   entries: ChainEntry[];
   is_default: boolean;
+  /**
+   * Strip `<think>…</think>` blocks and stray orphan `</think>` tags from
+   * responses routed through this chain. Useful for models (MiniMax, GLM) that
+   * leak reasoning into `content`.
+   */
+  strip_thinking: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -92,6 +98,7 @@ export async function createModelChain(data: {
   name: string;
   entries: ChainEntry[];
   is_default?: boolean;
+  strip_thinking?: boolean;
 }): Promise<ModelChain> {
   return apiPost("/api/model-routing/chains", data, "Failed to create model chain");
 }
@@ -102,6 +109,7 @@ export async function updateModelChain(
     name?: string;
     entries?: ChainEntry[];
     is_default?: boolean;
+    strip_thinking?: boolean;
   }
 ): Promise<ModelChain> {
   return apiPut(

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -316,6 +316,19 @@ export interface ProviderUsage {
   coding_plan?: Record<string, unknown>;
   // Z.AI last call usage
   last_call_usage?: Record<string, unknown>;
+  // Codex (OpenAI ChatGPT subscription) limits — primary = 5h window,
+  // secondary = weekly (7d) window. Reset fields are unix epoch seconds.
+  codex_plan_type?: string;
+  codex_active_limit?: string;
+  codex_primary_used_percent?: number;
+  codex_primary_window_minutes?: number;
+  codex_primary_reset_at?: number;
+  codex_secondary_used_percent?: number;
+  codex_secondary_window_minutes?: number;
+  codex_secondary_reset_at?: number;
+  codex_credits_balance?: number;
+  codex_credits_unlimited?: boolean;
+  codex_source?: "probe" | "passive";
   // Any additional fields
   [key: string]: unknown;
 }

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use std::sync::Arc;
 
 use crate::agents::{Agent, AgentContext, AgentId, AgentResult, AgentType, TerminalReason};
-use crate::api::control::{AgentEvent, AgentTreeNode, ControlRunState};
+use crate::api::control::{AgentEvent, AgentTreeNode, ControlRunState, FrontendToolHub};
 use crate::config::Config;
 use crate::opencode::{extract_reasoning, extract_text, OpenCodeClient, OpenCodeEvent};
 use crate::task::Task;
@@ -267,10 +267,18 @@ impl OpenCodeAgent {
                     });
                 }
             }
+            // Keep the mission marked as waiting on the user so the
+            // stuck-mission watchdog does not interrupt it while it is parked
+            // here awaiting an answer. The guard clears the mark on every exit
+            // path (answered or the channel closing).
+            let wait_guard = mission_id.map(|mid| FrontendToolHub::begin_waiting(&tool_hub, mid));
             let rx = tool_hub.register(tool_call_id.clone()).await;
             let Ok(result) = rx.await else {
                 return;
             };
+            // Answer received — the mission resumes emitting events; release
+            // the watchdog exemption.
+            drop(wait_guard);
             if let (Some(status), Some(events), Some(mid)) =
                 (&control_status, &events_tx, mission_id)
             {

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -6677,18 +6677,17 @@ async fn get_provider_usage(
                     // else probe the Codex backend directly. Never probed by the
                     // background loop (see spawn_usage_refresh_loop) — only here,
                     // on dashboard demand, throttled by the store's TTL.
-                    let token_ok = !oauth_token_expired(o.expires_at);
-                    let base = serde_json::json!({
+                    let mut base = serde_json::json!({
                         "provider_type": "openai",
                         "provider_name": provider_name,
                         "account_email": account_email,
-                        "status": if token_ok { "connected" } else { "needs_reauth" },
+                        "status": "connected",
                     });
                     // The codex_usage store is keyed by the provider account
                     // UUID so the proxy's passive `model_cooldown` capture
                     // (which only knows `entry.account_id`) and this active
-                    // probe agree on the key. The probe REQUEST still needs the
-                    // ChatGPT account id, decoded from the token below.
+                    // probe agree on the key. The probe REQUEST needs the
+                    // ChatGPT account id, decoded from the token.
                     let store_key = match provider_uuid {
                         Some(u) => u.to_string(),
                         None => crate::api::codex_usage::account_id_from_token(&o.access_token)
@@ -6707,17 +6706,51 @@ async fn get_provider_usage(
                     if let Some(snap) = state.codex_usage.get_fresh(&store_key).await {
                         return Ok(Json(merge_codex_usage(base, &snap)));
                     }
-                    // Expired token: don't probe (would 401). Show last known.
-                    if !token_ok {
+
+                    // Get a usable access token: refresh + persist if expired.
+                    // We excluded these accounts from the background refresh
+                    // loop, so don't rely on it having kept the token fresh.
+                    let working_dir = &state.config.working_dir;
+                    let token = match find_openai_oauth_account_by_chatgpt_account_id(
+                        working_dir,
+                        &chatgpt_account_id,
+                    ) {
+                        Some(acct) => {
+                            match prepare_codex_oauth_account_for_launch(working_dir, &acct).await {
+                                Ok(fresh) => Some(fresh.access_token),
+                                Err(e) => {
+                                    tracing::debug!("Codex usage token refresh failed: {}", e);
+                                    let lower = e.to_lowercase();
+                                    if lower.contains("invalid_grant")
+                                        || lower.contains("expired")
+                                        || lower.contains("revoked")
+                                    {
+                                        base["status"] = serde_json::json!("needs_reauth");
+                                    }
+                                    None
+                                }
+                            }
+                        }
+                        // Not in the store file (e.g. OpenCode-auth only): try
+                        // the token we already hold.
+                        None if !oauth_token_expired(o.expires_at) => Some(o.access_token.clone()),
+                        None => {
+                            base["status"] = serde_json::json!("needs_reauth");
+                            None
+                        }
+                    };
+                    let Some(token) = token else {
+                        // Couldn't get a live token — show last known snapshot.
                         if let Some(snap) = state.codex_usage.get_any(&store_key).await {
                             return Ok(Json(merge_codex_usage(base, &snap)));
                         }
                         return Ok(Json(base));
-                    }
+                    };
+
                     // Active probe (A).
                     match crate::api::codex_usage::probe(
                         &state.http_client,
-                        &o.access_token,
+                        &token,
                         &chatgpt_account_id,
                     )
                     .await

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -6724,6 +6724,8 @@ async fn get_provider_usage(
                                     if lower.contains("invalid_grant")
                                         || lower.contains("expired")
                                         || lower.contains("revoked")
+                                        || lower.contains("401")
+                                        || lower.contains("unauthorized")
                                     {
                                         base["status"] = serde_json::json!("needs_reauth");
                                     }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -6265,6 +6265,20 @@ async fn check_provider_health(
     }
 }
 
+/// Merge a Codex usage snapshot's `codex_*` fields into the base provider-usage
+/// JSON object the dashboard consumes.
+fn merge_codex_usage(
+    mut base: serde_json::Value,
+    snap: &crate::api::codex_usage::CodexUsageSnapshot,
+) -> serde_json::Value {
+    if let (Some(obj), serde_json::Value::Object(fields)) = (base.as_object_mut(), snap.to_json()) {
+        for (k, v) in fields {
+            obj.insert(k, v);
+        }
+    }
+    base
+}
+
 /// GET /api/ai/providers/:id/usage - Fetch live usage/rate-limit info from the provider API.
 ///
 /// Makes a minimal API call to the provider and captures rate-limit headers
@@ -6656,15 +6670,74 @@ async fn get_provider_usage(
                 if let Some(key) = get_openai_api_key_for_codex_default(&state.config.working_dir) {
                     key
                 } else {
-                    // No API key available. Validate OAuth token health before
-                    // returning status so expired sessions don't show as connected.
+                    // OAuth-only ChatGPT/Codex subscription account. There's no
+                    // sk- key and api.openai.com rejects the JWT, so the only
+                    // usage signal is the Codex backend's `x-codex-*` headers
+                    // (5h + weekly windows). Serve a cached snapshot when fresh,
+                    // else probe the Codex backend directly. Never probed by the
+                    // background loop (see spawn_usage_refresh_loop) — only here,
+                    // on dashboard demand, throttled by the store's TTL.
                     let token_ok = !oauth_token_expired(o.expires_at);
-                    return Ok(Json(serde_json::json!({
+                    let base = serde_json::json!({
                         "provider_type": "openai",
                         "provider_name": provider_name,
                         "account_email": account_email,
                         "status": if token_ok { "connected" } else { "needs_reauth" },
-                    })));
+                    });
+                    // The codex_usage store is keyed by the provider account
+                    // UUID so the proxy's passive `model_cooldown` capture
+                    // (which only knows `entry.account_id`) and this active
+                    // probe agree on the key. The probe REQUEST still needs the
+                    // ChatGPT account id, decoded from the token below.
+                    let store_key = match provider_uuid {
+                        Some(u) => u.to_string(),
+                        None => crate::api::codex_usage::account_id_from_token(&o.access_token)
+                            .unwrap_or_default(),
+                    };
+                    let chatgpt_account_id =
+                        crate::api::codex_usage::account_id_from_token(&o.access_token);
+                    let (Some(chatgpt_account_id), false) =
+                        (chatgpt_account_id, store_key.is_empty())
+                    else {
+                        return Ok(Json(base));
+                    };
+
+                    // Fresh cached snapshot (probe within TTL, or a recent
+                    // passive cooldown stamp) — serve without re-probing.
+                    if let Some(snap) = state.codex_usage.get_fresh(&store_key).await {
+                        return Ok(Json(merge_codex_usage(base, &snap)));
+                    }
+                    // Expired token: don't probe (would 401). Show last known.
+                    if !token_ok {
+                        if let Some(snap) = state.codex_usage.get_any(&store_key).await {
+                            return Ok(Json(merge_codex_usage(base, &snap)));
+                        }
+                        return Ok(Json(base));
+                    }
+                    // Active probe (A).
+                    match crate::api::codex_usage::probe(
+                        &state.http_client,
+                        &o.access_token,
+                        &chatgpt_account_id,
+                    )
+                    .await
+                    {
+                        Ok(snap) => {
+                            state
+                                .codex_usage
+                                .put_probe(store_key.clone(), snap.clone())
+                                .await;
+                            return Ok(Json(merge_codex_usage(base, &snap)));
+                        }
+                        Err(e) => {
+                            tracing::debug!("Codex usage probe failed: {}", e);
+                            // Fall back to any stale snapshot we still hold.
+                            if let Some(snap) = state.codex_usage.get_any(&store_key).await {
+                                return Ok(Json(merge_codex_usage(base, &snap)));
+                            }
+                            return Ok(Json(base));
+                        }
+                    }
                 }
             } else {
                 return Ok(Json(serde_json::json!({
@@ -7188,6 +7261,18 @@ pub fn spawn_usage_refresh_loop(state: Arc<super::routes::AppState>) {
         loop {
             let providers = state.ai_providers.list().await;
             for p in providers {
+                // Skip OpenAI OAuth-only (ChatGPT/Codex subscription) accounts:
+                // their only usage signal is an active Codex-backend probe that
+                // costs a message-quota unit, so we must never auto-poll it on
+                // the 2-min loop. It's refreshed on dashboard demand instead
+                // (get_provider_usage), throttled by the codex_usage TTL, and
+                // kept warm passively by the proxy's model_cooldown capture.
+                if p.provider_type == crate::ai_providers::ProviderType::OpenAI
+                    && p.api_key.is_none()
+                    && p.oauth.is_some()
+                {
+                    continue;
+                }
                 let id = p.id.to_string();
                 let bg_state = Arc::clone(&state);
                 if let Err(e) = live_fetch_and_cache(bg_state, id.clone()).await {

--- a/src/api/codex_usage.rs
+++ b/src/api/codex_usage.rs
@@ -1,0 +1,367 @@
+//! Codex (OpenAI ChatGPT subscription) usage & limits.
+//!
+//! ChatGPT-plan Codex accounts expose their rate-limit state on the Codex
+//! backend (`https://chatgpt.com/backend-api/codex/responses`) via `x-codex-*`
+//! response headers — the same data the Codex CLI's `/status` shows
+//! ("Rate Limits Remaining: 5h X%, Weekly Y%"). This mirrors Anthropic's
+//! `anthropic-ratelimit-unified-*` headers but for OpenAI subscriptions.
+//!
+//! The headers are NOT visible on the normal inference path: missions route
+//! Codex through the local CLIProxyAPI (`127.0.0.1:8317`), which strips them
+//! and only surfaces a derived `model_cooldown` error on 429. So we can't fully
+//! capture this passively. The design:
+//!
+//! - **Active probe (A)** — talk directly to the Codex backend with the
+//!   account's (auto-refreshed) OAuth token and read the `x-codex-*` headers.
+//!   This is the only source of the rich used-percent / window data. It costs
+//!   one Codex "message" when budget remains (free — a 429 — when exhausted),
+//!   so it is *throttled* ([`ACTIVE_TTL`]) and never run by the background
+//!   usage-refresh loop; only on explicit dashboard demand.
+//! - **Passive capture (B)** — when a real mission Codex call comes back as a
+//!   `model_cooldown` 429 through our proxy, we stamp the "exhausted + reset"
+//!   signal into the same store for free. It can't carry used-percent (the
+//!   cli-proxy hid it), but it keeps the exhaustion state live between probes
+//!   and lets the probe path short-circuit when we already know it's capped.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+/// Minimum wall-clock gap between two *active* probes for one account. Codex
+/// limits are message-based, so probing is not free when there is budget — keep
+/// it well below the dashboard poll rate. A snapshot younger than this is served
+/// as-is instead of re-probing.
+pub const ACTIVE_TTL: Duration = Duration::from_secs(900); // 15 min
+
+/// The Codex backend endpoint that returns `x-codex-*` rate-limit headers.
+const CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+
+/// A point-in-time view of one Codex account's subscription limits.
+///
+/// Field names mirror the `x-codex-*` headers. Serialized under `codex_*` keys
+/// so it slots into the dashboard's open-ended `ProviderUsage` shape next to
+/// the Anthropic `unified_*` fields.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct CodexUsageSnapshot {
+    #[serde(rename = "codex_plan_type", skip_serializing_if = "Option::is_none")]
+    pub plan_type: Option<String>,
+    #[serde(rename = "codex_active_limit", skip_serializing_if = "Option::is_none")]
+    pub active_limit: Option<String>,
+
+    /// Primary window = the 5-hour bucket.
+    #[serde(
+        rename = "codex_primary_used_percent",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub primary_used_percent: Option<f64>,
+    #[serde(
+        rename = "codex_primary_window_minutes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub primary_window_minutes: Option<u64>,
+    #[serde(
+        rename = "codex_primary_reset_at",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub primary_reset_at: Option<i64>,
+
+    /// Secondary window = the weekly (7-day) bucket.
+    #[serde(
+        rename = "codex_secondary_used_percent",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub secondary_used_percent: Option<f64>,
+    #[serde(
+        rename = "codex_secondary_window_minutes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub secondary_window_minutes: Option<u64>,
+    #[serde(
+        rename = "codex_secondary_reset_at",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub secondary_reset_at: Option<i64>,
+
+    #[serde(
+        rename = "codex_credits_balance",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub credits_balance: Option<f64>,
+    #[serde(
+        rename = "codex_credits_unlimited",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub credits_unlimited: Option<bool>,
+
+    /// `"probe"` (full, from an active probe) or `"passive"` (partial, from a
+    /// real-traffic 429). Lets the UI label staleness/source.
+    #[serde(rename = "codex_source", skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+impl CodexUsageSnapshot {
+    /// True when at least one window's used-percent is known — i.e. this is a
+    /// full probe snapshot rather than a bare passive exhaustion stamp.
+    pub fn has_windows(&self) -> bool {
+        self.primary_used_percent.is_some() || self.secondary_used_percent.is_some()
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+    }
+}
+
+struct Stored {
+    snapshot: CodexUsageSnapshot,
+    captured_at: Instant,
+}
+
+/// Per-account (`chatgpt_account_id`) Codex usage snapshots. Written by both the
+/// active probe and the passive proxy hook; read by the providers usage API.
+#[derive(Default)]
+pub struct CodexUsageStore {
+    entries: RwLock<HashMap<String, Stored>>,
+}
+
+impl CodexUsageStore {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Latest snapshot for an account if it is younger than [`ACTIVE_TTL`].
+    pub async fn get_fresh(&self, account_id: &str) -> Option<CodexUsageSnapshot> {
+        let entries = self.entries.read().await;
+        entries.get(account_id).and_then(|s| {
+            if s.captured_at.elapsed() < ACTIVE_TTL {
+                Some(s.snapshot.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Latest snapshot regardless of age (used as a last-resort fallback when a
+    /// live probe fails).
+    pub async fn get_any(&self, account_id: &str) -> Option<CodexUsageSnapshot> {
+        let entries = self.entries.read().await;
+        entries.get(account_id).map(|s| s.snapshot.clone())
+    }
+
+    /// Store a full snapshot from an active probe.
+    pub async fn put_probe(&self, account_id: String, mut snapshot: CodexUsageSnapshot) {
+        snapshot.source = Some("probe".to_string());
+        let mut entries = self.entries.write().await;
+        entries.insert(
+            account_id,
+            Stored {
+                snapshot,
+                captured_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Fold a passive exhaustion signal (from a real-traffic `model_cooldown`
+    /// 429) into the account's snapshot. Updates the secondary-window reset and
+    /// marks it 100% used, but preserves any richer fields a prior probe set.
+    pub async fn put_passive_cooldown(&self, account_id: String, secondary_reset_at: i64) {
+        let mut entries = self.entries.write().await;
+        let entry = entries.entry(account_id).or_insert_with(|| Stored {
+            snapshot: CodexUsageSnapshot::default(),
+            captured_at: Instant::now(),
+        });
+        entry.snapshot.secondary_used_percent = Some(100.0);
+        entry.snapshot.secondary_reset_at = Some(secondary_reset_at);
+        if entry.snapshot.source.is_none() {
+            entry.snapshot.source = Some("passive".to_string());
+        }
+        entry.captured_at = Instant::now();
+    }
+}
+
+/// Decode `chatgpt_account_id` from a ChatGPT OAuth access token (JWT). Mirrors
+/// the helper in `ai_providers` but kept local to avoid widening its surface.
+pub fn account_id_from_token(jwt: &str) -> Option<String> {
+    let parts: Vec<&str> = jwt.split('.').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let decoded = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    claims
+        .get("https://api.openai.com/auth")
+        .and_then(|auth| auth.get("chatgpt_account_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn header_str<'a>(headers: &'a reqwest::header::HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+/// Build a [`CodexUsageSnapshot`] from a Codex backend response's `x-codex-*`
+/// headers. Returns `None` when none of the rate-limit headers are present
+/// (e.g. a 400 that never reached the limit layer).
+pub fn parse_codex_headers(headers: &reqwest::header::HeaderMap) -> Option<CodexUsageSnapshot> {
+    let mut snap = CodexUsageSnapshot {
+        plan_type: header_str(headers, "x-codex-plan-type").map(str::to_string),
+        active_limit: header_str(headers, "x-codex-active-limit").map(str::to_string),
+        primary_used_percent: header_str(headers, "x-codex-primary-used-percent")
+            .and_then(|v| v.parse().ok()),
+        primary_window_minutes: header_str(headers, "x-codex-primary-window-minutes")
+            .and_then(|v| v.parse().ok()),
+        primary_reset_at: header_str(headers, "x-codex-primary-reset-at")
+            .and_then(|v| v.parse().ok()),
+        secondary_used_percent: header_str(headers, "x-codex-secondary-used-percent")
+            .and_then(|v| v.parse().ok()),
+        secondary_window_minutes: header_str(headers, "x-codex-secondary-window-minutes")
+            .and_then(|v| v.parse().ok()),
+        secondary_reset_at: header_str(headers, "x-codex-secondary-reset-at")
+            .and_then(|v| v.parse().ok()),
+        credits_balance: header_str(headers, "x-codex-credits-balance")
+            .and_then(|v| v.parse().ok()),
+        credits_unlimited: header_str(headers, "x-codex-credits-unlimited")
+            .map(|v| v.eq_ignore_ascii_case("true")),
+        source: None,
+    };
+    // Some deployments only carry the bare reset/used pair; treat the snapshot
+    // as valid as long as at least one window field came through.
+    if snap.plan_type.is_none()
+        && snap.primary_used_percent.is_none()
+        && snap.secondary_used_percent.is_none()
+        && snap.primary_reset_at.is_none()
+        && snap.secondary_reset_at.is_none()
+    {
+        return None;
+    }
+    snap.source = Some("probe".to_string());
+    Some(snap)
+}
+
+/// Parse a CLIProxyAPI `model_cooldown` 429 body into the absolute epoch-seconds
+/// at which the (weekly/secondary) limit resets. Shape:
+/// `{"error":{"code":"model_cooldown","reset_seconds":229689,...}}`.
+pub fn parse_cooldown_reset(body: &[u8], now_unix: i64) -> Option<i64> {
+    let v: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let err = v.get("error")?;
+    if err.get("code").and_then(|c| c.as_str()) != Some("model_cooldown") {
+        return None;
+    }
+    let reset_secs = err.get("reset_seconds").and_then(|r| r.as_i64())?;
+    Some(now_unix + reset_secs)
+}
+
+/// Active probe: ask the Codex backend for this account's limits and parse the
+/// `x-codex-*` headers. `access_token` must be a fresh ChatGPT OAuth token.
+///
+/// Sends a minimal `gpt-5.5` request — the only model class accepted on a
+/// ChatGPT account (codex-specific ids 400). When budget remains this consumes
+/// one message; when exhausted the backend 429s (free) but still returns the
+/// headers, which is exactly what we want.
+pub async fn probe(
+    client: &reqwest::Client,
+    access_token: &str,
+    account_id: &str,
+) -> Result<CodexUsageSnapshot, String> {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "instructions": "x",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hi"}],
+        }],
+        "stream": true,
+        "store": false,
+    });
+    let resp = client
+        .post(CODEX_RESPONSES_URL)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("chatgpt-account-id", account_id)
+        .header("OpenAI-Beta", "responses=experimental")
+        .header("originator", "codex_cli_rs")
+        .header("Content-Type", "application/json")
+        .timeout(Duration::from_secs(20))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Codex usage probe request failed: {e}"))?;
+
+    let status = resp.status();
+    if let Some(snap) = parse_codex_headers(resp.headers()) {
+        tracing::debug!(
+            account_id = %account_id,
+            status = %status.as_u16(),
+            "Codex usage probe captured rate-limit headers"
+        );
+        return Ok(snap);
+    }
+    Err(format!(
+        "Codex usage probe returned HTTP {} with no x-codex-* headers",
+        status.as_u16()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    fn hdrs(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn parses_full_codex_headers() {
+        let h = hdrs(&[
+            ("x-codex-plan-type", "pro"),
+            ("x-codex-active-limit", "premium"),
+            ("x-codex-primary-used-percent", "23"),
+            ("x-codex-primary-window-minutes", "300"),
+            ("x-codex-primary-reset-at", "1780918001"),
+            ("x-codex-secondary-used-percent", "100"),
+            ("x-codex-secondary-window-minutes", "10080"),
+            ("x-codex-secondary-reset-at", "1781139607"),
+            ("x-codex-credits-balance", "0"),
+            ("x-codex-credits-unlimited", "False"),
+        ]);
+        let s = parse_codex_headers(&h).expect("snapshot");
+        assert_eq!(s.plan_type.as_deref(), Some("pro"));
+        assert_eq!(s.primary_used_percent, Some(23.0));
+        assert_eq!(s.primary_window_minutes, Some(300));
+        assert_eq!(s.secondary_used_percent, Some(100.0));
+        assert_eq!(s.secondary_window_minutes, Some(10080));
+        assert_eq!(s.secondary_reset_at, Some(1781139607));
+        assert_eq!(s.credits_unlimited, Some(false));
+        assert!(s.has_windows());
+        // Serializes under codex_* keys for the dashboard.
+        let j = s.to_json();
+        assert_eq!(j["codex_primary_used_percent"], 23.0);
+        assert_eq!(j["codex_plan_type"], "pro");
+    }
+
+    #[test]
+    fn returns_none_without_rate_limit_headers() {
+        let h = hdrs(&[("content-type", "application/json")]);
+        assert!(parse_codex_headers(&h).is_none());
+    }
+
+    #[test]
+    fn parses_cooldown_reset() {
+        let body = br#"{"error":{"code":"model_cooldown","reset_seconds":1000}}"#;
+        assert_eq!(parse_cooldown_reset(body, 5_000), Some(6_000));
+        // Non-cooldown errors are ignored.
+        let other = br#"{"error":{"code":"usage_limit_reached"}}"#;
+        assert_eq!(parse_cooldown_reset(other, 5_000), None);
+    }
+}

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3282,19 +3282,40 @@ impl FrontendToolHub {
 
     /// Resolve a pending tool call by id.
     ///
-    /// Returns `true` if a live waiter was registered (the result reached the
-    /// running mission). Returns `false` if no waiter was registered and the
-    /// result had to be cached in `early_results` — which, for a
-    /// human-answered question, almost always means the mission is no longer
-    /// running and the answer was dropped on the floor (the rare benign case
-    /// is a resolve-before-register race, impossible for a human to win).
+    /// Returns `true` if a live waiter received the result (the running mission
+    /// is consuming it). Returns `false` only when no waiter ever appears and
+    /// the result had to be cached in `early_results` — which, for a
+    /// human-answered question, means the mission is no longer running and the
+    /// answer was dropped on the floor.
+    ///
+    /// The harnesses broadcast the `ToolCall` to the frontend *before*
+    /// [`register`](Self::register) runs (there are a couple of `.await`
+    /// points in between), so a fast `tool_result` can race ahead of the
+    /// matching `register`. To avoid misreporting such a delivery as dropped,
+    /// we briefly wait for the imminent registration before falling back to the
+    /// cache. The wait is only ever paid when no waiter is present yet — the
+    /// common case (waiter already parked) returns immediately, and a mission
+    /// that has truly ended simply waits out the short grace window before we
+    /// correctly report the answer as undelivered.
     pub async fn resolve(&self, tool_call_id: &str, result: serde_json::Value) -> bool {
-        let mut pending = self.pending.lock().await;
-        if let Some(tx) = pending.remove(tool_call_id) {
-            let _ = tx.send(result);
-            return true;
+        // Total grace window ~250ms (10 × 25ms), only incurred when the waiter
+        // has not registered yet. Bounded so a genuinely dead mission still
+        // reports `delivered: false` promptly.
+        const REGISTER_GRACE_ATTEMPTS: u32 = 10;
+        const REGISTER_GRACE_STEP: std::time::Duration = std::time::Duration::from_millis(25);
+
+        for attempt in 0..=REGISTER_GRACE_ATTEMPTS {
+            {
+                let mut pending = self.pending.lock().await;
+                if let Some(tx) = pending.remove(tool_call_id) {
+                    let _ = tx.send(result);
+                    return true;
+                }
+            }
+            if attempt < REGISTER_GRACE_ATTEMPTS {
+                tokio::time::sleep(REGISTER_GRACE_STEP).await;
+            }
         }
-        drop(pending);
 
         let mut early = self.early_results.lock().await;
         const MAX_EARLY_RESULTS: usize = 256;
@@ -9704,10 +9725,16 @@ async fn control_actor_loop(
                     ControlCommand::ToolResult { tool_call_id, name, result, respond } => {
                         // Deliver to the tool hub. resolve() caches the result if
                         // no one has registered yet (resolve-before-register), and
-                        // reports whether a live waiter actually received it.
-                        let delivered = tool_hub.resolve(&tool_call_id, result).await;
-                        let _ = respond.send(delivered);
-                        tracing::debug!(tool_call_id = %tool_call_id, name = %name, delivered, "ToolResult delivered to hub");
+                        // reports whether a live waiter actually received it. It
+                        // may wait out a short grace window for an imminent
+                        // registration, so run it off the control loop to keep
+                        // command processing responsive.
+                        let hub = Arc::clone(&tool_hub);
+                        tokio::spawn(async move {
+                            let delivered = hub.resolve(&tool_call_id, result).await;
+                            let _ = respond.send(delivered);
+                            tracing::debug!(tool_call_id = %tool_call_id, name = %name, delivered, "ToolResult delivered to hub");
+                        });
                     }
                     ControlCommand::Cancel => {
                         if let Some(token) = &running_cancel {

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -3042,6 +3042,9 @@ pub enum ControlCommand {
         tool_call_id: String,
         name: String,
         result: serde_json::Value,
+        /// Reports whether the result reached a live waiter (`true`) or had to
+        /// be cached because no mission was registered for it (`false`).
+        respond: oneshot::Sender<bool>,
     },
     Cancel,
     /// Load a mission (switch to it)
@@ -3238,6 +3241,15 @@ pub struct SetMissionTitleRequest {
 pub struct FrontendToolHub {
     pending: Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>,
     early_results: Mutex<HashMap<String, serde_json::Value>>,
+    /// Missions currently blocked awaiting a human-provided frontend tool
+    /// result (e.g. `AskUserQuestion`). Ref-counted so a mission with more
+    /// than one concurrent frontend tool call is only cleared once its last
+    /// wait ends. The stuck-mission watchdog consults this so a mission that
+    /// is legitimately waiting for the user is never auto-interrupted for
+    /// "inactivity" — humans routinely take longer than the stall threshold
+    /// to answer. A `std::sync::Mutex` (not tokio) so `WaitingGuard::drop`
+    /// can release the slot synchronously on the cancellation path.
+    waiting_missions: std::sync::Mutex<HashMap<Uuid, usize>>,
 }
 
 impl FrontendToolHub {
@@ -3245,6 +3257,7 @@ impl FrontendToolHub {
         Self {
             pending: Mutex::new(HashMap::new()),
             early_results: Mutex::new(HashMap::new()),
+            waiting_missions: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -3268,12 +3281,18 @@ impl FrontendToolHub {
     }
 
     /// Resolve a pending tool call by id.
-    /// If no one has registered yet, the result is cached for later pickup.
-    pub async fn resolve(&self, tool_call_id: &str, result: serde_json::Value) -> Result<(), ()> {
+    ///
+    /// Returns `true` if a live waiter was registered (the result reached the
+    /// running mission). Returns `false` if no waiter was registered and the
+    /// result had to be cached in `early_results` — which, for a
+    /// human-answered question, almost always means the mission is no longer
+    /// running and the answer was dropped on the floor (the rare benign case
+    /// is a resolve-before-register race, impossible for a human to win).
+    pub async fn resolve(&self, tool_call_id: &str, result: serde_json::Value) -> bool {
         let mut pending = self.pending.lock().await;
         if let Some(tx) = pending.remove(tool_call_id) {
             let _ = tx.send(result);
-            return Ok(());
+            return true;
         }
         drop(pending);
 
@@ -3289,13 +3308,57 @@ impl FrontendToolHub {
             }
         }
         early.insert(tool_call_id.to_string(), result);
-        Ok(())
+        false
+    }
+
+    /// Mark `mission_id` as blocked on user input. The returned guard clears
+    /// the mark when dropped, which covers both the answered path (the parked
+    /// task proceeds and drops the guard) and the cancelled path (the task
+    /// returns early and the guard drops during unwind).
+    pub fn begin_waiting(hub: &Arc<Self>, mission_id: Uuid) -> WaitingGuard {
+        {
+            let mut waiting = hub.waiting_missions.lock().unwrap();
+            *waiting.entry(mission_id).or_insert(0) += 1;
+        }
+        WaitingGuard {
+            hub: Arc::clone(hub),
+            mission_id,
+        }
+    }
+
+    /// True while a mission is parked awaiting a human-provided tool result.
+    pub fn is_waiting_for_input(&self, mission_id: Uuid) -> bool {
+        self.waiting_missions
+            .lock()
+            .unwrap()
+            .get(&mission_id)
+            .is_some_and(|count| *count > 0)
     }
 }
 
 impl Default for FrontendToolHub {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// RAII guard that keeps a mission marked as "waiting for user input" in the
+/// [`FrontendToolHub`] for as long as it is held. Created via
+/// [`FrontendToolHub::begin_waiting`].
+pub struct WaitingGuard {
+    hub: Arc<FrontendToolHub>,
+    mission_id: Uuid,
+}
+
+impl Drop for WaitingGuard {
+    fn drop(&mut self) {
+        let mut waiting = self.hub.waiting_missions.lock().unwrap();
+        if let Some(count) = waiting.get_mut(&self.mission_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                waiting.remove(&self.mission_id);
+            }
+        }
     }
 }
 
@@ -3597,17 +3660,26 @@ pub async fn post_tool_result(
     }
 
     let control = control_for_user(&state, &user).await;
+    let (tx, rx) = oneshot::channel();
     control
         .cmd_tx
         .send(ControlCommand::ToolResult {
             tool_call_id: req.tool_call_id,
             name: req.name,
             result: req.result,
+            respond: tx,
         })
         .await
         .map_err(session_unavailable)?;
 
-    Ok(ok_json())
+    // Surface whether the answer reached a live, parked mission. When it did
+    // not, the mission has already ended (e.g. interrupted by the watchdog)
+    // and the answer was dropped — the UI uses this to stop claiming success
+    // and offer a resume instead.
+    let delivered = rx.await.unwrap_or(false);
+    Ok(Json(
+        serde_json::json!({ "ok": true, "delivered": delivered }),
+    ))
 }
 
 /// Cancel the currently running control session task.
@@ -6596,7 +6668,7 @@ fn spawn_control_session(
         mission_cmd_tx,
         events_tx.clone(),
         events_rx,
-        tool_hub,
+        tool_hub.clone(),
         status,
         current_mission,
         current_tree,
@@ -6645,6 +6717,7 @@ fn spawn_control_session(
             Arc::clone(&state.mission_store),
             state.cmd_tx.clone(),
             events_tx.clone(),
+            Arc::clone(&tool_hub),
         ));
         tokio::spawn(ack_promotion_loop(
             Arc::clone(&state.mission_store),
@@ -6977,6 +7050,7 @@ async fn stuck_mission_watchdog_loop(
     mission_store: Arc<dyn MissionStore>,
     cmd_tx: mpsc::Sender<ControlCommand>,
     events_tx: broadcast::Sender<AgentEvent>,
+    tool_hub: Arc<FrontendToolHub>,
 ) {
     use std::collections::HashSet;
 
@@ -7024,6 +7098,20 @@ async fn stuck_mission_watchdog_loop(
         // the row Interrupted.
         for info in &running_list {
             if info.seconds_since_activity >= STUCK_SECONDS {
+                // A mission parked on a frontend tool (e.g. AskUserQuestion) is
+                // intentionally silent: its harness is killed while it awaits a
+                // human answer, so it emits no activity. Do not count that as a
+                // stall — humans routinely take longer than the threshold to
+                // reply. The wait is cleared the moment the answer arrives (or
+                // the mission is cancelled), so this can't pin a dead mission.
+                if tool_hub.is_waiting_for_input(info.mission_id) {
+                    tracing::debug!(
+                        mission_id = %info.mission_id,
+                        seconds_since_activity = info.seconds_since_activity,
+                        "Stuck-mission watchdog: skipping mission blocked on user input"
+                    );
+                    continue;
+                }
                 tracing::warn!(
                     "Stuck-mission watchdog: cancelling {} after {}s of inactivity",
                     info.mission_id,
@@ -9613,11 +9701,13 @@ async fn control_actor_loop(
                         }
                         let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
                     }
-                    ControlCommand::ToolResult { tool_call_id, name, result } => {
+                    ControlCommand::ToolResult { tool_call_id, name, result, respond } => {
                         // Deliver to the tool hub. resolve() caches the result if
-                        // no one has registered yet (resolve-before-register).
-                        let _ = tool_hub.resolve(&tool_call_id, result).await;
-                        tracing::debug!(tool_call_id = %tool_call_id, name = %name, "ToolResult delivered to hub");
+                        // no one has registered yet (resolve-before-register), and
+                        // reports whether a live waiter actually received it.
+                        let delivered = tool_hub.resolve(&tool_call_id, result).await;
+                        let _ = respond.send(delivered);
+                        tracing::debug!(tool_call_id = %tool_call_id, name = %name, delivered, "ToolResult delivered to hub");
                     }
                     ControlCommand::Cancel => {
                         if let Some(token) = &running_cancel {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -13163,6 +13163,84 @@ fn contains_ascii_word(haystack: &str, needle: &str) -> bool {
     false
 }
 
+/// Pull the "try again at <when>" reset window Codex appends to its usage-limit
+/// message, e.g. `Jun 11th, 2026 3:00 AM`. Returns the raw human string (without
+/// the trailing period) so it can be shown verbatim, since Codex does not
+/// include the timezone.
+fn extract_codex_reset_window(output: &str) -> Option<String> {
+    // The message is ASCII, so a case-insensitive byte search keeps offsets
+    // aligned with `output`.
+    let lower = output.to_ascii_lowercase();
+    let marker = "try again at ";
+    let start = lower.find(marker)? + marker.len();
+    let rest = &output[start..];
+    // Codex ends the sentence with a period; stop at that (or a newline).
+    let end = rest.find(['.', '\n']).unwrap_or(rest.len());
+    let window = rest[..end].trim();
+    (!window.is_empty()).then(|| window.to_string())
+}
+
+/// Best-effort parse of a Codex reset window into a comparable timestamp so the
+/// aggregated message can report the *earliest* reset across accounts. Returns
+/// `None` (and the caller falls back to display order) when the format drifts.
+fn parse_codex_reset_window(window: &str) -> Option<chrono::NaiveDateTime> {
+    // Drop the ordinal suffix that always precedes the comma ("11th," -> "11,").
+    let cleaned = window
+        .replace("th,", ",")
+        .replace("st,", ",")
+        .replace("nd,", ",")
+        .replace("rd,", ",");
+    for fmt in ["%b %d, %Y %I:%M %p", "%b %e, %Y %I:%M %p"] {
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(cleaned.trim(), fmt) {
+            return Some(dt);
+        }
+    }
+    None
+}
+
+/// Build a single user-facing message for the case where rotation tried every
+/// connected Codex account and they were *all* at their ChatGPT usage limit.
+/// Without this the runner just echoes the last account's raw "try again at …"
+/// line, which is identical to the first account's and reads as if no rotation
+/// happened at all.
+fn summarize_codex_usage_caps(capped_outputs: &[String], account_count: usize) -> String {
+    // Distinct reset windows, soonest first when parseable.
+    let mut windows: Vec<(Option<chrono::NaiveDateTime>, String)> = Vec::new();
+    for output in capped_outputs {
+        if let Some(window) = extract_codex_reset_window(output) {
+            if !windows.iter().any(|(_, existing)| existing == &window) {
+                windows.push((parse_codex_reset_window(&window), window));
+            }
+        }
+    }
+    windows.sort_by(|a, b| match (a.0, b.0) {
+        (Some(x), Some(y)) => x.cmp(&y),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+
+    let mut msg = format!(
+        "All {} connected Codex account{} are at their ChatGPT usage limit.",
+        account_count,
+        if account_count == 1 { "" } else { "s" }
+    );
+    match windows.split_first() {
+        Some(((_, earliest), [])) => {
+            msg.push_str(&format!(" Usage resets at {earliest}."));
+        }
+        Some(((_, earliest), _rest)) => {
+            msg.push_str(&format!(" Earliest reset at {earliest}."));
+        }
+        None => {}
+    }
+    msg.push_str(
+        " Connect a Codex account with available quota (or an OpenAI API key), \
+         switch this mission to another backend, or wait for the reset.",
+    );
+    msg
+}
+
 /// Run a codex turn through the unified credential pool with rotation and
 /// account-level cooldown handling. Shared by the initial mission dispatch
 /// and the control-channel follow-up path so a usage-capped ChatGPT account
@@ -13280,6 +13358,10 @@ pub(crate) async fn run_codex_turn_with_rotation(
         {
             let mut attempted_credentials: HashSet<String> = HashSet::new();
             let mut attempt_idx = 0usize;
+            // Raw outputs of attempts that failed specifically on a usage cap,
+            // so an exhausted pool can be summarized instead of echoing the
+            // last account's bare "try again at …" message.
+            let mut usage_capped_outputs: Vec<String> = Vec::new();
             let mut last_constrained_result: Option<AgentResult> = prior_empty_result;
 
             loop {
@@ -13400,6 +13482,16 @@ pub(crate) async fn run_codex_turn_with_rotation(
                 }
                 drop(lease);
 
+                // Record usage-cap failures so an all-capped pool can be
+                // summarized. Auth errors rotate too but aren't usage caps,
+                // so they're deliberately excluded from this tally.
+                if matches!(
+                    result.terminal_reason,
+                    Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
+                ) {
+                    usage_capped_outputs.push(result.output.clone());
+                }
+
                 match result.terminal_reason {
                     Some(
                         TerminalReason::RateLimited
@@ -13421,7 +13513,24 @@ pub(crate) async fn run_codex_turn_with_rotation(
                         );
                         last_constrained_result = Some(result);
                     }
-                    _ => break result,
+                    _ => {
+                        // When rotation tried multiple accounts and every one
+                        // was usage-capped, replace the last account's raw
+                        // message with an aggregate that makes the rotation
+                        // visible and names the soonest reset.
+                        let exhausted_all_on_usage_caps = matches!(
+                            result.terminal_reason,
+                            Some(TerminalReason::RateLimited | TerminalReason::CapacityLimited)
+                        ) && usage_capped_outputs.len() >= 2
+                            && usage_capped_outputs.len() == attempt_idx;
+                        if exhausted_all_on_usage_caps {
+                            result.output = summarize_codex_usage_caps(
+                                &usage_capped_outputs,
+                                usage_capped_outputs.len(),
+                            );
+                        }
+                        break result;
+                    }
                 }
             }
         }
@@ -14844,23 +14953,25 @@ mod tests {
         codex_key_fingerprint, codex_missing_goal_final_response_message,
         codex_tool_stall_should_retry_with_default_model, codex_turn_requires_tool_activity,
         custom_opencode_provider_definition, ensure_opencode_provider_for_model,
-        extract_model_from_message, extract_opencode_session_id, extract_part_text, extract_str,
-        is_capacity_limited_error, is_codex_chatgpt_account_model_blocked, is_codex_node_wrapper,
-        is_provider_payload_error, is_rate_limited_error, is_session_corruption_error,
-        is_success_path_auth_error, is_success_path_provider_payload_error,
-        is_success_path_rate_limited_error, is_tool_call_only_output,
-        opencode_goal_terminal_status, opencode_idle_timeout_result_message,
-        opencode_output_needs_fallback, opencode_session_token_from_line,
-        parse_opencode_goal_objective, parse_opencode_session_token, parse_opencode_sse_event,
-        parse_opencode_stderr_text_part, preferred_model_for_cost, record_codex_error_message,
+        extract_codex_reset_window, extract_model_from_message, extract_opencode_session_id,
+        extract_part_text, extract_str, is_capacity_limited_error,
+        is_codex_chatgpt_account_model_blocked, is_codex_node_wrapper, is_provider_payload_error,
+        is_rate_limited_error, is_session_corruption_error, is_success_path_auth_error,
+        is_success_path_provider_payload_error, is_success_path_rate_limited_error,
+        is_tool_call_only_output, opencode_goal_terminal_status,
+        opencode_idle_timeout_result_message, opencode_output_needs_fallback,
+        opencode_session_token_from_line, parse_opencode_goal_objective,
+        parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
+        preferred_model_for_cost, record_codex_error_message,
         replace_filepath_artifact_with_tool_output, resolve_cost_cents_and_source, running_health,
         sanitized_opencode_stdout, set_codex_account_cooldown, stall_severity, strip_ansi_codes,
-        strip_opencode_banner_lines, strip_think_tags, summarize_recent_opencode_stderr,
-        thinking_overlaps_visible_answer, use_thinking_only_fallback, utf8_safe_prefix,
-        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
-        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
-        OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
-        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        strip_opencode_banner_lines, strip_think_tags, summarize_codex_usage_caps,
+        summarize_recent_opencode_stderr, thinking_overlaps_visible_answer,
+        use_thinking_only_fallback, utf8_safe_prefix, ClaudeIncompleteTurnContext,
+        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
+        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState,
+        CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN, CODEX_RATE_LIMIT_COOLDOWN,
+        STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -14874,6 +14985,47 @@ mod tests {
     use std::fs;
     use std::time::Duration;
     use uuid::Uuid;
+
+    #[test]
+    fn extract_codex_reset_window_pulls_the_reset_time() {
+        let msg = "You've hit your usage limit. Visit \
+                   https://chatgpt.com/codex/settings/usage to purchase more credits \
+                   or try again at Jun 11th, 2026 3:00 AM.";
+        assert_eq!(
+            extract_codex_reset_window(msg).as_deref(),
+            Some("Jun 11th, 2026 3:00 AM")
+        );
+        assert_eq!(extract_codex_reset_window("some other error"), None);
+    }
+
+    #[test]
+    fn summarize_codex_usage_caps_reports_earliest_reset() {
+        // Two distinct accounts, different reset windows. The summary should
+        // name the soonest (2:26 AM), not whichever was tried last.
+        let outputs = vec![
+            "You've hit your usage limit. … try again at Jun 11th, 2026 3:00 AM.".to_string(),
+            "You've hit your usage limit. … try again at Jun 11th, 2026 2:26 AM.".to_string(),
+        ];
+        let summary = summarize_codex_usage_caps(&outputs, 2);
+        assert!(
+            summary.contains("All 2 connected Codex accounts are at their ChatGPT usage limit"),
+            "unexpected summary: {summary}"
+        );
+        assert!(
+            summary.contains("Earliest reset at Jun 11th, 2026 2:26 AM."),
+            "should report the soonest reset: {summary}"
+        );
+    }
+
+    #[test]
+    fn summarize_codex_usage_caps_single_window_uses_resets_at() {
+        let outputs = vec![
+            "hit your usage limit … try again at Jun 11th, 2026 3:00 AM.".to_string(),
+            "hit your usage limit … try again at Jun 11th, 2026 3:00 AM.".to_string(),
+        ];
+        let summary = summarize_codex_usage_caps(&outputs, 2);
+        assert!(summary.contains("Usage resets at Jun 11th, 2026 3:00 AM."));
+    }
 
     #[test]
     fn grok_typed_reasoning_event_is_not_answer_text() {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5524,6 +5524,13 @@ pub fn run_claudecode_turn<'a>(
                                                             )
                                                             .await;
                                                         }
+                                                        // Mark the mission as waiting on the user so the
+                                                        // stuck-mission watchdog does not interrupt it for
+                                                        // "inactivity" while it is parked here. The guard
+                                                        // clears the mark on every exit path (answered or
+                                                        // cancelled).
+                                                        let wait_guard =
+                                                            FrontendToolHub::begin_waiting(&hub, mission_id);
                                                         let rx = hub.register(id.clone()).await;
 
                                                         pty.kill();
@@ -5545,6 +5552,10 @@ pub fn run_claudecode_turn<'a>(
                                                                 }
                                                             }
                                                         };
+                                                        // Answer received — the mission is active again and
+                                                        // resumes emitting events, so release the watchdog
+                                                        // exemption before running the continuation turn.
+                                                        drop(wait_guard);
 
                                                         if let Some(ref status_ref) = status {
                                                             set_control_state_for_mission(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,7 @@ mod auth;
 pub mod automation_variables;
 pub mod backends;
 pub mod claudecode;
+pub mod codex_usage;
 mod console;
 pub mod control;
 pub mod control_metrics;

--- a/src/api/model_routing.rs
+++ b/src/api/model_routing.rs
@@ -47,6 +47,7 @@ struct ChainResponse {
     name: String,
     entries: Vec<ChainEntryResponse>,
     is_default: bool,
+    strip_thinking: bool,
     created_at: chrono::DateTime<chrono::Utc>,
     updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -71,6 +72,7 @@ impl From<ModelChain> for ChainResponse {
                 })
                 .collect(),
             is_default: chain.is_default,
+            strip_thinking: chain.strip_thinking,
             created_at: chain.created_at,
             updated_at: chain.updated_at,
         }
@@ -105,6 +107,8 @@ struct CreateChainRequest {
     entries: Vec<ChainEntryRequest>,
     #[serde(default)]
     is_default: bool,
+    #[serde(default)]
+    strip_thinking: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -169,6 +173,7 @@ async fn create_chain(
             })
             .collect(),
         is_default: req.is_default,
+        strip_thinking: req.strip_thinking,
         created_at: now,
         updated_at: now,
     };
@@ -182,6 +187,7 @@ struct UpdateChainRequest {
     name: Option<String>,
     entries: Option<Vec<ChainEntryRequest>>,
     is_default: Option<bool>,
+    strip_thinking: Option<bool>,
 }
 
 /// PUT /api/model-routing/chains/:id - Update a chain.
@@ -230,6 +236,10 @@ async fn update_chain(
 
     if let Some(is_default) = req.is_default {
         chain.is_default = is_default;
+    }
+
+    if let Some(strip_thinking) = req.strip_thinking {
+        chain.strip_thinking = strip_thinking;
     }
 
     state.chain_store.upsert(chain.clone()).await;

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -2710,15 +2710,34 @@ fn normalize_sse_stream(
     inner: impl futures::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
     strip_thinking: bool,
 ) -> impl futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + 'static {
+    // State carries the stream, the line buffer, the cross-chunk `<think>`
+    // stripper, a remembered chunk envelope (id/model/created — used to build a
+    // synthetic flush chunk for any text the stripper held back), and a flag so
+    // we flush that held-back text exactly once.
     futures::stream::unfold(
-        (Box::pin(inner), Vec::<u8>::new(), ThinkStripper::default()),
-        move |(mut stream, mut buf, mut stripper)| async move {
+        (
+            Box::pin(inner),
+            Vec::<u8>::new(),
+            ThinkStripper::default(),
+            Option::<serde_json::Value>::None,
+            false,
+        ),
+        move |(mut stream, mut buf, mut stripper, mut envelope, mut flushed)| async move {
             loop {
                 // Check if we have a complete line in the buffer
                 if let Some(pos) = buf.iter().position(|&b| b == b'\n') {
                     let line = buf.drain(..=pos).collect::<Vec<u8>>();
-                    let normalized = normalize_sse_line(&line, strip_thinking, &mut stripper);
-                    return Some((Ok(bytes::Bytes::from(normalized)), (stream, buf, stripper)));
+                    let normalized = normalize_sse_line(
+                        &line,
+                        strip_thinking,
+                        &mut stripper,
+                        &mut envelope,
+                        &mut flushed,
+                    );
+                    return Some((
+                        Ok(bytes::Bytes::from(normalized)),
+                        (stream, buf, stripper, envelope, flushed),
+                    ));
                 }
 
                 // Need more data
@@ -2729,18 +2748,43 @@ fn normalize_sse_stream(
                     Some(Err(e)) => {
                         return Some((
                             Err(std::io::Error::other(e.to_string())),
-                            (stream, buf, stripper),
+                            (stream, buf, stripper, envelope, flushed),
                         ));
                     }
                     None => {
-                        // Stream ended — flush remaining buffer
-                        if buf.is_empty() {
-                            return None;
+                        // Stream ended — flush remaining buffer first.
+                        if !buf.is_empty() {
+                            let remaining = std::mem::take(&mut buf);
+                            let normalized = normalize_sse_line(
+                                &remaining,
+                                strip_thinking,
+                                &mut stripper,
+                                &mut envelope,
+                                &mut flushed,
+                            );
+                            return Some((
+                                Ok(bytes::Bytes::from(normalized)),
+                                (stream, buf, stripper, envelope, flushed),
+                            ));
                         }
-                        let remaining = std::mem::take(&mut buf);
-                        let normalized =
-                            normalize_sse_line(&remaining, strip_thinking, &mut stripper);
-                        return Some((Ok(bytes::Bytes::from(normalized)), (stream, buf, stripper)));
+                        // Fallback flush for providers that end the stream without
+                        // a `[DONE]` terminator (the `[DONE]` path flushes inline,
+                        // before the terminator, so it doesn't reach here).
+                        if strip_thinking && !flushed {
+                            flushed = true;
+                            let leftover = stripper.flush();
+                            if !leftover.is_empty() {
+                                if let Some(chunk_line) =
+                                    build_flush_chunk_line(envelope.as_ref(), &leftover, b"\n")
+                                {
+                                    return Some((
+                                        Ok(bytes::Bytes::from(chunk_line)),
+                                        (stream, buf, stripper, envelope, flushed),
+                                    ));
+                                }
+                            }
+                        }
+                        return None;
                     }
                 }
             }
@@ -2750,7 +2794,13 @@ fn normalize_sse_stream(
 
 /// Normalize a single SSE line.  If it's a `data: {...}` line, parse and
 /// fix known provider quirks; otherwise pass through unchanged.
-fn normalize_sse_line(line: &[u8], strip_thinking: bool, stripper: &mut ThinkStripper) -> Vec<u8> {
+fn normalize_sse_line(
+    line: &[u8],
+    strip_thinking: bool,
+    stripper: &mut ThinkStripper,
+    envelope: &mut Option<serde_json::Value>,
+    flushed: &mut bool,
+) -> Vec<u8> {
     let trimmed = line
         .strip_suffix(b"\r\n")
         .or_else(|| line.strip_suffix(b"\n"))
@@ -2763,12 +2813,27 @@ fn normalize_sse_line(line: &[u8], strip_thinking: bool, stripper: &mut ThinkStr
 
     let json_bytes = &trimmed[data_prefix.len()..];
 
-    // "data: [DONE]" — pass through
+    // "data: [DONE]" — terminator. Before passing it through, emit any literal
+    // text the stripper held back at the last chunk boundary (e.g. a reply
+    // ending in `<` or `</thi`), so it isn't lost. It must precede `[DONE]`
+    // because clients stop reading at the terminator.
     let json_trimmed: &[u8] = {
         let s = std::str::from_utf8(json_bytes).unwrap_or("");
         s.trim().as_bytes()
     };
     if json_trimmed == b"[DONE]" {
+        if strip_thinking && !*flushed {
+            *flushed = true;
+            let leftover = stripper.flush();
+            if !leftover.is_empty() {
+                if let Some(mut chunk_line) =
+                    build_flush_chunk_line(envelope.as_ref(), &leftover, line)
+                {
+                    chunk_line.extend_from_slice(line);
+                    return chunk_line;
+                }
+            }
+        }
         return line.to_vec();
     }
 
@@ -2808,6 +2873,15 @@ fn normalize_sse_line(line: &[u8], strip_thinking: bool, stripper: &mut ThinkStr
         }
     }
 
+    // Remember the first envelope that has a `choices` array so an end-of-stream
+    // flush chunk can reuse its id/model/created framing.
+    if strip_thinking
+        && envelope.is_none()
+        && chunk.get("choices").and_then(|v| v.as_array()).is_some()
+    {
+        *envelope = Some(chunk.clone());
+    }
+
     if !modified {
         return line.to_vec();
     }
@@ -2824,6 +2898,44 @@ fn normalize_sse_line(line: &[u8], strip_thinking: bool, stripper: &mut ThinkStr
     let _ = serde_json::to_writer(&mut out, &chunk);
     out.extend_from_slice(suffix);
     out
+}
+
+/// Build a synthetic `data: {...}` SSE event carrying `leftover` as the first
+/// choice's `delta.content`, reusing `envelope` (a remembered chunk) for the
+/// id/model/created framing. Used to emit text the [`ThinkStripper`] held back
+/// at the final chunk boundary. Returns `None` when there is no usable
+/// envelope. The event is terminated with a blank line so clients treat it as
+/// its own SSE event.
+fn build_flush_chunk_line(
+    envelope: Option<&serde_json::Value>,
+    leftover: &str,
+    ref_line: &[u8],
+) -> Option<Vec<u8>> {
+    let mut chunk = envelope?.clone();
+    let choices = chunk.get_mut("choices")?.as_array_mut()?;
+    let first = choices.first_mut()?.as_object_mut()?;
+    let mut delta = serde_json::Map::new();
+    delta.insert(
+        "content".to_string(),
+        serde_json::Value::String(leftover.to_string()),
+    );
+    first.insert("delta".to_string(), serde_json::Value::Object(delta));
+    // A leftover-content chunk is not a terminal chunk.
+    first.remove("finish_reason");
+    // Keep only the first choice — we only carry single-choice leftover text.
+    choices.truncate(1);
+
+    let suffix: &[u8] = if ref_line.ends_with(b"\r\n") {
+        b"\r\n"
+    } else {
+        b"\n"
+    };
+    let mut out = Vec::from(&b"data: "[..]);
+    serde_json::to_writer(&mut out, &chunk).ok()?;
+    // Event line terminator + blank line separating this from the next event.
+    out.extend_from_slice(suffix);
+    out.extend_from_slice(suffix);
+    Some(out)
 }
 
 /// Wrap a streaming response to defer health tracking until the stream finishes.
@@ -4557,6 +4669,51 @@ mod tests {
         let body = Bytes::from(r#"{"choices":[{"message":{"content":"plain answer"}}]}"#);
         let out = strip_thinking_from_completion(&body);
         assert_eq!(out, body);
+    }
+
+    #[test]
+    fn normalize_sse_line_flushes_leftover_before_done() {
+        // Regression: a streamed reply whose final content delta ends in a
+        // tag-prefix char (`<`) had that char held back by the stripper and
+        // never emitted, because the stream-end flush ran after `[DONE]`.
+        let mut stripper = ThinkStripper::default();
+        let mut envelope = None;
+        let mut flushed = false;
+
+        // First content chunk — establishes the envelope, no tags to strip.
+        let l1 = b"data: {\"id\":\"x\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n";
+        let out1 = normalize_sse_line(l1, true, &mut stripper, &mut envelope, &mut flushed);
+        assert_eq!(out1, l1.to_vec());
+
+        // Final content chunk ends with `<` — a tag-prefix, so it is held back.
+        let l2 = b"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"a <\"}}]}\n";
+        let out2 = normalize_sse_line(l2, true, &mut stripper, &mut envelope, &mut flushed);
+        let s2 = String::from_utf8(out2).unwrap();
+        assert!(
+            s2.contains(r#""content":"a ""#),
+            "expected held-back `<`, got: {s2}"
+        );
+
+        // `[DONE]` — the held-back `<` must be emitted, and before the terminator.
+        let done = b"data: [DONE]\n";
+        let out3 = normalize_sse_line(done, true, &mut stripper, &mut envelope, &mut flushed);
+        let s3 = String::from_utf8(out3).unwrap();
+        let content_pos = s3
+            .find(r#""content":"<""#)
+            .unwrap_or_else(|| panic!("leftover `<` not flushed: {s3}"));
+        let done_pos = s3.find("[DONE]").unwrap();
+        assert!(content_pos < done_pos, "leftover must precede [DONE]: {s3}");
+    }
+
+    #[test]
+    fn normalize_sse_line_done_passthrough_when_nothing_held_back() {
+        // No leftover → `[DONE]` passes through untouched (no synthetic chunk).
+        let mut stripper = ThinkStripper::default();
+        let mut envelope = None;
+        let mut flushed = false;
+        let done = b"data: [DONE]\n";
+        let out = normalize_sse_line(done, true, &mut stripper, &mut envelope, &mut flushed);
+        assert_eq!(out, done.to_vec());
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -537,6 +537,16 @@ pub(crate) async fn chat_completions_inner(
         );
     };
 
+    // Per-chain post-processing: strip `<think>` markup from responses for
+    // chains routed to models that leak reasoning into `content`. Direct
+    // provider/model passthrough ids aren't chains, so this resolves to false.
+    let strip_thinking = state
+        .chain_store
+        .get(&chain_id)
+        .await
+        .map(|c| c.strip_thinking)
+        .unwrap_or(false);
+
     if entries.is_empty() {
         if defer_on_rate_limit {
             return enqueue_deferred_request(&state, &headers, &chain_id, &body).await;
@@ -1663,7 +1673,7 @@ pub(crate) async fn chat_completions_inner(
                 Ok::<_, reqwest::Error>(bytes::Bytes::from(peek_buf))
             });
             let combined = peek_stream.chain(byte_stream);
-            let byte_stream = normalize_sse_stream(combined);
+            let byte_stream = normalize_sse_stream(combined, strip_thinking);
 
             // Wrap the stream to record success/failure on completion.
             let tracked_stream = track_stream_health(
@@ -1776,6 +1786,13 @@ pub(crate) async fn chat_completions_inner(
                         state.health_tracker.record_fallback_event(evt).await;
                     }
                 }
+                // Strip `<think>` markup from the completion body when the
+                // chain opts in (only meaningful on successful responses).
+                let resp_body = if strip_thinking && status.is_success() {
+                    strip_thinking_from_completion(&resp_body)
+                } else {
+                    resp_body
+                };
                 let mut builder = Response::builder().status(status);
                 if let Some(ct) = response_headers.get(header::CONTENT_TYPE) {
                     builder = builder.header(header::CONTENT_TYPE, ct);
@@ -2541,22 +2558,167 @@ fn classify_embedded_error(v: &serde_json::Value) -> CooldownReason {
     CooldownReason::ServerError
 }
 
+const THINK_OPEN: &str = "<think>";
+const THINK_CLOSE: &str = "</think>";
+
+/// Incrementally strips model "thinking" markup from text: `<think>…</think>`
+/// blocks and stray orphan `</think>` tags. Some reasoning models prefill the
+/// opening `<think>` in the prompt template and emit only the closing tag, so
+/// orphan `</think>` must be dropped too. State persists across calls so a tag
+/// split across SSE deltas is handled correctly.
+#[derive(Default)]
+struct ThinkStripper {
+    /// True while inside an open `<think>` block.
+    inside: bool,
+    /// Trailing text held back because it may be the start of a tag that
+    /// continues in the next chunk.
+    pending: String,
+}
+
+impl ThinkStripper {
+    /// Feed a chunk of content; returns the text to emit. A partial tag at the
+    /// end is buffered until the next `feed`/`flush`.
+    fn feed(&mut self, input: &str) -> String {
+        let mut data = std::mem::take(&mut self.pending);
+        data.push_str(input);
+        let mut out = String::new();
+        loop {
+            if self.inside {
+                if let Some(pos) = data.find(THINK_CLOSE) {
+                    data.drain(..pos + THINK_CLOSE.len());
+                    self.inside = false;
+                    continue;
+                }
+                // No close yet — hold back a possible partial closing tag.
+                let keep = longest_tag_prefix_suffix(&data, &[THINK_CLOSE]);
+                self.pending = data.split_off(data.len() - keep);
+                return out;
+            }
+            // Outside a block: act on whichever of `<think>`/`</think>` is first.
+            match earliest_tag(data.find(THINK_OPEN), data.find(THINK_CLOSE)) {
+                Some((pos, true)) => {
+                    out.push_str(&data[..pos]);
+                    data.drain(..pos + THINK_OPEN.len());
+                    self.inside = true;
+                }
+                Some((pos, false)) => {
+                    // Orphan closing tag — emit preceding text, drop the tag.
+                    out.push_str(&data[..pos]);
+                    data.drain(..pos + THINK_CLOSE.len());
+                }
+                None => {
+                    let keep = longest_tag_prefix_suffix(&data, &[THINK_OPEN, THINK_CLOSE]);
+                    let emit_to = data.len() - keep;
+                    out.push_str(&data[..emit_to]);
+                    self.pending = data.split_off(emit_to);
+                    return out;
+                }
+            }
+        }
+    }
+
+    /// Flush buffered text at end of stream. Leftover `pending` that never
+    /// completed a tag is literal content; drop it if still inside a block
+    /// (unterminated reasoning).
+    fn flush(&mut self) -> String {
+        let pending = std::mem::take(&mut self.pending);
+        if self.inside {
+            String::new()
+        } else {
+            pending
+        }
+    }
+}
+
+/// Of two optional `<think>`/`</think>` byte positions, return (pos, is_open)
+/// for whichever appears first.
+fn earliest_tag(open: Option<usize>, close: Option<usize>) -> Option<(usize, bool)> {
+    match (open, close) {
+        (Some(o), Some(c)) => Some(if o <= c { (o, true) } else { (c, false) }),
+        (Some(o), None) => Some((o, true)),
+        (None, Some(c)) => Some((c, false)),
+        (None, None) => None,
+    }
+}
+
+/// Length (bytes) of the longest suffix of `data` that is a proper prefix of
+/// any tag — the slice to hold back at a chunk boundary in case the tag
+/// continues. Tags are ASCII, so suffix boundaries are always valid.
+fn longest_tag_prefix_suffix(data: &str, tags: &[&str]) -> usize {
+    let upper = tags
+        .iter()
+        .map(|t| t.len() - 1)
+        .max()
+        .unwrap_or(0)
+        .min(data.len());
+    for len in (1..=upper).rev() {
+        let start = data.len() - len;
+        if !data.is_char_boundary(start) {
+            continue;
+        }
+        let suffix = &data[start..];
+        if tags.iter().any(|t| t.len() > len && t.starts_with(suffix)) {
+            return len;
+        }
+    }
+    0
+}
+
+/// Strip `<think>` markup from a non-streaming chat-completion JSON body's
+/// `choices[].message.content`. Returns the original bytes on parse failure or
+/// when nothing changed.
+fn strip_thinking_from_completion(body: &bytes::Bytes) -> bytes::Bytes {
+    let mut v: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => return body.clone(),
+    };
+    let mut changed = false;
+    if let Some(choices) = v.get_mut("choices").and_then(|c| c.as_array_mut()) {
+        for choice in choices {
+            if let Some(msg) = choice.get_mut("message").and_then(|m| m.as_object_mut()) {
+                if let Some(content) = msg
+                    .get("content")
+                    .and_then(|c| c.as_str())
+                    .map(|s| s.to_string())
+                {
+                    let mut st = ThinkStripper::default();
+                    let mut stripped = st.feed(&content);
+                    stripped.push_str(&st.flush());
+                    if stripped != content {
+                        msg.insert("content".into(), serde_json::Value::String(stripped));
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+    if !changed {
+        return body.clone();
+    }
+    serde_json::to_vec(&v)
+        .map(bytes::Bytes::from)
+        .unwrap_or_else(|_| body.clone())
+}
+
 /// Normalize an SSE byte stream to fix provider-specific quirks.
 ///
 /// Processes `data:` lines, parses the JSON chunk, and strips fields that
 /// break OpenAI-compatible clients (e.g. MiniMax sending `delta.role: ""`).
+/// When `strip_thinking` is set, also removes `<think>…</think>` markup from
+/// streamed `delta.content` (state threaded across chunks).
 fn normalize_sse_stream(
     inner: impl futures::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+    strip_thinking: bool,
 ) -> impl futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + 'static {
     futures::stream::unfold(
-        (Box::pin(inner), Vec::<u8>::new()),
-        |(mut stream, mut buf)| async move {
+        (Box::pin(inner), Vec::<u8>::new(), ThinkStripper::default()),
+        move |(mut stream, mut buf, mut stripper)| async move {
             loop {
                 // Check if we have a complete line in the buffer
                 if let Some(pos) = buf.iter().position(|&b| b == b'\n') {
                     let line = buf.drain(..=pos).collect::<Vec<u8>>();
-                    let normalized = normalize_sse_line(&line);
-                    return Some((Ok(bytes::Bytes::from(normalized)), (stream, buf)));
+                    let normalized = normalize_sse_line(&line, strip_thinking, &mut stripper);
+                    return Some((Ok(bytes::Bytes::from(normalized)), (stream, buf, stripper)));
                 }
 
                 // Need more data
@@ -2565,7 +2727,10 @@ fn normalize_sse_stream(
                         buf.extend_from_slice(&chunk);
                     }
                     Some(Err(e)) => {
-                        return Some((Err(std::io::Error::other(e.to_string())), (stream, buf)));
+                        return Some((
+                            Err(std::io::Error::other(e.to_string())),
+                            (stream, buf, stripper),
+                        ));
                     }
                     None => {
                         // Stream ended — flush remaining buffer
@@ -2573,8 +2738,9 @@ fn normalize_sse_stream(
                             return None;
                         }
                         let remaining = std::mem::take(&mut buf);
-                        let normalized = normalize_sse_line(&remaining);
-                        return Some((Ok(bytes::Bytes::from(normalized)), (stream, buf)));
+                        let normalized =
+                            normalize_sse_line(&remaining, strip_thinking, &mut stripper);
+                        return Some((Ok(bytes::Bytes::from(normalized)), (stream, buf, stripper)));
                     }
                 }
             }
@@ -2584,7 +2750,7 @@ fn normalize_sse_stream(
 
 /// Normalize a single SSE line.  If it's a `data: {...}` line, parse and
 /// fix known provider quirks; otherwise pass through unchanged.
-fn normalize_sse_line(line: &[u8]) -> Vec<u8> {
+fn normalize_sse_line(line: &[u8], strip_thinking: bool, stripper: &mut ThinkStripper) -> Vec<u8> {
     let trimmed = line
         .strip_suffix(b"\r\n")
         .or_else(|| line.strip_suffix(b"\n"))
@@ -2613,13 +2779,30 @@ fn normalize_sse_line(line: &[u8]) -> Vec<u8> {
 
     let mut modified = false;
 
-    // Fix MiniMax: strip empty `delta.role` field
+    // Fix MiniMax: strip empty `delta.role` field, and (when enabled) strip
+    // `<think>` markup from streamed `delta.content`.
     if let Some(choices) = chunk.get_mut("choices").and_then(|v| v.as_array_mut()) {
         for choice in choices {
             if let Some(delta) = choice.get_mut("delta").and_then(|v| v.as_object_mut()) {
                 if delta.get("role").and_then(|v| v.as_str()) == Some("") {
                     delta.remove("role");
                     modified = true;
+                }
+                if strip_thinking {
+                    if let Some(content) = delta
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                    {
+                        // Always feed so the stripper's cross-chunk state
+                        // advances, even when the chunk is unchanged.
+                        let stripped = stripper.feed(&content);
+                        if stripped != content {
+                            delta
+                                .insert("content".to_string(), serde_json::Value::String(stripped));
+                            modified = true;
+                        }
+                    }
                 }
             }
         }
@@ -4304,6 +4487,77 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use futures::StreamExt;
+
+    /// Feed an input as a single chunk and flush; the full-content path.
+    fn strip_once(input: &str) -> String {
+        let mut s = ThinkStripper::default();
+        let mut out = s.feed(input);
+        out.push_str(&s.flush());
+        out
+    }
+
+    #[test]
+    fn think_stripper_removes_full_block() {
+        assert_eq!(strip_once("<think>reasoning here</think>Hello"), "Hello");
+    }
+
+    #[test]
+    fn think_stripper_removes_orphan_closing_tag() {
+        // MiniMax prefills `<think>` in the prompt, so only the closing tag is
+        // emitted — the symptom seen in the Hermes Telegram gateway.
+        assert_eq!(strip_once("</think>\n\nThe answer"), "\n\nThe answer");
+    }
+
+    #[test]
+    fn think_stripper_handles_repeated_orphans() {
+        assert_eq!(strip_once("</think>a</think>b</think>c"), "abc");
+    }
+
+    #[test]
+    fn think_stripper_passes_through_plain_text() {
+        assert_eq!(strip_once("just a normal answer"), "just a normal answer");
+    }
+
+    #[test]
+    fn think_stripper_handles_tag_split_across_chunks() {
+        let mut s = ThinkStripper::default();
+        // `</think>` arrives split: "</thi" then "nk>answer".
+        assert_eq!(s.feed("foo</thi"), "foo");
+        assert_eq!(s.feed("nk>answer"), "answer");
+        assert_eq!(s.flush(), "");
+    }
+
+    #[test]
+    fn think_stripper_block_split_across_chunks() {
+        let mut s = ThinkStripper::default();
+        assert_eq!(s.feed("<think>some "), "");
+        assert_eq!(s.feed("long reasoning"), "");
+        assert_eq!(s.feed("</think>visible"), "visible");
+        assert_eq!(s.flush(), "");
+    }
+
+    #[test]
+    fn think_stripper_drops_unterminated_block() {
+        // An open block with no close = trailing reasoning; drop it.
+        assert_eq!(strip_once("answer<think>cut off"), "answer");
+    }
+
+    #[test]
+    fn strip_thinking_from_completion_rewrites_message_content() {
+        let body = Bytes::from(
+            r#"{"choices":[{"message":{"role":"assistant","content":"</think>Hi there"}}]}"#,
+        );
+        let out = strip_thinking_from_completion(&body);
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["choices"][0]["message"]["content"], "Hi there");
+    }
+
+    #[test]
+    fn strip_thinking_from_completion_noop_when_clean() {
+        let body = Bytes::from(r#"{"choices":[{"message":{"content":"plain answer"}}]}"#);
+        let out = strip_thinking_from_completion(&body);
+        assert_eq!(out, body);
+    }
 
     #[test]
     fn parse_direct_model_entry_accepts_known_provider_prefix() {

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1370,6 +1370,26 @@ pub(crate) async fn chat_completions_inner(
         if status == StatusCode::TOO_MANY_REQUESTS || status.as_u16() == 529 {
             let elapsed_ms = request_start.elapsed().as_millis() as u64;
             let retry_after = parse_rate_limit_headers(upstream_resp.headers(), provider_type);
+            // Passive Codex usage capture (B): a 429 from the local CLIProxyAPI
+            // on the Codex path carries a `model_cooldown` body with the weekly
+            // (secondary) window reset. The cli-proxy strips the rich x-codex-*
+            // headers, so this exhaustion signal is all we can glean from real
+            // traffic — fold it into the same store the active probe writes, so
+            // the providers panel reflects "weekly limit reached" without a
+            // probe. Keyed by entry.account_id == the provider UUID the usage
+            // probe stores under. Only the codex path reads the body here.
+            if use_openai_oauth_cli_proxy_adapter {
+                let store_key = entry.account_id.to_string();
+                let codex_store = state.codex_usage.clone();
+                if let Ok(body) = upstream_resp.bytes().await {
+                    let now_unix = chrono::Utc::now().timestamp();
+                    if let Some(reset_at) =
+                        crate::api::codex_usage::parse_cooldown_reset(&body, now_unix)
+                    {
+                        codex_store.put_passive_cooldown(store_key, reset_at).await;
+                    }
+                }
+            }
             let reason = if status.as_u16() == 529 {
                 CooldownReason::Overloaded
             } else {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -143,6 +143,10 @@ pub struct AppState {
     /// `/api/ai/providers/:id/usage` and refreshed in the background so the
     /// dashboard sees fresh values without paying a round-trip latency cost.
     pub provider_usage_cache: Arc<super::provider_usage_cache::ProviderUsageCache>,
+    /// Per-account Codex (ChatGPT subscription) usage snapshots — populated by
+    /// an active probe on dashboard demand and by passive `model_cooldown`
+    /// capture on the proxy path. See [`super::codex_usage`].
+    pub codex_usage: Arc<super::codex_usage::CodexUsageStore>,
 }
 
 /// Start the HTTP server.
@@ -502,6 +506,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         fido_hub: Arc::new(super::fido::FidoSigningHub::new()),
         control_metrics: Arc::new(super::control_metrics::ControlMetrics::new()),
         provider_usage_cache: super::provider_usage_cache::ProviderUsageCache::new(),
+        codex_usage: super::codex_usage::CodexUsageStore::new(),
     });
 
     // Start background refresh of provider rate-limit / usage info so the

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -650,6 +650,15 @@ pub struct ModelChain {
     /// Whether this is the default chain.
     #[serde(default)]
     pub is_default: bool,
+    /// Strip model "thinking" markup from response content before returning
+    /// it: `<think>…</think>` blocks and stray orphan `</think>` tags, in both
+    /// streaming and non-streaming responses. Some reasoning models (MiniMax,
+    /// GLM) emit these tags inline in `content` rather than a separate
+    /// `reasoning_content` field, leaking raw reasoning into clients that
+    /// render content verbatim (e.g. the Hermes Telegram gateway). Off by
+    /// default; toggled per chain.
+    #[serde(default)]
+    pub strip_thinking: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -849,6 +858,7 @@ impl ModelChainStore {
                     },
                 ],
                 is_default: true,
+                strip_thinking: false,
                 created_at: now,
                 updated_at: now,
             });
@@ -900,6 +910,7 @@ impl ModelChainStore {
                     model_id: "glm-4.7".to_string(),
                 }],
                 is_default: false,
+                strip_thinking: false,
                 created_at: now,
                 updated_at: now,
             });
@@ -915,6 +926,7 @@ impl ModelChainStore {
                     model_id: "glm-5-turbo".to_string(),
                 }],
                 is_default: false,
+                strip_thinking: false,
                 created_at: now,
                 updated_at: now,
             });
@@ -942,6 +954,9 @@ impl ModelChainStore {
                     },
                 ],
                 is_default: false,
+                // MiniMax/GLM leak `<think>` tags into content; strip them so
+                // the Hermes gateway doesn't render raw reasoning.
+                strip_thinking: true,
                 created_at: now,
                 updated_at: now,
             });
@@ -965,6 +980,7 @@ impl ModelChainStore {
                         model_id: "zai-glm-4.7".to_string(),
                     },
                 ];
+                chain.strip_thinking = true;
                 chain.updated_at = now;
                 changed = true;
                 tracing::info!("Healed builtin/assistant chain to visible-content providers");
@@ -1449,6 +1465,7 @@ mod tests {
                 name: chain_id.to_string(),
                 entries,
                 is_default: false,
+                strip_thinking: false,
                 created_at: now,
                 updated_at: now,
             })
@@ -1475,6 +1492,7 @@ mod tests {
             name: id.to_string(),
             entries,
             is_default,
+            strip_thinking: false,
             created_at: now,
             updated_at: now,
         };


### PR DESCRIPTION
## Summary
Surfaces ChatGPT/Codex subscription usage in the dashboard and improves the message shown when every connected Codex account is rate-limited.

Two commits:

### 1. Codex usage & limits panel (`2efa4f9a`)
`/settings/providers` previously showed nothing for OpenAI OAuth (ChatGPT/Codex subscription) accounts beyond "Connected via OAuth", while Anthropic shows its 5h/weekly windows. ChatGPT-plan Codex exposes the same data via `x-codex-*` response headers — but the inference path routes Codex through the local CLIProxyAPI, which strips them.

- **Active probe** (`src/api/codex_usage.rs`): queries the Codex backend directly with the account's auto-refreshed OAuth token and parses the headers (primary 5h window %, secondary weekly %, plan, credits, resets). Costs one message-quota unit, so it's throttled (15-min store TTL) and excluded from the 2-min background refresh loop — only runs on dashboard demand.
- **Passive capture** (`proxy.rs` 429 path): when a real mission Codex call returns a `model_cooldown` 429, folds the weekly-window reset into the same store for free.
- Dashboard renders a Codex block mirroring the Anthropic panel.

### 2. Aggregate message when all accounts hit usage limit (`dc1e6b94`)
Rotation already tried each connected Codex account on a usage cap, but the runner surfaced only the **last** account's raw "try again at …" line — identical to the first account's, so it read as if no rotation happened. When ≥2 accounts are tried and all are usage-capped, this replaces that with an aggregate naming the account count and the **earliest** reset window across accounts.

Before: `You've hit your usage limit. … try again at Jun 11th, 2026 3:00 AM.`
After: `All 2 connected Codex accounts are at their ChatGPT usage limit. Earliest reset at Jun 11th, 2026 2:26 AM. Connect a Codex account with available quota (or an OpenAI API key), switch this mission to another backend, or wait for the reset.`

Single-account setups are unchanged (raw message preserved).

## Testing
- `cargo build` ✅
- `cargo fmt --all --check` ✅
- New unit tests for `extract_codex_reset_window` and `summarize_codex_usage_caps` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission watchdog, tool-result delivery, OAuth token refresh for Codex probes, and live proxy SSE rewriting—user-visible control behavior and provider auth paths, though changes are bounded and tested.
> 
> **Overview**
> Extends beyond the Codex-focused PR description with **control-plane UX**, **model-routing**, and **proxy post-processing**, alongside the **Codex usage** and **rotation messaging** work already outlined there.
> 
> **AskUserQuestion / tool results:** `postControlToolResult` now returns `{ ok, delivered }` (missing `delivered` treated as true for older backends). The control UI shows an amber warning when the answer did not reach a live mission instead of “Answer sent.” `FrontendToolHub::resolve` reports delivery, waits ~250ms for register-before-resolve races, and missions waiting on frontend tools register via `begin_waiting` so the **stuck-mission watchdog** does not cancel them for silence. Same guard is used in OpenCode and mission runner paths.
> 
> **Model chains — strip reasoning:** Chains gain `strip_thinking` (API, store, model-routing page toggle + create flow). The proxy strips `<think>…</think>` and orphan `</think>` from streaming SSE and non-streaming completion bodies when the resolved chain opts in; `builtin/assistant` defaults/heals to `strip_thinking: true`.
> 
> **Codex usage (dashboard):** New `codex_usage` store and module: throttled active probe of ChatGPT Codex backend headers, passive `model_cooldown` capture on proxy 429s, OAuth-only OpenAI providers excluded from the 2‑min usage refresh loop. Settings providers page shows 5h/weekly bars, plan, resets, credits.
> 
> **Codex rotation copy:** When every rotated Codex account hits usage caps, the runner replaces the last account’s raw “try again at …” with a summary of account count and earliest reset window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae179de9d3bfc7cabd70596d757c1199f5ffc69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->