### PR TITLE
feat(supervision): auto-resume orphaned worker missions once

### DIFF
--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -318,6 +318,13 @@ pub(crate) async fn stuck_mission_watchdog_loop(
     // previous tick. Entries for dead scopes are pruned each pass.
     let mut oom_seen: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
 
+    // Worker missions we have already auto-resumed once this process lifetime.
+    // Auto-resume is a single supervised retry for workers whose runner died
+    // (orphan / deploy SIGTERM) — an environmental interruption, not the
+    // worker's own fault. If the resumed worker dies again it stays
+    // interrupted and the boss handles it, so this can never resume-storm.
+    let mut auto_resumed_workers: HashSet<Uuid> = HashSet::new();
+
     loop {
         tokio::time::sleep(CHECK_INTERVAL).await;
 
@@ -465,6 +472,39 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                         .to_string(),
                 ),
             });
+
+            // One supervised auto-resume for orphaned WORKER missions. The
+            // boss used to babysit this by hand (10 manual resume_worker
+            // calls in one campaign); a runner death is environmental, so a
+            // single retry is safe. Once-only per process: a worker that dies
+            // again stays interrupted for the boss to triage.
+            if mission.parent_mission_id.is_some() && auto_resumed_workers.insert(mission.id) {
+                tracing::info!(
+                    mission_id = %mission.id,
+                    parent = ?mission.parent_mission_id,
+                    "Stuck-mission watchdog: auto-resuming orphaned worker once"
+                );
+                let (resume_tx, resume_rx) = oneshot::channel();
+                if cmd_tx
+                    .send(ControlCommand::ResumeMission {
+                        mission_id: mission.id,
+                        clean_workspace: false,
+                        skip_message: false,
+                        respond: resume_tx,
+                    })
+                    .await
+                    .is_ok()
+                {
+                    match resume_rx.await {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(e)) => tracing::warn!(
+                            mission_id = %mission.id,
+                            "Auto-resume failed: {}; leaving interrupted for the boss", e
+                        ),
+                        Err(_) => {}
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem
When a worker mission's runner dies — a deploy SIGTERM or a crash — the watchdog marks it `interrupted` (`orphan_no_runner`) and the orchestrator boss had to notice and call `resume_worker` manually. One campaign had **10 such manual resumes**; every prod deploy I did needed hand-resumes of the running workers.

## Fix
The stuck-mission watchdog now issues a single supervised `ResumeMission` for orphaned missions that have a `parent_mission_id` (i.e. workers), tracked in a once-per-process set so a worker that dies *again* stays interrupted for the boss to triage — no resume storms possible.

## Scope / safety
- **Only Case 2** (Active in DB, no live runner = runner death, environmental). Deliberately **not** Case 1 (`watchdog_stalled`), which can be a genuine hang that should not auto-restart.
- **Workers only** (parent_mission_id present); top-level missions are untouched.
- Once per process; resume failure leaves the worker interrupted with a warn log.

`cargo test --lib`: 998 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission lifecycle in supervision (automatic ResumeMission for workers); bounded by once-per-process and workers-only, but still affects orchestration behavior after deploys and crashes.
> 
> **Overview**
> The stuck-mission watchdog now **auto-resumes orphaned worker missions** once when it marks them interrupted for **Case 2** (DB still `Active`, no in-memory runner — e.g. deploy SIGTERM or runner crash).
> 
> After emitting `orphan_no_runner` / `MissionStatusChanged`, it enqueues **`ResumeMission`** only when **`parent_mission_id`** is set (workers, not top-level missions). A process-lifetime **`HashSet`** ensures **at most one auto-resume per worker**; a second death stays interrupted for manual triage. Failed resumes are logged and left interrupted. **Case 1** (watchdog stall / `watchdog_stalled`) is unchanged — no auto-restart there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c095feae6ef73a1b9e65797fd804ec79f6b633dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->