### PR TITLE
fix(opencode): proxy-aware liveness — don't kill long reasoning segments as stalls

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4839,6 +4839,10 @@ pub(crate) fn ensure_opencode_provider_for_model(
     // proxy on 127.0.0.1 — pointing builtin/* there made OpenCode exit
     // banner-only until the 120s inactivity watchdog SIGKILLed it.
     host_ip: &str,
+    // Mission id sent as a header on builtin proxy requests so runner
+    // watchdogs can see "this mission's LLM call is still streaming"
+    // (proxy_liveness). None for non-mission contexts.
+    mission_id: Option<&str>,
 ) {
     let model_override = model_override.trim();
     if model_override.is_empty() {
@@ -4922,16 +4926,22 @@ pub(crate) fn ensure_opencode_provider_for_model(
                     tracing::error!("SANDBOXED_PROXY_SECRET not set; builtin proxy auth will fail");
                     String::new()
                 });
+            let mut options = serde_json::json!({
+                "baseURL": format!("http://{}:{}/v1", host_ip, port),
+                "apiKey": proxy_key
+            });
+            if let Some(mid) = mission_id {
+                options["headers"] = serde_json::json!({
+                    crate::api::proxy_liveness::MISSION_ID_HEADER: mid
+                });
+            }
             Some(serde_json::json!({
                 "npm": "@ai-sdk/openai-compatible",
                 "name": "Builtin",
                 "models": {
                     model_id: { "name": model_id }
                 },
-                "options": {
-                    "baseURL": format!("http://{}:{}/v1", host_ip, port),
-                    "apiKey": proxy_key
-                }
+                "options": options
             }))
         }
         _ => custom_opencode_provider_definition(app_working_dir, provider_id),
