### PR TITLE
feat(automations): collapse completed wakeups into a history section

### DIFF
--- a/dashboard/src/components/mission-automations-dialog.test.tsx
+++ b/dashboard/src/components/mission-automations-dialog.test.tsx
@@ -49,6 +49,7 @@ describe("prepareVisibleAutomations", () => {
       active: boolean;
       created_at: string;
       last_triggered_at: string | null;
+      stop_policy: { type: string };
       command_source: { type: string };
     }> = {},
   ) => ({
@@ -56,6 +57,7 @@ describe("prepareVisibleAutomations", () => {
     active: overrides.active ?? true,
     created_at: overrides.created_at ?? "2026-05-21T00:00:00Z",
     last_triggered_at: overrides.last_triggered_at ?? null,
+    stop_policy: overrides.stop_policy ?? { type: "never" },
     command_source: overrides.command_source ?? { type: "inline" },
   });
 
@@ -141,10 +143,16 @@ describe("prepareVisibleAutomations", () => {
       make("spent-wakeup", {
         active: false,
         last_triggered_at: "2026-05-22T10:00:00Z",
+        stop_policy: { type: "after_first_fire" },
+      }),
+      make("paused-recurring", {
+        active: false,
+        last_triggered_at: "2026-05-22T10:00:00Z",
+        stop_policy: { type: "never" },
       }),
     ]);
     expect(result.live.map((a) => a.id).sort()).toEqual(
-      ["live-driver", "paused-never-fired"].sort(),
+      ["live-driver", "paused-never-fired", "paused-recurring"].sort(),
     );
     expect(result.spent.map((a) => a.id)).toEqual(["spent-wakeup"]);
   });

--- a/dashboard/src/components/mission-automations-dialog.test.tsx
+++ b/dashboard/src/components/mission-automations-dialog.test.tsx
@@ -48,12 +48,14 @@ describe("prepareVisibleAutomations", () => {
     overrides: Partial<{
       active: boolean;
       created_at: string;
+      last_triggered_at: string | null;
       command_source: { type: string };
     }> = {},
   ) => ({
     id,
     active: overrides.active ?? true,
     created_at: overrides.created_at ?? "2026-05-21T00:00:00Z",
+    last_triggered_at: overrides.last_triggered_at ?? null,
     command_source: overrides.command_source ?? { type: "inline" },
   });
 
@@ -63,7 +65,7 @@ describe("prepareVisibleAutomations", () => {
       make("running", { active: true, command_source: { type: "native_loop" } }),
     ]);
 
-    expect(result.map((a) => a.id)).toEqual(["running"]);
+    expect(result.live.map((a) => a.id)).toEqual(["running"]);
   });
 
   it("preserves inactive non-native_loop rows (user-paused automations stay visible)", () => {
@@ -72,7 +74,7 @@ describe("prepareVisibleAutomations", () => {
       make("paused-library", { active: false, command_source: { type: "library" } }),
     ]);
 
-    expect(result.map((a) => a.id).sort()).toEqual(
+    expect(result.live.map((a) => a.id).sort()).toEqual(
       ["paused-by-user", "paused-library"].sort(),
     );
   });
@@ -83,7 +85,7 @@ describe("prepareVisibleAutomations", () => {
       make("active-old", { active: true, created_at: "2026-05-20T00:00:00Z" }),
     ]);
 
-    expect(result.map((a) => a.id)).toEqual(["active-old", "paused"]);
+    expect(result.live.map((a) => a.id)).toEqual(["active-old", "paused"]);
   });
 
   it("within the same active state, sorts newest first", () => {
@@ -93,7 +95,7 @@ describe("prepareVisibleAutomations", () => {
       make("middle", { active: true, created_at: "2026-05-21T00:00:00Z" }),
     ]);
 
-    expect(result.map((a) => a.id)).toEqual(["newest", "middle", "oldest"]);
+    expect(result.live.map((a) => a.id)).toEqual(["newest", "middle", "oldest"]);
   });
 
   it("does not mutate the input array (sort + filter return a fresh list)", () => {
@@ -129,6 +131,21 @@ describe("prepareVisibleAutomations", () => {
       intervalDriver,
     ]);
 
-    expect(result.map((a) => a.id)).toEqual(["interval-driver"]);
+    expect(result.live.map((a) => a.id)).toEqual(["interval-driver"]);
+  });
+
+  it("routes fired one-shot wakeups (inactive + last_triggered_at) to spent", () => {
+    const result = prepareVisibleAutomations([
+      make("live-driver", { active: true }),
+      make("paused-never-fired", { active: false, last_triggered_at: null }),
+      make("spent-wakeup", {
+        active: false,
+        last_triggered_at: "2026-05-22T10:00:00Z",
+      }),
+    ]);
+    expect(result.live.map((a) => a.id).sort()).toEqual(
+      ["live-driver", "paused-never-fired"].sort(),
+    );
+    expect(result.spent.map((a) => a.id)).toEqual(["spent-wakeup"]);
   });
 });

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -215,20 +215,33 @@ export function prepareVisibleAutomations<
   A extends {
     active: boolean;
     created_at?: string;
+    last_triggered_at?: string | null;
     command_source?: { type: string } | null;
   }
