### PR TITLE
fix(ask+control): keep final answers when tools are disabled; allow live run-settings updates

### DIFF
--- a/src/api/ask/client.rs
+++ b/src/api/ask/client.rs
@@ -245,7 +245,12 @@ impl AskClient {
                 }
             }
         }
-        if tool_calls.is_empty() {
+        // Only reinterpret text as tool calls when tools were actually
+        // offered. The forced final-synthesis pass runs with tools disabled;
+        // without this gate a model that writes tool-shaped markup there gets
+        // its entire answer swallowed (content -> None) and the operator sees
+        // "(The assistant reached the tool-call limit without a final answer.)".
+        if tool_calls.is_empty() && !tools.is_empty() {
             if let Some(text) = content.as_deref() {
                 tool_calls = parse_text_tool_calls(text);
             }
@@ -405,7 +410,7 @@ impl AskClient {
                 arguments,
             })
             .collect();
-        if tool_calls.is_empty() {
+        if tool_calls.is_empty() && !tools.is_empty() {
             tool_calls = parse_text_tool_calls(&content);
         }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9106,12 +9106,22 @@ async fn control_actor_loop(
                         let parallel_running = parallel_runners
                             .get(&id)
                             .is_some_and(|runner| runner.is_running());
+                        // Run-settings (backend/model/agent/profile) are read
+                        // per turn, so changing them on a RUNNING mission is
+                        // safe: the in-flight turn keeps what it loaded and the
+                        // next turn picks up the new row (with the backend
+                        // handoff context below when the backend changed).
+                        // Long-lived missions (orchestrators, /goal loops)
+                        // rarely stop, so the previous hard refusal made them
+                        // effectively unswitchable. The fresh session id this
+                        // writes is also fine mid-run: every backend falls
+                        // back to a fresh/continued session when the stored id
+                        // is not loadable.
                         if main_running || parallel_running {
-                            let _ = respond.send(Err(
-                                "Cannot update mission settings while the mission is running"
-                                    .to_string(),
-                            ));
-                            continue;
+                            tracing::info!(
+                                mission_id = %id,
+                                "Updating run settings while mission is running; they apply from the next turn"
+                            );
                         }
 
                         // Capture the backend before the update so we can detect

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -754,7 +754,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "wait_for_worker".to_string(),
-                description: "Block until a single worker mission reaches a terminal status. Use wait_for_any_worker to monitor multiple workers simultaneously.".to_string(),
+                description: "Block until a single worker mission reaches a terminal status. Use wait_for_any_worker to monitor multiple workers simultaneously. For waits beyond a few minutes, end your turn and schedule a wakeup instead of polling (each ~90s poll costs a model call).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -781,7 +781,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "wait_for_any_worker".to_string(),
-                description: "Block until ANY of the specified worker missions reaches a terminal status. Returns the first worker that finishes. Use this to monitor a pool of workers and react as each completes.".to_string(),
+                description: "Block until ANY of the specified worker missions reaches a terminal status. Returns the first worker that finishes. Use this to monitor a pool of workers and react as each completes. TOKEN ECONOMY: the wait is capped at ~90s per call, so polling a long-running worker burns one of YOUR model calls per 90s. If no worker is likely to finish within a couple of polls, END YOUR TURN and schedule a wakeup (ScheduleWakeup, 10-30 min) instead — check workers once per wakeup.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_ids"],


### PR DESCRIPTION
Debugging mission `832725c5` surfaced two defects:

## 1. '(The assistant reached the tool-call limit without a final answer.)'

The Ask loop already forces a final synthesis pass with tools disabled — but `parse_text_tool_calls` ran unconditionally on the result. MiniMax often writes tool-shaped markup in that pass; the parser converted the whole answer into (undeliverable) tool calls, `content` became `None`, and the canned placeholder shipped. Text is now only reinterpreted as tool calls when tools were offered (both `complete` and `complete_stream`).

## 2. Mission stuck on claude-fable-5 despite selecting opencode/builtin-smart

`UpdateMissionSettings` hard-refused while the mission was running. Orchestrator missions effectively never stop (90s worker-poll loops + wakeups), so the backend/model switch was rejected every time and the mission stayed pinned to its creation-time settings. Run settings are read per turn, so the update is now applied immediately and takes effect from the next turn, with the existing backend-handoff context emitted on a backend change. The fresh session id minted by the update is safe mid-run: all backends fall back to fresh/continue when the stored session is unloadable.

Tests: full lib suite green (998).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ask and mission-control behavior changes affect live assistant threads and long-running orchestrators; scope is narrow and aligned with per-turn settings loading, but mid-run backend switches still depend on existing handoff logic.
> 
> **Overview**
> Fixes two user-visible bugs and adds orchestrator guidance on worker polling cost.
> 
> **Ask assistant:** Text is only parsed into tool calls when the request actually included tools (`complete` and `complete_stream`). The tool-limit **final synthesis** pass runs with an empty tools list; models like MiniMax that still emit tool-shaped markup there no longer have their reply turned into undeliverable pseudo–tool calls with `content` cleared and the canned “reached the tool-call limit without a final answer” placeholder.
> 
> **Mission run settings:** `UpdateMissionSettings` no longer errors when the main or parallel runner is active. Updates persist immediately and apply on the **next turn** (settings are read per turn); an info log notes mid-run changes. Existing backend-switch handoff behavior is unchanged.
> 
> **Orchestrator MCP:** `wait_for_worker` / `wait_for_any_worker` descriptions now warn that internal waits cap around ~90s per call (one boss model turn per poll) and recommend ending the turn and scheduling wakeups for long waits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0a73131d90ca41589735080257826368dcfac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->