### PR TITLE
feat(claudecode): opt-in stream-json input — inject operator notes mid-turn

### DIFF
--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -64,6 +64,13 @@ pub async fn ask_store(config: &crate::config::Config) -> Result<Arc<AskStore>, 
         .map(Arc::clone)
 }
 
+/// Non-initializing accessor for runners: returns the store only if some Ask
+/// interaction already opened it this process lifetime. Runners use this for
+/// best-effort mid-turn note injection without needing a `Config`.
+pub fn ask_store_if_initialized() -> Option<Arc<AskStore>> {
+    ASK_STORE.get().cloned()
+}
+
 /// Everything the Ask loop needs for one turn.
 pub struct AskTurn {
     pub ask_store: Arc<AskStore>,

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -882,13 +882,24 @@ pub fn run_claudecode_turn<'a>(
             }
         }
 
-        // Provide the prompt as a positional argument (instead of stdin).
-        //
-        // In production we have observed cases where piping stdin from the backend results in
-        // Claude Code producing no stdout events (even though it creates the session files),
-        // leaving missions stuck "Agent is working..." indefinitely.
-        args.push("--".to_string());
-        args.push(effective_message.clone());
+        // Stream-input mode (opt-in): deliver the prompt over stdin as
+        // stream-json and keep stdin open so messages can be injected
+        // MID-TURN (picked up after the current tool call completes, like
+        // typing in the interactive CLI). The positional prompt is ignored
+        // by the CLI in this mode, so it is not added.
+        let stream_input = crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false);
+        if stream_input {
+            args.push("--input-format".to_string());
+            args.push("stream-json".to_string());
+        } else {
+            // Provide the prompt as a positional argument (instead of stdin).
+            //
+            // In production we have observed cases where piping stdin from the backend results in
+            // Claude Code producing no stdout events (even though it creates the session files),
+            // leaving missions stuck "Agent is working..." indefinitely.
+            args.push("--".to_string());
+            args.push(effective_message.clone());
+        }
 
         // Build environment variables
         let mut env: HashMap<String, String> = HashMap::new();
@@ -1176,9 +1187,27 @@ pub fn run_claudecode_turn<'a>(
         };
 
         // Keep stdin open - dropping the writer (closing stdin) can cause some Claude CLI
