### PR TITLE
fix(rendering): keep inter-tool narration and strip MiniMax <mm:think> markup

### DIFF
--- a/dashboard/src/app/control/events-reducer.test.ts
+++ b/dashboard/src/app/control/events-reducer.test.ts
@@ -128,6 +128,25 @@ describe("eventsToItemsImpl text_delta replay", () => {
     const toolIdx = items.findIndex((item) => item.kind === "tool");
     expect(streamIdx).toBeLessThan(toolIdx);
   });
+
+  it("removes a flushed narration that duplicates the later assistant reply", () => {
+    const answer =
+      "All checks passed and the branch is pushed; the PR is ready for review now.";
+    const items = eventsToItemsImpl(
+      [
+        storedEvent(1, "text_delta", answer),
+        { ...storedEvent(2, "tool_call", '{"command":"true"}'), tool_call_id: "t1", tool_name: "Bash" },
+        { ...storedEvent(3, "tool_result", '{"content":"ok"}'), tool_call_id: "t1", tool_name: "Bash" },
+        storedEvent(4, "assistant_message", answer, undefined, {
+          success: true,
+        }),
+      ],
+      { status: "awaiting_user" } as Mission,
+    );
+
+    expect(items.filter((item) => item.kind === "stream")).toHaveLength(0);
+    expect(items.filter((item) => item.kind === "assistant")).toHaveLength(1);
+  });
 });
 
 describe("eventsToItemsImpl thinking replay", () => {

--- a/dashboard/src/app/control/events-reducer.test.ts
+++ b/dashboard/src/app/control/events-reducer.test.ts
@@ -98,6 +98,36 @@ describe("eventsToItemsImpl text_delta replay", () => {
 
     expect(items.filter((item) => item.kind === "stream")).toHaveLength(0);
   });
+
+  it("flushes narration emitted between tool calls instead of dropping it", () => {
+    const items = eventsToItemsImpl(
+      [
+        storedEvent(1, "text_delta", "Now regenerating artifacts and running make check."),
+        { ...storedEvent(2, "tool_call", '{"command":"make check"}'), tool_call_id: "t1", tool_name: "Bash" },
+        { ...storedEvent(3, "tool_result", '{"content":"ok"}'), tool_call_id: "t1", tool_name: "Bash" },
+        storedEvent(4, "text_delta", "All checks passed, opening the PR."),
+        storedEvent(5, "assistant_message", "Done: PR opened.", undefined, {
+          success: true,
+        }),
+      ],
+      { status: "awaiting_user" } as Mission,
+    );
+
+    const streams = items.filter((item) => item.kind === "stream");
+    expect(streams).toHaveLength(2);
+    expect(streams[0]).toMatchObject({
+      content: "Now regenerating artifacts and running make check.",
+      done: true,
+    });
+    expect(streams[1]).toMatchObject({
+      content: "All checks passed, opening the PR.",
+      done: true,
+    });
+    // The intermediate narration must render before the tool call.
+    const streamIdx = items.findIndex((item) => item.kind === "stream");
+    const toolIdx = items.findIndex((item) => item.kind === "tool");
+    expect(streamIdx).toBeLessThan(toolIdx);
+  });
 });
 
 describe("eventsToItemsImpl thinking replay", () => {

--- a/dashboard/src/app/control/events-reducer.ts
+++ b/dashboard/src/app/control/events-reducer.ts
@@ -212,6 +212,25 @@ export function eventsToItemsImpl(
     }
   };
 
+  // Materialize the pending text-delta run as a finished stream bubble.
+  // Without this, narration the agent emits between tool calls ("Now
+  // regenerating artifacts...") was silently dropped — only the trailing
+  // run after the last tool call ever rendered.
+  const flushTextDelta = (endTime: number) => {
+    if (!lastTextDelta) return;
+    if (!streamDuplicatesAssistant(lastTextDelta.content, lastAssistantContent)) {
+      items.push({
+        kind: "stream",
+        id: lastTextDelta.id,
+        content: lastTextDelta.content,
+        done: true,
+        startTime: lastTextDelta.timestamp,
+        endTime,
+      });
+    }
+    lastTextDelta = null;
+  };
+
   const pushGoalDeliverable = (event: StoredEvent, timestamp: number) => {
     const content = event.content.trim();
     if (!content) return;
@@ -458,7 +477,7 @@ export function eventsToItemsImpl(
 
       case "tool_call": {
         finalizePendingThinking(timestamp);
-        lastTextDelta = null;
+        flushTextDelta(timestamp);
         const toolCallId = event.tool_call_id || `unknown-${event.id}`;
         const name = event.tool_name || "unknown";
         const isUiTool =
@@ -489,7 +508,7 @@ export function eventsToItemsImpl(
 
       case "tool_stub": {
         finalizePendingThinking(timestamp);
-        lastTextDelta = null;
+        flushTextDelta(timestamp);
         const toolCallId = event.tool_call_id || `unknown-${event.id}`;
         const name = event.tool_name || "unknown";
         const isUiTool =

--- a/dashboard/src/app/control/events-reducer.ts
+++ b/dashboard/src/app/control/events-reducer.ts
@@ -216,6 +216,12 @@ export function eventsToItemsImpl(
   // Without this, narration the agent emits between tool calls ("Now
   // regenerating artifacts...") was silently dropped — only the trailing
   // run after the last tool call ever rendered.
+  // Stream items flushed since the last assistant message. A flushed run can
+  // turn out to duplicate the *next* assistant message of the same turn (the
+  // final text often repeats earlier narration); those are removed
+  // retroactively when that assistant message arrives.
+  let flushedStreamIds: string[] = [];
+
   const flushTextDelta = (endTime: number) => {
     if (!lastTextDelta) return;
     if (!streamDuplicatesAssistant(lastTextDelta.content, lastAssistantContent)) {
@@ -227,8 +233,26 @@ export function eventsToItemsImpl(
         startTime: lastTextDelta.timestamp,
         endTime,
       });
+      flushedStreamIds.push(lastTextDelta.id);
     }
     lastTextDelta = null;
+  };
+
+  const dropStreamsDuplicatedBy = (assistantContent: string) => {
+    if (flushedStreamIds.length > 0) {
+      const ids = new Set(flushedStreamIds);
+      for (let i = items.length - 1; i >= 0; i--) {
+        const it = items[i];
+        if (
+          it.kind === "stream" &&
+          ids.has(it.id) &&
+          streamDuplicatesAssistant(it.content, assistantContent)
+        ) {
+          items.splice(i, 1);
+        }
+      }
+    }
+    flushedStreamIds = [];
   };
 
   const pushGoalDeliverable = (event: StoredEvent, timestamp: number) => {
@@ -276,6 +300,7 @@ export function eventsToItemsImpl(
       case "assistant_message":
       case "assistant_message_canonical": {
         finalizePendingThinking(timestamp);
+        dropStreamsDuplicatedBy(event.content);
         const meta = event.metadata || {};
         const isFailure = meta.success === false;
         const { costCents, costSource } = parseCostMetadata(meta);

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -1398,10 +1398,22 @@ fn extract_part_text<'a>(part: &'a serde_json::Value, part_type: &str) -> Option
     }
 }
 
-/// Strip `<think>...</think>` tags from text output.
-/// Some models (e.g. Minimax, DeepSeek) emit internal reasoning inside inline
-/// `<think>` tags that should not be shown in the text output.
+/// Thinking tag pairs leaked into text output by various models:
+/// `<think>` (DeepSeek, GLM) and `<mm:think>` (MiniMax-M3).
+const THINK_TAG_PAIRS: [(&str, &str); 2] = [("<think>", "</think>"), ("<mm:think>", "</mm:think>")];
+
+/// Strip `<think>...</think>` / `<mm:think>...</mm:think>` tags from text
+/// output. Some models (e.g. Minimax, DeepSeek) emit internal reasoning
+/// inside inline thinking tags that should not be shown in the text output.
 pub(crate) fn strip_think_tags(text: &str) -> String {
+    let mut out = text.to_string();
+    for (open, close) in THINK_TAG_PAIRS {
+        out = strip_think_tags_pair(&out, open, close);
+    }
+    out
+}
+
+fn strip_think_tags_pair(text: &str, open_tag: &str, close_tag: &str) -> String {
     // Case-insensitive search directly on the original text to avoid
     // byte-offset misalignment from to_lowercase() on non-ASCII input.
     fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
@@ -1415,7 +1427,7 @@ pub(crate) fn strip_think_tags(text: &str) -> String {
             .position(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
     }
 
-    if find_ci(text, "<think>").is_none() {
+    if find_ci(text, open_tag).is_none() {
         return text.to_string();
     }
 
@@ -1423,21 +1435,21 @@ pub(crate) fn strip_think_tags(text: &str) -> String {
     let mut pos = 0;
 
     while pos < text.len() {
-        if let Some(rel_start) = find_ci(&text[pos..], "<think>") {
+        if let Some(rel_start) = find_ci(&text[pos..], open_tag) {
             let abs_start = pos + rel_start;
-            // find_ci searches for ASCII "<think>", so abs_start always lands on
+            // find_ci searches for an ASCII tag, so abs_start always lands on
             // a char boundary (the `<` byte). No boundary walk-back needed.
             result.push_str(&text[pos..abs_start]);
 
-            let after_open = abs_start + 7; // "<think>" is 7 ASCII bytes
+            let after_open = abs_start + open_tag.len();
             if after_open <= text.len() {
-                if let Some(rel_close) = find_ci(&text[after_open..], "</think>") {
-                    pos = after_open + rel_close + 8; // "</think>" is 8 ASCII bytes — always safe
+                if let Some(rel_close) = find_ci(&text[after_open..], close_tag) {
+                    pos = after_open + rel_close + close_tag.len();
                 } else {
-                    break; // unclosed tag: drop everything from <think> onwards
+                    break; // unclosed tag: drop everything from the opener onwards
                 }
             } else {
-                break; // unclosed tag: drop everything from <think> onwards
+                break; // unclosed tag: drop everything from the opener onwards
             }
         } else {
             result.push_str(&text[pos..]);
@@ -1448,11 +1460,28 @@ pub(crate) fn strip_think_tags(text: &str) -> String {
     result
 }
 
-/// Extract text inside `<think>...</think>` tags. Handles unclosed tags
-/// (the trailing unclosed opener is included verbatim) and multiple blocks
-/// (concatenated in order, separated by a single newline so callers can
-/// distinguish boundaries; trim will absorb the joiner's whitespace).
+/// Extract text inside `<think>...</think>` / `<mm:think>...</mm:think>`
+/// tags. Handles unclosed tags (the trailing unclosed opener is included
+/// verbatim) and multiple blocks (concatenated in order, separated by a
+/// single newline so callers can distinguish boundaries; trim will absorb
+/// the joiner's whitespace).
 pub(crate) fn extract_think_content(text: &str) -> Option<String> {
+    let mut combined: Option<String> = None;
+    for (open, close) in THINK_TAG_PAIRS {
+        if let Some(part) = extract_think_content_pair(text, open, close) {
+            match combined.as_mut() {
+                Some(acc) => {
+                    acc.push('\n');
+                    acc.push_str(&part);
+                }
+                None => combined = Some(part),
+            }
+        }
+    }
+    combined
+}
+
+fn extract_think_content_pair(text: &str, open_tag: &str, close_tag: &str) -> Option<String> {
     fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
         let needle_len = needle.len();
         if haystack.len() < needle_len {
@@ -1464,32 +1493,29 @@ pub(crate) fn extract_think_content(text: &str) -> Option<String> {
             .position(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
     }
 
-    const OPEN_TAG: &str = "<think>";
-    const CLOSE_TAG: &str = "</think>";
-
     // Walk every `<think>` opener in order. For each one, take everything up
     // to the next `</think>` (or to the end of the string if the close tag
     // is missing — the model streamed the tag header but not the footer yet).
     let mut combined = String::new();
     let mut cursor = 0usize;
     let mut found_any = false;
-    while let Some(open) = find_ci(&text[cursor..], OPEN_TAG) {
+    while let Some(open) = find_ci(&text[cursor..], open_tag) {
         found_any = true;
         let abs_open = cursor + open;
-        let after_open = abs_open + OPEN_TAG.len();
+        let after_open = abs_open + open_tag.len();
         let scan_from = if after_open <= text.len() {
             after_open
         } else {
             text.len()
         };
-        match find_ci(&text[scan_from..], CLOSE_TAG) {
+        match find_ci(&text[scan_from..], close_tag) {
             Some(rel_close) => {
                 let abs_close = scan_from + rel_close;
                 if !combined.is_empty() {
                     combined.push('\n');
                 }
                 combined.push_str(&text[after_open..abs_close]);
-                cursor = abs_close + CLOSE_TAG.len();
+                cursor = abs_close + close_tag.len();
             }
             None => {
                 // Unclosed trailing opener: include the rest of the string
@@ -9467,6 +9493,26 @@ mod tests {
         assert_eq!(result, "beforeafter");
     }
 
+    #[test]
+    fn strip_think_tags_removes_mm_think_blocks() {
+        // MiniMax-M3 leaks `<mm:think>` markup into assistant messages
+        // (seen in prod: assistant bubble starting with raw "<mm:think>").
+        let input = "<mm:think>internal reasoning</mm:think>visible answer";
+        assert_eq!(strip_think_tags(input), "visible answer");
+    }
+
+    #[test]
+    fn strip_think_tags_unclosed_mm_think_drops_rest() {
+        let input = "visible<mm:think>never closed";
+        assert_eq!(strip_think_tags(input), "visible");
+    }
+
+    #[test]
+    fn strip_think_tags_mixed_think_and_mm_think() {
+        let input = "a<think>1</think>b<mm:think>2</mm:think>c";
+        assert_eq!(strip_think_tags(input), "abc");
+    }
+
     // ── extract_think_content tests ───────────────────────────────────
 
     #[test]
@@ -9534,6 +9580,15 @@ mod tests {
         assert_eq!(
             extract_think_content(text).as_deref(),
             Some("mixed case reasoning")
+        );
+    }
+
+    #[test]
+    fn extract_think_content_mm_think_blocks() {
+        let text = "<mm:think>minimax reasoning</mm:think>answer";
+        assert_eq!(
+            extract_think_content(text).as_deref(),
+            Some("minimax reasoning")
         );
     }
 


### PR DESCRIPTION
Fixes the two response-rendering defects found while debugging prod missions `832725c5` / `5daaa900` / `f9ba703a`:

## 1. Inter-tool narration was silently dropped (dashboard reducer)

`eventsToItemsImpl` reset `lastTextDelta` to `null` on every `tool_call`/`tool_stub`, and only the **trailing** text-delta run (after the last tool call) was ever materialized as a stream bubble. In tool-heavy missions — e.g. the SPHINCS- /goal run with 200+ tool calls, where thinking is `[encrypted thinking]` placeholders — the agent's short narrations between tool calls were the only readable intent signal, and none of them rendered.

Now `tool_call`/`tool_stub` flush the pending run as a completed stream bubble, keeping the existing duplicate-vs-assistant-message guard. New reducer test pins the behavior (narration renders before the tool call, both runs survive).

## 2. Raw `<mm:think>` markup in assistant bubbles (backend)

MiniMax-M3 leaks `<mm:think>...</mm:think>` into message content; `strip_think_tags` / `extract_think_content` only knew `<think>`, so the markup rendered literally (mission f9ba703a, event 98). Both helpers now iterate a tag-pair table (`<think>`, `<mm:think>`), so the OpenCode runner's existing strip/extract call sites handle MiniMax too. Unit tests added for closed/unclosed/mixed mm:think blocks.

## Tests
- `cargo test --lib`: 996 passed
- dashboard `vitest`: all passing incl. new reducer test; `tsc --noEmit` and eslint clean

Follow-up candidate (not in this PR): emit a canonical `assistant_message` when a turn ends with unflushed streamed text, so final answers never depend on trailing-stream heuristics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display and text-sanitization changes with targeted tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes two mission chat rendering bugs: **inter-tool narration** no longer disappears in the dashboard, and **MiniMax `<mm:think>` markup** is stripped on the backend like existing `<think>` tags.
> 
> In `eventsToItemsImpl`, pending `text_delta` runs used to be cleared on every `tool_call` / `tool_stub`, so only text after the last tool call became a stream bubble. Tool boundaries now **flush** that pending run as a completed stream (still using the duplicate-vs-assistant guard). When the final assistant message repeats earlier narration, those flushed streams are **removed retroactively** so users do not see duplicate bubbles.
> 
> In `mission_runner`, `strip_think_tags` and `extract_think_content` now iterate a small tag-pair table (`<think>`, `<mm:think>`) via shared pair helpers, so MiniMax-M3 leaked markup is hidden from assistant text and reasoning can still be extracted. New reducer and Rust unit tests cover inter-tool flush, duplicate removal, and mm:think handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a4d6df31772bd5310c970ba357d05a6630b2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->