### PR TITLE
fix(grok): drop unloadable session id on pre-prompt ACP fallback

### DIFF
--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -1245,7 +1245,8 @@ async fn run_grok_acp_turn(
     // Wrapped so every early error kills the spawned CLI first — a dropped
     // tokio Child keeps running (no kill_on_drop), and the fallback path
     // would spawn a second CLI for the same turn.
-    let handshake: Result<String, String> = async {
+    let handshake: Result<(String, bool), String> = async {
+        let mut session_load_failed = false;
         send(
             &mut stdin,
             serde_json::json!({
@@ -1288,6 +1289,7 @@ async fn run_grok_acp_turn(
                     ));
                 }
                 Err(err) => {
+                    session_load_failed = true;
                     tracing::info!(
                         mission_id = %mission_id,
                         session_id = %sid,
@@ -1327,11 +1329,14 @@ async fn run_grok_acp_turn(
             });
             acp_session_id = Some(sid);
         }
-        Ok(acp_session_id.expect("session id established above"))
+        Ok((
+            acp_session_id.expect("session id established above"),
+            session_load_failed,
+        ))
     }
     .await;
-    let acp_session_id = match handshake {
-        Ok(sid) => sid,
+    let (acp_session_id, session_load_failed) = match handshake {
+        Ok(pair) => pair,
         Err(err) => {
             let _ = child.kill().await;
             let _ = child.wait().await;
@@ -1389,7 +1394,12 @@ async fn run_grok_acp_turn(
         // turn back to the fallback path (same orphan hazard as handshake).
         let _ = child.kill().await;
         let _ = child.wait().await;
-        return Err(GrokAcpFallback::from(e));
+        // If the stored session already failed to load over ACP, the legacy
+        // path must not upsert an empty session under that id either.
+        return Err(GrokAcpFallback {
+            reason: e,
+            drop_session_id: session_load_failed,
+        });
     }
 
     let mut thinking_buffer = String::new();


### PR DESCRIPTION
Follow-up to #520 for Bugbot finding 6a0adbdf (raised just before merge): when `session/load` fails on a non-continuation turn and a later pre-prompt failure triggers the streaming-json fallback, the original (already-unloadable) session id was still passed as `--session-id`, upserting an empty session. The handshake now returns a `session_load_failed` flag and the prompt-send fallback propagates `drop_session_id`, so the legacy path omits the id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 33ce2c7ced4a2c620ff2a1e92a87e9cd0b2fdca1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->