### PR TITLE
feat(ui): resizable Ask panel; hide chat avatars when narrow

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1181,7 +1181,7 @@ function QuestionToolItem({
       data-chat-item-id={item.id}
       className="flex justify-start gap-3"
     >
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
+      <div className="@max-[30rem]:hidden flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
         <Bot className="h-4 w-4 text-indigo-400" />
       </div>
       <div className="max-w-[90%] rounded-2xl rounded-tl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
@@ -2661,7 +2661,7 @@ const ChatItemRow = memo(function ChatItemRow({
             </span>
           </div>
         </div>
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.08]">
+        <div className="@max-[30rem]:hidden flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.08]">
           <User className="h-4 w-4 text-white/60" />
         </div>
       </div>
@@ -2690,7 +2690,7 @@ const ChatItemRow = memo(function ChatItemRow({
           highlighted && "ring-1 ring-amber-400/70 bg-amber-500/10",
         )}
       >
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
+        <div className="@max-[30rem]:hidden flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
           <Bot className="h-4 w-4 text-indigo-400" />
         </div>
         <div className="max-w-[80%] rounded-2xl rounded-tl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
@@ -2853,7 +2853,7 @@ const ChatItemRow = memo(function ChatItemRow({
             data-chat-item-id={item.id}
             className="flex justify-start gap-3"
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
+            <div className="@max-[30rem]:hidden flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
               <Bot className="h-4 w-4 text-indigo-400" />
             </div>
             <div className="max-w-[80%] rounded-2xl rounded-tl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
@@ -2900,7 +2900,7 @@ const ChatItemRow = memo(function ChatItemRow({
             data-chat-item-id={item.id}
             className="flex justify-start gap-3"
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
+            <div className="@max-[30rem]:hidden flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
               <Bot className="h-4 w-4 text-indigo-400" />
             </div>
             <div className="max-w-[90%] rounded-2xl rounded-tl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
@@ -9841,7 +9841,7 @@ export default function ControlClient() {
                   </div>
                 </div>
               ) : (
-                <div className="mx-auto max-w-3xl space-y-6">
+                <div className="@container mx-auto max-w-3xl space-y-6">
                   <div
                     className="relative w-full"
                     style={{ height: `${chatVirtualizer.getTotalSize()}px` }}

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -58,6 +58,18 @@ export function AskPanel({
   const [threadId, setThreadId] = useState<string | null>(null);
   const [messages, setMessages] = useState<AskMessage[]>([]);
   const [input, setInput] = useState("");
+  // Resizable: persisted so the chat/co-pilot split survives reloads.
+  const [panelWidth, setPanelWidthRaw] = useState(380);
+  useEffect(() => {
+    const saved = Number(localStorage.getItem("ask-panel-width"));
+    if (Number.isFinite(saved) && saved >= 300 && saved <= 760) {
+      setPanelWidthRaw(saved);
+    }
+  }, []);
+  const setPanelWidth = useCallback((w: number) => {
+    setPanelWidthRaw(w);
+    localStorage.setItem("ask-panel-width", String(Math.round(w)));
+  }, []);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showThreadList, setShowThreadList] = useState(false);
@@ -353,7 +365,34 @@ export function AskPanel({
     "border border-[rgb(var(--foreground)/0.1)] bg-[rgb(var(--foreground)/0.04)] text-[rgb(var(--foreground)/0.6)] hover:bg-[rgb(var(--foreground)/0.07)] hover:text-[rgb(var(--foreground)/0.85)]";
 
   return (
-    <div className="flex h-full w-[380px] shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl">
+    <div
+      className="@container relative flex h-full shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl"
+      style={{ width: panelWidth }}
+    >
+      {/* Drag the left edge to trade width between the chat and the co-pilot. */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        className="absolute -left-1 top-0 z-10 h-full w-2 cursor-col-resize hover:bg-[rgb(var(--copilot)/0.25)]"
+        onPointerDown={(e) => {
+          e.preventDefault();
+          const startX = e.clientX;
+          const startWidth = panelWidth;
+          const onMove = (ev: PointerEvent) => {
+            const next = Math.min(
+              760,
+              Math.max(300, startWidth + (startX - ev.clientX)),
+            );
+            setPanelWidth(next);
+          };
+          const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+          };
+          window.addEventListener("pointermove", onMove);
+          window.addEventListener("pointerup", onUp);
+        }}
+      />
       {/* Header */}
       <div className="flex items-center justify-between gap-2 border-b border-[rgb(var(--foreground)/0.1)] px-3 py-2.5">
         <div className="flex items-center gap-2">
@@ -640,7 +679,7 @@ function AskBubble({
             {content}
           </p>
         </div>
-        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--foreground)/0.07)]">
+        <div className="@max-[24rem]:hidden flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--foreground)/0.07)]">
           <User className="h-3.5 w-3.5 text-[rgb(var(--foreground)/0.5)]" />
         </div>
       </div>

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -59,13 +59,13 @@ export function AskPanel({
   const [messages, setMessages] = useState<AskMessage[]>([]);
   const [input, setInput] = useState("");
   // Resizable: persisted so the chat/co-pilot split survives reloads.
-  const [panelWidth, setPanelWidthRaw] = useState(380);
-  useEffect(() => {
-    const saved = Number(localStorage.getItem("ask-panel-width"));
-    if (Number.isFinite(saved) && saved >= 300 && saved <= 760) {
-      setPanelWidthRaw(saved);
-    }
-  }, []);
+  // Lazy initializer reads the saved width on first render so the panel never
+  // mounts at the default and then jumps to the stored value.
+  const [panelWidth, setPanelWidthRaw] = useState(() => {
+    if (typeof window === "undefined") return 380;
+    const saved = Number(window.localStorage.getItem("ask-panel-width"));
+    return Number.isFinite(saved) && saved >= 300 && saved <= 760 ? saved : 380;
+  });
   const setPanelWidth = useCallback((w: number) => {
     setPanelWidthRaw(w);
   }, []);

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -68,6 +68,8 @@ export function AskPanel({
   }, []);
   const setPanelWidth = useCallback((w: number) => {
     setPanelWidthRaw(w);
+  }, []);
+  const persistPanelWidth = useCallback((w: number) => {
     localStorage.setItem("ask-panel-width", String(Math.round(w)));
   }, []);
   const [loading, setLoading] = useState(false);
@@ -385,7 +387,10 @@ export function AskPanel({
             );
             setPanelWidth(next);
           };
-          const onUp = () => {
+          const onUp = (ev: PointerEvent) => {
+            persistPanelWidth(
+              Math.min(760, Math.max(300, startWidth + (startX - ev.clientX))),
+            );
             window.removeEventListener("pointermove", onMove);
             window.removeEventListener("pointerup", onUp);
             window.removeEventListener("pointercancel", onUp);

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -388,9 +388,11 @@ export function AskPanel({
           const onUp = () => {
             window.removeEventListener("pointermove", onMove);
             window.removeEventListener("pointerup", onUp);
+            window.removeEventListener("pointercancel", onUp);
           };
           window.addEventListener("pointermove", onMove);
           window.addEventListener("pointerup", onUp);
+          window.addEventListener("pointercancel", onUp);
         }}
       />
       {/* Header */}

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -708,7 +708,7 @@ function AskBubble({
   // assistant
   return (
     <div className="flex justify-start gap-2">
-      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--copilot)/0.15)] ring-1 ring-inset ring-[rgb(var(--copilot)/0.25)]">
+      <div className="@max-[24rem]:hidden flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--copilot)/0.15)] ring-1 ring-inset ring-[rgb(var(--copilot)/0.25)]">
         <Sparkles className="h-3.5 w-3.5 text-[rgb(var(--copilot))]" />
       </div>
       <div className="group max-w-[85%] rounded-2xl rounded-tl-md border border-[rgb(var(--copilot)/0.18)] bg-[rgb(var(--copilot)/0.07)] px-3 py-2">


### PR DESCRIPTION
Two operator-requested UX improvements:

1. **Resizable chat/co-pilot split**: drag the Ask panel's left edge (300–760px, persisted in `localStorage`) — widening the co-pilot narrows the chat and vice versa, since the chat column flexes.
2. **Avatar-free narrow mode**: Bot/User avatars hide via Tailwind 4 container queries when their column is below ~24rem (Ask panel) / ~30rem (main chat) — reclaiming space exactly when it is scarce, e.g. with Workbench + Ask both open.

tsc clean, 224 dashboard tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout and localStorage preference; no auth, API, or data-path changes.
> 
> **Overview**
> The **Ask co-pilot panel** is no longer fixed at 380px: users can drag its left edge to resize between **300–760px**, with width saved in **`localStorage`** (`ask-panel-width`) and initialized on first render to avoid a layout jump. The panel root is now a **`@container`** so width-driven styling can respond to the panel itself.
> 
> **Main control chat** and **Ask message bubbles** hide **Bot/User avatar circles** when their column is narrow—**~30rem** for the main chat list (via `@container` on the virtualized list wrapper) and **~24rem** inside the Ask panel—using Tailwind **`@max-[…]:hidden`** container queries to reclaim horizontal space when the chat column is squeezed (e.g. Workbench + Ask open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c942ab171144d561a2b60a1b200b156b439e35df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->