### PR TITLE
fix(claudecode): bound post-result process wait — lingering MCP children stalled completed turns

### DIFF
--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -2161,19 +2161,60 @@ pub fn run_claudecode_turn<'a>(
             mission_id = %mission_id,
             "Event loop completed, waiting for Claude Code process"
         );
-        let exit_status = tokio::task::spawn_blocking(move || {
+        // The final result has already been parsed at this point — the only
+        // thing left is process teardown. The CLI can fail to exit when a
+        // spawned MCP server (or any child) keeps running and holds the PTY
+        // open; an unbounded wait here loses the completed turn and stalls
+        // the mission until the 900s supervision watchdog force-aborts it
+        // (observed on orchestrator missions 832725c5/5daaa900). Bound the
+        // wait and kill the leftover process tree on expiry.
+        const CLI_EXIT_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
+        let child_pid = pty.process_id();
+        let mut wait_handle = tokio::task::spawn_blocking(move || {
             let mut pty = pty;
             pty.wait()
-        })
-        .await;
+        });
+        let exit_status = match tokio::time::timeout(CLI_EXIT_GRACE, &mut wait_handle).await {
+            Ok(joined) => joined,
+            Err(_) => {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    grace_secs = CLI_EXIT_GRACE.as_secs(),
+                    "Claude CLI did not exit after final result; killing leftover process tree"
+                );
+                #[cfg(unix)]
+                if let Some(pid) = child_pid {
+                    // The CLI is the session leader on its PTY, so its pgid
+                    // matches its pid — killpg takes down lingering MCP
+                    // children too. Plain kill as a fallback.
+                    unsafe {
+                        libc::killpg(pid as i32, libc::SIGKILL);
+                        libc::kill(pid as i32, libc::SIGKILL);
+                    }
+                }
+                wait_handle.await
+            }
+        };
         tracing::debug!(
             mission_id = %mission_id,
             exit_status = ?exit_status,
             "Claude Code process exited"
         );
 
-        // Ensure the PTY reader task stops (it should naturally end after process exit).
-        let _ = reader_handle.await;
+        // Ensure the PTY reader task stops (it should naturally end after
+        // process exit). Bounded: an orphaned child holding the PTY slave
+        // open keeps the blocking read alive indefinitely.
+        let mut reader_handle = reader_handle;
+        if tokio::time::timeout(std::time::Duration::from_secs(10), &mut reader_handle)
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                mission_id = %mission_id,
+                "PTY reader did not stop after process exit; abandoning it"
+            );
+            reader_handle.abort();
+        }
 
         let usage = crate::cost::TokenUsage {
             input_tokens: total_input_tokens,


### PR DESCRIPTION
## What happened (missions `832725c5` and `5daaa900`)

Both orchestrator missions appeared to 'just stop'. Prod logs show the turns actually **finished**:

```
18:45:50 Claude Code execution completed mission_id=832725c5 cost_usd=3.94
18:45:50 Event loop completed, waiting for Claude Code process
   ... 15 minutes of silence ...
19:01:30 Interrupted: no agent activity for 940s (>900s threshold)
19:01:59 Cancel timed out; force-aborted stuck runner.
```

The final result JSON was parsed, but the CLI process never exited — these missions run the orchestrator MCP server, and a lingering child holding the PTY keeps the CLI from terminating. `pty.wait()` at the end of the runner is **unbounded**, so the completed (and paid-for) turn was never returned: no assistant message, mission stuck 'active' until the 900s supervision watchdog force-aborted it. Same story on both missions, and on their worker missions.

## Fix

- After the final result, wait at most **30s** for the CLI to exit. On expiry, SIGKILL the process group (the CLI is its PTY session leader, so `killpg` also reaps lingering MCP children) and reap normally.
- Bound the PTY reader join to 10s for the same reason — an orphaned child holding the PTY slave open keeps the blocking read from ever hitting EOF.

The turn result then flows back normally instead of being discarded.

## Tests
`cargo test --lib`: 992 passed. fmt clean. The timeout path is teardown-only — the result is already in hand before it runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission teardown by forcibly killing process groups on Unix when cleanup times out; logic runs only after a parsed terminal result, but wrong PID/session assumptions could affect sibling processes in edge cases.
> 
> **Overview**
> After the stream-json **result** event is handled, teardown no longer blocks forever on `pty.wait()` or joining the PTY reader.
> 
> **CLI exit** is capped at **30 seconds**. If the process still has not exited (typical when an MCP child keeps the PTY open), the runner logs a warning and on Unix sends **SIGKILL** to the process group and the main PID, then waits for the blocking join to finish.
> 
> **PTY reader** join is capped at **10 seconds**; on timeout the task is **aborted** so a stuck blocking read cannot hold the mission open.
> 
> Turn output and cost are already parsed before this path runs, so completed turns should return to the mission loop instead of sitting until the ~900s stuck-mission watchdog fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d6a32c9404d55bcb906d0c834e3598164d0116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->