### PR TITLE
fix(ask): strip leaked think blocks from final Ask answers

### DIFF
--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -200,6 +200,12 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
         }
     }
 
+    // Reasoning models (MiniMax, GLM) can leak <think>/<mm:think> blocks into
+    // the visible answer; strip them like the mission path does.
+    final_answer = crate::api::mission_runner::strip_think_tags(&final_answer)
+        .trim()
+        .to_string();
+
     turn.ask_store
         .append_message(
             turn.thread_id,
@@ -381,6 +387,12 @@ async fn run_ask_turn_streaming_inner(
                 "(The assistant reached the tool-call limit without a final answer.)".to_string();
         }
     }
+
+    // Reasoning models (MiniMax, GLM) can leak <think>/<mm:think> blocks into
+    // the visible answer; strip them like the mission path does.
+    final_answer = crate::api::mission_runner::strip_think_tags(&final_answer)
+        .trim()
+        .to_string();
 
     turn.ask_store
         .append_message(


### PR DESCRIPTION
An Ask reply on prod opened with a raw `<think>…</think>` block (MiniMax reasoning leaking into the visible answer). Apply `strip_think_tags` (which already handles `<think>` and `<mm:think>`) to the final answer in both the blocking and streaming Ask paths before persisting. Lib tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized output sanitization reusing tested mission-runner logic; no auth, persistence schema, or control-flow changes.
> 
> **Overview**
> Ask assistant replies could show raw **`<think>`** / **`<mm:think>`** reasoning from models like MiniMax and GLM in the operator-visible answer.
> 
> Both the blocking **`run_ask_turn`** and streaming **`run_ask_turn_streaming`** paths now run the same **`strip_think_tags`** helper the mission runner already uses on **`final_answer`** (after the forced final-answer pass when needed), then trim whitespace, **before** persisting to **`ask_store`** and emitting the streaming **`Done`** payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fffeb01a22b81658bbcac26bc067fa7d6cd531f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->