### PR TITLE
fix(ask): parse MiniMax sentinel/invoke-style text tool calls; stop overpromising follow-ups

### DIFF
--- a/src/api/ask/client.rs
+++ b/src/api/ask/client.rs
@@ -60,7 +60,19 @@ fn decode_xml_text(s: &str) -> String {
         .replace("&amp;", "&")
 }
 
-fn parse_text_tool_calls(content: &str) -> Vec<ToolCall> {
+/// Strip MiniMax interleave sentinels (`]<]minimax[>[`, `]<]minimax[>`) that
+/// the model wraps around tool-call markup when it falls back to emitting the
+/// call as text. Without this, neither regex below matches and the raw markup
+/// leaks into the chat as garbage (observed in prod Ask threads).
+fn strip_model_markup_sentinels(content: &str) -> String {
+    content
+        .replace("]<]minimax[>[", "")
+        .replace("]<]minimax[>", "")
+}
+
+fn parse_text_tool_calls(raw_content: &str) -> Vec<ToolCall> {
+    let content = strip_model_markup_sentinels(raw_content);
+    let content = content.as_str();
     let tool_re =
         regex::Regex::new(r#"(?s)<tool_call>\s*([A-Za-z_][A-Za-z0-9_-]*)\s*(.*?)</tool_call>"#)
             .expect("valid tool-call regex");
@@ -69,7 +81,7 @@ fn parse_text_tool_calls(content: &str) -> Vec<ToolCall> {
     )
     .expect("valid tool-arg regex");
 
-    tool_re
+    let calls: Vec<ToolCall> = tool_re
         .captures_iter(content)
         .filter_map(|caps| {
             let name = caps.get(1)?.as_str().trim().to_string();
@@ -84,6 +96,47 @@ fn parse_text_tool_calls(content: &str) -> Vec<ToolCall> {
                     .map(|m| decode_xml_text(m.as_str()))
                     .unwrap_or_default();
                 args.insert(key.to_string(), Value::String(value));
+            }
+            if args.is_empty() {
+                return None;
+            }
+            Some(ToolCall {
+                id: format!("text-tool-{}", Uuid::new_v4()),
+                name,
+                arguments: Value::Object(args).to_string(),
+            })
+        })
+        .collect();
+    if !calls.is_empty() {
+        return calls;
+    }
+
+    // Fallback: Anthropic-style `<invoke name="X"><param>value</param></invoke>`
+    // blocks — MiniMax emits these (wrapped in its sentinels) when it
+    // free-styles a tool call into text instead of the function-call channel.
+    let invoke_re =
+        regex::Regex::new(r#"(?s)<invoke\s+name="([A-Za-z_][A-Za-z0-9_-]*)"\s*>(.*?)</invoke>"#)
+            .expect("valid invoke regex");
+    let param_re =
+        regex::Regex::new(r#"(?s)<([A-Za-z_][A-Za-z0-9_]*)>(.*?)</([A-Za-z_][A-Za-z0-9_]*)>"#)
+            .expect("valid param regex");
+    invoke_re
+        .captures_iter(content)
+        .filter_map(|caps| {
+            let name = caps.get(1)?.as_str().trim().to_string();
+            let body = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+            let mut args = serde_json::Map::new();
+            for p in param_re.captures_iter(body) {
+                let (Some(open), Some(value), Some(close)) = (p.get(1), p.get(2), p.get(3)) else {
+                    continue;
+                };
+                if open.as_str() != close.as_str() {
+                    continue;
+                }
+                args.insert(
+                    open.as_str().to_string(),
+                    Value::String(decode_xml_text(value.as_str().trim())),
+                );
             }
             if args.is_empty() {
                 return None;
@@ -377,6 +430,33 @@ impl AskClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_minimax_sentinel_invoke_tool_call() {
+        // Verbatim shape observed in a prod Ask thread (mission 5daaa900):
+        // MiniMax wraps Anthropic-style invoke markup in its interleave
+        // sentinels; previously this parsed to nothing and rendered raw.
+        let calls = parse_text_tool_calls(
+            "]<]minimax[>[<tool_call>> ]<]minimax[>[<invoke name=\"bash\">]<]minimax[>[<command>echo \"=== TASK ===\"; ls -la /tmp/probe1.out</command>]<]minimax[>[</invoke> ]<]minimax[>[</tool_call>",
+        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "bash");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert!(args["command"]
+            .as_str()
+            .unwrap()
+            .starts_with("echo \"=== TASK ===\""));
+    }
+
+    #[test]
+    fn parses_multiple_invoke_blocks() {
+        let calls = parse_text_tool_calls(
+            "<invoke name=\"bash\"><command>date -u</command></invoke> <invoke name=\"read_history\"><limit>15</limit></invoke>",
+        );
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "bash");
+        assert_eq!(calls[1].name, "read_history");
+    }
 
     #[test]
     fn parses_opencode_style_text_tool_call() {

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -505,6 +505,11 @@ async fn build_system_prompt(turn: &AskTurn, user_content: &str) -> String {
          operator decide. When you do steer, make the message self-contained and \
          bounded (what to stop, what to do instead, when to stop doing it) — the \
          working agent has no access to this conversation.\n\n\
+         You are strictly reactive: you run only when the operator sends a \
+         message, and you cannot watch, poll, or follow up on your own. Never \
+         promise to \"keep an eye on\" or \"let you know when\" something \
+         happens — instead tell the operator what to ask about next time, or \
+         queue a steering note for the working agent.\n\n\
          Be concise and concrete. Cite event sequence numbers or file paths when \
          relevant. When you identify a blocker the operator could fix through \
          configuration (missing env var, unused key), propose the concrete fix — \


### PR DESCRIPTION
Found while live-testing the Ask co-pilot on mission `5daaa900`.

## Bug 1: raw MiniMax tool-call markup leaking into chat

The co-pilot (builtin/smart → MiniMax-M3) sometimes emits its tool call as **text** instead of the function-call channel, wrapped in MiniMax interleave sentinels and Anthropic-style invoke markup:

```
]<]minimax[>[<tool_call>> ]<]minimax[>[<invoke name="bash">]<]minimax[>[<command>echo ...</command>...
```

`parse_text_tool_calls` only knew the `<tool_call>name<arg_key>…` shape, so this parsed to nothing: the tool never executed and the raw markup rendered in the Ask panel.

Fix: strip the sentinels first, and add a fallback parser for `<invoke name="X"><param>value</param></invoke>` blocks. Regression test uses the verbatim prod string.

## Bug 2: promised follow-ups it can't deliver

The co-pilot ended a reply with *"I'll keep an eye on the transcript and let you know when the commit lands"* — but Ask turns are strictly reactive; there is no background watch. Added a system-prompt constraint: never promise monitoring; offer the next question or a steering note instead.

## Tests
23 ask tests pass (2 new); full lib suite green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Ask client parsing and prompt text with unit tests; no auth, persistence, or control-path changes beyond better tool extraction from model text.
> 
> **Overview**
> Fixes Ask when **MiniMax** puts tool calls in the assistant text instead of native `tool_calls`: **`parse_text_tool_calls`** now strips interleave sentinels (`]<]minimax[>[`, etc.) and, if the existing `<tool_call>` / `<arg_key>` path finds nothing, falls back to **`<invoke name="…">`** with nested param tags so tools like `bash` still run instead of raw markup showing in the panel.
> 
> The Ask **system prompt** now states the co-pilot is **strictly reactive**—no promising to watch the mission or follow up later; suggest what to ask next or use steering instead.
> 
> Two regression tests cover sentinel-wrapped invoke markup and multiple invoke blocks; existing OpenCode-style parsing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f5c0a4a9817a502f6ba92cea9d3038cc1c02a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->