->(automations: A[]): A[] {
-  return automations
-    .filter(
-      (a) => !(a.command_source?.type === 'native_loop' && !a.active)
-    )
-    .slice()
-    .sort((a, b) => {
-      if (a.active !== b.active) return a.active ? -1 : 1;
-      const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
-      const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
-      return bTime - aTime;
-    });
+>(automations: A[]): { live: A[]; spent: A[] } {
+  const sortByCreated = (a: A, b: A) => {
+    if (a.active !== b.active) return a.active ? -1 : 1;
+    const aTime = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const bTime = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return bTime - aTime;
+  };
+  const kept = automations.filter(
+    (a) => !(a.command_source?.type === 'native_loop' && !a.active),
+  );
+  // "Spent" = an inactive automation that already fired at least once — almost
+  // always a one-shot ScheduleWakeup the harness completed. These are history,
+  // not actionable, and used to bury the single live driver under dozens of
+  // dead rows. Anything still active, or inactive-but-never-fired (a paused or
+  // failed-on-create automation worth seeing), stays in `live`.
+  const live: A[] = [];
+  const spent: A[] = [];
+  for (const a of kept) {
+    if (!a.active && a.last_triggered_at) spent.push(a);
+    else live.push(a);
+  }
+  live.sort(sortByCreated);
+  spent.sort(sortByCreated);
+  return { live, spent };
 }
 
 export function MissionAutomationsDialog({
@@ -250,6 +263,7 @@ export function MissionAutomationsDialog({
   const [hasLoaded, setHasLoaded] = useState(false);
   const [loadedMissionId, setLoadedMissionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showSpent, setShowSpent] = useState(false);
 
   useEffect(() => {
     automationsRef.current = automations;
@@ -916,7 +930,9 @@ export function MissionAutomationsDialog({
 
   const isMissionDataReady = !!missionId && loadedMissionId === missionId;
   const showLoadingPlaceholder = !!missionId && (!isMissionDataReady || (loading && !hasLoaded));
-  const visibleAutomations = isMissionDataReady ? prepareVisibleAutomations(automations) : [];
+  const { live: visibleAutomations, spent: spentAutomations } = isMissionDataReady
+    ? prepareVisibleAutomations(automations)
+    : { live: [], spent: [] };
   const visibleError = isMissionDataReady ? error : null;
   const selectClass =
     'rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50 appearance-none cursor-pointer';
@@ -1422,6 +1438,7 @@ export function MissionAutomationsDialog({
                 {isMissionDataReady &&
                   !loading &&
                   visibleAutomations.length === 0 &&
+                  spentAutomations.length === 0 &&
                   !visibleError && (
                     <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 text-center text-sm text-white/40">
                       No automations yet. Create one above.
@@ -1703,6 +1720,39 @@ export function MissionAutomationsDialog({
                     );
                   })}
                 </div>
+
+                {spentAutomations.length > 0 && (
+                  <div className="mt-3 border-t border-white/[0.06] pt-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowSpent((v) => !v)}
+                      className="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-[11px] text-white/40 hover:bg-white/[0.04] hover:text-white/60"
+                    >
+                      <span>
+                        {showSpent ? 'Hide' : 'Show'} {spentAutomations.length} completed
+                        {' '}wakeup{spentAutomations.length === 1 ? '' : 's'} (history)
+                      </span>
+                      <span>{showSpent ? '▾' : '▸'}</span>
+                    </button>
+                    {showSpent && (
+                      <div className="mt-1 space-y-1">
+                        {spentAutomations.map((automation) => (
+                          <div
+                            key={automation.id}
+                            className="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-[11px] text-white/35"
+                          >
+                            <span className="truncate">{getAutomationLabel(automation)}</span>
+                            <span className="shrink-0 text-white/25">
+                              {automation.last_triggered_at
+                                ? new Date(automation.last_triggered_at).toLocaleString()
+                                : ''}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             </>
           )}

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -216,6 +216,7 @@ export function prepareVisibleAutomations<
     active: boolean;
     created_at?: string;
     last_triggered_at?: string | null;
+    stop_policy?: { type: string } | null;
     command_source?: { type: string } | null;
   }
 >(automations: A[]): { live: A[]; spent: A[] } {
@@ -236,7 +237,15 @@ export function prepareVisibleAutomations<
   const live: A[] = [];
   const spent: A[] = [];
   for (const a of kept) {
-    if (!a.active && a.last_triggered_at) spent.push(a);
+    // Spent = a fired ONE-SHOT (stop_policy after_first_fire) that is now
+    // inactive — i.e. a completed ScheduleWakeup. A user-paused recurring
+    // automation (interval/webhook, different stop policy) is NOT spent even
+    // though it has fired before; it stays in `live` so it remains editable.
+    const isFiredOneShot =
+      !a.active &&
+      !!a.last_triggered_at &&
+      a.stop_policy?.type === "after_first_fire";
+    if (isFiredOneShot) spent.push(a);
     else live.push(a);
   }
   live.sort(sortByCreated);


### PR DESCRIPTION
The mission automations dialog showed **every** automation a mission ever had. For a long-lived orchestrator that means its single live driver is buried under dozens of fired one-shot `ScheduleWakeup`s (mission 832725c5: **47 dead rows vs 1 live**).

`prepareVisibleAutomations` now returns `{ live, spent }`:
- **spent** = inactive AND `last_triggered_at` set — a completed one-shot wakeup, pure history.
- **live** = active, or inactive-but-never-fired (paused/failed-on-create automations worth seeing). Renders exactly as before.

Spent rows collapse behind a compact, read-only "Show N completed wakeups (history)" toggle. Empty-state only shows when both are empty. Unit tests updated for the new shape + a case pinning the live/spent routing; 225 dashboard tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only display and filtering logic; no API or automation execution changes.
> 
> **Overview**
> The mission automations dialog no longer mixes **completed one-shot wakeups** into the main list. **`prepareVisibleAutomations`** now returns **`{ live, spent }`** instead of a single array: **spent** rows are inactive automations with **`stop_policy.type === "after_first_fire"`** and a **`last_triggered_at`** (finished ScheduleWakeup history); **live** keeps active rows, never-fired paused automations, and user-paused recurring automations that have fired before. Existing filter/sort behavior for **live** is unchanged.
> 
> The dialog renders **live** automations as before and adds a **“Show N completed wakeups (history)”** toggle with read-only labels and last-triggered timestamps. The empty state appears only when both **live** and **spent** are empty. Unit tests assert the new return shape and live/spent routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de03196e5904eb1738b6506365ccf672e039dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->