### PR TITLE
fix(claudecode): one encrypted-thinking marker per CLI run

### DIFF
--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1337,6 +1337,7 @@ pub fn run_claudecode_turn<'a>(
         // decode (OAuth-encrypted / signature-only) so the turn end can
         // surface a marker instead of a silently empty thoughts panel.
         let mut thinking_audit = crate::backend::shared::ThinkingDeltaAudit::default();
+        let mut encrypted_marker_emitted = false;
         let mut text_buffer: HashMap<u32, String> = HashMap::new();
         let mut active_thinking_index: Option<u32> = None; // Track which thinking block is active
         let mut finalized_thinking_indices: std::collections::HashSet<u32> =
@@ -2128,8 +2129,16 @@ pub fn run_claudecode_turn<'a>(
                                     // surface a marker so the panel isn't silently empty
                                     // (also warns once about unknown delta types).
                                     if let Some(marker) = thinking_audit.finish_turn() {
-                                        let _ = events_tx
-                                            .send(thinking_final_event(marker, mission_id));
+                                        // Coalesce: Fable/OAuth missions emit a signature-only
+                                        // thinking block on EVERY assistant round, which used to
+                                        // render dozens of identical "[encrypted thinking]"
+                                        // bubbles per turn (47 in one observed mission). One
+                                        // marker per CLI run says everything the panel needs.
+                                        if !encrypted_marker_emitted {
+                                            encrypted_marker_emitted = true;
+                                            let _ = events_tx
+                                                .send(thinking_final_event(marker, mission_id));
+                                        }
                                     }
                                     // Reset per-turn accumulation state so the next turn
                                     // starts fresh (block indices restart from 0 each turn)


### PR DESCRIPTION
Mission `e598e214` (Fable/OAuth) showed **47 thinking events, all `[encrypted thinking]`** — one per assistant round, since the finish_turn audit fires at every `ClaudeEvent::Assistant` boundary. The placeholder exists to say 'thinking happened but is provider-encrypted'; once per CLI run says that without burying the transcript in identical dead bubbles. Flag is reset per run, so each user turn still gets its one marker.

Part 1 of the encrypted-thinking UX plan; the response-streaming improvement (incremental `text_delta` into a first-class answer bubble) is a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-only change in event emission; no auth, persistence, or tool-flow changes.
> 
> **Overview**
> **Claude Code streaming** now emits at most **one** `[encrypted thinking]` thoughts-panel marker for the whole CLI invocation when OAuth/Fable turns only produce signature-only thinking blocks.
> 
> Previously, `thinking_audit.finish_turn()` ran on every `Assistant` event boundary, so multi-round tool loops could flood the transcript with dozens of identical placeholder bubbles. The new **`encrypted_marker_emitted`** gate still runs the audit each round but only sends **`thinking_final_event`** the first time a marker is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3777c4bb1e4051369aaa7feb1b946a5df167ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->