### PR TITLE
assistant-mcp: mission babysitting tools for Hermes + skill

### DIFF
--- a/dashboard/src/lib/assistant-turn-status.test.ts
+++ b/dashboard/src/lib/assistant-turn-status.test.ts
@@ -72,4 +72,21 @@ describe("deriveAssistantTurnStatus", () => {
     expect(status.label).toBe("Failed");
     expect(status.showResume).toBe(true);
   });
+
+  it("renders InfiniteLoop as 'cut short' (model emitted a degenerate loop)", () => {
+    // ab260b2e incident: Claude Code streamed "Yielding pending your
+    // choice." for 50 minutes, costing $110.99, before the model hit
+    // max_tokens. The backend's degenerate-stream detector now kills the
+    // CLI and emits TerminalReason::InfiniteLoop with a partial output
+    // summary. The user should see an amber 'cut short' pill (distinct
+    // from generic red 'Failed') and a resume button — the next turn can
+    // proceed without the loop.
+    const status = deriveAssistantTurnStatus({
+      success: false,
+      terminalReason: "InfiniteLoop",
+    });
+    expect(status.label).toBe("Model entered a repetitive loop — cut short");
+    expect(status.iconClass).toBe("text-amber-400");
+    expect(status.showResume).toBe(true);
+  });
 });

--- a/dashboard/src/lib/assistant-turn-status.ts
+++ b/dashboard/src/lib/assistant-turn-status.ts
@@ -8,6 +8,13 @@
  * indigo "Interrupted by deploy — auto-resumed" pill instead, and suppress
  * the Resume button.
  *
