### PR TITLE
feat(workbench): plan + up-next panels; richer Ask co-pilot mission context

### DIFF
--- a/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
+++ b/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
@@ -24,6 +24,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { getMissionShortName } from "@/lib/mission-display";
 import type { inferMissionRole } from "@/lib/mission-role";
 import type { Mission, MissionStatus } from "@/lib/api";
+import type { MissionStateSummary } from "../events-reducer";
 import { missionStatusDotClass, missionStatusLabel } from "./common";
 
 export function MissionWorkbenchPanel({
@@ -33,6 +34,7 @@ export function MissionWorkbenchPanel({
   isRunning,
   childMissions,
   queueLen,
+  missionState,
   onClose,
   onResume,
   onCancel,
@@ -51,6 +53,8 @@ export function MissionWorkbenchPanel({
   childMissions: Mission[];
   /** Pending message count, surfaced inline alongside status. */
   queueLen?: number;
+  /** Agent task board + next-wakeup marker derived from chat items. */
+  missionState?: MissionStateSummary;
   onClose: () => void;
   onResume: () => void;
   onCancel: (missionId: string) => void;
@@ -335,6 +339,65 @@ export function MissionWorkbenchPanel({
                 </div>
               )}
             </div>
+
+            {missionState?.upNext && (
+              <div className="mt-3 border-t border-white/[0.06] pt-2.5">
+                <div className="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-white/40">
+                  <Clock className="h-3 w-3" />
+                  Up next
+                </div>
+                <div className="text-[11px] leading-snug text-white/70">
+                  {missionState.upNext.reason.length > 160
+                    ? missionState.upNext.reason.slice(0, 160) + "…"
+                    : missionState.upNext.reason}
+                </div>
+                <div className="mt-0.5 text-[10px] text-white/35">
+                  scheduled{" "}
+                  <RelativeTime date={new Date(missionState.upNext.timestamp)} />
+                  {missionState.upNext.delaySeconds != null &&
+                    ` · fires ~${Math.round(missionState.upNext.delaySeconds / 60)}min later`}
+                </div>
+              </div>
+            )}
+
+            {missionState?.plan && missionState.plan.items.length > 0 && (
+              <div className="mt-3 border-t border-white/[0.06] pt-2.5">
+                <div className="mb-1.5 flex items-center justify-between">
+                  <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-white/40">
+                    <Flag className="h-3 w-3" />
+                    Plan
+                  </div>
+                  <span className="text-[10px] text-white/35">
+                    {missionState.plan.items.filter((t) => t.status === "completed").length}
+                    /{missionState.plan.items.length} done
+                  </span>
+                </div>
+                <ul className="space-y-1">
+                  {missionState.plan.items.map((task, i) => (
+                    <li
+                      key={i}
+                      className={cn(
+                        "flex items-start gap-1.5 text-[11px] leading-snug",
+                        task.status === "completed"
+                          ? "text-white/30 line-through"
+                          : task.status === "in_progress"
+                            ? "text-amber-200/90"
+                            : "text-white/60",
+                      )}
+                    >
+                      <span className="mt-px shrink-0">
+                        {task.status === "completed"
+                          ? "✓"
+                          : task.status === "in_progress"
+                            ? "●"
+                            : "○"}
+                      </span>
+                      <span>{task.content}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
 
             {childMissions.length > 0 && (
               <div className="mt-3 border-t border-white/[0.06] pt-2.5">

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/stream-continuation";
 import {
   eventsToItemsImpl,
+  extractMissionState,
   isRecord,
   parseCostMetadata,
   type ChatItem,
@@ -3014,6 +3015,9 @@ export default function ControlClient() {
   const showPerfOverlay = searchParams.get("debug") === "perf";
 
   const [items, setItems] = useControlItemsStore();
+  // Agent task board + next-wakeup marker for the Workbench panel, derived
+  // from the same chat items the transcript renders (single source of truth).
+  const workbenchMissionState = useMemo(() => extractMissionState(items), [items]);
   const itemsRef = useRef<ChatItem[]>([]);
   const [input, setInput] = useState(() => loadControlDraftForMission(null));
   const [canSubmitInput, setCanSubmitInput] = useState(false);
@@ -10232,6 +10236,7 @@ export default function ControlClient() {
                   isRunning={viewingMissionIsRunning}
                   childMissions={childMissions}
                   queueLen={viewingQueueLen}
+                  missionState={workbenchMissionState}
                   onClose={() => setShowWorkbenchPanel(false)}
                   onResume={handleResumeMission}
                   onCancel={handleCancelMission}

--- a/dashboard/src/app/control/events-reducer.test.ts
+++ b/dashboard/src/app/control/events-reducer.test.ts
@@ -247,3 +247,37 @@ describe("eventsToItemsImpl lazy tool stubs", () => {
     ]);
   });
 });
+
+describe("extractMissionState", () => {
+  it("derives plan and up-next from harness tool items", async () => {
+    const { extractMissionState } = await import("./events-reducer");
+    const items = eventsToItemsImpl([
+      {
+        ...storedEvent(1, "tool_call", JSON.stringify({
+          todos: [
+            { content: "merge PR", status: "completed" },
+            { content: "port Frames", status: "in_progress" },
+          ],
+        })),
+        tool_call_id: "t1",
+        tool_name: "TodoWrite",
+      },
+      {
+        ...storedEvent(2, "tool_call", JSON.stringify({
+          delaySeconds: 1500,
+          reason: "review foundry shard 3 then merge",
+          prompt: "Wakeup: ...",
+        })),
+        tool_call_id: "t2",
+        tool_name: "ScheduleWakeup",
+      },
+    ]);
+    const state = extractMissionState(items);
+    expect(state.plan?.items).toEqual([
+      { content: "merge PR", status: "completed" },
+      { content: "port Frames", status: "in_progress" },
+    ]);
+    expect(state.upNext?.reason).toBe("review foundry shard 3 then merge");
+    expect(state.upNext?.delaySeconds).toBe(1500);
+  });
+});

--- a/dashboard/src/app/control/events-reducer.ts
+++ b/dashboard/src/app/control/events-reducer.ts
@@ -689,9 +689,9 @@ export function extractMissionState(items: ChatItem[]): MissionStateSummary {
           if (!content) continue;
           parsed.push({ content, status: normalizePlanStatus(entry["status"]) });
         }
-        if (parsed.length > 0) {
-          plan = { items: parsed, timestamp: item.startTime };
-        }
+        // An empty/unparseable board still supersedes the previous one —
+        // keeping the old snapshot would present stale state as current.
+        plan = parsed.length > 0 ? { items: parsed, timestamp: item.startTime } : null;
       }
     } else if (name === "ScheduleWakeup") {
       const args = item.args as Record<string, unknown>;
@@ -701,7 +701,13 @@ export function extractMissionState(items: ChatItem[]): MissionStateSummary {
           : typeof args["prompt"] === "string"
             ? args["prompt"]
             : "";
-      if (reason) {
+      // A wakeup without usable text still replaces (clears) the previous
+      // marker — the old "up next" is no longer what happens next.
+      if (!reason) {
+        upNext = null;
+        continue;
+      }
+      {
         upNext = {
           reason,
           delaySeconds:

--- a/dashboard/src/app/control/events-reducer.ts
+++ b/dashboard/src/app/control/events-reducer.ts
@@ -627,3 +627,76 @@ export function eventsToItemsImpl(
 
   return items;
 }
+
+// ── Mission state extraction (Workbench panel) ──────────────────────
+
+export type PlanItem = {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+};
+
+export type MissionStateSummary = {
+  /** Latest task-board snapshot from the harness's native plan tool. */
+  plan: { items: PlanItem[]; timestamp: number } | null;
+  /** Latest self-scheduled wakeup: what the agent said it will do next. */
+  upNext: { reason: string; delaySeconds: number | null; timestamp: number } | null;
+};
+
+function normalizePlanStatus(raw: unknown): PlanItem["status"] {
+  if (raw === "completed" || raw === "in_progress" || raw === "pending") return raw;
+  if (raw === "done" || raw === "complete") return "completed";
+  return "pending";
+}
+
+/**
+ * Derive the agent's task board and "up next" marker from already-rendered
+ * chat items. Reads the harness's own plan tools (Claude Code `TodoWrite`,
+ * Codex `update_plan`, OpenCode `todowrite`) and the last `ScheduleWakeup`
+ * call — no new agent behavior or events required, so it stays truthful.
+ */
+export function extractMissionState(items: ChatItem[]): MissionStateSummary {
+  let plan: MissionStateSummary["plan"] = null;
+  let upNext: MissionStateSummary["upNext"] = null;
+  for (const item of items) {
+    if (item.kind !== "tool" || !isRecord(item.args)) continue;
+    const name = item.name;
+    if (name === "TodoWrite" || name === "todowrite" || name === "update_plan") {
+      const raw = (item.args as Record<string, unknown>)["todos"] ??
+        (item.args as Record<string, unknown>)["plan"];
+      if (Array.isArray(raw)) {
+        const parsed: PlanItem[] = [];
+        for (const entry of raw) {
+          if (!isRecord(entry)) continue;
+          const content =
+            typeof entry["content"] === "string"
+              ? entry["content"]
+              : typeof entry["step"] === "string"
+                ? entry["step"]
+                : null;
+          if (!content) continue;
+          parsed.push({ content, status: normalizePlanStatus(entry["status"]) });
+        }
+        if (parsed.length > 0) {
+          plan = { items: parsed, timestamp: item.startTime };
+        }
+      }
+    } else if (name === "ScheduleWakeup") {
+      const args = item.args as Record<string, unknown>;
+      const reason =
+        typeof args["reason"] === "string" && args["reason"].trim()
+          ? args["reason"]
+          : typeof args["prompt"] === "string"
+            ? args["prompt"]
+            : "";
+      if (reason) {
+        upNext = {
+          reason,
+          delaySeconds:
+            typeof args["delaySeconds"] === "number" ? args["delaySeconds"] : null,
+          timestamp: item.startTime,
+        };
+      }
+    }
+  }
+  return { plan, upNext };
+}

--- a/dashboard/src/app/control/events-reducer.ts
+++ b/dashboard/src/app/control/events-reducer.ts
@@ -657,9 +657,22 @@ function normalizePlanStatus(raw: unknown): PlanItem["status"] {
 export function extractMissionState(items: ChatItem[]): MissionStateSummary {
   let plan: MissionStateSummary["plan"] = null;
   let upNext: MissionStateSummary["upNext"] = null;
+  // Lazily-loaded history stubs carry no args; if a stub for one of these
+  // tools is NEWER than the last parsed snapshot, the parsed one is stale —
+  // drop it rather than present outdated state as current.
+  let stalePlanAfter = 0;
+  let staleUpNextAfter = 0;
   for (const item of items) {
-    if (item.kind !== "tool" || !isRecord(item.args)) continue;
+    if (item.kind !== "tool") continue;
     const name = item.name;
+    if (!isRecord(item.args)) {
+      if (name === "TodoWrite" || name === "todowrite" || name === "update_plan") {
+        stalePlanAfter = Math.max(stalePlanAfter, item.startTime);
+      } else if (name === "ScheduleWakeup") {
+        staleUpNextAfter = Math.max(staleUpNextAfter, item.startTime);
+      }
+      continue;
+    }
     if (name === "TodoWrite" || name === "todowrite" || name === "update_plan") {
       const raw = (item.args as Record<string, unknown>)["todos"] ??
         (item.args as Record<string, unknown>)["plan"];
@@ -692,11 +705,17 @@ export function extractMissionState(items: ChatItem[]): MissionStateSummary {
         upNext = {
           reason,
           delaySeconds:
-            typeof args["delaySeconds"] === "number" ? args["delaySeconds"] : null,
+            typeof args["delaySeconds"] === "number"
+              ? args["delaySeconds"]
+              : typeof args["delay_seconds"] === "number"
+                ? args["delay_seconds"]
+                : null,
           timestamp: item.startTime,
         };
       }
     }
   }
+  if (plan && stalePlanAfter > plan.timestamp) plan = null;
+  if (upNext && staleUpNextAfter > upNext.timestamp) upNext = null;
   return { plan, upNext };
 }

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -454,6 +454,35 @@ async fn build_system_prompt(turn: &AskTurn, user_content: &str) -> String {
                 truncate(&goal.content, 600)
             ));
         }
+        // Latest plan snapshot (Claude Code TodoWrite / Codex update_plan /
+        // OpenCode todowrite): the working agent's own task board is the
+        // single best "where are we" signal — surface the newest one.
+        if let Some(plan) = events.iter().rev().find(|ev| {
+            ev.event_type == "tool_call"
+                && matches!(
+                    ev.tool_name.as_deref(),
+                    Some("TodoWrite") | Some("update_plan") | Some("todowrite")
+                )
+        }) {
+            seed.push_str(&format!(
+                "\nWorking agent's latest task board [{} {}]:\n{}\n",
+                plan.sequence,
+                plan.timestamp,
+                truncate(&plan.content, 1500)
+            ));
+        }
+        if let Some(iter_ev) = events
+            .iter()
+            .rev()
+            .find(|ev| ev.event_type == "goal_iteration")
+        {
+            seed.push_str(&format!(
+                "\nLatest loop/wakeup marker [{} {}]: {}\n",
+                iter_ev.sequence,
+                iter_ev.timestamp,
+                truncate(&iter_ev.content, 400)
+            ));
+        }
         let start = events.len().saturating_sub(SEED_EVENT_COUNT);
         seed.push_str("\nRecent mission events (newest last):\n");
         for ev in &events[start..] {
@@ -469,6 +498,37 @@ async fn build_system_prompt(turn: &AskTurn, user_content: &str) -> String {
                 ev.event_type,
                 tool,
                 truncate(&ev.content, 300)
+            ));
+        }
+    }
+
+    // Worker fleet: for orchestrator missions, list child missions so the
+    // co-pilot can answer "what is running right now" without grepping.
+    if let Ok(children) = turn.mission_store.get_child_missions(turn.mission_id).await {
+        if !children.is_empty() {
+            seed.push_str("\nWorker missions (children):\n");
+            for c in children.iter().rev().take(12) {
+                seed.push_str(&format!(
+                    "- {} [{} {}] {:?} {}\n",
+                    c.id,
+                    c.backend,
+                    c.model_override.as_deref().unwrap_or("-"),
+                    c.status,
+                    truncate(c.title.as_deref().unwrap_or("untitled"), 80)
+                ));
+            }
+        }
+    }
+    // Pending wakeups: when the next scheduled turn fires and why.
+    if let Ok(autos) = turn
+        .mission_store
+        .get_mission_automations(turn.mission_id)
+        .await
+    {
+        for a in autos.iter().filter(|a| a.active) {
+            seed.push_str(&format!(
+                "\nPending automation: trigger={:?} last_triggered={:?}\n",
+                a.trigger, a.last_triggered_at
             ));
         }
     }


### PR DESCRIPTION
First slice of the Workbench redesign (state over transcript), all derived from already-persisted events:

## Dashboard
- **Plan panel**: latest task board from the harness's native plan tool (`TodoWrite`/`update_plan`/`todowrite`), with ✓/●/○ status, done-count, and strikethrough on completed — via a new pure `extractMissionState(items)` (unit-tested).
- **Up next**: the agent's last `ScheduleWakeup` reason + fire delay in the Workbench panel — answers 'what is it going to do next' at a glance.

## Ask co-pilot
`build_system_prompt` now seeds: latest task board, latest goal_iteration/wakeup marker, the worker-fleet (child missions with backend/model/status), and pending automations. The operator question that motivated this ('what work is queued?') becomes answerable from seeded state instead of requiring the model to grep history.

Tests: 224 dashboard tests green (1 new), ask lib tests green, tsc clean; the one eslint error in MissionWorkbenchPanel pre-exists on master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard UI and read-only prompt seeding only; no auth, persistence, or agent execution paths changed.
> 
> **Overview**
> Surfaces **mission state in the Workbench** without new events: chat items are scanned for harness plan tools and the latest **ScheduleWakeup**, then **Plan** (task list with done count and status styling) and **Up next** (reason, schedule time, delay) render in `MissionWorkbenchPanel`. Logic lives in new **`extractMissionState`** on the control events reducer, wired from `ControlClient` via `useMemo` on the same items as the transcript, with stale-state handling when lazy tool stubs lack args.
> 
> The **Ask co-pilot** system prompt seed in `build_system_prompt` is expanded with the newest task-board tool call, latest **goal_iteration**, up to 12 **child worker missions** (backend/model/status), and **active automations**—so queued work and fleet status can be answered from seeded context instead of inferring from raw history alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1a132ca269bd5fd9306ee8fe7ea481f015b7f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->