### PR TITLE
Task board orchestration + model-routing/catalog fixes

### DIFF
--- a/dashboard/src/app/control/components/MissionTaskBoard.tsx
+++ b/dashboard/src/app/control/components/MissionTaskBoard.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+// Task board section for the mission workbench. Polls the server-owned board
+// (see backend api::control::board) and renders task status, dependencies,
+// and worker links. Renders nothing for missions without a board.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { KanbanSquare, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  cancelBoardTask,
+  getMissionBoard,
+  postBoardTaskVerdict,
+  type BoardTask,
+  type MissionBoard,
+} from "@/lib/api";
+
+const POLL_MS = 5000;
+
+function statusGlyph(task: BoardTask): { glyph: string; cls: string } {
+  switch (task.status) {
+    case "running":
+      return { glyph: "●", cls: "text-emerald-400" };
+    case "settled":
+      return task.outcome === "blocked"
+        ? { glyph: "◆", cls: "text-orange-300" }
+        : task.outcome === "failed"
+          ? { glyph: "✗", cls: "text-red-400" }
+          : { glyph: "◐", cls: "text-amber-300" };
+    case "accepted":
+      return { glyph: "✓", cls: "text-white/30" };
+    case "failed":
+      return { glyph: "✗", cls: "text-red-400" };
+    case "cancelled":
+      return { glyph: "–", cls: "text-white/25" };
+    default:
+      return { glyph: "○", cls: "text-white/40" };
+  }
+}
+
+function rowTextClass(task: BoardTask): string {
+  switch (task.status) {
+    case "accepted":
+      return "text-white/30 line-through";
+    case "cancelled":
+      return "text-white/25 line-through";
+    case "running":
+      return "text-white/80";
+    case "settled":
+      return task.outcome === "success" ? "text-amber-200/90" : "text-orange-300";
+    case "failed":
+      return "text-red-400";
+    default:
+      return "text-white/55";
+  }
+}
+
+export function MissionTaskBoard({
+  missionId,
+  onViewMission,
+}: {
+  missionId: string;
+  onViewMission: (missionId: string) => void;
+}) {
+  const [board, setBoard] = useState<MissionBoard | null>(null);
+  const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const b = await getMissionBoard(missionId);
+      setBoard(b);
+    } catch {
+      // Board endpoint unavailable (old backend) or mission gone: hide section.
+      setBoard(null);
+    }
+  }, [missionId]);
+
+  useEffect(() => {
+    setBoard(null);
+    void refresh();
+    timerRef.current = setInterval(() => void refresh(), POLL_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [refresh]);
+
+  if (!board || board.tasks.length === 0) return null;
+  const u = board.utilization;
+  const done = u.accepted + u.cancelled;
+
+  return (
+    <div className="mt-3 border-t border-white/[0.06] pt-2.5">
+      <div className="mb-1.5 flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-white/40">
+          <KanbanSquare className="h-3 w-3" />
+          Task board
+        </div>
+        <span
+          className="text-[10px] tabular-nums text-white/35"
+          title={`${u.running} running · ${u.pending} pending · ${u.settled} awaiting verdict · ${u.failed} failed · capacity ${u.max_parallel}`}
+        >
+          {u.running > 0 && (
+            <span className="text-emerald-400">{u.running} running · </span>
+          )}
+          {u.settled > 0 && (
+            <span className="text-amber-300">{u.settled} verdict · </span>
+          )}
+          {done}/{u.total} done
+        </span>
+      </div>
+      <ul className="space-y-0.5">
+        {board.tasks.map((task) => {
+          const { glyph, cls } = statusGlyph(task);
+          const clickable = !!task.worker_mission_id;
+          const blockedBy =
+            task.status === "pending" && task.depends_on.length > 0
+              ? task.depends_on.join(", ")
+              : null;
+          return (
+            <li key={task.id} className="group flex items-start gap-1.5">
+              <span className={cn("mt-px shrink-0 text-[11px]", cls)}>
+                {glyph}
+              </span>
+              <button
+                type="button"
+                disabled={!clickable}
+                onClick={() =>
+                  task.worker_mission_id &&
+                  onViewMission(task.worker_mission_id)
+                }
+                title={[
+                  `${task.task_key} · ${task.status}${task.outcome ? ` (${task.outcome})` : ""} · ${task.backend}${task.model_override ? ` ${task.model_override}` : ""}${task.attempts > 1 ? ` · attempt ${task.attempts}` : ""}`,
+                  task.result_digest ? `\n${task.result_digest.slice(0, 500)}` : "",
+                ].join("")}
+                className={cn(
+                  "min-w-0 flex-1 text-left text-[11px] leading-snug",
+                  rowTextClass(task),
+                  clickable && "hover:underline",
+                )}
+              >
+                <span className="font-mono text-[10px] opacity-70">
+                  {task.task_key}
+                </span>{" "}
+                {task.title}
+                {blockedBy && (
+                  <span className="text-[10px] text-white/30"> ← {blockedBy}</span>
+                )}
+              </button>
+              {(task.status === "pending" || task.status === "running") && (
+                <button
+                  type="button"
+                  title="Cancel task"
+                  disabled={busyTaskId === task.id}
+                  onClick={async () => {
+                    setBusyTaskId(task.id);
+                    try {
+                      await cancelBoardTask(task.id);
+                      await refresh();
+                    } catch {
+                      // surfaced by next poll
+                    } finally {
+                      setBusyTaskId(null);
+                    }
+                  }}
+                  className="hidden shrink-0 rounded p-0.5 text-white/30 hover:bg-white/[0.06] hover:text-red-400 group-hover:block"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+              {task.status === "settled" && (
+                <button
+                  type="button"
+                  title="Accept result (boss normally judges; this overrides)"
+                  disabled={busyTaskId === task.id}
+                  onClick={async () => {
+                    setBusyTaskId(task.id);
+                    try {
+                      await postBoardTaskVerdict(task.id, "accept");
+                      await refresh();
+                    } catch {
+                      // surfaced by next poll
+                    } finally {
+                      setBusyTaskId(null);
+                    }
+                  }}
+                  className="hidden shrink-0 rounded p-0.5 text-white/30 hover:bg-white/[0.06] hover:text-emerald-400 group-hover:block"
+                >
+                  ✓
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
+++ b/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
@@ -26,6 +26,7 @@ import type { inferMissionRole } from "@/lib/mission-role";
 import type { Mission, MissionStatus } from "@/lib/api";
 import type { MissionStateSummary } from "../events-reducer";
 import { missionStatusDotClass, missionStatusLabel } from "./common";
+import { MissionTaskBoard } from "./MissionTaskBoard";
 
 export function MissionWorkbenchPanel({
   mission,
@@ -397,6 +398,13 @@ export function MissionWorkbenchPanel({
                   ))}
                 </ul>
               </div>
+            )}
+
+            {mission && (
+              <MissionTaskBoard
+                missionId={mission.id}
+                onViewMission={onViewMission}
+              />
             )}
 
             {childMissions.length > 0 && (

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -1175,6 +1175,48 @@ function QuestionToolItem({
     }
   };
 
+  // An already-answered question that came back as a lazy history stub carries
+  // no args (the question text wasn't loaded), so `parseQuestionArgs` is empty.
+  // Without this guard it would render the misleading "reply below to continue"
+  // input for a question the user already answered. Show a compact answered
+  // state instead — the live, unanswered empty-args case still falls through to
+  // the input fallback below.
+  const answeredStub = isFallback && (hasResult || item.hasResult === true);
+  if (answeredStub) {
+    const answerText = (() => {
+      const r = item.result;
+      if (isRecord(r) && Array.isArray(r["answers"])) {
+        const flat = (r["answers"] as unknown[])
+          .flat()
+          .filter((a): a is string => typeof a === "string");
+        if (flat.length > 0) return flat.join(", ");
+      }
+      return null;
+    })();
+    return (
+      <div
+        id={`chat-item-${item.id}`}
+        data-chat-item-id={item.id}
+        className="flex justify-start gap-3"
+      >
+        <div className="@max-[30rem]:hidden flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-500/20">
+          <Bot className="h-4 w-4 text-indigo-400" />
+        </div>
+        <div className="max-w-[90%] rounded-2xl rounded-tl-md bg-white/[0.03] border border-white/[0.06] px-4 py-3">
+          <div className="text-xs text-white/40">
+            Tool: <span className="font-mono text-indigo-400">question</span>
+            <span className="ml-2 text-emerald-400/80">answered</span>
+          </div>
+          {answerText && (
+            <div className="mt-1 text-sm text-white/70">
+              Your answer: <span className="text-white/90">{answerText}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       id={`chat-item-${item.id}`}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -419,7 +419,9 @@ select:focus-visible {
   [class~="text-amber-400/80"],
   [class~="text-amber-400/70"],
   [class~="text-amber-400/60"],
+  [class~="text-amber-300/90"],
   [class~="text-amber-300/80"],
+  [class~="text-amber-200/90"],
   [class~="text-amber-200/80"],
   [class~="text-amber-500/70"],
   [class~="text-amber-500/50"] {

--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -183,10 +183,12 @@ function EntryEditor({
   entries,
   onChange,
   providers,
+  configuredProviderIds,
 }: {
   entries: ChainEntry[];
   onChange: (entries: ChainEntry[]) => void;
   providers: Provider[];
+  configuredProviderIds: Set<string> | null;
 }) {
   const addEntry = () => {
     onChange([...entries, { provider_id: '', model_id: '' }]);
@@ -256,9 +258,18 @@ function EntryEditor({
               }}
             >
               <option value="" className="bg-[#1a1a1a]">Select provider</option>
-              {providers.map((p) => (
-                <option key={p.id} value={p.id} className="bg-[#1a1a1a]">{p.name}</option>
-              ))}
+              {providers.map((p) => {
+                // When the set is null (older backend without this info) we
+                // can't tell, so don't mark anything.
+                const connected =
+                  !configuredProviderIds || configuredProviderIds.has(p.id);
+                return (
+                  <option key={p.id} value={p.id} className="bg-[#1a1a1a]">
+                    {p.name}
+                    {connected ? "" : " — not connected"}
+                  </option>
+                );
+              })}
             </select>
             <span className="text-white/20">/</span>
             <ModelDropdown
@@ -347,12 +358,14 @@ function ChainCard({
   onDelete,
   onSetDefault,
   providers,
+  configuredProviderIds,
 }: {
   chain: ModelChain;
   onUpdate: (id: string, data: { name?: string; entries?: ChainEntry[]; is_default?: boolean; strip_thinking?: boolean }) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
   onSetDefault: (id: string) => Promise<void>;
   providers: Provider[];
+  configuredProviderIds: Set<string> | null;
 }) {
   const [savingStrip, setSavingStrip] = useState(false);
 
@@ -489,7 +502,7 @@ function ChainCard({
                   className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50"
                 />
               </div>
-              <EntryEditor entries={editEntries} onChange={setEditEntries} providers={providers} />
+              <EntryEditor entries={editEntries} onChange={setEditEntries} providers={providers} configuredProviderIds={configuredProviderIds} />
               <div className="flex items-center justify-end gap-2 pt-1">
                 <button
                   onClick={() => setEditing(false)}
@@ -719,6 +732,19 @@ export default function ModelRoutingPage() {
   );
   const providers = useMemo(
     () => providersData?.providers ?? [],
+    [providersData]
+  );
+  // Providers with working credentials. With includeAll the list above also
+  // contains unconfigured catalog providers (e.g. Google when never connected),
+  // so the chain editor marks the rest as "not connected" rather than implying
+  // they're ready to use.
+  // null when the backend didn't report it (older build) — in that case we
+  // don't mark anything, to avoid labelling connected providers as not.
+  const configuredProviderIds = useMemo(
+    () =>
+      providersData?.configured_ids
+        ? new Set(providersData.configured_ids)
+        : null,
     [providersData]
   );
 
@@ -1034,6 +1060,7 @@ export default function ModelRoutingPage() {
                   setCreateForm({ ...createForm, entries })
                 }
                 providers={providers}
+                configuredProviderIds={configuredProviderIds}
               />
               <div className="flex items-center justify-between pt-1">
                 <div className="flex items-center gap-4">
@@ -1107,6 +1134,7 @@ export default function ModelRoutingPage() {
                   onDelete={handleDelete}
                   onSetDefault={handleSetDefault}
                   providers={providers}
+                  configuredProviderIds={configuredProviderIds}
                 />
               ))
             )}

--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -26,7 +26,9 @@ import {
 } from '@/lib/api/proxy-keys';
 import {
   listProviders,
+  getModelCatalog,
   type Provider,
+  type CatalogModel,
 } from '@/lib/api/providers';
 import { getRuntimeApiBase } from '@/lib/settings';
 import {
@@ -51,6 +53,8 @@ import {
   Pencil,
   Sparkles,
   Eraser,
+  Library,
+  Search,
 } from 'lucide-react';
 import { cn, formatRelativeTime } from '@/lib/utils';
 
@@ -815,6 +819,34 @@ export default function ModelRoutingPage() {
     }
   };
 
+  // ── Supported models catalog (lazy: only fetched once expanded) ──
+  const [catalogOpen, setCatalogOpen] = useState(false);
+  const [catalogQuery, setCatalogQuery] = useState('');
+  const { data: catalog, isLoading: catalogLoading } = useSWR(
+    catalogOpen ? 'model-catalog' : null,
+    getModelCatalog,
+    { revalidateOnFocus: false },
+  );
+  const catalogByProvider = useMemo(() => {
+    const models = catalog?.models ?? [];
+    const q = catalogQuery.trim().toLowerCase();
+    const filtered = q
+      ? models.filter(
+          (m) =>
+            m.value.toLowerCase().includes(q) ||
+            m.name.toLowerCase().includes(q) ||
+            m.provider_name.toLowerCase().includes(q),
+        )
+      : models;
+    const groups = new Map<string, { name: string; models: CatalogModel[] }>();
+    for (const m of filtered) {
+      const g = groups.get(m.provider_id) ?? { name: m.provider_name, models: [] };
+      g.models.push(m);
+      groups.set(m.provider_id, g);
+    }
+    return Array.from(groups.entries()).sort((a, b) => a[1].name.localeCompare(b[1].name));
+  }, [catalog, catalogQuery]);
+
   // ── Proxy API Keys ──
   const {
     data: apiKeys = [],
@@ -1407,6 +1439,101 @@ export default function ModelRoutingPage() {
                   </button>
                 </div>
               ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── Supported Models Catalog (collapsible) ── */}
+        <div className="rounded-xl bg-white/[0.02] border border-white/[0.04] p-5 mt-6">
+          <button
+            onClick={() => setCatalogOpen((v) => !v)}
+            className="flex w-full items-center justify-between cursor-pointer"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-500/10">
+                <Library className="h-5 w-5 text-indigo-400" />
+              </div>
+              <div className="text-left">
+                <h2 className="text-sm font-medium text-white">Supported Models</h2>
+                <p className="text-xs text-white/40">
+                  Every <span className="font-mono">provider/model</span> id the router accepts —
+                  usable directly, no chain required
+                  {catalog ? ` · ${catalog.count} models` : ''}
+                </p>
+              </div>
+            </div>
+            {catalogOpen ? (
+              <ChevronDown className="h-4 w-4 text-white/40" />
+            ) : (
+              <ChevronRight className="h-4 w-4 text-white/40" />
+            )}
+          </button>
+
+          {catalogOpen && (
+            <div className="mt-4">
+              <div className="mb-3 flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.01] px-3 py-1.5">
+                <Search className="h-3.5 w-3.5 text-white/30 flex-shrink-0" />
+                <input
+                  value={catalogQuery}
+                  onChange={(e) => setCatalogQuery(e.target.value)}
+                  placeholder="Filter by model, provider, or id…"
+                  className="w-full bg-transparent text-xs text-white/80 placeholder:text-white/30 focus:outline-none"
+                />
+              </div>
+
+              {catalogLoading ? (
+                <div className="flex items-center justify-center py-6">
+                  <Loader className="h-4 w-4 animate-spin text-white/30" />
+                </div>
+              ) : catalogByProvider.length === 0 ? (
+                <p className="text-xs text-white/30 text-center py-4">
+                  {catalog ? 'No models match your filter.' : 'Failed to load catalog.'}
+                </p>
+              ) : (
+                <div className="space-y-4 max-h-[28rem] overflow-y-auto pr-1">
+                  {catalogByProvider.map(([providerId, group]) => (
+                    <div key={providerId}>
+                      <div className="mb-1.5 flex items-center gap-2">
+                        <span className="text-[10px] uppercase tracking-wider text-white/40">
+                          {group.name}
+                        </span>
+                        <span className="text-[10px] text-white/20 font-mono">{providerId}</span>
+                        <span className="text-[10px] text-white/20">{group.models.length}</span>
+                      </div>
+                      <div className="space-y-1">
+                        {group.models.map((m) => (
+                          <div
+                            key={m.value}
+                            className="group flex items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.01] px-3 py-1.5"
+                          >
+                            <span className="text-xs text-white/70 flex-shrink-0 w-40 truncate" title={m.name}>
+                              {m.name}
+                            </span>
+                            <code className="text-[11px] text-indigo-300/80 font-mono flex-1 min-w-0 truncate" title={m.value}>
+                              {m.value}
+                            </code>
+                            {!m.configured && (
+                              <span
+                                className="text-[10px] text-amber-400/70 flex-shrink-0"
+                                title="No credential configured for this provider yet"
+                              >
+                                no key
+                              </span>
+                            )}
+                            <button
+                              onClick={() => handleCopyKey(m.value)}
+                              className={`p-1.5 rounded-md transition-colors cursor-pointer flex-shrink-0 ${copiedText === m.value ? 'text-emerald-400' : 'text-white/20 hover:text-white/60 hover:bg-white/[0.04] opacity-0 group-hover:opacity-100'}`}
+                              title="Copy provider/model id"
+                            >
+                              {copiedText === m.value ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -445,6 +445,85 @@ export async function postControlMessage(
   return res.json();
 }
 
+// ---- Mission task board ----------------------------------------------------
+
+export type BoardTaskStatus =
+  | "pending"
+  | "running"
+  | "settled"
+  | "accepted"
+  | "failed"
+  | "cancelled";
+
+export type BoardTaskOutcome = "success" | "blocked" | "failed";
+
+export interface BoardTask {
+  id: string;
+  boss_mission_id: string;
+  task_key: string;
+  title: string;
+  prompt: string;
+  backend: string;
+  model_override?: string;
+  model_effort?: string;
+  working_directory?: string;
+  depends_on: string[];
+  status: BoardTaskStatus;
+  outcome?: BoardTaskOutcome;
+  worker_mission_id?: string;
+  attempts: number;
+  result_digest?: string;
+  notes?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BoardUtilization {
+  pending: number;
+  running: number;
+  settled: number;
+  accepted: number;
+  failed: number;
+  cancelled: number;
+  total: number;
+  max_parallel: number;
+}
+
+export interface MissionBoard {
+  tasks: BoardTask[];
+  utilization: BoardUtilization;
+}
+
+export async function getMissionBoard(
+  missionId: string,
+): Promise<MissionBoard> {
+  const res = await apiFetch(`/api/control/missions/${missionId}/board`);
+  if (!res.ok) throw new Error("Failed to fetch mission board");
+  return res.json();
+}
+
+export async function postBoardTaskVerdict(
+  taskId: string,
+  action: "accept" | "reject",
+  feedback?: string,
+): Promise<BoardTask> {
+  const res = await apiFetch(`/api/control/board/tasks/${taskId}/verdict`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, feedback }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function cancelBoardTask(taskId: string): Promise<BoardTask> {
+  const res = await apiFetch(`/api/control/board/tasks/${taskId}/cancel`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
 export async function postControlToolResult(payload: {
   tool_call_id: string;
   name: string;

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -136,6 +136,10 @@ export interface Provider {
 
 export interface ProvidersResponse {
   providers: Provider[];
+  /** Provider ids with working credentials. When `includeAll` is set, the
+   * `providers` list also includes unconfigured catalog providers; use this to
+   * tell which are actually connected. */
+  configured_ids?: string[];
 }
 
 /** A model in the full supported-models catalog (`/api/providers/catalog`). */

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -138,6 +138,24 @@ export interface ProvidersResponse {
   providers: Provider[];
 }
 
+/** A model in the full supported-models catalog (`/api/providers/catalog`). */
+export interface CatalogModel {
+  provider_id: string;
+  provider_name: string;
+  id: string;
+  /** The `provider/model` id to pass to the router (e.g. "zai/glm-5.2"). */
+  value: string;
+  name: string;
+  description?: string;
+  /** True when a credential for this provider is configured. */
+  configured: boolean;
+}
+
+export interface ModelCatalogResponse {
+  count: number;
+  models: CatalogModel[];
+}
+
 export interface BackendModelOption {
   value: string;
   label: string;
@@ -430,6 +448,13 @@ export async function listProviders(options?: {
   const query = params.toString();
   const res = await apiFetch(`/api/providers${query ? `?${query}` : ""}`);
   if (!res.ok) throw new Error("Failed to fetch providers");
+  return res.json();
+}
+
+/** The full catalog of supported `provider/model` ids the router accepts. */
+export async function getModelCatalog(): Promise<ModelCatalogResponse> {
+  const res = await apiFetch("/api/providers/catalog");
+  if (!res.ok) throw new Error("Failed to fetch model catalog");
   return res.json();
 }
 

--- a/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
+++ b/ios_dashboard/SandboxedDashboard.xcodeproj/project.pbxproj
@@ -15,8 +15,10 @@
 		110C67FF7A62B86FB7AD4CD0 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD2C112534D498211B26C38 /* NetworkMonitor.swift */; };
 		13C5370F22B2BDFF2C337A0E /* AskSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F800962F5A1EFD8380ADE25C /* AskSheet.swift */; };
 		1750DD5DC204F7506E885D83 /* WorkspacesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384691169D9EC024B03AA57F /* WorkspacesView.swift */; };
+		20629DBCC7F1A2D09E435D75 /* BoardTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B805F407A9145CA937B3917 /* BoardTask.swift */; };
 		277C491E1B1B5E9673DF1CD8 /* MessageBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EF1D3FCDDC536A1D824359 /* MessageBubbles.swift */; };
 		2BBA61051DFCB7A780604B87 /* NetworkResilienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1828D2FC9160FC8677E10502 /* NetworkResilienceTests.swift */; };
+		2CDCE8E0A95E85009EC43B51 /* TaskBoardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF933753B68F0B468D9F3864 /* TaskBoardViews.swift */; };
 		3481363ED532A70935FA6B9E /* ChatHistoryReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77025B7F25E968FE5757E18 /* ChatHistoryReducer.swift */; };
 		3A706E457E3E27DA1B69E152 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 750C4C8090EAD0168794EEE4 /* Assets.xcassets */; };
 		40C09530EC6F9C083B5474C4 /* GlassButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DFFD4B67ABE07FB546B2B /* GlassButton.swift */; };
@@ -98,6 +100,7 @@
 		370F364BA05D1236D9B630AB /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		384691169D9EC024B03AA57F /* WorkspacesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacesView.swift; sourceTree = "<group>"; };
 		3B74AB5DF6829813AE79229D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		3B805F407A9145CA937B3917 /* BoardTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTask.swift; sourceTree = "<group>"; };
 		3BE62F9666647C1F41F15251 /* DesktopStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopStreamService.swift; sourceTree = "<group>"; };
 		4802677F01F1504267EC2BE2 /* SandboxedDashboardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SandboxedDashboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		492E8CF2E0A3AEF64A472C85 /* FileEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEntry.swift; sourceTree = "<group>"; };
@@ -122,6 +125,7 @@
 		AABA66FA1F19D379397ABA68 /* TerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalView.swift; sourceTree = "<group>"; };
 		ADBAC1664CAF3CD9DCCDB8B4 /* WorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceState.swift; sourceTree = "<group>"; };
 		AED7C0B17601881E8725F04D /* MissionSwitcherSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionSwitcherSheet.swift; sourceTree = "<group>"; };
+		AF933753B68F0B468D9F3864 /* TaskBoardViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBoardViews.swift; sourceTree = "<group>"; };
 		B920E504080EAEEA7CFD5201 /* ToolUIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIModels.swift; sourceTree = "<group>"; };
 		C0E02066E781D088A194C232 /* ControlPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPerformanceDiagnostics.swift; sourceTree = "<group>"; };
 		C433FADB27AED6165D3EE2E4 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
@@ -208,6 +212,7 @@
 				A636998B83DD23C5D2688C2D /* RunningMissionsBar.swift */,
 				C4B973A9078E4E085D489E93 /* SlashCommandSuggestions.swift */,
 				28244CFFEB655FD5E5F3EB17 /* StatusBadge.swift */,
+				AF933753B68F0B468D9F3864 /* TaskBoardViews.swift */,
 				1FF9A2A12846A5FFB3FC7497 /* WorkerPeekView.swift */,
 				2A514C239AAC192BD2AE8038 /* WorkerPillView.swift */,
 				081ACA60E04DBCB6E7313072 /* WorkerSheetView.swift */,
@@ -315,6 +320,7 @@
 				A99DCA3D66FD93467432EA1C /* Ask.swift */,
 				7BF62094FF29193B33EC7009 /* Automation.swift */,
 				CAC389FA8B9B5C969E606A22 /* Backend.swift */,
+				3B805F407A9145CA937B3917 /* BoardTask.swift */,
 				F77025B7F25E968FE5757E18 /* ChatHistoryReducer.swift */,
 				370F364BA05D1236D9B630AB /* ChatMessage.swift */,
 				CCD9630B60B3E470E64B1AB4 /* FidoSignRequest.swift */,
@@ -455,6 +461,7 @@
 				D5968B6DE2272A9C8C3A4A0E /* AutomationsView.swift in Sources */,
 				F6B883AB96DE0FFF99A2A614 /* Backend.swift in Sources */,
 				BFD7D29C1F46E9F130A05F34 /* BackendAgentService.swift in Sources */,
+				20629DBCC7F1A2D09E435D75 /* BoardTask.swift in Sources */,
 				3481363ED532A70935FA6B9E /* ChatHistoryReducer.swift in Sources */,
 				B6263AC356BE51962E2D0145 /* ChatMessage.swift in Sources */,
 				66E208F9D4759B79ED653374 /* ContentView.swift in Sources */,
@@ -487,6 +494,7 @@
 				A9B4F30DDAD9DBAEB009F77B /* SettingsView.swift in Sources */,
 				8CFF9CE3602771549F982D58 /* SlashCommandSuggestions.swift in Sources */,
 				CA5C6851DB279D7305EF2A91 /* StatusBadge.swift in Sources */,
+				2CDCE8E0A95E85009EC43B51 /* TaskBoardViews.swift in Sources */,
 				692C694570F45D74CCBAC75B /* TerminalState.swift in Sources */,
 				DEEC0DB78E50196BEEA6AFC1 /* TerminalView.swift in Sources */,
 				71559C7052796FED7EBACF3F /* Theme.swift in Sources */,

--- a/ios_dashboard/SandboxedDashboard/Models/BoardTask.swift
+++ b/ios_dashboard/SandboxedDashboard/Models/BoardTask.swift
@@ -1,0 +1,116 @@
+//
+//  BoardTask.swift
+//  SandboxedDashboard
+//
+//  Mission task board: server-scheduled worker tasks owned by a boss mission.
+//  Mirrors the backend's BoardTask / BoardUtilization payloads
+//  (GET /api/control/missions/:id/board).
+//
+
+import Foundation
+import SwiftUI
+
+enum BoardTaskStatus: String, Codable, CaseIterable {
+    case pending
+    case running
+    case settled
+    case accepted
+    case failed
+    case cancelled
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = BoardTaskStatus(rawValue: raw) ?? .pending
+    }
+}
+
+enum BoardTaskOutcome: String, Codable {
+    case success
+    case blocked
+    case failed
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = BoardTaskOutcome(rawValue: raw) ?? .failed
+    }
+}
+
+struct BoardTask: Codable, Identifiable, Hashable {
+    let id: String
+    let bossMissionId: String
+    let taskKey: String
+    let title: String
+    let prompt: String
+    let backend: String
+    let modelOverride: String?
+    let modelEffort: String?
+    let workingDirectory: String?
+    let dependsOn: [String]
+    let status: BoardTaskStatus
+    let outcome: BoardTaskOutcome?
+    let workerMissionId: String?
+    let attempts: Int
+    let resultDigest: String?
+    let notes: String?
+    let createdAt: String
+    let updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, prompt, backend, status, outcome, attempts, notes
+        case bossMissionId = "boss_mission_id"
+        case taskKey = "task_key"
+        case modelOverride = "model_override"
+        case modelEffort = "model_effort"
+        case workingDirectory = "working_directory"
+        case dependsOn = "depends_on"
+        case workerMissionId = "worker_mission_id"
+        case resultDigest = "result_digest"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    var statusColor: Color {
+        switch status {
+        case .running: return Theme.success
+        case .settled: return outcome == .success ? Theme.warning : Theme.error
+        case .accepted: return Theme.textMuted
+        case .failed: return Theme.error
+        case .cancelled: return Theme.textMuted
+        case .pending: return Theme.info
+        }
+    }
+
+    var statusLabel: String {
+        switch status {
+        case .settled:
+            switch outcome {
+            case .blocked: return "blocked"
+            case .failed: return "failed"
+            default: return "needs verdict"
+            }
+        default:
+            return status.rawValue
+        }
+    }
+}
+
+struct BoardUtilization: Codable, Hashable {
+    let pending: Int
+    let running: Int
+    let settled: Int
+    let accepted: Int
+    let failed: Int
+    let cancelled: Int
+    let total: Int
+    let maxParallel: Int
+
+    enum CodingKeys: String, CodingKey {
+        case pending, running, settled, accepted, failed, cancelled, total
+        case maxParallel = "max_parallel"
+    }
+}
+
+struct MissionBoard: Codable, Hashable {
+    let tasks: [BoardTask]
+    let utilization: BoardUtilization
+}

--- a/ios_dashboard/SandboxedDashboard/Services/APIService.swift
+++ b/ios_dashboard/SandboxedDashboard/Services/APIService.swift
@@ -230,6 +230,40 @@ final class APIService {
     func getMission(id: String) async throws -> Mission {
         try await get("/api/control/missions/\(id)")
     }
+
+    // MARK: - Mission task board
+
+    /// Server-owned task board for a boss mission. Returns an empty board
+    /// (not an error) for missions that never registered tasks.
+    func getMissionBoard(missionId: String) async throws -> MissionBoard {
+        try await get("/api/control/missions/\(missionId)/board")
+    }
+
+    struct BoardVerdictBody: Encodable {
+        let action: String
+        let feedback: String?
+    }
+
+    @discardableResult
+    func boardTaskVerdict(
+        taskId: String,
+        action: String,
+        feedback: String? = nil
+    ) async throws -> BoardTask {
+        try await post(
+            "/api/control/board/tasks/\(taskId)/verdict",
+            body: BoardVerdictBody(action: action, feedback: feedback)
+        )
+    }
+
+    @discardableResult
+    func cancelBoardTask(taskId: String) async throws -> BoardTask {
+        struct Empty: Encodable {}
+        return try await post(
+            "/api/control/board/tasks/\(taskId)/cancel",
+            body: Empty()
+        )
+    }
     
     func getCurrentMission() async throws -> Mission? {
         try await get("/api/control/missions/current")

--- a/ios_dashboard/SandboxedDashboard/Views/Components/TaskBoardViews.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/TaskBoardViews.swift
@@ -1,0 +1,329 @@
+//
+//  TaskBoardViews.swift
+//  SandboxedDashboard
+//
+//  Task board pill + sheet for boss missions running on the server-owned
+//  task board (see backend api::control::board). The pill mirrors
+//  WorkerPillView's grammar; the sheet lists tasks grouped by status with
+//  digest previews and verdict actions.
+//
+
+import SwiftUI
+
+// MARK: - Pill
+
+struct TaskBoardPillView: View {
+    let board: MissionBoard
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 6) {
+                Image(systemName: "square.grid.3x1.below.line.grid.1x2")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Theme.accent)
+
+                Text("\(board.utilization.total)")
+                    .font(.caption.weight(.semibold))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .foregroundStyle(Theme.textPrimary)
+
+                if board.utilization.running > 0 {
+                    countBadge(board.utilization.running, color: Theme.success)
+                }
+                if board.utilization.settled > 0 {
+                    countBadge(board.utilization.settled, color: Theme.warning)
+                }
+                if board.utilization.failed > 0 {
+                    countBadge(board.utilization.failed, color: Theme.error)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(.ultraThinMaterial)
+            .clipShape(Capsule())
+            .overlay(Capsule().stroke(Theme.border, lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func countBadge(_ count: Int, color: Color) -> some View {
+        HStack(spacing: 3) {
+            Circle()
+                .fill(color)
+                .frame(width: 5, height: 5)
+            Text("\(count)")
+                .font(.system(size: 10, weight: .medium).monospaced())
+                .contentTransition(.numericText())
+                .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - Self-polling pill loader
+
+/// Owns board fetching so the host view only needs a mission id. Renders
+/// nothing for missions without a board; polls every 10s while mounted.
+struct TaskBoardPillLoader: View {
+    let missionId: String
+
+    @State private var board: MissionBoard?
+    @State private var showSheet = false
+
+    private let api = APIService.shared
+
+    var body: some View {
+        ZStack {
+            // Zero-size anchor keeps this view installed in the hierarchy
+            // while there is no pill to show — without it, `.task` on the
+            // empty conditional never fires and the board is never fetched.
+            Color.clear.frame(width: 0, height: 0)
+            if let board, !board.tasks.isEmpty {
+                TaskBoardPillView(board: board) {
+                    HapticService.lightTap()
+                    showSheet = true
+                }
+            }
+        }
+        .task(id: missionId) {
+            board = nil
+            while !Task.isCancelled {
+                do {
+                    board = try await api.getMissionBoard(missionId: missionId)
+                } catch {
+                    #if DEBUG
+                        print("[task-board] fetch failed for \(missionId): \(error)")
+                    #endif
+                }
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+        .sheet(isPresented: $showSheet) {
+            TaskBoardSheetView(missionId: missionId)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+                .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+        }
+    }
+}
+
+// MARK: - Sheet
+
+struct TaskBoardSheetView: View {
+    let missionId: String
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var board: MissionBoard?
+    @State private var busyTaskId: String?
+    @State private var errorMessage: String?
+    @State private var peekWorker: Mission?
+
+    private let api = APIService.shared
+
+    private static let sectionOrder: [BoardTaskStatus] = [
+        .settled, .running, .pending, .failed, .accepted, .cancelled,
+    ]
+
+    private func sectionTitle(_ status: BoardTaskStatus) -> String {
+        switch status {
+        case .settled: return "Awaiting verdict"
+        case .running: return "Running"
+        case .pending: return "Pending"
+        case .failed: return "Failed"
+        case .accepted: return "Accepted"
+        case .cancelled: return "Cancelled"
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let board {
+                    boardList(board)
+                } else {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .navigationTitle("Task Board")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task { await refresh() }
+            .refreshable { await refresh() }
+            .sheet(item: $peekWorker) { worker in
+                WorkerPeekView(mission: worker)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+    }
+
+    private func refresh() async {
+        do {
+            board = try await api.getMissionBoard(missionId: missionId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @ViewBuilder
+    private func boardList(_ board: MissionBoard) -> some View {
+        List {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(Theme.error)
+            }
+            Section {
+                HStack(spacing: 14) {
+                    utilizationStat("Running", board.utilization.running, Theme.success)
+                    utilizationStat("Verdict", board.utilization.settled, Theme.warning)
+                    utilizationStat("Pending", board.utilization.pending, Theme.info)
+                    utilizationStat(
+                        "Done",
+                        board.utilization.accepted + board.utilization.cancelled,
+                        Theme.textSecondary
+                    )
+                    Spacer()
+                    Text("cap \(board.utilization.maxParallel)")
+                        .font(.system(size: 10).monospaced())
+                        .foregroundStyle(Theme.textMuted)
+                }
+                .listRowBackground(Color.clear)
+            }
+            ForEach(Self.sectionOrder, id: \.self) { status in
+                let tasks = board.tasks.filter { $0.status == status }
+                if !tasks.isEmpty {
+                    Section(sectionTitle(status)) {
+                        ForEach(tasks) { task in
+                            taskRow(task)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func utilizationStat(_ label: String, _ value: Int, _ color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text("\(value)")
+                .font(.callout.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(color)
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Theme.textMuted)
+        }
+    }
+
+    @ViewBuilder
+    private func taskRow(_ task: BoardTask) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(task.statusColor)
+                    .frame(width: 7, height: 7)
+                Text(task.taskKey)
+                    .font(.system(size: 11, weight: .semibold).monospaced())
+                    .foregroundStyle(Theme.textSecondary)
+                Text(task.statusLabel)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(task.statusColor)
+                Spacer()
+                if task.attempts > 1 {
+                    Text("attempt \(task.attempts)")
+                        .font(.system(size: 9).monospaced())
+                        .foregroundStyle(Theme.textMuted)
+                }
+                Text(task.backend)
+                    .font(.system(size: 9, weight: .medium).monospaced())
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(Theme.border)
+                    .clipShape(Capsule())
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            Text(task.title)
+                .font(.subheadline)
+                .foregroundStyle(Theme.textPrimary)
+            if task.status == .pending, !task.dependsOn.isEmpty {
+                Text("waits for \(task.dependsOn.joined(separator: ", "))")
+                    .font(.system(size: 10).monospaced())
+                    .foregroundStyle(Theme.textMuted)
+            }
+            if let digest = task.resultDigest, !digest.isEmpty {
+                Text(digest)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(4)
+            }
+            HStack(spacing: 10) {
+                if let workerId = task.workerMissionId {
+                    Button {
+                        Task {
+                            if let worker = try? await api.getMission(id: workerId) {
+                                peekWorker = worker
+                            }
+                        }
+                    } label: {
+                        Label("Worker", systemImage: "arrow.up.right.square")
+                            .font(.caption2)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.mini)
+                }
+                if task.status == .settled {
+                    Button {
+                        Task { await verdict(task, action: "accept") }
+                    } label: {
+                        Label("Accept", systemImage: "checkmark")
+                            .font(.caption2)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.mini)
+                    .tint(Theme.success)
+                    .disabled(busyTaskId == task.id)
+                }
+                if task.status == .pending || task.status == .running {
+                    Button(role: .destructive) {
+                        Task { await cancel(task) }
+                    } label: {
+                        Label("Cancel", systemImage: "xmark")
+                            .font(.caption2)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.mini)
+                    .disabled(busyTaskId == task.id)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func verdict(_ task: BoardTask, action: String) async {
+        busyTaskId = task.id
+        defer { busyTaskId = nil }
+        do {
+            try await api.boardTaskVerdict(taskId: task.id, action: action)
+            await refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func cancel(_ task: BoardTask) async {
+        busyTaskId = task.id
+        defer { busyTaskId = nil }
+        do {
+            try await api.cancelBoardTask(taskId: task.id)
+            await refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios_dashboard/SandboxedDashboard/Views/Components/WorkerPillView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/WorkerPillView.swift
@@ -29,23 +29,18 @@ struct WorkerPillView: View {
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(Theme.accent)
 
-                Text("\(workers.count)")
+                // Headline = workers running right now, NOT the cumulative
+                // total. The total counts every sub-mission that ever ran,
+                // most of which have finished and are never reused, so leading
+                // with it implied a far larger live fleet than exists.
+                Text("\(activeCount)")
                     .font(.caption.weight(.semibold))
                     .monospacedDigit()
                     .contentTransition(.numericText())
-                    .foregroundStyle(Theme.textPrimary)
-
-                if activeCount > 0 {
-                    HStack(spacing: 3) {
-                        Circle()
-                            .fill(Theme.accent)
-                            .frame(width: 5, height: 5)
-                        Text("\(activeCount)")
-                            .font(.system(size: 10, weight: .medium).monospaced())
-                            .contentTransition(.numericText())
-                            .foregroundStyle(Theme.accent)
-                    }
-                }
+                    .foregroundStyle(activeCount > 0 ? Theme.textPrimary : Theme.textMuted)
+                Text("active")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Theme.textTertiary)
 
                 if waitingCount > 0 {
                     HStack(spacing: 3) {
@@ -55,17 +50,6 @@ struct WorkerPillView: View {
                         Text("\(waitingCount)")
                             .font(.system(size: 10, weight: .medium).monospaced())
                             .foregroundStyle(Theme.info)
-                    }
-                }
-
-                if completedCount > 0 {
-                    HStack(spacing: 3) {
-                        Circle()
-                            .fill(Theme.success)
-                            .frame(width: 5, height: 5)
-                        Text("\(completedCount)")
-                            .font(.system(size: 10, weight: .medium).monospaced())
-                            .foregroundStyle(Theme.success)
                     }
                 }
 
@@ -79,6 +63,14 @@ struct WorkerPillView: View {
                             .foregroundStyle(Theme.error)
                     }
                 }
+
+                // Cumulative count of every sub-mission ever spawned — kept
+                // for reference but visually muted so it doesn't read as a
+                // live fleet size.
+                Text("· \(workers.count) total")
+                    .font(.system(size: 10))
+                    .monospacedDigit()
+                    .foregroundStyle(Theme.textMuted)
 
                 Image(systemName: "chevron.up")
                     .font(.system(size: 9, weight: .bold))

--- a/ios_dashboard/SandboxedDashboard/Views/Components/WorkerSheetView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Components/WorkerSheetView.swift
@@ -12,6 +12,9 @@ struct WorkerSheetView: View {
     let workers: [Mission]
     let runningWorkers: [RunningMissionInfo]
     @State private var peekingWorker: Mission?
+    // Completed workers are terminal and never reused, so they start collapsed
+    // to keep the focus on what's still in flight.
+    @State private var showCompleted = false
 
     private var buckets: WorkerBuckets {
         WorkerBuckets(workers: workers, runningWorkers: runningWorkers)
@@ -29,6 +32,13 @@ struct WorkerSheetView: View {
                     // Summary cards
                     summaryRow
 
+                    if !workers.isEmpty {
+                        Text("\(workers.count) sub-mission\(workers.count == 1 ? "" : "s") spawned in total. Completed ones have finished and are not reused.")
+                            .font(.caption2)
+                            .foregroundStyle(Theme.textMuted)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
                     // Active workers
                     if !activeWorkers.isEmpty {
                         workerSection("Running", icon: "bolt.fill", tint: Theme.accent, missions: activeWorkers)
@@ -39,14 +49,14 @@ struct WorkerSheetView: View {
                         workerSection("Waiting", icon: "hourglass", tint: Theme.info, missions: waitingWorkers)
                     }
 
-                    // Completed workers
-                    if !completedWorkers.isEmpty {
-                        workerSection("Completed", icon: "checkmark.circle.fill", tint: Theme.success, missions: completedWorkers)
-                    }
-
-                    // Failed workers
+                    // Failed workers (actionable — surfaced before completed)
                     if !failedWorkers.isEmpty {
                         workerSection("Failed", icon: "xmark.circle.fill", tint: Theme.error, missions: failedWorkers)
+                    }
+
+                    // Completed workers — collapsed by default (terminal noise).
+                    if !completedWorkers.isEmpty {
+                        collapsibleCompletedSection
                     }
 
                     if workers.isEmpty {
@@ -82,14 +92,14 @@ struct WorkerSheetView: View {
                 tint: Theme.info
             )
             summaryCard(
-                count: completedWorkers.count,
-                label: "Done",
-                tint: Theme.success
-            )
-            summaryCard(
                 count: failedWorkers.count,
                 label: "Failed",
                 tint: Theme.error
+            )
+            summaryCard(
+                count: completedWorkers.count,
+                label: "Done",
+                tint: Theme.success
             )
         }
     }
@@ -119,6 +129,38 @@ struct WorkerSheetView: View {
     }
 
     // MARK: - Sections
+
+    private var collapsibleCompletedSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                HapticService.lightTap()
+                withAnimation(.snappy) { showCompleted.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Theme.success)
+                    Text("Completed")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                    Text("(\(completedWorkers.count))")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textMuted)
+                    Spacer()
+                    Image(systemName: showCompleted ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.textMuted)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if showCompleted {
+                ForEach(completedWorkers) { mission in
+                    workerRow(mission)
+                }
+            }
+        }
+    }
 
     private func workerSection(_ title: String, icon: String, tint: Color, missions: [Mission]) -> some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
+++ b/ios_dashboard/SandboxedDashboard/Views/Control/ControlView.swift
@@ -830,18 +830,26 @@ struct ControlView: View {
 
     @ViewBuilder
     private var workerPillOrNil: some View {
-        if !childMissions.isEmpty {
-            WorkerPillView(
-                workers: childMissions,
-                runningWorkers: runningMissions,
-                onTap: {
-                    HapticService.lightTap()
-                    showWorkerSheet = true
-                }
-            )
-            .padding(.bottom, 12)
-            .transition(.move(edge: .bottom).combined(with: .opacity))
-            .animation(.spring(response: 0.3), value: childMissions.count)
+        HStack(spacing: 8) {
+            // Board belongs to the mission being VIEWED (viewingMissionId),
+            // which can differ from the session's current mission.
+            if let missionId = viewingMissionId ?? currentMission?.id {
+                TaskBoardPillLoader(missionId: missionId)
+                    .padding(.bottom, 12)
+            }
+            if !childMissions.isEmpty {
+                WorkerPillView(
+                    workers: childMissions,
+                    runningWorkers: runningMissions,
+                    onTap: {
+                        HapticService.lightTap()
+                        showWorkerSheet = true
+                    }
+                )
+                .padding(.bottom, 12)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(.spring(response: 0.3), value: childMissions.count)
+            }
         }
     }
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -1,0 +1,769 @@
+//! Task board scheduler: server-owned orchestration of worker missions.
+//!
+//! The boss agent registers a task DAG once (via the orchestrator MCP's
+//! `plan_tasks`, which lands in `MissionStore::upsert_board_tasks`). From that
+//! point the control loop owns the schedule:
+//!
+//! - `scheduler_pass` (throttled inside the actor's 100ms tick) spawns a
+//!   worker mission for every dependency-satisfied `pending` task while
+//!   capacity allows, and sweeps zombies (workers lost to a restart).
+//! - `on_worker_settled` (called when a parallel runner parks) classifies the
+//!   outcome, retries failures once, persists a digest, and notifies the boss
+//!   with a short message so it can judge the result.
+//!
+//! The boss never waits or polls: parallelism is an invariant of this module,
+//! not of prompt compliance. Spawning and digest delivery both reuse the
+//! battle-tested `ControlCommand::UserMessage` routing path by self-sending
+//! into the actor's own command channel (never awaited — `try_send` only —
+//! because the scheduler runs on the consuming task).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+use crate::agents::TerminalReason;
+use crate::api::mission_store::{BoardTask, BoardTaskOutcome, BoardTaskStatus, MissionStore};
+
+use super::{ControlCommand, MissionStatus};
+
+/// One slot is always reserved for the boss itself so digest delivery can
+/// never be starved by board workers occupying every parallel slot.
+const RESERVED_BOSS_SLOTS: usize = 1;
+
+/// Max attempts per task (1 original + 1 automatic retry).
+const MAX_ATTEMPTS: u32 = 2;
+
+/// How long a `running` task may sit with its worker mission still `pending`
+/// (spawn message lost, e.g. dropped on a capacity race) before the scheduler
+/// re-kicks it.
+const STUCK_PENDING_SECS: i64 = 90;
+
+/// Digest truncation: keep the head and tail of the worker's final message.
+const DIGEST_HEAD_CHARS: usize = 400;
+const DIGEST_TAIL_CHARS: usize = 1200;
+
+/// Snapshot of runner occupancy, computed by the actor loop each pass.
+pub struct RunnerSnapshot {
+    /// Mission ids present in `parallel_runners` (running or parked).
+    pub present: HashSet<Uuid>,
+    /// Count of runners actively executing a turn.
+    pub running_count: usize,
+    /// Whether the main (non-parallel) session is executing a turn.
+    pub main_running: bool,
+}
+
+/// Tasks whose dependencies are satisfied and that are ready to spawn.
+/// A dependency is satisfied when the dep task settled successfully or was
+/// accepted by the boss. Unknown dep keys block forever (visible in the UI)
+/// rather than silently passing.
+pub fn ready_tasks(tasks: &[BoardTask]) -> Vec<&BoardTask> {
+    tasks
+        .iter()
+        .filter(|t| t.status == BoardTaskStatus::Pending)
+        .filter(|t| {
+            t.depends_on.iter().all(|dep_key| {
+                tasks.iter().any(|d| {
+                    d.task_key == *dep_key
+                        && (d.status == BoardTaskStatus::Accepted
+                            || (d.status == BoardTaskStatus::Settled
+                                && d.outcome == Some(BoardTaskOutcome::Success)))
+                })
+            })
+        })
+        .collect()
+}
+
+/// Classify how a worker turn ended.
+pub fn classify_outcome(
+    terminal_reason: Option<TerminalReason>,
+    success: bool,
+    output: &str,
+) -> BoardTaskOutcome {
+    let failed = matches!(
+        terminal_reason,
+        Some(TerminalReason::Cancelled)
+            | Some(TerminalReason::ServerShutdown)
+            | Some(TerminalReason::LlmError)
+            | Some(TerminalReason::Stalled)
+            | Some(TerminalReason::InfiniteLoop)
+            | Some(TerminalReason::MaxIterations)
+            | Some(TerminalReason::RateLimited)
+            | Some(TerminalReason::CapacityLimited)
+            | Some(TerminalReason::AuthError)
+    ) || (terminal_reason.is_none() && !success);
+    if failed {
+        return BoardTaskOutcome::Failed;
+    }
+    // Worker contract: a stuck worker ends its turn with a line starting
+    // "BLOCKED". Look near the start of the final message.
+    let head: String = output.trim_start().chars().take(600).collect();
+    if head.lines().any(|l| {
+        let l = l.trim_start();
+        l.starts_with("BLOCKED") || l.starts_with("**BLOCKED")
+    }) {
+        return BoardTaskOutcome::Blocked;
+    }
+    BoardTaskOutcome::Success
+}
+
+/// Head+tail truncation that keeps the final summary (workers put their
+/// conclusion at the end of the turn).
+pub fn digest_excerpt(output: &str) -> String {
+    let chars: Vec<char> = output.trim().chars().collect();
+    if chars.len() <= DIGEST_HEAD_CHARS + DIGEST_TAIL_CHARS {
+        return chars.into_iter().collect();
+    }
+    let head: String = chars[..DIGEST_HEAD_CHARS].iter().collect();
+    let tail: String = chars[chars.len() - DIGEST_TAIL_CHARS..].iter().collect();
+    format!("{head}\n[… truncated …]\n{tail}")
+}
+
+/// The standing contract appended to every worker prompt.
+fn worker_contract(task: &BoardTask) -> String {
+    format!(
+        "\n\n---\n[task-board contract] You are the worker for task `{key}` (\"{title}\") \
+         of boss mission {boss}.\n\
+         - Work autonomously until the success condition in the task is met and verified.\n\
+         - Do NOT end your turn to report progress; partial updates are wasted.\n\
+         - End your turn ONLY when: (a) the task is done and verified — finish with a short \
+         summary of what changed and how you verified it; or (b) you are genuinely stuck — \
+         finish with a line starting `BLOCKED:` plus the obstacle, what you tried, and ONE \
+         specific question.\n\
+         - Never widen scope beyond the task.",
+        key = task.task_key,
+        title = task.title,
+        boss = task.boss_mission_id,
+    )
+}
+
+fn board_summary_line(tasks: &[BoardTask]) -> String {
+    let keys_in = |status: BoardTaskStatus| -> Vec<&str> {
+        tasks
+            .iter()
+            .filter(|t| t.status == status)
+            .map(|t| t.task_key.as_str())
+            .collect()
+    };
+    let running = keys_in(BoardTaskStatus::Running);
+    let settled = keys_in(BoardTaskStatus::Settled);
+    let pending = tasks
+        .iter()
+        .filter(|t| t.status == BoardTaskStatus::Pending)
+        .count();
+    let accepted = tasks
+        .iter()
+        .filter(|t| t.status == BoardTaskStatus::Accepted)
+        .count();
+    let failed = keys_in(BoardTaskStatus::Failed);
+    let mut line = format!(
+        "Board: {} running [{}] · {} pending · {} awaiting-verdict [{}] · {}/{} accepted",
+        running.len(),
+        running.join(","),
+        pending,
+        settled.len(),
+        settled.join(","),
+        accepted,
+        tasks.len(),
+    );
+    if !failed.is_empty() {
+        line.push_str(&format!(" · FAILED [{}]", failed.join(",")));
+    }
+    line
+}
+
+/// True when no task can make further progress without boss action.
+fn board_drained(tasks: &[BoardTask]) -> bool {
+    !tasks.is_empty()
+        && tasks.iter().all(|t| {
+            t.status.is_terminal()
+                || (t.status == BoardTaskStatus::Settled
+                    && t.outcome != Some(BoardTaskOutcome::Success))
+        })
+        && !tasks.iter().any(|t| {
+            matches!(
+                t.status,
+                BoardTaskStatus::Pending | BoardTaskStatus::Running
+            )
+        })
+}
+
+/// Fire-and-forget self-send into the actor's own command channel. Never
+/// await: the scheduler runs on the task that consumes this channel.
+fn self_send_message(
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    target_mission_id: Uuid,
+    content: String,
+) -> bool {
+    let (respond, _rx) = oneshot::channel();
+    match cmd_tx.try_send(ControlCommand::UserMessage {
+        id: Uuid::new_v4(),
+        content,
+        agent: None,
+        target_mission_id: Some(target_mission_id),
+        respond,
+    }) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(target = %target_mission_id, "board: self-send failed: {}", e);
+            false
+        }
+    }
+}
+
+fn seconds_since(rfc3339: &str) -> i64 {
+    chrono::DateTime::parse_from_rfc3339(rfc3339)
+        .map(|t| (chrono::Utc::now() - t.with_timezone(&chrono::Utc)).num_seconds())
+        .unwrap_or(i64::MAX)
+}
+
+/// Spawn workers for ready tasks while capacity allows, and sweep zombies.
+/// Called from the control actor's tick, throttled by the caller (~2s).
+pub async fn scheduler_pass(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    snapshot: &RunnerSnapshot,
+    max_parallel: usize,
+) {
+    let boards = match mission_store.list_active_board_missions().await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("board: failed to list active boards: {}", e);
+            return;
+        }
+    };
+    if boards.is_empty() {
+        return;
+    }
+
+    let total_running = snapshot.running_count + usize::from(snapshot.main_running);
+    let spawnable_cap = max_parallel.saturating_sub(RESERVED_BOSS_SLOTS);
+    let mut available = spawnable_cap.saturating_sub(total_running);
+
+    for boss_id in boards {
+        let tasks = match mission_store.list_board_tasks(boss_id).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(boss = %boss_id, "board: failed to list tasks: {}", e);
+                continue;
+            }
+        };
+
+        // --- Zombie sweep: running tasks whose worker is not actually running.
+        for task in tasks
+            .iter()
+            .filter(|t| t.status == BoardTaskStatus::Running)
+        {
+            let Some(worker_id) = task.worker_mission_id else {
+                continue;
+            };
+            if snapshot.present.contains(&worker_id) {
+                continue; // runner alive (running or about to be reaped normally)
+            }
+            let Ok(Some(worker)) = mission_store.get_mission(worker_id).await else {
+                continue;
+            };
+            match worker.status {
+                // Spawn message lost (e.g. capacity race) — re-kick after a grace period.
+                MissionStatus::Pending => {
+                    if seconds_since(&task.updated_at) > STUCK_PENDING_SECS {
+                        tracing::info!(task = %task.task_key, worker = %worker_id,
+                            "board: re-kicking stuck pending worker");
+                        let prompt = format!("{}{}", task.prompt, worker_contract(task));
+                        if self_send_message(cmd_tx, worker_id, prompt) {
+                            let mut t = task.clone();
+                            t.notes = append_note(&t.notes, "re-kicked stuck pending worker");
+                            let _ = mission_store.save_board_task(&t).await;
+                        }
+                    }
+                }
+                // Worker settled while we weren't looking (server restart).
+                MissionStatus::AwaitingUser
+                | MissionStatus::Completed
+                | MissionStatus::Acknowledged => {
+                    let last = worker
+                        .history
+                        .iter()
+                        .rev()
+                        .find(|h| h.role == "assistant")
+                        .map(|h| h.content.clone())
+                        .unwrap_or_default();
+                    settle_task(
+                        mission_store,
+                        cmd_tx,
+                        task.clone(),
+                        classify_outcome(None, true, &last),
+                        &last,
+                    )
+                    .await;
+                }
+                MissionStatus::Failed
+                | MissionStatus::Interrupted
+                | MissionStatus::Blocked
+                | MissionStatus::NotFeasible => {
+                    let last = worker
+                        .history
+                        .iter()
+                        .rev()
+                        .find(|h| h.role == "assistant")
+                        .map(|h| h.content.clone())
+                        .unwrap_or_default();
+                    settle_task(
+                        mission_store,
+                        cmd_tx,
+                        task.clone(),
+                        BoardTaskOutcome::Failed,
+                        &last,
+                    )
+                    .await;
+                }
+                MissionStatus::Active => {
+                    // Runner may exist in another control session or be mid-start;
+                    // leave it alone.
+                }
+            }
+        }
+
+        // --- Spawn ready tasks while capacity allows.
+        if available == 0 {
+            continue;
+        }
+        let Ok(Some(boss)) = mission_store.get_mission(boss_id).await else {
+            continue;
+        };
+        let ready: Vec<BoardTask> = ready_tasks(&tasks).into_iter().cloned().collect();
+        for task in ready {
+            if available == 0 {
+                break;
+            }
+            match spawn_task_worker(mission_store, cmd_tx, &task, boss.workspace_id).await {
+                Ok(worker_id) => {
+                    available -= 1;
+                    tracing::info!(task = %task.task_key, worker = %worker_id, boss = %boss_id,
+                        "board: spawned worker for ready task");
+                }
+                Err(e) => {
+                    tracing::warn!(task = %task.task_key, boss = %boss_id,
+                        "board: failed to spawn worker: {}", e);
+                }
+            }
+        }
+    }
+}
+
+fn append_note(notes: &Option<String>, line: &str) -> Option<String> {
+    let stamp = chrono::Utc::now().to_rfc3339();
+    match notes {
+        Some(n) => Some(format!("{n}\n[{stamp}] {line}")),
+        None => Some(format!("[{stamp}] {line}")),
+    }
+}
+
+async fn spawn_task_worker(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    task: &BoardTask,
+    workspace_id: Uuid,
+) -> Result<Uuid, String> {
+    let mission = mission_store
+        .create_mission_with_parent(
+            Some(&format!("[{}] {}", task.task_key, task.title)),
+            Some(workspace_id),
+            None,
+            task.model_override.as_deref(),
+            task.model_effort.as_deref(),
+            Some(&task.backend),
+            None,
+            Some(task.boss_mission_id),
+            task.working_directory.as_deref(),
+        )
+        .await?;
+
+    let mut t = task.clone();
+    t.worker_mission_id = Some(mission.id);
+    t.status = BoardTaskStatus::Running;
+    t.attempts += 1;
+    if t.attempts > 1 {
+        t.notes = append_note(&t.notes, &format!("retry: attempt {}", t.attempts));
+    }
+    mission_store.save_board_task(&t).await?;
+
+    let prompt = format!("{}{}", t.prompt, worker_contract(&t));
+    if !self_send_message(cmd_tx, mission.id, prompt) {
+        // Channel full: leave the task running; the zombie sweep re-kicks the
+        // pending worker mission after the grace period.
+        tracing::warn!(task = %t.task_key, "board: spawn message deferred (channel full)");
+    }
+    Ok(mission.id)
+}
+
+/// Settle a task: persist outcome + digest, retry failures once, and notify
+/// the boss. Shared by the live settle hook and the zombie sweep.
+async fn settle_task(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    mut task: BoardTask,
+    outcome: BoardTaskOutcome,
+    output: &str,
+) {
+    let boss_id = task.boss_mission_id;
+
+    if outcome == BoardTaskOutcome::Failed && task.attempts < MAX_ATTEMPTS {
+        // Silent automatic retry: back to pending, next pass respawns fresh.
+        task.status = BoardTaskStatus::Pending;
+        task.notes = append_note(
+            &task.notes,
+            &format!(
+                "attempt {} failed (worker {}); auto-retrying",
+                task.attempts,
+                task.worker_mission_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_default()
+            ),
+        );
+        task.worker_mission_id = None;
+        if let Err(e) = mission_store.save_board_task(&task).await {
+            tracing::warn!(task = %task.task_key, "board: failed to persist retry: {}", e);
+        }
+        return;
+    }
+
+    task.status = if outcome == BoardTaskOutcome::Failed {
+        BoardTaskStatus::Failed
+    } else {
+        BoardTaskStatus::Settled
+    };
+    task.outcome = Some(outcome);
+    task.result_digest = Some(digest_excerpt(output));
+    if let Err(e) = mission_store.save_board_task(&task).await {
+        tracing::warn!(task = %task.task_key, "board: failed to persist settle: {}", e);
+        return;
+    }
+
+    // Compose the boss digest from the post-settle board state.
+    let tasks = mission_store
+        .list_board_tasks(boss_id)
+        .await
+        .unwrap_or_default();
+    let outcome_label = outcome.to_string().to_uppercase();
+    let mut msg = format!(
+        "[task-board] Task `{}` (\"{}\") settled: {} (attempt {}, worker mission {}).\n\nWorker final message (excerpt):\n{}\n\n{}",
+        task.task_key,
+        task.title,
+        outcome_label,
+        task.attempts,
+        task.worker_mission_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+        task.result_digest.as_deref().unwrap_or("(empty)"),
+        board_summary_line(&tasks),
+    );
+    msg.push_str(
+        "\n\nAct now: judge this result with accept_task / reject_task (review_task for the \
+         full output). Add follow-up work with plan_tasks. Scheduling and re-dispatch are \
+         automatic — do NOT wait, poll, or call wait_for_* tools; end your turn once verdicts \
+         are given.",
+    );
+    if board_drained(&tasks) {
+        msg.push_str(
+            "\n\nBOARD DRAINED: no task can progress without your action. Judge the settled \
+             tasks, re-plan failed ones or finish the mission.",
+        );
+    }
+    self_send_message(cmd_tx, boss_id, msg);
+}
+
+/// Live settle hook: called from the control actor's tick when a parallel
+/// runner parks with no queued follow-up. No-op for missions that are not
+/// board workers.
+pub async fn on_worker_settled(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    worker_mission_id: Uuid,
+    output: &str,
+    terminal_reason: Option<TerminalReason>,
+    success: bool,
+) {
+    let task = match mission_store
+        .get_board_task_by_worker(worker_mission_id)
+        .await
+    {
+        Ok(Some(t)) => t,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(worker = %worker_mission_id, "board: task lookup failed: {}", e);
+            return;
+        }
+    };
+    if task.status != BoardTaskStatus::Running {
+        return; // already settled (sweep) or cancelled meanwhile
+    }
+    let outcome = classify_outcome(terminal_reason, success, output);
+    settle_task(mission_store, cmd_tx, task, outcome, output).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::mission_store::NewBoardTask;
+
+    fn mk(
+        key: &str,
+        deps: &[&str],
+        status: BoardTaskStatus,
+        outcome: Option<BoardTaskOutcome>,
+    ) -> BoardTask {
+        BoardTask {
+            id: Uuid::new_v4(),
+            boss_mission_id: Uuid::nil(),
+            task_key: key.to_string(),
+            title: key.to_string(),
+            prompt: "p".into(),
+            backend: "codex".into(),
+            model_override: None,
+            model_effort: None,
+            working_directory: None,
+            depends_on: deps.iter().map(|s| s.to_string()).collect(),
+            status,
+            outcome,
+            worker_mission_id: None,
+            attempts: 0,
+            result_digest: None,
+            notes: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn ready_respects_dependencies() {
+        let tasks = vec![
+            mk(
+                "a",
+                &[],
+                BoardTaskStatus::Settled,
+                Some(BoardTaskOutcome::Success),
+            ),
+            mk("b", &["a"], BoardTaskStatus::Pending, None),
+            mk("c", &["b"], BoardTaskStatus::Pending, None),
+            mk("d", &["missing"], BoardTaskStatus::Pending, None),
+            mk("e", &[], BoardTaskStatus::Pending, None),
+        ];
+        let ready: Vec<&str> = ready_tasks(&tasks)
+            .iter()
+            .map(|t| t.task_key.as_str())
+            .collect();
+        assert_eq!(ready, vec!["b", "e"]);
+    }
+
+    #[test]
+    fn ready_blocks_on_failed_or_blocked_dep() {
+        let tasks = vec![
+            mk(
+                "a",
+                &[],
+                BoardTaskStatus::Settled,
+                Some(BoardTaskOutcome::Blocked),
+            ),
+            mk("b", &["a"], BoardTaskStatus::Pending, None),
+            mk(
+                "c",
+                &[],
+                BoardTaskStatus::Failed,
+                Some(BoardTaskOutcome::Failed),
+            ),
+            mk("d", &["c"], BoardTaskStatus::Pending, None),
+        ];
+        assert!(ready_tasks(&tasks).is_empty());
+    }
+
+    #[test]
+    fn accepted_dep_unblocks() {
+        let tasks = vec![
+            mk(
+                "a",
+                &[],
+                BoardTaskStatus::Accepted,
+                Some(BoardTaskOutcome::Success),
+            ),
+            mk("b", &["a"], BoardTaskStatus::Pending, None),
+        ];
+        let ready: Vec<&str> = ready_tasks(&tasks)
+            .iter()
+            .map(|t| t.task_key.as_str())
+            .collect();
+        assert_eq!(ready, vec!["b"]);
+    }
+
+    #[test]
+    fn classify_blocked_and_failed() {
+        assert_eq!(
+            classify_outcome(
+                Some(TerminalReason::TurnComplete),
+                true,
+                "All done, verified."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(
+                Some(TerminalReason::TurnComplete),
+                true,
+                "BLOCKED: cannot find the artifact.\nTried X and Y."
+            ),
+            BoardTaskOutcome::Blocked
+        );
+        assert_eq!(
+            classify_outcome(Some(TerminalReason::Stalled), false, "whatever"),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(classify_outcome(None, false, "x"), BoardTaskOutcome::Failed);
+        assert_eq!(
+            classify_outcome(Some(TerminalReason::Completed), true, "done"),
+            BoardTaskOutcome::Success
+        );
+    }
+
+    #[test]
+    fn digest_excerpt_truncates_keeping_tail() {
+        let long = "a".repeat(5000);
+        let d = digest_excerpt(&long);
+        assert!(d.len() < 2000);
+        assert!(d.contains("[… truncated …]"));
+        let short = "short output";
+        assert_eq!(digest_excerpt(short), short);
+    }
+
+    #[test]
+    fn drained_detection() {
+        let drained = vec![
+            mk(
+                "a",
+                &[],
+                BoardTaskStatus::Accepted,
+                Some(BoardTaskOutcome::Success),
+            ),
+            mk(
+                "b",
+                &[],
+                BoardTaskStatus::Settled,
+                Some(BoardTaskOutcome::Blocked),
+            ),
+        ];
+        assert!(board_drained(&drained));
+        let active = vec![
+            mk(
+                "a",
+                &[],
+                BoardTaskStatus::Accepted,
+                Some(BoardTaskOutcome::Success),
+            ),
+            mk("b", &[], BoardTaskStatus::Running, None),
+        ];
+        assert!(!board_drained(&active));
+        // settled-success awaiting verdict: not drained in the "stuck" sense?
+        // It is: nothing progresses without the boss. But a settled success
+        // also unblocks dependents, which may be pending — covered by the
+        // Pending check.
+        let settled_with_dependent = vec![
+            mk(
+                "a",
+                &[],
+                BoardTaskStatus::Settled,
+                Some(BoardTaskOutcome::Success),
+            ),
+            mk("b", &["a"], BoardTaskStatus::Pending, None),
+        ];
+        assert!(!board_drained(&settled_with_dependent));
+        assert!(board_drained(&[mk(
+            "only",
+            &[],
+            BoardTaskStatus::Settled,
+            Some(BoardTaskOutcome::Failed)
+        )]));
+        assert!(!board_drained(&[]));
+    }
+
+    #[tokio::test]
+    async fn upsert_and_dep_flow_in_memory_store() {
+        use crate::api::mission_store::InMemoryMissionStore;
+        let store = InMemoryMissionStore::new();
+        let boss = Uuid::new_v4();
+        let tasks = store
+            .upsert_board_tasks(
+                boss,
+                vec![
+                    NewBoardTask {
+                        task_key: "t1".into(),
+                        title: "first".into(),
+                        prompt: "do x".into(),
+                        backend: "codex".into(),
+                        model_override: Some("gpt-5.5".into()),
+                        model_effort: None,
+                        working_directory: None,
+                        depends_on: vec![],
+                    },
+                    NewBoardTask {
+                        task_key: "t2".into(),
+                        title: "second".into(),
+                        prompt: "do y".into(),
+                        backend: "opencode".into(),
+                        model_override: None,
+                        model_effort: None,
+                        working_directory: None,
+                        depends_on: vec!["t1".into()],
+                    },
+                ],
+            )
+            .await
+            .expect("upsert");
+        assert_eq!(tasks.len(), 2);
+
+        let listed = store.list_board_tasks(boss).await.expect("list");
+        let ready: Vec<&str> = ready_tasks(&listed)
+            .iter()
+            .map(|t| t.task_key.as_str())
+            .collect();
+        assert_eq!(ready, vec!["t1"]);
+
+        // Settle t1 successfully → t2 becomes ready.
+        let mut t1 = listed.iter().find(|t| t.task_key == "t1").unwrap().clone();
+        t1.status = BoardTaskStatus::Settled;
+        t1.outcome = Some(BoardTaskOutcome::Success);
+        store.save_board_task(&t1).await.expect("save");
+        let listed = store.list_board_tasks(boss).await.expect("list");
+        let ready: Vec<&str> = ready_tasks(&listed)
+            .iter()
+            .map(|t| t.task_key.as_str())
+            .collect();
+        assert_eq!(ready, vec!["t2"]);
+
+        // Upsert with same key on a pending task updates it; settled untouched.
+        let again = store
+            .upsert_board_tasks(
+                boss,
+                vec![NewBoardTask {
+                    task_key: "t1".into(),
+                    title: "changed".into(),
+                    prompt: "p".into(),
+                    backend: "codex".into(),
+                    model_override: None,
+                    model_effort: None,
+                    working_directory: None,
+                    depends_on: vec![],
+                }],
+            )
+            .await
+            .expect("upsert again");
+        assert_eq!(
+            again[0].title, "first",
+            "settled task must not be clobbered"
+        );
+
+        assert_eq!(
+            store.list_active_board_missions().await.expect("active"),
+            vec![boss]
+        );
+    }
+}

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -96,6 +96,24 @@ pub fn classify_outcome(
     if failed {
         return BoardTaskOutcome::Failed;
     }
+    // Harness-level failures can surface as a "successful" turn whose entire
+    // output is an error banner (e.g. opencode session errors arrive via
+    // stderr text, not terminal_reason — observed in the dev smoke test).
+    // Only match banners at the very start so a legit summary that merely
+    // mentions errors isn't misclassified.
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return BoardTaskOutcome::Failed;
+    }
+    const ERROR_BANNERS: [&str; 4] = [
+        "Error:",
+        "[session.error]",
+        "[MAIN] SESSION.ERROR",
+        "Session ended with error",
+    ];
+    if ERROR_BANNERS.iter().any(|b| trimmed.starts_with(b)) {
+        return BoardTaskOutcome::Failed;
+    }
     // Worker contract: a stuck worker ends its turn with a line starting
     // "BLOCKED". Look near the start of the final message.
     let head: String = output.trim_start().chars().take(600).collect();
@@ -617,6 +635,28 @@ mod tests {
         assert_eq!(
             classify_outcome(Some(TerminalReason::Stalled), false, "whatever"),
             BoardTaskOutcome::Failed
+        );
+        // Harness error banners masquerading as a successful turn.
+        assert_eq!(
+            classify_outcome(
+                Some(TerminalReason::TurnComplete),
+                true,
+                "Error: Unexpected error, check log file at /root/.local/share/opencode/log"
+            ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(Some(TerminalReason::TurnComplete), true, "   "),
+            BoardTaskOutcome::Failed
+        );
+        // A summary that merely mentions an error is still a success.
+        assert_eq!(
+            classify_outcome(
+                Some(TerminalReason::TurnComplete),
+                true,
+                "Done. Fixed the Error: handling path and verified with cargo test."
+            ),
+            BoardTaskOutcome::Success
         );
         assert_eq!(classify_outcome(None, false, "x"), BoardTaskOutcome::Failed);
         assert_eq!(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4788,6 +4788,13 @@ fn conversation_profile_enabled(profile: Option<&str>) -> bool {
     matches!(profile, Some("conversation"))
 }
 
+/// Interactive/frontend tools whose call args (the question payload) must
+/// survive history projection so the dashboard can render the item — even
+/// after it's answered. Mirrors the dashboard's `isUiTool` check.
+fn is_interactive_ui_tool(name: &str) -> bool {
+    name == "question" || name == "AskUserQuestion" || name.starts_with("ui_")
+}
+
 fn project_conversation_events(
     events: Vec<mission_store::StoredEvent>,
     keep_full_tool_call_ids: &HashSet<String>,
@@ -4838,6 +4845,19 @@ fn project_conversation_events(
             continue;
         };
         if keep_full_tool_call_ids.contains(&tool_call_id) {
+            projected.push(event);
+            continue;
+        }
+        // Interactive UI tools (question / AskUserQuestion / ui_*) carry the
+        // question payload the dashboard needs to render the item even after
+        // it's answered. Stubbing them drops the args, so an answered question
+        // would reload as an empty "reply below" prompt. Never stub them or
+        // their results, regardless of the recency window.
+        if event
+            .tool_name
+            .as_deref()
+            .is_some_and(is_interactive_ui_tool)
+        {
             projected.push(event);
             continue;
         }
@@ -14929,6 +14949,55 @@ mod tests {
             stub.metadata["call_content_bytes"],
             serde_json::json!("{\"cmd\":\"old\"}".len())
         );
+    }
+
+    #[test]
+    fn conversation_projection_keeps_interactive_ui_tools_full() {
+        // An old, answered AskUserQuestion must NOT be stubbed: the dashboard
+        // needs its args to render the question, otherwise it shows the
+        // misleading empty "reply below" prompt for an already-answered item.
+        let mission_id = Uuid::new_v4();
+        let mut call = stored_test_event(
+            mission_id,
+            1,
+            "tool_call",
+            Some("q-1"),
+            "{\"questions\":[{\"question\":\"Pick one\",\"options\":[]}]}",
+        );
+        call.tool_name = Some("AskUserQuestion".to_string());
+        let mut result = stored_test_event(
+            mission_id,
+            2,
+            "tool_result",
+            Some("q-1"),
+            "{\"answers\":[[\"A\"]]}",
+        );
+        result.tool_name = Some("AskUserQuestion".to_string());
+        // A newer ordinary tool pair that SHOULD still be stubbed.
+        let newer_call =
+            stored_test_event(mission_id, 3, "tool_call", Some("b-1"), "{\"cmd\":\"x\"}");
+        let newer_result =
+            stored_test_event(mission_id, 4, "tool_result", Some("b-1"), "{\"ok\":true}");
+
+        let projected = project_conversation_events(
+            vec![call, result, newer_call, newer_result],
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        // The question call + result survive intact.
+        let q_call = projected
+            .iter()
+            .find(|e| e.tool_call_id.as_deref() == Some("q-1") && e.event_type == "tool_call")
+            .expect("question tool_call kept full");
+        assert!(q_call.content.contains("Pick one"));
+        assert!(projected
+            .iter()
+            .any(|e| e.tool_call_id.as_deref() == Some("q-1") && e.event_type == "tool_result"));
+        // The ordinary newer pair is stubbed as usual.
+        assert!(projected
+            .iter()
+            .any(|e| e.tool_call_id.as_deref() == Some("b-1") && e.event_type == "tool_stub"));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 // Control event/command types (Phase 6 of the decomposition).
+pub mod board;
 pub mod events;
 pub use events::*;
 
@@ -54,8 +55,8 @@ use super::auth::AuthUser;
 use super::desktop;
 use super::library::SharedLibrary;
 use super::mission_store::{
-    self, create_mission_store, now_string, Mission, MissionHistoryEntry, MissionStore,
-    MissionStoreType,
+    self, create_mission_store, now_string, BoardTask, BoardTaskStatus, Mission,
+    MissionHistoryEntry, MissionStore, MissionStoreType, NewBoardTask,
 };
 use super::routes::AppState;
 
@@ -3166,6 +3167,284 @@ pub async fn post_message(
     Ok(Json(ControlMessageResponse { id, queued }))
 }
 
+// ---------------------------------------------------------------------------
+// Task board API (see `board` module for the scheduler).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize)]
+pub struct BoardUpsertRequest {
+    pub tasks: Vec<NewBoardTask>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct BoardUtilization {
+    pub pending: usize,
+    pub running: usize,
+    pub settled: usize,
+    pub accepted: usize,
+    pub failed: usize,
+    pub cancelled: usize,
+    pub total: usize,
+    pub max_parallel: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct BoardResponse {
+    pub tasks: Vec<BoardTask>,
+    pub utilization: BoardUtilization,
+}
+
+fn board_utilization(tasks: &[BoardTask], max_parallel: usize) -> BoardUtilization {
+    let count = |s: BoardTaskStatus| tasks.iter().filter(|t| t.status == s).count();
+    BoardUtilization {
+        pending: count(BoardTaskStatus::Pending),
+        running: count(BoardTaskStatus::Running),
+        settled: count(BoardTaskStatus::Settled),
+        accepted: count(BoardTaskStatus::Accepted),
+        failed: count(BoardTaskStatus::Failed),
+        cancelled: count(BoardTaskStatus::Cancelled),
+        total: tasks.len(),
+        max_parallel,
+    }
+}
+
+/// GET /api/control/missions/:id/board — full board for a boss mission.
+pub async fn get_mission_board(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<BoardResponse>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let tasks = control
+        .mission_store
+        .list_board_tasks(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let max_parallel = crate::settings::max_parallel_missions_cached_or(control.max_parallel);
+    Ok(Json(BoardResponse {
+        utilization: board_utilization(&tasks, max_parallel),
+        tasks,
+    }))
+}
+
+/// POST /api/control/missions/:id/board/tasks — register/update tasks.
+/// The scheduler picks up ready tasks within one pass (~3s).
+pub async fn upsert_mission_board_tasks(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<BoardUpsertRequest>,
+) -> Result<Json<BoardResponse>, (StatusCode, String)> {
+    if req.tasks.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "tasks is required".to_string()));
+    }
+    for t in &req.tasks {
+        if t.task_key.trim().is_empty() || t.prompt.trim().is_empty() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "every task needs a non-empty task_key and prompt".to_string(),
+            ));
+        }
+        // Same operator policy as the orchestrator MCP: worker missions never
+        // burn Claude tokens. Enforced here too so the API can't be used to
+        // bypass the MCP-level check.
+        let claude_allowed = std::env::var("SANDBOXED_SH_ALLOW_CLAUDE_WORKERS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let is_claude = t.backend.eq_ignore_ascii_case("claudecode")
+            || t.model_override
+                .as_deref()
+                .map(|m| m.to_ascii_lowercase().contains("claude"))
+                .unwrap_or(false);
+        if t.backend.trim().is_empty() || (is_claude && !claude_allowed) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "task `{}`: workers need an explicit non-Claude backend (got `{}`)",
+                    t.task_key, t.backend
+                ),
+            ));
+        }
+    }
+
+    let control = control_for_user(&state, &user).await;
+    // The boss mission must exist — tasks attached to a typo'd uuid would
+    // never be scheduled against the right workspace.
+    let boss = control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
+        .ok_or((StatusCode::NOT_FOUND, format!("mission {} not found", id)))?;
+
+    control
+        .mission_store
+        .upsert_board_tasks(boss.id, req.tasks)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let tasks = control
+        .mission_store
+        .list_board_tasks(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let max_parallel = crate::settings::max_parallel_missions_cached_or(control.max_parallel);
+    Ok(Json(BoardResponse {
+        utilization: board_utilization(&tasks, max_parallel),
+        tasks,
+    }))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct BoardVerdictRequest {
+    /// "accept" or "reject".
+    pub action: String,
+    /// Required for reject: feedback delivered to the worker.
+    #[serde(default)]
+    pub feedback: Option<String>,
+}
+
+/// POST /api/control/board/tasks/:task_id/verdict — boss judgment on a
+/// settled task. Accept is terminal; reject resumes the worker with feedback
+/// (or re-queues the task if the worker mission is gone).
+pub async fn board_task_verdict(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(task_id): Path<Uuid>,
+    Json(req): Json<BoardVerdictRequest>,
+) -> Result<Json<BoardTask>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let mut task = control
+        .mission_store
+        .get_board_task(task_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
+        .ok_or((StatusCode::NOT_FOUND, format!("task {} not found", task_id)))?;
+
+    match req.action.as_str() {
+        "accept" => {
+            if task.status != BoardTaskStatus::Settled && task.status != BoardTaskStatus::Failed {
+                return Err((
+                    StatusCode::CONFLICT,
+                    format!("task `{}` is {}, not settled", task.task_key, task.status),
+                ));
+            }
+            task.status = BoardTaskStatus::Accepted;
+        }
+        "reject" => {
+            let feedback = req
+                .feedback
+                .as_deref()
+                .map(str::trim)
+                .filter(|f| !f.is_empty())
+                .ok_or((
+                    StatusCode::BAD_REQUEST,
+                    "reject requires non-empty feedback".to_string(),
+                ))?;
+            if task.status.is_terminal() && task.status != BoardTaskStatus::Failed {
+                return Err((
+                    StatusCode::CONFLICT,
+                    format!("task `{}` is already {}", task.task_key, task.status),
+                ));
+            }
+            task.notes = {
+                let stamp = now_string();
+                Some(match &task.notes {
+                    Some(n) => format!("{n}\n[{stamp}] rejected: {feedback}"),
+                    None => format!("[{stamp}] rejected: {feedback}"),
+                })
+            };
+            // Prefer resuming the existing worker (it has the context); fall
+            // back to a fresh spawn via the scheduler when the worker is gone.
+            let resumed = if let Some(worker_id) = task.worker_mission_id {
+                let (tx, _rx) = oneshot::channel();
+                control
+                    .cmd_tx
+                    .send(ControlCommand::UserMessage {
+                        id: Uuid::new_v4(),
+                        content: format!(
+                            "[task-board] The boss rejected your result for task `{}`. \
+                             Address this feedback, then end your turn with the same \
+                             done/BLOCKED contract as before:\n\n{}",
+                            task.task_key, feedback
+                        ),
+                        agent: None,
+                        target_mission_id: Some(worker_id),
+                        respond: tx,
+                    })
+                    .await
+                    .is_ok()
+            } else {
+                false
+            };
+            if resumed {
+                task.status = BoardTaskStatus::Running;
+                // A rejection grants a fresh retry budget: the boss explicitly
+                // asked for another attempt.
+                task.attempts = 1;
+            } else {
+                task.status = BoardTaskStatus::Pending;
+                task.attempts = 0;
+                task.worker_mission_id = None;
+                task.prompt = format!(
+                    "{}\n\n[task-board] Previous attempt was rejected with feedback:\n{}",
+                    task.prompt, feedback
+                );
+            }
+            task.outcome = None;
+        }
+        other => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("unknown action `{}` (use accept|reject)", other),
+            ));
+        }
+    }
+
+    control
+        .mission_store
+        .save_board_task(&task)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(task))
+}
+
+/// POST /api/control/board/tasks/:task_id/cancel — mark a task cancelled.
+/// A running worker is left to finish its current turn; its settle is ignored.
+pub async fn cancel_board_task(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(task_id): Path<Uuid>,
+) -> Result<Json<BoardTask>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let mut task = control
+        .mission_store
+        .get_board_task(task_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
+        .ok_or((StatusCode::NOT_FOUND, format!("task {} not found", task_id)))?;
+    if task.status.is_terminal() {
+        return Err((
+            StatusCode::CONFLICT,
+            format!("task `{}` is already {}", task.task_key, task.status),
+        ));
+    }
+    task.status = BoardTaskStatus::Cancelled;
+    task.notes = {
+        let stamp = now_string();
+        Some(match &task.notes {
+            Some(n) => format!("{n}\n[{stamp}] cancelled"),
+            None => format!("[{stamp}] cancelled"),
+        })
+    };
+    control
+        .mission_store
+        .save_board_task(&task)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(task))
+}
+
 /// Submit a frontend tool result to resume the running agent.
 pub async fn post_tool_result(
     State(state): State<Arc<AppState>>,
@@ -6261,6 +6540,7 @@ fn spawn_control_session(
         cmd_rx,
         mission_cmd_rx,
         mission_cmd_tx,
+        state.cmd_tx.clone(),
         events_tx.clone(),
         events_rx,
         tool_hub.clone(),
@@ -8131,6 +8411,10 @@ async fn control_actor_loop(
     mut cmd_rx: mpsc::Receiver<ControlCommand>,
     mut mission_cmd_rx: mpsc::Receiver<crate::tools::mission::MissionControlCommand>,
     mission_cmd_tx: mpsc::Sender<crate::tools::mission::MissionControlCommand>,
+    // Clone of the actor's own command sender, used by the task-board
+    // scheduler to spawn workers and deliver digests through the normal
+    // message-routing path (always try_send, never await — see board.rs).
+    self_cmd_tx: mpsc::Sender<ControlCommand>,
     events_tx: broadcast::Sender<AgentEvent>,
     mut events_rx: broadcast::Receiver<AgentEvent>,
     tool_hub: Arc<FrontendToolHub>,
@@ -8185,6 +8469,12 @@ async fn control_actor_loop(
         Uuid,
         super::mission_runner::MissionRunner,
     > = std::collections::HashMap::new();
+
+    // Task-board scheduler cadence: the 100ms tick is far too hot for store
+    // scans, so passes run every few seconds (and a settle triggers work via
+    // the digest message rather than a faster pass).
+    const BOARD_PASS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+    let mut last_board_pass = tokio::time::Instant::now();
 
     // Helper to extract file paths from text (for mission summaries)
     fn extract_file_paths(text: &str) -> Vec<String> {
@@ -10763,6 +11053,18 @@ async fn control_actor_loop(
                                         "parallel turn finished with no follow-up queued",
                                     )
                                     .await;
+                                    // Task-board settle hook: if this mission is a
+                                    // board worker, persist the outcome and notify
+                                    // the boss. No-op otherwise.
+                                    board::on_worker_settled(
+                                        &mission_store,
+                                        &self_cmd_tx,
+                                        *mission_id,
+                                        &result.output,
+                                        result.terminal_reason,
+                                        result.success,
+                                    )
+                                    .await;
                                     completed_missions.push(*mission_id);
                                 }
                             }
@@ -10780,6 +11082,31 @@ async fn control_actor_loop(
                     )
                     .await;
                     tracing::info!("Parallel mission {} removed from runners", mid);
+                }
+
+                // Task-board scheduler: spawn workers for ready tasks and
+                // sweep zombies. Throttled — store scans on every 100ms tick
+                // would hammer sqlite for nothing.
+                if last_board_pass.elapsed() >= BOARD_PASS_INTERVAL {
+                    last_board_pass = tokio::time::Instant::now();
+                    let snapshot = board::RunnerSnapshot {
+                        present: parallel_runners.keys().copied().collect(),
+                        running_count: parallel_runners
+                            .values()
+                            .filter(|r| r.is_running())
+                            .count(),
+                        main_running: running.is_some(),
+                    };
+                    let max_parallel = crate::settings::max_parallel_missions_cached_or(
+                        config.max_parallel_missions,
+                    );
+                    board::scheduler_pass(
+                        &mission_store,
+                        &self_cmd_tx,
+                        &snapshot,
+                        max_parallel,
+                    )
+                    .await;
                 }
             }
             // Force-reap a runner whose cancel was fired but whose

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -1,7 +1,8 @@
 //! In-memory mission store (non-persistent).
 
 use super::{
-    now_string, Mission, MissionHistoryEntry, MissionStatus, MissionStatusCounts, MissionStore,
+    now_string, BoardTask, BoardTaskStatus, Mission, MissionHistoryEntry, MissionStatus,
+    MissionStatusCounts, MissionStore, NewBoardTask,
 };
 use crate::api::control::{AgentTreeNode, DesktopSessionInfo};
 use async_trait::async_trait;
@@ -17,6 +18,7 @@ const METADATA_SOURCE_USER: &str = "user";
 pub struct InMemoryMissionStore {
     missions: Arc<RwLock<HashMap<Uuid, Mission>>>,
     trees: Arc<RwLock<HashMap<Uuid, AgentTreeNode>>>,
+    board_tasks: Arc<RwLock<HashMap<Uuid, BoardTask>>>,
 }
 
 impl InMemoryMissionStore {
@@ -24,6 +26,7 @@ impl InMemoryMissionStore {
         Self {
             missions: Arc::new(RwLock::new(HashMap::new())),
             trees: Arc::new(RwLock::new(HashMap::new())),
+            board_tasks: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -461,6 +464,119 @@ impl MissionStore for InMemoryMissionStore {
         _key_files: &[String],
         _success: bool,
     ) -> Result<(), String> {
+        Ok(())
+    }
+
+    // ---- Task board ------------------------------------------------------
+
+    async fn upsert_board_tasks(
+        &self,
+        boss_mission_id: Uuid,
+        tasks: Vec<NewBoardTask>,
+    ) -> Result<Vec<BoardTask>, String> {
+        let mut map = self.board_tasks.write().await;
+        let now = now_string();
+        let mut out = Vec::with_capacity(tasks.len());
+        for t in tasks {
+            let existing_id = map
+                .values()
+                .find(|bt| bt.boss_mission_id == boss_mission_id && bt.task_key == t.task_key)
+                .map(|bt| bt.id);
+            match existing_id {
+                Some(id) => {
+                    let bt = map.get_mut(&id).expect("just found");
+                    if bt.status == BoardTaskStatus::Pending {
+                        bt.title = t.title;
+                        bt.prompt = t.prompt;
+                        bt.backend = t.backend;
+                        bt.model_override = t.model_override;
+                        bt.model_effort = t.model_effort;
+                        bt.working_directory = t.working_directory;
+                        bt.depends_on = t.depends_on;
+                        bt.updated_at = now.clone();
+                    }
+                    out.push(bt.clone());
+                }
+                None => {
+                    let bt = BoardTask {
+                        id: Uuid::new_v4(),
+                        boss_mission_id,
+                        task_key: t.task_key,
+                        title: t.title,
+                        prompt: t.prompt,
+                        backend: t.backend,
+                        model_override: t.model_override,
+                        model_effort: t.model_effort,
+                        working_directory: t.working_directory,
+                        depends_on: t.depends_on,
+                        status: BoardTaskStatus::Pending,
+                        outcome: None,
+                        worker_mission_id: None,
+                        attempts: 0,
+                        result_digest: None,
+                        notes: None,
+                        created_at: now.clone(),
+                        updated_at: now.clone(),
+                    };
+                    map.insert(bt.id, bt.clone());
+                    out.push(bt);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn list_board_tasks(&self, boss_mission_id: Uuid) -> Result<Vec<BoardTask>, String> {
+        let map = self.board_tasks.read().await;
+        let mut tasks: Vec<BoardTask> = map
+            .values()
+            .filter(|bt| bt.boss_mission_id == boss_mission_id)
+            .cloned()
+            .collect();
+        tasks.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.task_key.cmp(&b.task_key))
+        });
+        Ok(tasks)
+    }
+
+    async fn list_active_board_missions(&self) -> Result<Vec<Uuid>, String> {
+        let map = self.board_tasks.read().await;
+        let mut ids: Vec<Uuid> = map
+            .values()
+            .filter(|bt| !bt.status.is_terminal())
+            .map(|bt| bt.boss_mission_id)
+            .collect();
+        ids.sort();
+        ids.dedup();
+        Ok(ids)
+    }
+
+    async fn get_board_task(&self, task_id: Uuid) -> Result<Option<BoardTask>, String> {
+        Ok(self.board_tasks.read().await.get(&task_id).cloned())
+    }
+
+    async fn get_board_task_by_worker(
+        &self,
+        worker_mission_id: Uuid,
+    ) -> Result<Option<BoardTask>, String> {
+        let map = self.board_tasks.read().await;
+        Ok(map
+            .values()
+            .filter(|bt| bt.worker_mission_id == Some(worker_mission_id))
+            .max_by(|a, b| a.updated_at.cmp(&b.updated_at))
+            .cloned())
+    }
+
+    async fn save_board_task(&self, task: &BoardTask) -> Result<(), String> {
+        let mut map = self.board_tasks.write().await;
+        if !map.contains_key(&task.id) {
+            return Err(format!("Board task {} not found", task.id));
+        }
+        let mut saved = task.clone();
+        saved.updated_at = now_string();
+        map.insert(task.id, saved);
         Ok(())
     }
 }

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1008,6 +1008,156 @@ pub fn now_string() -> String {
     Utc::now().to_rfc3339()
 }
 
+// ---------------------------------------------------------------------------
+// Task board: server-scheduled worker tasks owned by a boss mission.
+//
+// The board replaces LLM-driven scheduling: the boss agent registers a task
+// DAG once, and the control loop spawns worker missions for ready tasks up to
+// capacity, settles them when their turn ends, and notifies the boss with a
+// digest. See `api::control::board` for the scheduler.
+// ---------------------------------------------------------------------------
+
+/// Lifecycle of a board task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoardTaskStatus {
+    /// Registered; waiting on dependencies and/or capacity.
+    Pending,
+    /// A worker mission is executing this task.
+    Running,
+    /// The worker's turn ended; awaiting a boss verdict.
+    Settled,
+    /// Boss accepted the result (terminal).
+    Accepted,
+    /// Worker failed after retry (terminal unless re-planned).
+    Failed,
+    /// Cancelled by the boss or the user (terminal).
+    Cancelled,
+}
+
+impl std::fmt::Display for BoardTaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Settled => "settled",
+            Self::Accepted => "accepted",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl BoardTaskStatus {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "running" => Some(Self::Running),
+            "settled" => Some(Self::Settled),
+            "accepted" => Some(Self::Accepted),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    /// Terminal states never transition again (except via explicit re-plan).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Accepted | Self::Failed | Self::Cancelled)
+    }
+}
+
+/// How a settled task's worker turn ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoardTaskOutcome {
+    /// Worker reported completion.
+    Success,
+    /// Worker stopped with a BLOCKED question for the boss.
+    Blocked,
+    /// Worker turn failed (llm error, stall, interruption).
+    Failed,
+}
+
+impl std::fmt::Display for BoardTaskOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Success => "success",
+            Self::Blocked => "blocked",
+            Self::Failed => "failed",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl BoardTaskOutcome {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "success" => Some(Self::Success),
+            "blocked" => Some(Self::Blocked),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// A task on a boss mission's board.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardTask {
+    pub id: Uuid,
+    pub boss_mission_id: Uuid,
+    /// Stable, boss-chosen key (unique per board) used for `depends_on`
+    /// references and digests.
+    pub task_key: String,
+    pub title: String,
+    pub prompt: String,
+    /// Worker backend (e.g. "codex", "opencode", "grok"). Never claudecode.
+    pub backend: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_override: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_effort: Option<String>,
+    /// Working directory for the worker (usually an isolated git worktree).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    /// Task keys (same board) that must settle successfully or be accepted
+    /// before this task may start.
+    pub depends_on: Vec<String>,
+    pub status: BoardTaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<BoardTaskOutcome>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_mission_id: Option<Uuid>,
+    /// Number of worker spawns so far (1 = first attempt).
+    pub attempts: u32,
+    /// Truncated tail of the worker's final message, set on settle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_digest: Option<String>,
+    /// Free-form audit trail: rejections with feedback, retries, cancellations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Payload for registering/updating tasks on a board.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewBoardTask {
+    pub task_key: String,
+    pub title: String,
+    pub prompt: String,
+    pub backend: String,
+    #[serde(default)]
+    pub model_override: Option<String>,
+    #[serde(default)]
+    pub model_effort: Option<String>,
+    #[serde(default)]
+    pub working_directory: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
 /// Sanitize a string for use as a filename.
 pub fn sanitize_filename(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
@@ -2492,6 +2642,54 @@ pub trait MissionStore: Send + Sync {
     ) -> Result<Vec<TelegramWorkflowEvent>, String> {
         let _ = (workflow_id, limit);
         Ok(vec![])
+    }
+
+    // ---- Task board ------------------------------------------------------
+
+    /// Register or update tasks on a boss mission's board. Tasks are keyed by
+    /// `(boss_mission_id, task_key)`: a new key inserts, an existing key in
+    /// `pending` status is updated in place, and any other status is left
+    /// untouched (the current row is returned so the caller sees the real
+    /// state). Returns the post-upsert rows in input order.
+    async fn upsert_board_tasks(
+        &self,
+        boss_mission_id: Uuid,
+        tasks: Vec<NewBoardTask>,
+    ) -> Result<Vec<BoardTask>, String> {
+        let _ = (boss_mission_id, tasks);
+        Err("Task board not supported by this mission store".to_string())
+    }
+
+    /// All tasks on a boss mission's board, oldest first.
+    async fn list_board_tasks(&self, boss_mission_id: Uuid) -> Result<Vec<BoardTask>, String> {
+        let _ = boss_mission_id;
+        Ok(vec![])
+    }
+
+    /// Boss mission ids that have at least one non-terminal task. Drives the
+    /// scheduler's per-tick scan.
+    async fn list_active_board_missions(&self) -> Result<Vec<Uuid>, String> {
+        Ok(vec![])
+    }
+
+    async fn get_board_task(&self, task_id: Uuid) -> Result<Option<BoardTask>, String> {
+        let _ = task_id;
+        Ok(None)
+    }
+
+    /// Look up the task currently bound to a worker mission, if any.
+    async fn get_board_task_by_worker(
+        &self,
+        worker_mission_id: Uuid,
+    ) -> Result<Option<BoardTask>, String> {
+        let _ = worker_mission_id;
+        Ok(None)
+    }
+
+    /// Persist the full state of a task (matched by `task.id`).
+    async fn save_board_task(&self, task: &BoardTask) -> Result<(), String> {
+        let _ = task;
+        Err("Task board not supported by this mission store".to_string())
     }
 }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -1,9 +1,10 @@
 //! SQLite-based mission store with full event logging.
 
 use super::{
-    now_string, sanitize_filename, Automation, AutomationExecution, CommandSource, DailyUsageStats,
-    ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode,
-    MissionStatus, MissionStatusCounts, MissionStore, ModelUsageStats, PalomaCooldownState,
+    now_string, sanitize_filename, Automation, AutomationExecution, BoardTask, BoardTaskOutcome,
+    BoardTaskStatus, CommandSource, DailyUsageStats, ExecutionStatus, FreshSession,
+    HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode, MissionStatus,
+    MissionStatusCounts, MissionStore, ModelUsageStats, NewBoardTask, PalomaCooldownState,
     PalomaDecision, PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig,
     StopPolicy, StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
     TelegramActionExecutionStatus, TelegramAlert, TelegramAlertPreference, TelegramChannel,
@@ -627,6 +628,36 @@ CREATE TABLE IF NOT EXISTS proxy_usage (
 
 CREATE INDEX IF NOT EXISTS idx_proxy_usage_timestamp ON proxy_usage(timestamp);
 CREATE INDEX IF NOT EXISTS idx_proxy_usage_model ON proxy_usage(model);
+
+-- Task board: server-scheduled worker tasks owned by a boss mission.
+-- The control loop spawns workers for ready tasks and settles them when the
+-- worker turn ends; the boss only plans and judges. See api::control::board.
+CREATE TABLE IF NOT EXISTS board_tasks (
+    id TEXT PRIMARY KEY,
+    boss_mission_id TEXT NOT NULL,
+    task_key TEXT NOT NULL,
+    title TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    model_override TEXT,
+    model_effort TEXT,
+    working_directory TEXT,
+    depends_on TEXT NOT NULL DEFAULT '[]',
+    status TEXT NOT NULL DEFAULT 'pending',
+    outcome TEXT,
+    worker_mission_id TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    result_digest TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(boss_mission_id, task_key),
+    FOREIGN KEY (boss_mission_id) REFERENCES missions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_board_tasks_boss ON board_tasks(boss_mission_id);
+CREATE INDEX IF NOT EXISTS idx_board_tasks_worker ON board_tasks(worker_mission_id);
+CREATE INDEX IF NOT EXISTS idx_board_tasks_status ON board_tasks(status);
 "#;
 
 /// Content size threshold for inline storage (64KB).
@@ -9111,6 +9142,258 @@ impl MissionStore for SqliteMissionStore {
         .await
         .map_err(|e| e.to_string())?
     }
+
+    // ---- Task board ------------------------------------------------------
+
+    async fn upsert_board_tasks(
+        &self,
+        boss_mission_id: Uuid,
+        tasks: Vec<NewBoardTask>,
+    ) -> Result<Vec<BoardTask>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let now = now_string();
+            let mut out = Vec::with_capacity(tasks.len());
+            for t in tasks {
+                let existing: Option<(String, String)> = conn
+                    .query_row(
+                        "SELECT id, status FROM board_tasks WHERE boss_mission_id = ?1 AND task_key = ?2",
+                        params![boss_mission_id.to_string(), t.task_key],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .optional()
+                    .map_err(|e| format!("Failed to look up board task: {e}"))?;
+
+                let depends_on_json = serde_json::to_string(&t.depends_on)
+                    .map_err(|e| format!("Failed to serialize depends_on: {e}"))?;
+
+                let row_id = match existing {
+                    Some((id, status)) if status == "pending" => {
+                        conn.execute(
+                            "UPDATE board_tasks SET title = ?1, prompt = ?2, backend = ?3, \
+                             model_override = ?4, model_effort = ?5, working_directory = ?6, \
+                             depends_on = ?7, updated_at = ?8 WHERE id = ?9",
+                            params![
+                                t.title,
+                                t.prompt,
+                                t.backend,
+                                t.model_override,
+                                t.model_effort,
+                                t.working_directory,
+                                depends_on_json,
+                                now,
+                                id,
+                            ],
+                        )
+                        .map_err(|e| format!("Failed to update board task: {e}"))?;
+                        id
+                    }
+                    Some((id, _)) => id, // non-pending: leave untouched
+                    None => {
+                        let id = Uuid::new_v4().to_string();
+                        conn.execute(
+                            "INSERT INTO board_tasks (id, boss_mission_id, task_key, title, prompt, \
+                             backend, model_override, model_effort, working_directory, depends_on, \
+                             status, attempts, created_at, updated_at) \
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', 0, ?11, ?11)",
+                            params![
+                                id,
+                                boss_mission_id.to_string(),
+                                t.task_key,
+                                t.title,
+                                t.prompt,
+                                t.backend,
+                                t.model_override,
+                                t.model_effort,
+                                t.working_directory,
+                                depends_on_json,
+                                now,
+                            ],
+                        )
+                        .map_err(|e| format!("Failed to insert board task: {e}"))?;
+                        id
+                    }
+                };
+
+                let task = conn
+                    .query_row(
+                        &format!("SELECT {BOARD_TASK_COLUMNS} FROM board_tasks WHERE id = ?1"),
+                        params![row_id],
+                        parse_board_task_row,
+                    )
+                    .map_err(|e| format!("Failed to re-read board task: {e}"))?;
+                out.push(task);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| format!("Task join error: {e}"))?
+    }
+
+    async fn list_board_tasks(&self, boss_mission_id: Uuid) -> Result<Vec<BoardTask>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT {BOARD_TASK_COLUMNS} FROM board_tasks \
+                     WHERE boss_mission_id = ?1 ORDER BY created_at ASC, task_key ASC"
+                ))
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![boss_mission_id.to_string()], parse_board_task_row)
+                .map_err(|e| e.to_string())?;
+            rows.collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("Task join error: {e}"))?
+    }
+
+    async fn list_active_board_missions(&self) -> Result<Vec<Uuid>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT boss_mission_id FROM board_tasks \
+                     WHERE status IN ('pending', 'running', 'settled')",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|e| e.to_string())?;
+            let mut out = Vec::new();
+            for r in rows {
+                let s = r.map_err(|e| e.to_string())?;
+                if let Ok(id) = Uuid::parse_str(&s) {
+                    out.push(id);
+                }
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| format!("Task join error: {e}"))?
+    }
+
+    async fn get_board_task(&self, task_id: Uuid) -> Result<Option<BoardTask>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                &format!("SELECT {BOARD_TASK_COLUMNS} FROM board_tasks WHERE id = ?1"),
+                params![task_id.to_string()],
+                parse_board_task_row,
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("Task join error: {e}"))?
+    }
+
+    async fn get_board_task_by_worker(
+        &self,
+        worker_mission_id: Uuid,
+    ) -> Result<Option<BoardTask>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                &format!(
+                    "SELECT {BOARD_TASK_COLUMNS} FROM board_tasks \
+                     WHERE worker_mission_id = ?1 ORDER BY updated_at DESC LIMIT 1"
+                ),
+                params![worker_mission_id.to_string()],
+                parse_board_task_row,
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("Task join error: {e}"))?
+    }
+
+    async fn save_board_task(&self, task: &BoardTask) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let t = task.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let depends_on_json = serde_json::to_string(&t.depends_on)
+                .map_err(|e| format!("Failed to serialize depends_on: {e}"))?;
+            let updated = conn
+                .execute(
+                    "UPDATE board_tasks SET task_key = ?1, title = ?2, prompt = ?3, backend = ?4, \
+                     model_override = ?5, model_effort = ?6, working_directory = ?7, depends_on = ?8, \
+                     status = ?9, outcome = ?10, worker_mission_id = ?11, attempts = ?12, \
+                     result_digest = ?13, notes = ?14, updated_at = ?15 WHERE id = ?16",
+                    params![
+                        t.task_key,
+                        t.title,
+                        t.prompt,
+                        t.backend,
+                        t.model_override,
+                        t.model_effort,
+                        t.working_directory,
+                        depends_on_json,
+                        t.status.to_string(),
+                        t.outcome.map(|o| o.to_string()),
+                        t.worker_mission_id.map(|id| id.to_string()),
+                        t.attempts as i64,
+                        t.result_digest,
+                        t.notes,
+                        now_string(),
+                        t.id.to_string(),
+                    ],
+                )
+                .map_err(|e| format!("Failed to save board task: {e}"))?;
+            if updated == 0 {
+                return Err(format!("Board task {} not found", t.id));
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task join error: {e}"))?
+    }
+}
+
+/// Column list shared by every board task SELECT so `parse_board_task_row`
+/// indices stay in sync.
+const BOARD_TASK_COLUMNS: &str = "id, boss_mission_id, task_key, title, prompt, backend, \
+    model_override, model_effort, working_directory, depends_on, status, outcome, \
+    worker_mission_id, attempts, result_digest, notes, created_at, updated_at";
+
+fn parse_board_task_row(row: &rusqlite::Row<'_>) -> Result<BoardTask, rusqlite::Error> {
+    let id: String = row.get(0)?;
+    let boss_mission_id: String = row.get(1)?;
+    let depends_on_json: String = row.get(9)?;
+    let status_str: String = row.get(10)?;
+    let outcome_str: Option<String> = row.get(11)?;
+    let worker_mission_id: Option<String> = row.get(12)?;
+    let attempts: i64 = row.get(13)?;
+    Ok(BoardTask {
+        id: Uuid::parse_str(&id)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+        boss_mission_id: Uuid::parse_str(&boss_mission_id)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+        task_key: row.get(2)?,
+        title: row.get(3)?,
+        prompt: row.get(4)?,
+        backend: row.get(5)?,
+        model_override: row.get(6)?,
+        model_effort: row.get(7)?,
+        working_directory: row.get(8)?,
+        depends_on: serde_json::from_str(&depends_on_json).unwrap_or_default(),
+        status: BoardTaskStatus::parse(&status_str).unwrap_or(BoardTaskStatus::Pending),
+        outcome: outcome_str.as_deref().and_then(BoardTaskOutcome::parse),
+        worker_mission_id: worker_mission_id.and_then(|s| Uuid::parse_str(&s).ok()),
+        attempts: attempts as u32,
+        result_digest: row.get(14)?,
+        notes: row.get(15)?,
+        created_at: row.get(16)?,
+        updated_at: row.get(17)?,
+    })
 }
 
 fn telegram_user_role_to_str(role: TelegramUserRole) -> &'static str {
@@ -13120,5 +13403,91 @@ mod tests {
             .await
             .expect("filtered");
         assert!(filtered.is_empty());
+    }
+
+    #[tokio::test]
+    async fn board_tasks_roundtrip() {
+        use crate::api::mission_store::{BoardTaskOutcome, BoardTaskStatus, NewBoardTask};
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("store");
+
+        let boss = store
+            .create_mission(Some("boss"), None, None, None, None, None, None)
+            .await
+            .expect("boss mission");
+
+        let new = |key: &str, deps: Vec<&str>| NewBoardTask {
+            task_key: key.to_string(),
+            title: format!("title-{key}"),
+            prompt: format!("prompt-{key}"),
+            backend: "codex".to_string(),
+            model_override: Some("gpt-5.5".to_string()),
+            model_effort: Some("high".to_string()),
+            working_directory: Some("/workspaces/x/wt-1".to_string()),
+            depends_on: deps.into_iter().map(String::from).collect(),
+        };
+
+        let tasks = store
+            .upsert_board_tasks(boss.id, vec![new("t1", vec![]), new("t2", vec!["t1"])])
+            .await
+            .expect("upsert");
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].status, BoardTaskStatus::Pending);
+        assert_eq!(tasks[1].depends_on, vec!["t1".to_string()]);
+
+        // Active boards includes our boss.
+        let active = store.list_active_board_missions().await.expect("active");
+        assert_eq!(active, vec![boss.id]);
+
+        // Bind t1 to a worker, settle it, look it up by worker.
+        let worker = Uuid::new_v4();
+        let mut t1 = tasks[0].clone();
+        t1.worker_mission_id = Some(worker);
+        t1.status = BoardTaskStatus::Running;
+        t1.attempts = 1;
+        store.save_board_task(&t1).await.expect("save running");
+
+        let by_worker = store
+            .get_board_task_by_worker(worker)
+            .await
+            .expect("by worker")
+            .expect("found");
+        assert_eq!(by_worker.task_key, "t1");
+
+        let mut settled = by_worker;
+        settled.status = BoardTaskStatus::Settled;
+        settled.outcome = Some(BoardTaskOutcome::Success);
+        settled.result_digest = Some("did the thing".to_string());
+        store.save_board_task(&settled).await.expect("save settled");
+
+        let listed = store.list_board_tasks(boss.id).await.expect("list");
+        let t1 = listed.iter().find(|t| t.task_key == "t1").unwrap();
+        assert_eq!(t1.status, BoardTaskStatus::Settled);
+        assert_eq!(t1.outcome, Some(BoardTaskOutcome::Success));
+        assert_eq!(t1.result_digest.as_deref(), Some("did the thing"));
+
+        // Upserting an existing pending task updates it; settled stays.
+        let updated = store
+            .upsert_board_tasks(boss.id, vec![new("t2", vec![]), new("t1", vec![])])
+            .await
+            .expect("upsert again");
+        let t2 = updated.iter().find(|t| t.task_key == "t2").unwrap();
+        assert!(t2.depends_on.is_empty(), "pending task should be updated");
+        let t1 = updated.iter().find(|t| t.task_key == "t1").unwrap();
+        assert_eq!(
+            t1.status,
+            BoardTaskStatus::Settled,
+            "settled task must not be reset by upsert"
+        );
+
+        // get_board_task by id.
+        let fetched = store
+            .get_board_task(t2.id)
+            .await
+            .expect("get")
+            .expect("some");
+        assert_eq!(fetched.task_key, "t2");
     }
 }

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1127,6 +1127,85 @@ pub fn get_api_key_for_provider(
 ///
 /// Returns a map of provider ID -> fetched models. Providers that fail
 /// or lack credentials are simply omitted (hardcoded defaults will be used).
+/// Fetch the catalog once and replace the cached snapshot, returning
+/// `(provider_count, model_count)`.
+async fn refresh_catalog_once(
+    catalog: &ModelCatalog,
+    ai_providers: &AIProviderStore,
+    working_dir: &Path,
+) -> (usize, usize) {
+    let fetched = fetch_model_catalog(ai_providers, working_dir).await;
+    let provider_count = fetched.len();
+    let model_count: usize = fetched.values().map(|v| v.len()).sum();
+    *catalog.write().await = fetched;
+    (provider_count, model_count)
+}
+
+/// Spawn the background task that keeps the model catalog populated. Performs an
+/// initial fetch immediately, then refreshes on an interval so newly-added
+/// provider models (e.g. a custom router exposing a new model via `/v1/models`)
+/// appear without a backend restart.
+///
+/// The interval is controlled by `MODEL_CATALOG_REFRESH_SECS` (default 600s).
+/// Set it to `0` to disable periodic refresh and keep the startup-only snapshot.
+pub fn spawn_model_catalog_refresh(
+    catalog: ModelCatalog,
+    ai_providers: Arc<AIProviderStore>,
+    working_dir: std::path::PathBuf,
+) {
+    let refresh_secs = std::env::var("MODEL_CATALOG_REFRESH_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(600);
+
+    tokio::spawn(async move {
+        loop {
+            let (providers, models) =
+                refresh_catalog_once(&catalog, &ai_providers, &working_dir).await;
+            tracing::info!(
+                "Model catalog populated: {} models from {} providers (refresh every {}s)",
+                models,
+                providers,
+                refresh_secs
+            );
+
+            if refresh_secs == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(refresh_secs)).await;
+        }
+    });
+}
+
+#[derive(Debug, Serialize)]
+pub struct RefreshCatalogResponse {
+    pub refreshed: bool,
+    pub providers: usize,
+    pub models: usize,
+}
+
+/// Force an immediate refetch of the model catalog from all provider APIs and
+/// custom routers, replacing the cached snapshot. Useful right after adding a
+/// model to a custom provider's `/v1/models` without waiting for the periodic
+/// refresh.
+pub async fn refresh_model_catalog(
+    State(state): State<Arc<AppState>>,
+) -> Json<RefreshCatalogResponse> {
+    let working_dir = state.config.working_dir.clone();
+    let (providers, models) =
+        refresh_catalog_once(&state.model_catalog, &state.ai_providers, &working_dir).await;
+    tracing::info!(
+        "Model catalog manually refreshed: {} models from {} providers",
+        models,
+        providers
+    );
+    Json(RefreshCatalogResponse {
+        refreshed: true,
+        providers,
+        models,
+    })
+}
+
 pub async fn fetch_model_catalog(
     ai_providers: &AIProviderStore,
     _working_dir: &Path,

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1419,6 +1419,40 @@ fn get_configured_provider_ids(working_dir: &std::path::Path) -> HashSet<String>
 /// and descriptions. Only includes providers that are actually configured
 /// and authenticated. This endpoint is used by the frontend to render
 /// a grouped model selector.
+/// Replace each custom provider's operator-configured `custom_models` with the
+/// live model list fetched from its `/v1/models` (cached in `model_catalog`).
+/// Built-in providers are left untouched — they keep MERGE semantics so a
+/// subscription probe can't hide valid defaults. Custom providers (self-hosted
+/// OpenAI-compatible routers like the dgx-spark-router) instead treat the
+/// router's reported models as the source of truth.
+fn apply_live_custom_provider_models(
+    providers: &mut [Provider],
+    store_providers: &[crate::ai_providers::AIProvider],
+    cached: &HashMap<String, Vec<CatalogEntry>>,
+    include_unverified: bool,
+) {
+    let custom_provider_ids: HashSet<String> = store_providers
+        .iter()
+        .filter(|p| p.provider_type == ProviderType::Custom && p.enabled)
+        .map(|p| sanitize_custom_provider_id(&p.name))
+        .collect();
+    for provider in providers.iter_mut() {
+        if !custom_provider_ids.contains(&provider.id) {
+            continue;
+        }
+        if let Some(entries) = cached.get(&provider.id) {
+            let live: Vec<ProviderModel> = entries
+                .iter()
+                .filter(|e| include_unverified || e.is_selectable_by_default())
+                .map(CatalogEntry::to_provider_model)
+                .collect();
+            if !live.is_empty() {
+                provider.models = live;
+            }
+        }
+    }
+}
+
 pub async fn list_providers(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ProvidersQuery>,
@@ -1449,31 +1483,12 @@ pub async fn list_providers(
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, query.include_all);
 
-    // For custom providers (self-hosted OpenAI-compatible routers like the
-    // dgx-spark-router), the live model list fetched from /v1/models is the
-    // source of truth — replace the operator's hardcoded `custom_models` so
-    // stale entries don't linger. Built-in providers keep MERGE semantics
-    // (handled above) so subscription probes can't hide valid defaults.
-    let custom_provider_ids: HashSet<String> = store_providers
-        .iter()
-        .filter(|p| p.provider_type == ProviderType::Custom && p.enabled)
-        .map(|p| sanitize_custom_provider_id(&p.name))
-        .collect();
-    for provider in &mut providers {
-        if !custom_provider_ids.contains(&provider.id) {
-            continue;
-        }
-        if let Some(entries) = cached.get(&provider.id) {
-            let live: Vec<ProviderModel> = entries
-                .iter()
-                .filter(|e| query.include_unverified || e.is_selectable_by_default())
-                .map(CatalogEntry::to_provider_model)
-                .collect();
-            if !live.is_empty() {
-                provider.models = live;
-            }
-        }
-    }
+    apply_live_custom_provider_models(
+        &mut providers,
+        &store_providers,
+        &cached,
+        query.include_unverified,
+    );
     drop(cached);
 
     Json(ProvidersResponse {
@@ -1499,13 +1514,14 @@ pub async fn list_full_model_catalog(
     // models and providers that aren't configured yet.
     let cached = state.model_catalog.read().await;
     merge_cached_provider_models(&mut config, &cached, true);
-    drop(cached);
 
     let configured = get_configured_provider_ids(state.config.working_dir.as_path());
 
     let mut providers = config.providers;
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, true);
+    apply_live_custom_provider_models(&mut providers, &store_providers, &cached, true);
+    drop(cached);
 
     let mut models = Vec::new();
     for provider in &providers {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -159,6 +159,12 @@ pub struct ProvidersQuery {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProvidersResponse {
     pub providers: Vec<Provider>,
+    /// Provider ids that currently have working credentials for this account.
+    /// When `include_all` is set the `providers` list also contains
+    /// unconfigured catalog providers (so chains can be pre-built); clients use
+    /// this set to mark which are actually connected.
+    #[serde(default)]
+    pub configured_ids: Vec<String>,
 }
 
 /// Model option for a specific backend.
@@ -1404,7 +1410,10 @@ pub async fn list_providers(
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, query.include_all);
 
-    Json(ProvidersResponse { providers })
+    Json(ProvidersResponse {
+        providers,
+        configured_ids: configured.into_iter().collect(),
+    })
 }
 
 /// Full catalog of every supported model across all providers — configured or

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1263,6 +1263,46 @@ pub async fn fetch_model_catalog(
         }));
     }
 
+    // Custom providers (self-hosted OpenAI-compatible routers, e.g. the
+    // dgx-spark-router) expose /v1/models. Fetch their live model list so the
+    // catalog reflects what the router actually serves instead of the
+    // operator's hardcoded `custom_models`, which drift out of date.
+    for provider in &providers_list {
+        if provider.provider_type != ProviderType::Custom || !provider.enabled {
+            continue;
+        }
+        let Some(base_url) = provider.base_url.clone().filter(|u| !u.trim().is_empty()) else {
+            continue;
+        };
+        let provider_id = sanitize_custom_provider_id(&provider.name);
+        // /v1/models is usually unauthenticated on these routers; send the key
+        // when present, empty otherwise.
+        let api_key = provider.api_key.clone().unwrap_or_default();
+        handles.push(tokio::spawn(async move {
+            match fetch_openai_compatible_models(&base_url, &api_key, &[]).await {
+                Ok(models) if !models.is_empty() => {
+                    tracing::info!(
+                        "Fetched {} models from custom provider {} ({})",
+                        models.len(),
+                        provider_id,
+                        base_url
+                    );
+                    Some((provider_id, models))
+                }
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to fetch custom provider {} models from {}: {}",
+                        provider_id,
+                        base_url,
+                        e
+                    );
+                    None
+                }
+            }
+        }));
+    }
+
     if let Ok(Some(public_catalog)) = models_dev_handle.await {
         for (provider_id, entries) in public_catalog {
             merge_catalog_entries(&mut result, &provider_id, entries);
@@ -1391,7 +1431,6 @@ pub async fn list_providers(
     // the defaults would hide valid choices such as newly released Claude Opus.
     let cached = state.model_catalog.read().await;
     merge_cached_provider_models(&mut config, &cached, query.include_unverified);
-    drop(cached);
 
     // Get the set of configured provider IDs
     let configured = get_configured_provider_ids(state.config.working_dir.as_path());
@@ -1409,6 +1448,33 @@ pub async fn list_providers(
 
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, query.include_all);
+
+    // For custom providers (self-hosted OpenAI-compatible routers like the
+    // dgx-spark-router), the live model list fetched from /v1/models is the
+    // source of truth — replace the operator's hardcoded `custom_models` so
+    // stale entries don't linger. Built-in providers keep MERGE semantics
+    // (handled above) so subscription probes can't hide valid defaults.
+    let custom_provider_ids: HashSet<String> = store_providers
+        .iter()
+        .filter(|p| p.provider_type == ProviderType::Custom && p.enabled)
+        .map(|p| sanitize_custom_provider_id(&p.name))
+        .collect();
+    for provider in &mut providers {
+        if !custom_provider_ids.contains(&provider.id) {
+            continue;
+        }
+        if let Some(entries) = cached.get(&provider.id) {
+            let live: Vec<ProviderModel> = entries
+                .iter()
+                .filter(|e| query.include_unverified || e.is_selectable_by_default())
+                .map(CatalogEntry::to_provider_model)
+                .collect();
+            if !live.is_empty() {
+                provider.models = live;
+            }
+        }
+    }
+    drop(cached);
 
     Json(ProvidersResponse {
         providers,

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -752,9 +752,14 @@ fn default_providers_config() -> ProvidersConfig {
                     // Check Z.AI / GLM model IDs here:
                     // https://docs.z.ai/guides/llm/glm
                     ProviderModel {
+                        id: "glm-5.2".to_string(),
+                        name: "GLM-5.2".to_string(),
+                        description: Some("Most capable GLM reasoning model".to_string()),
+                    },
+                    ProviderModel {
                         id: "glm-5.1".to_string(),
                         name: "GLM-5.1".to_string(),
-                        description: Some("Most capable GLM reasoning model".to_string()),
+                        description: Some("Previous flagship GLM reasoning model".to_string()),
                     },
                     ProviderModel {
                         id: "glm-5-turbo".to_string(),

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1403,7 +1403,15 @@ fn get_configured_provider_ids(working_dir: &std::path::Path) -> HashSet<String>
         {
             for provider in providers {
                 if provider.enabled && provider.has_credentials() {
-                    configured.insert(provider.provider_type.id().to_string());
+                    // Use the same id the provider listing exposes: custom
+                    // providers are keyed by their sanitized name (e.g.
+                    // "spark"), not the generic "custom" type id, so the
+                    // dashboard's connected-marker lookup matches.
+                    if provider.provider_type == ProviderType::Custom {
+                        configured.insert(sanitize_custom_provider_id(&provider.name));
+                    } else {
+                        configured.insert(provider.provider_type.id().to_string());
+                    }
                 }
             }
         }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -572,23 +572,13 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         });
     }
 
-    // Fetch model catalog from provider APIs in background
-    {
-        let catalog = Arc::clone(&state.model_catalog);
-        let ai_providers = Arc::clone(&state.ai_providers);
-        let working_dir = config.working_dir.clone();
-        tokio::spawn(async move {
-            let fetched = super::providers::fetch_model_catalog(&ai_providers, &working_dir).await;
-            let provider_count = fetched.len();
-            let model_count: usize = fetched.values().map(|v| v.len()).sum();
-            *catalog.write().await = fetched;
-            tracing::info!(
-                "Model catalog populated: {} models from {} providers",
-                model_count,
-                provider_count
-            );
-        });
-    }
+    // Keep the model catalog populated: initial fetch + periodic refresh so
+    // newly-added provider models appear without a backend restart.
+    super::providers::spawn_model_catalog_refresh(
+        Arc::clone(&state.model_catalog),
+        Arc::clone(&state.ai_providers),
+        config.working_dir.clone(),
+    );
 
     let public_routes = Router::new()
         .route("/api/health", get(health))
@@ -1037,6 +1027,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/providers/catalog",
             get(super::providers::list_full_model_catalog),
+        )
+        .route(
+            "/api/providers/catalog/refresh",
+            post(super::providers::refresh_model_catalog),
         )
         .route(
             "/api/monitoring/memory-health",

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -695,6 +695,22 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         )
         .route("/api/control/missions/:id", get(control::get_mission))
         .route(
+            "/api/control/missions/:id/board",
+            get(control::get_mission_board),
+        )
+        .route(
+            "/api/control/missions/:id/board/tasks",
+            post(control::upsert_mission_board_tasks),
+        )
+        .route(
+            "/api/control/board/tasks/:task_id/verdict",
+            post(control::board_task_verdict),
+        )
+        .route(
+            "/api/control/board/tasks/:task_id/cancel",
+            post(control::cancel_board_task),
+        )
+        .route(
             "/api/control/missions/:id/tree",
             get(control::get_mission_tree),
         )

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -249,6 +249,107 @@ struct RemoveWorktreeParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct PlanWorktreeSpec {
+    /// Absolute path where the worktree will be created
+    path: String,
+    /// Branch name (created from `base` if it doesn't exist)
+    branch: String,
+    #[serde(default)]
+    base: Option<String>,
+    #[serde(default)]
+    repo_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanTaskSpec {
+    /// Stable key unique on this board; used in depends_on and digests
+    task_key: String,
+    title: String,
+    /// Full worker prompt: scope, absolute paths, success condition,
+    /// verification command. The done/BLOCKED turn contract is appended
+    /// automatically by the scheduler.
+    prompt: String,
+    /// Worker backend (codex, opencode, grok, ...). Never claudecode.
+    backend: String,
+    #[serde(default)]
+    model_override: Option<String>,
+    #[serde(default)]
+    model_effort: Option<String>,
+    /// Working directory for the worker. Overridden by `worktree.path` when a
+    /// worktree spec is given.
+    #[serde(default)]
+    working_directory: Option<String>,
+    /// Task keys (this board) that must settle successfully or be accepted first
+    #[serde(default)]
+    depends_on: Vec<String>,
+    /// Create an isolated git worktree for the worker before registering
+    #[serde(default)]
+    worktree: Option<PlanWorktreeSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanTasksParams {
+    tasks: Vec<PlanTaskSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskRefParams {
+    /// Task key on this board (preferred)
+    #[serde(default)]
+    task_key: Option<String>,
+    /// Task UUID (alternative to task_key)
+    #[serde(default)]
+    task_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RejectTaskParams {
+    #[serde(default)]
+    task_key: Option<String>,
+    #[serde(default)]
+    task_id: Option<String>,
+    /// Feedback delivered to the worker (what's wrong, what to change)
+    feedback: String,
+}
+
+fn default_review_history() -> usize {
+    6
+}
+
+#[derive(Debug, Deserialize)]
+struct ReviewTaskParams {
+    #[serde(default)]
+    task_key: Option<String>,
+    #[serde(default)]
+    task_id: Option<String>,
+    /// How many history entries from the worker mission to include
+    #[serde(default = "default_review_history")]
+    history_limit: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct MergeBranchParams {
+    /// Branch to merge from (a worker's worktree branch)
+    source_branch: String,
+    /// Branch to merge into (e.g. the PR branch)
+    target_branch: String,
+    #[serde(default)]
+    repo_path: Option<String>,
+    /// Push the target branch to origin after a clean merge
+    #[serde(default)]
+    push: bool,
+    /// Delete the source branch after a clean merge
+    #[serde(default)]
+    delete_source: bool,
+    /// Backend for the auto-registered conflict-resolver task (default codex)
+    #[serde(default)]
+    resolver_backend: Option<String>,
+    /// Model for the resolver task (default gpt-5.5)
+    #[serde(default)]
+    resolver_model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct WaitForWorkerParams {
     /// UUID of the worker mission to wait for
     mission_id: String,
@@ -499,8 +600,103 @@ impl OrchestratorMcp {
                 }),
             },
             ToolDefinition {
+                name: "plan_tasks".to_string(),
+                description: "PREFERRED orchestration tool. Register tasks on this mission's task board. The server-side scheduler then owns everything mechanical: it spawns a worker mission for every dependency-satisfied task while capacity allows, retries failures once, and MESSAGES YOU A DIGEST as each task settles. You never create workers, wait, or poll. Each task needs: task_key (stable, unique), title, full prompt (scope, absolute paths, success condition, verification command — the done/BLOCKED turn contract is appended automatically), backend (codex/opencode/grok — never claudecode), and optionally model_override/model_effort, depends_on (keys of tasks that must settle successfully first), and worktree {path, branch, base} for an isolated checkout (created here, before registration). Re-calling with an existing key updates the task while it is still pending. After planning: END YOUR TURN — digests will wake you.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["tasks"],
+                    "properties": {
+                        "tasks": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": ["task_key", "title", "prompt", "backend"],
+                                "properties": {
+                                    "task_key": { "type": "string", "description": "Stable unique key on this board (e.g. 'p3-nonce')" },
+                                    "title": { "type": "string" },
+                                    "prompt": { "type": "string", "description": "Full worker prompt: exact scope, absolute paths, success condition, verification command" },
+                                    "backend": { "type": "string", "description": "codex | opencode | grok (never claudecode)" },
+                                    "model_override": { "type": "string" },
+                                    "model_effort": { "type": "string", "description": "low | medium | high (codex)" },
+                                    "working_directory": { "type": "string", "description": "Worker cwd; superseded by worktree.path if a worktree is given" },
+                                    "depends_on": { "type": "array", "items": { "type": "string" }, "description": "task_keys that must settle successfully or be accepted first" },
+                                    "worktree": {
+                                        "type": "object",
+                                        "required": ["path", "branch"],
+                                        "properties": {
+                                            "path": { "type": "string", "description": "Absolute worktree path (inside the workspace)" },
+                                            "branch": { "type": "string" },
+                                            "base": { "type": "string", "description": "Base branch/commit (default HEAD)" },
+                                            "repo_path": { "type": "string", "description": "Repo owning the worktree (auto-detected if omitted)" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "board_status".to_string(),
+                description: "Current task board: every task with status (pending/running/settled/accepted/failed/cancelled), outcome, worker mission id, digest, plus utilization counters. Cheap snapshot — use instead of list_worker_missions/get_worker_status for board work.".to_string(),
+                input_schema: json!({ "type": "object", "properties": {} }),
+            },
+            ToolDefinition {
+                name: "review_task".to_string(),
+                description: "Full review payload for a board task: the task record (prompt, digest, notes) plus the tail of the worker mission's conversation. Use before accept_task/reject_task when the digest alone isn't enough to judge.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "task_key": { "type": "string", "description": "Task key on this board (preferred)" },
+                        "task_id": { "type": "string", "description": "Task UUID (alternative)" },
+                        "history_limit": { "type": "integer", "description": "Worker history entries to include (default 6)" }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "accept_task".to_string(),
+                description: "Accept a settled task's result (terminal verdict). Unblocks nothing extra — successful settles already unblock dependents — but records your judgment and clears the awaiting-verdict queue.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "task_key": { "type": "string" },
+                        "task_id": { "type": "string" }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "reject_task".to_string(),
+                description: "Reject a settled (or failed) task with feedback. The worker mission is resumed with your feedback so it keeps its context; if the worker is gone the task is re-queued with the feedback appended to its prompt. You'll get a fresh digest when it settles again.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["feedback"],
+                    "properties": {
+                        "task_key": { "type": "string" },
+                        "task_id": { "type": "string" },
+                        "feedback": { "type": "string", "description": "What is wrong and what to change — delivered verbatim to the worker" }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "merge_branch".to_string(),
+                description: "Merge a worker branch into a target branch (e.g. worker worktree branch → PR branch). Clean merge: optionally push and delete the source branch. Conflict: the merge is aborted safely and a conflict-resolver task is registered on the board automatically — you'll get a digest when it settles. This makes splitting one PR across several worktree workers routine.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["source_branch", "target_branch"],
+                    "properties": {
+                        "source_branch": { "type": "string" },
+                        "target_branch": { "type": "string" },
+                        "repo_path": { "type": "string", "description": "Repo directory (auto-detected if omitted). Must be checked out on target_branch or switchable to it." },
+                        "push": { "type": "boolean", "description": "Push target to origin after a clean merge" },
+                        "delete_source": { "type": "boolean", "description": "Delete the source branch after a clean merge" },
+                        "resolver_backend": { "type": "string", "description": "Backend for the auto conflict-resolver task (default codex)" },
+                        "resolver_model": { "type": "string", "description": "Model for the resolver task (default gpt-5.5)" }
+                    }
+                }),
+            },
+            ToolDefinition {
                 name: "create_worker_mission".to_string(),
-                description: "Create a new worker mission (child of the current boss mission). The worker will start executing immediately and runs in the same workspace as the boss by default, so it sees the boss's container, mounts, and installed tooling. IMPORTANT: You must set the 'backend' field to match the harness you want (claudecode, codex, gemini, grok, opencode). If omitted, defaults to the workspace default (usually claudecode).".to_string(),
+                description: "LEGACY — prefer plan_tasks, which schedules, retries, and notifies automatically. Create a new worker mission (child of the current boss mission). The worker will start executing immediately and runs in the same workspace as the boss by default, so it sees the boss's container, mounts, and installed tooling. IMPORTANT: You must set the 'backend' field to match the harness you want (claudecode, codex, gemini, grok, opencode). If omitted, defaults to the workspace default (usually claudecode).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["title", "prompt"],
@@ -754,7 +950,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "wait_for_worker".to_string(),
-                description: "Block until a single worker mission reaches a terminal status. Use wait_for_any_worker to monitor multiple workers simultaneously. For waits beyond a few minutes, end your turn and schedule a wakeup instead of polling (each ~90s poll costs a model call).".to_string(),
+                description: "Block until a single worker mission reaches a settled status (including awaiting_user, the normal end-of-turn state). Prefer wait_for_any_worker to monitor multiple workers simultaneously — blocking on one worker while others sit idle serializes your pipeline. For waits beyond a few minutes, end your turn and schedule a wakeup instead of polling (each ~90s poll costs a model call).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -766,7 +962,7 @@ impl OrchestratorMcp {
                         "target_statuses": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Statuses to wait for (default: ['completed', 'failed', 'interrupted'])"
+                            "description": "Statuses to wait for (default: ['completed', 'awaiting_user', 'failed', 'interrupted', 'not_feasible'])"
                         },
                         "timeout_seconds": {
                             "type": "integer",
@@ -781,7 +977,7 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "wait_for_any_worker".to_string(),
-                description: "Block until ANY of the specified worker missions reaches a terminal status. Returns the first worker that finishes. Use this to monitor a pool of workers and react as each completes. TOKEN ECONOMY: the wait is capped at ~90s per call, so polling a long-running worker burns one of YOUR model calls per 90s. If no worker is likely to finish within a couple of polls, END YOUR TURN and schedule a wakeup (ScheduleWakeup, 10-30 min) instead — check workers once per wakeup.".to_string(),
+                description: "Block until ANY of the specified worker missions reaches a settled status (including awaiting_user, the normal end-of-turn state). Returns the first worker that settles. Use this to monitor a pool of workers and react as each completes. PARALLELISM: when this returns, re-dispatch ALL idle workers (resume_worker / create_worker_mission for every independent track) BEFORE doing any deep analysis of the returned result — workers sitting in awaiting_user are wasted capacity while you read logs. TOKEN ECONOMY: the wait is capped at ~90s per call, so polling a long-running worker burns one of YOUR model calls per 90s. If no worker is likely to finish within a couple of polls, END YOUR TURN and schedule a wakeup (ScheduleWakeup, 10-30 min) instead — check workers once per wakeup.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_ids"],
@@ -794,7 +990,7 @@ impl OrchestratorMcp {
                         "target_statuses": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Statuses to wait for (default: ['completed', 'failed', 'interrupted'])"
+                            "description": "Statuses to wait for (default: ['completed', 'awaiting_user', 'failed', 'interrupted', 'not_feasible'])"
                         },
                         "timeout_seconds": {
                             "type": "integer",
@@ -1535,6 +1731,337 @@ impl OrchestratorMcp {
         }))
     }
 
+    // ---- Task board -------------------------------------------------------
+
+    /// Register tasks on this boss mission's board. The server-side scheduler
+    /// spawns workers for ready tasks automatically — no create/wait calls.
+    async fn plan_tasks(&self, params: PlanTasksParams) -> Result<Value, String> {
+        if params.tasks.is_empty() {
+            return Err("tasks is required".to_string());
+        }
+
+        let claude_allowed = std::env::var("SANDBOXED_SH_ALLOW_CLAUDE_WORKERS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        let mut registered = Vec::with_capacity(params.tasks.len());
+        let mut worktrees_created = Vec::new();
+        for spec in params.tasks {
+            // Same operator policy as create_worker_mission: workers never
+            // burn Claude tokens.
+            let is_claude = spec.backend.eq_ignore_ascii_case("claudecode")
+                || spec
+                    .model_override
+                    .as_deref()
+                    .map(|m| m.to_ascii_lowercase().contains("claude"))
+                    .unwrap_or(false);
+            if spec.backend.trim().is_empty() || (is_claude && !claude_allowed) {
+                return Err(format!(
+                    "task `{}`: specify an explicit non-Claude backend (got `{}`) — \
+                     use codex, opencode, or grok (operator policy)",
+                    spec.task_key, spec.backend
+                ));
+            }
+
+            let working_directory = if let Some(wt) = &spec.worktree {
+                self.create_worktree(CreateWorktreeParams {
+                    path: wt.path.clone(),
+                    branch: wt.branch.clone(),
+                    base: wt.base.clone(),
+                    repo_path: wt.repo_path.clone(),
+                })
+                .map_err(|e| format!("task `{}`: worktree failed: {}", spec.task_key, e))?;
+                worktrees_created.push(json!({
+                    "task_key": spec.task_key,
+                    "path": wt.path,
+                    "branch": wt.branch,
+                }));
+                Some(wt.path.clone())
+            } else {
+                spec.working_directory.clone()
+            };
+            if let Some(wd) = working_directory.as_deref() {
+                validate_working_directory_visible_to_worker(wd)?;
+            }
+
+            registered.push(json!({
+                "task_key": spec.task_key,
+                "title": spec.title,
+                "prompt": spec.prompt,
+                "backend": spec.backend,
+                "model_override": spec.model_override,
+                "model_effort": spec.model_effort,
+                "working_directory": working_directory,
+                "depends_on": spec.depends_on,
+            }));
+        }
+
+        let response = self
+            .api_post(
+                &format!("/api/control/missions/{}/board/tasks", self.mission_id),
+                json!({ "tasks": registered }),
+            )
+            .await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to register board tasks: {}", text));
+        }
+        let mut board: Value = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse board response: {}", e))?;
+        if let Some(obj) = board.as_object_mut() {
+            obj.insert("worktrees_created".to_string(), json!(worktrees_created));
+            obj.insert(
+                "hint".to_string(),
+                json!(
+                    "Tasks registered. The scheduler spawns workers automatically and will \
+                     message you a digest as each task settles. Do NOT wait or poll — end \
+                     your turn now."
+                ),
+            );
+        }
+        Ok(board)
+    }
+
+    /// Current board state with utilization counters.
+    async fn board_status(&self) -> Result<Value, String> {
+        let response = self
+            .api_get(&format!("/api/control/missions/{}/board", self.mission_id))
+            .await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to fetch board: {}", text));
+        }
+        response
+            .json::<Value>()
+            .await
+            .map_err(|e| format!("Failed to parse board: {}", e))
+    }
+
+    /// Resolve a task by key (on this board) or by UUID.
+    async fn resolve_board_task(
+        &self,
+        task_key: Option<&str>,
+        task_id: Option<&str>,
+    ) -> Result<Value, String> {
+        let board = self.board_status().await?;
+        let tasks = board["tasks"]
+            .as_array()
+            .ok_or("Malformed board response")?;
+        let found = tasks.iter().find(|t| match (task_key, task_id) {
+            (Some(k), _) => t["task_key"].as_str() == Some(k),
+            (None, Some(id)) => t["id"].as_str() == Some(id),
+            (None, None) => false,
+        });
+        found.cloned().ok_or_else(|| {
+            format!(
+                "Task not found (key={:?}, id={:?}). Keys on this board: {}",
+                task_key,
+                task_id,
+                tasks
+                    .iter()
+                    .filter_map(|t| t["task_key"].as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+    }
+
+    /// Full review payload for a settled task: the task record plus the tail
+    /// of the worker mission's conversation.
+    async fn review_task(&self, params: ReviewTaskParams) -> Result<Value, String> {
+        let task = self
+            .resolve_board_task(params.task_key.as_deref(), params.task_id.as_deref())
+            .await?;
+        let mut out = json!({ "task": task });
+        if let Some(worker_id) = task["worker_mission_id"].as_str() {
+            let response = self
+                .api_get(&format!("/api/control/missions/{}", worker_id))
+                .await?;
+            if response.status().is_success() {
+                if let Ok(mission) = response.json::<Value>().await {
+                    let history = mission["history"].as_array().cloned().unwrap_or_default();
+                    let tail: Vec<Value> = history
+                        .iter()
+                        .rev()
+                        .take(params.history_limit.max(1))
+                        .rev()
+                        .cloned()
+                        .collect();
+                    out["worker_history_tail"] = json!(tail);
+                    out["worker_status"] = mission["status"].clone();
+                    out["worker_working_directory"] = mission["working_directory"].clone();
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn task_verdict(
+        &self,
+        task_key: Option<&str>,
+        task_id: Option<&str>,
+        action: &str,
+        feedback: Option<&str>,
+    ) -> Result<Value, String> {
+        let task = self.resolve_board_task(task_key, task_id).await?;
+        let id = task["id"].as_str().ok_or("Malformed task record")?;
+        let response = self
+            .api_post(
+                &format!("/api/control/board/tasks/{}/verdict", id),
+                json!({ "action": action, "feedback": feedback }),
+            )
+            .await?;
+        if !response.status().is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Verdict failed: {}", text));
+        }
+        response
+            .json::<Value>()
+            .await
+            .map_err(|e| format!("Failed to parse verdict response: {}", e))
+    }
+
+    /// Merge a worker branch into a target branch. On conflict the merge is
+    /// aborted and a resolver task is registered on the board automatically.
+    async fn merge_branch(&self, params: MergeBranchParams) -> Result<Value, String> {
+        let repo_dir = resolve_repo_path(params.repo_path.as_deref());
+        let source = params.source_branch.trim();
+        let target = params.target_branch.trim();
+        if source.is_empty() || target.is_empty() {
+            return Err("source_branch and target_branch are required".to_string());
+        }
+
+        let run = |args: &[&str]| -> Result<(bool, String), String> {
+            let output = Command::new("git")
+                .current_dir(&repo_dir)
+                .args(args)
+                .output()
+                .map_err(|e| format!("Failed to run git {:?}: {}", args, e))?;
+            let text = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            Ok((output.status.success(), text))
+        };
+
+        // The main checkout must be on the target branch; checking it out
+        // under a running worker would yank files out from under it.
+        let (ok, head) = run(&["rev-parse", "--abbrev-ref", "HEAD"])?;
+        if !ok {
+            return Err(format!("git rev-parse failed in {}: {}", repo_dir, head));
+        }
+        let head = head.trim().to_string();
+        if head != target {
+            let (ok, out) = run(&["checkout", target])?;
+            if !ok {
+                return Err(format!(
+                    "Cannot checkout target branch `{}` (HEAD is `{}`): {}",
+                    target, head, out
+                ));
+            }
+        }
+
+        let (merged, merge_out) = run(&["merge", "--no-edit", source])?;
+        if merged {
+            let mut result = json!({
+                "merged": true,
+                "source_branch": source,
+                "target_branch": target,
+                "repo_path": repo_dir,
+                "output": merge_out.trim(),
+            });
+            if params.push {
+                let (pushed, push_out) = run(&["push", "origin", target])?;
+                result["pushed"] = json!(pushed);
+                if !pushed {
+                    result["push_error"] = json!(push_out.trim());
+                }
+            }
+            if params.delete_source {
+                let (deleted, del_out) = run(&["branch", "-D", source])?;
+                result["source_deleted"] = json!(deleted);
+                if !deleted {
+                    result["delete_error"] = json!(del_out.trim());
+                }
+            }
+            return Ok(result);
+        }
+
+        // Conflict (or other merge failure): collect conflicted files, abort,
+        // and register a resolver task.
+        let (_, conflicted) = run(&["diff", "--name-only", "--diff-filter=U"])?;
+        let conflicted_files: Vec<String> = conflicted
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+        let _ = run(&["merge", "--abort"]);
+
+        if conflicted_files.is_empty() {
+            // Not a content conflict — surface the raw error instead of
+            // spawning a resolver that can't do anything.
+            return Err(format!(
+                "git merge failed (no conflicted files detected): {}",
+                merge_out.trim()
+            ));
+        }
+
+        let stamp = chrono::Utc::now().format("%H%M%S");
+        let resolver_key = format!("merge-{}-{}", source.replace('/', "_"), stamp);
+        let resolver_prompt = format!(
+            "Merge conflict resolution in {repo}.\n\
+             Run: `git checkout {target}` then `git merge --no-edit {source}`.\n\
+             Conflicted files:\n{files}\n\
+             Resolve every conflict so BOTH changes' intent is preserved (read both branch \
+             histories with `git log {target} -5 --oneline` and `git log {source} -5 --oneline` \
+             for context). After resolving: build/verify, `git add -A`, `git commit --no-edit`. \
+             Do NOT push. Success condition: merge commit exists on `{target}` and verification \
+             passes.",
+            repo = repo_dir,
+            target = target,
+            source = source,
+            files = conflicted_files.join("\n"),
+        );
+        let resolver = self
+            .plan_tasks(PlanTasksParams {
+                tasks: vec![PlanTaskSpec {
+                    task_key: resolver_key.clone(),
+                    title: format!("Resolve merge conflict {} → {}", source, target),
+                    prompt: resolver_prompt,
+                    backend: params
+                        .resolver_backend
+                        .unwrap_or_else(|| "codex".to_string()),
+                    model_override: Some(
+                        params
+                            .resolver_model
+                            .unwrap_or_else(|| "gpt-5.5".to_string()),
+                    ),
+                    model_effort: Some("high".to_string()),
+                    working_directory: Some(repo_dir.clone()),
+                    depends_on: vec![],
+                    worktree: None,
+                }],
+            })
+            .await;
+
+        Ok(json!({
+            "merged": false,
+            "conflict": true,
+            "source_branch": source,
+            "target_branch": target,
+            "repo_path": repo_dir,
+            "conflicted_files": conflicted_files,
+            "resolver_task": resolver_key,
+            "resolver_registered": resolver.is_ok(),
+            "resolver_error": resolver.err(),
+            "hint": "Merge aborted cleanly. A resolver task was registered on the board; \
+                     you'll get a digest when it settles. End your turn.",
+        }))
+    }
+
     async fn batch_create_workers(
         &self,
         params: BatchCreateWorkersParams,
@@ -1631,6 +2158,7 @@ impl OrchestratorMcp {
         let target_statuses = if params.target_statuses.is_empty() {
             vec![
                 "completed".to_string(),
+                "awaiting_user".to_string(),
                 "failed".to_string(),
                 "interrupted".to_string(),
                 "not_feasible".to_string(),
@@ -1748,6 +2276,7 @@ impl OrchestratorMcp {
         let target_statuses = if params.target_statuses.is_empty() {
             vec![
                 "completed".to_string(),
+                "awaiting_user".to_string(),
                 "failed".to_string(),
                 "interrupted".to_string(),
                 "not_feasible".to_string(),
@@ -1969,6 +2498,44 @@ impl OrchestratorMcp {
                 let params: SendMessageParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
                 self.retask_worker(params).await
+            }
+            "plan_tasks" => {
+                let params: PlanTasksParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.plan_tasks(params).await
+            }
+            "board_status" => self.board_status().await,
+            "review_task" => {
+                let params: ReviewTaskParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.review_task(params).await
+            }
+            "accept_task" => {
+                let params: TaskRefParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.task_verdict(
+                    params.task_key.as_deref(),
+                    params.task_id.as_deref(),
+                    "accept",
+                    None,
+                )
+                .await
+            }
+            "reject_task" => {
+                let params: RejectTaskParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.task_verdict(
+                    params.task_key.as_deref(),
+                    params.task_id.as_deref(),
+                    "reject",
+                    Some(&params.feedback),
+                )
+                .await
+            }
+            "merge_branch" => {
+                let params: MergeBranchParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
+                self.merge_branch(params).await
             }
             "create_worktree" => {
                 let params: CreateWorktreeParams =

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -257,6 +257,13 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(1_250, 2_500, None, Some(200)),
     },
     PricingEntry {
+        // glm-5.2 list price not yet published separately; mirrors glm-5.1
+        // ($1.4/$4.4 per Mtok, $0.26 cached) until Z.AI publishes it.
+        canonical: "glm-5.2",
+        aliases: &["glm-5.2", "glm-5-2"],
+        pricing: pricing(1_400, 4_400, None, Some(260)),
+    },
+    PricingEntry {
         canonical: "glm-5.1",
         aliases: &["glm-5.1", "glm-5-1"],
         pricing: pricing(1_400, 4_400, None, Some(260)),
@@ -529,6 +536,7 @@ mod tests {
         assert_eq!(normalize_model("xAI/Grok Inference"), "grok-4-fast");
         assert_eq!(normalize_model("grok-build"), "grok-build");
         assert_eq!(normalize_model("zai/glm-5"), "glm-5");
+        assert_eq!(normalize_model("zai/glm-5.2"), "glm-5.2");
         assert_eq!(normalize_model("zai/glm-5.1"), "glm-5.1");
         assert_eq!(normalize_model("zai/glm-5-turbo"), "glm-5-turbo");
         assert_eq!(normalize_model("zai/glm-4.7"), "glm-4.7");
@@ -560,6 +568,7 @@ mod tests {
         assert!(pricing_for_model("xAI/Grok Inference").is_some());
         assert!(pricing_for_model("grok-build").is_some());
         assert!(pricing_for_model("glm-5").is_some());
+        assert!(pricing_for_model("zai/glm-5.2").is_some());
         assert!(pricing_for_model("glm-5.1").is_some());
         assert!(pricing_for_model("zai/glm-5-turbo").is_some());
         assert!(pricing_for_model("zai/glm-4.7").is_some());

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -854,7 +854,7 @@ impl ModelChainStore {
                     },
                     ChainEntry {
                         provider_id: "zai".to_string(),
-                        model_id: "glm-5.1".to_string(),
+                        model_id: "glm-5.2".to_string(),
                     },
                 ],
                 is_default: true,
@@ -869,8 +869,10 @@ impl ModelChainStore {
             if let Some(chain) = chains.iter_mut().find(|c| c.id == "builtin/smart") {
                 let mut migrated = false;
                 for entry in &mut chain.entries {
-                    if entry.provider_id == "zai" && entry.model_id == "glm-5" {
-                        entry.model_id = "glm-5.1".to_string();
+                    if entry.provider_id == "zai"
+                        && matches!(entry.model_id.as_str(), "glm-5" | "glm-5.1")
+                    {
+                        entry.model_id = "glm-5.2".to_string();
                         migrated = true;
                     }
                     if entry.provider_id == "minimax"


### PR DESCRIPTION
## Summary

Server-owned **task board** orchestration (replacing the boss-driven wait/spawn loop), plus a batch of model-routing, catalog, and UI fixes from the same working session. All commits are already on `master` (deploys build from `master`); this PR exists for review — its base is a frozen baseline branch (`pr-base/pre-task-board` = the pre-work commit) so the diff shows exactly this work, with no history rewritten.

## Orchestration — server-owned task board
- **`fc083b69` feat(orchestration): server-owned task board scheduler** — `board_tasks` table + scheduler in the control loop. The boss registers a task DAG once (`plan_tasks`); the loop spawns workers for dependency-satisfied tasks up to capacity, retries failures once, settles them, and messages the boss a digest. No more `wait_for_*`/manual spawning. MCP tools: `plan_tasks`, `board_status`, `review_task`, `accept_task`, `reject_task`, `merge_branch` (conflict → auto-resolver task).
- **`7f66670c` fix(board): classify harness error banners and empty output as failed** — opencode session errors surface as a "successful" turn whose body is an error banner; now classified as failed so retry/digest engage.

## Dashboard + iOS — task board surfaces
- **`8769aa78` feat(dashboard): task board section in mission workbench** — per-task status/deps/verdict + utilization, light/dark correct.
- **`2914df3e` feat(ios): task board pill + sheet for boss missions** — pill + grouped sheet with verdict/cancel.
- **`8e78f554` fix(ios): worker pill leads with active count, not cumulative total** — headline is running workers; cumulative total muted; Completed section collapsed. (Addresses the "30 workers" overstatement.)

## Model routing + catalog
- **`c88b403e` feat(models): add GLM-5.2** — catalog + pricing + default `builtin/smart` chain (verified live on Z.AI; reasoning-on by default).
- **`00e75f76` feat(dashboard): collapsible Supported Models catalog on /model-routing** — every `provider/model` id the router accepts, searchable, copyable.
- **`298d3bc5` fix(model-routing): mark unconnected providers in chain editor** — `/api/providers` returns `configured_ids`; unconnected providers (e.g. Google when never linked) are labelled "— not connected" instead of looking ready.
- **`3a56ab48` feat(providers): fetch custom-provider models live from their /v1/models** — custom providers (the dgx-spark-router) now reflect what the router actually serves instead of stale hardcoded `custom_models`.
- **`ba125bdd` refactor(providers): share live-custom-models logic; apply to full catalog too**
- **`a178cc30` fix(providers): key custom providers by sanitized name in configured_ids** — fixes a connected custom provider being mislabelled "not connected".
- **`d71b3294` feat(providers): periodic + manual model-catalog refresh** — (authored by @Th0rgal)

## UI fix
- **`23e3335f` fix(ui): answered AskUserQuestion no longer shows empty 'reply below' prompt** — lazy history stubbing dropped an answered question's args, triggering the empty-question fallback; backend no longer stubs interactive tools and the frontend renders a compact "answered" state.

## Tests
New unit tests for board DAG readiness/scheduler, outcome classification, digest truncation, sqlite board round-trip, conversation projection keeping interactive tools full, and GLM-5.2 pricing/normalization. Full suite green; `cargo fmt` + `tsc --noEmit` clean.

## Deploy status
All verified on **dev**. **Not yet deployed to prod** — held while mission `832725c5` is actively running (a restart would interrupt a live worker). The live-routing edits + `zai/glm-5.2` passthrough already work on prod without a deploy; the catalog/`configured_ids`/spark-live-models/board-projection pieces need the new prod binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core control-loop orchestration (parallel worker spawning, capacity, settle/retry) and mission store schema; misbehavior could affect live missions, though APIs are additive and clients hide when the board is absent.
> 
> **Overview**
> Introduces a **server-owned task board** so boss missions register a worker DAG once and the control loop handles scheduling, retries, digests, and boss notifications—replacing boss-driven wait/spawn loops. New `board_tasks` persistence (SQLite + in-memory), `api::control::board` scheduler hooked into the actor tick (~3s), REST endpoints for board read/upsert/verdict/cancel, and outcome classification fixes (harness error banners, empty output). **Dashboard** and **iOS** add polled task-board UI (status, deps, cancel/accept, worker navigation); iOS worker pill/sheet now emphasize **active** workers over cumulative totals.
> 
> **Model routing / providers:** `configured_ids` on list providers; chain editor labels unconnected providers; collapsible searchable **Supported Models** catalog via `/api/providers/catalog`; live `/v1/models` for custom routers; periodic + manual catalog refresh; GLM-5.2 in defaults.
> 
> **UI:** Conversation history no longer stubs interactive `question` tools—answered lazy stubs render a compact “answered” state instead of a false “reply below” prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71b32941257e9792b0dc5fd4c11960f893f1fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->