### PR TITLE
fix(lifecycle): robust workspace deletion + single pending wakeup per mission

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11811,17 +11811,31 @@ pub async fn create_automation(
         driver: mission_store::AutomationDriver::Scheduler,
     };
 
+    let is_builtin_wakeup = automation
+        .variables
+        .get("__wakeup_source")
+        .map(String::as_str)
+        == Some("claude-builtin");
+
+    let mut automation = control
+        .mission_store
+        .create_automation(automation)
+        .await
+        .map_err(internal_error)?;
+
     // One pending built-in wakeup per mission: a new ScheduleWakeup
     // supersedes any earlier un-fired one. Without this, a turn that starts
     // before the previous wakeup fires (user message, other automation)
     // schedules a second wakeup, and the leftovers pile up into overlapping
     // re-triggers (observed: 5 concurrent pending wakeups on one mission,
     // all firing within two minutes).
-    let is_builtin_wakeup = automation
-        .variables
-        .get("__wakeup_source")
-        .map(String::as_str)
-        == Some("claude-builtin");
+    //
+    // Ordering: the new wakeup is created *first*, then older ones are
+    // deactivated — if creation fails the mission keeps its previous wakeup
+    // instead of losing all of them. Only automations strictly older than
+    // the new row are deactivated ((created_at, id) tie-break), so two
+    // overlapping creates converge on exactly the newest wakeup instead of
+    // deactivating each other.
     let mut wakeup_iteration: u32 = 1;
     if is_builtin_wakeup {
         if let Ok(existing) = control
@@ -11829,14 +11843,20 @@ pub async fn create_automation(
             .get_mission_automations(mission_id)
             .await
         {
+            let new_key = (automation.created_at.clone(), automation.id.to_string());
             let priors: Vec<_> = existing
                 .into_iter()
                 .filter(|a| {
-                    a.variables.get("__wakeup_source").map(String::as_str) == Some("claude-builtin")
+                    a.id != automation.id
+                        && a.variables.get("__wakeup_source").map(String::as_str)
+                            == Some("claude-builtin")
                 })
                 .collect();
             wakeup_iteration = (priors.len() as u32).saturating_add(1);
-            for prior in priors.into_iter().filter(|a| a.active) {
+            for prior in priors
+                .into_iter()
+                .filter(|a| a.active && (a.created_at.clone(), a.id.to_string()) < new_key)
+            {
                 if let Err(e) = control
                     .mission_store
                     .update_automation_active(prior.id, false)
@@ -11851,12 +11871,6 @@ pub async fn create_automation(
             }
         }
     }
-
-    let mut automation = control
-        .mission_store
-        .create_automation(automation)
-        .await
-        .map_err(internal_error)?;
 
     // Persist a goal-iteration marker for self-paced loops so the dashboard
     // and assistant can see loop progress after a reload — previously this

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11811,11 +11811,67 @@ pub async fn create_automation(
         driver: mission_store::AutomationDriver::Scheduler,
     };
 
+    // One pending built-in wakeup per mission: a new ScheduleWakeup
+    // supersedes any earlier un-fired one. Without this, a turn that starts
+    // before the previous wakeup fires (user message, other automation)
+    // schedules a second wakeup, and the leftovers pile up into overlapping
+    // re-triggers (observed: 5 concurrent pending wakeups on one mission,
+    // all firing within two minutes).
+    let is_builtin_wakeup = automation
+        .variables
+        .get("__wakeup_source")
+        .map(String::as_str)
+        == Some("claude-builtin");
+    let mut wakeup_iteration: u32 = 1;
+    if is_builtin_wakeup {
+        if let Ok(existing) = control
+            .mission_store
+            .get_mission_automations(mission_id)
+            .await
+        {
+            let priors: Vec<_> = existing
+                .into_iter()
+                .filter(|a| {
+                    a.variables.get("__wakeup_source").map(String::as_str) == Some("claude-builtin")
+                })
+                .collect();
+            wakeup_iteration = (priors.len() as u32).saturating_add(1);
+            for prior in priors.into_iter().filter(|a| a.active) {
+                if let Err(e) = control
+                    .mission_store
+                    .update_automation_active(prior.id, false)
+                    .await
+                {
+                    tracing::warn!(
+                        "Failed to deactivate superseded wakeup automation {}: {}",
+                        prior.id,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
     let mut automation = control
         .mission_store
         .create_automation(automation)
         .await
         .map_err(internal_error)?;
+
+    // Persist a goal-iteration marker for self-paced loops so the dashboard
+    // and assistant can see loop progress after a reload — previously this
+    // state lived only in the (transient) wakeup automations.
+    if is_builtin_wakeup {
+        let _ = control.events_tx.send(AgentEvent::GoalIteration {
+            iteration: wakeup_iteration,
+            objective: automation
+                .variables
+                .get("__wakeup_reason")
+                .cloned()
+                .unwrap_or_default(),
+            mission_id: Some(mission_id),
+        });
+    }
 
     // If start_immediately is requested for agent_finished triggers, fire the
     // first execution right away by resolving the command and sending it as a

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -793,6 +793,32 @@ async fn delete_workspace(
     // If it's a container workspace, destroy the container first
     if let Some(ws) = state.workspaces.get(id).await {
         if ws.workspace_type == WorkspaceType::Container {
+            // Stop any live mission/exec scopes for this workspace first.
+            // Surviving scope processes (Tailscale daemons, leftover exec
+            // shells) keep the rootfs busy and make removal fail with EBUSY
+            // — this is how `dna` resisted deletion.
+            match list_workspace_scope_units(&ws).await {
+                Ok(units) => {
+                    for unit in units {
+                        let stopped = tokio::process::Command::new("systemctl")
+                            .args(["stop", &unit])
+                            .output()
+                            .await
+                            .map(|out| out.status.success())
+                            .unwrap_or(false);
+                        if !stopped {
+                            tracing::warn!(unit = %unit, "Failed to stop workspace scope before deletion");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Could not list scopes for workspace {} before deletion: {}",
+                        ws.name,
+                        e
+                    );
+                }
+            }
             if let Err(e) = crate::workspace::destroy_container_workspace(&ws).await {
                 tracing::error!("Failed to destroy container for workspace {}: {}", id, e);
                 return Err((

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -901,6 +901,9 @@ pub async fn destroy_container(path: &Path) -> NspawnResult<()> {
             "Container path {} does not exist, nothing to destroy",
             path.display()
         );
+        // Still reap the sibling build log: a partially removed workspace
+        // (rootfs gone, log left) should not orphan it forever.
+        let _ = tokio::fs::remove_file(build_log_path_for(path)).await;
         return Ok(());
     }
 

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -910,13 +910,67 @@ pub async fn destroy_container(path: &Path) -> NspawnResult<()> {
     let _ = unmount_if_present(path, "/sys").await;
     let _ = unmount_if_present(path, "/proc").await;
 
+    // Unmount anything else still mounted under the container path (X11
+    // binds, overlay leftovers, runtime mounts not in the legacy list).
+    // A single live mount makes remove_dir_all fail with EBUSY — and worse,
+    // it would recurse *into* a live bind mount.
+    unmount_all_under(path).await;
+
     match tokio::fs::remove_dir_all(path).await {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(NspawnError::DirectoryRemoval(e)),
     }
 
+    // Remove the sibling build log (e.g. containers/<name>.build.log) so a
+    // deleted workspace leaves nothing behind.
+    let _ = tokio::fs::remove_file(build_log_path_for(path)).await;
+
     tracing::info!("Container destroyed successfully");
 
     Ok(())
+}
+
+/// Unmount every mount point under `root` (deepest first), best effort.
+///
+/// Reads `/proc/self/mountinfo` rather than guessing a fixed list; falls back
+/// to a lazy unmount when a regular one fails so a busy mount cannot wedge
+/// container deletion forever.
+async fn unmount_all_under(root: &Path) {
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let root_str = root.to_string_lossy().into_owned();
+    let prefix = format!("{}/", root_str.trim_end_matches('/'));
+
+    let Ok(mountinfo) = tokio::fs::read_to_string("/proc/self/mountinfo").await else {
+        return;
+    };
+    // mountinfo field 5 (index 4) is the mount point, octal-escaped.
+    let mut mounts: Vec<String> = mountinfo
+        .lines()
+        .filter_map(|line| line.split_whitespace().nth(4))
+        .map(|mp| mp.replace("\\040", " ").replace("\\011", "\t"))
+        .filter(|mp| mp == &root_str || mp.starts_with(&prefix))
+        .collect();
+    if mounts.is_empty() {
+        return;
+    }
+    // Deepest first so nested mounts release their parents.
+    mounts.sort_by_key(|mp| std::cmp::Reverse(mp.matches('/').count()));
+    mounts.dedup();
+
+    for mp in mounts {
+        let ok = tokio::process::Command::new("umount")
+            .arg(&mp)
+            .output()
+            .await
+            .map(|out| out.status.success())
+            .unwrap_or(false);
+        if !ok {
+            tracing::warn!(mount = %mp, "umount failed; retrying lazily");
+            let _ = tokio::process::Command::new("umount")
+                .args(["-l", &mp])
+                .output()
+                .await;
+        }
+    }
 }


### PR DESCRIPTION
Fixes the two lifecycle defects found while operating prod today (plus the cheap visibility rider).

## 1. Workspace deletion fails when the container is busy (the `dna` case)

`destroy_container` only ran `machinectl terminate <dirname>` + `remove_dir_all`. Two gaps:
- Live per-mission scopes (`sandboxed-exec-sandboxed-<name>-*.scope`, `sandboxed-mission-sandboxed-<name>.scope`) were never stopped — surviving processes (Tailscale daemon, exec shells) keep the rootfs busy → EBUSY → the handler (correctly) refuses to drop the registry entry, and the workspace 'won't delete'.
- Mount cleanup was a fixed legacy list (`/dev/shm`, `/dev/pts`, `/sys`, `/proc`); any other live mount under the path (X11 binds, overlay leftovers) → same EBUSY, and `remove_dir_all` could recurse into a live bind mount.

Now: `delete_workspace` stops every matching scope unit first (reusing `list_workspace_scope_units`), `destroy_container` unmounts everything under the container path from `/proc/self/mountinfo` (deepest first, `umount -l` fallback), and the orphaned `<name>.build.log` is removed (4 were left behind on prod today).

## 2. ScheduleWakeup automations pile up

Built-in wakeups are `after_first_fire`, but a turn that starts before the pending wakeup fires (user message, other automation) schedules a *second* one — leftovers accumulate. Observed on mission `832725c5`: 5 concurrent pending wakeups (3×270s, 600s, 1500s), all firing within two minutes, each re-triggering the mission and burning tokens.

Now `create_automation` enforces one pending claude-builtin wakeup per mission: creating a new one deactivates earlier active ones (scoped via `variables.__wakeup_source == "claude-builtin"`, so user automations are untouched).

## 3. Rider: persisted loop-progress marker

Each builtin wakeup creation emits a `goal_iteration` event (iteration = count of wakeups so far, objective = the wakeup reason). Previously self-paced loop state lived only in transient automations — after a dashboard reload there was zero trace of loop progress (the SPHINCS /goal mission had no goal events at all).

## Tests
`cargo test --lib`: 992 passed, 0 failed; fmt + clippy clean (no new warnings).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run `systemctl stop` and host `umount` during deletion and deactivate automations on create; failures are mostly best-effort but incorrect scope matching could affect unrelated units on the host.
> 
> **Overview**
> Hardens **container workspace teardown** and **built-in ScheduleWakeup** behavior so prod lifecycle issues (EBUSY deletes, stacked wakeups) stop recurring.
> 
> **Workspace deletion** now stops all matching `sandboxed-mission-*` / `sandboxed-exec-*` scope units via `list_workspace_scope_units` before `destroy_container_workspace`, so leftover Tailscale/exec processes no longer block registry removal. **`destroy_container`** adds **`unmount_all_under`** (from `/proc/self/mountinfo`, deepest-first, lazy `umount` fallback) beyond the fixed legacy mount list, and removes sibling **`.build.log`** files even when the rootfs is already gone.
> 
> **Automation creation** for `variables.__wakeup_source == "claude-builtin"` creates the new wakeup first, then deactivates older active built-in wakeups on the same mission ( `(created_at, id)` tie-break), keeping one pending wakeup. Each such create emits a **`GoalIteration`** event (iteration count + `__wakeup_reason`) for dashboard visibility after reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5d19442b134b8ef3e297f84ab998ddd82667309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->