### PR TITLE
feat(orchestrator-mcp): enforce no-Claude-workers policy at create_worker

### DIFF
--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -893,6 +893,28 @@ impl OrchestratorMcp {
     }
 
     async fn create_worker(&self, params: CreateWorkerParams) -> Result<Value, String> {
+        // Worker model allowlist: Claude models are reserved for the boss and
+        // the oracle; spending them on workers defeats the budget the policy
+        // protects. Prompt-level policy proved insufficient (two violations in
+        // one campaign), so this is enforced here. Override with
+        // SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1 when the operator explicitly
+        // approves a Claude worker.
+        let claude_worker = params.backend.as_deref() == Some("claudecode")
+            || params
+                .model_override
+                .as_deref()
+                .map(|m| m.contains("claude"))
+                .unwrap_or(false);
+        let claude_allowed = std::env::var("SANDBOXED_SH_ALLOW_CLAUDE_WORKERS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if claude_worker && !claude_allowed {
+            return Err(
+                "Refused: Claude models/backends are not allowed for worker missions                  (operator policy). Use opencode+builtin/smart, opencode+genius,                  codex+gpt-5.5, or grok instead. If the operator explicitly approved a                  Claude worker, set SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1."
+                    .to_string(),
+            );
+        }
+
         // Fail fast if working_directory points outside the boss's container
         // workspace mount: the worker container will not be able to see paths
         // outside the bind-mounted workspace root, so accepting the request

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -908,6 +908,15 @@ impl OrchestratorMcp {
         let claude_allowed = std::env::var("SANDBOXED_SH_ALLOW_CLAUDE_WORKERS")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
+        // Omitted backend/model would fall through to the server-side default
+        // (which may be a Claude backend) — require an explicit choice so the
+        // policy cannot be bypassed by omission.
+        if !claude_allowed && params.backend.as_deref().unwrap_or("").trim().is_empty() {
+            return Err(
+                "Refused: specify an explicit non-Claude `backend` (and matching                  `model_override`) for worker missions — omitting it falls back to                  the server default, which may be a Claude backend (operator policy)."
+                    .to_string(),
+            );
+        }
         if claude_worker && !claude_allowed {
             return Err(
                 "Refused: Claude models/backends are not allowed for worker missions                  (operator policy). Use opencode+builtin/smart, opencode+genius,                  codex+gpt-5.5, or grok instead. If the operator explicitly approved a                  Claude worker, set SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1."

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -903,7 +903,7 @@ impl OrchestratorMcp {
             || params
                 .model_override
                 .as_deref()
-                .map(|m| m.contains("claude"))
+                .map(|m| m.to_ascii_lowercase().contains("claude"))
                 .unwrap_or(false);
         let claude_allowed = std::env::var("SANDBOXED_SH_ALLOW_CLAUDE_WORKERS")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))


### PR DESCRIPTION
The no-Claude-workers fleet policy (Claude tokens are the budget being protected; workers run on opencode/codex/grok/genius) was stated twice in skill + steering and violated twice anyway (a haiku worker, then a sonnet worker). Constraints beat instructions: `create_worker` now refuses `claudecode` backends and `claude-*` model overrides with an error that names the sanctioned alternatives. Escape hatch for explicit operator approval: `SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1`. Batch creation goes through the same path. Lib tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration behavior for all worker spawns (including batch); bosses must pass explicit non-Claude backends, but impact is limited to MCP worker creation with a clear env override.
> 
> **Overview**
> **Orchestrator MCP** now **hard-blocks** worker creation that would spend Claude budget: at the start of `create_worker`, requests are rejected unless the operator opts in.
> 
> **Claude detection** treats `backend: claudecode` or any `model_override` containing `"claude"` (case-insensitive) as a Claude worker. **Omitting `backend`** is also refused when the policy is active, so callers cannot rely on the server/workspace default (often Claude) to bypass instructions.
> 
> Errors point bosses at allowed stacks (opencode, codex, grok, etc.). **`SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1`** (or `true`) is the explicit override. **`batch_create_workers`** inherits the same checks because it delegates to `create_worker`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d30acf693f9fd5911b24ff0873543a7162da031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->