@@ -9144,6 +9154,7 @@ mod tests {
             &app_dir,
             "spark/qwen3.5-397b",
             "127.0.0.1",
+            None,
         );
 
         let opencode_json: serde_json::Value = serde_json::from_str(
@@ -9197,7 +9208,13 @@ mod tests {
 
         // Private-network container case: the proxy must be addressed via
         // the veth gateway, not the container's own loopback.
-        ensure_opencode_provider_for_model(&config_dir, &app_dir, "builtin/smart", "10.88.0.1");
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "builtin/smart",
+            "10.88.0.1",
+            Some("00000000-0000-0000-0000-000000000123"),
+        );
 
         let opencode_json: serde_json::Value = serde_json::from_str(
             &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
@@ -9210,6 +9227,11 @@ mod tests {
             base_url.starts_with("http://10.88.0.1:"),
             "expected veth gateway baseURL, got {base_url}"
         );
+        let mission_header = opencode_json["provider"]["builtin"]["options"]["headers"]
+            [crate::api::proxy_liveness::MISSION_ID_HEADER]
+            .as_str()
+            .expect("mission id header");
+        assert_eq!(mission_header, "00000000-0000-0000-0000-000000000123");
     }
 
     // ── extract_part_text tests ───────────────────────────────────────

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,6 +48,7 @@ mod provider_usage_cache;
 mod providers;
 pub(crate) mod proxy;
 mod proxy_keys;
+pub(crate) mod proxy_liveness;
 mod routes;
 pub(crate) mod runners;
 pub mod secrets;

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -481,6 +481,17 @@ pub(crate) async fn chat_completions_inner(
     }
     let requested_model = req.model.clone();
 
+    // Mission attribution for runner watchdogs: the per-workspace builtin
+    // provider sends this header so the proxy can report "this mission's LLM
+    // call is still streaming" while the harness CLI emits nothing.
+    let liveness_mission_id = headers
+        .get(crate::api::proxy_liveness::MISSION_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| uuid::Uuid::parse_str(v.trim()).ok());
+    if let Some(id) = liveness_mission_id {
+        crate::api::proxy_liveness::note_activity(id);
+    }
+
     // 2. Resolve the requested model to chain entries:
     //    (a) A known chain id — exact, or "builtin/{model}" (the
     //        @ai-sdk/openai-compatible adapter strips the provider prefix, so
@@ -949,6 +960,7 @@ pub(crate) async fn chat_completions_inner(
                     None,
                     entry.subscription_key.clone(),
                     Some(proxy_usage_sink(state.clone(), entry.model_id.clone())),
+                    liveness_mission_id,
                 );
 
                 let success_provider = entry.provider_id.clone();
@@ -1189,6 +1201,7 @@ pub(crate) async fn chat_completions_inner(
                     None,
                     entry.subscription_key.clone(),
                     Some(proxy_usage_sink(state.clone(), entry.model_id.clone())),
+                    liveness_mission_id,
                 );
 
                 let success_provider = entry.provider_id.clone();
@@ -1692,6 +1705,7 @@ pub(crate) async fn chat_completions_inner(
                 rate_limit_snapshot,
                 entry.subscription_key.clone(),
                 Some(proxy_usage_sink(state.clone(), entry.model_id.clone())),
+                liveness_mission_id,
             );
 
             return (status, response_headers, Body::from_stream(tracked_stream)).into_response();
@@ -2968,6 +2982,7 @@ fn track_stream_health(
     rate_limit_snapshot: Option<crate::provider_health::RateLimitSnapshot>,
     subscription_key: Option<crate::provider_health::SubscriptionKey>,
     usage_sink: Option<Box<dyn FnOnce(u64, u64) + Send>>,
+    liveness_mission_id: Option<uuid::Uuid>,
 ) -> impl futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + 'static {
     async_stream::stream! {
         let mut stream = std::pin::pin!(inner);
@@ -3000,6 +3015,9 @@ fn track_stream_health(
                     received_any = true;
                     match &item {
                         Ok(chunk) => {
+                            if let Some(id) = liveness_mission_id {
+                                crate::api::proxy_liveness::note_activity(id);
+                            }
                             // Scan SSE data lines for usage in the final chunk.
                             // OpenAI-compatible providers include a `usage` object
                             // in the last `data:` event of the stream.
@@ -5647,7 +5665,8 @@ mod tests {
             yield Ok::<bytes::Bytes, std::io::Error>(bytes::Bytes::from("never sent"));
         };
 
-        let tracked = track_stream_health(inner, tracker.clone(), account_id, None, None, None);
+        let tracked =
+            track_stream_health(inner, tracker.clone(), account_id, None, None, None, None);
         let mut tracked = std::pin::pin!(tracked);
 
         // First chunk should pass through immediately.
@@ -5686,7 +5705,8 @@ mod tests {
             }
         };
 
-        let tracked = track_stream_health(inner, tracker.clone(), account_id, None, None, None);
+        let tracked =
+            track_stream_health(inner, tracker.clone(), account_id, None, None, None, None);
         let mut tracked = std::pin::pin!(tracked);
         let mut count = 0;
         while let Some(item) = tracked.next().await {

--- a/src/api/proxy_liveness.rs
+++ b/src/api/proxy_liveness.rs
@@ -1,0 +1,66 @@
+//! Per-mission liveness signals from the builtin LLM proxy.
+//!
+//! Harness runners watch their CLI's stdout/stderr to decide whether a turn is
+//! stuck, but thinking models (MiniMax-M3, GLM, ...) can spend minutes inside a
+//! reasoning segment during which OpenCode emits no JSON events at all. The
+//! proxy, however, sees the upstream tokens streaming the whole time. This
+//! registry lets the proxy record "mission X received an upstream chunk just
+//! now" so runner watchdogs can distinguish "model is still generating" from
+//! "process is genuinely hung".
+//!
+//! Attribution: the per-workspace builtin provider config sends an
+//! `x-sandboxed-mission-id` header with every proxy request (see
+//! `ensure_opencode_provider_for_model`). Requests without the header (router
+//! traffic, chain tests, older workspace configs) are simply not tracked.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use uuid::Uuid;
+
+/// Header carrying the mission id on builtin proxy requests.
+pub const MISSION_ID_HEADER: &str = "x-sandboxed-mission-id";
+
+/// Entries older than this are pruned opportunistically on writes; a turn that
+/// has been silent for an hour is long past any watchdog decision.
+const PRUNE_AFTER: Duration = Duration::from_secs(3600);
+
+static REGISTRY: OnceLock<Mutex<HashMap<Uuid, Instant>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<HashMap<Uuid, Instant>> {
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record proxy activity (request accepted or upstream chunk received) for a
+/// mission.
+pub fn note_activity(mission_id: Uuid) {
+    if let Ok(mut map) = registry().lock() {
+        map.insert(mission_id, Instant::now());
+        if map.len() > 64 {
+            map.retain(|_, ts| ts.elapsed() < PRUNE_AFTER);
+        }
+    }
+}
+
+/// Time since the proxy last saw activity for this mission, if any.
+pub fn time_since_activity(mission_id: Uuid) -> Option<Duration> {
+    registry()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&mission_id).map(|ts| ts.elapsed()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_then_query_roundtrip() {
+        let id = Uuid::new_v4();
+        assert!(time_since_activity(id).is_none());
+        note_activity(id);
+        let elapsed = time_since_activity(id).expect("activity recorded");
+        assert!(elapsed < Duration::from_secs(5));
+    }
+}

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -18,6 +18,20 @@ use crate::opencode::{extract_reasoning, extract_text};
 use crate::workspace::Workspace;
 use crate::workspace_exec::WorkspaceExec;
 
+/// Hard inactivity threshold when neither heartbeats nor proxy streaming are
+/// observed. Thinking models routinely spend 2–5 minutes inside a reasoning
+/// segment with zero harness output, so 120s produced false stall kills
+/// (mission f9ba703a: MiniMax-M3 killed mid-reasoning after exactly 120s).
+const GLOBAL_INACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+/// Inactivity threshold while OpenCode server heartbeats are still arriving.
+const HEARTBEAT_INACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(420);
+/// A builtin-proxy chunk within this window counts as "the LLM call is alive".
+const PROXY_STREAM_RECENT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Absolute cap on the proxy-stream grace: even with live upstream chunks,
+/// kill after this much harness silence (protects against a wedged CLI that
+/// stopped consuming its own LLM stream).
+const PROXY_STREAM_INACTIVITY_CAP: std::time::Duration = std::time::Duration::from_secs(1800);
+
 /// Execute a turn using OpenCode CLI backend.
 ///
 /// For Host workspaces: spawns the CLI directly on the host.
@@ -253,6 +267,7 @@ pub async fn run_opencode_turn(
             app_working_dir,
             model_override,
             &workspace_host_ip,
+            Some(&mission_id.to_string()),
         );
     }
     if let Some(ref am) = agent_model {
@@ -262,6 +277,7 @@ pub async fn run_opencode_turn(
                 app_working_dir,
                 am,
                 &workspace_host_ip,
+                Some(&mission_id.to_string()),
             );
         }
     }
@@ -327,6 +343,7 @@ pub async fn run_opencode_turn(
             app_working_dir,
             opencode_model,
             &workspace_host_ip,
+            Some(&mission_id.to_string()),
         );
     }
 
@@ -1147,7 +1164,16 @@ pub async fn run_opencode_turn(
                             .ok()
                             .map(|g| g.elapsed() < std::time::Duration::from_secs(opencode_text_idle_timeout_secs))
                             .unwrap_or(false);
-                        if !recent_activity && !tools_active {
+                        // Proxy-stream grace: thinking models can spend minutes
+                        // inside a reasoning segment with no OpenCode events at
+                        // all, while the builtin proxy sees upstream chunks
+                        // streaming the whole time. Don't kill while the
+                        // mission's own LLM call is demonstrably alive.
+                        let proxy_streaming =
+                            crate::api::proxy_liveness::time_since_activity(mission_id)
+                                .map(|d| d <= PROXY_STREAM_RECENT)
+                                .unwrap_or(false);
+                        if !recent_activity && !tools_active && !proxy_streaming {
                             tracing::info!(
                                 mission_id = %mission_id,
                                 "OpenCode output idle timeout reached; terminating CLI process"
@@ -1159,8 +1185,8 @@ pub async fn run_opencode_turn(
                     }
                 }
                 // Global inactivity timeout: if nothing at all has happened
-                // for 120s (no SSE events, no stdout, no stderr), the process
-                // is likely stuck.  Kill it and let the fallback recovery
+                // (no SSE events, no stdout, no stderr), the process is
+                // likely stuck.  Kill it and let the fallback recovery
                 // logic read the result from OpenCode storage.
                 // Skip this check while tools are actively running — long
                 // commands (builds, tests) may produce no SSE events for
@@ -1184,26 +1210,36 @@ pub async fn run_opencode_turn(
                     .and_then(|g| *g)
                     .map(|ts| ts.elapsed() <= std::time::Duration::from_secs(45))
                     .unwrap_or(false);
-                if !tools_active && inactivity_elapsed >= std::time::Duration::from_secs(120) {
-                    // Heartbeat-only grace: avoid killing while the OpenCode server is
-                    // still alive and sending heartbeats. This especially affects smart
-                    // routing chains (e.g. GLM/Minimax fallbacks) that can take longer
-                    // to produce non-heartbeat events.
-                    if recent_heartbeat {
-                        if inactivity_elapsed >= std::time::Duration::from_secs(420) {
-                            tracing::warn!(
-                                mission_id = %mission_id,
-                                inactivity_secs = inactivity_elapsed.as_secs(),
-                                "Heartbeat-only inactivity timeout (420s); terminating stuck CLI process"
-                            );
-                            killed_by_idle_timeout = true;
-                            let _ = child.kill().await;
-                            break;
-                        }
+                if !tools_active && inactivity_elapsed >= GLOBAL_INACTIVITY_TIMEOUT {
+                    // Proxy-stream grace: the mission's own LLM call is still
+                    // streaming chunks through the builtin proxy (long
+                    // reasoning segments emit no OpenCode events). Defer the
+                    // kill up to a hard cap in case OpenCode itself wedged
+                    // while the proxy keeps receiving.
+                    let proxy_streaming =
+                        crate::api::proxy_liveness::time_since_activity(mission_id)
+                            .map(|d| d <= PROXY_STREAM_RECENT)
+                            .unwrap_or(false);
+                    if proxy_streaming && inactivity_elapsed < PROXY_STREAM_INACTIVITY_CAP {
+                        tracing::debug!(
+                            mission_id = %mission_id,
+                            inactivity_secs = inactivity_elapsed.as_secs(),
+                            "No harness output but builtin proxy stream is active; deferring inactivity kill"
+                        );
+                    } else if recent_heartbeat
+                        && inactivity_elapsed < HEARTBEAT_INACTIVITY_TIMEOUT
+                    {
+                        // Heartbeat-only grace: avoid killing while the OpenCode server is
+                        // still alive and sending heartbeats. This especially affects smart
+                        // routing chains (e.g. GLM/Minimax fallbacks) that can take longer
+                        // to produce non-heartbeat events.
                     } else {
                         tracing::warn!(
                             mission_id = %mission_id,
-                            "Global inactivity timeout (120s); terminating stuck CLI process"
+                            inactivity_secs = inactivity_elapsed.as_secs(),
+                            recent_heartbeat = recent_heartbeat,
+                            proxy_streaming = proxy_streaming,
+                            "Global inactivity timeout; terminating stuck CLI process"
                         );
                         killed_by_idle_timeout = true;
                         let _ = child.kill().await;


### PR DESCRIPTION
## Problem

Mission `f9ba703a` (`builtin/smart` → MiniMax-M3, dgx-spark workspace) was aborted with *"idle timeout"* while the model was **actively generating reasoning tokens**. Timeline from prod logs:

- 07:37:48 `step_finish` (tool-calls), proxy forwards next completion to MiniMax-M3
- 07:37:58 `step_start` — last activity-refreshing stdout event
- 07:37:58→07:39:58 MiniMax reasons for >2 min; `opencode run --format json` emits **nothing** during a reasoning segment
- 07:39:58 `Global inactivity timeout (120s); terminating stuck CLI process` — the in-flight thinking flushes milliseconds before the abort, mission finalized as failed/stalled

The watchdog's only liveness signals were OpenCode stdout/stderr; it couldn't see that the mission's own LLM call was streaming the whole time through our in-process proxy.

## Fix

1. **`proxy_liveness` registry** (new module): the builtin proxy records a per-mission `Instant` on every accepted `/v1/chat/completions` request and on every upstream stream chunk (`track_stream_health`).
2. **Mission attribution**: `ensure_opencode_provider_for_model` now writes `options.headers.x-sandboxed-mission-id` into the per-workspace builtin provider config, so proxy requests are attributable to the mission.
3. **Watchdog grace**: both kill branches (text-idle and global-inactivity) skip the kill while the mission's proxy stream has been active within the last 30s — bounded by a hard 1800s cap so a wedged CLI that stopped consuming its stream still dies.
4. **Mitigation for non-builtin chains**: the no-signal hard threshold goes 120s → 300s (heartbeat-grace stays at 420s); thinking models routinely reason 2–5 min between visible events.

## Notes

- Requests without the header (router traffic, chain tests, stale workspace configs) are simply untracked — behavior degrades to the (raised) timeouts.
- `cargo check`, `cargo fmt`, targeted tests pass; clippy warnings in the diff scope: none (remaining warnings pre-exist on master).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission termination timing and adds in-process shared state on the LLM proxy path; mis-attribution or stale liveness could delay kills, but a 1800s cap and unchanged tool-active behavior limit exposure.
> 
> **Overview**
> OpenCode mission turns were killed as "stuck" during long **reasoning** segments when the harness emitted no stdout/SSE, even though the mission's LLM call was still streaming through the builtin proxy.
> 
> A new **`proxy_liveness`** registry records per-mission activity when the proxy accepts a chat completion and on each upstream stream chunk. **Builtin** OpenCode provider config now optionally adds **`x-sandboxed-mission-id`** so those requests tie back to the running mission.
> 
> The OpenCode runner **defers idle kills** (text-idle and global inactivity) while proxy activity was seen within the last **30s**, capped at **1800s** of harness silence. With no proxy signal, the hard inactivity threshold rises **120s → 300s**; heartbeat-only grace stays **420s**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb59d7728d900c4501f0d94639b86f8a642e2dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->