### PR TITLE
fix(runner): don't misreport provisioned containers as missing CLI under host load

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5694,13 +5694,32 @@ pub(crate) async fn command_available(
         } else {
             args.push(format!("command -v {} 2>/dev/null", program));
         }
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(8),
+        // Probe timeout: generous by default. Under heavy host load a
+        // systemd-run + nsenter + login-shell round trip can take >10s;
+        // with the old 8s budget every probe "failed" and a fully
+        // provisioned container was misreported as "Claude Code CLI not
+        // found and neither npm nor bun is available" (prod, 2026-06-11,
+        // load ~60 from a memory-throttled lean build).
+        let probe_timeout = std::env::var("SANDBOXED_SH_EXEC_PROBE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(30);
+        let output = match tokio::time::timeout(
+            std::time::Duration::from_secs(probe_timeout),
             workspace_exec.output(cwd, "/bin/sh", &args, HashMap::new()),
         )
         .await
-        .ok()?
-        .ok()?;
+        {
+            Ok(result) => result.ok()?,
+            Err(_) => {
+                tracing::warn!(
+                    program = %program,
+                    timeout_secs = probe_timeout,
+                    "Workspace command probe timed out — host overloaded? Treating as unavailable"
+                );
+                return None;
+            }
+        };
         if !output.status.success() {
             return Some(false);
         }
@@ -6450,10 +6469,24 @@ async fn claude_cli_matches_desired_version(
     desired_version: &str,
 ) -> bool {
     let args = vec!["-lc".to_string(), format!("{} --version", cli_path)];
-    match workspace_exec
-        .output(cwd, "/bin/sh", &args, HashMap::new())
-        .await
+    // Bounded: an unbounded version probe was observed wedged for 51
+    // minutes on an overloaded host, stalling CLI discovery entirely.
+    let result = match tokio::time::timeout(
+        std::time::Duration::from_secs(120),
+        workspace_exec.output(cwd, "/bin/sh", &args, HashMap::new()),
+    )
+    .await
     {
+        Ok(result) => result,
+        Err(_) => {
+            tracing::warn!(
+                cli_path,
+                "Claude CLI version probe timed out after 120s; treating as mismatch"
+            );
+            return false;
+        }
+    };
+    match result {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Incident

After today's deploy + mission resumes, missions in the dumbcontracts container failed with *'Claude Code CLI "claude" not found and neither npm nor bun is available'* — but the container had `/usr/local/bin/claude` and `/usr/bin/npm` the whole time.

Root cause chain:
1. The mission's lean probe grew past its 28G `MemoryHigh` (30.3GB, 14.7M memory.high breach events, ~48% full memory-stall PSI) → kernel reclaim loop → host at load ~60 with 95% sys time.
2. Under that load a `systemd-run` + `nsenter` + login-shell probe takes ~12s (measured), but `command_available` had a hard-coded **8s** timeout.
3. Every probe (claude, npm, bun, the bun copy's `test -x`) 'failed' → misleading CLI-missing error, mission turn dead.

(The runaway lean process was killed; load and memory recovered immediately. This PR fixes the fragility it exposed.)

## Fix
- Probe timeout 8s → 30s, tunable via `SANDBOXED_SH_EXEC_PROBE_TIMEOUT_SECS`; timeouts log a distinct *'host overloaded?'* warning instead of silently reading as not-found.
- `claude --version` matcher bounded at 120s — one was observed wedged for 51 minutes, which stalls CLI discovery entirely.

## Tests
`cargo test --lib`: 996 passed. fmt clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission-runner CLI discovery behavior under slow or overloaded hosts; longer waits delay failure but reduce misreporting, while version-probe timeouts may skip a valid CLI if the host is severely wedged.
> 
> **Overview**
> Workspace **command availability probes** (`command -v` / `test -x` via sandboxed shell) now use a **30s** default timeout (was **8s**), overridable with **`SANDBOXED_SH_EXEC_PROBE_TIMEOUT_SECS`**. On timeout they log a **host-overload** warning and treat the command as unavailable instead of collapsing timeouts into “not found,” which was causing false “Claude CLI / npm / bun missing” errors when probes legitimately took >10s under load.
> 
> **Claude CLI version matching** (`claude --version`) is now capped at **120s**; a timeout is logged and treated as a version **mismatch** so discovery cannot hang indefinitely on a wedged probe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3b4420af7bb385f4d827b6568dcff32be5778e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->