### PR TITLE
feat(grok): reliable tool + thinking streaming via ACP (grok agent stdio)

### DIFF
--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -615,13 +615,37 @@ pub async fn run_grok_turn(
         .await
         {
             Ok(result) => return result,
-            Err(reason) => {
+            Err(fallback) => {
                 tracing::warn!(
                     mission_id = %mission_id,
-                    reason = %reason,
+                    reason = %fallback.reason,
+                    drop_session_id = fallback.drop_session_id,
                     "Grok ACP handshake failed before the prompt was sent; \
                      falling back to streaming-json mode"
                 );
+                // An unloadable session must not be passed as --session-id:
+                // its upsert semantics would create a fresh EMPTY session
+                // under that id. Omitting it makes the legacy path use
+                // --continue, which resumes the last session in this
+                // mission directory and preserves context.
+                let fallback_session_id = if fallback.drop_session_id {
+                    None
+                } else {
+                    session_id
+                };
+                return run_grok_streaming_json_turn(
+                    workspace,
+                    work_dir,
+                    message,
+                    model,
+                    mission_id,
+                    events_tx,
+                    cancel,
+                    app_working_dir,
+                    fallback_session_id,
+                    is_continuation,
+                )
+                .await;
             }
         }
     }
@@ -1052,6 +1076,31 @@ const GROK_ACP_SESSION_NEW_ID: u64 = 3;
 const GROK_ACP_SET_MODEL_ID: u64 = 4;
 const GROK_ACP_PROMPT_ID: u64 = 5;
 
+/// Marker embedded in handshake errors that mean "the stored session can't
+/// be resumed over ACP — the legacy path must use --continue, not
+/// --session-id". Matched by the dispatcher to set `drop_session_id`.
+const GROK_ACP_DEFER_TO_CONTINUE: &str = "deferring to --continue";
+
+/// Why the ACP path handed the turn back to the streaming-json fallback.
+pub(crate) struct GrokAcpFallback {
+    reason: String,
+    /// True when the stored session id is not loadable over ACP: the
+    /// fallback must NOT pass it as `--session-id` (upsert semantics would
+    /// create a fresh empty session under that id) — omitting it makes the
+    /// legacy path use `--continue`, which resumes the CLI's last session
+    /// in the mission directory and preserves context.
+    drop_session_id: bool,
+}
+
+impl From<String> for GrokAcpFallback {
+    fn from(reason: String) -> Self {
+        Self {
+            reason,
+            drop_session_id: false,
+        }
+    }
+}
+
 /// Per-call state for an in-flight grok ACP tool call.
 #[derive(Default, Clone)]
 struct GrokAcpToolCall {
@@ -1084,7 +1133,7 @@ async fn run_grok_acp_turn(
     app_working_dir: &std::path::Path,
     session_id: Option<&str>,
     is_continuation: bool,
-) -> Result<AgentResult, String> {
+) -> Result<AgentResult, GrokAcpFallback> {
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     let workspace_exec = WorkspaceExec::new(workspace.clone());
@@ -1235,7 +1284,7 @@ async fn run_grok_acp_turn(
                     // defer to it instead of silently dropping context.
                     return Err(format!(
                         "stored session {sid} not loadable over ACP on a continuation \
-                         turn ({err}); deferring to --continue"
+                         turn ({err}); {GROK_ACP_DEFER_TO_CONTINUE}"
                     ));
                 }
                 Err(err) => {
@@ -1250,10 +1299,9 @@ async fn run_grok_acp_turn(
         } else if is_continuation {
             // Continuation with no stored session id at all: only the
             // streaming path's `--continue` can recover the prior session.
-            return Err(
-                "continuation turn without a stored session id; deferring to --continue"
-                    .to_string(),
-            );
+            return Err(format!(
+                "continuation turn without a stored session id; {GROK_ACP_DEFER_TO_CONTINUE}"
+            ));
         }
         if acp_session_id.is_none() {
             send(
@@ -1287,7 +1335,11 @@ async fn run_grok_acp_turn(
         Err(err) => {
             let _ = child.kill().await;
             let _ = child.wait().await;
-            return Err(err);
+            let drop_session_id = err.contains(GROK_ACP_DEFER_TO_CONTINUE);
+            return Err(GrokAcpFallback {
+                reason: err,
+                drop_session_id,
+            });
         }
     };
 
@@ -1337,7 +1389,7 @@ async fn run_grok_acp_turn(
         // turn back to the fallback path (same orphan hazard as handshake).
         let _ = child.kill().await;
         let _ = child.wait().await;
-        return Err(e);
+        return Err(GrokAcpFallback::from(e));
     }
 
     let mut thinking_buffer = String::new();

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -1249,7 +1249,17 @@ async fn run_grok_acp_turn(
     }
     let acp_session_id = acp_session_id.expect("session id established above");
 
-    if let Some(model) = model.filter(|m| !m.trim().is_empty()) {
+    // The ACP session default is the non-reasoning chat model
+    // (grok-4.20-*-non-reasoning), which emits no thought chunks. The legacy
+    // `grok -p` path defaulted to grok-build (a reasoning model), so missions
+    // without an explicit model keep that behavior — and a populated thoughts
+    // panel — here too. Override via backend setting `default_model`.
+    let effective_model = model
+        .filter(|m| !m.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| get_backend_string_setting("grok", "default_model"))
+        .or_else(|| Some("grok-build-0.1".to_string()));
+    if let Some(model) = effective_model.as_deref() {
         // Best-effort: an unknown model shouldn't kill the turn.
         send(
             &mut stdin,
@@ -1288,7 +1298,7 @@ async fn run_grok_acp_turn(
     let mut thinking_done_emitted = false;
     let mut text_buffer = String::new();
     let mut tool_calls: HashMap<String, GrokAcpToolCall> = HashMap::new();
-    let mut model_used: Option<String> = Some(model.unwrap_or("grok-build").to_string());
+    let mut model_used: Option<String> = effective_model.clone();
     let mut usage = crate::cost::TokenUsage::default();
     let mut stop_reason: Option<String> = None;
     let mut transport_error: Option<String> = None;

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -3,6 +3,7 @@
 //! Moved verbatim from `mission_runner.rs` (Phase 2 of the decomposition).
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use uuid::Uuid;
 
@@ -202,7 +203,13 @@ fn grok_auth_file_expires_at(contents: &str) -> i64 {
 fn grok_event_is_reasoning_type(value: &serde_json::Value) -> bool {
     value.get("type").and_then(|v| v.as_str()).is_some_and(|t| {
         let lower = t.to_ascii_lowercase();
-        lower == "reasoning" || lower == "thinking" || lower == "reasoning_delta"
+        // grok-cli 0.2.x `--output-format streaming-json` emits incremental
+        // thinking as `{"type":"thought","data":"..."}` (verified against
+        // grok 0.2.16 with grok-build-0.1 and grok-4.20-reasoning).
+        lower == "reasoning"
+            || lower == "thinking"
+            || lower == "reasoning_delta"
+            || lower == "thought"
     })
 }
 
@@ -433,9 +440,171 @@ pub(crate) fn grok_stdout_line_requests_interactive_login(line: &str) -> bool {
         && grok_line_requests_interactive_login(line)
 }
 
+/// Resolve the env the Grok CLI needs for non-interactive auth: refresh the
+/// xAI OAuth token if stale, materialize/sync the CLI auth file, and export
+/// `XAI_API_KEY` (key > OAuth access token > ambient env). Shared by the
+/// streaming-json and ACP turn paths.
+async fn prepare_grok_auth_env(
+    workspace_exec: &WorkspaceExec,
+    work_dir: &std::path::Path,
+    app_working_dir: &std::path::Path,
+    mission_id: Uuid,
+) -> Result<HashMap<String, String>, AgentResult> {
+    let mut oauth_access_token: Option<String> = None;
+    if let Some(entry) =
+        crate::api::ai_providers::read_oauth_token_entry(crate::ai_providers::ProviderType::Xai)
+    {
+        if crate::api::ai_providers::oauth_token_expired(entry.expires_at) {
+            match crate::api::ai_providers::refresh_oauth_token_with_lock(
+                crate::ai_providers::ProviderType::Xai,
+                entry.expires_at,
+            )
+            .await
+            {
+                Ok((access, _refresh, expires_at)) => {
+                    oauth_access_token = Some(access);
+                    tracing::info!(
+                        mission_id = %mission_id,
+                        expires_at,
+                        "Refreshed xAI OAuth token before starting Grok Build"
+                    );
+                }
+                Err(crate::api::ai_providers::OAuthRefreshError::InvalidGrant(err)) => {
+                    return Err(AgentResult::failure(
+                        format!(
+                            "Grok Build xAI OAuth refresh token is expired or revoked. Reconnect the xAI provider, then retry the mission. {}",
+                            err
+                        ),
+                        0,
+                    )
+                    .with_terminal_reason(TerminalReason::LlmError));
+                }
+                Err(err) => {
+                    return Err(AgentResult::failure(
+                        format!(
+                            "Failed to refresh xAI OAuth before starting Grok Build: {}",
+                            err
+                        ),
+                        0,
+                    )
+                    .with_terminal_reason(TerminalReason::LlmError));
+                }
+            }
+        } else {
+            oauth_access_token = Some(entry.access_token.clone());
+            if let Err(err) = crate::api::ai_providers::write_grok_oauth_auth_file(
+                &entry.refresh_token,
+                &entry.access_token,
+                entry.expires_at,
+            ) {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    error = %err,
+                    "Failed to materialize fresh xAI OAuth token into Grok auth file"
+                );
+            }
+        }
+    }
+
+    if let Err(err) = sync_grok_oauth_auth_file(workspace_exec, work_dir).await {
+        tracing::warn!(mission_id = %mission_id, error = %err, "Failed to sync Grok OAuth auth file");
+    }
+
+    // Authenticate the Grok CLI non-interactively via XAI_API_KEY. Priority:
+    // an explicit xAI API key, then the captured OAuth access token, then any
+    // ambient env key. Setting this is what prevents the interactive-sign-in
+    // hang; the CLI prints "You are using XAI_API_KEY" and goes straight to
+    // api.x.ai.
+    let mut env = HashMap::new();
+    let xai_api_key = crate::api::ai_providers::get_xai_api_key_for_grok(app_working_dir)
+        .or_else(|| oauth_access_token.clone())
+        .or_else(|| {
+            std::env::var("XAI_API_KEY")
+                .ok()
+                .filter(|k| !k.trim().is_empty())
+        })
+        .or_else(|| {
+            std::env::var("GROK_CODE_XAI_API_KEY")
+                .ok()
+                .filter(|k| !k.trim().is_empty())
+        });
+    if let Some(key) = xai_api_key {
+        // Newer Grok CLIs read XAI_API_KEY; keep GROK_CODE_XAI_API_KEY for
+        // backward compatibility with older builds.
+        env.insert("XAI_API_KEY".to_string(), key.clone());
+        env.insert("GROK_CODE_XAI_API_KEY".to_string(), key);
+    }
+
+    Ok(env)
+}
+
 /// Execute a turn using the Grok Build CLI backend.
+///
+/// Dispatches to the ACP path (`grok agent stdio`) by default — it is the
+/// only mode that surfaces tool calls and works for thinking on every model.
+/// Set `SANDBOXED_SH_GROK_ACP=0` to force the legacy `--output-format
+/// streaming-json` path; the dispatcher also falls back to it automatically
+/// when the ACP handshake fails before the prompt is sent.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_grok_turn(
+    workspace: &Workspace,
+    work_dir: &std::path::Path,
+    message: &str,
+    model: Option<&str>,
+    mission_id: Uuid,
+    events_tx: broadcast::Sender<AgentEvent>,
+    cancel: CancellationToken,
+    app_working_dir: &std::path::Path,
+    session_id: Option<&str>,
+    is_continuation: bool,
+) -> AgentResult {
+    if env_var_bool("SANDBOXED_SH_GROK_ACP", true) {
+        match run_grok_acp_turn(
+            workspace,
+            work_dir,
+            message,
+            model,
+            mission_id,
+            events_tx.clone(),
+            cancel.clone(),
+            app_working_dir,
+            session_id,
+        )
+        .await
+        {
+            Ok(result) => return result,
+            Err(reason) => {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    reason = %reason,
+                    "Grok ACP handshake failed before the prompt was sent; \
+                     falling back to streaming-json mode"
+                );
+            }
+        }
+    }
+    run_grok_streaming_json_turn(
+        workspace,
+        work_dir,
+        message,
+        model,
+        mission_id,
+        events_tx,
+        cancel,
+        app_working_dir,
+        session_id,
+        is_continuation,
+    )
+    .await
+}
+
+/// Legacy turn path: `grok -p <msg> --output-format streaming-json`.
+///
+/// Emits `thought`/`text` events only — the CLI executes tools silently in
+/// this mode (verified on grok 0.2.16), so tool calls never reach the UI.
+/// Kept as the fallback while the ACP path soaks.
+#[allow(clippy::too_many_arguments)]
+async fn run_grok_streaming_json_turn(
     workspace: &Workspace,
     work_dir: &std::path::Path,
     message: &str,
@@ -533,90 +702,11 @@ pub async fn run_grok_turn(
     // capture the freshest one here and inject it below. Without it the CLI
     // falls back to an interactive browser sign-in that never completes in a
     // headless mission — the run then hangs forever ("Agent is working").
-    let mut oauth_access_token: Option<String> = None;
-    if let Some(entry) =
-        crate::api::ai_providers::read_oauth_token_entry(crate::ai_providers::ProviderType::Xai)
-    {
-        if crate::api::ai_providers::oauth_token_expired(entry.expires_at) {
-            match crate::api::ai_providers::refresh_oauth_token_with_lock(
-                crate::ai_providers::ProviderType::Xai,
-                entry.expires_at,
-            )
-            .await
-            {
-                Ok((access, _refresh, expires_at)) => {
-                    oauth_access_token = Some(access);
-                    tracing::info!(
-                        mission_id = %mission_id,
-                        expires_at,
-                        "Refreshed xAI OAuth token before starting Grok Build"
-                    );
-                }
-                Err(crate::api::ai_providers::OAuthRefreshError::InvalidGrant(err)) => {
-                    return AgentResult::failure(
-                        format!(
-                            "Grok Build xAI OAuth refresh token is expired or revoked. Reconnect the xAI provider, then retry the mission. {}",
-                            err
-                        ),
-                        0,
-                    )
-                    .with_terminal_reason(TerminalReason::LlmError);
-                }
-                Err(err) => {
-                    return AgentResult::failure(
-                        format!(
-                            "Failed to refresh xAI OAuth before starting Grok Build: {}",
-                            err
-                        ),
-                        0,
-                    )
-                    .with_terminal_reason(TerminalReason::LlmError);
-                }
-            }
-        } else {
-            oauth_access_token = Some(entry.access_token.clone());
-            if let Err(err) = crate::api::ai_providers::write_grok_oauth_auth_file(
-                &entry.refresh_token,
-                &entry.access_token,
-                entry.expires_at,
-            ) {
-                tracing::warn!(
-                    mission_id = %mission_id,
-                    error = %err,
-                    "Failed to materialize fresh xAI OAuth token into Grok auth file"
-                );
-            }
-        }
-    }
-
-    if let Err(err) = sync_grok_oauth_auth_file(&workspace_exec, work_dir).await {
-        tracing::warn!(mission_id = %mission_id, error = %err, "Failed to sync Grok OAuth auth file");
-    }
-
-    // Authenticate the Grok CLI non-interactively via XAI_API_KEY. Priority:
-    // an explicit xAI API key, then the captured OAuth access token, then any
-    // ambient env key. Setting this is what prevents the interactive-sign-in
-    // hang; the CLI prints "You are using XAI_API_KEY" and goes straight to
-    // api.x.ai.
-    let mut env = HashMap::new();
-    let xai_api_key = crate::api::ai_providers::get_xai_api_key_for_grok(app_working_dir)
-        .or_else(|| oauth_access_token.clone())
-        .or_else(|| {
-            std::env::var("XAI_API_KEY")
-                .ok()
-                .filter(|k| !k.trim().is_empty())
-        })
-        .or_else(|| {
-            std::env::var("GROK_CODE_XAI_API_KEY")
-                .ok()
-                .filter(|k| !k.trim().is_empty())
-        });
-    if let Some(key) = xai_api_key {
-        // Newer Grok CLIs read XAI_API_KEY; keep GROK_CODE_XAI_API_KEY for
-        // backward compatibility with older builds.
-        env.insert("XAI_API_KEY".to_string(), key.clone());
-        env.insert("GROK_CODE_XAI_API_KEY".to_string(), key);
-    }
+    let env =
+        match prepare_grok_auth_env(&workspace_exec, work_dir, app_working_dir, mission_id).await {
+            Ok(env) => env,
+            Err(result) => return result,
+        };
 
     let mut child = match workspace_exec
         .spawn_streaming(work_dir, &cli_path, &args, env)
@@ -939,4 +1029,561 @@ pub async fn run_grok_turn(
     }
     result = result.with_model(model_used.unwrap_or_else(|| "grok-build".to_string()));
     result
+}
+
+// ── ACP (`grok agent stdio`) turn path ─────────────────────────────────
+//
+// The streaming-json mode hides tool execution entirely and its event
+// vocabulary depends on the model. The ACP mode (JSON-RPC over stdio, see
+// https://docs.x.ai/build/cli/headless-scripting) emits the full session
+// stream — verified against grok 0.2.16:
+//   session/update: tool_call {toolCallId, title, rawInput}
+//                   tool_call_update {kind, title, content, locations, status?}
+//                   agent_thought_chunk {content.text}   (incremental thinking)
+//                   agent_message_chunk {content.text}   (assistant text)
+//   result of session/prompt: {stopReason, _meta: {totalTokens, modelId, ...}}
+// Sessions persist server-side (`loadSession: true`), addressed by the same
+// session ids the streaming path stored, so continuity carries over.
+
+const GROK_ACP_INIT_ID: u64 = 1;
+const GROK_ACP_SESSION_ID: u64 = 2;
+const GROK_ACP_SET_MODEL_ID: u64 = 3;
+const GROK_ACP_PROMPT_ID: u64 = 4;
+
+/// Per-call state for an in-flight grok ACP tool call.
+#[derive(Default, Clone)]
+struct GrokAcpToolCall {
+    name: String,
+    latest_update: serde_json::Value,
+    result_emitted: bool,
+}
+
+fn grok_acp_update_is_terminal(update: &serde_json::Value) -> bool {
+    matches!(
+        update.get("status").and_then(|v| v.as_str()),
+        Some("completed") | Some("failed")
+    )
+}
+
+/// Execute a turn over `grok agent stdio` (ACP JSON-RPC).
+///
+/// Returns `Err(reason)` only for failures BEFORE the prompt is sent
+/// (spawn, initialize, session setup) so the dispatcher can safely fall
+/// back to the streaming-json path without double-executing the turn.
+#[allow(clippy::too_many_arguments)]
+async fn run_grok_acp_turn(
+    workspace: &Workspace,
+    work_dir: &std::path::Path,
+    message: &str,
+    model: Option<&str>,
+    mission_id: Uuid,
+    events_tx: broadcast::Sender<AgentEvent>,
+    cancel: CancellationToken,
+    app_working_dir: &std::path::Path,
+    session_id: Option<&str>,
+) -> Result<AgentResult, String> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    let workspace_exec = WorkspaceExec::new(workspace.clone());
+
+    let cli_path =
+        get_backend_string_setting("grok", "cli_path").unwrap_or_else(|| "grok".to_string());
+    let cli_path = ensure_grok_cli_available(&workspace_exec, work_dir, &cli_path)
+        .await
+        .map_err(|e| format!("grok CLI unavailable: {e}"))?;
+
+    let env =
+        match prepare_grok_auth_env(&workspace_exec, work_dir, app_working_dir, mission_id).await {
+            Ok(env) => env,
+            // Auth failures are terminal for BOTH paths — surface them directly
+            // instead of falling back into the same failure.
+            Err(result) => return Ok(result),
+        };
+
+    // `grok agent stdio` accepts no further flags (verified: it rejects
+    // --no-auto-update). cwd comes from spawn_streaming's working dir and
+    // the session/new params.
+    let args = vec!["agent".to_string(), "stdio".to_string()];
+    let mut child = workspace_exec
+        .spawn_streaming(work_dir, &cli_path, &args, env)
+        .await
+        .map_err(|e| format!("failed to spawn grok agent stdio: {e}"))?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "failed to capture grok stdin".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture grok stdout".to_string())?;
+    let mut lines = BufReader::new(stdout).lines();
+
+    // Capture stderr for diagnostics (the CLI logs there).
+    let stderr_tail = Arc::new(tokio::sync::Mutex::new(String::new()));
+    if let Some(stderr) = child.stderr.take() {
+        let stderr_tail = Arc::clone(&stderr_tail);
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let mut tail = stderr_tail.lock().await;
+                tail.push_str(&line);
+                tail.push('\n');
+                if tail.len() > 8_192 {
+                    let cut = tail.len() - 8_192;
+                    tail.drain(..cut);
+                }
+            }
+        });
+    }
+
+    async fn send(
+        stdin: &mut (impl tokio::io::AsyncWrite + Unpin),
+        value: serde_json::Value,
+    ) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt;
+        let mut payload = value.to_string();
+        payload.push('\n');
+        stdin
+            .write_all(payload.as_bytes())
+            .await
+            .map_err(|e| format!("grok ACP stdin write failed: {e}"))
+    }
+
+    /// Read lines until the response for `id` arrives, with a deadline.
+    /// Notifications received meanwhile are returned to the caller.
+    async fn await_response(
+        lines: &mut tokio::io::Lines<impl tokio::io::AsyncBufRead + Unpin>,
+        id: u64,
+        deadline_secs: u64,
+    ) -> Result<(serde_json::Value, Vec<serde_json::Value>), String> {
+        let mut notifications = Vec::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(deadline_secs);
+        loop {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .ok_or_else(|| format!("grok ACP timed out waiting for response id {id}"))?;
+            let line = tokio::time::timeout(remaining, lines.next_line())
+                .await
+                .map_err(|_| format!("grok ACP timed out waiting for response id {id}"))?
+                .map_err(|e| format!("grok ACP stdout read failed: {e}"))?
+                .ok_or_else(|| "grok ACP stream closed during handshake".to_string())?;
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+                continue;
+            };
+            if value.get("id").and_then(|v| v.as_u64()) == Some(id) {
+                if let Some(err) = value.get("error") {
+                    return Err(format!("grok ACP request {id} failed: {err}"));
+                }
+                return Ok((value, notifications));
+            }
+            notifications.push(value);
+        }
+    }
+
+    // ── Handshake (failures here fall back to streaming-json) ──────────
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": GROK_ACP_INIT_ID,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": 1,
+                "clientCapabilities": { "fs": { "readTextFile": false, "writeTextFile": false } }
+            }
+        }),
+    )
+    .await?;
+    let _ = await_response(&mut lines, GROK_ACP_INIT_ID, 30).await?;
+
+    let acp_cwd = workspace_exec.translate_path_for_container(work_dir);
+    let mut acp_session_id: Option<String> = None;
+    if let Some(sid) = session_id.filter(|s| !s.trim().is_empty()) {
+        // Sessions persist server-side; `session/load` resumes prior context.
+        send(
+            &mut stdin,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": GROK_ACP_SESSION_ID,
+                "method": "session/load",
+                "params": { "sessionId": sid, "cwd": acp_cwd, "mcpServers": [] }
+            }),
+        )
+        .await?;
+        match await_response(&mut lines, GROK_ACP_SESSION_ID, 60).await {
+            Ok(_) => acp_session_id = Some(sid.to_string()),
+            Err(err) => {
+                tracing::info!(
+                    mission_id = %mission_id,
+                    session_id = %sid,
+                    error = %err,
+                    "Grok ACP session/load failed; starting a fresh session"
+                );
+            }
+        }
+    }
+    if acp_session_id.is_none() {
+        send(
+            &mut stdin,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": GROK_ACP_SESSION_ID,
+                "method": "session/new",
+                "params": { "cwd": acp_cwd, "mcpServers": [] }
+            }),
+        )
+        .await?;
+        let (resp, _) = await_response(&mut lines, GROK_ACP_SESSION_ID, 60).await?;
+        let sid = resp
+            .get("result")
+            .and_then(|r| r.get("sessionId"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "grok ACP session/new returned no sessionId".to_string())?
+            .to_string();
+        let _ = events_tx.send(AgentEvent::SessionIdUpdate {
+            mission_id,
+            session_id: sid.clone(),
+        });
+        acp_session_id = Some(sid);
+    }
+    let acp_session_id = acp_session_id.expect("session id established above");
+
+    if let Some(model) = model.filter(|m| !m.trim().is_empty()) {
+        // Best-effort: an unknown model shouldn't kill the turn.
+        send(
+            &mut stdin,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": GROK_ACP_SET_MODEL_ID,
+                "method": "session/set_model",
+                "params": { "sessionId": acp_session_id, "modelId": model }
+            }),
+        )
+        .await?;
+        if let Err(err) = await_response(&mut lines, GROK_ACP_SET_MODEL_ID, 30).await {
+            tracing::warn!(mission_id = %mission_id, model, error = %err, "Grok ACP set_model failed; using session default");
+        }
+    }
+
+    // ── Prompt (from here on, failures are real turn failures) ─────────
+    if let Err(e) = send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": GROK_ACP_PROMPT_ID,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": acp_session_id,
+                "prompt": [{ "type": "text", "text": message }]
+            }
+        }),
+    )
+    .await
+    {
+        return Err(e);
+    }
+
+    let mut thinking_buffer = String::new();
+    let mut thinking_done_emitted = false;
+    let mut text_buffer = String::new();
+    let mut tool_calls: HashMap<String, GrokAcpToolCall> = HashMap::new();
+    let mut model_used: Option<String> = Some(model.unwrap_or("grok-build").to_string());
+    let mut usage = crate::cost::TokenUsage::default();
+    let mut stop_reason: Option<String> = None;
+    let mut transport_error: Option<String> = None;
+
+    // Idle guard: tool executions stream tool_call_update events, so a long
+    // silent gap means the CLI is stuck (or waiting on something that will
+    // never arrive in headless mode).
+    let idle_limit = std::time::Duration::from_secs(180);
+
+    loop {
+        let line = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                let _ = child.kill().await;
+                return Ok(AgentResult::failure("Mission cancelled".to_string(), 0)
+                    .with_terminal_reason(TerminalReason::Cancelled));
+            }
+            line = tokio::time::timeout(idle_limit, lines.next_line()) => match line {
+                Err(_) => {
+                    transport_error = Some(format!(
+                        "Grok ACP produced no events for {}s; killing the CLI",
+                        idle_limit.as_secs()
+                    ));
+                    let _ = child.kill().await;
+                    break;
+                }
+                Ok(Err(e)) => {
+                    transport_error = Some(format!("Grok ACP stdout read failed: {e}"));
+                    break;
+                }
+                Ok(Ok(None)) => {
+                    if stop_reason.is_none() {
+                        transport_error =
+                            Some("Grok ACP stream closed before the prompt completed".to_string());
+                    }
+                    break;
+                }
+                Ok(Ok(Some(line))) => line,
+            }
+        };
+
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+
+        // Incoming request FROM the agent (has both id and method): the only
+        // one we expect is a permission prompt — auto-approve it, mirroring
+        // the streaming path's --always-approve.
+        if let (Some(req_id), Some(method)) = (value.get("id"), value.get("method")) {
+            if method == "session/request_permission" {
+                let option_id = value
+                    .pointer("/params/options")
+                    .and_then(|v| v.as_array())
+                    .and_then(|opts| {
+                        opts.iter()
+                            .find(|o| {
+                                o.get("kind")
+                                    .and_then(|k| k.as_str())
+                                    .is_some_and(|k| k.starts_with("allow"))
+                            })
+                            .or_else(|| opts.first())
+                    })
+                    .and_then(|o| o.get("optionId"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let _ = send(
+                    &mut stdin,
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "params": null,
+                        "result": { "outcome": { "outcome": "selected", "optionId": option_id } }
+                    }),
+                )
+                .await;
+            }
+            continue;
+        }
+
+        // Prompt completion.
+        if value.get("id").and_then(|v| v.as_u64()) == Some(GROK_ACP_PROMPT_ID) {
+            if let Some(err) = value.get("error") {
+                transport_error = Some(format!("Grok ACP prompt failed: {err}"));
+                break;
+            }
+            let result = value.get("result").cloned().unwrap_or_default();
+            stop_reason = result
+                .get("stopReason")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if let Some(meta) = result.get("_meta") {
+                if let Some(m) = meta.get("modelId").and_then(|v| v.as_str()) {
+                    model_used = Some(m.to_string());
+                }
+                usage.input_tokens = usage_value_tokens(meta, &["inputTokens", "input_tokens"]);
+                usage.output_tokens = usage_value_tokens(meta, &["outputTokens", "output_tokens"]);
+                if !usage.has_usage() {
+                    // Only a total is exposed: attribute it to input so cost
+                    // estimation has something to work with.
+                    usage.input_tokens = usage_value_tokens(meta, &["totalTokens", "total_tokens"]);
+                }
+            }
+            break;
+        }
+
+        // Session updates arrive both as standard `session/update` and the
+        // vendor-prefixed `_x.ai/session_notification` envelope.
+        let update = match value.get("method").and_then(|v| v.as_str()) {
+            Some("session/update") | Some("_x.ai/session_notification") => {
+                value.pointer("/params/update").cloned()
+            }
+            _ => None,
+        };
+        let Some(update) = update else { continue };
+        match update.get("sessionUpdate").and_then(|v| v.as_str()) {
+            Some("agent_thought_chunk") => {
+                if let Some(text) = update.pointer("/content/text").and_then(|v| v.as_str()) {
+                    thinking_buffer.push_str(text);
+                    thinking_done_emitted = false;
+                    let _ = events_tx.send(AgentEvent::Thinking {
+                        content: thinking_buffer.clone(),
+                        done: false,
+                        mission_id: Some(mission_id),
+                    });
+                }
+            }
+            Some("agent_message_chunk") => {
+                if let Some(text) = update.pointer("/content/text").and_then(|v| v.as_str()) {
+                    text_buffer.push_str(text);
+                    let _ = events_tx.send(AgentEvent::TextDelta {
+                        content: text_buffer.clone(),
+                        mission_id: Some(mission_id),
+                    });
+                }
+            }
+            Some("tool_call") => {
+                // Close the open thinking block: tool execution marks a
+                // boundary, and the finalizer is the only persisted form.
+                if !thinking_buffer.is_empty() && !thinking_done_emitted {
+                    let _ = events_tx.send(thinking_final_event(
+                        std::mem::take(&mut thinking_buffer),
+                        mission_id,
+                    ));
+                    thinking_done_emitted = true;
+                }
+                let id = update
+                    .get("toolCallId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                if id.is_empty() {
+                    continue;
+                }
+                let name = update
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("tool")
+                    .to_string();
+                let args = update.get("rawInput").cloned().unwrap_or_default();
+                let _ = events_tx.send(AgentEvent::ToolCall {
+                    tool_call_id: id.clone(),
+                    name: name.clone(),
+                    args,
+                    mission_id: Some(mission_id),
+                });
+                tool_calls.insert(
+                    id,
+                    GrokAcpToolCall {
+                        name,
+                        latest_update: update,
+                        result_emitted: false,
+                    },
+                );
+            }
+            Some("tool_call_update") => {
+                let Some(id) = update.get("toolCallId").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let entry = tool_calls.entry(id.to_string()).or_default();
+                if entry.name.is_empty() {
+                    entry.name = update
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("tool")
+                        .to_string();
+                }
+                entry.latest_update = update.clone();
+                if grok_acp_update_is_terminal(&update) && !entry.result_emitted {
+                    entry.result_emitted = true;
+                    let _ = events_tx.send(AgentEvent::ToolResult {
+                        tool_call_id: id.to_string(),
+                        name: entry.name.clone(),
+                        result: update,
+                        mission_id: Some(mission_id),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    drop(stdin);
+    let _ = child.wait().await;
+
+    // The CLI doesn't always stamp a terminal status on the last
+    // tool_call_update — flush whatever we have so every ToolCall gets a
+    // matching ToolResult in the UI/history.
+    for (id, call) in tool_calls.iter() {
+        if !call.result_emitted {
+            let _ = events_tx.send(AgentEvent::ToolResult {
+                tool_call_id: id.clone(),
+                name: call.name.clone(),
+                result: call.latest_update.clone(),
+                mission_id: Some(mission_id),
+            });
+        }
+    }
+    if !thinking_buffer.is_empty() && !thinking_done_emitted {
+        let _ = events_tx.send(thinking_final_event(thinking_buffer.clone(), mission_id));
+    }
+
+    if let Some(err) = transport_error {
+        let stderr_tail = stderr_tail.lock().await.trim().to_string();
+        let detail = if stderr_tail.is_empty() {
+            err
+        } else {
+            format!("{err}\nstderr tail:\n{stderr_tail}")
+        };
+        return Ok(AgentResult::failure(detail, 0)
+            .with_terminal_reason(TerminalReason::LlmError)
+            .with_model(model_used.unwrap_or_else(|| "grok-build".to_string())));
+    }
+
+    let final_text = text_buffer.trim().to_string();
+    let (cost_cents, cost_source) =
+        resolve_cost_cents_and_source(None, model_used.as_deref().or(Some("grok-build")), &usage);
+    let mut result = if final_text.is_empty() {
+        AgentResult::failure(
+            format!(
+                "Grok completed the turn (stopReason: {}) without producing assistant text.",
+                stop_reason.as_deref().unwrap_or("unknown")
+            ),
+            cost_cents,
+        )
+        .with_terminal_reason(TerminalReason::LlmError)
+    } else {
+        AgentResult::success(final_text, cost_cents)
+            .with_terminal_reason(TerminalReason::TurnComplete)
+    };
+    result = result.with_cost_source(cost_source);
+    let outcome = turn_outcome_for_result(
+        &result,
+        CompletionSignal::ProcessExit,
+        CompletionConfidence::High,
+    );
+    result = result.with_turn_outcome(outcome);
+    if usage.has_usage() {
+        result = result.with_usage(usage);
+    }
+    result = result.with_model(model_used.unwrap_or_else(|| "grok-build".to_string()));
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grok_event_reasoning_handles_streaming_json_thought_events() {
+        // Real event captured from grok 0.2.16 `--output-format streaming-json`
+        // with grok-build-0.1: thinking arrives as type "thought" with the
+        // chunk in `data`. This was silently dropped before.
+        let event = serde_json::json!({ "type": "thought", "data": "The user wants" });
+        assert_eq!(
+            grok_event_reasoning(&event).as_deref(),
+            Some("The user wants")
+        );
+        assert_eq!(grok_event_text(&event), None);
+    }
+
+    #[test]
+    fn grok_acp_terminal_update_detection() {
+        assert!(grok_acp_update_is_terminal(
+            &serde_json::json!({ "sessionUpdate": "tool_call_update", "status": "completed" })
+        ));
+        assert!(grok_acp_update_is_terminal(
+            &serde_json::json!({ "status": "failed" })
+        ));
+        // Real captured update without a status stamp — not terminal; the
+        // end-of-turn flush covers it.
+        assert!(!grok_acp_update_is_terminal(&serde_json::json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "call-1",
+            "kind": "edit",
+            "title": "Write `/tmp/x`",
+            "content": [{ "type": "diff", "path": "/tmp/x", "oldText": "", "newText": "delta" }]
+        })));
+    }
 }

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -1333,6 +1333,10 @@ async fn run_grok_acp_turn(
     )
     .await
     {
+        // Prompt never reached the agent — kill the CLI before handing the
+        // turn back to the fallback path (same orphan hazard as handshake).
+        let _ = child.kill().await;
+        let _ = child.wait().await;
         return Err(e);
     }
 

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -558,6 +558,47 @@ pub async fn run_grok_turn(
     session_id: Option<&str>,
     is_continuation: bool,
 ) -> AgentResult {
+    if workspace.id == crate::workspace::DEFAULT_WORKSPACE_ID && !work_dir.join(".git").exists() {
+        let file_count = std::fs::read_dir(work_dir)
+            .map(|mut d| {
+                d.by_ref()
+                    .filter(|e| {
+                        e.as_ref()
+                            .map(|e| {
+                                let n = e.file_name();
+                                let n = n.to_string_lossy();
+                                !n.starts_with('.') && n != "output"
+                            })
+                            .unwrap_or(false)
+                    })
+                    .count()
+            })
+            .unwrap_or(0);
+        if file_count == 0 && !is_continuation {
+            let dir_display = work_dir.display();
+            tracing::warn!(
+                mission_id = %mission_id,
+                work_dir = %dir_display,
+                "Grok mission running in empty host workspace with no git repo — goal loop will hallucinate edits"
+            );
+            let msg = format!(
+                "The mission workspace ({dir_display}) is empty and has no git repository. \
+                 Grok cannot edit files or push changes without a project checkout. \
+                 Create this mission on a workspace that contains the target repository, \
+                 or clone the repo into the workspace first.",
+            );
+            // Return a failure result so the control loop emits a single
+            // `AssistantMessage { success: false }` and marks the mission
+            // `Failed` (Bugbot f4a7a2d8). Emitting a manual AssistantMessage
+            // and then returning success:true caused the control loop to
+            // emit a SECOND assistant message with success:true and record
+            // automations as successful, despite the workspace being
+            // unusable. LlmError is the right terminal reason: this is a
+            // "can't run" error, not a clean turn boundary.
+            return AgentResult::failure(msg, 0).with_terminal_reason(TerminalReason::LlmError);
+        }
+    }
+
     if env_var_bool("SANDBOXED_SH_GROK_ACP", true) {
         match run_grok_acp_turn(
             workspace,
@@ -569,6 +610,7 @@ pub async fn run_grok_turn(
             cancel.clone(),
             app_working_dir,
             session_id,
+            is_continuation,
         )
         .await
         {
@@ -619,47 +661,6 @@ async fn run_grok_streaming_json_turn(
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     let workspace_exec = WorkspaceExec::new(workspace.clone());
-
-    if workspace.id == crate::workspace::DEFAULT_WORKSPACE_ID && !work_dir.join(".git").exists() {
-        let file_count = std::fs::read_dir(work_dir)
-            .map(|mut d| {
-                d.by_ref()
-                    .filter(|e| {
-                        e.as_ref()
-                            .map(|e| {
-                                let n = e.file_name();
-                                let n = n.to_string_lossy();
-                                !n.starts_with('.') && n != "output"
-                            })
-                            .unwrap_or(false)
-                    })
-                    .count()
-            })
-            .unwrap_or(0);
-        if file_count == 0 && !is_continuation {
-            let dir_display = work_dir.display();
-            tracing::warn!(
-                mission_id = %mission_id,
-                work_dir = %dir_display,
-                "Grok mission running in empty host workspace with no git repo — goal loop will hallucinate edits"
-            );
-            let msg = format!(
-                "The mission workspace ({dir_display}) is empty and has no git repository. \
-                 Grok cannot edit files or push changes without a project checkout. \
-                 Create this mission on a workspace that contains the target repository, \
-                 or clone the repo into the workspace first.",
-            );
-            // Return a failure result so the control loop emits a single
-            // `AssistantMessage { success: false }` and marks the mission
-            // `Failed` (Bugbot f4a7a2d8). Emitting a manual AssistantMessage
-            // and then returning success:true caused the control loop to
-            // emit a SECOND assistant message with success:true and record
-            // automations as successful, despite the workspace being
-            // unusable. LlmError is the right terminal reason: this is a
-            // "can't run" error, not a clean turn boundary.
-            return AgentResult::failure(msg, 0).with_terminal_reason(TerminalReason::LlmError);
-        }
-    }
 
     let cli_path =
         get_backend_string_setting("grok", "cli_path").unwrap_or_else(|| "grok".to_string());
@@ -1047,8 +1048,9 @@ async fn run_grok_streaming_json_turn(
 
 const GROK_ACP_INIT_ID: u64 = 1;
 const GROK_ACP_SESSION_ID: u64 = 2;
-const GROK_ACP_SET_MODEL_ID: u64 = 3;
-const GROK_ACP_PROMPT_ID: u64 = 4;
+const GROK_ACP_SESSION_NEW_ID: u64 = 3;
+const GROK_ACP_SET_MODEL_ID: u64 = 4;
+const GROK_ACP_PROMPT_ID: u64 = 5;
 
 /// Per-call state for an in-flight grok ACP tool call.
 #[derive(Default, Clone)]
@@ -1081,6 +1083,7 @@ async fn run_grok_acp_turn(
     cancel: CancellationToken,
     app_working_dir: &std::path::Path,
     session_id: Option<&str>,
+    is_continuation: bool,
 ) -> Result<AgentResult, String> {
     use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -1119,13 +1122,21 @@ async fn run_grok_acp_turn(
         .ok_or_else(|| "failed to capture grok stdout".to_string())?;
     let mut lines = BufReader::new(stdout).lines();
 
-    // Capture stderr for diagnostics (the CLI logs there).
+    // Capture stderr for diagnostics, and watch for the interactive
+    // sign-in prompt: without a usable XAI_API_KEY the CLI prints it to
+    // stderr and blocks on a browser OAuth callback that never arrives in
+    // headless mode. Fail fast instead of waiting out the idle guard.
     let stderr_tail = Arc::new(tokio::sync::Mutex::new(String::new()));
+    let auth_fail = CancellationToken::new();
     if let Some(stderr) = child.stderr.take() {
         let stderr_tail = Arc::clone(&stderr_tail);
+        let auth_fail = auth_fail.clone();
         tokio::spawn(async move {
             let mut lines = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
+                if grok_line_requests_interactive_login(line.trim()) {
+                    auth_fail.cancel();
+                }
                 let mut tail = stderr_tail.lock().await;
                 tail.push_str(&line);
                 tail.push('\n');
@@ -1182,72 +1193,103 @@ async fn run_grok_acp_turn(
     }
 
     // ── Handshake (failures here fall back to streaming-json) ──────────
-    send(
-        &mut stdin,
-        serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": GROK_ACP_INIT_ID,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": 1,
-                "clientCapabilities": { "fs": { "readTextFile": false, "writeTextFile": false } }
-            }
-        }),
-    )
-    .await?;
-    let _ = await_response(&mut lines, GROK_ACP_INIT_ID, 30).await?;
+    // Wrapped so every early error kills the spawned CLI first — a dropped
+    // tokio Child keeps running (no kill_on_drop), and the fallback path
+    // would spawn a second CLI for the same turn.
+    let handshake: Result<String, String> = async {
+        send(
+            &mut stdin,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": GROK_ACP_INIT_ID,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                    "clientCapabilities": { "fs": { "readTextFile": false, "writeTextFile": false } }
+                }
+            }),
+        )
+        .await?;
+        let _ = await_response(&mut lines, GROK_ACP_INIT_ID, 30).await?;
 
-    let acp_cwd = workspace_exec.translate_path_for_container(work_dir);
-    let mut acp_session_id: Option<String> = None;
-    if let Some(sid) = session_id.filter(|s| !s.trim().is_empty()) {
-        // Sessions persist server-side; `session/load` resumes prior context.
-        send(
-            &mut stdin,
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": GROK_ACP_SESSION_ID,
-                "method": "session/load",
-                "params": { "sessionId": sid, "cwd": acp_cwd, "mcpServers": [] }
-            }),
-        )
-        .await?;
-        match await_response(&mut lines, GROK_ACP_SESSION_ID, 60).await {
-            Ok(_) => acp_session_id = Some(sid.to_string()),
-            Err(err) => {
-                tracing::info!(
-                    mission_id = %mission_id,
-                    session_id = %sid,
-                    error = %err,
-                    "Grok ACP session/load failed; starting a fresh session"
-                );
+        let acp_cwd = workspace_exec.translate_path_for_container(work_dir);
+        let mut acp_session_id: Option<String> = None;
+        if let Some(sid) = session_id.filter(|s| !s.trim().is_empty()) {
+            // Sessions persist server-side; `session/load` resumes prior context.
+            send(
+                &mut stdin,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": GROK_ACP_SESSION_ID,
+                    "method": "session/load",
+                    "params": { "sessionId": sid, "cwd": acp_cwd, "mcpServers": [] }
+                }),
+            )
+            .await?;
+            match await_response(&mut lines, GROK_ACP_SESSION_ID, 60).await {
+                Ok(_) => acp_session_id = Some(sid.to_string()),
+                Err(err) if is_continuation => {
+                    // The stored session holds real prior context we cannot
+                    // reach over ACP. The streaming path's `--continue`
+                    // resumes the CLI's last session in this directory —
+                    // defer to it instead of silently dropping context.
+                    return Err(format!(
+                        "stored session {sid} not loadable over ACP on a continuation \
+                         turn ({err}); deferring to --continue"
+                    ));
+                }
+                Err(err) => {
+                    tracing::info!(
+                        mission_id = %mission_id,
+                        session_id = %sid,
+                        error = %err,
+                        "Grok ACP session/load failed; starting a fresh session"
+                    );
+                }
             }
+        } else if is_continuation {
+            // Continuation with no stored session id at all: only the
+            // streaming path's `--continue` can recover the prior session.
+            return Err(
+                "continuation turn without a stored session id; deferring to --continue"
+                    .to_string(),
+            );
         }
+        if acp_session_id.is_none() {
+            send(
+                &mut stdin,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": GROK_ACP_SESSION_NEW_ID,
+                    "method": "session/new",
+                    "params": { "cwd": acp_cwd, "mcpServers": [] }
+                }),
+            )
+            .await?;
+            let (resp, _) = await_response(&mut lines, GROK_ACP_SESSION_NEW_ID, 60).await?;
+            let sid = resp
+                .get("result")
+                .and_then(|r| r.get("sessionId"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "grok ACP session/new returned no sessionId".to_string())?
+                .to_string();
+            let _ = events_tx.send(AgentEvent::SessionIdUpdate {
+                mission_id,
+                session_id: sid.clone(),
+            });
+            acp_session_id = Some(sid);
+        }
+        Ok(acp_session_id.expect("session id established above"))
     }
-    if acp_session_id.is_none() {
-        send(
-            &mut stdin,
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": GROK_ACP_SESSION_ID,
-                "method": "session/new",
-                "params": { "cwd": acp_cwd, "mcpServers": [] }
-            }),
-        )
-        .await?;
-        let (resp, _) = await_response(&mut lines, GROK_ACP_SESSION_ID, 60).await?;
-        let sid = resp
-            .get("result")
-            .and_then(|r| r.get("sessionId"))
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "grok ACP session/new returned no sessionId".to_string())?
-            .to_string();
-        let _ = events_tx.send(AgentEvent::SessionIdUpdate {
-            mission_id,
-            session_id: sid.clone(),
-        });
-        acp_session_id = Some(sid);
-    }
-    let acp_session_id = acp_session_id.expect("session id established above");
+    .await;
+    let acp_session_id = match handshake {
+        Ok(sid) => sid,
+        Err(err) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(err);
+        }
+    };
 
     // The ACP session default is the non-reasoning chat model
     // (grok-4.20-*-non-reasoning), which emits no thought chunks. The legacy
@@ -1315,6 +1357,16 @@ async fn run_grok_acp_turn(
                 let _ = child.kill().await;
                 return Ok(AgentResult::failure("Mission cancelled".to_string(), 0)
                     .with_terminal_reason(TerminalReason::Cancelled));
+            }
+            _ = auth_fail.cancelled() => {
+                let _ = child.kill().await;
+                return Ok(AgentResult::failure(
+                    "Grok Build requires interactive sign-in (no usable XAI_API_KEY). \
+                     Reconnect the xAI provider or set an API key, then retry."
+                        .to_string(),
+                    0,
+                )
+                .with_terminal_reason(TerminalReason::AuthError));
             }
             line = tokio::time::timeout(idle_limit, lines.next_line()) => match line {
                 Err(_) => {
@@ -1534,7 +1586,17 @@ async fn run_grok_acp_turn(
     let final_text = text_buffer.trim().to_string();
     let (cost_cents, cost_source) =
         resolve_cost_cents_and_source(None, model_used.as_deref().or(Some("grok-build")), &usage);
-    let mut result = if final_text.is_empty() {
+    let mut result = if final_text.is_empty() && stop_reason.is_some() && !tool_calls.is_empty() {
+        // Tool-only turn: the model acted but never emitted a final
+        // message chunk. The work happened — surface it as success with a
+        // synthetic summary instead of a phantom LLM error.
+        let summary = format!(
+            "Completed {} tool action(s) without a final text reply (stopReason: {}).",
+            tool_calls.len(),
+            stop_reason.as_deref().unwrap_or("unknown")
+        );
+        AgentResult::success(summary, cost_cents).with_terminal_reason(TerminalReason::TurnComplete)
+    } else if final_text.is_empty() {
         AgentResult::failure(
             format!(
                 "Grok completed the turn (stopReason: {}) without producing assistant text.",


### PR DESCRIPTION
## Research (probed live on prod, grok-cli 0.2.16)

**`--output-format streaming-json`** (current mode) emits only:
```
{"type":"thought","data":"The"}   ← thinking chunks — our parser missed the 'thought' type entirely
{"type":"text","data":"epsilon"}
{"type":"end","stopReason":"EndTurn","sessionId":"..."}
```
No tool events exist in this format — a 5-tool run emits nothing but final text.

**`grok agent stdio`** (ACP/JSON-RPC, per https://docs.x.ai/build/cli/headless-scripting) emits the full stream: `tool_call` {toolCallId, title, rawInput}, `tool_call_update` {kind, title, diff content, locations}, `agent_thought_chunk` (63/turn on a reasoning model), `agent_message_chunk`, and a prompt result with stopReason + token totals. `loadSession: true` + `session/set_model` supported.

## Changes
1. **One-line thinking fix**: add `thought` to `grok_event_is_reasoning_type` — grok-build-0.1 emits 18+ thought chunks per turn that were all dropped. Works immediately even on the legacy path.
2. **ACP turn path** (`run_grok_acp_turn`): full JSON-RPC client mapping the ACP stream onto our unified events (ToolCall/ToolResult with end-of-turn flush, Thinking deltas + block-final finalizers, TextDelta, usage/cost from the prompt result). Auto-approves permission requests, 180s idle guard, session resume via `session/load` against the same stored session ids.
3. **Dispatch + fallback**: `run_grok_turn` uses ACP by default; pre-prompt handshake failures fall back to streaming-json automatically (no double execution — fallback only before the prompt is sent). `SANDBOXED_SH_GROK_ACP=0` forces legacy.
4. Shared `prepare_grok_auth_env` (OAuth refresh + auth-file sync + XAI_API_KEY) used by both paths.

991 lib tests + clippy + fmt green. E2E verification on dev in progress — will report tool/thinking persistence results on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new ACP client on the mission critical path with session/fallback semantics and auto-approved permissions; auth handling is shared but OAuth/API key behavior is unchanged in substance.
> 
> **Overview**
> Grok mission turns now **default to `grok agent stdio` (ACP JSON-RPC)** instead of only `streaming-json`, so the UI can receive **tool calls/results**, **thinking chunks**, and **text** from the full session stream. **`SANDBOXED_SH_GROK_ACP=0`** keeps the legacy path; if ACP fails **before the prompt is sent**, the runner **falls back** to streaming-json (kills the orphan CLI, and on continuation may **drop the stored session id** so legacy **`--continue`** preserves context instead of a bad **`--session-id`** upsert).
> 
> OAuth refresh, auth-file sync, and **`XAI_API_KEY`** injection are **factored into `prepare_grok_auth_env`**, shared by both paths. The legacy streaming-json loop is **`run_grok_streaming_json_turn`**.
> 
> On the legacy parser, **`type: "thought"`** is treated as reasoning so grok 0.2.x thinking chunks are no longer dropped. Unit tests cover thought events and ACP terminal tool updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9a261bb13ad3bc8f077213205034f24ffcdc3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->