-        // agent modes to hang. We pass the prompt via argv so stdin is not needed, but the
-        // CLI may check if stdin is open during initialization.
-        let _stdin_writer = pty.take_writer();
+        // agent modes to hang. In argv mode stdin is unused but must stay open;
+        // in stream-input mode it carries the prompt and mid-turn injections.
+        let mut stdin_writer = pty.take_writer().ok();
+        if stream_input {
+            #[cfg(unix)]
+            if let Err(e) = pty.set_raw_input_mode() {
+                tracing::warn!(mission_id = %mission_id, "Failed to set PTY raw input mode: {e}");
+            }
+            if let Some(w) = stdin_writer.as_mut() {
+                let init = serde_json::json!({
+                    "type": "user",
+                    "message": { "role": "user", "content": [{ "type": "text", "text": effective_message }] }
+                });
+                use std::io::Write as _;
+                if let Err(e) = writeln!(w, "{}", init).and_then(|_| w.flush()) {
+                    tracing::error!(mission_id = %mission_id, "Failed to write initial stream-json prompt: {e}");
+                }
+            }
+        }
+        // Poll cadence for mid-turn operator-note injection (stream-input mode).
+        let mut last_note_poll = Instant::now();
         tracing::debug!(mission_id = %mission_id, "PTY writer taken (kept alive)");
 
         let reader = match pty.try_clone_reader() {
@@ -1507,6 +1536,49 @@ pub fn run_claudecode_turn<'a>(
                 // immediately leaves the turn in AwaitingTerminalResult/
                 // AwaitingClaude (not this state), so those stalls remain subject
                 // to the watchdog as before.
+                _ = tokio::time::sleep_until(last_note_poll + Duration::from_secs(5)), if stream_input && stdin_writer.is_some() => {
+                    last_note_poll = Instant::now();
+                    if let Some(store) = crate::api::ask::ask_store_if_initialized() {
+                        match store.take_pending_operator_notes(mission_id).await {
+                            Ok(notes) if !notes.is_empty() => {
+                                let mut block = String::from("<operator-note>\n");
+                                for note in &notes {
+                                    block.push_str(&note.body);
+                                    block.push('\n');
+                                }
+                                block.push_str("</operator-note>");
+                                let msg = serde_json::json!({
+                                    "type": "user",
+                                    "message": { "role": "user", "content": [{ "type": "text", "text": block }] }
+                                });
+                                let mut delivered = false;
+                                if let Some(w) = stdin_writer.as_mut() {
+                                    use std::io::Write as _;
+                                    delivered = writeln!(w, "{}", msg).and_then(|_| w.flush()).is_ok();
+                                }
+                                if delivered {
+                                    tracing::info!(
+                                        mission_id = %mission_id,
+                                        notes = notes.len(),
+                                        "Injected operator notes mid-turn via stream-json stdin"
+                                    );
+                                    let _ = events_tx.send(AgentEvent::UserMessage {
+                                        id: Uuid::new_v4(),
+                                        content: block,
+                                        queued: false,
+                                        mission_id: Some(mission_id),
+                                    });
+                                } else {
+                                    tracing::warn!(
+                                        mission_id = %mission_id,
+                                        "Mid-turn note injection failed; notes will not be re-queued this turn"
+                                    );
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 _ = tokio::time::sleep_until(last_heartbeat_at + heartbeat_interval),
                     if saw_non_init_event
                         && matches!(turn_wait_state, ClaudeTurnWaitState::AwaitingToolResults) => {
@@ -2168,6 +2240,9 @@ pub fn run_claudecode_turn<'a>(
         // the mission until the 900s supervision watchdog force-aborts it
         // (observed on orchestrator missions 832725c5/5daaa900). Bound the
         // wait and kill the leftover process tree on expiry.
+        // In stream-input mode the CLI waits for more stdin after the result;
+        // close it so the process exits instead of hitting the kill grace.
+        drop(stdin_writer.take());
         const CLI_EXIT_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
         let child_pid = pty.process_id();
         let mut wait_handle = tokio::task::spawn_blocking(move || {

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1195,15 +1195,30 @@ pub fn run_claudecode_turn<'a>(
             if let Err(e) = pty.set_raw_input_mode() {
                 tracing::warn!(mission_id = %mission_id, "Failed to set PTY raw input mode: {e}");
             }
+            let mut initial_prompt_delivered = false;
             if let Some(w) = stdin_writer.as_mut() {
                 let init = serde_json::json!({
                     "type": "user",
                     "message": { "role": "user", "content": [{ "type": "text", "text": effective_message }] }
                 });
                 use std::io::Write as _;
-                if let Err(e) = writeln!(w, "{}", init).and_then(|_| w.flush()) {
-                    tracing::error!(mission_id = %mission_id, "Failed to write initial stream-json prompt: {e}");
+                match writeln!(w, "{}", init).and_then(|_| w.flush()) {
+                    Ok(()) => initial_prompt_delivered = true,
+                    Err(e) => tracing::error!(
+                        mission_id = %mission_id,
+                        "Failed to write initial stream-json prompt: {e}"
+                    ),
                 }
+            }
+            if !initial_prompt_delivered {
+                // Without the prompt the CLI would idle on an empty session —
+                // a silent no-op turn. Fail loudly instead.
+                pty.kill();
+                return AgentResult::failure(
+                    "Stream-input mode could not deliver the initial prompt over stdin".to_string(),
+                    0,
+                )
+                .with_terminal_reason(TerminalReason::LlmError);
             }
         }
         // Poll cadence for mid-turn operator-note injection (stream-input mode).
@@ -1569,9 +1584,28 @@ pub fn run_claudecode_turn<'a>(
                                         mission_id: Some(mission_id),
                                     });
                                 } else {
+                                    // take_pending_operator_notes already marked them
+                                    // flushed — re-enqueue so they deliver at the next
+                                    // poll or the next turn-prep instead of being lost.
+                                    for note in &notes {
+                                        if let Err(e) = store
+                                            .enqueue_operator_note(
+                                                mission_id,
+                                                &note.body,
+                                                note.source_thread_id,
+                                            )
+                                            .await
+                                        {
+                                            tracing::error!(
+                                                mission_id = %mission_id,
+                                                "Failed to re-enqueue operator note after injection failure: {e}"
+                                            );
+                                        }
+                                    }
                                     tracing::warn!(
                                         mission_id = %mission_id,
-                                        "Mid-turn note injection failed; notes will not be re-queued this turn"
+                                        notes = notes.len(),
+                                        "Mid-turn note injection failed; notes re-enqueued for next delivery"
                                     );
                                 }
                             }
@@ -2242,7 +2276,11 @@ pub fn run_claudecode_turn<'a>(
         // wait and kill the leftover process tree on expiry.
         // In stream-input mode the CLI waits for more stdin after the result;
         // close it so the process exits instead of hitting the kill grace.
-        drop(stdin_writer.take());
+        // In argv mode the writer must stay open through the wait — closing
+        // stdin early can change CLI exit behavior (see spawn-site comment).
+        if stream_input {
+            drop(stdin_writer.take());
+        }
         const CLI_EXIT_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
         let child_pid = pty.process_id();
         let mut wait_handle = tokio::task::spawn_blocking(move || {

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1193,7 +1193,20 @@ pub fn run_claudecode_turn<'a>(
         if stream_input {
             #[cfg(unix)]
             if let Err(e) = pty.set_raw_input_mode() {
-                tracing::warn!(mission_id = %mission_id, "Failed to set PTY raw input mode: {e}");
+                // Without raw mode, canonical-mode line buffering truncates
+                // stdin writes >4096 bytes and echo reflects injected JSON
+                // back into the parsed stdout stream — stream-input cannot
+                // work. Fail the turn loudly; the operator can unset
+                // SANDBOXED_SH_CLAUDE_STREAM_INPUT to fall back to argv mode.
+                tracing::error!(mission_id = %mission_id, "Failed to set PTY raw input mode: {e}");
+                pty.kill();
+                return AgentResult::failure(
+                    format!(
+                        "Stream-input mode requires PTY raw input mode, which failed: {e}.                          Unset SANDBOXED_SH_CLAUDE_STREAM_INPUT to use argv prompt delivery."
+                    ),
+                    0,
+                )
+                .with_terminal_reason(TerminalReason::LlmError);
             }
             let mut initial_prompt_delivered = false;
             if let Some(w) = stdin_writer.as_mut() {

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -395,6 +395,34 @@ impl PtyChild {
         }
     }
 
+    /// Disable canonical mode and echo on the PTY line discipline.
+    ///
+    /// Needed when feeding structured input (stream-json) through the PTY:
+    /// canonical mode truncates lines at 4096 bytes and echo would reflect
+    /// every injected line back into the child's stdout stream that we parse.
+    #[cfg(unix)]
+    pub fn set_raw_input_mode(&self) -> std::io::Result<()> {
+        use std::os::unix::io::AsRawFd;
+        let fd = match &self.master {
+            PtyMasterHandle::PortablePty(m) => m
+                .as_raw_fd()
+                .ok_or_else(|| std::io::Error::other("PTY master has no raw fd"))?,
+            PtyMasterHandle::Unix(fd) => fd.as_raw_fd(),
+        };
+        // SAFETY: fd is a valid open PTY master descriptor owned by self.
+        unsafe {
+            let mut termios: libc::termios = std::mem::zeroed();
+            if libc::tcgetattr(fd, &mut termios) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            termios.c_lflag &= !(libc::ICANON | libc::ECHO | libc::ECHONL);
+            if libc::tcsetattr(fd, libc::TCSANOW, &termios) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
+
     /// Wait for the child process to exit. Must be called from a blocking context.
     pub fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
         match &mut self.child {


### PR DESCRIPTION
Implements the 'talk to the running harness without interrupting it' capability for Claude Code, behind `SANDBOXED_SH_CLAUDE_STREAM_INPUT=1` (default off).

## How it works
- The CLI is spawned with `--input-format stream-json` and the prompt is written to stdin as a stream-json user message. (Verified locally: in this mode the positional argv prompt is **ignored**, so stdin is the only delivery path.)
- The PTY line discipline is set to raw input first: canonical mode would truncate stdin lines at 4096 bytes (prompts are routinely larger) and echo would reflect every injected line back into the stdout stream we parse.
- Every 5s during a turn, pending Ask-copilot operator notes are drained and written to stdin as a user message — Claude Code consumes them **after the current tool call completes**, exactly like typing into the interactive CLI mid-run. A `user_message` event is emitted so the injection is visible in the dashboard.
- When the terminal result arrives, stdin is closed so the CLI exits cleanly (it otherwise waits for more input and would hit the post-result kill grace from #525 every turn).

## Feasibility evidence
Tested against the real CLI: with two user messages written to stdin (second one 4s in, while an 8s `sleep` tool ran), the agent executed both and reported receiving the mid-run instruction in the same turn.

## Rollout
Default off. Argv prompt delivery is byte-for-byte unchanged when the flag is unset. Plan: enable on dev, validate a few missions (incl. >4KB prompts in containers via nsenter PTYs), then enable in prod and rewire `send_to_agent(interrupt=false)` to prefer the mid-turn channel.

Tests: full lib suite green (998).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Claude Code runner’s prompt transport and mid-turn stdin injection when the env flag is set; failures are mitigated by default-off and explicit fallbacks, but bugs could affect live missions or lose operator notes on write failure.
> 
> **Overview**
> **Opt-in mid-turn steering for Claude Code** behind `SANDBOXED_SH_CLAUDE_STREAM_INPUT` (default off). When enabled, the runner spawns the CLI with `--input-format stream-json`, sends the turn prompt as a stream-json user message on stdin instead of a positional argv argument, and keeps stdin open for the rest of the turn.
> 
> **PTY raw input** is added on Unix (`set_raw_input_mode`) so canonical line buffering does not truncate large prompts and echo does not pollute parsed stdout. Raw mode or initial stdin write failures fail the turn with a clear message so operators can disable the flag and fall back to argv delivery.
> 
> Every **5 seconds** during the turn event loop, the runner uses new **`ask_store_if_initialized()`** to drain pending Ask operator notes and inject them as `<operator-note>` stream-json user messages on stdin, emitting a **`UserMessage`** event on success and **re-enqueueing** notes if stdin write fails. After the terminal result, **stdin is closed** in stream mode so the CLI exits instead of waiting indefinitely (argv mode still keeps stdin open through teardown).
> 
> **Risk:** Default-off preserves existing argv behavior; enabled path changes how prompts and notes are delivered and depends on PTY termios behavior in containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b20e59188c9df24d9fb6b3a37b54b411bfcd82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->