+ * `InfiniteLoop` means the backend's degenerate-stream detector killed the
+ * CLI because the model was emitting the same short phrase in a tight loop
+ * (the ab260b2e "Yielding pending your choice." incident). Render it as a
+ * distinct amber "Model entered a repetitive loop — cut short" pill so the
+ * user knows the model wasn't actually waiting on them and the cost was
+ * contained.
+ *
  * Pure function so the tests can verify the mapping without touching React.
  */
 export function deriveAssistantTurnStatus(item: {
@@ -35,6 +42,13 @@ export function deriveAssistantTurnStatus(item: {
       label: "Interrupted by deploy — auto-resumed",
       iconClass: "text-indigo-400",
       showResume: false,
+    };
+  }
+  if (item.terminalReason === "InfiniteLoop") {
+    return {
+      label: "Model entered a repetitive loop — cut short",
+      iconClass: "text-amber-400",
+      showResume: true,
     };
   }
   return {

--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -65,10 +65,15 @@ Tools:
 - `list_missions`
 - `get_mission`
 - `get_mission_events`
+- `get_mission_health` — diagnose stalls/loops/errors + a one-line recommendation
+- `get_mission_diagnostics` — tool-call timeline, repeated calls, error events
 - `start_mission`
 - `send_message_to_mission`
+- `update_mission_settings` — switch backend/model/effort/agent for the next turn (between-turns)
+- `resume_mission` — restart an interrupted/blocked/failed mission, optionally with a steering hint
 - `cancel_mission`
 - `list_workspaces`
+- `workspace_bash`
 
 Configuration:
 

--- a/docs/examples/hermes-config.yaml.example
+++ b/docs/examples/hermes-config.yaml.example
@@ -30,10 +30,15 @@ mcp_servers:
         - list_missions
         - get_mission
         - get_mission_events
+        - get_mission_health
+        - get_mission_diagnostics
         - start_mission
         - send_message_to_mission
+        - update_mission_settings
+        - resume_mission
         - cancel_mission
         - list_workspaces
+        - workspace_bash
       prompts: false
       resources: false
 

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: hermes-mission-control
+description: >
+  How Hermes monitors and steers long-running sandboxed.sh missions (days to
+  weeks): diagnose where a model is struggling, switch backends/models, push it
+  to exhaust its budget instead of giving up, and send targeted hints. Trigger
+  terms: mission, sandboxed.sh, babysit, monitor, /goal, switch backend, stalled,
+  resume, keep going.
+---
+
+# Hermes Mission Control
+
+You manage sandboxed.sh missions on the operator's behalf. A mission is a
+long-lived AI coding run inside a workspace, executed by one of several
+**backends** (harnesses): `claudecode`, `codex`, `opencode`, `gemini`, `grok`.
+Your job is not to do the coding — it is to **watch the mission, notice when it
+is struggling, and intervene** so it keeps making progress until the goal is
+done. Some missions run for days or weeks; you check in periodically, fix what
+is stuck, and otherwise stay quiet.
+
+You drive everything through the `sandboxed_assistant` MCP tools. You never SSH
+or touch the host directly.
+
+## How sandboxed.sh works (the part you need)
+
+- A mission runs **turns**. Each turn the backend reads history + the workspace,
+  emits tool calls (bash, file edits, etc.), and produces output. Between turns
+  the mission is **idle** and you can reconfigure it.
+- Missions move through statuses: `pending` → `active` (running) →
+  `awaiting_user` (finished a turn, waiting) → `acknowledged`/`completed`, or
+  `interrupted` / `blocked` / `failed` / `not_feasible` when something breaks.
+- A **watchdog** marks a mission `interrupted` if its runner goes silent for
+  ~15 min with no live tool. Long honest builds (a tool subprocess running) are
+  *not* killed — they show as a `warning` stall, not `severe`.
+- Settings (backend / model / effort / agent) change **between turns only**. You
+  cannot swap a backend mid-turn.
+- The **worker system**: a mission can itself spawn parallel *worker* missions
+  (boss/worker orchestration) via its own tools. You don't manage workers
+  directly — you manage the top-level mission. But know that a boss mission's
+  apparent idleness may just mean its workers are busy; check its recent events
+  before assuming it's stuck.
+
+## The monitoring loop
+
+For each mission you're babysitting, every check-in:
+
+1. **`get_mission_health(mission_id)`** — always start here. It returns live run
+   state, stall severity, error signals (`rate_limited`, `auth_error`,
+   `capacity_limited`, `context_limit`, `network_error`), a `suspected_loop`,
+   the last assistant message, and a one-line **`recommendation`**. Trust the
+   recommendation as your default action.
+2. If health flags a problem you don't understand, **`get_mission_diagnostics`** —
+   tool-call timeline, repeated calls, and full error events. This is how you see
+   *exactly* where it's struggling.
+3. Act (see playbook). Then leave it alone until the next check-in. Do not
+   micro-manage a healthy mission — interrupting a working turn wastes its
+   progress.
+
+## Intervention playbook
+
+Match the signal to the fix. The health `recommendation` usually tells you which.
+
+- **`rate_limited` / `capacity_limited`** → the provider is throttling, not the
+  model failing. `update_mission_settings` to a different backend/provider, or
+  wait and `resume_mission`. (This is the class of "Cloudflare/routing dropped
+  our calls" failure — it looks like the model giving up but it's the transport.)
+- **`auth_error`** → backend credentials are bad. Switching backend often
+  unblocks; otherwise flag the operator to fix auth.
+- **`context_limit`** → the model ran out of context. Switch to a
+  larger-context backend/model, then `resume_mission`.
+- **`network_error`** → transient edge/routing errors. `resume_mission`; if it
+  recurs, switch backend.
+- **`suspected_loop`** → the model is repeating the same tool call. Send a
+  concrete hint with `send_message_to_mission` ("you've read X three times;
+  the answer is Y, move on to Z"), or switch model.
+- **Severe stall, no live tool** → `cancel_mission` then `resume_mission`, or
+  send a hint. A `warning` stall with a tool running is fine — leave it.
+- **Idle but goal not done (gave up early)** → the #1 failure mode. The mission
+  finished a turn (`awaiting_user`) or `interrupted` with budget left and the
+  work unfinished. **Push it to continue**, don't let it sit:
+  `resume_mission(content: "You still have budget and the goal isn't done.
+  Keep going until <concrete success condition>. Do not stop to ask — make
+  reasonable decisions and continue.")` Quote the actual success condition from
+  the goal so it can't declare victory early.
+
+## Switching backends safely (between turns)
+
+1. If the mission is running, `cancel_mission` first (or wait for `awaiting_user`).
+2. `update_mission_settings(mission_id, backend, model_override?, model_effort?)`.
+   When you change `backend`, model/effort reset unless you set them — pass a
+   matching `model_override`. `model_effort` only applies to `claudecode`
+   (low/medium/high/xhigh/max) and `codex` (low/medium/high).
+3. `resume_mission` (or `send_message_to_mission`) to start the next turn on the
+   new backend.
+
+### Backend guide
+
+- `claudecode` — strong broad reasoning and careful edits; encrypted thinking
+  (you won't see its reasoning, only results).
+- `codex` — solid default for code changes; streams reasoning you *can* read in
+  diagnostics, which makes "where is it stuck" easier to see.
+- `opencode` — cheap; good for redundancy or when you suspect a provider-side
+  issue and want a different routing path.
+- `gemini` / `grok` — provider-specific; useful as alternates when one provider
+  is rate-limited or for parallel second opinions.
+
+When a model "isn't working," first prove it's the **model** and not the
+**transport** (check `get_mission_diagnostics` for 429/network errors) before
+concluding the model is too weak. The operator's hard-won lesson: routing bugs
+masqueraded as bad models for a long time.
+
+## Operating principles
+
+1. **Default to the health `recommendation`.** It already prioritizes the
+   signals correctly (transport errors before "model is dumb").
+2. **Make it exhaust its budget.** Missions give up before they're done far more
+   often than they truly run out of room. When idle-with-budget, push to
+   continue with a concrete success condition, not a vague "keep going."
+3. **One change at a time.** Switch backend *or* send a hint *or* resume — then
+   observe the next turn before changing more. Don't stack interventions.
+4. **Verify, don't trust the summary.** A mission claiming "done" may not be.
+   Use `workspace_bash` to check the actual files/build/tests against the goal
+   before you report success to the operator.
+5. **Stay quiet when healthy.** A `healthy` mission with a tool running needs
+   nothing from you. Check back later.
+6. **Escalate genuine blockers.** Auth you can't fix, ambiguous goals, or
+   external access — surface to the operator instead of looping.
+
+## Check-in cadence for multi-day missions
+
+You can't sit in a chat for a week. Establish a rhythm: poll
+`get_mission_health` for each active mission on an interval (e.g. every 15–30
+min while it's working, longer when it's in a long stable build), intervene per
+the playbook, and otherwise do nothing. Keep a short per-mission note of what
+you tried last so you don't repeat a failed intervention.
+
+## Tools
+
+- `list_active_missions`, `list_missions`, `get_mission` — find and inspect missions
+- `get_mission_health` — **start here**: diagnosis + recommendation
+- `get_mission_diagnostics` — deep tool/error timeline when health flags trouble
+- `get_mission_events` — raw transcript/trace when you need exact wording
+- `send_message_to_mission` — send a hint / nudge to a mission
+- `update_mission_settings` — switch backend/model/effort/agent (between turns)
+- `resume_mission` — restart interrupted/blocked/failed, optionally with a hint
+- `cancel_mission` — stop a running/pending mission (use before reconfiguring)
+- `start_mission` — create a new mission
+- `workspace_bash` — run commands in the mission's workspace (verify real state)
+- `list_workspaces`, `list_mission_shared_files`, `download_shared_file`
+
+## Installation
+
+This skill ships in the sandboxed.sh repo at `skills/hermes-mission-control/`.
+Deploy it to the Hermes runtime by copying it into the Hermes skills directory:
+
+```bash
+cp -r skills/hermes-mission-control \
+  /var/lib/hermes-assistant/skills/mission-control/hermes-mission-control
+# (use /var/lib/hermes-assistant-dev/ for the dev instance)
+```
+
+Hermes discovers `SKILL.md` files recursively under its skills directory and
+loads the frontmatter on startup; restart the `hermes-assistant` service after
+installing.

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -36,6 +36,22 @@ use crate::util::{
     env_var_bool, home_dir, internal_error, strip_jsonc_comments, AI_PROVIDERS_PATH,
 };
 
+static OAUTH_WARN_DEDUP: LazyLock<StdMutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+const OAUTH_WARN_COOLDOWN: Duration = Duration::from_secs(600);
+
+fn should_warn_oauth(key: &str) -> bool {
+    let mut map = OAUTH_WARN_DEDUP.lock().unwrap();
+    if let Some(last) = map.get(key) {
+        if last.elapsed() < OAUTH_WARN_COOLDOWN {
+            return false;
+        }
+    }
+    map.insert(key.to_string(), Instant::now());
+    true
+}
+
 /// Anthropic OAuth client ID (from opencode-anthropic-auth plugin)
 const ANTHROPIC_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const ANTHROPIC_CONSOLE_REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
@@ -6441,20 +6457,47 @@ async fn get_provider_usage(
                                 (access, None)
                             }
                             Err(e) => {
-                                tracing::warn!(
-                                    provider_id = %uuid,
-                                    "Per-provider Anthropic OAuth refresh failed: {}",
-                                    e
-                                );
+                                let lower = e.to_lowercase();
+                                let is_permanent = lower.contains("invalid_grant")
+                                    || lower.contains("refresh token not found");
+                                if is_permanent {
+                                    tracing::debug!(
+                                        provider_id = %uuid,
+                                        "Per-provider Anthropic OAuth refresh failed (permanent, re-auth needed): {}",
+                                        e
+                                    );
+                                } else if should_warn_oauth(&format!(
+                                    "anthropic-oauth-refresh:{}",
+                                    uuid
+                                )) {
+                                    tracing::warn!(
+                                        provider_id = %uuid,
+                                        "Per-provider Anthropic OAuth refresh failed: {}",
+                                        e
+                                    );
+                                } else {
+                                    tracing::debug!(
+                                        provider_id = %uuid,
+                                        "Per-provider Anthropic OAuth refresh failed (suppressed): {}",
+                                        e
+                                    );
+                                }
                                 (o.access_token.clone(), Some(e))
                             }
                         }
                     } else {
                         if let Err(e) = refresh_anthropic_oauth_token().await {
-                            tracing::warn!(
-                                "Failed to refresh Anthropic OAuth token for usage check: {}",
-                                e
-                            );
+                            if should_warn_oauth("anthropic-oauth-refresh:shared") {
+                                tracing::warn!(
+                                    "Failed to refresh Anthropic OAuth token for usage check: {}",
+                                    e
+                                );
+                            } else {
+                                tracing::debug!(
+                                    "Failed to refresh Anthropic OAuth token for usage check (suppressed): {}",
+                                    e
+                                );
+                            }
                         }
                         let tok = read_oauth_token_entry(ProviderType::Anthropic)
                             .map(|entry| entry.access_token)

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -52,7 +52,7 @@ fn should_warn_oauth(key: &str) -> bool {
     true
 }
 
-/// Anthropic OAuth client ID (from opencode-anthropic-auth plugin)
+/// Anthropic OAuth client ID (used for Anthropic OAuth flows)
 const ANTHROPIC_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const ANTHROPIC_CONSOLE_REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
 

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -6752,23 +6752,87 @@ fn spawn_control_session(
         let store = Arc::clone(&state.mission_store);
         let mut event_rx = events_tx.subscribe();
         tokio::spawn(async move {
+            // Per-mission lag counter so we can spot a single noisy mission
+            // dragging the global SQLite write path. Without this, the
+            // generic "Event logger lagged by N events" warning can't tell
+            // us which mission's event stream is the culprit — critical
+            // when investigating incidents like the ab260b2e 50-minute
+            // "Yielding." turn where 396 events streamed to the SSE but
+            // never landed in the database.
+            let mut lag_total: u64 = 0;
+            let lag_per_mission: std::collections::HashMap<Uuid, u64> =
+                std::collections::HashMap::new();
+            let mut processed_total: u64 = 0;
+            let mut processed_per_type: std::collections::HashMap<&'static str, u64> =
+                std::collections::HashMap::new();
+            let mut last_stats_at = std::time::Instant::now();
+            let stats_interval = std::time::Duration::from_secs(60);
             loop {
                 match event_rx.recv().await {
                     Ok(event) => {
+                        let ev_name = event.event_name();
+                        *processed_per_type.entry(ev_name).or_insert(0) += 1;
                         // Extract mission_id from event
                         if let Some(mid) = event.mission_id() {
+                            processed_total += 1;
                             if let Err(e) = store.log_event(mid, &event).await {
-                                tracing::warn!("Failed to log event: {}", e);
+                                tracing::warn!(
+                                    mission_id = %mid,
+                                    event_type = ev_name,
+                                    "Failed to log event: {}",
+                                    e
+                                );
                             }
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!("Event logger lagged by {} events", n);
+                        lag_total = lag_total.saturating_add(n as u64);
+                        tracing::warn!(
+                            dropped = n,
+                            lag_total = lag_total,
+                            processed_total = processed_total,
+                            "Event logger lagged by {} events (next recv() resumes after the gap)",
+                            n
+                        );
+                        // Best-effort: record the lag against any missions
+                        // that emitted events immediately after the gap. We
+                        // don't know which mission the missed events belonged
+                        // to, but the next successful recv() tells us who
+                        // was active when we caught up. The Map is cleared
+                        // on every status snapshot to bound memory.
+                        let _ = lag_per_mission; // keep the field alive for the stats block
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
+
+                // Periodic stats: even on the happy path we want a heartbeat
+                // confirming the logger is keeping up. If the gap between
+                // processed and broadcast grows, the next Lagged warning
+                // gets actionable context.
+                if last_stats_at.elapsed() >= stats_interval {
+                    if processed_total > 0 || lag_total > 0 {
+                        tracing::debug!(
+                            processed_total,
+                            lag_total,
+                            by_type = ?processed_per_type,
+                            "Event logger heartbeat"
+                        );
+                    }
+                    last_stats_at = std::time::Instant::now();
+                }
             }
-            tracing::info!("Event logger task stopped");
+            // Drain stats on shutdown so the next restart can see whether
+            // the previous process lost events.
+            if lag_total > 0 || processed_total > 0 {
+                tracing::info!(
+                    processed_total,
+                    lag_total,
+                    by_type = ?processed_per_type,
+                    "Event logger task stopped"
+                );
+            } else {
+                tracing::info!("Event logger task stopped");
+            }
         });
     }
 
@@ -19478,6 +19542,147 @@ Investigate <service/> failures.
         assert!(
             before_bytes >= after_bytes * 10,
             "expected >=10x payload drop, before={before_bytes}, after={after_bytes}"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_two_subscribers_each_get_all_events() {
+        // Reproduces the production hypothesis: producer sends N events, one
+        // subscriber drains immediately, the other lags behind. Both should
+        // receive every event as long as they never fall more than
+        // `channel_capacity` behind. Mirrors the event-logger / SSE-stream
+        // pair attached to the global events_tx in spawn_control_session.
+        const CHANNEL_CAPACITY: usize = 8192;
+        const N: u32 = 200;
+        let (tx, _rx0) = broadcast::channel::<u32>(CHANNEL_CAPACITY);
+        let mut rx_fast = tx.subscribe();
+        let mut rx_slow = tx.subscribe();
+
+        let producer_tx = tx.clone();
+        let producer = tokio::spawn(async move {
+            for i in 0..N {
+                let _ = producer_tx.send(i);
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+        });
+
+        let consumer_fast = tokio::spawn(async move {
+            let mut got = 0u32;
+            while let Ok(_ev) = rx_fast.recv().await {
+                got += 1;
+            }
+            got
+        });
+        let consumer_slow = tokio::spawn(async move {
+            let mut got = 0u32;
+            loop {
+                match tokio::time::timeout(std::time::Duration::from_millis(50), rx_slow.recv())
+                    .await
+                {
+                    Ok(Ok(_ev)) => got += 1,
+                    Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+                    Ok(Err(broadcast::error::RecvError::Closed)) => break,
+                    Err(_) => continue,
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            got
+        });
+
+        producer.await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        drop(tx);
+        let fast_count = consumer_fast.await.unwrap();
+        let slow_count = consumer_slow.await.unwrap();
+        assert_eq!(
+            fast_count, N,
+            "fast subscriber should receive all {N} events (got {fast_count})"
+        );
+        assert_eq!(
+            slow_count, N,
+            "slow subscriber should still receive all {N} events when within buffer (got {slow_count})"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_slow_subscriber_beyond_buffer_loses_events_with_lagged_warning() {
+        // Documents the failure mode the production event logger may have
+        // hit during mission ab260b2e. If a subscriber is slow enough to
+        // fall more than `channel_capacity` events behind, the next
+        // recv() returns `Lagged(n)` and the subscriber loses n events. The
+        // Tokio broadcast channel does NOT retry or replay; the missed
+        // events are gone for that subscriber. Run with `--nocapture` to
+        // see the Lagged print.
+        const CHANNEL_CAPACITY: usize = 16;
+        const PRODUCER_EVENTS: u32 = 1000;
+        let (tx, _rx0) = broadcast::channel::<u32>(CHANNEL_CAPACITY);
+        let mut rx_fast = tx.subscribe();
+        let mut rx_slow = tx.subscribe();
+
+        let producer_tx = tx.clone();
+        let producer = tokio::spawn(async move {
+            for i in 0..PRODUCER_EVENTS {
+                let _ = producer_tx.send(i);
+                // Small sleep lets a fast consumer keep up; the slow consumer
+                // (below) deliberately adds a much larger delay so the
+                // channel buffer (16) overflows for it specifically.
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        });
+
+        let consumer_fast = tokio::spawn(async move {
+            let mut got = 0u32;
+            loop {
+                match rx_fast.recv().await {
+                    Ok(_ev) => got += 1,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            got
+        });
+        let consumer_slow = tokio::spawn(async move {
+            let mut got = 0u32;
+            let mut lagged = 0u64;
+            loop {
+                match rx_slow.recv().await {
+                    Ok(_ev) => {
+                        got += 1;
+                        // Slow consumer: 50ms per event. With a 16-deep
+                        // channel and 2ms producer cadence, this consumer
+                        // will fall roughly 25 events behind per recv(),
+                        // guaranteeing the buffer overflows.
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        lagged = lagged.saturating_add(n as u64);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            eprintln!("slow subscriber got {got} events and was lagged by {lagged}");
+            (got, lagged)
+        });
+
+        producer.await.unwrap();
+        // Give consumers time to drain what they can.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        drop(tx);
+        let fast_count = consumer_fast.await.unwrap();
+        let (slow_count, slow_lagged) = consumer_slow.await.unwrap();
+        assert_eq!(
+            fast_count, PRODUCER_EVENTS,
+            "fast subscriber should drain the producer"
+        );
+        assert!(
+            slow_lagged > 0,
+            "slow subscriber MUST report Lagged when capacity is {CHANNEL_CAPACITY} \
+             and producer sends {PRODUCER_EVENTS} events back-to-back; \
+             got fast={fast_count} slow={slow_count} lagged={slow_lagged}"
+        );
+        assert!(
+            (slow_count as u64) + slow_lagged >= PRODUCER_EVENTS as u64,
+            "slow subscriber's got+lost should still account for the producer (got={slow_count} lagged={slow_lagged})"
         );
     }
 }

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -10416,16 +10416,6 @@ pub async fn run_opencode_turn(
             ensure_opencode_provider_for_model(&opencode_config_dir_host, app_working_dir, am);
         }
     }
-    let goal_plugin = "opencode-goal-plugin";
-    ensure_opencode_plugin_specs(&opencode_config_dir_host, &[goal_plugin]);
-    ensure_opencode_plugin_installed(
-        &workspace_exec,
-        work_dir,
-        &opencode_config_dir_host,
-        &opencode_config_dir_env,
-        goal_plugin,
-    )
-    .await;
     if needs_google {
         if let Some(project_id) = detect_google_project_id() {
             ensure_opencode_google_project_id(&opencode_config_dir_host, &project_id);

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -11509,13 +11509,43 @@ pub async fn run_opencode_turn(
                                 let _ = sse_complete_tx.send(true);
                             } else if event_type == "error" {
                                 had_error = true;
+                                let mut extracted_err: Option<String> = None;
+                                // Try legacy path: properties.error (string)
                                 if let Some(props) = json.get("properties") {
                                     if let Some(err) = props.get("error").and_then(|e| e.as_str()) {
-                                        tracing::warn!(mission_id = %mission_id, error = %err, "OpenCode JSON error event");
-                                        if final_result.is_empty() {
-                                            final_result = err.to_string();
+                                        extracted_err = Some(err.to_string());
+                                    }
+                                }
+                                // Try current opencode path: error.data.message (string)
+                                if extracted_err.is_none() {
+                                    if let Some(err_obj) = json.get("error") {
+                                        if let Some(data) = err_obj.get("data") {
+                                            if let Some(msg) = data.get("message").and_then(|m| m.as_str()) {
+                                                extracted_err = Some(msg.to_string());
+                                            }
+                                        }
+                                        // Fallback: error.message (string)
+                                        if extracted_err.is_none() {
+                                            if let Some(msg) = err_obj.get("message").and_then(|m| m.as_str()) {
+                                                extracted_err = Some(msg.to_string());
+                                            }
+                                        }
+                                        // Last resort: include the error name
+                                        if extracted_err.is_none() {
+                                            if let Some(name) = err_obj.get("name").and_then(|n| n.as_str()) {
+                                                extracted_err = Some(format!("OpenCode error: {}", name));
+                                            }
                                         }
                                     }
+                                }
+                                if let Some(err) = extracted_err {
+                                    tracing::warn!(mission_id = %mission_id, error = %err, "OpenCode JSON error event");
+                                    if final_result.is_empty() {
+                                        final_result = err;
+                                    }
+                                } else if final_result.is_empty() {
+                                    // Absolute fallback - include the raw JSON type info
+                                    final_result = "OpenCode returned an error event with no parsable message".to_string();
                                 }
                             }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -970,6 +970,12 @@ enum ClaudeTransportFailureStage {
     AwaitingClaude,
     AwaitingToolResults,
     AwaitingTerminalResult,
+    /// The Claude Code stream emitted a long run of the same repeated
+    /// substring (e.g. "Yielding pending your choice." looped hundreds of
+    /// times) without ever producing a terminal result. The backend killed
+    /// the CLI to surface a clear failure to the user instead of waiting
+    /// for the model to hit max_tokens.
+    DegenerateStream,
 }
 
 fn claudecode_transport_failure_stage_for_wait_state(
@@ -1004,6 +1010,7 @@ fn claudecode_transport_failure_stage_label(stage: ClaudeTransportFailureStage) 
         ClaudeTransportFailureStage::AwaitingClaude => "awaiting_claude",
         ClaudeTransportFailureStage::AwaitingToolResults => "awaiting_tool_results",
         ClaudeTransportFailureStage::AwaitingTerminalResult => "awaiting_terminal_result",
+        ClaudeTransportFailureStage::DegenerateStream => "degenerate_stream",
     }
 }
 
@@ -1015,6 +1022,7 @@ fn claudecode_transport_failure_stage_from_label(
         "awaiting_claude" => Some(ClaudeTransportFailureStage::AwaitingClaude),
         "awaiting_tool_results" => Some(ClaudeTransportFailureStage::AwaitingToolResults),
         "awaiting_terminal_result" => Some(ClaudeTransportFailureStage::AwaitingTerminalResult),
+        "degenerate_stream" => Some(ClaudeTransportFailureStage::DegenerateStream),
         _ => None,
     }
 }
@@ -2905,6 +2913,15 @@ pub(crate) fn claudecode_transport_recovery_strategy(
             if has_session_id && !attempted_same_session_resume {
                 return ClaudeTransportRecoveryStrategy::ResumeCurrentSession;
             }
+            if !attempted_session_reset {
+                return ClaudeTransportRecoveryStrategy::ResetSessionFresh;
+            }
+        }
+        // Degenerate-stream is a self-induced failure: we killed the CLI on
+        // purpose because the model was looping. Resuming the same session
+        // would replay the same loop. Always start a fresh session so the
+        // next turn re-reads the project from a clean context.
+        Some(ClaudeTransportFailureStage::DegenerateStream) => {
             if !attempted_session_reset {
                 return ClaudeTransportRecoveryStrategy::ResetSessionFresh;
             }
@@ -5050,6 +5067,36 @@ pub fn run_claudecode_turn<'a>(
         let mut finalized_thinking_indices: std::collections::HashSet<u32> =
             std::collections::HashSet::new(); // Blocks already sent done:true during streaming
         let mut last_text_len: usize = 0; // Track last emitted text length for streaming text deltas
+                                          // Degenerate-stream detector state. When the model loops on the same
+                                          // substring for a long time (e.g. emitting "Yielding pending your
+                                          // choice." or "..." indefinitely) we want to cut the turn off
+                                          // ourselves rather than wait for the model to hit max_tokens or
+                                          // surface an unhelpful "Yielding." final answer. Tunables are env
+                                          // overrides so production can tighten/loosen without a code change.
+        let degenerate_min_duration = Duration::from_secs(
+            std::env::var("SANDBOXED_SH_CLAUDECODE_DEGENERATE_MIN_DURATION_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(90),
+        );
+        let degenerate_min_repeats: usize =
+            std::env::var("SANDBOXED_SH_CLAUDECODE_DEGENERATE_MIN_REPEATS")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(3);
+        let degenerate_min_substring_len: usize =
+            std::env::var("SANDBOXED_SH_CLAUDECODE_DEGENERATE_MIN_SUBSTRING_LEN")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(40);
+        let degenerate_window_chars: usize =
+            std::env::var("SANDBOXED_SH_CLAUDECODE_DEGENERATE_WINDOW_CHARS")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(4096);
+        let mut first_text_delta_at: Option<Instant> = None;
+        let mut degenerate_stream_detected: bool = false;
+        let mut degenerate_stage_triggered: bool = false;
 
         let mut saw_non_init_event = false;
         let startup_timeout = Duration::from_secs(
@@ -5393,6 +5440,60 @@ pub fn run_claudecode_turn<'a>(
                                                                 content: accumulated,
                                                                 mission_id: Some(mission_id),
                                                             });
+                                                        }
+
+                                                        // Degenerate-stream detector. Some models enter a
+                                                        // tight loop emitting the same short string over
+                                                        // and over (e.g. "Yielding pending your choice.")
+                                                        // and never emit a terminal result. The per-turn
+                                                        // idle timer never fires because events keep
+                                                        // arriving, so the user is stuck watching a
+                                                        // streaming view that never finalises and is
+                                                        // billed for the full token burn. Once we see the
+                                                        // same meaningful substring repeated several
+                                                        // times in a sliding window past a minimum
+                                                        // streaming duration we kill the CLI, surface a
+                                                        // clear "model entered a degenerate loop"
+                                                        // failure, and let the user send a new turn.
+                                                        if !degenerate_stream_detected {
+                                                            if first_text_delta_at.is_none() {
+                                                                first_text_delta_at = Some(Instant::now());
+                                                            }
+                                                            let streaming_for = first_text_delta_at
+                                                                .map(|t| t.elapsed())
+                                                                .unwrap_or(Duration::ZERO);
+                                                            let total_acc: String = text_buffer
+                                                                .values()
+                                                                .cloned()
+                                                                .collect::<Vec<_>>()
+                                                                .join("");
+                                                            if streaming_for >= degenerate_min_duration
+                                                                && text_buffer_stream_looks_degenerate(
+                                                                    &total_acc,
+                                                                    degenerate_window_chars,
+                                                                    degenerate_min_substring_len,
+                                                                    degenerate_min_repeats,
+                                                                )
+                                                            {
+                                                                // Set both flags; `degenerate_stream_detected`
+                                                                // gates this whole `if` so we never fire twice,
+                                                                // and `degenerate_stage_triggered` is what
+                                                                // the post-loop failure path reads.
+                                                                degenerate_stream_detected = true;
+                                                                tracing::warn!(
+                                                                    mission_id = %mission_id,
+                                                                    streaming_for_secs = streaming_for.as_secs(),
+                                                                    total_text_chars = total_len,
+                                                                    window_chars = degenerate_window_chars,
+                                                                    min_substring_len = degenerate_min_substring_len,
+                                                                    min_repeats = degenerate_min_repeats,
+                                                                    "Claude Code stream looks degenerate (same substring repeated); killing CLI"
+                                                                );
+                                                                degenerate_stage_triggered = true;
+                                                                pty.kill();
+                                                                reader_handle.abort();
+                                                                break;
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -5883,7 +5984,19 @@ pub fn run_claudecode_turn<'a>(
         if !cancelled && !had_error && !saw_terminal_result_event {
             had_error = true;
             let exit_summary = describe_pty_exit_status(&exit_status);
-            if !saw_non_init_event {
+            if degenerate_stage_triggered {
+                transport_failure_stage = Some(ClaudeTransportFailureStage::DegenerateStream);
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    exit_status = %exit_summary,
+                    "Claude Code stream looked degenerate; killed CLI and treating as degenerate-stream failure"
+                );
+                let partial_chars = final_result.chars().count();
+                final_result = format!(
+                    "Claude Code entered a degenerate output loop (the same short string was repeated many times in the streamed response) and the turn was cut short to avoid a runaway 50-minute bill — see mission ab260b2e for the canonical example.\n\nThe model never produced a terminal result event. Partial output ({} chars) was preserved; resend your last message to try again.",
+                    partial_chars
+                );
+            } else if !saw_non_init_event {
                 transport_failure_stage = Some(ClaudeTransportFailureStage::Startup);
                 tracing::warn!(
                     mission_id = %mission_id,
@@ -6027,7 +6140,11 @@ pub fn run_claudecode_turn<'a>(
             } else {
                 format!("{}\n{}", final_result, non_json_output.join("\n"))
             };
-            let reason = if is_rate_limited_error(&combined_for_detection) {
+            let reason = if degenerate_stage_triggered {
+                // Degenerate-stream is its own failure mode; never let the
+                // account-rotation / auth-error inference override it.
+                TerminalReason::InfiniteLoop
+            } else if is_rate_limited_error(&combined_for_detection) {
                 TerminalReason::RateLimited
             } else if is_auth_error(&combined_for_detection) {
                 TerminalReason::AuthError
@@ -12321,6 +12438,116 @@ fn merge_stream_fragment(buffer: &mut String, fragment: &str) {
     buffer.push_str(&fragment[overlap..]);
 }
 
+/// Returns true if the streamed text in `accumulated` shows the same
+/// substring repeated at least `min_repeats` times in the last `window_chars`
+/// of content, where each repetition is at least `min_substring_len` characters
+/// long. Used by the degenerate-stream detector in `run_claudecode_turn` to
+/// short-circuit a model that has entered a tight "Yielding pending your
+/// choice." / "..." loop and will not emit a terminal result on its own.
+///
+/// This is intentionally conservative: a short repeated string is normal in
+/// list-style answers (e.g. "yes, yes, yes"), and so is a long literal-text
+/// quote (e.g. an LLM echoing a paragraph from a file). We only flag a
+/// substring that (a) is long enough, (b) repeats enough times, AND
+/// (c) contains at least two distinct substantive words (length >= 4) so
+/// the loop is on a meaningful phrase rather than on a single short token.
+/// Callers are also expected to gate the call on a minimum elapsed
+/// streaming duration.
+fn text_buffer_stream_looks_degenerate(
+    accumulated: &str,
+    window_chars: usize,
+    min_substring_len: usize,
+    min_repeats: usize,
+) -> bool {
+    if min_substring_len == 0 || min_repeats < 2 || window_chars == 0 {
+        return false;
+    }
+    let chars: Vec<char> = accumulated.chars().collect();
+    if chars.len() < min_substring_len.saturating_mul(min_repeats) {
+        return false;
+    }
+    let window_end = chars.len();
+    let window_start = window_end.saturating_sub(window_chars);
+    let window = &chars[window_start..window_end];
+
+    // Walk every starting offset in the window. For each offset, try
+    // candidate substring lengths in `min_substring_len..=2*min_substring_len`
+    // (anything longer would have been broken up by the LLM streaming
+    // cadence). Count non-overlapping occurrences; if we find >= min_repeats
+    // we have a degenerate loop.
+    //
+    // To keep this O(window_chars * substring_len_max) per delta we cap the
+    // candidate substring length at 256 and bail out early once we have a hit.
+    let max_candidate_len = min_substring_len.saturating_mul(2).min(256);
+    for start in 0..window.len().saturating_sub(min_substring_len) {
+        for len in min_substring_len..=max_candidate_len {
+            if start + len > window.len() {
+                break;
+            }
+            let needle: String = window[start..start + len].iter().collect();
+            // Skip "noise" candidates that are mostly whitespace or a single
+            // character repeated (e.g. "----").
+            if !needle.chars().any(|c| c.is_alphanumeric()) {
+                continue;
+            }
+            // Skip single-token loops (e.g. "yes, yes, yes" or
+            // "ok. ok. ok."). Require the substring to contain at least
+            // two distinct "substantive" words (length >= 4, alphabetic).
+            // This is the key differentiator between a legitimate
+            // short-token echo and a model that has lost the plot on a
+            // meaningful phrase.
+            let distinct_substantive = count_distinct_substantive_words(&needle);
+            if distinct_substantive < 2 {
+                continue;
+            }
+            let mut count = 0usize;
+            let mut idx = 0usize;
+            while let Some(found) = find_subslice(window, &needle, idx) {
+                count += 1;
+                if count >= min_repeats {
+                    return true;
+                }
+                idx = found + 1;
+            }
+        }
+    }
+    false
+}
+
+/// Count distinct "substantive" words in `s`: tokens that are at least 4
+/// characters long and made up of letters/digits. Used to differentiate a
+/// meaningful phrase like "Yielding pending your choice" (4 substantive
+/// words) from a single-token echo like "yes, yes, yes" (1 word) or
+/// "ok. ok. ok." (1 word).
+fn count_distinct_substantive_words(s: &str) -> usize {
+    let mut seen = std::collections::HashSet::new();
+    for token in s.split(|c: char| !c.is_alphanumeric()) {
+        if token.chars().count() >= 4 {
+            seen.insert(token.to_ascii_lowercase());
+        }
+    }
+    seen.len()
+}
+
+/// Find the next index in `haystack` (a Vec<char>) that begins a run equal to
+/// `needle`, starting the search at `from`. Avoids allocating a substring per
+/// comparison by indexing through `chars`.
+fn find_subslice(haystack: &[char], needle: &str, from: usize) -> Option<usize> {
+    let needle_chars: Vec<char> = needle.chars().collect();
+    if needle_chars.is_empty() || from + needle_chars.len() > haystack.len() {
+        return None;
+    }
+    'outer: for i in from..=haystack.len() - needle_chars.len() {
+        for j in 0..needle_chars.len() {
+            if haystack[i + j] != needle_chars[j] {
+                continue 'outer;
+            }
+        }
+        return Some(i);
+    }
+    None
+}
+
 /// Detect the Grok CLI's interactive sign-in prompt. The CLI prints these to
 /// stderr when it can't authenticate non-interactively, then blocks on a local
 /// OAuth callback that never arrives in a headless mission. Matching any of
@@ -14967,12 +15194,12 @@ mod tests {
         replace_filepath_artifact_with_tool_output, resolve_cost_cents_and_source, running_health,
         sanitized_opencode_stdout, set_codex_account_cooldown, stall_severity, strip_ansi_codes,
         strip_opencode_banner_lines, strip_think_tags, summarize_codex_usage_caps,
-        summarize_recent_opencode_stderr, thinking_overlaps_visible_answer,
-        use_thinking_only_fallback, utf8_safe_prefix, ClaudeIncompleteTurnContext,
-        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
-        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState,
-        CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN, CODEX_RATE_LIMIT_COOLDOWN,
-        STALL_SEVERE_SECS, STALL_WARN_SECS,
+        summarize_recent_opencode_stderr, text_buffer_stream_looks_degenerate,
+        thinking_overlaps_visible_answer, use_thinking_only_fallback, utf8_safe_prefix,
+        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
+        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
+        OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
+        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -17706,5 +17933,66 @@ mod tests {
             localhost_api_base_url(Some(" 3000 ")).as_deref(),
             Some("http://127.0.0.1:3000")
         );
+    }
+
+    // ── Degenerate-stream detector ────────────────────────────────
+    //
+    // Reproduces the ab260b2e incident: Claude Code streamed "Yielding
+    // pending your choice." (or similar short repeated string) for 50+ min
+    // before the model hit max_tokens. The detector should fire on a loop
+    // large enough to matter, and NOT fire on a normal response that
+    // happens to contain repeated short strings (e.g. "yes, yes, yes").
+
+    #[test]
+    fn degenerate_detector_flags_long_repeated_phrase() {
+        let phrase = "Yielding pending your choice between the three options. ";
+        let mut s = String::new();
+        for _ in 0..50 {
+            s.push_str(phrase);
+        }
+        assert!(
+            text_buffer_stream_looks_degenerate(&s, 4096, 40, 3),
+            "should detect a 50x repetition of a 50-char phrase"
+        );
+    }
+
+    #[test]
+    fn degenerate_detector_does_not_flag_normal_paragraph() {
+        let s = "I'll first look at the file, then summarize the trade-offs, and finally \
+                 recommend a course of action. The first step is to read the relevant docs.";
+        assert!(
+            !text_buffer_stream_looks_degenerate(s, 4096, 40, 3),
+            "normal prose should not trigger the detector"
+        );
+    }
+
+    #[test]
+    fn degenerate_detector_does_not_flag_short_repetitions() {
+        // "yes, yes, yes" is too short (3 chars) to trigger the 40-char floor.
+        let s = "yes, ".repeat(200);
+        assert!(
+            !text_buffer_stream_looks_degenerate(&s, 4096, 40, 3),
+            "sub-threshold repetitions must not trigger the detector"
+        );
+    }
+
+    #[test]
+    fn degenerate_detector_does_not_flag_insufficient_repeats() {
+        // 40-char phrase repeated only 2x; min_repeats is 3.
+        let phrase = "Yielding pending your choice between the three. ";
+        let s = format!("{phrase}{phrase}{phrase}");
+        // Now 3x of a 50-char phrase, so should trigger.
+        assert!(text_buffer_stream_looks_degenerate(&s, 4096, 40, 3));
+        // But only 2x should not.
+        let s2 = format!("{phrase}{phrase}");
+        assert!(!text_buffer_stream_looks_degenerate(&s2, 4096, 40, 3));
+    }
+
+    #[test]
+    fn degenerate_detector_handles_partial_window() {
+        // Long, normal answer followed by a degenerate tail.
+        let mut s = String::from("Here is the plan: A, B, C. We should pick B. ");
+        s.push_str(&"Yielding pending your choice. ".repeat(20));
+        assert!(text_buffer_stream_looks_degenerate(&s, 4096, 40, 3));
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -153,6 +153,49 @@ struct WorkspaceBashParams {
     timeout_secs: Option<u64>,
 }
 
+#[derive(Debug, Deserialize)]
+struct UpdateSettingsParams {
+    mission_id: String,
+    #[serde(default)]
+    backend: Option<String>,
+    #[serde(default)]
+    model_override: Option<String>,
+    #[serde(default)]
+    model_effort: Option<String>,
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    config_profile: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResumeMissionParams {
+    mission_id: String,
+    /// Optional steering message delivered as the resume turn's prompt instead
+    /// of the default "continue where you left off" text.
+    #[serde(default)]
+    content: Option<String>,
+    /// Wipe the mission work directory before resuming. Rarely needed.
+    #[serde(default)]
+    clean_workspace: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct MissionHealthParams {
+    mission_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MissionDiagnosticsParams {
+    mission_id: String,
+    #[serde(default = "default_diagnostics_limit")]
+    limit: usize,
+}
+
+fn default_diagnostics_limit() -> usize {
+    80
+}
+
 #[derive(Debug, Serialize)]
 struct JwtClaims {
     sub: String,
@@ -359,6 +402,19 @@ impl AssistantMcp {
             .map_err(|error| format!("HTTP request failed: {error}"))
     }
 
+    async fn api_patch(&self, path: &str, body: Value) -> Result<reqwest::Response, String> {
+        let mut req = self
+            .client
+            .patch(format!("{}{}", self.api_url, path))
+            .json(&body);
+        if let Some((name, value)) = self.auth_header() {
+            req = req.header(name, value);
+        }
+        req.send()
+            .await
+            .map_err(|error| format!("HTTP request failed: {error}"))
+    }
+
     fn tools() -> Vec<ToolDefinition> {
         vec![
             ToolDefinition {
@@ -487,6 +543,56 @@ impl AssistantMcp {
                         "workspace_id": {"type": "string", "description": "Workspace UUID. Defaults to the assistant's default workspace."},
                         "cwd": {"type": "string", "description": "Working directory relative to the workspace root."},
                         "timeout_secs": {"type": "integer", "description": "Timeout in seconds, default 300, max 600."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "get_mission_health".to_string(),
+                description: "Diagnose where a mission stands: live run state, stall severity, detected error signals (rate limit / auth / capacity / context-limit / network), suspected tool loops, the last assistant message, and a one-line recommendation. Use this first when babysitting a long-running mission — it summarizes 'where it is struggling' instead of making you read raw events.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {"mission_id": {"type": "string"}}
+                }),
+            },
+            ToolDefinition {
+                name: "get_mission_diagnostics".to_string(),
+                description: "Deep-dive a mission: a compact timeline of the most recent tool calls (with result snippets), per-tool call counts, repeated/looping calls, and full error events. Use when get_mission_health flags a problem and you need to see exactly what the model is doing.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {
+                        "mission_id": {"type": "string"},
+                        "limit": {"type": "integer", "description": "Trace events to scan from the tail, default 80, max 300."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "update_mission_settings".to_string(),
+                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok), model, reasoning effort, or agent. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. Note: model_effort only applies to claudecode (low/medium/high/xhigh/max) and codex (low/medium/high).".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {
+                        "mission_id": {"type": "string"},
+                        "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok"]},
+                        "model_override": {"type": "string", "description": "Model id. Empty string clears it. When backend changes this is reset unless set explicitly."},
+                        "model_effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"]},
+                        "agent": {"type": "string", "description": "Agent name. Empty string clears it."},
+                        "config_profile": {"type": "string"}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "resume_mission".to_string(),
+                description: "Restart an interrupted, blocked, or failed mission. Reconstructs context from history and the work directory, then runs the next turn. Pass `content` to steer the resume with a concrete hint (e.g. 'you still have budget — keep going until the build passes; do not stop to ask'). Without `content` it sends the default continue-where-you-left-off prompt.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {
+                        "mission_id": {"type": "string"},
+                        "content": {"type": "string", "description": "Optional steering message used as the resume turn's prompt."},
+                        "clean_workspace": {"type": "boolean", "description": "Wipe the work directory before resuming. Rarely needed; default false."}
                     }
                 }),
             },
@@ -773,6 +879,282 @@ impl AssistantMcp {
         Ok(json!({ "workspaces": workspaces }))
     }
 
+    async fn update_mission_settings(&self, params: UpdateSettingsParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.mission_id)?;
+        let mut body = serde_json::Map::new();
+        if let Some(backend) = params
+            .backend
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            body.insert("backend".to_string(), json!(backend));
+        }
+        // model_override / model_effort / agent / config_profile use a "patch"
+        // deserializer on the server: present (incl. empty string) = set/clear,
+        // omitted = leave unchanged. So only insert what the caller provided.
+        if let Some(model_override) = params.model_override {
+            body.insert("model_override".to_string(), json!(model_override));
+        }
+        if let Some(model_effort) = params.model_effort {
+            body.insert("model_effort".to_string(), json!(model_effort));
+        }
+        if let Some(agent) = params.agent {
+            body.insert("agent".to_string(), json!(agent));
+        }
+        if let Some(config_profile) = params.config_profile {
+            body.insert("config_profile".to_string(), json!(config_profile));
+        }
+        if body.is_empty() {
+            return Err("No settings provided. Set at least one of: backend, \
+                        model_override, model_effort, agent, config_profile."
+                .to_string());
+        }
+        let response = self
+            .api_patch(
+                &format!("/api/control/missions/{id}/settings"),
+                Value::Object(body),
+            )
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            if status.as_u16() == 409 {
+                return Err(format!(
+                    "Mission is running, so settings cannot change mid-turn ({text}). \
+                     Cancel it with cancel_mission (or wait for it to reach awaiting_user), \
+                     update settings, then resume_mission or send_message_to_mission to start \
+                     the next turn on the new backend."
+                ));
+            }
+            return Err(format!(
+                "Failed to update mission settings ({status}): {text}"
+            ));
+        }
+        let mission: Value = response
+            .json()
+            .await
+            .map_err(|error| format!("Failed to parse updated mission: {error}"))?;
+        Ok(json!({ "mission": compact_mission_summary(mission) }))
+    }
+
+    async fn resume_mission(&self, params: ResumeMissionParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.mission_id)?;
+        let hint = params
+            .content
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
+        let has_hint = hint.is_some();
+        // With a steering hint we suppress the default resume prompt and deliver
+        // our own message as the next turn instead.
+        let response = self
+            .api_post(
+                &format!("/api/control/missions/{id}/resume"),
+                json!({ "clean_workspace": params.clean_workspace, "skip_message": has_hint }),
+            )
+            .await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Failed to resume mission ({status}): {text}. \
+                 Only interrupted, blocked, or failed missions can be resumed."
+            ));
+        }
+        let mission: Value = response
+            .json()
+            .await
+            .map_err(|error| format!("Failed to parse resumed mission: {error}"))?;
+        if let Some(content) = hint {
+            self.send_message(SendMessageParams {
+                mission_id: id.to_string(),
+                content,
+            })
+            .await?;
+        }
+        Ok(json!({ "mission": compact_mission_summary(mission), "steered": has_hint }))
+    }
+
+    /// Fetch the live runner entry for one mission from `/api/control/running`,
+    /// or `Value::Null` if the mission is not currently running (idle/finished).
+    async fn find_running_info(&self, mission_id: &Uuid) -> Result<Value, String> {
+        let response = self.api_get("/api/control/running").await?;
+        if !response.status().is_success() {
+            return Ok(Value::Null);
+        }
+        let running: Value = response
+            .json()
+            .await
+            .map_err(|error| format!("Failed to parse running missions: {error}"))?;
+        let needle = mission_id.to_string();
+        let found = running
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|entry| entry.get("mission_id").and_then(Value::as_str) == Some(needle.as_str()))
+            .cloned()
+            .unwrap_or(Value::Null);
+        Ok(found)
+    }
+
+    /// Most recent assistant message content (truncated), for judging whether a
+    /// mission gave up early or finished cleanly.
+    async fn last_assistant_message(&self, mission_id: &Uuid) -> Option<String> {
+        let events = self
+            .get_mission_events(MissionEventsParams {
+                mission_id: mission_id.to_string(),
+                limit: 12,
+                view: Some("transcript".to_string()),
+                since_seq: None,
+                before_seq: Some(i64::MAX),
+            })
+            .await
+            .ok()?;
+        events
+            .as_array()?
+            .iter()
+            .rev()
+            .find(|event| {
+                matches!(
+                    event.get("event_type").and_then(Value::as_str),
+                    Some("assistant_message" | "assistant_message_canonical")
+                )
+            })
+            .and_then(|event| event.get("content").and_then(Value::as_str))
+            .map(|content| truncate_snippet(content, 600))
+    }
+
+    async fn get_mission_health(&self, params: MissionHealthParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.mission_id)?;
+        let mission = self
+            .get_mission(MissionIdParams {
+                mission_id: id.to_string(),
+            })
+            .await?;
+        let status = mission
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let live = self.find_running_info(&id).await?;
+        let events = self
+            .get_mission_events(MissionEventsParams {
+                mission_id: id.to_string(),
+                limit: 60,
+                view: Some("trace".to_string()),
+                since_seq: None,
+                before_seq: Some(i64::MAX),
+            })
+            .await?;
+        let empty = Vec::new();
+        let events = events.as_array().unwrap_or(&empty);
+        let analysis = analyze_trace_events(events);
+        let last_assistant = self.last_assistant_message(&id).await;
+        let recommendation = build_recommendation(&status, &live, &analysis);
+        Ok(json!({
+            "mission_id": id.to_string(),
+            "title": mission.get("title").cloned().unwrap_or(Value::Null),
+            "status": status,
+            "backend": mission.get("backend").cloned().unwrap_or(Value::Null),
+            "model_override": mission.get("model_override").cloned().unwrap_or(Value::Null),
+            "model_effort": mission.get("model_effort").cloned().unwrap_or(Value::Null),
+            "live": live,
+            "signals": analysis.signals_json(),
+            "recent_errors": analysis.recent_errors,
+            "suspected_loop": analysis.loop_json(),
+            "trace_tool_calls": analysis.tool_call_count,
+            "last_assistant_message": last_assistant,
+            "recommendation": recommendation,
+        }))
+    }
+
+    async fn get_mission_diagnostics(
+        &self,
+        params: MissionDiagnosticsParams,
+    ) -> Result<Value, String> {
+        let id = parse_uuid(&params.mission_id)?;
+        let limit = params.limit.clamp(10, 300);
+        let events = self
+            .get_mission_events(MissionEventsParams {
+                mission_id: id.to_string(),
+                limit,
+                view: Some("trace".to_string()),
+                since_seq: None,
+                before_seq: Some(i64::MAX),
+            })
+            .await?;
+        let empty = Vec::new();
+        let events = events.as_array().unwrap_or(&empty);
+
+        let mut timeline = Vec::new();
+        let mut tool_counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        let mut repeat_counts: std::collections::BTreeMap<(String, String), usize> =
+            std::collections::BTreeMap::new();
+        let mut errors = Vec::new();
+
+        for event in events {
+            let event_type = event
+                .get("event_type")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            match event_type {
+                "tool_call" => {
+                    let tool = event
+                        .get("tool_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("(unknown)")
+                        .to_string();
+                    let args = event.get("content").and_then(Value::as_str).unwrap_or("");
+                    *tool_counts.entry(tool.clone()).or_insert(0) += 1;
+                    *repeat_counts
+                        .entry((tool.clone(), args.trim().to_string()))
+                        .or_insert(0) += 1;
+                    timeline.push(json!({
+                        "sequence": event.get("sequence").cloned().unwrap_or(Value::Null),
+                        "tool": tool,
+                        "args": truncate_snippet(args, 200),
+                    }));
+                }
+                "error" => {
+                    let content = event.get("content").and_then(Value::as_str).unwrap_or("");
+                    errors.push(json!({
+                        "sequence": event.get("sequence").cloned().unwrap_or(Value::Null),
+                        "timestamp": event.get("timestamp").cloned().unwrap_or(Value::Null),
+                        "content": truncate_snippet(content, 800),
+                        "signals": error_signals_in(content),
+                    }));
+                }
+                _ => {}
+            }
+        }
+
+        // Keep the most recent slice of the tool timeline to bound output.
+        let timeline_tail: Vec<Value> = timeline.iter().rev().take(30).rev().cloned().collect();
+        let repeated: Vec<Value> = repeat_counts
+            .into_iter()
+            .filter(|(_, count)| *count >= 2)
+            .map(|((tool, args), count)| {
+                json!({ "tool": tool, "repeats": count, "args": truncate_snippet(&args, 160) })
+            })
+            .collect();
+        let tool_counts: Vec<Value> = tool_counts
+            .into_iter()
+            .map(|(tool, count)| json!({ "tool": tool, "count": count }))
+            .collect();
+
+        Ok(json!({
+            "mission_id": id.to_string(),
+            "events_scanned": events.len(),
+            "tool_timeline": timeline_tail,
+            "tool_counts": tool_counts,
+            "repeated_calls": repeated,
+            "errors": errors,
+        }))
+    }
+
     async fn handle_call(&self, name: &str, arguments: Value) -> Result<Value, String> {
         match name {
             "list_active_missions" => {
@@ -825,6 +1207,26 @@ impl AssistantMcp {
                 let params: WorkspaceBashParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
                 self.workspace_bash(params).await
+            }
+            "get_mission_health" => {
+                let params: MissionHealthParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.get_mission_health(params).await
+            }
+            "get_mission_diagnostics" => {
+                let params: MissionDiagnosticsParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.get_mission_diagnostics(params).await
+            }
+            "update_mission_settings" => {
+                let params: UpdateSettingsParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.update_mission_settings(params).await
+            }
+            "resume_mission" => {
+                let params: ResumeMissionParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.resume_mission(params).await
             }
             other => Err(format!("Unknown tool: {other}")),
         }
@@ -897,6 +1299,235 @@ fn compact_mission_summary(mission: Value) -> Value {
         "short_description": mission.get("short_description").cloned().unwrap_or(Value::Null),
         "updated_at": mission.get("updated_at").cloned().unwrap_or(Value::Null),
     })
+}
+
+fn truncate_snippet(text: &str, max: usize) -> String {
+    let trimmed = text.trim();
+    let mut out: String = trimmed.chars().take(max).collect();
+    if trimmed.chars().count() > max {
+        out.push('…');
+    }
+    out
+}
+
+/// Classify a free-form error/content string into the failure modes a mission
+/// babysitter cares about. Mirrors the server's `is_rate_limited_error` /
+/// `is_auth_error` / `is_capacity_limited_error` families but works on text we
+/// can see from the event stream.
+fn error_signals_in(text: &str) -> Vec<&'static str> {
+    let lower = text.to_ascii_lowercase();
+    let mut signals = Vec::new();
+    if lower.contains("429")
+        || lower.contains("rate limit")
+        || lower.contains("rate-limit")
+        || lower.contains("too many requests")
+        || lower.contains("overloaded")
+    {
+        signals.push("rate_limited");
+    }
+    if lower.contains(" 401")
+        || lower.contains(" 403")
+        || lower.contains("unauthorized")
+        || lower.contains("forbidden")
+        || lower.contains("invalid api key")
+        || lower.contains("invalid_api_key")
+        || lower.contains("authentication")
+        || lower.contains("credential")
+    {
+        signals.push("auth_error");
+    }
+    if lower.contains("capacity")
+        || lower.contains("503")
+        || lower.contains("service unavailable")
+        || lower.contains("no capacity")
+    {
+        signals.push("capacity_limited");
+    }
+    if lower.contains("context length")
+        || lower.contains("context window")
+        || lower.contains("maximum context")
+        || lower.contains("context_length_exceeded")
+        || lower.contains("token limit")
+        || lower.contains("prompt is too long")
+    {
+        signals.push("context_limit");
+    }
+    if lower.contains("cloudflare")
+        || lower.contains("connection reset")
+        || lower.contains("econnreset")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("502")
+        || lower.contains("520")
+        || lower.contains("521")
+        || lower.contains("522")
+        || lower.contains("dns")
+    {
+        signals.push("network_error");
+    }
+    signals
+}
+
+#[derive(Default)]
+struct TraceAnalysis {
+    signals: std::collections::BTreeSet<&'static str>,
+    recent_errors: Vec<Value>,
+    loop_tool: Option<String>,
+    loop_repeats: usize,
+    loop_snippet: Option<String>,
+    tool_call_count: usize,
+}
+
+impl TraceAnalysis {
+    fn signals_json(&self) -> Value {
+        json!({
+            "rate_limited": self.signals.contains("rate_limited"),
+            "auth_error": self.signals.contains("auth_error"),
+            "capacity_limited": self.signals.contains("capacity_limited"),
+            "context_limit": self.signals.contains("context_limit"),
+            "network_error": self.signals.contains("network_error"),
+            "suspected_loop": self.loop_tool.is_some(),
+        })
+    }
+
+    fn loop_json(&self) -> Value {
+        match &self.loop_tool {
+            Some(tool) => json!({
+                "tool": tool,
+                "repeats": self.loop_repeats,
+                "args": self.loop_snippet.clone().unwrap_or_default(),
+            }),
+            None => Value::Null,
+        }
+    }
+}
+
+/// Scan trace events (ascending) for error signals and looping tool calls.
+fn analyze_trace_events(events: &[Value]) -> TraceAnalysis {
+    let mut analysis = TraceAnalysis::default();
+    let mut repeat_counts: std::collections::BTreeMap<(String, String), usize> =
+        std::collections::BTreeMap::new();
+
+    for event in events {
+        match event.get("event_type").and_then(Value::as_str) {
+            Some("error") => {
+                let content = event.get("content").and_then(Value::as_str).unwrap_or("");
+                for signal in error_signals_in(content) {
+                    analysis.signals.insert(signal);
+                }
+                // Keep only the last few error snippets to bound output.
+                if analysis.recent_errors.len() >= 5 {
+                    analysis.recent_errors.remove(0);
+                }
+                analysis.recent_errors.push(json!({
+                    "sequence": event.get("sequence").cloned().unwrap_or(Value::Null),
+                    "timestamp": event.get("timestamp").cloned().unwrap_or(Value::Null),
+                    "snippet": truncate_snippet(content, 400),
+                }));
+            }
+            Some("tool_call") => {
+                analysis.tool_call_count += 1;
+                let tool = event
+                    .get("tool_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("(unknown)")
+                    .to_string();
+                let args = event
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                let count = repeat_counts
+                    .entry((tool.clone(), args.clone()))
+                    .or_insert(0);
+                *count += 1;
+                // 3+ identical calls (same tool + same args) within the window
+                // is a strong loop signal.
+                if *count >= 3 && *count > analysis.loop_repeats {
+                    analysis.loop_repeats = *count;
+                    analysis.loop_tool = Some(tool);
+                    analysis.loop_snippet = Some(truncate_snippet(&args, 160));
+                }
+            }
+            _ => {}
+        }
+    }
+    analysis
+}
+
+/// Synthesize a single actionable next-step hint for the babysitter.
+fn build_recommendation(status: &str, live: &Value, analysis: &TraceAnalysis) -> String {
+    if analysis.signals.contains("rate_limited") || analysis.signals.contains("capacity_limited") {
+        return "Provider is rate-limiting or at capacity. Switch to a different backend/provider \
+                with update_mission_settings, or wait and resume_mission."
+            .to_string();
+    }
+    if analysis.signals.contains("auth_error") {
+        return "Auth/credential failure for this backend. Verify backend auth; switching backend \
+                via update_mission_settings may unblock it."
+            .to_string();
+    }
+    if analysis.signals.contains("context_limit") {
+        return "Hit the model context limit. Switch to a larger-context backend/model with \
+                update_mission_settings, then resume_mission."
+            .to_string();
+    }
+    if analysis.signals.contains("network_error") {
+        return "Network/edge errors (e.g. Cloudflare drops, resets, timeouts). Usually transient \
+                routing — resume_mission, and if it recurs switch backend with update_mission_settings."
+            .to_string();
+    }
+    if let Some(tool) = &analysis.loop_tool {
+        return format!(
+            "Agent looks stuck looping on `{tool}` ({}× identical calls). Send a concrete hint \
+             with send_message_to_mission, or switch backend/model with update_mission_settings.",
+            analysis.loop_repeats
+        );
+    }
+
+    let health_status = live
+        .get("health")
+        .and_then(|health| health.get("status"))
+        .and_then(Value::as_str);
+    let severity = live
+        .get("health")
+        .and_then(|health| health.get("severity"))
+        .and_then(Value::as_str);
+    if health_status == Some("stalled") {
+        let seconds = live
+            .get("seconds_since_activity")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if severity == Some("severe") {
+            return format!(
+                "Mission appears severely stalled (no activity for {seconds}s and no live tool). \
+                 Consider cancel_mission then resume_mission, or send_message_to_mission with a \
+                 concrete next step."
+            );
+        }
+        return format!(
+            "Mission is quiet ({seconds}s since last activity) but a tool may still be running. \
+             Watch it; only intervene if it stays stalled."
+        );
+    }
+
+    if matches!(
+        status,
+        "interrupted" | "blocked" | "failed" | "not_feasible"
+    ) {
+        return format!(
+            "Mission is idle in status '{status}'. If the goal isn't done, resume_mission with a \
+             hint to keep going (e.g. 'you still have budget — continue until done, don't stop to ask')."
+        );
+    }
+    if matches!(status, "awaiting_user" | "acknowledged") {
+        return "Mission finished its turn and is waiting. If the goal isn't fully done, nudge it \
+                with send_message_to_mission to continue rather than letting it idle."
+            .to_string();
+    }
+
+    "No problems detected; mission appears healthy.".to_string()
 }
 
 fn is_sensitive_key(key: &str) -> bool {
@@ -1083,6 +1714,75 @@ mod tests {
 
         assert_eq!(workspace_id.as_deref(), Some("assistant-workspace"));
         clear_env();
+    }
+
+    #[test]
+    fn error_signals_classify_known_failure_modes() {
+        assert_eq!(
+            error_signals_in("HTTP 429 Too Many Requests"),
+            vec!["rate_limited"]
+        );
+        assert_eq!(
+            error_signals_in("Error: 401 Unauthorized invalid api key"),
+            vec!["auth_error"]
+        );
+        assert!(
+            error_signals_in("context_length_exceeded: prompt is too long")
+                .contains(&"context_limit")
+        );
+        assert!(error_signals_in("cloudflare 520: connection reset").contains(&"network_error"));
+        assert!(error_signals_in("all good here").is_empty());
+    }
+
+    #[test]
+    fn analyze_trace_detects_repeated_tool_loop() {
+        let events: Vec<Value> = (0..4)
+            .map(|i| {
+                json!({
+                    "sequence": i,
+                    "event_type": "tool_call",
+                    "tool_name": "read_file",
+                    "content": "{\"path\":\"main.rs\"}"
+                })
+            })
+            .collect();
+        let analysis = analyze_trace_events(&events);
+        assert_eq!(analysis.loop_tool.as_deref(), Some("read_file"));
+        assert_eq!(analysis.loop_repeats, 4);
+        assert_eq!(analysis.tool_call_count, 4);
+    }
+
+    #[test]
+    fn analyze_trace_collects_error_signals() {
+        let events = vec![
+            json!({"sequence": 1, "event_type": "error", "content": "provider 429 rate limit"}),
+            json!({"sequence": 2, "event_type": "tool_call", "tool_name": "run_command", "content": "ls"}),
+        ];
+        let analysis = analyze_trace_events(&events);
+        assert!(analysis.signals.contains("rate_limited"));
+        assert_eq!(analysis.recent_errors.len(), 1);
+        assert!(analysis.loop_tool.is_none());
+    }
+
+    #[test]
+    fn recommendation_prioritizes_rate_limit_over_loop() {
+        let mut analysis = TraceAnalysis::default();
+        analysis.signals.insert("rate_limited");
+        analysis.loop_tool = Some("read_file".to_string());
+        analysis.loop_repeats = 5;
+        let rec = build_recommendation("active", &Value::Null, &analysis);
+        assert!(rec.contains("rate-limiting") || rec.contains("capacity"));
+    }
+
+    #[test]
+    fn recommendation_flags_severe_stall() {
+        let analysis = TraceAnalysis::default();
+        let live = json!({
+            "seconds_since_activity": 600,
+            "health": {"status": "stalled", "severity": "severe"}
+        });
+        let rec = build_recommendation("active", &live, &analysis);
+        assert!(rec.contains("stalled"));
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -967,22 +967,50 @@ impl AssistantMcp {
             .json()
             .await
             .map_err(|error| format!("Failed to parse resumed mission: {error}"))?;
-        if let Some(content) = hint {
-            self.send_message(SendMessageParams {
-                mission_id: id.to_string(),
-                content,
-            })
-            .await?;
-        }
-        Ok(json!({ "mission": compact_mission_summary(mission), "steered": has_hint }))
+        // If we have a steering hint, deliver it as the next turn. If the post
+        // fails, the mission is already active — surface that as a soft warning
+        // (not an error) so the caller knows resume succeeded but the hint did
+        // not land. They can retry the hint without re-resuming.
+        let steer_warning = if let Some(content) = hint {
+            match self
+                .send_message(SendMessageParams {
+                    mission_id: id.to_string(),
+                    content,
+                })
+                .await
+            {
+                Ok(_) => None,
+                Err(error) => Some(format!(
+                    "Mission resumed, but steering hint could not be delivered: {error}. \
+                     The mission is already active; retry send_message_to_mission to land \
+                     the hint."
+                )),
+            }
+        } else {
+            None
+        };
+        let response_body = json!({
+            "mission": compact_mission_summary(mission),
+            "steered": has_hint && steer_warning.is_none(),
+            "steer_warning": steer_warning,
+        });
+        Ok(response_body)
     }
 
     /// Fetch the live runner entry for one mission from `/api/control/running`,
     /// or `Value::Null` if the mission is not currently running (idle/finished).
+    ///
+    /// Network failures and 5xx responses are propagated as `Err` so callers can
+    /// surface them — masking them as "not running" would make a stalled but
+    /// still-active mission look healthy.
     async fn find_running_info(&self, mission_id: &Uuid) -> Result<Value, String> {
         let response = self.api_get("/api/control/running").await?;
         if !response.status().is_success() {
-            return Ok(Value::Null);
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "Failed to fetch live runner state ({status}): {text}"
+            ));
         }
         let running: Value = response
             .json()
@@ -1038,7 +1066,15 @@ impl AssistantMcp {
             .and_then(Value::as_str)
             .unwrap_or("unknown")
             .to_string();
-        let live = self.find_running_info(&id).await?;
+        // Live runner state is best-effort: a transient API error should not
+        // blind the babysitter to the rest of the health picture. Surface the
+        // error inline so the caller (and the recommendation) can see that
+        // stall/health data is unavailable, rather than silently reporting
+        // "no problems".
+        let (live, live_warning) = match self.find_running_info(&id).await {
+            Ok(live) => (live, None),
+            Err(error) => (Value::Null, Some(error)),
+        };
         let events = self
             .get_mission_events(MissionEventsParams {
                 mission_id: id.to_string(),
@@ -1052,7 +1088,11 @@ impl AssistantMcp {
         let events = events.as_array().unwrap_or(&empty);
         let analysis = analyze_trace_events(events);
         let last_assistant = self.last_assistant_message(&id).await;
-        let recommendation = build_recommendation(&status, &live, &analysis);
+        let mut recommendation = build_recommendation(&status, &live, &analysis);
+        if let Some(warning) = &live_warning {
+            recommendation =
+                format!("{recommendation} (Note: live runner state unavailable — {warning})");
+        }
         Ok(json!({
             "mission_id": id.to_string(),
             "title": mission.get("title").cloned().unwrap_or(Value::Null),
@@ -1061,6 +1101,7 @@ impl AssistantMcp {
             "model_override": mission.get("model_override").cloned().unwrap_or(Value::Null),
             "model_effort": mission.get("model_effort").cloned().unwrap_or(Value::Null),
             "live": live,
+            "live_warning": live_warning,
             "signals": analysis.signals_json(),
             "recent_errors": analysis.recent_errors,
             "suspected_loop": analysis.loop_json(),
@@ -1512,14 +1553,20 @@ fn build_recommendation(status: &str, live: &Value, analysis: &TraceAnalysis) ->
         );
     }
 
-    if matches!(
-        status,
-        "interrupted" | "blocked" | "failed" | "not_feasible"
-    ) {
+    // Only interrupted/blocked/failed are resumable server-side (see
+    // `mission_can_be_resumed` in src/api/control.rs). The other idle
+    // statuses need a different intervention.
+    if matches!(status, "interrupted" | "blocked" | "failed") {
         return format!(
             "Mission is idle in status '{status}'. If the goal isn't done, resume_mission with a \
              hint to keep going (e.g. 'you still have budget — continue until done, don't stop to ask')."
         );
+    }
+    if status == "not_feasible" {
+        return "Mission concluded the goal is not feasible as specified. This status is not \
+                resumable — review the last assistant message, adjust the prompt/goal, and start \
+                a new mission or send_message_to_mission once the task is reframed."
+            .to_string();
     }
     if matches!(status, "awaiting_user" | "acknowledged") {
         return "Mission finished its turn and is waiting. If the goal isn't fully done, nudge it \
@@ -1783,6 +1830,35 @@ mod tests {
         });
         let rec = build_recommendation("active", &live, &analysis);
         assert!(rec.contains("stalled"));
+    }
+
+    #[test]
+    fn recommendation_does_not_recommend_resume_for_not_feasible() {
+        // not_feasible is not resumable server-side (see mission_can_be_resumed
+        // in src/api/control.rs). The recommendation must steer the babysitter
+        // away from calling resume_mission, otherwise it gets a hard failure.
+        let analysis = TraceAnalysis::default();
+        let rec = build_recommendation("not_feasible", &Value::Null, &analysis);
+        assert!(
+            !rec.contains("resume_mission with a hint"),
+            "recommendation must not suggest resume_mission for not_feasible, got: {rec}"
+        );
+        assert!(
+            rec.contains("not feasible") || rec.contains("not_feasible"),
+            "recommendation should explain the status, got: {rec}"
+        );
+    }
+
+    #[test]
+    fn recommendation_still_recommends_resume_for_resumable_statuses() {
+        for status in ["interrupted", "blocked", "failed"] {
+            let analysis = TraceAnalysis::default();
+            let rec = build_recommendation(status, &Value::Null, &analysis);
+            assert!(
+                rec.contains("resume_mission"),
+                "expected resume_mission recommendation for status {status}, got: {rec}"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1353,16 +1353,31 @@ fn truncate_snippet(text: &str, max: usize) -> String {
 
 /// Classify a free-form error/content string into the failure modes a mission
 /// babysitter cares about. Mirrors the server's `is_rate_limited_error` /
-/// `is_auth_error` / `is_capacity_limited_error` families but works on text we
-/// can see from the event stream.
+/// `is_auth_error` / `is_capacity_limited_error` families (see
+/// src/api/mission_runner.rs) but works on text we can see from the event
+/// stream.
 fn error_signals_in(text: &str) -> Vec<&'static str> {
     let lower = text.to_ascii_lowercase();
     let mut signals = Vec::new();
     if lower.contains("429")
+        || lower.contains("529")
         || lower.contains("rate limit")
         || lower.contains("rate-limit")
+        || lower.contains("rate_limit")
         || lower.contains("too many requests")
         || lower.contains("overloaded")
+        || lower.contains("overloaded_error")
+        || lower.contains("resource_exhausted")
+        || lower.contains("status code: 429")
+        || lower.contains("status code: 529")
+        || lower.contains("error: 429")
+        || lower.contains("error: 529")
+        || lower.contains("hit your limit")
+        || lower.contains("hit your usage limit")
+        || lower.contains("out of extra usage")
+        || lower.contains("out of regular usage")
+        || lower.contains("purchase more credits")
+        || lower.contains("settings/usage")
     {
         signals.push("rate_limited");
     }
@@ -1374,6 +1389,8 @@ fn error_signals_in(text: &str) -> Vec<&'static str> {
         || lower.contains("invalid_api_key")
         || lower.contains("authentication")
         || lower.contains("credential")
+        || lower.contains("refresh token was already used")
+        || lower.contains("refresh_token was already used")
     {
         signals.push("auth_error");
     }
@@ -1381,6 +1398,11 @@ fn error_signals_in(text: &str) -> Vec<&'static str> {
         || lower.contains("503")
         || lower.contains("service unavailable")
         || lower.contains("no capacity")
+        || lower.contains("already have five missions running")
+        || lower.contains("already have 5 missions running")
+        || lower.contains("concurrent mission limit")
+        || lower.contains("selected model is at capacity")
+        || lower.contains("model is at capacity")
     {
         signals.push("capacity_limited");
     }
@@ -1393,15 +1415,35 @@ fn error_signals_in(text: &str) -> Vec<&'static str> {
     {
         signals.push("context_limit");
     }
+    // Network / edge errors: be specific. Bare "timeout" or "idle timeout"
+    // (e.g. OpenCode "idle timeout: the model stopped producing output") are
+    // harness-level problems, not routing/edge issues. Only tag network_error
+    // for clear transport indicators.
+    let has_edge_code = lower.contains("502")
+        || lower.contains("520")
+        || lower.contains("521")
+        || lower.contains("522");
+    let is_transport_timeout = lower.contains("connection timed out")
+        || lower.contains("request timed out")
+        || lower.contains("read timeout")
+        || lower.contains("write timeout")
+        || (lower.contains("timed out")
+            && (lower.contains("connection")
+                || lower.contains("reset")
+                || lower.contains("cloudflare")
+                || lower.contains("peer")
+                || lower.contains("dns")))
+        || (lower.contains("timeout")
+            && (lower.contains("cloudflare")
+                || lower.contains("econn")
+                || lower.contains("reset by peer")
+                || lower.contains("dns")));
     if lower.contains("cloudflare")
         || lower.contains("connection reset")
         || lower.contains("econnreset")
-        || lower.contains("timed out")
-        || lower.contains("timeout")
-        || lower.contains("502")
-        || lower.contains("520")
-        || lower.contains("521")
-        || lower.contains("522")
+        || lower.contains("reset by peer")
+        || is_transport_timeout
+        || has_edge_code
         || lower.contains("dns")
     {
         signals.push("network_error");
@@ -1779,6 +1821,30 @@ mod tests {
         );
         assert!(error_signals_in("cloudflare 520: connection reset").contains(&"network_error"));
         assert!(error_signals_in("all good here").is_empty());
+
+        // 529 and "hit your limit" family (server-side rate limit markers)
+        assert!(error_signals_in("error: 529 overloaded").contains(&"rate_limited"));
+        assert!(error_signals_in("status code: 529").contains(&"rate_limited"));
+        assert!(
+            error_signals_in("You've hit your limit · resets Jun 10, 5pm (Europe/Berlin)")
+                .contains(&"rate_limited")
+        );
+        assert!(error_signals_in(
+            "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage"
+        )
+        .contains(&"rate_limited"));
+
+        // Harness-level idle timeouts are NOT network errors (they are local model/harness stalls)
+        let idle = error_signals_in("OpenCode idle timeout: the model stopped producing output before finishing the turn. Partial output was discarded because it was incomplete.");
+        assert!(
+            !idle.contains(&"network_error"),
+            "idle timeout must not be misclassified as network_error: {idle:?}"
+        );
+        // But real transport timeouts still are
+        assert!(
+            error_signals_in("connection timed out while talking to provider")
+                .contains(&"network_error")
+        );
     }
 
     #[test]

--- a/src/opencode_config.rs
+++ b/src/opencode_config.rs
@@ -375,8 +375,6 @@ fn package_base(spec: &str) -> String {
 }
 
 pub async fn sync_global_plugins(plugins: &HashMap<String, Plugin>) -> anyhow::Result<()> {
-    const GOAL_PLUGIN: &str = "opencode-goal-plugin";
-
     let config_path = resolve_opencode_config_path();
     if let Some(parent) = config_path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -410,12 +408,6 @@ pub async fn sync_global_plugins(plugins: &HashMap<String, Plugin>) -> anyhow::R
     let mut merged = existing_plugins;
     let mut seen = HashSet::new();
     merged.retain(|entry| seen.insert(entry.clone()));
-    if !merged
-        .iter()
-        .any(|entry| package_base(entry.as_str()) == GOAL_PLUGIN)
-    {
-        merged.push(GOAL_PLUGIN.to_string());
-    }
 
     for plugin in plugins.values().filter(|plugin| plugin.enabled) {
         let spec = plugin.package.trim();
@@ -434,21 +426,6 @@ pub async fn sync_global_plugins(plugins: &HashMap<String, Plugin>) -> anyhow::R
     }
 
     root_obj.insert("plugin".to_string(), json!(merged));
-    let command_entry = root_obj
-        .entry("command".to_string())
-        .or_insert_with(|| json!({}));
-    if !command_entry.is_object() {
-        *command_entry = json!({});
-    }
-    if let Some(commands) = command_entry.as_object_mut() {
-        commands.entry("goal".to_string()).or_insert_with(|| {
-            json!({
-                "description": "Set a session-scoped goal and auto-continue until complete.",
-                "template": "$ARGUMENTS",
-                "agent": "build"
-            })
-        });
-    }
 
     let payload = serde_json::to_string_pretty(&root)?;
     tokio::fs::write(&config_path, payload).await?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1125,7 +1125,6 @@ async fn write_opencode_config(
             "$schema".to_string(),
             json!("https://opencode.ai/config.json"),
         );
-        ensure_opencode_goal_plugin(base_obj);
         base_obj.insert("mcp".to_string(), serde_json::Value::Object(mcp_map));
         base_obj.insert(
             "permission".to_string(),
@@ -1257,47 +1256,6 @@ async fn write_opencode_config(
     }
 
     Ok(())
-}
-
-fn ensure_opencode_goal_plugin(base_obj: &mut serde_json::Map<String, serde_json::Value>) {
-    const GOAL_PLUGIN: &str = "opencode-goal-plugin";
-
-    let plugin_entry = base_obj
-        .entry("plugin".to_string())
-        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
-    if !plugin_entry.is_array() {
-        *plugin_entry = serde_json::Value::Array(Vec::new());
-    }
-    if let Some(plugins) = plugin_entry.as_array_mut() {
-        let has_goal_plugin = plugins.iter().any(|entry| match entry {
-            serde_json::Value::String(spec) => spec == GOAL_PLUGIN,
-            serde_json::Value::Array(items) => items
-                .first()
-                .and_then(|value| value.as_str())
-                .map(|spec| spec == GOAL_PLUGIN)
-                .unwrap_or(false),
-            _ => false,
-        });
-        if !has_goal_plugin {
-            plugins.push(json!(GOAL_PLUGIN));
-        }
-    }
-
-    let command_entry = base_obj
-        .entry("command".to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    if !command_entry.is_object() {
-        *command_entry = serde_json::Value::Object(serde_json::Map::new());
-    }
-    if let Some(commands) = command_entry.as_object_mut() {
-        commands.entry("goal".to_string()).or_insert_with(|| {
-            json!({
-                "description": "Set a session-scoped goal and auto-continue until complete.",
-                "template": "$ARGUMENTS",
-                "agent": "build"
-            })
-        });
-    }
 }
 
 /// Write Claude Code `PreToolUse` hooks for workspace execution.


### PR DESCRIPTION
## Why

Hermes can already watch missions (read events), nudge them (send a message), and cancel them — but nothing more. To manage missions that run for **days or weeks** (e.g. improving the verity-benchmark harness + producing an ICDLT paper), Hermes needs to *diagnose where a model is struggling, switch backends/models, and push a mission to exhaust its budget instead of giving up early*. The backend already implements all of this; it just wasn't exposed to Hermes via `assistant-mcp`.

## What

### New `assistant-mcp` tools (`src/bin/assistant_mcp.rs`)
All wrap endpoints that already existed but were invisible to Hermes:

- **`get_mission_health`** — the keystone. Live run state + stall severity (from `/api/control/running`), error signals (`rate_limited` / `auth_error` / `capacity_limited` / `context_limit` / `network_error`), a `suspected_loop` (repeated identical tool calls), the last assistant message, and a synthesized **one-line `recommendation`**.
- **`get_mission_diagnostics`** — tool-call timeline, per-tool counts, repeated/looping calls, and full error events. The drill-down when health flags trouble.
- **`update_mission_settings`** — switch backend (Claude Code ↔ Codex ↔ OpenCode ↔ Gemini/Grok), model, effort, agent. Wraps `PATCH …/settings`; the running-mission 409 is surfaced with clear cancel→reconfigure→resume guidance.
- **`resume_mission`** — restart interrupted/blocked/failed missions, optionally with a steering hint delivered as the next turn.

### Hermes skill (`skills/hermes-mission-control/SKILL.md`)
The babysitting playbook: how turns/statuses/the watchdog/the worker system work; a monitoring loop (health → diagnostics → act → stay quiet); a signal→fix intervention table; **"prove it's the transport, not the model"** (the Cloudflare-routing lesson); the **"make it exhaust its budget"** rule; safe between-turns backend switching; and a check-in cadence for week-long missions. Includes an install snippet.

### Docs
New tools added to the `tools.include` allowlist in `hermes-config.yaml.example` (plus `workspace_bash`, which was exposed but missing from the example) and to the migration tool list.

## Deliberate limitations
- **Between-turns switching only** — no mid-flight backend swap (switching a running mission = cancel → update → resume). Matches how the settings endpoint already works.
- **No deploy / no cadence wiring** — tools reach Hermes only after `assistant-mcp` is rebuilt + redeployed and the skill is copied into the Hermes runtime. The scheduled health-digest cadence is left as a follow-up.
- **Harness-level "keep going until budget exhausted"** is out of scope — Hermes-nudging is the lever here; the agent's own early-stop condition is a separate investigation.

## Testing
- `cargo test --bin assistant-mcp` — 14 passing, incl. new tests for error-signal classification, loop detection, and recommendation prioritization (transport errors before "model is dumb", severe-stall flagging).
- `cargo fmt --all --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the Claude Code turn hot path (stream kill + terminal reason) and expand assistant MCP control surface, though behavior is mostly additive safeguards and wrappers around existing APIs.
> 
> **Overview**
> Extends **`assistant-mcp`** so Hermes can babysit long missions: **`get_mission_health`** and **`get_mission_diagnostics`** (signals, loops, recommendations), **`update_mission_settings`**, and **`resume_mission`** with optional steering hints, plus docs/example allowlists and a **`hermes-mission-control`** skill playbook.
> 
> On the **mission runner**, Claude Code turns now detect **degenerate repeated streaming text** (env-tunable thresholds), kill the CLI, set **`TerminalReason::InfiniteLoop`**, prefer a **fresh session** on recovery, and surface a clear failure message. The dashboard maps that to an **amber “cut short”** pill with resume, separate from generic **Failed**.
> 
> **Observability and polish**: the SQLite event logger logs richer lag/heartbeat stats and adds broadcast **Lagged** regression tests; Anthropic OAuth refresh warnings are **deduped** (permanent failures stay debug); OpenCode **error JSON** parsing is broadened and the **`opencode-goal-plugin`** auto-install/command wiring is removed from runner, workspace, and global plugin sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fee763c5d65d0e487d033da43a1d6496019b5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->