### PR TITLE
fix(dashboard): truncate worker-strip chip titles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,30 @@ STALE_MISSION_HOURS=24
 MAX_PARALLEL_MISSIONS=1
 
 # =============================================================================
+# Mission resource isolation (cgroups)
+# =============================================================================
+# Each mission's container/exec runs in a transient systemd scope under
+# `missions.slice`, separate from the API service (system.slice). These caps
+# stop one mission's runaway build (e.g. a Lean/proof fan-out) from starving
+# the host, the API, or the harness's own response streaming.
+#
+# Unset (default) = no scope wrapping (Docker installs without systemd PID 1,
+# dev hosts). Set per-workspace via the Resources panel without restarting.
+#
+# Memory (systemd MemoryMax/High/SwapMax syntax: bytes, K/M/G/T, %, infinity):
+# MISSION_MEMORY_MAX=24G
+# MISSION_MEMORY_HIGH=20G
+# MISSION_MEMORY_SWAP_MAX=0
+#
+# CPU. CPUWeight is the relative share under contention (1..=10000, default
+# 100); keep it LOW so missions yield to the API tier. CPUQuota is a hard
+# ceiling per mission ("400%" = 4 cores) so a single mission can't take the box.
+# NOTE: the cross-tier guarantee lives in a `missions.slice` drop-in
+# (CPUWeight lower than system.slice + an aggregate CPUQuota) — see DEBUGGING.md.
+# MISSION_CPU_WEIGHT=40
+# MISSION_CPU_QUOTA=400%
+
+# =============================================================================
 # Auth (JWT)
 # =============================================================================
 # Set DEV_MODE=false in production

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -511,3 +511,71 @@ curl -sS "https://agent-backend-dev.thomas.md/api/control/progress" \
 curl -sS "https://agent-backend-dev.thomas.md/api/control/diagnostics/opencode" \
   -H "Authorization: Bearer <token>" | jq
 ```
+
+## Resource Isolation & Host Overload (cgroups: memory + CPU)
+
+Symptom: the whole server feels overloaded, dashboards lag, and harnesses can
+barely stream — usually while a mission runs a heavy fan-out (Lean/proof or
+contract builds). Diagnose **what kind** of pressure it is before touching
+anything:
+
+```bash
+uptime; nproc                       # load average vs core count
+free -h                             # is memory/swap the problem?
+cat /proc/pressure/cpu              # `some avg10` high + load > nproc => CPU-bound
+cat /proc/pressure/memory /proc/pressure/io
+ps -eo pid,pcpu,ni,comm --sort=-pcpu | head -20
+```
+
+If it's **CPU**, confirm the cgroup tiering is actually in effect:
+
+```bash
+# All three should NOT be equal — missions.slice must be < system.slice.
+for s in missions.slice system.slice user.slice; do
+  echo -n "$s cpu.weight="; cat /sys/fs/cgroup/$s/cpu.weight 2>/dev/null
+done
+systemctl show sandboxed-sh-prod -p CPUWeight -p Slice   # API tier weight
+systemctl show missions.slice -p CPUWeight -p CPUQuotaPerSecUSec
+# Is the cpu controller delegated into the slice? (must contain `cpu`)
+cat /sys/fs/cgroup/missions.slice/cgroup.subtree_control
+# Which cgroup is a harness actually in? (claude/codex/opencode)
+cat /proc/$(pgrep -n claude)/cgroup
+```
+
+Gotcha seen on prod 2026-06-15: every slice sat at the default `cpu.weight=100`
+with `CPUQuota=infinity`, the `cpu` controller was **not** delegated into
+`missions.slice` (`subtree_control = memory pids`), and the harness CLIs live
+*inside* `missions.slice` next to the build hogs. Boosting only the API service
+(`CPUWeight=10000`) didn't help because the bottleneck was the harness, not the
+API. A single mission running ~21 parallel `harness.cli run-task` jobs
+oversubscribed all 8 cores.
+
+### Fix — aggregate slice guard (persistent drop-in)
+
+```bash
+mkdir -p /etc/systemd/system/missions.slice.d
+cat > /etc/systemd/system/missions.slice.d/cpu.conf <<'EOF'
+[Slice]
+# Missions yield CPU to the API tier (system.slice = 100) under contention,
+# and can never take more than ~6.5 of 8 cores in aggregate.
+CPUWeight=30
+CPUQuota=650%
+EOF
+systemctl daemon-reload
+# Apply to the already-running slice immediately (runtime, also covered by the
+# drop-in on next boot):
+systemctl set-property missions.slice CPUWeight=30 CPUQuota=650%
+```
+
+Tune `CPUQuota` to `(cores - ~1.5) * 100%`. A runtime-only `set-property`
+without the drop-in is lost on restart — always write the drop-in too.
+
+### Fix — per-mission guard (code, env-driven)
+
+Set `MISSION_CPU_WEIGHT` (low, e.g. 40) and `MISSION_CPU_QUOTA` (e.g. `400%`) in
+the prod env file so each new mission scope is capped; existing missions can be
+retuned live from the dashboard **Resources** panel (or
+`POST /api/workspaces/:id/resources` with `cpu_weight`/`cpu_quota`). Setting any
+CPU property is also what makes systemd delegate the `cpu` controller into
+`missions.slice` — without it, a per-scope `CPUQuota` is silently unenforced.
+See the "Resource isolation" section in `CLAUDE.md` for the architecture.

--- a/agents.md
+++ b/agents.md
@@ -136,6 +136,42 @@ The UI receives:
 
 This preserves the UI experience while keeping execution isolated per workspace.
 
+## Resource isolation (cgroups: memory + CPU)
+
+Mission work is CPU/RAM-heavy and bursty (a single mission can spawn dozens of
+parallel Lean/proof or contract builds). To keep one mission from starving the
+host, the API service, or even its own harness's response streaming, every
+mission container/exec runs in a **transient systemd scope** under
+`missions.slice` — a cgroup *sibling* of the API service (`system.slice`), not a
+child. Two tiers of caps apply:
+
+- **Aggregate (slice level, ops-owned).** `missions.slice` carries a drop-in
+  with a `CPUWeight` **lower** than `system.slice` (so missions yield CPU to the
+  API tier under contention) plus an aggregate `MemoryHigh`/`MemoryMax` and an
+  optional `CPUQuota` ceiling. This is the guarantee that the API → SSE → UI
+  path stays responsive no matter how hot the missions get. The API service
+  itself runs at a high `CPUWeight` within `system.slice`.
+- **Per-mission (scope level, code-owned).** `MissionResourceCaps`
+  (`workspace_exec.rs`) emits `MemoryMax/High/SwapMax` and `CPUWeight/CPUQuota`
+  on each scope via `systemd-run --property`. Sourced from env with a
+  per-workspace override: `MISSION_MEMORY_{MAX,HIGH,SWAP_MAX}` and
+  `MISSION_CPU_{WEIGHT,QUOTA}` (see `.env.example`). The Resources panel
+  (`POST /api/workspaces/:id/resources`) retunes running scopes live via
+  `systemctl set-property --runtime` and persists the override.
+
+Gotchas:
+- **The harness CLI and the build it spawns share one scope** (the Bash tool's
+  child), so cgroups can't separate harness from build *within* a mission — the
+  per-mission `CPUQuota` (capping the mission) and the slice tiering (capping
+  missions vs the API) are the real levers, not per-process priority.
+- **Emitting a CPU property is what delegates the `cpu` controller into
+  `missions.slice`.** Without any CPU property, `missions.slice`
+  `cgroup.subtree_control` lacks `cpu` and a per-scope `CPUQuota` is silently
+  unenforced. Only memory caps had been shipped, so on prod every slice sat at
+  the default `cpu.weight=100` and Lean fan-outs oversubscribed all cores.
+- Unset env (default) = no scope wrapping at all, so Docker installs without
+  systemd PID 1 stay on the direct path.
+
 ## Operational notes
 
 - **No central OpenCode server needed**: Missions spawn per-workspace CLI

--- a/dashboard/src/app/control/components/ThinkingPanel.tsx
+++ b/dashboard/src/app/control/components/ThinkingPanel.tsx
@@ -5,7 +5,14 @@
 // Extracted mechanically from control-client.tsx.
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Brain, ChevronDown, ChevronUp, X } from "lucide-react";
+import {
+  ArrowDown,
+  Brain,
+  ChevronDown,
+  ChevronUp,
+  PenLine,
+  X,
+} from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { StreamingMarkdown } from "@/components/streaming-markdown";
 import { cn } from "@/lib/utils";
@@ -17,11 +24,19 @@ export function ThinkingGroupItem({
   basePath,
   workspaceId,
   missionId,
+  defaultExpanded = false,
 }: {
   items: SidePanelItem[];
   basePath?: string;
   workspaceId?: string;
   missionId?: string;
+  /**
+   * When true (this is the last row in the transcript), the pill opens by
+   * default so the live thought/draft is readable without a click. Once a
+   * newer row arrives this flips back to false and — absent a manual
+   * override — the group auto-collapses, keeping only the current tail open.
+   */
+  defaultExpanded?: boolean;
 }) {
   // Filter out empty items for display
   const nonEmptyItems = useMemo(
@@ -30,11 +45,11 @@ export function ThinkingGroupItem({
   );
 
   const hasActiveItem = items.some((item) => !item.done);
-  // Collapsed by default, including while active: the transcript shows one
-  // compact pill ("Thinking for 12s") that matches the tool-call rows'
-  // height, instead of auto-expanding into a tall content card. Live
-  // reasoning is one click away here or in the Thinking side panel.
-  const [expanded, setExpanded] = useState(false);
+  // Expansion tracks `defaultExpanded` (the last transcript row opens; older
+  // rows stay compact) until the user clicks, after which their explicit
+  // choice sticks. `null` = follow the default.
+  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
+  const expanded = manualExpanded ?? defaultExpanded;
 
   // Get the earliest start time and latest end time
   const startTime = Math.min(...items.map((item) => item.startTime));
@@ -77,11 +92,18 @@ export function ThinkingGroupItem({
     return "Thinking";
   })();
 
+  // Streaming the final response (kind "stream") is not reasoning — give it a
+  // writing glyph so the brain icon stays reserved for actual thoughts.
+  const isStreamView = hasActiveItem
+    ? activeLabel === "Streaming"
+    : label === "Draft" || label === "Drafts";
+  const HeaderIcon = isStreamView ? PenLine : Brain;
+
   return (
     <div className="my-2">
       {/* Compact header */}
       <button
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setManualExpanded(!expanded)}
         className={cn(
           "flex items-center gap-1.5 px-2.5 py-1 rounded-full",
           "bg-white/[0.04] border border-white/[0.06]",
@@ -89,7 +111,7 @@ export function ThinkingGroupItem({
           "transition-all duration-200",
         )}
       >
-        <Brain
+        <HeaderIcon
           className={cn(
             "h-3 w-3",
             hasActiveItem && "animate-pulse text-indigo-400",
@@ -181,6 +203,7 @@ const ThinkingPanelItem = memo(function ThinkingPanelItem({
 
   const activeLabel = item.kind === "stream" ? "Streaming" : "Thinking";
   const pastLabel = item.kind === "stream" ? "Draft" : "Thought";
+  const ItemIcon = item.kind === "stream" ? PenLine : Brain;
 
   // For completed items, check if content is long enough to collapse
   const isLongContent =
@@ -203,7 +226,7 @@ const ThinkingPanelItem = memo(function ThinkingPanelItem({
       )}
     >
       <div className="flex items-center gap-2 mb-2">
-        <Brain
+        <ItemIcon
           className={cn(
             "h-3.5 w-3.5 shrink-0",
             isActive ? "animate-pulse text-indigo-400" : "text-white/40",
@@ -312,6 +335,9 @@ export const ThinkingPanel = memo(function ThinkingPanel({
   const activeItems = useMemo(() => items.filter((t) => !t.done), [items]);
   const hasActiveThinking = activeItems.some((i) => i.kind === "thinking");
   const hasActiveStream = activeItems.some((i) => i.kind === "stream");
+  // Brain for thinking; pen when the only thing in flight is a streamed reply.
+  const PanelHeaderIcon =
+    hasActiveStream && !hasActiveThinking ? PenLine : Brain;
 
   // Performance: limit visible thoughts, load more on demand
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -359,6 +385,7 @@ export const ThinkingPanel = memo(function ThinkingPanel({
   const {
     isAtBottom: isThoughtsAtBottom,
     scrollToBottom: scrollThoughtsToBottom,
+    registerContent: registerThoughtsContent,
   } = useVirtualTimelineAnchor({
     scrollElementRef: scrollRef,
     virtualizer: thoughtsVirtualizer,
@@ -403,7 +430,7 @@ export const ThinkingPanel = memo(function ThinkingPanel({
       {/* Header */}
       <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
         <div className="flex items-center gap-2">
-          <Brain
+          <PanelHeaderIcon
             className={cn(
               "h-4 w-4",
               activeItems.length > 0
@@ -447,6 +474,7 @@ export const ThinkingPanel = memo(function ThinkingPanel({
         ) : (
           <>
             <div
+              ref={registerThoughtsContent}
               className="relative w-full"
               style={{
                 height: `${thoughtsVirtualizer.getTotalSize()}px`,

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3018,6 +3018,7 @@ const ChatItemRow = memo(function ChatItemRow({
         workspaceId={workspaceId}
         missionId={missionId}
         onLoadDetails={onLoadToolDetails}
+        defaultExpanded={isLast}
       />
     );
   }

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -2124,14 +2124,19 @@ const ToolCallItem = memo(function ToolCallItem({
   workspaceId,
   missionId,
   onLoadDetails,
+  defaultExpanded = false,
 }: {
   item: Extract<ChatItem, { kind: "tool" }>;
   highlighted?: boolean;
   workspaceId?: string;
   missionId?: string;
   onLoadDetails?: (toolCallId: string) => Promise<void>;
+  /** Last transcript row opens by default; collapses again once superseded. */
+  defaultExpanded?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  // `null` follows `defaultExpanded`; a click pins the user's explicit choice.
+  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
+  const expanded = manualExpanded ?? defaultExpanded;
   const isLazy = item.lazy === true;
   const isDone = !isLazy && item.result !== undefined;
 
@@ -2157,7 +2162,7 @@ const ToolCallItem = memo(function ToolCallItem({
   const [resultExpanded, setResultExpanded] = useState(false);
   const handleToggleExpanded = useCallback(() => {
     const nextExpanded = !expanded;
-    setExpanded(nextExpanded);
+    setManualExpanded(nextExpanded);
     if (nextExpanded && isLazy && !item.loading) {
       void onLoadDetails?.(item.toolCallId);
     }
@@ -2434,6 +2439,7 @@ function CollapsedToolGroup({
   workspaceId,
   missionId,
   onLoadToolDetails,
+  isLast = false,
 }: {
   tools: Extract<ChatItem, { kind: "tool" }>[];
   isExpanded: boolean;
@@ -2445,6 +2451,10 @@ function CollapsedToolGroup({
   workspaceId?: string;
   missionId?: string;
   onLoadToolDetails?: (toolCallId: string) => Promise<void>;
+  /** True when this group is the last transcript row: its newest (always
+      shown) tool then opens by default. The hidden "previous" tools stay
+      collapsed regardless. */
+  isLast?: boolean;
 }) {
   const hiddenCount = tools.length - 1;
   const lastTool = tools[tools.length - 1];
@@ -2489,8 +2499,12 @@ function CollapsedToolGroup({
     return () => cancelAnimationFrame(raf);
   }, [isExpanded, measureRow]);
 
-  // Helper to render appropriate tool component
-  const renderTool = (tool: Extract<ChatItem, { kind: "tool" }>) => {
+  // Helper to render appropriate tool component. `isLastTool` only applies to
+  // the newest tool of the group when the group itself is the transcript tail.
+  const renderTool = (
+    tool: Extract<ChatItem, { kind: "tool" }>,
+    isLastTool = false,
+  ) => {
     if (isSubagentTool(tool.name)) {
       return <SubagentToolItem key={tool.id} item={tool} />;
     }
@@ -2501,6 +2515,7 @@ function CollapsedToolGroup({
         workspaceId={workspaceId}
         missionId={missionId}
         onLoadDetails={onLoadToolDetails}
+        defaultExpanded={isLastTool}
       />
     );
   };
@@ -2530,7 +2545,7 @@ function CollapsedToolGroup({
             Hide {hiddenCount} previous tool{hiddenCount > 1 ? "s" : ""}
           </span>
         </button>
-        {renderTool(lastTool)}
+        {renderTool(lastTool, isLast)}
       </div>
     );
   }
@@ -2553,7 +2568,7 @@ function CollapsedToolGroup({
           Show {hiddenCount} previous tool{hiddenCount > 1 ? "s" : ""}
         </span>
       </button>
-      {renderTool(lastTool)}
+      {renderTool(lastTool, isLast)}
     </div>
   );
 }
@@ -2564,6 +2579,8 @@ type ChatItemRowProps = {
   workspaceId: string | undefined;
   missionId: string | undefined;
   basePath: string | undefined;
+  /** This row is the transcript tail: its collapsible content opens by default. */
+  isLast: boolean;
   isToolGroupExpanded: boolean;
   onToggleToolGroup: (groupId: string) => void;
   measureRow?: (el: HTMLElement) => void;
@@ -2595,6 +2612,7 @@ const ChatItemRow = memo(function ChatItemRow({
   workspaceId,
   missionId,
   basePath,
+  isLast,
   isToolGroupExpanded,
   onToggleToolGroup,
   measureRow,
@@ -2632,6 +2650,7 @@ const ChatItemRow = memo(function ChatItemRow({
           workspaceId={workspaceId}
           missionId={missionId}
           onLoadToolDetails={onLoadToolDetails}
+          isLast={isLast}
         />
       </div>
     );
@@ -2838,6 +2857,7 @@ const ChatItemRow = memo(function ChatItemRow({
         basePath={basePath}
         workspaceId={workspaceId}
         missionId={missionId}
+        defaultExpanded={isLast}
       />
     );
   }
@@ -2849,6 +2869,7 @@ const ChatItemRow = memo(function ChatItemRow({
         basePath={basePath}
         workspaceId={workspaceId}
         missionId={missionId}
+        defaultExpanded={isLast}
       />
     );
   }
@@ -2975,6 +2996,7 @@ const ChatItemRow = memo(function ChatItemRow({
           workspaceId={workspaceId}
           missionId={missionId}
           onLoadDetails={onLoadToolDetails}
+          defaultExpanded={isLast}
         />
       );
     }
@@ -3883,7 +3905,11 @@ export default function ControlClient() {
         .join("|"),
     [groupedItems],
   );
-  const { isAtBottom, scrollToBottom } = useVirtualTimelineAnchor({
+  const {
+    isAtBottom,
+    scrollToBottom,
+    registerContent: registerChatContent,
+  } = useVirtualTimelineAnchor({
     scrollElementRef: containerRef,
     virtualizer: chatVirtualizer,
     itemCount: groupedItems.length,
@@ -9886,6 +9912,7 @@ export default function ControlClient() {
               ) : (
                 <div className="@container mx-auto max-w-3xl space-y-6">
                   <div
+                    ref={registerChatContent}
                     className="relative w-full"
                     style={{ height: `${chatVirtualizer.getTotalSize()}px` }}
                   >
@@ -9893,6 +9920,8 @@ export default function ControlClient() {
                       const item = groupedItems[virtualRow.index];
                       if (!item) return null;
                       const key = getGroupedItemKey(item);
+                      const isLast =
+                        virtualRow.index === groupedItems.length - 1;
                       const isToolGroupExpanded =
                         item.kind === "tool_group"
                           ? expandedToolGroups.has(item.groupId)
@@ -9913,6 +9942,7 @@ export default function ControlClient() {
                             workspaceId={missionForDownloads?.workspace_id}
                             missionId={missionForDownloads?.id}
                             basePath={missionWorkingDirectory}
+                            isLast={isLast}
                             isToolGroupExpanded={isToolGroupExpanded}
                             onToggleToolGroup={handleToggleToolGroup}
                             measureRow={measureRowSync}

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -375,15 +375,21 @@ function removeOutboxEntry(missionId: string, id: string): void {
   writeOutbox(map);
 }
 
-function formatMissionDocumentTitle(mission: Mission | null | undefined) {
-  if (!mission) return DEFAULT_DOCUMENT_TITLE;
+function formatMissionDocumentTitle(
+  mission: Mission | null | undefined,
+  awaitingUser = false,
+) {
+  // Prefix mirrors the favicon's "needs answer" badge so a backgrounded tab
+  // reads as needing input from the tab list alone.
+  const prefix = awaitingUser ? "● " : "";
+  if (!mission) return `${prefix}${DEFAULT_DOCUMENT_TITLE}`;
   const title = getMissionTitle(mission, {
     maxLength: MAX_DOCUMENT_MISSION_TITLE_LENGTH,
     fallback: getMissionShortName(mission.id),
   }).trim();
   return title
-    ? `${title} | ${DEFAULT_DOCUMENT_TITLE}`
-    : DEFAULT_DOCUMENT_TITLE;
+    ? `${prefix}${title} | ${DEFAULT_DOCUMENT_TITLE}`
+    : `${prefix}${DEFAULT_DOCUMENT_TITLE}`;
 }
 
 function readLegacyControlDraft(): string {
@@ -8998,15 +9004,15 @@ export default function ControlClient() {
     };
   }, [showMissionMenu]);
 
-  // Update favicon with mission status dot
-  useFaviconStatus(faviconStatus, viewingMissionIsRunning);
+  // Update favicon with mission status dot + a "needs answer" attention badge.
+  useFaviconStatus(faviconStatus, viewingMissionIsRunning, hasPendingUserInput);
 
   useEffect(() => {
-    document.title = formatMissionDocumentTitle(activeMission);
+    document.title = formatMissionDocumentTitle(activeMission, hasPendingUserInput);
     return () => {
       document.title = DEFAULT_DOCUMENT_TITLE;
     };
-  }, [activeMission]);
+  }, [activeMission, hasPendingUserInput]);
 
   // Derive the last resolved model from assistant messages (for the debug dropdown)
   const lastResolvedModel = useMemo(() => {

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -57,6 +57,7 @@ const providerConfig: Record<string, { color: string; icon: string }> = {
   'together-ai': { color: 'bg-orange-500/10 text-orange-400', icon: '🤝' },
   perplexity: { color: 'bg-cyan-500/10 text-cyan-400', icon: '🔍' },
   cohere: { color: 'bg-rose-500/10 text-rose-400', icon: '💬' },
+  kimi: { color: 'bg-violet-500/10 text-violet-400', icon: '🌙' },
   custom: { color: 'bg-white/10 text-white/60', icon: '🔧' },
 };
 
@@ -75,6 +76,7 @@ const defaultProviderTypes: AIProviderTypeInfo[] = [
   { id: 'zai', name: 'Z.AI', uses_oauth: false, env_var: 'ZHIPU_API_KEY' },
   { id: 'minimax', name: 'Minimax', uses_oauth: false, env_var: 'MINIMAX_API_KEY' },
   { id: 'github-copilot', name: 'GitHub Copilot', uses_oauth: true, env_var: null },
+  { id: 'kimi', name: 'Kimi', uses_oauth: true, env_var: null },
 ];
 
 /** Format a number with commas */

--- a/dashboard/src/components/ui/add-provider-modal.tsx
+++ b/dashboard/src/components/ui/add-provider-modal.tsx
@@ -28,6 +28,7 @@ const providerIcons: Record<string, string> = {
   zai: '⚡',
   xai: '𝕏',
   minimax: 'M',
+  kimi: '🌙',
   custom: '🔧',
 };
 
@@ -75,6 +76,15 @@ const getProviderAuthMethods = (providerType: AIProviderType): AIProviderAuthMet
         description: 'Use your grok.com account through Grok Build',
       },
       { label: 'Enter API Key', type: 'api', description: 'Use an existing xAI API key' },
+    ];
+  }
+  if (providerType === 'kimi') {
+    return [
+      {
+        label: 'Kimi Code (Device OAuth)',
+        type: 'oauth',
+        description: 'Authorize your Kimi Code subscription via device-code login',
+      },
     ];
   }
   return [];
@@ -144,6 +154,33 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [handleClose, open, loading]);
+
+  // Auto-poll the Kimi device-code flow so the user doesn't have to keep
+  // clicking Connect: the backend returns "not connected yet" until the
+  // browser authorization completes, at which point this resolves.
+  useEffect(() => {
+    if (step !== 'oauth-callback') return;
+    if (oauthResponse?.method !== 'auto') return;
+    if (selectedProvider !== 'kimi' || selectedMethodIndex === null) return;
+    let cancelled = false;
+    const interval = setInterval(async () => {
+      if (cancelled || loading) return;
+      try {
+        await oauthCallback(selectedProvider, selectedMethodIndex, '');
+        if (cancelled) return;
+        clearInterval(interval);
+        toast.success('Provider connected');
+        onSuccess();
+        onClose();
+      } catch {
+        // Still pending — keep polling until the user finishes in the browser.
+      }
+    }, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [step, oauthResponse, selectedProvider, selectedMethodIndex, loading, onSuccess, onClose]);
 
   // Handle click outside
   useEffect(() => {
@@ -753,6 +790,12 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
                   {loading ? <Loader className="h-4 w-4 animate-spin mx-auto" /> : 'Connect'}
                 </button>
               </div>
+              {oauthResponse.method === 'auto' && selectedProvider === 'kimi' && (
+                <div className="flex items-center gap-2 text-xs text-white/40">
+                  <Loader className="h-3 w-3 animate-spin" />
+                  Waiting for authorization in your browser…
+                </div>
+              )}
             </div>
           )}
 

--- a/dashboard/src/components/workers-strip.tsx
+++ b/dashboard/src/components/workers-strip.tsx
@@ -273,9 +273,11 @@ export const WorkersStrip = memo(function WorkersStrip({
             style={{ width: `${pct}%` }}
           />
         )}
-        <span className="relative z-10 flex items-center gap-1.5">
+        <span className="relative z-10 flex min-w-0 items-center gap-1.5">
           {status.indicator}
-          <span className="truncate font-medium text-foreground/85">{title}</span>
+          <span className="min-w-0 truncate font-medium text-foreground/85">
+            {title}
+          </span>
           {status.activity && status.isActive && (
             <span className="hidden truncate text-white/40 lg:inline max-w-[120px]">
               {status.activity}
@@ -336,7 +338,7 @@ export const WorkersStrip = memo(function WorkersStrip({
           >
             <ArrowLeft className="h-3 w-3 shrink-0" />
             <Crown className="h-3 w-3 shrink-0" />
-            <span className="truncate">{parentTitle}</span>
+            <span className="min-w-0 truncate">{parentTitle}</span>
           </button>
           {total > 0 && (
             <span aria-hidden className="shrink-0 h-3.5 w-px bg-white/10" />

--- a/dashboard/src/components/workspace-resources.tsx
+++ b/dashboard/src/components/workspace-resources.tsx
@@ -6,7 +6,10 @@
  * Shows the aggregated memory consumption of the workspace's transient
  * mission scopes (boot + exec) and lets the operator retune the caps:
  * applied live to running scopes via `systemctl set-property --runtime`
- * and persisted as workspace env overrides (MISSION_MEMORY_*).
+ * and persisted as workspace env overrides (MISSION_MEMORY_* / MISSION_CPU_*).
+ *
+ * CPU caps keep one mission's runaway build (e.g. a Lean/proof fan-out) from
+ * saturating every core and starving the harness's own response streaming.
  */
 
 import { useState } from 'react';
@@ -26,6 +29,8 @@ function formatBytes(bytes: number | null): string {
 }
 
 const MEM_VALUE_RE = /^(\d+(\.\d+)?[KMGTkmgt]?|\d+(\.\d+)?%|infinity)?$/;
+const CPU_WEIGHT_RE = /^(\d{1,5}|idle)?$/;
+const CPU_QUOTA_RE = /^(\d+(\.\d+)?%|infinity)?$/;
 
 export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
   const { data: stats, mutate } = useSWR(
@@ -36,6 +41,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
 
   const [memoryHigh, setMemoryHigh] = useState('');
   const [memoryMax, setMemoryMax] = useState('');
+  const [cpuWeight, setCpuWeight] = useState('');
+  const [cpuQuota, setCpuQuota] = useState('');
   const [applying, setApplying] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -48,8 +55,15 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
       : null;
 
   const inputsValid =
-    MEM_VALUE_RE.test(memoryHigh.trim()) && MEM_VALUE_RE.test(memoryMax.trim());
-  const hasInput = memoryHigh.trim() !== '' || memoryMax.trim() !== '';
+    MEM_VALUE_RE.test(memoryHigh.trim()) &&
+    MEM_VALUE_RE.test(memoryMax.trim()) &&
+    CPU_WEIGHT_RE.test(cpuWeight.trim()) &&
+    CPU_QUOTA_RE.test(cpuQuota.trim());
+  const hasInput =
+    memoryHigh.trim() !== '' ||
+    memoryMax.trim() !== '' ||
+    cpuWeight.trim() !== '' ||
+    cpuQuota.trim() !== '';
 
   const apply = async () => {
     if (!hasInput || !inputsValid) return;
@@ -60,6 +74,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
       const res = await updateWorkspaceResources(workspaceId, {
         ...(memoryHigh.trim() !== '' ? { memory_high: memoryHigh.trim() } : {}),
         ...(memoryMax.trim() !== '' ? { memory_max: memoryMax.trim() } : {}),
+        ...(cpuWeight.trim() !== '' ? { cpu_weight: cpuWeight.trim() } : {}),
+        ...(cpuQuota.trim() !== '' ? { cpu_quota: cpuQuota.trim() } : {}),
         persist: true,
         apply_live: true,
       });
@@ -80,6 +96,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
       }
       setMemoryHigh('');
       setMemoryMax('');
+      setCpuWeight('');
+      setCpuQuota('');
       mutate();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to update resources');
@@ -99,6 +117,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
       const res = await updateWorkspaceResources(workspaceId, {
         memory_high: '',
         memory_max: '',
+        cpu_weight: '',
+        cpu_quota: '',
         persist: true,
         apply_live: true,
       });
@@ -119,6 +139,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
       }
       setMemoryHigh('');
       setMemoryMax('');
+      setCpuWeight('');
+      setCpuQuota('');
       mutate();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to reset resources');
@@ -136,8 +158,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
             Resources
           </p>
           <p className="text-[10px] text-white/30 mt-0.5">
-            Memory caps for this workspace&apos;s mission scopes. Changes apply live —
-            no restart needed.
+            Memory + CPU caps for this workspace&apos;s mission scopes. Changes
+            apply live — no restart needed.
           </p>
         </div>
         <span className="text-xs font-mono text-white/70">
@@ -210,6 +232,33 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
         </button>
       </div>
 
+      <div className="mt-2 flex items-end gap-2">
+        <div className="flex-1">
+          <label className="text-[10px] text-white/40 block mb-1">
+            CPUWeight (1–10000)
+          </label>
+          <input
+            type="text"
+            value={cpuWeight}
+            onChange={(e) => setCpuWeight(e.target.value)}
+            placeholder="e.g. 30 (lower = yields)"
+            className="w-full rounded-lg border border-white/[0.06] bg-black/20 px-2.5 py-1.5 text-xs text-white font-mono placeholder:text-white/20 focus:border-indigo-500/50 focus:outline-none"
+          />
+        </div>
+        <div className="flex-1">
+          <label className="text-[10px] text-white/40 block mb-1">
+            CPUQuota (ceiling)
+          </label>
+          <input
+            type="text"
+            value={cpuQuota}
+            onChange={(e) => setCpuQuota(e.target.value)}
+            placeholder="e.g. 400% (= 4 cores)"
+            className="w-full rounded-lg border border-white/[0.06] bg-black/20 px-2.5 py-1.5 text-xs text-white font-mono placeholder:text-white/20 focus:border-indigo-500/50 focus:outline-none"
+          />
+        </div>
+      </div>
+
       <button
         onClick={resetDefaults}
         disabled={applying}
@@ -220,7 +269,8 @@ export function WorkspaceResources({ workspaceId }: { workspaceId: string }) {
 
       {!inputsValid && hasInput && (
         <p className="text-[10px] text-red-300/80 mt-1.5">
-          Values: bytes with K/M/G/T suffix, %, or &quot;infinity&quot;.
+          Memory: bytes with K/M/G/T suffix, %, or &quot;infinity&quot;. CPUWeight:
+          1–10000 or &quot;idle&quot;. CPUQuota: a percentage like &quot;400%&quot;.
         </p>
       )}
       {result && <p className="text-[10px] text-emerald-300/80 mt-1.5">{result}</p>}

--- a/dashboard/src/hooks/use-favicon-status.ts
+++ b/dashboard/src/hooks/use-favicon-status.ts
@@ -21,10 +21,20 @@ const STATUS_COLORS: Record<MissionStatus, string> = {
   not_feasible: "#f87171", // red-400
 };
 
-/** Dot radius & position (on a 64×64 canvas). */
+/** Status dot radius & position (bottom-right, on a 64×64 canvas). */
 const DOT_RADIUS = 10;
 const DOT_X = 52;
 const DOT_Y = 52;
+
+/**
+ * Attention badge (top-right): drawn only while a mission is waiting for the
+ * user to answer a prompt. Bigger than the status dot and in a distinct
+ * corner so a pending question is unmistakable even in a background tab.
+ */
+const ATTENTION_RADIUS = 12;
+const ATTENTION_X = 52;
+const ATTENTION_Y = 12;
+const ATTENTION_COLOR = "#f472b6"; // pink-400, the "needs user" hue
 
 /** Always use the SVG source as the base image for canvas drawing. */
 const BASE_FAVICON = "/favicon.svg";
@@ -39,7 +49,11 @@ const DATA_ATTR = "data-favicon-status";
  * remove framework-managed head nodes: React tracks those as hoistable
  * resources and expects to own their lifecycle during route updates.
  */
-export function useFaviconStatus(status: MissionStatus | null, isRunning: boolean) {
+export function useFaviconStatus(
+  status: MissionStatus | null,
+  isRunning: boolean,
+  awaitingUser = false,
+) {
   const cachedImg = useRef<HTMLImageElement | null>(null);
   const originalLinks = useRef(new Map<HTMLLinkElement, { href: string; type: string | null }>());
 
@@ -88,6 +102,19 @@ export function useFaviconStatus(status: MissionStatus | null, isRunning: boolea
       ctx.arc(DOT_X, DOT_Y, DOT_RADIUS, 0, Math.PI * 2);
       ctx.fillStyle = color;
       ctx.fill();
+
+      // Attention badge (top-right) when the agent is paused on a question.
+      if (awaitingUser) {
+        ctx.beginPath();
+        ctx.arc(ATTENTION_X, ATTENTION_Y, ATTENTION_RADIUS + 2, 0, Math.PI * 2);
+        ctx.fillStyle = "#121214";
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(ATTENTION_X, ATTENTION_Y, ATTENTION_RADIUS, 0, Math.PI * 2);
+        ctx.fillStyle = ATTENTION_COLOR;
+        ctx.fill();
+      }
 
       const dataUrl = canvas.toDataURL("image/png");
 
@@ -151,7 +178,7 @@ export function useFaviconStatus(status: MissionStatus | null, isRunning: boolea
       document.removeEventListener("visibilitychange", onVisibility);
       observer.disconnect();
     };
-  }, [status, isRunning]);
+  }, [status, isRunning, awaitingUser]);
 
   // Cleanup on full unmount: restore originals, remove managed link
   useEffect(() => {

--- a/dashboard/src/hooks/use-virtual-timeline-anchor.ts
+++ b/dashboard/src/hooks/use-virtual-timeline-anchor.ts
@@ -30,6 +30,7 @@ export function useVirtualTimelineAnchor<TScrollElement extends HTMLElement>({
   const [isAtBottom, setIsAtBottom] = useState(true);
   const isAtBottomRef = useRef(true);
   const rafRef = useRef<number | null>(null);
+  const contentObserverRef = useRef<ResizeObserver | null>(null);
 
   const cancelPendingScroll = useCallback(() => {
     if (rafRef.current !== null) {
@@ -60,6 +61,38 @@ export function useVirtualTimelineAnchor<TScrollElement extends HTMLElement>({
       });
     },
     [cancelPendingScroll, scrollElementRef, virtualizer],
+  );
+
+  // Callback ref for the virtualizer's sizer element (the tall content div
+  // whose height tracks `getTotalSize()`). A row expanding by default, a tool
+  // result landing in an already-open row, or heavy markdown that only
+  // settles its height after paint all grow this element *without* changing
+  // `changeKey` — so neither the layout-effect correction nor tanstack's
+  // (disabled) size-change compensation re-pins. Observing the sizer catches
+  // every such growth; the `isAtBottomRef` gate means a user who has scrolled
+  // up is never dragged back down.
+  const registerContent = useCallback(
+    (node: HTMLElement | null) => {
+      contentObserverRef.current?.disconnect();
+      contentObserverRef.current = null;
+      if (!node || typeof ResizeObserver === "undefined") return;
+      const observer = new ResizeObserver(() => {
+        if (!isAtBottomRef.current) return;
+        const el = scrollElementRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+      });
+      observer.observe(node);
+      contentObserverRef.current = observer;
+    },
+    [scrollElementRef],
+  );
+
+  useEffect(
+    () => () => {
+      contentObserverRef.current?.disconnect();
+      contentObserverRef.current = null;
+    },
+    [],
   );
 
   const updateAnchorFromScroll = useCallback(() => {
@@ -119,5 +152,6 @@ export function useVirtualTimelineAnchor<TScrollElement extends HTMLElement>({
   return {
     isAtBottom,
     scrollToBottom,
+    registerContent,
   };
 }

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -26,6 +26,7 @@ export type AIProviderType =
   | "zai"
   | "minimax"
   | "github-copilot"
+  | "kimi"
   | "custom";
 
 export interface AIProviderTypeInfo {

--- a/dashboard/src/lib/api/workspaces.ts
+++ b/dashboard/src/lib/api/workspaces.ts
@@ -184,6 +184,10 @@ export interface UpdateWorkspaceResourcesRequest {
   memory_max?: string;
   memory_high?: string;
   memory_swap_max?: string;
+  /** CPUWeight 1..=10000 or "idle"; "" clears the override. */
+  cpu_weight?: string;
+  /** CPUQuota e.g. "400%" (4 cores) or "infinity"; "" clears the override. */
+  cpu_quota?: string;
   /** Persist as a workspace env override (default true). */
   persist?: boolean;
   /** Retune currently-running scopes live (default true). */
@@ -197,6 +201,8 @@ export interface UpdateWorkspaceResourcesResponse {
   memory_max: string | null;
   memory_high: string | null;
   memory_swap_max: string | null;
+  cpu_weight: string | null;
+  cpu_quota: string | null;
 }
 
 export async function updateWorkspaceResources(

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -104,6 +104,7 @@ pub enum ProviderType {
     GithubCopilot,
     Zai,
     Minimax,
+    Kimi,
     Custom,
 }
 
@@ -127,6 +128,7 @@ impl ProviderType {
             Self::GithubCopilot => "GitHub Copilot",
             Self::Zai => "Z.AI",
             Self::Minimax => "Minimax",
+            Self::Kimi => "Kimi",
             Self::Custom => "Custom",
         }
     }
@@ -150,6 +152,7 @@ impl ProviderType {
             Self::GithubCopilot => "github-copilot",
             Self::Zai => "zai",
             Self::Minimax => "minimax",
+            Self::Kimi => "kimi",
             Self::Custom => "custom",
         }
     }
@@ -174,6 +177,7 @@ impl ProviderType {
             "github-copilot" => Some(Self::GithubCopilot),
             "zai" => Some(Self::Zai),
             "minimax" => Some(Self::Minimax),
+            "kimi" => Some(Self::Kimi),
             "custom" => Some(Self::Custom),
             _ => None,
         }
@@ -198,6 +202,7 @@ impl ProviderType {
             Self::GithubCopilot => None, // Uses OAuth
             Self::Zai => Some("ZHIPU_API_KEY"),
             Self::Minimax => Some("MINIMAX_API_KEY"),
+            Self::Kimi => None, // OAuth-only (Kimi Code subscription)
             Self::Custom => None,
         }
     }
@@ -206,7 +211,12 @@ impl ProviderType {
     pub fn uses_oauth(&self) -> bool {
         matches!(
             self,
-            Self::Anthropic | Self::GithubCopilot | Self::OpenAI | Self::Google | Self::Xai
+            Self::Anthropic
+                | Self::GithubCopilot
+                | Self::OpenAI
+                | Self::Google
+                | Self::Xai
+                | Self::Kimi
         )
     }
 
@@ -283,6 +293,13 @@ impl ProviderType {
                     description: Some("Enter an existing xAI API key".to_string()),
                 },
             ],
+            Self::Kimi => vec![AuthMethod {
+                label: "Kimi Code (Device OAuth)".to_string(),
+                method_type: AuthMethodType::Oauth,
+                description: Some(
+                    "Authorize your Kimi Code subscription via device-code login".to_string(),
+                ),
+            }],
             _ => vec![AuthMethod {
                 label: "API Key".to_string(),
                 method_type: AuthMethodType::Api,

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8022,10 +8022,19 @@ fn spawn_kimi_device_poll(key: String, dev: KimiDeviceAuthResponse) {
             600
         };
         let deadline = Instant::now() + Duration::from_secs(expires_in);
+        // Last transient poll error, surfaced only if we never get a definitive
+        // answer before the device code expires (see the `Err` arm below).
+        let mut last_transient_error: Option<String> = None;
 
         loop {
             if Instant::now() >= deadline {
-                set_kimi_device_status(&key, KimiDeviceStatus::Expired);
+                let status = match last_transient_error.take() {
+                    Some(e) => KimiDeviceStatus::Error(format!(
+                        "Kimi device login timed out after repeated polling errors: {e}"
+                    )),
+                    None => KimiDeviceStatus::Expired,
+                };
+                set_kimi_device_status(&key, status);
                 return;
             }
             tokio::time::sleep(Duration::from_secs(interval)).await;
@@ -8064,8 +8073,13 @@ fn spawn_kimi_device_poll(key: String, dev: KimiDeviceAuthResponse) {
                     return;
                 }
                 Err(e) => {
-                    set_kimi_device_status(&key, KimiDeviceStatus::Error(e));
-                    return;
+                    // Transient transport/parse failure — a single network blip
+                    // must not permanently fail the flow. Keep polling until the
+                    // device code expires; the error is only surfaced at the
+                    // deadline if no definitive outcome ever arrives.
+                    tracing::warn!("Kimi device-token poll error (will retry until expiry): {e}");
+                    last_transient_error = Some(e);
+                    continue;
                 }
             }
         }

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -5887,6 +5887,12 @@ async fn list_provider_types() -> Json<Vec<ProviderTypeInfo>> {
             uses_oauth: true,
             env_var: None,
         },
+        ProviderTypeInfo {
+            id: "kimi".to_string(),
+            name: "Kimi".to_string(),
+            uses_oauth: true,
+            env_var: None,
+        },
     ];
     Json(types)
 }
@@ -7823,6 +7829,417 @@ fn parse_openai_authorization_input(input: &str) -> (Option<String>, Option<Stri
 }
 
 /// POST /api/ai/providers/:id/oauth/authorize - Initiate OAuth authorization.
+// ─────────────────────────────────────────────────────────────────────────────
+// Kimi (Moonshot) Code subscription — OAuth 2.0 Device Authorization Grant
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kimi Code OAuth client id (hardcoded, shared with kimi-cli; no registration).
+const KIMI_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
+const KIMI_DEVICE_AUTH_URL: &str = "https://auth.kimi.com/api/oauth/device_authorization";
+const KIMI_TOKEN_URL: &str = "https://auth.kimi.com/api/oauth/token";
+/// Kimi Code coding endpoint (OpenAI Chat Completions compatible).
+pub(crate) const KIMI_API_BASE_URL: &str = "https://api.kimi.com/coding/v1";
+/// The coding endpoint returns 403 unless the User-Agent matches a known
+/// coding-agent pattern, so pin it to the Kimi CLI's UA.
+const KIMI_USER_AGENT: &str = "KimiCLI/1.5";
+const KIMI_DEVICE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+#[derive(Clone)]
+enum KimiDeviceStatus {
+    Pending,
+    Authorized {
+        refresh_token: String,
+        access_token: String,
+        expires_at: i64,
+    },
+    Expired,
+    Error(String),
+}
+
+struct KimiDeviceFlow {
+    status: KimiDeviceStatus,
+    #[allow(dead_code)]
+    created_at: Instant,
+}
+
+/// In-flight Kimi device-authorization flows, keyed by the route path id
+/// ("kimi" for first-time add, or a provider-row UUID for reconnect).
+static KIMI_DEVICE_FLOWS: LazyLock<StdMutex<HashMap<String, KimiDeviceFlow>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+fn set_kimi_device_status(key: &str, status: KimiDeviceStatus) {
+    let mut flows = KIMI_DEVICE_FLOWS.lock().unwrap();
+    if let Some(flow) = flows.get_mut(key) {
+        flow.status = status;
+    }
+}
+
+/// Stable device id for the Kimi `X-Msh-Device-Id` header, persisted under
+/// `~/.sandboxed-sh/kimi_device_id` so it survives restarts.
+fn kimi_device_id() -> String {
+    let path = PathBuf::from(home_dir())
+        .join(".sandboxed-sh")
+        .join("kimi_device_id");
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, &id);
+    id
+}
+
+/// Apply the headers Kimi's auth/token endpoints expect (UA + device metadata).
+fn kimi_device_headers(builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    builder
+        .header("User-Agent", KIMI_USER_AGENT)
+        .header("X-Msh-Platform", "sandboxed-sh")
+        .header("X-Msh-Version", "1.5.0")
+        .header("X-Msh-Device-Name", "sandboxed-sh")
+        .header("X-Msh-Device-Model", "server")
+        .header("X-Msh-Os-Version", std::env::consts::OS)
+        .header("X-Msh-Device-Id", kimi_device_id())
+}
+
+#[derive(Debug, Deserialize)]
+struct KimiDeviceAuthResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    #[serde(default)]
+    verification_uri_complete: Option<String>,
+    #[serde(default = "kimi_default_interval")]
+    interval: u64,
+    #[serde(default)]
+    expires_in: u64,
+}
+
+fn kimi_default_interval() -> u64 {
+    5
+}
+
+enum KimiPollOutcome {
+    Pending,
+    SlowDown,
+    Authorized {
+        refresh_token: String,
+        access_token: String,
+        expires_at: i64,
+    },
+    Denied(String),
+}
+
+async fn kimi_start_device_authorization(
+    client: &reqwest::Client,
+) -> Result<KimiDeviceAuthResponse, String> {
+    let resp = kimi_device_headers(
+        client
+            .post(KIMI_DEVICE_AUTH_URL)
+            .form(&[("client_id", KIMI_CLIENT_ID)]),
+    )
+    .send()
+    .await
+    .map_err(|e| format!("Failed to start Kimi device authorization: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "Kimi device authorization failed ({status}): {text}"
+        ));
+    }
+
+    resp.json::<KimiDeviceAuthResponse>()
+        .await
+        .map_err(|e| format!("Failed to parse Kimi device authorization response: {e}"))
+}
+
+async fn kimi_poll_token_once(
+    client: &reqwest::Client,
+    device_code: &str,
+) -> Result<KimiPollOutcome, String> {
+    let resp = kimi_device_headers(client.post(KIMI_TOKEN_URL).form(&[
+        ("grant_type", KIMI_DEVICE_GRANT),
+        ("client_id", KIMI_CLIENT_ID),
+        ("device_code", device_code),
+    ]))
+    .send()
+    .await
+    .map_err(|e| format!("Failed to poll Kimi token endpoint: {e}"))?;
+
+    let status = resp.status();
+    let data: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Kimi token response: {e}"))?;
+
+    if status.is_success() {
+        let access_token = data
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Kimi token response missing access_token".to_string())?
+            .to_string();
+        let refresh_token = data
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let expires_in = data
+            .get("expires_in")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(3600);
+        let expires_at = chrono::Utc::now().timestamp_millis() + expires_in * 1000;
+        return Ok(KimiPollOutcome::Authorized {
+            refresh_token,
+            access_token,
+            expires_at,
+        });
+    }
+
+    let error = data
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown_error");
+    match error {
+        "authorization_pending" => Ok(KimiPollOutcome::Pending),
+        "slow_down" => Ok(KimiPollOutcome::SlowDown),
+        other => Ok(KimiPollOutcome::Denied(other.to_string())),
+    }
+}
+
+/// Background task: poll the Kimi token endpoint until the user authorizes the
+/// device, then persist the OAuth credentials (auth.json + sandboxed store).
+fn spawn_kimi_device_poll(key: String, dev: KimiDeviceAuthResponse) {
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        let mut interval = dev.interval.max(1);
+        let expires_in = if dev.expires_in > 0 {
+            dev.expires_in
+        } else {
+            600
+        };
+        let deadline = Instant::now() + Duration::from_secs(expires_in);
+
+        loop {
+            if Instant::now() >= deadline {
+                set_kimi_device_status(&key, KimiDeviceStatus::Expired);
+                return;
+            }
+            tokio::time::sleep(Duration::from_secs(interval)).await;
+            match kimi_poll_token_once(&client, &dev.device_code).await {
+                Ok(KimiPollOutcome::Pending) => continue,
+                Ok(KimiPollOutcome::SlowDown) => {
+                    interval += 5;
+                    continue;
+                }
+                Ok(KimiPollOutcome::Authorized {
+                    refresh_token,
+                    access_token,
+                    expires_at,
+                }) => {
+                    if let Err(e) = sync_to_opencode_auth(
+                        ProviderType::Kimi,
+                        &refresh_token,
+                        &access_token,
+                        expires_at,
+                    ) {
+                        set_kimi_device_status(&key, KimiDeviceStatus::Error(e));
+                    } else {
+                        set_kimi_device_status(
+                            &key,
+                            KimiDeviceStatus::Authorized {
+                                refresh_token,
+                                access_token,
+                                expires_at,
+                            },
+                        );
+                    }
+                    return;
+                }
+                Ok(KimiPollOutcome::Denied(msg)) => {
+                    set_kimi_device_status(&key, KimiDeviceStatus::Error(msg));
+                    return;
+                }
+                Err(e) => {
+                    set_kimi_device_status(&key, KimiDeviceStatus::Error(e));
+                    return;
+                }
+            }
+        }
+    });
+}
+
+async fn refresh_kimi_oauth_tokens(
+    client: &reqwest::Client,
+    refresh_token: &str,
+) -> Result<(String, String, i64), OAuthRefreshError> {
+    let resp = kimi_device_headers(client.post(KIMI_TOKEN_URL).form(&[
+        ("grant_type", "refresh_token"),
+        ("client_id", KIMI_CLIENT_ID),
+        ("refresh_token", refresh_token),
+    ]))
+    .send()
+    .await
+    .map_err(|e| OAuthRefreshError::Other(format!("Failed to refresh Kimi token: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if text.contains("invalid_grant") {
+            return Err(OAuthRefreshError::InvalidGrant(format!(
+                "Kimi refresh token expired or revoked ({status}): {text}"
+            )));
+        }
+        return Err(OAuthRefreshError::Other(format!(
+            "Kimi OAuth refresh failed ({status}): {text}"
+        )));
+    }
+
+    let data: serde_json::Value = resp.json().await.map_err(|e| {
+        OAuthRefreshError::Other(format!("Failed to parse Kimi refresh response: {e}"))
+    })?;
+    let access_token = data
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            OAuthRefreshError::Other("No access_token in Kimi refresh response".to_string())
+        })?;
+    let new_refresh = data
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .unwrap_or(refresh_token);
+    let expires_in = data
+        .get("expires_in")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(3600);
+    let expires_at = chrono::Utc::now().timestamp_millis() + expires_in * 1000;
+    Ok((
+        access_token.to_string(),
+        new_refresh.to_string(),
+        expires_at,
+    ))
+}
+
+/// Create or update the stored Kimi provider row from fresh OAuth credentials.
+/// Modeled on [`upsert_grok_oauth_provider`], but Kimi mirrors creds into the
+/// store (so the chain resolver/multi-account UI see them) and pins `base_url`.
+async fn upsert_kimi_oauth_provider(
+    state: &super::routes::AppState,
+    refresh_token: &str,
+    access_token: &str,
+    expires_at: i64,
+    use_for_backends: Option<Vec<String>>,
+    target_id: Option<uuid::Uuid>,
+) -> Result<ProviderResponse, (StatusCode, String)> {
+    let backends =
+        use_for_backends.unwrap_or_else(|| default_backends_for_provider(ProviderType::Kimi));
+    let existing = state.ai_providers.get_all_by_type(ProviderType::Kimi).await;
+    let mut provider = target_id
+        .and_then(|tid| existing.iter().find(|p| p.id == tid).cloned())
+        .or_else(|| existing.iter().find(|p| p.has_oauth()).cloned())
+        .unwrap_or_else(|| {
+            crate::ai_providers::AIProvider::new(
+                ProviderType::Kimi,
+                "Kimi (Subscription)".to_string(),
+            )
+        });
+
+    provider.api_key = None;
+    provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+        refresh_token: refresh_token.to_string(),
+        access_token: access_token.to_string(),
+        expires_at,
+    });
+    provider.base_url = Some(KIMI_API_BASE_URL.to_string());
+    provider.use_for_backends = Some(backends.clone());
+    provider.enabled = true;
+
+    let stored = if state.ai_providers.get(provider.id).await.is_some() {
+        state.ai_providers.update(provider.id, provider).await
+    } else {
+        let id = state.ai_providers.add(provider).await;
+        state.ai_providers.get(id).await
+    }
+    .ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to save Kimi OAuth provider".to_string(),
+        )
+    })?;
+
+    if let Err(e) =
+        update_provider_backends(&state.config.working_dir, ProviderType::Kimi.id(), backends)
+    {
+        tracing::error!("Failed to save Kimi provider backends: {}", e);
+    }
+
+    Ok(build_response_from_store(&stored))
+}
+
+/// Background loop: keep the Kimi OAuth access token fresh. The chain resolver
+/// forwards the access token as a Bearer but does NOT refresh it, so without
+/// this a short-lived Kimi token would be dropped mid-mission.
+pub fn spawn_kimi_oauth_refresh_loop(state: Arc<super::routes::AppState>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(300)).await;
+
+            // Only do work if a Kimi provider exists.
+            if state
+                .ai_providers
+                .get_all_by_type(ProviderType::Kimi)
+                .await
+                .is_empty()
+            {
+                continue;
+            }
+            let Some(entry) = read_oauth_token_entry(ProviderType::Kimi) else {
+                continue;
+            };
+            // Refresh only when within 10 minutes of expiry.
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            if entry.expires_at > now_ms + 600_000 || entry.refresh_token.trim().is_empty() {
+                continue;
+            }
+
+            let client = reqwest::Client::new();
+            match refresh_kimi_oauth_tokens(&client, &entry.refresh_token).await {
+                Ok((access, refresh, expires_at)) => {
+                    if let Err(e) =
+                        sync_to_opencode_auth(ProviderType::Kimi, &refresh, &access, expires_at)
+                    {
+                        tracing::warn!("Failed to persist refreshed Kimi token: {e}");
+                    }
+                    // Update store rows so the chain resolver sees the fresh token.
+                    for mut acct in state.ai_providers.get_all_by_type(ProviderType::Kimi).await {
+                        if acct.oauth.is_some() {
+                            acct.oauth = Some(crate::ai_providers::OAuthCredentials {
+                                refresh_token: refresh.clone(),
+                                access_token: access.clone(),
+                                expires_at,
+                            });
+                            let id = acct.id;
+                            state.ai_providers.update(id, acct).await;
+                        }
+                    }
+                    tracing::info!("Refreshed Kimi OAuth token (expires_at={expires_at})");
+                }
+                Err(OAuthRefreshError::InvalidGrant(msg)) => {
+                    tracing::warn!("Kimi refresh token invalid; user must re-authenticate: {msg}");
+                }
+                Err(e) => {
+                    tracing::debug!("Kimi token refresh failed: {e}");
+                }
+            }
+        }
+    });
+}
+
 async fn oauth_authorize(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
@@ -7986,6 +8403,39 @@ async fn oauth_authorize(
                 method: "auto".to_string(),
             }))
         }
+        ProviderType::Kimi => {
+            let client = reqwest::Client::new();
+            let dev = kimi_start_device_authorization(&client)
+                .await
+                .map_err(internal_error)?;
+            let verify_url = dev
+                .verification_uri_complete
+                .clone()
+                .unwrap_or_else(|| dev.verification_uri.clone());
+            let user_code = dev.user_code.clone();
+
+            // Track the in-flight flow keyed by the path id, then poll in the
+            // background until the user approves in the browser.
+            {
+                let mut flows = KIMI_DEVICE_FLOWS.lock().unwrap();
+                flows.insert(
+                    id.clone(),
+                    KimiDeviceFlow {
+                        status: KimiDeviceStatus::Pending,
+                        created_at: std::time::Instant::now(),
+                    },
+                );
+            }
+            spawn_kimi_device_poll(id.clone(), dev);
+
+            Ok(Json(OAuthAuthorizeResponse {
+                url: verify_url,
+                instructions: format!(
+                    "1. Open the Kimi authorization page.\n2. Confirm code: {user_code}\n3. After approving in the browser, return here and click Connect."
+                ),
+                method: "auto".to_string(),
+            }))
+        }
         _ => Err((
             StatusCode::BAD_REQUEST,
             "OAuth not supported for this provider".to_string(),
@@ -8021,8 +8471,12 @@ async fn oauth_callback(
                 },
             };
 
-            if resolved_type_and_uuid.map(|(pt, _)| pt) == Some(ProviderType::Xai) {
-                // xAI tracks creds in auth.json only; don't mirror to the store.
+            if matches!(
+                resolved_type_and_uuid.map(|(pt, _)| pt),
+                Some(ProviderType::Xai) | Some(ProviderType::Kimi)
+            ) {
+                // xAI/Kimi already upserted the store row inside
+                // oauth_callback_inner; don't double-mirror here.
                 return json.into_response();
             }
 
@@ -8185,6 +8639,56 @@ async fn oauth_callback_inner(
             upsert_grok_oauth_provider(&state, &entry, req.use_for_backends.clone(), target_id)
                 .await?;
         return Ok(Json(response));
+    }
+
+    if provider_type == ProviderType::Kimi {
+        // The background poll task (spawned in oauth_authorize) drives the
+        // device flow; here we just gate on its current status.
+        let status = {
+            let flows = KIMI_DEVICE_FLOWS.lock().unwrap();
+            flows.get(&id).map(|f| f.status.clone())
+        };
+        match status {
+            Some(KimiDeviceStatus::Authorized {
+                refresh_token,
+                access_token,
+                expires_at,
+            }) => {
+                KIMI_DEVICE_FLOWS.lock().unwrap().remove(&id);
+                let target_id = uuid::Uuid::parse_str(&id).ok();
+                let response = upsert_kimi_oauth_provider(
+                    &state,
+                    &refresh_token,
+                    &access_token,
+                    expires_at,
+                    req.use_for_backends.clone(),
+                    target_id,
+                )
+                .await?;
+                return Ok(Json(response));
+            }
+            Some(KimiDeviceStatus::Expired) => {
+                KIMI_DEVICE_FLOWS.lock().unwrap().remove(&id);
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "Kimi device authorization expired. Please start again.".to_string(),
+                ));
+            }
+            Some(KimiDeviceStatus::Error(msg)) => {
+                KIMI_DEVICE_FLOWS.lock().unwrap().remove(&id);
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    format!("Kimi authorization failed: {msg}"),
+                ));
+            }
+            Some(KimiDeviceStatus::Pending) | None => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "Kimi is not connected yet. Finish the browser authorization, then click Connect."
+                        .to_string(),
+                ));
+            }
+        }
     }
 
     // Get pending OAuth state

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -6446,31 +6446,29 @@ async fn get_provider_usage(
                 // months-stale access_token and surface as HTTP 401.
                 if oauth_token_expired(o.expires_at) {
                     let (token, refresh_err) = if let Some(uuid) = provider_uuid {
-                        match exchange_anthropic_refresh_token(&o.refresh_token).await {
-                            Ok(fresh) => {
-                                let access = fresh.access_token.clone();
-                                if state
-                                    .ai_providers
-                                    .set_oauth_credentials(uuid, fresh)
-                                    .await
-                                    .is_none()
-                                {
-                                    tracing::warn!(
-                                        provider_id = %uuid,
-                                        "Provider disappeared while persisting refreshed OAuth credentials"
-                                    );
-                                }
-                                (access, None)
-                            }
+                        // Route through the single locked, all-tiers refresh path so
+                        // this on-demand probe can't rotate the (rotating) Anthropic
+                        // refresh token out from under the proactive refresher or the
+                        // shared credential tiers and leave them with invalid_grant.
+                        match refresh_store_account_oauth_locked(
+                            &state.ai_providers,
+                            uuid,
+                            ProviderType::Anthropic,
+                            &o.refresh_token,
+                        )
+                        .await
+                        {
+                            Ok((access, _refresh, _expires_at)) => (access, None),
                             Err(e) => {
-                                let lower = e.to_lowercase();
+                                let msg = e.to_string();
+                                let lower = msg.to_lowercase();
                                 let is_permanent = lower.contains("invalid_grant")
                                     || lower.contains("refresh token not found");
                                 if is_permanent {
                                     tracing::debug!(
                                         provider_id = %uuid,
                                         "Per-provider Anthropic OAuth refresh failed (permanent, re-auth needed): {}",
-                                        e
+                                        msg
                                     );
                                 } else if should_warn_oauth(&format!(
                                     "anthropic-oauth-refresh:{}",
@@ -6479,16 +6477,16 @@ async fn get_provider_usage(
                                     tracing::warn!(
                                         provider_id = %uuid,
                                         "Per-provider Anthropic OAuth refresh failed: {}",
-                                        e
+                                        msg
                                     );
                                 } else {
                                     tracing::debug!(
                                         provider_id = %uuid,
                                         "Per-provider Anthropic OAuth refresh failed (suppressed): {}",
-                                        e
+                                        msg
                                     );
                                 }
-                                (o.access_token.clone(), Some(e))
+                                (o.access_token.clone(), Some(msg))
                             }
                         }
                     } else {
@@ -9776,20 +9774,15 @@ pub async fn refresh_due_store_oauth(
         if oauth.expires_at - now_ms > refresh_threshold_ms {
             continue;
         }
-        // Serialize with the file-based refresher to avoid racing a rotating
-        // refresh token (best-effort — proceed unlocked if contended).
-        let _lock = acquire_oauth_refresh_lock(provider_type).ok();
-        match refresh_oauth_token_internal(&provider_type, &oauth.refresh_token).await {
-            Ok((access, refresh, expires_at)) => {
-                let mut updated = account.clone();
-                updated.oauth = Some(crate::ai_providers::OAuthCredentials {
-                    access_token: access.clone(),
-                    refresh_token: refresh.clone(),
-                    expires_at,
-                });
-                ai_providers.update(account.id, updated).await;
-                // Keep the credential tiers consistent too (best-effort).
-                let _ = sync_oauth_to_all_tiers(provider_type, &refresh, &access, expires_at);
+        match refresh_store_account_oauth_locked(
+            ai_providers,
+            account.id,
+            provider_type,
+            &oauth.refresh_token,
+        )
+        .await
+        {
+            Ok((_access, _refresh, expires_at)) => {
                 refreshed += 1;
                 tracing::info!(
                     provider = ?provider_type,
@@ -9802,11 +9795,88 @@ pub async fn refresh_due_store_oauth(
                 tracing::warn!(
                     provider = ?provider_type,
                     account_id = %account.id,
-                    error = ?e,
+                    error = %e,
                     "Failed to refresh store-backed OAuth token (account may need reconnect)"
                 );
             }
         }
     }
     (found, refreshed)
+}
+
+/// Refresh a single **store-backed** OAuth account under the global per-type
+/// refresh lock, writing the rotated token back to the AIProviderStore record
+/// and — only when this account currently owns the shared credential tiers —
+/// to the credential tiers (`credentials.json` / OpenCode `auth.json` / Claude
+/// CLI creds).
+///
+/// This is the single writer for store-account OAuth rotation. Providers like
+/// Anthropic rotate **and revoke** the refresh token on every refresh, so every
+/// stored copy of the token must move together. Ad-hoc callers (e.g. the usage
+/// probe) MUST go through here rather than rotating the token in isolation —
+/// otherwise the other stores hit `invalid_grant` on their next refresh.
+///
+/// The credential tiers are a singleton per provider type, but the store can
+/// hold several accounts of the same type (e.g. multiple Anthropic logins). We
+/// therefore mirror to the tiers only when the account's current refresh token
+/// matches the tier token — i.e. this account is the one the harnesses/tiers
+/// are actually using — so refreshing a secondary account never clobbers the
+/// primary account's tier credentials.
+pub async fn refresh_store_account_oauth_locked(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+    account_id: uuid::Uuid,
+    provider_type: ProviderType,
+    fallback_refresh_token: &str,
+) -> Result<(String, String, i64), OAuthRefreshError> {
+    // Serialize with every other refresh path for this provider type so a
+    // rotating refresh token is only ever consumed once.
+    let _lock = acquire_oauth_refresh_lock(provider_type).ok();
+
+    // Re-read the freshest refresh token now that we hold the lock — another
+    // path may have rotated it while we were waiting.
+    let refresh_token = ai_providers
+        .get(account_id)
+        .await
+        .and_then(|p| p.oauth)
+        .map(|o| o.refresh_token)
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or_else(|| fallback_refresh_token.to_string());
+
+    // Does this account currently back the shared credential tiers? If there is
+    // no tier entry yet (e.g. a freshly connected single account), treat it as
+    // the owner so the tiers get populated.
+    let owns_tiers = read_oauth_token_entry(provider_type)
+        .map(|e| e.refresh_token)
+        .map_or(true, |tier_token| tier_token == refresh_token);
+
+    let (access, refresh, expires_at) =
+        refresh_oauth_token_internal(&provider_type, &refresh_token).await?;
+
+    // Always update this account's own store record.
+    if ai_providers
+        .set_oauth_credentials(
+            account_id,
+            crate::ai_providers::OAuthCredentials {
+                access_token: access.clone(),
+                refresh_token: refresh.clone(),
+                expires_at,
+            },
+        )
+        .await
+        .is_none()
+    {
+        tracing::warn!(
+            provider = ?provider_type,
+            account_id = %account_id,
+            "Provider disappeared while persisting refreshed OAuth credentials"
+        );
+    }
+
+    // Only mirror to the shared tiers when this account owns them, so a
+    // secondary login never overwrites the primary's tier credentials.
+    if owns_tiers {
+        let _ = sync_oauth_to_all_tiers(provider_type, &refresh, &access, expires_at);
+    }
+
+    Ok((access, refresh, expires_at))
 }

--- a/src/api/ask/client.rs
+++ b/src/api/ask/client.rs
@@ -70,6 +70,32 @@ fn strip_model_markup_sentinels(content: &str) -> String {
         .replace("]<]minimax[>", "")
 }
 
+/// Sanitize a *final* answer before it is shown to the operator.
+///
+/// The forced final-synthesis pass runs with tools disabled, so
+/// [`parse_text_tool_calls`] is skipped (it only fires when tools are offered).
+/// MiniMax nonetheless sometimes free-styles a tool call as text on that pass —
+/// wrapped in its interleave sentinels — and the raw `<tool_call>`/`<invoke>`
+/// markup would otherwise reach the chat verbatim (observed in prod). This
+/// strips the sentinels and any leaked tool-call markup, returning only the
+/// prose the model actually wrote (often empty when it emitted only a call).
+pub(crate) fn strip_leaked_tool_markup(content: &str) -> String {
+    let content = strip_model_markup_sentinels(content);
+    // Remove well-formed tool-call blocks (non-greedy; an `<invoke>` nested in a
+    // `<tool_call>` is consumed by the outer match).
+    let tool_block = regex::Regex::new(r#"(?s)<tool_call>.*?</tool_call>"#)
+        .expect("valid tool-call block regex");
+    let invoke_block =
+        regex::Regex::new(r#"(?s)<invoke\b.*?</invoke>"#).expect("valid invoke block regex");
+    let s = tool_block.replace_all(&content, "");
+    let s = invoke_block.replace_all(&s, "");
+    // Drop any dangling/unclosed markup fragments the model left behind.
+    let dangling =
+        regex::Regex::new(r#"(?s)</?(?:tool_call|invoke|command|arg_key|arg_value)\b[^>]*>"#)
+            .expect("valid dangling-tag regex");
+    dangling.replace_all(&s, "").trim().to_string()
+}
+
 fn parse_text_tool_calls(raw_content: &str) -> Vec<ToolCall> {
     let content = strip_model_markup_sentinels(raw_content);
     let content = content.as_str();
@@ -461,6 +487,26 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].name, "bash");
         assert_eq!(calls[1].name, "read_history");
+    }
+
+    #[test]
+    fn strips_leaked_minimax_tool_markup_to_empty() {
+        // Verbatim shape leaked into a prod Ask answer (mission cd6cfe3f) on the
+        // tools-disabled synthesis pass, where the text tool-call parser is
+        // skipped. Nothing but markup → sanitized result is empty so the caller
+        // falls back to the canned notice instead of showing garbage.
+        let out = strip_leaked_tool_markup(
+            "]<]minimax[>[<tool_call> ]<]minimax[>[<invoke name=\"bash\">]<]minimax[>[<command>cd /workspaces/mission-cd6cfe3f/verity-benchmark && echo hi</command>]<]minimax[>[</invoke> ]<]minimax[>[</tool_call>",
+        );
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn keeps_prose_around_leaked_markup() {
+        let out = strip_leaked_tool_markup(
+            "Here is the status.\n]<]minimax[>[<invoke name=\"bash\"><command>ls</command></invoke> Done.",
+        );
+        assert_eq!(out, "Here is the status.\n Done.");
     }
 
     #[test]

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -47,6 +47,34 @@ const SEED_EVENT_COUNT: usize = 40;
 /// fetch serves both this scan and the [`SEED_EVENT_COUNT`] seed.
 const GOAL_SCAN_EVENT_COUNT: usize = 200;
 
+/// Nudge appended before the forced, tools-disabled synthesis pass. MiniMax-M3
+/// tends to free-style another tool call here (emitting raw `<invoke>`/`<tool_call>`
+/// markup wrapped in its interleave sentinels); this pushes it to answer in prose
+/// instead. `finalize_answer` strips any markup that leaks through regardless.
+const FINAL_SYNTHESIS_NUDGE: &str = "You have no tools available for this reply. Do NOT emit any tool call, function call, or XML markup such as <invoke> or <tool_call>. Answer the operator directly in prose, using only what you already gathered from the tool results above.";
+
+/// Shown when the turn produced no usable prose (tool-call limit hit, or the
+/// model emitted only tool-call markup that was stripped away).
+const TOOL_LIMIT_FALLBACK: &str =
+    "(The assistant reached the tool-call limit without a final answer.)";
+
+/// Clean a final answer before it is shown/persisted: strip reasoning blocks
+/// (`<think>`/`<mm:think>`) like the mission path does, then strip any tool-call
+/// markup the model leaked into prose. The text tool-call parser only runs when
+/// tools are offered, so the tools-disabled synthesis pass can otherwise leak
+/// raw `]<]minimax[>[<invoke …>` markup verbatim into the chat (observed in prod
+/// on mission cd6cfe3f). Falls back to a canned notice when nothing but markup
+/// remains.
+fn finalize_answer(raw: &str) -> String {
+    let stripped = crate::api::mission_runner::strip_think_tags(raw);
+    let cleaned = client::strip_leaked_tool_markup(&stripped);
+    if cleaned.is_empty() {
+        TOOL_LIMIT_FALLBACK.to_string()
+    } else {
+        cleaned
+    }
+}
+
 static ASK_STORE: OnceCell<Arc<AskStore>> = OnceCell::const_new();
 
 /// Get (lazily initializing) the global Ask store, placed next to the mission
@@ -194,6 +222,7 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
         // final answer. Give it one more pass with tools disabled so it must
         // synthesize from the results it already gathered, rather than bailing
         // with a canned "tool-call limit" message.
+        messages.push(json!({ "role": "user", "content": FINAL_SYNTHESIS_NUDGE }));
         match turn.llm.complete(&messages, &[]).await {
             Ok(c) => {
                 total_tokens += c.total_tokens.unwrap_or(0);
@@ -201,17 +230,9 @@ pub async fn run_ask_turn(turn: &AskTurn, user_content: &str) -> Result<String, 
             }
             Err(e) => tracing::warn!("[Ask] forced final-answer pass failed: {e}"),
         }
-        if final_answer.is_empty() {
-            final_answer =
-                "(The assistant reached the tool-call limit without a final answer.)".to_string();
-        }
     }
 
-    // Reasoning models (MiniMax, GLM) can leak <think>/<mm:think> blocks into
-    // the visible answer; strip them like the mission path does.
-    final_answer = crate::api::mission_runner::strip_think_tags(&final_answer)
-        .trim()
-        .to_string();
+    final_answer = finalize_answer(&final_answer);
 
     turn.ask_store
         .append_message(
@@ -370,36 +391,33 @@ async fn run_ask_turn_streaming_inner(
         }
     }
 
+    let mut synthesized = false;
     if final_answer.is_empty() {
         // Same forced synthesis as the non-streaming path: one more pass with
-        // tools disabled, streamed so the operator sees the answer arrive.
-        let txc = tx.clone();
-        match turn
-            .llm
-            .complete_stream(&messages, &[], |frag| {
-                let _ = txc.send(AskStreamEvent::Delta {
-                    content: frag.to_string(),
-                });
-            })
-            .await
-        {
+        // tools disabled. Unlike the in-loop turns, this pass is NOT streamed
+        // live — a tools-disabled MiniMax pass may free-style raw tool-call
+        // markup, which would flash into the UI before the post-stream
+        // reconcile. We collect it, clean it, and emit the result as one delta.
+        messages.push(json!({ "role": "user", "content": FINAL_SYNTHESIS_NUDGE }));
+        synthesized = true;
+        match turn.llm.complete_stream(&messages, &[], |_| {}).await {
             Ok(c) => {
                 total_tokens += c.total_tokens.unwrap_or(0);
                 final_answer = c.content.unwrap_or_default();
             }
             Err(e) => tracing::warn!("[Ask] forced final-answer pass (stream) failed: {e}"),
         }
-        if final_answer.is_empty() {
-            final_answer =
-                "(The assistant reached the tool-call limit without a final answer.)".to_string();
-        }
     }
 
-    // Reasoning models (MiniMax, GLM) can leak <think>/<mm:think> blocks into
-    // the visible answer; strip them like the mission path does.
-    final_answer = crate::api::mission_runner::strip_think_tags(&final_answer)
-        .trim()
-        .to_string();
+    final_answer = finalize_answer(&final_answer);
+
+    // The synthesis pass was suppressed above; surface its cleaned text so the
+    // operator sees an answer before `onDone` reconciles against the store.
+    if synthesized {
+        let _ = tx.send(AskStreamEvent::Delta {
+            content: final_answer.clone(),
+        });
+    }
 
     turn.ask_store
         .append_message(

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -570,6 +570,9 @@ mod tests {
             default_backend: None,
             automations_enabled: true,
             max_concurrent_tasks: 5,
+            spark_arbiter_url: None,
+            spark_arbiter_token: None,
+            spark_ssh_target: None,
         }
     }
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -211,6 +211,72 @@ fn self_send_message(
     }
 }
 
+/// Fire-and-forget cancel of a specific (worker) mission's runner. Mirrors
+/// [`self_send_message`]: try_send only, receiver dropped — the scheduler runs
+/// on the task that consumes this channel and must never await it.
+fn self_cancel_mission(cmd_tx: &mpsc::Sender<ControlCommand>, mission_id: Uuid) -> bool {
+    let (respond, _rx) = oneshot::channel();
+    match cmd_tx.try_send(ControlCommand::CancelMission {
+        mission_id,
+        min_idle: None,
+        respond,
+    }) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(target = %mission_id, "board: cancel-worker send failed: {}", e);
+            false
+        }
+    }
+}
+
+/// Boss-mission statuses that mean the board can no longer be driven: the boss
+/// will never run another turn to deliver verdicts or read a wake, so its board
+/// must stop scheduling. `Active`/`Pending` are live; `AwaitingUser` and
+/// `Acknowledged` are the NORMAL idle states a boss parks in between board
+/// wakes, so they are deliberately NOT terminal here.
+fn boss_status_is_terminal(status: MissionStatus) -> bool {
+    matches!(
+        status,
+        MissionStatus::Completed
+            | MissionStatus::Failed
+            | MissionStatus::Interrupted
+            | MissionStatus::Blocked
+            | MissionStatus::NotFeasible
+    )
+}
+
+/// Tear down the board of a boss mission that has terminated: cancel every
+/// non-terminal task (and stop any live worker) so the scheduler stops reviving
+/// work the boss can never judge. Once all tasks are terminal the boss drops out
+/// of `list_active_board_missions` on the next pass.
+async fn cancel_dead_boss_board(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    boss_id: Uuid,
+    tasks: &[BoardTask],
+) {
+    let mut cancelled = 0u32;
+    for task in tasks.iter().filter(|t| !t.status.is_terminal()) {
+        if let Some(worker_id) = task.worker_mission_id {
+            self_cancel_mission(cmd_tx, worker_id);
+        }
+        let mut t = task.clone();
+        t.status = BoardTaskStatus::Cancelled;
+        t.notes = append_note(&t.notes, "cancelled: boss mission terminated");
+        match mission_store.save_board_task(&t).await {
+            Ok(()) => cancelled += 1,
+            Err(e) => tracing::warn!(
+                boss = %boss_id, task = %t.task_key,
+                "board: failed to cancel orphaned task: {}", e
+            ),
+        }
+    }
+    if cancelled > 0 {
+        tracing::info!(boss = %boss_id, cancelled,
+            "board: boss mission terminated — cancelled orphaned board tasks");
+    }
+}
+
 fn seconds_since(rfc3339: &str) -> i64 {
     chrono::DateTime::parse_from_rfc3339(rfc3339)
         .map(|t| (chrono::Utc::now() - t.with_timezone(&chrono::Utc)).num_seconds())
@@ -251,6 +317,20 @@ pub async fn scheduler_pass(
                 continue;
             }
         };
+
+        // --- Dead-boss teardown: `list_active_board_missions` keys only on task
+        // status, so a boss whose own mission has terminated (failed, completed,
+        // interrupted, …) with tasks still in flight would otherwise keep
+        // getting workers re-spawned and wake banners it can never act on.
+        // Cancel its non-terminal tasks (+ live workers) and skip; next pass the
+        // boss drops out entirely.
+        if let Ok(Some(boss)) = mission_store.get_mission(boss_id).await {
+            if boss_status_is_terminal(boss.status) {
+                cancel_dead_boss_board(mission_store, cmd_tx, boss_id, &tasks).await;
+                wake_state.remove(&boss_id);
+                continue;
+            }
+        }
 
         // --- Zombie sweep: running tasks whose worker is not actually running.
         for task in tasks
@@ -755,5 +835,137 @@ mod tests {
             store.list_active_board_missions().await.expect("active"),
             vec![boss]
         );
+    }
+
+    #[test]
+    fn boss_terminal_status_classification() {
+        for s in [
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::Interrupted,
+            MissionStatus::Blocked,
+            MissionStatus::NotFeasible,
+        ] {
+            assert!(boss_status_is_terminal(s), "{s} should be terminal");
+        }
+        // Live + the two idle states a boss legitimately parks in between wakes.
+        for s in [
+            MissionStatus::Pending,
+            MissionStatus::Active,
+            MissionStatus::AwaitingUser,
+            MissionStatus::Acknowledged,
+        ] {
+            assert!(!boss_status_is_terminal(s), "{s} should NOT be terminal");
+        }
+    }
+
+    #[tokio::test]
+    async fn dead_boss_board_is_cancelled_and_drops_out() {
+        use crate::api::mission_store::InMemoryMissionStore;
+
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("benchmark"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        let boss_id = boss.id;
+        store
+            .upsert_board_tasks(
+                boss_id,
+                vec![
+                    NewBoardTask {
+                        task_key: "running".into(),
+                        title: "in flight".into(),
+                        prompt: "p".into(),
+                        backend: "codex".into(),
+                        model_override: None,
+                        model_effort: None,
+                        working_directory: None,
+                        depends_on: vec![],
+                    },
+                    NewBoardTask {
+                        task_key: "pending".into(),
+                        title: "queued".into(),
+                        prompt: "p".into(),
+                        backend: "codex".into(),
+                        model_override: None,
+                        model_effort: None,
+                        working_directory: None,
+                        depends_on: vec![],
+                    },
+                ],
+            )
+            .await
+            .expect("upsert");
+
+        // Mark one task running with a worker, then kill the boss.
+        let listed = store.list_board_tasks(boss_id).await.expect("list");
+        let mut running = listed
+            .iter()
+            .find(|t| t.task_key == "running")
+            .unwrap()
+            .clone();
+        running.status = BoardTaskStatus::Running;
+        running.worker_mission_id = Some(Uuid::new_v4());
+        store.save_board_task(&running).await.expect("save");
+        store
+            .update_mission_status(boss_id, MissionStatus::Failed)
+            .await
+            .expect("kill boss");
+
+        // Before the pass the dead boss is still listed (task-status keyed).
+        assert_eq!(
+            store.list_active_board_missions().await.expect("active"),
+            vec![boss_id]
+        );
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<ControlCommand>(16);
+        let snapshot = RunnerSnapshot {
+            present: HashSet::new(),
+            running_ids: HashSet::new(),
+            running_count: 0,
+            main_running: false,
+        };
+        let mut wake_state = HashMap::new();
+        wake_state.insert(boss_id, true);
+
+        scheduler_pass(&store, &cmd_tx, &snapshot, 4, &mut wake_state).await;
+
+        // All tasks cancelled, boss no longer scheduled, wake state cleared.
+        let after = store.list_board_tasks(boss_id).await.expect("list");
+        assert!(
+            after.iter().all(|t| t.status == BoardTaskStatus::Cancelled),
+            "every task should be cancelled, got {:?}",
+            after.iter().map(|t| t.status).collect::<Vec<_>>()
+        );
+        assert!(store
+            .list_active_board_missions()
+            .await
+            .expect("active")
+            .is_empty());
+        assert!(!wake_state.contains_key(&boss_id));
+
+        // The live worker got a cancel; no wake banner was sent to the dead boss.
+        let mut saw_cancel = false;
+        let mut saw_wake = false;
+        while let Ok(cmd) = cmd_rx.try_recv() {
+            match cmd {
+                ControlCommand::CancelMission { .. } => saw_cancel = true,
+                ControlCommand::UserMessage { .. } => saw_wake = true,
+                _ => {}
+            }
+        }
+        assert!(saw_cancel, "live worker should have been cancelled");
+        assert!(!saw_wake, "dead boss must not receive a board wake");
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2479,6 +2479,34 @@ fn serialize_queue_snapshot(
     serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
+/// Persist the control queue snapshot iff it changed since `last_persisted`
+/// (debounced so unchanged iterations don't churn the DB).
+///
+/// Called both at the actor-loop top and immediately after every dequeue. The
+/// post-dequeue call is what prevents stale double-execution: without it, a
+/// popped message lingers in the persisted snapshot until the next loop pass, so
+/// a crash after the pop (during the potentially-awaiting work that starts the
+/// run) would restore and re-run a message that already started — bypassing the
+/// in-memory idempotency guard.
+async fn persist_control_queue_if_changed(
+    mission_store: &Arc<dyn MissionStore>,
+    session_user_id: &str,
+    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+    last_persisted: &mut String,
+) {
+    let snapshot = serialize_queue_snapshot(queue);
+    if snapshot != *last_persisted {
+        if let Err(e) = mission_store
+            .save_control_queue(session_user_id, &snapshot)
+            .await
+        {
+            tracing::warn!("Failed to persist control queue: {e}");
+        } else {
+            *last_persisted = snapshot;
+        }
+    }
+}
+
 /// Tool result posted by the frontend for an interactive tool call.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ControlToolResultRequest {
@@ -8723,20 +8751,16 @@ async fn control_actor_loop(
         // Persist the pending queue whenever it changes so a restart doesn't
         // lose queued messages. Debounced by snapshot comparison — the DB is
         // written only when the queue actually changed (no per-iteration churn
-        // during streaming, where the queue is usually unchanged).
-        {
-            let snapshot = serialize_queue_snapshot(&queue);
-            if snapshot != last_persisted_queue {
-                if let Err(e) = mission_store
-                    .save_control_queue(&session_user_id, &snapshot)
-                    .await
-                {
-                    tracing::warn!("Failed to persist control queue: {e}");
-                } else {
-                    last_persisted_queue = snapshot;
-                }
-            }
-        }
+        // during streaming, where the queue is usually unchanged). Each dequeue
+        // site below also persists immediately so a popped message can't be
+        // re-run after a crash (see `persist_control_queue_if_changed`).
+        persist_control_queue_if_changed(
+            &mission_store,
+            &session_user_id,
+            &queue,
+            &mut last_persisted_queue,
+        )
+        .await;
         tokio::select! {
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else { break };
@@ -9198,6 +9222,15 @@ async fn control_actor_loop(
                         }
                         if running.is_none() {
                             if let Some((mid, msg, per_msg_agent, msg_target_mid)) = queue.pop_front() {
+                                // Persist the dequeue before the awaits that start
+                                // the run, so a crash here can't restore + re-run it.
+                                persist_control_queue_if_changed(
+                                    &mission_store,
+                                    &session_user_id,
+                                    &queue,
+                                    &mut last_persisted_queue,
+                                )
+                                .await;
                                 set_and_emit_status(
                                     &status,
                                     &events_tx,
@@ -10094,6 +10127,16 @@ async fn control_actor_loop(
                                 // Start execution if not already running
                                 if running.is_none() {
                                     if let Some((mid, msg, _per_msg_agent, msg_target_mid)) = queue.pop_front() {
+                                        // Persist the dequeue before the awaits that
+                                        // start the run, so a crash here can't
+                                        // restore + re-run it.
+                                        persist_control_queue_if_changed(
+                                            &mission_store,
+                                            &session_user_id,
+                                            &queue,
+                                            &mut last_persisted_queue,
+                                        )
+                                        .await;
                                         let target_mid = msg_target_mid.unwrap_or(mission_id);
                                         set_and_emit_status(
                                             &status,
@@ -10847,6 +10890,15 @@ async fn control_actor_loop(
 
                 // Start next queued message, if any.
                 if let Some((mid, msg, per_msg_agent, msg_target_mid)) = queue.pop_front() {
+                    // Persist the dequeue before the awaits that start the run, so
+                    // a crash here can't restore + re-run it.
+                    persist_control_queue_if_changed(
+                        &mission_store,
+                        &session_user_id,
+                        &queue,
+                        &mut last_persisted_queue,
+                    )
+                    .await;
                     set_and_emit_status(
                         &status,
                         &events_tx,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -8510,6 +8510,13 @@ async fn control_actor_loop(
     // ignore repeated commands with the same id instead of queueing/running
     // the same user message twice.
     let mut accepted_user_message_ids: HashSet<Uuid> = HashSet::new();
+    // Seed the dedup guard with any messages restored from the persisted queue
+    // above. Without this, a client that retries a send after a restart (common
+    // when the connection dropped mid-request) would pass the idempotency check
+    // and get the same message queued — and executed — a second time.
+    for (id, _, _, _) in &queue {
+        accepted_user_message_ids.insert(*id);
+    }
     // Track subtasks for the main runner
     let mut main_runner_subtasks: Vec<super::mission_runner::SubtaskInfo> = Vec::new();
     // Track number of in-flight tool calls on the main runner so the stall

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -8497,21 +8497,39 @@ async fn control_actor_loop(
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
     let mut queue: VecDeque<(Uuid, String, Option<String>, Option<Uuid>)> = VecDeque::new();
-    // Restore any messages that were queued before the last restart. The queue
-    // is persisted as a JSON snapshot (see `persist_queue` at the loop top) so
-    // pending messages aren't lost when sandboxed.sh restarts.
+    // Re-drive any messages that were queued before the last restart. They are
+    // persisted as a JSON snapshot (see `persist_control_queue_if_changed`) so a
+    // restart doesn't lose pending work. We re-inject them through the normal
+    // command channel rather than pushing straight onto `queue`: an idle actor
+    // never dequeues a pre-filled `queue` on its own, so the work would
+    // otherwise sit forever. Routing them as commands also de-duplicates against
+    // a client retry of the same id via `accept_user_message_id` (whichever
+    // arrives first runs; the other is dropped), so nothing executes twice.
+    let mut restored_db_snapshot = String::new();
     if let Ok(payload) = mission_store.load_control_queue(&session_user_id).await {
         if !payload.trim().is_empty() {
             match serde_json::from_str::<Vec<QueuedMessage>>(&payload) {
                 Ok(items) => {
+                    let count = items.len();
                     for it in items {
-                        queue.push_back((it.id, it.content, it.agent, it.mission_id));
+                        let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
+                        if let Err(e) = self_cmd_tx.try_send(ControlCommand::UserMessage {
+                            id: it.id,
+                            content: it.content,
+                            agent: it.agent,
+                            target_mission_id: it.mission_id,
+                            strict: false,
+                            respond: ack_tx,
+                        }) {
+                            tracing::warn!("Failed to re-queue restored control message: {e}");
+                        }
                     }
-                    if !queue.is_empty() {
-                        tracing::info!(
-                            "Restored {} queued message(s) from the previous session",
-                            queue.len()
-                        );
+                    if count > 0 {
+                        // Remember the stale on-disk snapshot so the first
+                        // loop-top persist below rewrites the DB to the real
+                        // (re-injected) state instead of leaving it stale.
+                        restored_db_snapshot = payload;
+                        tracing::info!("Re-queued {count} message(s) from the previous session");
                     }
                 }
                 Err(e) => tracing::warn!("Failed to parse persisted control queue: {e}"),
@@ -8520,7 +8538,13 @@ async fn control_actor_loop(
     }
     // Snapshot of the queue as last written to the store; used to debounce
     // persistence so we only write to the DB when the queue actually changes.
-    let mut last_persisted_queue: String = serialize_queue_snapshot(&queue);
+    // When messages were restored, seed it with the stale on-disk snapshot so
+    // the first loop-top persist overwrites it with the live queue.
+    let mut last_persisted_queue: String = if restored_db_snapshot.is_empty() {
+        serialize_queue_snapshot(&queue)
+    } else {
+        restored_db_snapshot
+    };
     let mut history: Vec<(String, String)> = Vec::new(); // (role, content) pairs (user/assistant)
     let mut running: Option<tokio::task::JoinHandle<(Uuid, String, crate::agents::AgentResult)>> =
         None;
@@ -8533,18 +8557,12 @@ async fn control_actor_loop(
     // Track current activity label for the main runner
     let mut main_runner_activity: Option<String> = None;
     // Idempotency guard for user sends. The dashboard may retry a POST if a
-    // weak connection drops after the command reached this actor but before
-    // the HTTP response got back. Since the client can now provide the UUID,
-    // ignore repeated commands with the same id instead of queueing/running
-    // the same user message twice.
+    // weak connection drops after the command reached this actor but before the
+    // HTTP response got back; since the client provides the UUID, repeated
+    // commands with the same id are ignored instead of running twice. Restored
+    // messages (re-injected as commands above) rely on this same guard: the
+    // first occurrence runs, any later duplicate is dropped.
     let mut accepted_user_message_ids: HashSet<Uuid> = HashSet::new();
-    // Seed the dedup guard with any messages restored from the persisted queue
-    // above. Without this, a client that retries a send after a restart (common
-    // when the connection dropped mid-request) would pass the idempotency check
-    // and get the same message queued — and executed — a second time.
-    for (id, _, _, _) in &queue {
-        accepted_user_message_ids.insert(*id);
-    }
     // Track subtasks for the main runner
     let mut main_runner_subtasks: Vec<super::mission_runner::SubtaskInfo> = Vec::new();
     // Track number of in-flight tool calls on the main runner so the stall

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2453,13 +2453,30 @@ pub struct ControlMessageResponse {
 }
 
 /// A message waiting in the queue
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueuedMessage {
     pub id: Uuid,
     pub content: String,
     pub agent: Option<String>,
     /// Which mission this queued message belongs to
     pub mission_id: Option<Uuid>,
+}
+
+/// Serialize the control session queue to a stable JSON snapshot for
+/// persistence across restarts (see `MissionStore::save_control_queue`).
+fn serialize_queue_snapshot(
+    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+) -> String {
+    let items: Vec<QueuedMessage> = queue
+        .iter()
+        .map(|(id, content, agent, target_mid)| QueuedMessage {
+            id: *id,
+            content: content.clone(),
+            agent: agent.clone(),
+            mission_id: *target_mid,
+        })
+        .collect();
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// Tool result posted by the frontend for an interactive tool call.
@@ -8452,6 +8469,30 @@ async fn control_actor_loop(
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
     let mut queue: VecDeque<(Uuid, String, Option<String>, Option<Uuid>)> = VecDeque::new();
+    // Restore any messages that were queued before the last restart. The queue
+    // is persisted as a JSON snapshot (see `persist_queue` at the loop top) so
+    // pending messages aren't lost when sandboxed.sh restarts.
+    if let Ok(payload) = mission_store.load_control_queue(&session_user_id).await {
+        if !payload.trim().is_empty() {
+            match serde_json::from_str::<Vec<QueuedMessage>>(&payload) {
+                Ok(items) => {
+                    for it in items {
+                        queue.push_back((it.id, it.content, it.agent, it.mission_id));
+                    }
+                    if !queue.is_empty() {
+                        tracing::info!(
+                            "Restored {} queued message(s) from the previous session",
+                            queue.len()
+                        );
+                    }
+                }
+                Err(e) => tracing::warn!("Failed to parse persisted control queue: {e}"),
+            }
+        }
+    }
+    // Snapshot of the queue as last written to the store; used to debounce
+    // persistence so we only write to the DB when the queue actually changes.
+    let mut last_persisted_queue: String = serialize_queue_snapshot(&queue);
     let mut history: Vec<(String, String)> = Vec::new(); // (role, content) pairs (user/assistant)
     let mut running: Option<tokio::task::JoinHandle<(Uuid, String, crate::agents::AgentResult)>> =
         None;
@@ -8672,6 +8713,23 @@ async fn control_actor_loop(
     }
 
     loop {
+        // Persist the pending queue whenever it changes so a restart doesn't
+        // lose queued messages. Debounced by snapshot comparison — the DB is
+        // written only when the queue actually changed (no per-iteration churn
+        // during streaming, where the queue is usually unchanged).
+        {
+            let snapshot = serialize_queue_snapshot(&queue);
+            if snapshot != last_persisted_queue {
+                if let Err(e) = mission_store
+                    .save_control_queue(&session_user_id, &snapshot)
+                    .await
+                {
+                    tracing::warn!("Failed to persist control queue: {e}");
+                } else {
+                    last_persisted_queue = snapshot;
+                }
+            }
+        }
         tokio::select! {
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else { break };

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -2691,6 +2691,20 @@ pub trait MissionStore: Send + Sync {
         let _ = task;
         Err("Task board not supported by this mission store".to_string())
     }
+
+    /// Persist the control session's pending message queue as a JSON snapshot
+    /// so queued messages survive a server restart. Default no-op for
+    /// non-durable stores (memory/file); SQLite overrides this.
+    async fn save_control_queue(&self, user_id: &str, payload: &str) -> Result<(), String> {
+        let _ = (user_id, payload);
+        Ok(())
+    }
+
+    /// Load the persisted control-queue snapshot (empty string if none).
+    async fn load_control_queue(&self, user_id: &str) -> Result<String, String> {
+        let _ = user_id;
+        Ok(String::new())
+    }
 }
 
 /// Mission store type selection.

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -658,6 +658,14 @@ CREATE TABLE IF NOT EXISTS board_tasks (
 CREATE INDEX IF NOT EXISTS idx_board_tasks_boss ON board_tasks(boss_mission_id);
 CREATE INDEX IF NOT EXISTS idx_board_tasks_worker ON board_tasks(worker_mission_id);
 CREATE INDEX IF NOT EXISTS idx_board_tasks_status ON board_tasks(status);
+
+-- Persisted control-session message queue (JSON snapshot) so pending queued
+-- messages survive a restart. Single row (the DB is already per-user).
+CREATE TABLE IF NOT EXISTS control_queue (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    payload TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
 "#;
 
 /// Content size threshold for inline storage (64KB).
@@ -2919,6 +2927,42 @@ impl MissionStore for SqliteMissionStore {
             )
             .map_err(|e| e.to_string())?;
             Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn save_control_queue(&self, _user_id: &str, payload: &str) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let payload = payload.to_string();
+        let now = now_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO control_queue (id, payload, updated_at) VALUES (1, ?1, ?2)
+                 ON CONFLICT(id) DO UPDATE SET payload = ?1, updated_at = ?2",
+                params![payload, now],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn load_control_queue(&self, _user_id: &str) -> Result<String, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let payload: Option<String> = conn
+                .query_row(
+                    "SELECT payload FROM control_queue WHERE id = 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| e.to_string())?;
+            Ok(payload.unwrap_or_default())
         })
         .await
         .map_err(|e| e.to_string())?

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -46,7 +46,7 @@ mod native_loop_observer;
 pub mod opencode;
 pub mod paloma;
 mod provider_usage_cache;
-mod providers;
+pub(crate) mod providers;
 pub(crate) mod proxy;
 mod proxy_keys;
 pub(crate) mod proxy_liveness;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -54,6 +54,7 @@ mod routes;
 pub(crate) mod runners;
 pub mod secrets;
 pub mod settings;
+pub(crate) mod spark;
 pub(crate) mod supervision;
 pub mod system;
 pub mod telegram;

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -338,7 +338,7 @@ fn merge_cached_provider_models(
     }
 }
 
-fn sanitize_custom_provider_id(name: &str) -> String {
+pub(crate) fn sanitize_custom_provider_id(name: &str) -> String {
     name.chars()
         .filter(|c| c.is_alphanumeric() || *c == '_' || *c == '-')
         .collect::<String>()

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -836,6 +836,33 @@ fn default_providers_config() -> ProvidersConfig {
                     },
                 ],
             },
+            Provider {
+                id: "kimi".to_string(),
+                name: "Kimi (Subscription)".to_string(),
+                billing: "subscription".to_string(),
+                description: "Kimi Code via Moonshot OAuth (device login)".to_string(),
+                models: vec![
+                    ProviderModel {
+                        id: "kimi-for-coding".to_string(),
+                        name: "Kimi for Coding".to_string(),
+                        description: Some(
+                            "Stable coding alias that tracks the latest Kimi coding model \
+                             (recommended)"
+                                .to_string(),
+                        ),
+                    },
+                    ProviderModel {
+                        id: "kimi-k2.6".to_string(),
+                        name: "Kimi K2.6".to_string(),
+                        description: Some("Latest Kimi K2 model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "kimi-k2-thinking".to_string(),
+                        name: "Kimi K2 Thinking".to_string(),
+                        description: Some("Extended-reasoning Kimi K2 variant".to_string()),
+                    },
+                ],
+            },
         ],
     }
 }

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -798,8 +798,15 @@ pub(crate) async fn chat_completions_inner(
                 );
                 continue;
             };
-            // Build the upstream request body: replace model with the real model ID
-            let upstream_body = match rewrite_model(&body, &entry.model_id) {
+            // Build the upstream request body: replace model with the real model ID.
+            // Kimi additionally rejects any temperature other than 1, so normalize
+            // sampling params for it (see `rewrite_model_for_kimi`).
+            let rewrite_result = if provider_type == ProviderType::Kimi {
+                rewrite_model_for_kimi(&body, &entry.model_id)
+            } else {
+                rewrite_model(&body, &entry.model_id)
+            };
+            let upstream_body = match rewrite_result {
                 Ok(b) => b,
                 Err(e) => {
                     tracing::error!("Failed to rewrite model in request body: {}", e);
@@ -2106,6 +2113,28 @@ fn strip_thinking_blocks(messages: &mut [serde_json::Value]) {
             }));
         }
     }
+}
+
+/// Rewrite the model id and normalize sampling params for Kimi's coding endpoint.
+///
+/// `kimi-for-coding` rejects any temperature other than 1 with
+/// `400 invalid temperature: only 1 is allowed for this model`. Clients that
+/// send `temperature: 0` (e.g. deterministic benchmark harnesses) would
+/// therefore 400 on every request. Force the only accepted value when the
+/// caller specified a temperature; leave it absent otherwise so Kimi's own
+/// default applies.
+fn rewrite_model_for_kimi(body: &[u8], new_model: &str) -> Result<bytes::Bytes, String> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+    value["model"] = serde_json::Value::String(new_model.to_string());
+    if let Some(obj) = value.as_object_mut() {
+        if obj.contains_key("temperature") {
+            obj.insert("temperature".to_string(), serde_json::json!(1));
+        }
+    }
+    serde_json::to_vec(&value)
+        .map(bytes::Bytes::from)
+        .map_err(|e| format!("Failed to serialize: {}", e))
 }
 
 fn rewrite_model_for_anthropic_cli_proxy(

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -385,6 +385,65 @@ fn parse_direct_model_entry(model: &str) -> Option<crate::provider_health::Chain
     })
 }
 
+/// Parse a direct `provider/model` id whose prefix is a **custom** provider
+/// referenced by its sanitized name (e.g. `spark/step3p7-flash-148b`) — the id
+/// the catalog and model-routing UI expose for self-hosted OpenAI-compatible
+/// routers. Built-in prefixes are handled by [`parse_direct_model_entry`]; this
+/// only matches when no built-in type owns the prefix.
+///
+/// Returns a synthetic entry only when a configured custom provider has that
+/// sanitized name **and** advertises the model — either in its stored
+/// `custom_models` or in its live `/v1/models` catalog (so models discovered
+/// after startup still route). Returning `None` for everything else keeps typos
+/// surfacing as `model_not_found` instead of a generic cooldown error.
+async fn parse_custom_direct_model_entry(
+    state: &super::routes::AppState,
+    model: &str,
+) -> Option<crate::provider_health::ChainEntry> {
+    let (provider, rest) = model.split_once('/')?;
+    if provider.is_empty() || rest.is_empty() {
+        return None;
+    }
+    // Built-in provider prefixes are the other branch's job.
+    if crate::ai_providers::ProviderType::from_id(provider).is_some() {
+        return None;
+    }
+
+    let accounts = state
+        .ai_providers
+        .get_all_by_type(crate::ai_providers::ProviderType::Custom)
+        .await;
+    let name_matches = accounts
+        .iter()
+        .any(|a| crate::api::providers::sanitize_custom_provider_id(&a.name) == provider);
+    if !name_matches {
+        return None;
+    }
+
+    let known_in_store = accounts.iter().any(|a| {
+        crate::api::providers::sanitize_custom_provider_id(&a.name) == provider
+            && a.custom_models
+                .as_ref()
+                .map(|ms| ms.iter().any(|m| m.id == rest))
+                .unwrap_or(false)
+    });
+    let known_in_catalog = {
+        let cached = state.model_catalog.read().await;
+        cached
+            .get(provider)
+            .map(|entries| entries.iter().any(|e| e.id == rest))
+            .unwrap_or(false)
+    };
+    if known_in_store || known_in_catalog {
+        Some(crate::provider_health::ChainEntry {
+            provider_id: provider.to_string(),
+            model_id: rest.to_string(),
+        })
+    } else {
+        None
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Usage accounting
 // ─────────────────────────────────────────────────────────────────────────────
@@ -500,6 +559,9 @@ pub(crate) async fn chat_completions_inner(
     //        passthrough to that provider's first healthy configured account,
     //        no stored chain required. This lets clients reach ANY supported
     //        model, not just the predefined fallback chains.
+    //    (c) A direct "<custom-provider>/model" id where the prefix is a custom
+    //        provider's sanitized name (e.g. "spark/step3p7-flash-148b") — the
+    //        same id the catalog exposes for self-hosted routers.
     //    Anything else errors — no silent fallback, so typos surface.
     let standard_accounts = super::ai_providers::read_standard_accounts(&state.config.working_dir);
 
@@ -525,8 +587,11 @@ pub(crate) async fn chat_completions_inner(
             )
             .await;
         (id, entries)
-    } else if let Some(direct) = parse_direct_model_entry(&requested_model) {
-        // Direct provider/model passthrough (single synthetic entry).
+    } else if let Some(direct) = parse_direct_model_entry(&requested_model)
+        .or(parse_custom_direct_model_entry(&state, &requested_model).await)
+    {
+        // Direct provider/model passthrough (single synthetic entry) — either a
+        // built-in provider prefix or a custom provider's sanitized name.
         let entries = state
             .chain_store
             .resolve_entries(
@@ -580,10 +645,11 @@ pub(crate) async fn chat_completions_inner(
 
     let chain_length = entries.len() as u32;
     for (entry_idx, entry) in entries.iter().enumerate() {
-        let provider_type = match ProviderType::from_id(&entry.provider_id) {
-            Some(pt) => pt,
-            None => continue,
-        };
+        // Non-builtin prefixes are custom providers referenced by their
+        // sanitized name (e.g. "spark"); they all route as `Custom` through the
+        // OpenAI-compatible path using the account's `base_url`.
+        let provider_type =
+            ProviderType::from_id(&entry.provider_id).unwrap_or(ProviderType::Custom);
 
         // Custom providers may work without an API key (base_url only).
         // Standard providers require credentials (API key or provider OAuth).

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1129,6 +1129,8 @@ pub(crate) async fn chat_completions_inner(
                 let retry_after = parse_rate_limit_headers(&response_headers, provider_type);
                 let reason = if status.as_u16() == 529 {
                     CooldownReason::Overloaded
+                } else if body_is_quota_exhausted(&resp_body) {
+                    CooldownReason::QuotaExhausted
                 } else {
                     CooldownReason::RateLimit
                 };
@@ -1369,9 +1371,14 @@ pub(crate) async fn chat_completions_inner(
                 let elapsed_ms = request_start.elapsed().as_millis() as u64;
                 let retry_after = parse_google_retry_after(&response_headers, &resp_body)
                     .or_else(|| parse_rate_limit_headers(&response_headers, provider_type));
+                let reason = if body_is_quota_exhausted(&resp_body) {
+                    CooldownReason::QuotaExhausted
+                } else {
+                    CooldownReason::RateLimit
+                };
                 let cooldown = state
                     .health_tracker
-                    .record_entry_failure(entry, CooldownReason::RateLimit, retry_after)
+                    .record_entry_failure(entry, reason, retry_after)
                     .await;
                 pending_fallback_events.push(crate::provider_health::FallbackEvent {
                     timestamp: chrono::Utc::now(),
@@ -1379,7 +1386,7 @@ pub(crate) async fn chat_completions_inner(
                     from_provider: entry.provider_id.clone(),
                     from_model: entry.model_id.clone(),
                     from_account_id: entry.account_id,
-                    reason: CooldownReason::RateLimit,
+                    reason,
                     cooldown_secs: Some(cooldown.as_secs_f64()),
                     to_provider: None,
                     latency_ms: Some(elapsed_ms),
@@ -1396,7 +1403,9 @@ pub(crate) async fn chat_completions_inner(
                 let reason = maybe_reason.unwrap_or(CooldownReason::AuthError);
                 let retry_after = if matches!(
                     reason,
-                    CooldownReason::RateLimit | CooldownReason::Overloaded
+                    CooldownReason::RateLimit
+                        | CooldownReason::QuotaExhausted
+                        | CooldownReason::Overloaded
                 ) {
                     parse_google_retry_after(&response_headers, &resp_body)
                         .or_else(|| parse_rate_limit_headers(&response_headers, provider_type))
@@ -1421,7 +1430,9 @@ pub(crate) async fn chat_completions_inner(
                     chain_length,
                 });
                 match reason {
-                    CooldownReason::RateLimit | CooldownReason::Overloaded => rate_limit_count += 1,
+                    CooldownReason::RateLimit
+                    | CooldownReason::QuotaExhausted
+                    | CooldownReason::Overloaded => rate_limit_count += 1,
                     CooldownReason::AuthError => client_error_count += 1,
                     _ => server_error_count += 1,
                 }
@@ -1536,20 +1547,24 @@ pub(crate) async fn chat_completions_inner(
             // the providers panel reflects "weekly limit reached" without a
             // probe. Keyed by entry.account_id == the provider UUID the usage
             // probe stores under. Only the codex path reads the body here.
+            // Read the 429 body once: used both for passive Codex cooldown
+            // capture and to distinguish a hard quota/usage-limit exhaustion
+            // (long cooldown) from a transient rate limit (short cooldown).
+            let err_body = upstream_resp.bytes().await.unwrap_or_default();
             if use_openai_oauth_cli_proxy_adapter {
                 let store_key = entry.account_id.to_string();
                 let codex_store = state.codex_usage.clone();
-                if let Ok(body) = upstream_resp.bytes().await {
-                    let now_unix = chrono::Utc::now().timestamp();
-                    if let Some(reset_at) =
-                        crate::api::codex_usage::parse_cooldown_reset(&body, now_unix)
-                    {
-                        codex_store.put_passive_cooldown(store_key, reset_at).await;
-                    }
+                let now_unix = chrono::Utc::now().timestamp();
+                if let Some(reset_at) =
+                    crate::api::codex_usage::parse_cooldown_reset(&err_body, now_unix)
+                {
+                    codex_store.put_passive_cooldown(store_key, reset_at).await;
                 }
             }
             let reason = if status.as_u16() == 529 {
                 CooldownReason::Overloaded
+            } else if body_is_quota_exhausted(&err_body) {
+                CooldownReason::QuotaExhausted
             } else {
                 CooldownReason::RateLimit
             };
@@ -1779,7 +1794,9 @@ pub(crate) async fn chat_completions_inner(
                     chain_length,
                 });
                 match reason {
-                    CooldownReason::RateLimit | CooldownReason::Overloaded => rate_limit_count += 1,
+                    CooldownReason::RateLimit
+                    | CooldownReason::QuotaExhausted
+                    | CooldownReason::Overloaded => rate_limit_count += 1,
                     CooldownReason::AuthError => client_error_count += 1,
                     _ => server_error_count += 1,
                 }
@@ -1876,9 +1893,9 @@ pub(crate) async fn chat_completions_inner(
                                 chain_length,
                             });
                             match reason {
-                                CooldownReason::RateLimit | CooldownReason::Overloaded => {
-                                    rate_limit_count += 1
-                                }
+                                CooldownReason::RateLimit
+                                | CooldownReason::QuotaExhausted
+                                | CooldownReason::Overloaded => rate_limit_count += 1,
                                 CooldownReason::AuthError => client_error_count += 1,
                                 _ => server_error_count += 1,
                             }
@@ -2682,6 +2699,25 @@ fn parse_rate_limit_duration(s: &str) -> Option<std::time::Duration> {
 /// Providers sometimes return HTTP 200 with an error payload.  This function
 /// inspects the parsed JSON to determine the appropriate cooldown reason
 /// instead of blindly treating every such error as a rate limit.
+/// Detect a hard quota/usage-limit exhaustion from a raw upstream error body
+/// (e.g. a 429 response payload). Used to park an exhausted subscription on a
+/// long cooldown instead of the short transient-rate-limit backoff.
+fn body_is_quota_exhausted(body: &[u8]) -> bool {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) {
+        if matches!(classify_embedded_error(&v), CooldownReason::QuotaExhausted) {
+            return true;
+        }
+    }
+    // Fallback for non-JSON or unusually-shaped bodies: scan for unambiguous
+    // quota phrases only (avoid generic "rate limit" which is transient).
+    let lower = String::from_utf8_lossy(body).to_ascii_lowercase();
+    lower.contains("usage limit")
+        || lower.contains("insufficient_quota")
+        || lower.contains("exceeded your current quota")
+        || lower.contains("out of credits")
+        || lower.contains("insufficient balance")
+}
+
 fn classify_embedded_error(v: &serde_json::Value) -> CooldownReason {
     let error_obj = v.get("error");
 
@@ -2700,6 +2736,33 @@ fn classify_embedded_error(v: &serde_json::Value) -> CooldownReason {
         .unwrap_or("");
 
     let error_type_lower = error_type.to_ascii_lowercase();
+
+    // Free-text message, used to spot hard quota/usage-limit exhaustion that
+    // isn't distinguishable from the error type/code alone (e.g. z.ai returns
+    // a generic 429 whose body says "The usage limit has been reached").
+    let message_lower = error_obj
+        .and_then(|e| e.get("message"))
+        .or_else(|| v.get("message"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    // Hard quota exhaustion → long cooldown (parked, not flapped). Checked
+    // before the transient rate-limit branch since these are more specific.
+    // NOTE: Google's "resource_exhausted" is a *transient* per-minute limit, so
+    // it is deliberately NOT treated as quota exhaustion here.
+    if error_type_lower.contains("insufficient_quota")
+        || error_type_lower.contains("quota_exceeded")
+        || error_type_lower.contains("usage_limit")
+        || message_lower.contains("usage limit")
+        || message_lower.contains("insufficient_quota")
+        || message_lower.contains("quota exceeded")
+        || message_lower.contains("exceeded your current quota")
+        || message_lower.contains("out of credits")
+        || message_lower.contains("insufficient balance")
+    {
+        return CooldownReason::QuotaExhausted;
+    }
 
     if error_type_lower.contains("rate_limit")
         || error_type_lower.contains("rate-limit")
@@ -5222,6 +5285,61 @@ mod tests {
         let reason =
             classify_google_error_reason(serde_json::to_vec(&body).unwrap().as_slice()).unwrap();
         assert!(matches!(reason, CooldownReason::Overloaded));
+    }
+
+    #[test]
+    fn classify_embedded_quota_from_message() {
+        // z.ai-style: generic code, quota signalled only in the message text.
+        let v = serde_json::json!({
+            "error": {"code": "1113", "message": "The usage limit has been reached"}
+        });
+        assert!(matches!(
+            classify_embedded_error(&v),
+            CooldownReason::QuotaExhausted
+        ));
+    }
+
+    #[test]
+    fn classify_embedded_insufficient_quota_type() {
+        let v = serde_json::json!({
+            "error": {"type": "insufficient_quota", "message": "You exceeded your current quota"}
+        });
+        assert!(matches!(
+            classify_embedded_error(&v),
+            CooldownReason::QuotaExhausted
+        ));
+    }
+
+    #[test]
+    fn classify_embedded_transient_rate_limit_stays_rate_limit() {
+        // A transient rate limit must NOT be upgraded to the long quota cooldown.
+        let v = serde_json::json!({
+            "error": {"type": "rate_limit_error", "message": "slow down"}
+        });
+        assert!(matches!(
+            classify_embedded_error(&v),
+            CooldownReason::RateLimit
+        ));
+        // Google's per-minute RESOURCE_EXHAUSTED is also transient.
+        let g = serde_json::json!({"error": {"status": "RESOURCE_EXHAUSTED"}});
+        assert!(matches!(
+            classify_embedded_error(&g),
+            CooldownReason::RateLimit
+        ));
+    }
+
+    #[test]
+    fn body_quota_detector_matches_quota_bodies_only() {
+        assert!(body_is_quota_exhausted(
+            br#"{"error":{"message":"The usage limit has been reached"}}"#
+        ));
+        assert!(body_is_quota_exhausted(
+            br#"{"error":{"type":"insufficient_quota"}}"#
+        ));
+        assert!(!body_is_quota_exhausted(
+            br#"{"error":{"type":"rate_limit_error"}}"#
+        ));
+        assert!(!body_is_quota_exhausted(b"plain transient 429"));
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -136,6 +136,8 @@ fn default_base_url(provider_type: ProviderType) -> Option<&'static str> {
         ProviderType::Mistral => Some("https://api.mistral.ai/v1"),
         ProviderType::TogetherAI => Some("https://api.together.xyz/v1"),
         ProviderType::Perplexity => Some("https://api.perplexity.ai"),
+        // Kimi Code subscription endpoint (OpenAI Chat Completions compatible).
+        ProviderType::Kimi => Some("https://api.kimi.com/coding/v1"),
         ProviderType::Custom => None, // uses account's base_url
         // Non-OpenAI-compatible providers
         ProviderType::Anthropic => None,
@@ -805,7 +807,13 @@ pub(crate) async fn chat_completions_inner(
                     continue;
                 }
             };
-            (url, upstream_body, HeaderMap::new())
+            // Kimi's coding endpoint returns 403 unless the User-Agent matches a
+            // known coding-agent pattern; pin it to the Kimi CLI's UA.
+            let mut extra = HeaderMap::new();
+            if provider_type == ProviderType::Kimi {
+                extra.insert(header::USER_AGENT, HeaderValue::from_static("KimiCLI/1.5"));
+            }
+            (url, upstream_body, extra)
         };
 
         // Forward the request.

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -265,7 +265,7 @@ struct ModelObject {
 ///
 /// Accepts either the internal `SANDBOXED_PROXY_SECRET` or any user-generated
 /// proxy API key from the `ProxyApiKeyStore`.
-async fn verify_proxy_auth(
+pub(crate) async fn verify_proxy_auth(
     headers: &HeaderMap,
     state: &super::routes::AppState,
 ) -> Result<(), Response> {

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -119,6 +119,28 @@ fn header_truthy(headers: &HeaderMap, key: &str) -> bool {
 // Provider Base URLs
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Client-side concurrency gate for Kimi.
+///
+/// Kimi Code subscriptions enforce a 5-hour rolling call/token budget (separate
+/// from the monthly quota), so a burst of parallel requests — e.g. a benchmark
+/// fanning out many tasks — trips upstream 429s and the account gets cooled
+/// down. Cap how many Kimi requests we have in flight so we pace into the
+/// budget instead of bursting. Excess requests wait for a slot (backpressure)
+/// rather than failing. Tunable via `KIMI_MAX_CONCURRENCY` (default 6).
+static KIMI_CONCURRENCY: std::sync::LazyLock<tokio::sync::Semaphore> =
+    std::sync::LazyLock::new(|| {
+        let n = std::env::var("KIMI_MAX_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(6);
+        tracing::info!(
+            max_concurrency = n,
+            "Kimi proxy concurrency gate initialized"
+        );
+        tokio::sync::Semaphore::new(n)
+    });
+
 /// Default base URL for OpenAI-compatible providers.
 ///
 /// Returns `None` for providers that don't have an OpenAI-compatible API
@@ -659,6 +681,17 @@ pub(crate) async fn chat_completions_inner(
         {
             continue;
         }
+
+        // Pace Kimi: hold a concurrency slot for the duration of this attempt so
+        // parallel callers (e.g. a benchmark) don't burst past Kimi's rolling
+        // rate limit. Excess requests wait here instead of bursting into 429s.
+        // The guard is dropped at the end of the iteration (on `continue` or
+        // when the response is returned). `None` for every other provider.
+        let _kimi_permit = if provider_type == ProviderType::Kimi {
+            KIMI_CONCURRENCY.acquire().await.ok()
+        } else {
+            None
+        };
 
         // The synthetic "anthropic-cli-proxy" account is the only Anthropic
         // entry without an api_key — `read_standard_accounts` hoists the
@@ -1482,7 +1515,19 @@ pub(crate) async fn chat_completions_inner(
         // Pre-stream error handling: 429, 529, 5xx → cooldown + try next
         if status == StatusCode::TOO_MANY_REQUESTS || status.as_u16() == 529 {
             let elapsed_ms = request_start.elapsed().as_millis() as u64;
-            let retry_after = parse_rate_limit_headers(upstream_resp.headers(), provider_type);
+            let mut retry_after = parse_rate_limit_headers(upstream_resp.headers(), provider_type);
+            // Kimi: keep the rate-limit cooldown short instead of letting it grow
+            // exponentially (5s→300s). Its rolling-window quota frees up
+            // continuously and we already throttle via `KIMI_CONCURRENCY`, so a
+            // brief account-wide pause is enough; a multi-minute cooldown would
+            // outlast a caller's retry budget and make the whole run give up.
+            // Honor a real upstream `retry-after` when present (and shorter).
+            if provider_type == ProviderType::Kimi && status == StatusCode::TOO_MANY_REQUESTS {
+                let capped = retry_after
+                    .unwrap_or(std::time::Duration::from_secs(5))
+                    .min(std::time::Duration::from_secs(15));
+                retry_after = Some(capped);
+            }
             // Passive Codex usage capture (B): a 429 from the local CLIProxyAPI
             // on the Codex path carries a `model_cooldown` body with the weekly
             // (secondary) window reset. The cli-proxy strips the rich x-codex-*

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -529,6 +529,9 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // dashboard always reads a fresh-enough cache.
     super::ai_providers::spawn_usage_refresh_loop(Arc::clone(&state));
 
+    // Keep short-lived Kimi OAuth access tokens fresh for the chain resolver.
+    super::ai_providers::spawn_kimi_oauth_refresh_loop(Arc::clone(&state));
+
     // Initialize the metadata LLM client for AI-powered mission titles/descriptions
     {
         super::metadata_llm::init_metadata_llm(state.http_client.clone());

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -650,7 +650,13 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest(
             "/v1",
             proxy_api::routes().layer(DefaultBodyLimit::max(50 * 1024 * 1024)),
-        );
+        )
+        // Spark build-offload endpoint authenticates with a per-mission scoped
+        // HMAC capability token verified inside the handler
+        // (verify_spark_offload_token), NOT the dashboard JWT — so it must
+        // bypass require_auth like the /v1 proxy, otherwise the in-workspace
+        // spark-build wrapper's token is rejected at the auth layer.
+        .nest("/api/spark", super::spark::routes());
 
     // File upload routes with increased body limit (10GB)
     let upload_route = Router::new()
@@ -1113,7 +1119,6 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest("/api/durable-jobs", durable_jobs::routes())
         // System component management endpoints
         .nest("/api/system", system_api::routes())
-        .nest("/api/spark", super::spark::routes())
         // Auth management endpoints
         .route("/api/auth/status", get(auth::auth_status))
         .route("/api/auth/change-password", post(auth::change_password))

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1113,6 +1113,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest("/api/durable-jobs", durable_jobs::routes())
         // System component management endpoints
         .nest("/api/system", system_api::routes())
+        .nest("/api/spark", super::spark::routes())
         // Auth management endpoints
         .route("/api/auth/status", get(auth::auth_status))
         .route("/api/auth/change-password", post(auth::change_password))

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2742,7 +2742,30 @@ async fn oauth_token_refresher_loop(
         }
     }
 
+    // Store-backed account types refreshed proactively (their tokens live in
+    // the AIProviderStore, possibly with several accounts per type).
+    let store_oauth_types = [ProviderType::Anthropic, ProviderType::Xai];
+
     loop {
+        // Refresh store-backed OAuth accounts FIRST. For any account that also
+        // owns the shared credential tiers, this rotates the token AND writes it
+        // to the tiers before the file-tier pass runs below — otherwise that
+        // pass would refresh the tier copy independently and revoke the store
+        // record's refresh token (the Anthropic split-brain that produced
+        // recurring invalid_grant). xAI lives only in the store.
+        let mut store_found = 0u32;
+        let mut store_refreshed = 0u32;
+        for &store_type in &store_oauth_types {
+            let (f, r) = ai_providers_api::refresh_due_store_oauth(
+                &ai_providers,
+                store_type,
+                refresh_threshold_ms,
+            )
+            .await;
+            store_found += f;
+            store_refreshed += r;
+        }
+
         // Check credential files directly for each OAuth-capable provider type.
         // This ensures we find tokens even if they aren't in the AIProviderStore.
         let mut found_count = 0u32;
@@ -2822,17 +2845,6 @@ async fn oauth_token_refresher_loop(
                 },
             }
         }
-
-        // Also refresh store-backed OAuth accounts whose tokens live only in
-        // the AIProviderStore (not auth.json/credentials.json) — notably
-        // xAI/Grok connected via the dashboard. Without this their short-lived
-        // access token expires and model-routing silently drops the provider.
-        let (store_found, store_refreshed) = ai_providers_api::refresh_due_store_oauth(
-            &ai_providers,
-            ProviderType::Xai,
-            refresh_threshold_ms,
-        )
-        .await;
 
         tracing::debug!(
             oauth_tokens_found = found_count,

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1032,6 +1032,13 @@ pub fn run_claudecode_turn<'a>(
             tracing::warn!("No authentication available for Claude Code!");
         }
 
+        // DGX Spark build offload (opt-in per workspace): expose the local host
+        // endpoint + token + workspace paths so the in-workspace `spark-build`
+        // wrapper can ship Lean builds to the Spark. Credentials stay on the host.
+        if let Some(spark_vars) = workspace.spark_offload_env(mission_id) {
+            env.extend(spark_vars);
+        }
+
         // Inject Telegram action environment variables when processing a Telegram message.
         // These are needed by the telegram-action CLI helper inside the container to schedule
         // reminders, send replies, etc.

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -841,10 +841,16 @@ pub async fn run_codex_turn(
         "Starting Codex execution via WorkspaceExec"
     );
 
+    // DGX Spark build offload (opt-in per workspace) — see
+    // Workspace::spark_offload_env. Exported to the codex app-server process so
+    // the in-workspace `spark-build` wrapper can reach the host offload endpoint.
+    let extra_env = workspace.spark_offload_env(mission_id).unwrap_or_default();
+
     let codex_config = crate::backend::codex::client::CodexConfig {
         cli_path,
         model_effort: model_effort.map(|s| s.to_string()),
         cancel_token: Some(cancel.clone()),
+        extra_env,
         external_chatgpt_auth: prepared_oauth_account.as_ref().map(|account| {
             crate::backend::codex::client::CodexExternalChatgptAuth {
                 access_token: account.access_token.clone(),

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -451,6 +451,10 @@ pub async fn run_opencode_turn(
     // Build environment variables
     let mut env: HashMap<String, String> = HashMap::new();
     env.insert("MISSION_ID".to_string(), mission_id.to_string());
+    // DGX Spark build offload (opt-in per workspace) — see Workspace::spark_offload_env.
+    if let Some(spark_vars) = workspace.spark_offload_env(mission_id) {
+        env.extend(spark_vars);
+    }
     if let Some(public_url) = public_api_base_url_from_env() {
         env.insert("API_URL".to_string(), public_url);
     } else if let Some(local_url) = workspace_api_base_url(workspace) {

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -154,6 +154,21 @@ async fn run(args: &[&str]) -> (bool, String) {
     }
 }
 
+/// Whether a slash-trimmed `rel` is safe to interpolate into the remote build
+/// path. The path is re-parsed by the Spark's login shell (via `ssh`/rsync), so
+/// only `[A-Za-z0-9._-]` components are allowed — no shell metacharacters, no
+/// `..` traversal, no argv-flag-leading (`-`) component. Empty = workspace root.
+fn rel_path_is_safe(rel_clean: &str) -> bool {
+    rel_clean.is_empty()
+        || rel_clean.split('/').all(|c| {
+            !c.is_empty()
+                && c != ".."
+                && !c.starts_with('-')
+                && c.chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+        })
+}
+
 async fn offload_build(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -223,7 +238,14 @@ async fn offload_build(
     // Reject path traversal so `rel` can't escape the (already mission-bound)
     // host_dir.
     let rel_clean = req.rel.trim_matches('/');
-    if rel_clean.split('/').any(|c| c == "..") {
+    // `rel` is interpolated into `remote_cwd`, which is re-parsed by the remote
+    // login shell (both `ssh … mkdir -p <remote_cwd>` and rsync's `host:path`
+    // spec). A scoped-token holder must NOT be able to smuggle shell
+    // metacharacters or argv flags onto the Spark (where the ssh user has
+    // sudo). Strict allowlist: each path component is non-empty, not `..`, not
+    // a flag (`-`-leading), and only `[A-Za-z0-9._-]`. Empty rel = build at the
+    // workspace root, which is allowed.
+    if !rel_path_is_safe(rel_clean) {
         return (StatusCode::BAD_REQUEST, "invalid rel").into_response();
     }
     let remote_cwd = if rel_clean.is_empty() {
@@ -350,4 +372,45 @@ async fn offload_build(
     .await;
 
     Json(OffloadResponse { exit_code, log }).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rel_path_is_safe;
+
+    #[test]
+    fn rel_allows_real_verity_worktrees() {
+        for ok in [
+            "",
+            "verity",
+            "morpho-verity",
+            "wt-c13-0x20-bridge/verity",
+            "wt-catalog-claude/verity",
+            "wk-2009",
+            "w-2005",
+            "a.b/c_d-e",
+        ] {
+            assert!(rel_path_is_safe(ok), "should allow {ok:?}");
+        }
+    }
+
+    #[test]
+    fn rel_rejects_injection_and_traversal() {
+        for bad in [
+            "verity; rm -rf ~",
+            "verity && reboot",
+            "$(touch /tmp/x)",
+            "`id`",
+            "a|b",
+            "a b",
+            "../etc",
+            "verity/../../root",
+            "-rf",          // argv flag smuggling
+            "verity/-e/sh", // flag in a later component
+            "a\nb",
+            "x>y",
+        ] {
+            assert!(!rel_path_is_safe(bad), "should reject {bad:?}");
+        }
+    }
 }

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -22,6 +22,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::routes::AppState;
 
@@ -29,8 +30,57 @@ pub fn routes() -> Router<Arc<AppState>> {
     Router::new().route("/offload", post(offload_build))
 }
 
+/// Secret used to sign the per-mission spark-offload capability token. Reuses
+/// the same internal-action secret as Telegram action tokens.
+fn spark_offload_secret() -> Option<String> {
+    std::env::var("SANDBOXED_INTERNAL_ACTION_SECRET")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("JWT_SECRET")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+}
+
+/// Mint a per-mission, scope-bound capability token for spark offload. Unlike
+/// the master `SANDBOXED_PROXY_SECRET`, a leaked token only authorizes spark
+/// builds for THIS mission — it can't be replayed against the LLM proxy or any
+/// other proxy route, nor against another mission's workspace. Returns `None`
+/// when no signing secret is configured.
+pub fn build_spark_offload_token(mission_id: Uuid) -> Option<String> {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    let secret = spark_offload_secret()?;
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+    mac.update(b"spark-offload:");
+    mac.update(mission_id.as_bytes());
+    Some(hex::encode(mac.finalize().into_bytes()))
+}
+
+fn verify_spark_offload_token(mission_id: Uuid, token: &str) -> bool {
+    let Some(expected) = build_spark_offload_token(mission_id) else {
+        return false;
+    };
+    super::auth::constant_time_eq(&expected, token.trim())
+}
+
+/// Extract the bearer token from the `Authorization` header.
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 #[derive(Deserialize)]
 struct OffloadRequest {
+    /// Mission this build belongs to. The bearer token must be the scoped
+    /// capability token minted for exactly this mission, and `host_dir` must
+    /// resolve to this mission's workspace directory.
+    mission_id: Uuid,
     /// Host filesystem path of the mission workspace root, injected as
     /// `SPARK_WORKSPACE_HOST_DIR` and echoed back by the wrapper.
     host_dir: String,
@@ -51,6 +101,41 @@ fn default_priority() -> String {
 struct OffloadResponse {
     exit_code: i64,
     log: String,
+}
+
+/// Validate and canonicalize a caller-supplied mission workspace path.
+///
+/// Returns the resolved absolute path only when it is a real directory shaped
+/// like `<root>/workspaces/mission-*` (the layout produced by
+/// `workspace::mission_workspace_dir_for_root`, for both container and host
+/// workspaces). `canonicalize` resolves symlinks and requires existence, so a
+/// symlink whose target escapes that layout — or any path merely *containing*
+/// the `/workspaces/mission-` substring — is rejected.
+fn canonical_mission_host_dir(raw: &str) -> Result<String, &'static str> {
+    // Cheap pre-filter before touching the filesystem.
+    if !raw.starts_with('/') || raw.contains("..") {
+        return Err("invalid host_dir");
+    }
+    let canon = std::fs::canonicalize(raw).map_err(|_| "invalid host_dir")?;
+    if !canon.is_dir() {
+        return Err("invalid host_dir");
+    }
+    let is_mission = canon
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("mission-"));
+    let in_workspaces = canon
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n == "workspaces");
+    if !is_mission || !in_workspaces {
+        return Err("invalid host_dir");
+    }
+    canon
+        .to_str()
+        .map(|s| s.to_string())
+        .ok_or("invalid host_dir")
 }
 
 /// Run a host subprocess, returning (success, combined output).
@@ -74,8 +159,16 @@ async fn offload_build(
     headers: HeaderMap,
     Json(req): Json<OffloadRequest>,
 ) -> axum::response::Response {
-    if let Err(resp) = super::proxy::verify_proxy_auth(&headers, &state).await {
-        return resp;
+    // Host-privileged endpoint (rsyncs host paths, SSHes to the Spark). Auth is
+    // a per-mission, scope-bound capability token — NOT the master proxy secret
+    // — so a token leaked from a workspace can't be replayed against the LLM
+    // proxy or another mission. The legitimate caller is the in-workspace
+    // `spark-build` wrapper, handed the token minted for its own mission.
+    let Some(token_in) = bearer_token(&headers) else {
+        return (StatusCode::UNAUTHORIZED, "missing bearer token").into_response();
+    };
+    if !verify_spark_offload_token(req.mission_id, &token_in) {
+        return (StatusCode::UNAUTHORIZED, "invalid spark offload token").into_response();
     }
 
     // All three must be set, else tell the caller to build locally.
@@ -91,30 +184,34 @@ async fn offload_build(
             .into_response();
     };
 
-    // Security: only rsync real mission workspace dirs (the host_dir comes from a
-    // workspace-authenticated caller, but constrain it anyway). Require an
-    // absolute path containing the mission marker and no `..`. The leading-`/`
-    // anchor also guarantees host_dir can't start with `-`, which — combined
-    // with the `--` separator before the positional rsync paths below — closes
-    // the argv flag-smuggling vector (e.g. a `--rsync-path=<cmd>` value that
-    // still contains `/workspaces/mission-` would otherwise reach rsync as an
-    // option and run a command on the Spark host).
-    if !req.host_dir.starts_with('/')
-        || !req.host_dir.contains("/workspaces/mission-")
-        || req.host_dir.contains("..")
-    {
-        return (StatusCode::BAD_REQUEST, "invalid host_dir").into_response();
-    }
+    // Security: confine host_dir to a genuine mission workspace directory.
+    // A substring check (`contains("/workspaces/mission-")`) is not real
+    // containment — an attacker-controlled path or a symlink like
+    // `<workspace>/workspaces/mission-x -> /etc` would pass it, and the
+    // download rsync below WRITES into host_dir (arbitrary host write as root).
+    // So canonicalize (resolving symlinks, requiring existence) and assert the
+    // resolved path is `<root>/workspaces/mission-*` — the layout every
+    // container and host workspace uses. Using the canonical path for the rsync
+    // also removes the argv flag-smuggling surface (it can never start with `-`).
+    let host_dir = match canonical_mission_host_dir(&req.host_dir) {
+        Ok(p) => p,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
     if req.cmd.trim().is_empty() {
         return (StatusCode::BAD_REQUEST, "cmd required").into_response();
     }
 
-    let host_dir = req.host_dir.trim_end_matches('/').to_string();
     let name = host_dir.rsplit('/').next().unwrap_or("build").to_string();
-    // Belt-and-suspenders: the derived `name` feeds remote paths; never let it
-    // look like a flag even if host_dir's last segment somehow began with `-`.
-    if name.starts_with('-') {
-        return (StatusCode::BAD_REQUEST, "invalid host_dir").into_response();
+    // The token authenticates a specific mission; the workspace dir is named
+    // `mission-<short>`. Reject any attempt to point a mission's token at a
+    // different mission's workspace (the rsync below WRITES into host_dir).
+    let expected_name = format!("mission-{}", &req.mission_id.to_string()[..8]);
+    if name != expected_name {
+        return (
+            StatusCode::FORBIDDEN,
+            "host_dir does not belong to this mission",
+        )
+            .into_response();
     }
     let user = ssh.split('@').next().unwrap_or("th0rgal");
     let remote_rel = format!(".spark-builds/{}", name);

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -215,18 +215,43 @@ async fn offload_build(
     }
     let user = ssh.split('@').next().unwrap_or("th0rgal");
     let remote_rel = format!(".spark-builds/{}", name);
-    let remote_cwd = if req.rel.is_empty() {
+
+    // Confine the transfer to the build subtree (`rel`) rather than the whole
+    // mission workspace. A mega-mission can carry dozens of multi-GB Lean
+    // worktrees (84GB+), and rsyncing the entire root per build is
+    // impractical; the build only needs its own self-contained package dir.
+    // Reject path traversal so `rel` can't escape the (already mission-bound)
+    // host_dir.
+    let rel_clean = req.rel.trim_matches('/');
+    if rel_clean.split('/').any(|c| c == "..") {
+        return (StatusCode::BAD_REQUEST, "invalid rel").into_response();
+    }
+    let remote_cwd = if rel_clean.is_empty() {
         format!("/home/{}/{}", user, remote_rel)
     } else {
-        format!(
-            "/home/{}/{}/{}",
-            user,
-            remote_rel,
-            req.rel.trim_matches('/')
-        )
+        format!("/home/{}/{}/{}", user, remote_rel, rel_clean)
     };
+    // Local source + remote destination, both scoped to the build subtree.
+    let local_src = if rel_clean.is_empty() {
+        format!("{}/", host_dir)
+    } else {
+        format!("{}/{}/", host_dir, rel_clean)
+    };
+    let remote_dst = format!("{}:{}/", ssh, remote_cwd);
 
-    // 1. Sync the workspace up to the Spark.
+    // rsync won't create missing parent dirs; ensure the (possibly nested)
+    // remote build dir exists first.
+    let mk = run(&["ssh", "--", ssh, "mkdir", "-p", &remote_cwd]).await;
+    if !mk.0 {
+        tracing::warn!("spark offload: remote mkdir failed: {}", mk.1);
+        return (
+            StatusCode::BAD_GATEWAY,
+            format!("remote mkdir failed: {}", mk.1),
+        )
+            .into_response();
+    }
+
+    // 1. Sync the build subtree up to the Spark.
     let up = run(&[
         "rsync",
         "-az",
@@ -236,8 +261,8 @@ async fn offload_build(
         "-e",
         "ssh",
         "--",
-        &format!("{}/", host_dir),
-        &format!("{}:{}/", ssh, remote_rel),
+        &local_src,
+        &remote_dst,
     ])
     .await;
     if !up.0 {
@@ -312,15 +337,15 @@ async fn offload_build(
         return (StatusCode::GATEWAY_TIMEOUT, "build timed out on spark").into_response();
     }
 
-    // 4. Sync artifacts (.olean etc.) back into the workspace.
+    // 4. Sync artifacts (.olean etc.) back into the build subtree.
     let _back = run(&[
         "rsync",
         "-az",
         "-e",
         "ssh",
         "--",
-        &format!("{}:{}/", ssh, remote_rel),
-        &format!("{}/", host_dir),
+        &format!("{}:{}/", ssh, remote_cwd),
+        &local_src,
     ])
     .await;
 

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -24,6 +24,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::mission_store::MissionStore;
 use super::routes::AppState;
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -169,6 +170,41 @@ fn rel_path_is_safe(rel_clean: &str) -> bool {
         })
 }
 
+/// Walk a mission's `parent_mission_id` chain and return true if any ANCESTOR's
+/// id begins with `short` — the 8-char prefix encoded in a `mission-<short>`
+/// workspace dir name. Lets an orchestrator worker offload a build that lives in
+/// its parent/boss mission's shared workspace dir (per-PR worktrees). The walk
+/// is bounded; a missing record or cyclic chain just yields `false` (→ 403).
+async fn mission_has_ancestor_short(
+    store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    short: &str,
+) -> bool {
+    if short.is_empty() {
+        return false;
+    }
+    let mut cur = match store.get_mission(mission_id).await {
+        Ok(Some(m)) => m.parent_mission_id,
+        _ => None,
+    };
+    let mut depth = 0;
+    while let Some(id) = cur {
+        let id_str = id.to_string();
+        if id_str.len() >= 8 && id_str[..8] == *short {
+            return true;
+        }
+        cur = match store.get_mission(id).await {
+            Ok(Some(m)) => m.parent_mission_id,
+            _ => None,
+        };
+        depth += 1;
+        if depth > 64 {
+            break;
+        }
+    }
+    false
+}
+
 async fn offload_build(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -185,19 +221,6 @@ async fn offload_build(
     if !verify_spark_offload_token(req.mission_id, &token_in) {
         return (StatusCode::UNAUTHORIZED, "invalid spark offload token").into_response();
     }
-
-    // All three must be set, else tell the caller to build locally.
-    let (Some(url), Some(token), Some(ssh)) = (
-        state.config.spark_arbiter_url.as_deref(),
-        state.config.spark_arbiter_token.as_deref(),
-        state.config.spark_ssh_target.as_deref(),
-    ) else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "spark offload not configured",
-        )
-            .into_response();
-    };
 
     // Security: confine host_dir to a genuine mission workspace directory.
     // A substring check (`contains("/workspaces/mission-")`) is not real
@@ -218,16 +241,47 @@ async fn offload_build(
 
     let name = host_dir.rsplit('/').next().unwrap_or("build").to_string();
     // The token authenticates a specific mission; the workspace dir is named
-    // `mission-<short>`. Reject any attempt to point a mission's token at a
-    // different mission's workspace (the rsync below WRITES into host_dir).
-    let expected_name = format!("mission-{}", &req.mission_id.to_string()[..8]);
-    if name != expected_name {
+    // `mission-<short>`. A mission's scoped token may target its OWN workspace
+    // dir, OR the shared workspace dir of an ANCESTOR mission. Orchestrator
+    // fleets build in per-PR git worktrees under the boss mission's dir
+    // (`mission-<boss>/wk-NNNN`), so a worker legitimately offloads a build that
+    // physically lives in its parent's dir. The worker already has filesystem
+    // r/w to that shared dir (its harness operates there), so authorizing the
+    // offload into it is no privilege escalation — but an UNRELATED mission's
+    // dir (not in the caller's ancestor chain) is still rejected, since the
+    // rsync below WRITES into host_dir.
+    let host_short = name.strip_prefix("mission-").unwrap_or("");
+    let req_short = &req.mission_id.to_string()[..8];
+    let host_dir_authorized = if host_short.is_empty() {
+        false
+    } else if host_short == req_short {
+        true
+    } else {
+        let store = state.control.get_mission_store().await;
+        mission_has_ancestor_short(&store, req.mission_id, host_short).await
+    };
+    if !host_dir_authorized {
         return (
             StatusCode::FORBIDDEN,
-            "host_dir does not belong to this mission",
+            "host_dir does not belong to this mission or an ancestor",
         )
             .into_response();
     }
+
+    // Availability check runs AFTER authorization so an unauthorized caller can
+    // never probe whether Spark is configured. All three must be set, else tell
+    // the (authorized) caller to build locally via a 503.
+    let (Some(url), Some(token), Some(ssh)) = (
+        state.config.spark_arbiter_url.as_deref(),
+        state.config.spark_arbiter_token.as_deref(),
+        state.config.spark_ssh_target.as_deref(),
+    ) else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "spark offload not configured",
+        )
+            .into_response();
+    };
     let user = ssh.split('@').next().unwrap_or("th0rgal");
     let remote_rel = format!(".spark-builds/{}", name);
 
@@ -376,7 +430,60 @@ async fn offload_build(
 
 #[cfg(test)]
 mod tests {
+    use super::mission_has_ancestor_short;
     use super::rel_path_is_safe;
+    use crate::api::mission_store::{InMemoryMissionStore, MissionStore};
+    use std::sync::Arc;
+
+    async fn mk(
+        store: &Arc<dyn MissionStore>,
+        title: &str,
+        parent: Option<uuid::Uuid>,
+    ) -> uuid::Uuid {
+        store
+            .create_mission_with_parent(
+                Some(title),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                parent,
+                None,
+            )
+            .await
+            .expect("create mission")
+            .id
+    }
+
+    fn short(id: uuid::Uuid) -> String {
+        id.to_string()[..8].to_string()
+    }
+
+    #[tokio::test]
+    async fn ancestry_matches_parent_and_grandparent_not_strangers() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = mk(&store, "boss", None).await;
+        let worker = mk(&store, "worker", Some(boss)).await;
+        let grandchild = mk(&store, "grandchild", Some(worker)).await;
+        let stranger = mk(&store, "stranger", None).await;
+
+        // A worker's token may offload into its boss (parent) dir.
+        assert!(mission_has_ancestor_short(&store, worker, &short(boss)).await);
+        // …and a grandchild reaches the boss two hops up.
+        assert!(mission_has_ancestor_short(&store, grandchild, &short(boss)).await);
+        assert!(mission_has_ancestor_short(&store, grandchild, &short(worker)).await);
+        // An unrelated mission's dir is never authorized.
+        assert!(!mission_has_ancestor_short(&store, worker, &short(stranger)).await);
+        // The own-dir case is handled by the caller (host_short == req_short),
+        // so the ancestor walk (parents only) must NOT self-match.
+        assert!(!mission_has_ancestor_short(&store, worker, &short(worker)).await);
+        // Empty short never authorizes.
+        assert!(!mission_has_ancestor_short(&store, worker, "").await);
+        // Unknown mission id → no ancestors → false.
+        assert!(!mission_has_ancestor_short(&store, uuid::Uuid::new_v4(), &short(boss)).await);
+    }
 
     #[test]
     fn rel_allows_real_verity_worktrees() {

--- a/src/api/spark.rs
+++ b/src/api/spark.rs
@@ -1,0 +1,231 @@
+//! DGX Spark build-offload endpoint.
+//!
+//! A harness inside a mission workspace calls `POST /api/spark/offload` over the
+//! host veth link (`10.88.0.1`) to run a Lean build on the DGX Spark instead of
+//! the main box. The HOST holds the Spark credentials (arbiter token + SSH
+//! target, from [`crate::config::Config`]), so workspaces never carry them.
+//!
+//! Flow: rsync the mission workspace to the Spark, submit the build to the
+//! arbiter (`dgx-spark-arbiter`, which time-shares the Spark's unified memory
+//! against vLLM/step37 by priority), poll to completion, rsync artifacts back,
+//! return the result. Responds `503` when Spark config is absent so the
+//! in-workspace `spark-build` wrapper transparently falls back to a local build.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use super::routes::AppState;
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new().route("/offload", post(offload_build))
+}
+
+#[derive(Deserialize)]
+struct OffloadRequest {
+    /// Host filesystem path of the mission workspace root, injected as
+    /// `SPARK_WORKSPACE_HOST_DIR` and echoed back by the wrapper.
+    host_dir: String,
+    /// Build cwd relative to the workspace root (e.g. `"morpho-verity"`).
+    #[serde(default)]
+    rel: String,
+    /// The build command, e.g. `"lake build"`.
+    cmd: String,
+    #[serde(default = "default_priority")]
+    priority: String,
+}
+
+fn default_priority() -> String {
+    "P0".to_string()
+}
+
+#[derive(Serialize)]
+struct OffloadResponse {
+    exit_code: i64,
+    log: String,
+}
+
+/// Run a host subprocess, returning (success, combined output).
+async fn run(args: &[&str]) -> (bool, String) {
+    match tokio::process::Command::new(args[0])
+        .args(&args[1..])
+        .output()
+        .await
+    {
+        Ok(o) => {
+            let mut s = String::from_utf8_lossy(&o.stdout).to_string();
+            s.push_str(&String::from_utf8_lossy(&o.stderr));
+            (o.status.success(), s)
+        }
+        Err(e) => (false, e.to_string()),
+    }
+}
+
+async fn offload_build(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<OffloadRequest>,
+) -> axum::response::Response {
+    if let Err(resp) = super::proxy::verify_proxy_auth(&headers, &state).await {
+        return resp;
+    }
+
+    // All three must be set, else tell the caller to build locally.
+    let (Some(url), Some(token), Some(ssh)) = (
+        state.config.spark_arbiter_url.as_deref(),
+        state.config.spark_arbiter_token.as_deref(),
+        state.config.spark_ssh_target.as_deref(),
+    ) else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "spark offload not configured",
+        )
+            .into_response();
+    };
+
+    // Security: only rsync real mission workspace dirs (the host_dir comes from a
+    // workspace-authenticated caller, but constrain it anyway). Require an
+    // absolute path containing the mission marker and no `..`. The leading-`/`
+    // anchor also guarantees host_dir can't start with `-`, which — combined
+    // with the `--` separator before the positional rsync paths below — closes
+    // the argv flag-smuggling vector (e.g. a `--rsync-path=<cmd>` value that
+    // still contains `/workspaces/mission-` would otherwise reach rsync as an
+    // option and run a command on the Spark host).
+    if !req.host_dir.starts_with('/')
+        || !req.host_dir.contains("/workspaces/mission-")
+        || req.host_dir.contains("..")
+    {
+        return (StatusCode::BAD_REQUEST, "invalid host_dir").into_response();
+    }
+    if req.cmd.trim().is_empty() {
+        return (StatusCode::BAD_REQUEST, "cmd required").into_response();
+    }
+
+    let host_dir = req.host_dir.trim_end_matches('/').to_string();
+    let name = host_dir.rsplit('/').next().unwrap_or("build").to_string();
+    // Belt-and-suspenders: the derived `name` feeds remote paths; never let it
+    // look like a flag even if host_dir's last segment somehow began with `-`.
+    if name.starts_with('-') {
+        return (StatusCode::BAD_REQUEST, "invalid host_dir").into_response();
+    }
+    let user = ssh.split('@').next().unwrap_or("th0rgal");
+    let remote_rel = format!(".spark-builds/{}", name);
+    let remote_cwd = if req.rel.is_empty() {
+        format!("/home/{}/{}", user, remote_rel)
+    } else {
+        format!(
+            "/home/{}/{}/{}",
+            user,
+            remote_rel,
+            req.rel.trim_matches('/')
+        )
+    };
+
+    // 1. Sync the workspace up to the Spark.
+    let up = run(&[
+        "rsync",
+        "-az",
+        "--delete",
+        "--exclude",
+        ".git",
+        "-e",
+        "ssh",
+        "--",
+        &format!("{}/", host_dir),
+        &format!("{}:{}/", ssh, remote_rel),
+    ])
+    .await;
+    if !up.0 {
+        tracing::warn!("spark offload: rsync up failed: {}", up.1);
+        return (
+            StatusCode::BAD_GATEWAY,
+            format!("rsync up failed: {}", up.1),
+        )
+            .into_response();
+    }
+
+    // 2. Submit the build to the arbiter.
+    let client = &state.http_client;
+    let submit = client
+        .post(format!("{}/build", url))
+        .bearer_auth(token)
+        .json(&serde_json::json!({
+            "priority": req.priority, "cmd": req.cmd, "cwd": remote_cwd,
+        }))
+        .send()
+        .await;
+    let jid = match submit {
+        Ok(r) => match r.json::<serde_json::Value>().await {
+            Ok(v) => v.get("id").and_then(|x| x.as_str()).map(|s| s.to_string()),
+            Err(e) => {
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    format!("arbiter submit parse: {e}"),
+                )
+                    .into_response()
+            }
+        },
+        Err(e) => {
+            return (StatusCode::BAD_GATEWAY, format!("arbiter unreachable: {e}")).into_response()
+        }
+    };
+    let Some(jid) = jid else {
+        return (StatusCode::BAD_GATEWAY, "arbiter returned no job id").into_response();
+    };
+
+    // 3. Poll to completion (cap ~60 min — Lean builds can be long).
+    let mut log = String::new();
+    let mut exit_code = -1i64;
+    let mut done = false;
+    for _ in 0..1200 {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let st = client
+            .get(format!("{}/build/{}", url, jid))
+            .bearer_auth(token)
+            .send()
+            .await
+            .ok();
+        let Some(v) = st else { continue };
+        let Ok(v) = v.json::<serde_json::Value>().await else {
+            continue;
+        };
+        log = v
+            .get("log_tail")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string();
+        match v.get("status").and_then(|x| x.as_str()) {
+            Some("done") | Some("failed") => {
+                exit_code = v.get("exit_code").and_then(|x| x.as_i64()).unwrap_or(-1);
+                done = true;
+                break;
+            }
+            _ => continue,
+        }
+    }
+    if !done {
+        return (StatusCode::GATEWAY_TIMEOUT, "build timed out on spark").into_response();
+    }
+
+    // 4. Sync artifacts (.olean etc.) back into the workspace.
+    let _back = run(&[
+        "rsync",
+        "-az",
+        "-e",
+        "ssh",
+        "--",
+        &format!("{}:{}/", ssh, remote_rel),
+        &format!("{}/", host_dir),
+    ])
+    .await;
+
+    Json(OffloadResponse { exit_code, log }).into_response()
+}

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1840,6 +1840,12 @@ pub struct UpdateWorkspaceResourcesRequest {
     pub memory_max: Option<String>,
     pub memory_high: Option<String>,
     pub memory_swap_max: Option<String>,
+    /// `CPUWeight` (1..=10000, or "idle"). Relative CPU share of this mission's
+    /// scopes under contention. `Some("")` clears the override.
+    pub cpu_weight: Option<String>,
+    /// `CPUQuota` (e.g. "400%" = 4 cores, or "infinity"). Hard per-mission CPU
+    /// ceiling so one mission can't saturate the host. `Some("")` clears it.
+    pub cpu_quota: Option<String>,
     /// Persist into the workspace env-var overrides (default true). When
     /// false the change is runtime-only: it survives until the scopes die.
     #[serde(default = "default_true")]
@@ -1866,6 +1872,8 @@ pub struct UpdateWorkspaceResourcesResponse {
     pub memory_max: Option<String>,
     pub memory_high: Option<String>,
     pub memory_swap_max: Option<String>,
+    pub cpu_weight: Option<String>,
+    pub cpu_quota: Option<String>,
 }
 
 /// Validate a systemd memory size: bytes, suffixed (K/M/G/T), percentage,
@@ -1891,6 +1899,30 @@ fn valid_memory_size(value: &str) -> bool {
     seen_digit
 }
 
+/// Validate a systemd `CPUWeight`: integer 1..=10000, or "idle".
+fn valid_cpu_weight(value: &str) -> bool {
+    let v = value.trim();
+    if v.eq_ignore_ascii_case("idle") {
+        return true;
+    }
+    matches!(v.parse::<u32>(), Ok(n) if (1..=10000).contains(&n))
+}
+
+/// Validate a systemd `CPUQuota`: "infinity", or a percentage like "400%"
+/// (>= 1%, optional decimals). "100%" == one core.
+fn valid_cpu_quota(value: &str) -> bool {
+    let v = value.trim();
+    if v.eq_ignore_ascii_case("infinity") {
+        return true;
+    }
+    let Some(num) = v.strip_suffix('%') else {
+        return false;
+    };
+    // Rust's f64 parser accepts "inf"/"nan"; require a finite percentage so
+    // "infinity%" and friends don't slip through.
+    matches!(num.trim().parse::<f64>(), Ok(pct) if pct.is_finite() && pct >= 1.0)
+}
+
 /// POST /api/workspaces/:id/resources — adjust a workspace's memory caps.
 ///
 /// This is the "boost" path: raise (or clear) one workspace's memory limits
@@ -1904,20 +1936,34 @@ async fn update_workspace_resources(
 ) -> Result<Json<UpdateWorkspaceResourcesResponse>, (StatusCode, String)> {
     let mut workspace = require_workspace(&state.workspaces, id).await?;
 
-    let updates: [(&str, &Option<String>); 3] = [
+    let updates: [(&str, &Option<String>); 5] = [
         ("MISSION_MEMORY_MAX", &req.memory_max),
         ("MISSION_MEMORY_HIGH", &req.memory_high),
         ("MISSION_MEMORY_SWAP_MAX", &req.memory_swap_max),
+        ("MISSION_CPU_WEIGHT", &req.cpu_weight),
+        ("MISSION_CPU_QUOTA", &req.cpu_quota),
     ];
 
     for (key, value) in &updates {
         if let Some(v) = value {
-            if !v.trim().is_empty() && !valid_memory_size(v) {
+            let v = v.trim();
+            if v.is_empty() {
+                continue;
+            }
+            let ok = match *key {
+                "MISSION_CPU_WEIGHT" => valid_cpu_weight(v),
+                "MISSION_CPU_QUOTA" => valid_cpu_quota(v),
+                _ => valid_memory_size(v),
+            };
+            if !ok {
+                let hint = match *key {
+                    "MISSION_CPU_WEIGHT" => "expected an integer 1..=10000 or 'idle'",
+                    "MISSION_CPU_QUOTA" => "expected a percentage like '400%' or 'infinity'",
+                    _ => "expected bytes, K/M/G/T suffix, %, or 'infinity'",
+                };
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    format!(
-                        "Invalid {key} value '{v}': expected bytes, K/M/G/T suffix, %, or 'infinity'"
-                    ),
+                    format!("Invalid {key} value '{v}': {hint}"),
                 ));
             }
         }
@@ -1937,7 +1983,7 @@ async fn update_workspace_resources(
     }
 
     let exec = crate::workspace_exec::WorkspaceExec::new(workspace.clone());
-    let caps = exec.mission_memory_caps();
+    let caps = exec.mission_resource_caps();
 
     let mut applied_units = Vec::new();
     let mut failed_units = Vec::new();
@@ -1970,6 +2016,17 @@ async fn update_workspace_resources(
                 "MemorySwapMax={}",
                 caps.swap_max.as_deref().unwrap_or("infinity")
             ));
+            // CPUWeight defaults back to systemd's 100 when cleared; CPUQuota
+            // is reset with an empty value ("infinity" is not a valid
+            // set-property argument for it).
+            cmd.arg(format!(
+                "CPUWeight={}",
+                caps.cpu_weight.as_deref().unwrap_or("100")
+            ));
+            cmd.arg(format!(
+                "CPUQuota={}",
+                caps.cpu_quota.as_deref().unwrap_or("")
+            ));
             match cmd.output().await {
                 Ok(out) if out.status.success() => applied_units.push(unit),
                 Ok(out) => {
@@ -1990,11 +2047,13 @@ async fn update_workspace_resources(
     }
 
     tracing::info!(
-        "Workspace {} memory caps updated: max={:?} high={:?} swap_max={:?} (live: {} unit(s), persisted: {})",
+        "Workspace {} resource caps updated: max={:?} high={:?} swap_max={:?} cpu_weight={:?} cpu_quota={:?} (live: {} unit(s), persisted: {})",
         workspace.name,
         caps.max,
         caps.high,
         caps.swap_max,
+        caps.cpu_weight,
+        caps.cpu_quota,
         applied_units.len(),
         req.persist
     );
@@ -2006,6 +2065,8 @@ async fn update_workspace_resources(
         memory_max: caps.max,
         memory_high: caps.high,
         memory_swap_max: caps.swap_max,
+        cpu_weight: caps.cpu_weight,
+        cpu_quota: caps.cpu_quota,
     }))
 }
 
@@ -2115,6 +2176,26 @@ mod tests {
             "1e10", "inf", "nan", "+5", "-5", "1.2.3", "", ".", "0x10", " ",
         ] {
             assert!(!valid_memory_size(v), "should reject {v:?}");
+        }
+    }
+
+    #[test]
+    fn valid_cpu_weight_matches_systemd_range() {
+        for v in ["1", "100", "10000", "idle", "IDLE"] {
+            assert!(valid_cpu_weight(v), "should accept {v}");
+        }
+        for v in ["0", "10001", "", "100%", "-1", "1.5", "abc"] {
+            assert!(!valid_cpu_weight(v), "should reject {v:?}");
+        }
+    }
+
+    #[test]
+    fn valid_cpu_quota_matches_systemd_forms() {
+        for v in ["400%", "100%", "1%", "12.5%", "infinity"] {
+            assert!(valid_cpu_quota(v), "should accept {v}");
+        }
+        for v in ["400", "0%", "0.5%", "", "%", "-100%", "infinity%"] {
+            assert!(!valid_cpu_quota(v), "should reject {v:?}");
         }
     }
 

--- a/src/backend/codex/client.rs
+++ b/src/backend/codex/client.rs
@@ -23,6 +23,9 @@ pub struct CodexConfig {
     /// observes it directly so goal-mode cancellation can call
     /// `thread/goal/clear` against the live thread before shutdown.
     pub cancel_token: Option<tokio_util::sync::CancellationToken>,
+    /// Extra environment variables exported to the codex app-server process
+    /// (e.g. the per-mission DGX Spark offload vars). Empty by default.
+    pub extra_env: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -41,6 +44,7 @@ impl Default for CodexConfig {
             model_effort: None,
             external_chatgpt_auth: None,
             cancel_token: None,
+            extra_env: std::collections::HashMap::new(),
         }
     }
 }

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -212,7 +212,7 @@ async fn send_message_streaming_app_server(
         enabled_features: vec!["goals".to_string()],
         default_model: cfg.default_model.clone(),
         model_effort: cfg.model_effort.clone(),
-        env: std::collections::HashMap::new(),
+        env: cfg.extra_env.clone(),
     };
     // Keep an owned clone of the spawn config so the driver task can
     // re-spawn the codex process via `thread/resume` if the stdio

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,6 +236,16 @@ pub struct Config {
 
     /// Whether mission automations are enabled
     pub automations_enabled: bool,
+
+    /// DGX Spark build-offload config (all optional; offload is disabled unless
+    /// all three are set). The host holds these credentials so workspaces never
+    /// need Spark access. See `src/api/spark.rs`.
+    /// Arbiter base URL, e.g. `http://100.77.4.93:8088`.
+    pub spark_arbiter_url: Option<String>,
+    /// Arbiter bearer token (matches `/etc/spark-arbiter.env` on the Spark).
+    pub spark_arbiter_token: Option<String>,
+    /// SSH target for rsync of the workspace, e.g. `th0rgal@100.77.4.93`.
+    pub spark_ssh_target: Option<String>,
 }
 
 /// API auth configuration.
@@ -605,6 +615,16 @@ impl Config {
             .transpose()?
             .unwrap_or(true);
 
+        let env_opt = |k: &str| {
+            std::env::var(k)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+        let spark_arbiter_url = env_opt("SPARK_ARBITER_URL");
+        let spark_arbiter_token = env_opt("SPARK_ARBITER_TOKEN");
+        let spark_ssh_target = env_opt("SPARK_SSH_TARGET");
+
         Ok(Self {
             default_model,
             working_dir,
@@ -623,6 +643,9 @@ impl Config {
             library_path,
             default_backend,
             automations_enabled,
+            spark_arbiter_url,
+            spark_arbiter_token,
+            spark_ssh_target,
         })
     }
 
@@ -647,6 +670,9 @@ impl Config {
             library_path,
             default_backend: None,
             automations_enabled: true,
+            spark_arbiter_url: None,
+            spark_arbiter_token: None,
+            spark_ssh_target: None,
         }
     }
 }

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -549,7 +549,7 @@ async fn unmount_if_present(root: &Path, target: &str) -> NspawnResult<()> {
 /// service's cgroup and can throttle the whole service — same failure mode
 /// as the mission boot/attach paths in `workspace_exec.rs`.
 fn scope_wrapped_nspawn_command(path: &Path, env: &HashMap<String, String>) -> Command {
-    let caps = crate::workspace_exec::mission_memory_caps_from_env(env);
+    let caps = crate::workspace_exec::mission_resource_caps_from_env(env);
     // Embed the same machine-name token the mission boot/attach scopes use so
     // this one-shot scope is discoverable by `list_workspace_scope_units`
     // (live stats, retune, OOM watchdog). A divergent token would make the

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -21,8 +21,14 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CooldownReason {
-    /// HTTP 429 rate limit
+    /// HTTP 429 rate limit (transient — short exponential cooldown)
     RateLimit,
+    /// Hard usage/quota exhaustion (e.g. a subscription's daily/period limit is
+    /// reached). Distinguished from a transient `RateLimit` so the account is
+    /// parked for a long fixed cooldown instead of being re-tried as a primary
+    /// chain entry every few seconds. Detected from upstream error bodies
+    /// ("usage limit reached", "insufficient_quota", …).
+    QuotaExhausted,
     /// HTTP 529 overloaded
     Overloaded,
     /// Connection timeout or network error
@@ -41,6 +47,7 @@ impl std::fmt::Display for CooldownReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RateLimit => write!(f, "rate_limit"),
+            Self::QuotaExhausted => write!(f, "quota_exhausted"),
             Self::Overloaded => write!(f, "overloaded"),
             Self::Timeout => write!(f, "timeout"),
             Self::ServerError => write!(f, "server_error"),
@@ -48,6 +55,19 @@ impl std::fmt::Display for CooldownReason {
             Self::ClientError => write!(f, "client_error"),
         }
     }
+}
+
+/// Fixed cooldown (seconds) applied when an account/subscription reports a hard
+/// usage/quota exhaustion. Defaults to 1 hour; override with
+/// `PROVIDER_QUOTA_COOLDOWN_SECS`. A hard quota won't recover within a caller's
+/// retry budget, so parking it long keeps the chain on healthy providers
+/// instead of flapping back to the exhausted one every few seconds.
+fn quota_cooldown_secs() -> u64 {
+    std::env::var("PROVIDER_QUOTA_COOLDOWN_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(3600)
 }
 
 /// Snapshot of rate-limit quota state from provider response headers.
@@ -403,7 +423,9 @@ impl ProviderHealthTracker {
 
         health.total_requests += 1;
         match &reason {
-            CooldownReason::RateLimit | CooldownReason::Overloaded => health.total_rate_limits += 1,
+            CooldownReason::RateLimit
+            | CooldownReason::QuotaExhausted
+            | CooldownReason::Overloaded => health.total_rate_limits += 1,
             _ => health.total_errors += 1,
         }
 
@@ -416,14 +438,23 @@ impl ProviderHealthTracker {
         // Auth errors (401/403) are almost always permanent (bad API key,
         // revoked credentials), so use a long fixed cooldown instead of
         // short exponential backoff that implies eventual recovery.
-        let cooldown = retry_after.unwrap_or_else(|| {
-            if is_auth_error {
-                std::time::Duration::from_secs(3600) // 1 hour
-            } else {
+        // QuotaExhausted (a subscription's hard usage limit) won't recover for
+        // hours/days, so park it for a long fixed window so the chain stops
+        // re-trying an exhausted subscription as a primary entry; honor a
+        // longer upstream retry_after when one is supplied.
+        let cooldown = match reason {
+            CooldownReason::QuotaExhausted => {
+                let base = std::time::Duration::from_secs(quota_cooldown_secs());
+                retry_after.map(|r| r.max(base)).unwrap_or(base)
+            }
+            CooldownReason::AuthError => {
+                retry_after.unwrap_or(std::time::Duration::from_secs(3600))
+            }
+            _ => retry_after.unwrap_or_else(|| {
                 self.backoff_config
                     .cooldown_for(health.consecutive_failures.saturating_sub(1))
-            }
-        });
+            }),
+        };
 
         health.cooldown_until = Some(std::time::Instant::now() + cooldown);
 

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -1275,6 +1275,8 @@ impl ModelChainStore {
                 //     `oauth-2025-04-20` beta header), and
                 //   - xAI/Grok: `api.x.ai/v1/chat/completions` accepts the
                 //     Grok-Build OAuth token as a Bearer (scope `api:access`).
+                //   - Kimi: `api.kimi.com/coding/v1/chat/completions` accepts the
+                //     Kimi Code subscription OAuth access token as a Bearer.
                 // OpenAI (Codex) JWTs do NOT work at
                 // `api.openai.com/v1/chat/completions`; those accounts keep
                 // `api_key = None, has_oauth = true` and route through the
@@ -1284,6 +1286,7 @@ impl ModelChainStore {
                         provider_type,
                         crate::ai_providers::ProviderType::Anthropic
                             | crate::ai_providers::ProviderType::Xai
+                            | crate::ai_providers::ProviderType::Kimi
                     ) {
                         return None;
                     }

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -1206,13 +1206,13 @@ impl ModelChainStore {
             let provider_type = match crate::ai_providers::ProviderType::from_id(&entry.provider_id)
             {
                 Some(pt) => pt,
-                None => {
-                    tracing::warn!(
-                        provider_id = %entry.provider_id,
-                        "Unknown provider type in chain, skipping"
-                    );
-                    continue;
-                }
+                // A non-builtin prefix is a custom provider referenced by its
+                // sanitized name (e.g. "spark") — the id the catalog/UI exposes.
+                // All custom providers share `ProviderType::Custom`; the account
+                // loop below filters to the specific account whose sanitized name
+                // matches `entry.provider_id`, so a bogus prefix simply resolves
+                // to no accounts rather than mis-routing.
+                None => crate::ai_providers::ProviderType::Custom,
             };
 
             // Collect account IDs we've already added to avoid duplicates
@@ -1237,17 +1237,29 @@ impl ModelChainStore {
                 if !account.has_credentials() {
                     continue;
                 }
-                // Custom providers are a shared type: an entry like
-                // "custom/claude-fable-5" must only resolve to the custom
-                // account(s) that actually declare that model, not every
-                // custom endpoint in the store.
+                // Custom providers are a shared type, so an entry must be tied to
+                // the right account. Entries reference a custom provider two ways:
+                //   - the generic "custom" type id, which matches any custom
+                //     account that declares the model (the model id disambiguates
+                //     which endpoint serves it), or
+                //   - the provider's sanitized name (e.g. "spark/<model>"), which
+                //     targets that specific account — the id the catalog exposes.
+                // A name-qualified entry already identifies the account, so the
+                // model need not appear in the stored `custom_models` list (it may
+                // be a model discovered live via the router's `/v1/models`).
                 if matches!(provider_type, crate::ai_providers::ProviderType::Custom) {
-                    let model_known = account
-                        .custom_models
-                        .as_ref()
-                        .map(|ms| ms.iter().any(|m| m.id == entry.model_id))
-                        .unwrap_or(false);
-                    if !model_known {
+                    if entry.provider_id == "custom" {
+                        let model_known = account
+                            .custom_models
+                            .as_ref()
+                            .map(|ms| ms.iter().any(|m| m.id == entry.model_id))
+                            .unwrap_or(false);
+                        if !model_known {
+                            continue;
+                        }
+                    } else if crate::api::providers::sanitize_custom_provider_id(&account.name)
+                        != entry.provider_id
+                    {
                         continue;
                     }
                 }
@@ -1693,6 +1705,107 @@ mod tests {
             "expired standard OAuth token should not be routed, got {:?}",
             resolved
         );
+    }
+
+    fn custom_account(name: &str, base_url: &str, models: &[&str]) -> AIProvider {
+        let mut p = AIProvider::new(ProviderType::Custom, name.to_string());
+        p.api_key = Some(format!("sk-{name}"));
+        p.base_url = Some(base_url.to_string());
+        p.custom_models = Some(
+            models
+                .iter()
+                .map(|m| crate::ai_providers::CustomModel {
+                    id: m.to_string(),
+                    name: None,
+                    context_limit: None,
+                    output_limit: None,
+                })
+                .collect(),
+        );
+        p.status = ProviderStatus::Connected;
+        p
+    }
+
+    #[tokio::test]
+    async fn resolve_entries_routes_custom_provider_by_sanitized_name() {
+        // "spark/<model>" — the id the catalog exposes — must resolve to the
+        // Spark custom account even though "spark" is not a built-in provider
+        // type. A non-matching name must resolve to nothing.
+        let store = store_with(vec![
+            custom_account("Spark", "https://spark.example/v1", &["step3p7-flash-148b"]),
+            custom_account("Other", "https://other.example/v1", &["other-model"]),
+        ])
+        .await;
+        let chains = store_with_chain("noop", vec![]).await;
+        let tracker = ProviderHealthTracker::new();
+
+        let resolved = chains
+            .resolve_entries(
+                &[ChainEntry {
+                    provider_id: "spark".to_string(),
+                    model_id: "step3p7-flash-148b".to_string(),
+                }],
+                &store,
+                &[],
+                &tracker,
+            )
+            .await;
+
+        assert_eq!(
+            resolved.len(),
+            1,
+            "should resolve exactly the Spark account"
+        );
+        assert_eq!(resolved[0].provider_id, "spark");
+        assert_eq!(resolved[0].model_id, "step3p7-flash-148b");
+        assert_eq!(
+            resolved[0].base_url.as_deref(),
+            Some("https://spark.example/v1")
+        );
+
+        // A name that matches no custom provider resolves to nothing.
+        let none = chains
+            .resolve_entries(
+                &[ChainEntry {
+                    provider_id: "ghost".to_string(),
+                    model_id: "step3p7-flash-148b".to_string(),
+                }],
+                &store,
+                &[],
+                &tracker,
+            )
+            .await;
+        assert!(none.is_empty(), "unknown custom name must not route");
+    }
+
+    #[tokio::test]
+    async fn resolve_entries_name_qualified_custom_allows_live_only_model() {
+        // A name-qualified entry identifies the account, so a model that is NOT
+        // in the stored custom_models (e.g. discovered live via /v1/models) must
+        // still route to that account.
+        let store = store_with(vec![custom_account(
+            "Spark",
+            "https://spark.example/v1",
+            &["already-known"],
+        )])
+        .await;
+        let chains = store_with_chain("noop", vec![]).await;
+        let tracker = ProviderHealthTracker::new();
+
+        let resolved = chains
+            .resolve_entries(
+                &[ChainEntry {
+                    provider_id: "spark".to_string(),
+                    model_id: "freshly-discovered".to_string(),
+                }],
+                &store,
+                &[],
+                &tracker,
+            )
+            .await;
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].model_id, "freshly-discovered");
     }
 
     #[tokio::test]

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -261,17 +261,70 @@ pub(crate) async fn write_opencode_config(
         );
         base_obj.insert("tools".to_string(), serde_json::Value::Object(tools));
 
-        // Add custom providers if any
+        // Add custom providers if any. Kimi is handled here too: like Custom
+        // providers it is not an OpenCode built-in, so it needs an explicit
+        // provider block (OpenAI-compatible npm package + base URL + creds).
         if let Some(providers) = custom_providers {
-            let custom_only: Vec<_> = providers
+            let provider_blocks: Vec<_> = providers
                 .iter()
-                .filter(|p| p.provider_type == ProviderType::Custom && p.enabled)
+                .filter(|p| {
+                    matches!(p.provider_type, ProviderType::Custom | ProviderType::Kimi)
+                        && p.enabled
+                })
                 .collect();
 
-            if !custom_only.is_empty() {
+            if !provider_blocks.is_empty() {
                 let mut provider_map = serde_json::Map::new();
 
-                for provider in custom_only {
+                for provider in provider_blocks {
+                    // Kimi: OpenAI-compatible block with the OAuth access token as
+                    // the bearer key and the Kimi CLI User-Agent (the coding
+                    // endpoint 403s without a known coding-agent UA).
+                    if provider.provider_type == ProviderType::Kimi {
+                        let mut provider_config = serde_json::Map::new();
+                        provider_config
+                            .insert("npm".to_string(), json!("@ai-sdk/openai-compatible"));
+                        provider_config.insert("name".to_string(), json!("Kimi"));
+
+                        let mut options = serde_json::Map::new();
+                        options.insert(
+                            "baseURL".to_string(),
+                            json!(crate::api::ai_providers::KIMI_API_BASE_URL),
+                        );
+                        if let Some(oauth) = &provider.oauth {
+                            if !oauth.access_token.trim().is_empty() {
+                                options.insert("apiKey".to_string(), json!(oauth.access_token));
+                            }
+                        }
+                        let mut headers = serde_json::Map::new();
+                        headers.insert("User-Agent".to_string(), json!("KimiCLI/1.5"));
+                        options.insert("headers".to_string(), serde_json::Value::Object(headers));
+                        provider_config
+                            .insert("options".to_string(), serde_json::Value::Object(options));
+
+                        let mut models_map = serde_json::Map::new();
+                        for (model_id, model_name) in [
+                            ("kimi-for-coding", "Kimi for Coding"),
+                            ("kimi-k2.6", "Kimi K2.6"),
+                            ("kimi-k2-thinking", "Kimi K2 Thinking"),
+                        ] {
+                            let mut model_config = serde_json::Map::new();
+                            model_config.insert("name".to_string(), json!(model_name));
+                            models_map.insert(
+                                model_id.to_string(),
+                                serde_json::Value::Object(model_config),
+                            );
+                        }
+                        provider_config
+                            .insert("models".to_string(), serde_json::Value::Object(models_map));
+
+                        provider_map.insert(
+                            "kimi".to_string(),
+                            serde_json::Value::Object(provider_config),
+                        );
+                        continue;
+                    }
+
                     let provider_id = sanitize_key(&provider.name);
                     let mut provider_config = serde_json::Map::new();
 

--- a/src/workspace/git_credentials.rs
+++ b/src/workspace/git_credentials.rs
@@ -44,15 +44,44 @@ use uuid::Uuid;
 
 use crate::github_connection::{GithubConnection, GithubConnectionStore};
 use crate::util::{env_var_nonempty, home_dir, write_file_0600, GITHUB_CONNECTION_PATH};
-use crate::workspace::{
-    container_fallback_from_env, resolve_workspace_home_root, Workspace, WorkspaceType,
-};
+use crate::workspace::{container_fallback_from_env, Workspace, WorkspaceType};
 
 const MANAGED_BEGIN: &str = "# >>> sandboxed.sh git credentials >>>";
 const MANAGED_END: &str = "# <<< sandboxed.sh git credentials <<<";
 /// Host the `store` credential helper is scoped to, so we never hijack auth
 /// for other git hosts the workspace may talk to.
 const GITHUB_CREDENTIAL_HOST: &str = "https://github.com";
+
+/// Subdirectory under a **host** workspace's root used as the git/gh credential
+/// home. Containers already get an isolated home (`<root>/root`), but host
+/// workspaces previously shared the operator's real `$HOME` — so a connected
+/// account's `~/.gitconfig` / `~/.git-credentials` / `~/.config/gh/hosts.yml`
+/// would land on (and overwrite) the operator's own files. Writing them under
+/// this sandboxed subdir keeps the operator's dotfiles untouched; git/gh still
+/// find the creds because [`GitCredentialConfig::apply_to_env`] points them here
+/// explicitly (`GIT_CONFIG_*`, `GH_CONFIG_DIR`, `SANDBOXED_SH_GIT_CREDENTIALS_FILE`).
+const HOST_GIT_HOME_SUBDIR: &str = ".sandboxed-sh/git-home";
+
+/// Git/gh credential home for a workspace. Mirrors the harness's `$HOME` for
+/// containers (so creds are visible to the agent), but isolates **host**
+/// workspaces into [`HOST_GIT_HOME_SUBDIR`] instead of the operator's real
+/// `$HOME`. Container fallback (Docker/macOS) keeps using the host `$HOME`,
+/// matching where that harness actually runs.
+fn resolve_git_home_root(
+    workspace_root: &Path,
+    workspace_type: WorkspaceType,
+    workspace_env: &HashMap<String, String>,
+) -> PathBuf {
+    if workspace_type == WorkspaceType::Host {
+        workspace_root.join(HOST_GIT_HOME_SUBDIR)
+    } else if workspace_type == WorkspaceType::Container
+        && !container_fallback_from_env(workspace_env)
+    {
+        workspace_root.join("root")
+    } else {
+        PathBuf::from(home_dir())
+    }
+}
 
 /// Resolved git credential configuration sourced from the backend environment.
 #[derive(Debug, Clone)]
@@ -234,18 +263,17 @@ impl GitCredentialConfig {
         );
     }
 
-    /// Materialize git credential files into the workspace home.
-    ///
-    /// Resolves the home the same way Codex/Claude credentials are placed
-    /// ([`resolve_workspace_home_root`]) so git creds always land in the
-    /// `$HOME` the harness actually runs with:
+    /// Materialize git credential files into the workspace's git-credential home
+    /// ([`resolve_git_home_root`]):
     ///
     /// - Container under systemd-nspawn → `<workspace_root>/root` (the
     ///   container's `/root`).
     /// - Container in fallback mode (no nspawn, e.g. Docker/macOS — flagged via
     ///   `SANDBOXED_SH_CONTAINER_FALLBACK` in the workspace env) → the host
     ///   `$HOME`, because the harness then runs directly on the host.
-    /// - Host → the host `$HOME`.
+    /// - Host → a sandboxed subdir ([`HOST_GIT_HOME_SUBDIR`]), NOT the
+    ///   operator's real `$HOME`, so we never clobber their dotfiles. git/gh are
+    ///   pointed here via env in [`Self::apply_to_env`].
     ///
     /// Returns the home directory written into (for logging).
     pub fn write_for_workspace(
@@ -254,7 +282,7 @@ impl GitCredentialConfig {
         workspace_type: WorkspaceType,
         workspace_env: &HashMap<String, String>,
     ) -> std::io::Result<PathBuf> {
-        let home = resolve_workspace_home_root(workspace_root, workspace_type, workspace_env);
+        let home = resolve_git_home_root(workspace_root, workspace_type, workspace_env);
         std::fs::create_dir_all(&home)?;
 
         self.write_git_credentials(&home)?;
@@ -272,7 +300,7 @@ impl GitCredentialConfig {
         workspace_type: WorkspaceType,
         workspace_env: &HashMap<String, String>,
     ) -> std::io::Result<PathBuf> {
-        let home = resolve_workspace_home_root(workspace_root, workspace_type, workspace_env);
+        let home = resolve_git_home_root(workspace_root, workspace_type, workspace_env);
         scrub_home(&home, &self.token)?;
         Ok(home)
     }
@@ -302,6 +330,11 @@ impl GitCredentialConfig {
     /// Requires the account login, so it only runs on the dashboard-connected
     /// path. On the env-var fallback the login is unknown, so `gh` is left
     /// untouched (git still works via `.git-credentials`).
+    ///
+    /// Merges the `github.com` entry into any existing `hosts.yml` rather than
+    /// overwriting the file, so a pre-existing entry for another host (e.g. a
+    /// GitHub Enterprise instance, or — on a host workspace — the operator's own
+    /// `gh auth`) is preserved.
     fn write_gh_hosts(&self, home: &Path) -> std::io::Result<()> {
         let Some(login) = self
             .login
@@ -313,14 +346,10 @@ impl GitCredentialConfig {
         };
         let gh_dir = home.join(".config").join("gh");
         std::fs::create_dir_all(&gh_dir)?;
-        // Both the host-level `oauth_token`/`user` (older gh) and the `users`
-        // map (newer gh) are written so `gh auth status` works across versions.
-        let hosts = format!(
-            "github.com:\n    git_protocol: https\n    user: {login}\n    oauth_token: {token}\n    users:\n        {login}:\n            oauth_token: {token}\n",
-            login = login,
-            token = self.token,
-        );
-        write_file_0600(&gh_dir.join("hosts.yml"), hosts.as_bytes())
+        let path = gh_dir.join("hosts.yml");
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+        let merged = merge_gh_hosts(&existing, login, &self.token);
+        write_file_0600(&path, merged.as_bytes())
     }
 
     /// The managed `.gitconfig` block (between the sentinel markers).
@@ -338,6 +367,52 @@ impl GitCredentialConfig {
         s.push_str(MANAGED_END);
         s
     }
+}
+
+/// Merge the `github.com` entry into existing `gh` `hosts.yml` content, dropping
+/// any prior `github.com` entry and preserving every other host. Both the
+/// host-level `oauth_token`/`user` (older gh) and the `users` map (newer gh) are
+/// written so `gh auth status` works across versions. Falls back to a
+/// github.com-only document if the existing file can't be parsed as a mapping.
+fn merge_gh_hosts(existing: &str, login: &str, token: &str) -> String {
+    use serde_yaml::{Mapping, Value};
+
+    let github_entry = {
+        let mut entry = Mapping::new();
+        entry.insert(
+            Value::String("git_protocol".into()),
+            Value::String("https".into()),
+        );
+        entry.insert(Value::String("user".into()), Value::String(login.into()));
+        entry.insert(
+            Value::String("oauth_token".into()),
+            Value::String(token.into()),
+        );
+        let mut user_entry = Mapping::new();
+        user_entry.insert(
+            Value::String("oauth_token".into()),
+            Value::String(token.into()),
+        );
+        let mut users = Mapping::new();
+        users.insert(Value::String(login.into()), Value::Mapping(user_entry));
+        entry.insert(Value::String("users".into()), Value::Mapping(users));
+        Value::Mapping(entry)
+    };
+
+    let mut doc: Mapping = serde_yaml::from_str::<Value>(existing)
+        .ok()
+        .and_then(|v| match v {
+            Value::Mapping(m) => Some(m),
+            _ => None,
+        })
+        .unwrap_or_default();
+    doc.insert(Value::String("github.com".into()), github_entry);
+
+    serde_yaml::to_string(&Value::Mapping(doc)).unwrap_or_else(|_| {
+        format!(
+            "github.com:\n    git_protocol: https\n    user: {login}\n    oauth_token: {token}\n    users:\n        {login}:\n            oauth_token: {token}\n"
+        )
+    })
 }
 
 /// Merge a github.com token line into existing `.git-credentials` content,
@@ -430,12 +505,19 @@ fn push_unique_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf) {
     }
 }
 
+/// The git-credential home as the *agent process* sees it. Matches
+/// [`resolve_git_home_root`] except for nspawn containers, where the host path
+/// `<workspace_root>/root` is the container-internal `/root`.
 fn resolve_workspace_home_for_process(
-    _workspace_root: &Path,
+    workspace_root: &Path,
     workspace_type: WorkspaceType,
     workspace_env: &HashMap<String, String>,
 ) -> PathBuf {
-    if workspace_type == WorkspaceType::Container && !container_fallback_from_env(workspace_env) {
+    if workspace_type == WorkspaceType::Host {
+        workspace_root.join(HOST_GIT_HOME_SUBDIR)
+    } else if workspace_type == WorkspaceType::Container
+        && !container_fallback_from_env(workspace_env)
+    {
         PathBuf::from("/root")
     } else {
         PathBuf::from(home_dir())
@@ -573,6 +655,7 @@ fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workspace::resolve_workspace_home_root;
 
     #[test]
     fn merge_credentials_into_empty() {
@@ -677,6 +760,60 @@ mod tests {
         let env = HashMap::new();
         let home = resolve_workspace_home_root(root, WorkspaceType::Host, &env);
         assert_eq!(home, PathBuf::from(crate::util::home_dir()));
+    }
+
+    #[test]
+    fn git_home_isolates_host_workspace_from_operator_home() {
+        // Host workspace: git creds go to a sandboxed subdir, NOT the operator's
+        // real $HOME, so we never clobber their ~/.gitconfig / ~/.config/gh.
+        let root = Path::new("/srv/ws/mission-1");
+        let env = HashMap::new();
+        let write = resolve_git_home_root(root, WorkspaceType::Host, &env);
+        let process = resolve_workspace_home_for_process(root, WorkspaceType::Host, &env);
+        assert_eq!(write, root.join(HOST_GIT_HOME_SUBDIR));
+        // Write and process homes must agree for a host workspace (no namespace).
+        assert_eq!(write, process);
+        assert_ne!(write, PathBuf::from(crate::util::home_dir()));
+        // Containers are unchanged (already isolated at <root>/root).
+        assert_eq!(
+            resolve_git_home_root(root, WorkspaceType::Container, &env),
+            root.join("root")
+        );
+    }
+
+    #[test]
+    fn gh_hosts_merge_preserves_other_hosts_and_replaces_github() {
+        let existing = "\
+git.example.com:
+    git_protocol: ssh
+    user: someone
+    oauth_token: keep-me
+github.com:
+    git_protocol: https
+    user: old-user
+    oauth_token: stale-token
+";
+        let merged = merge_gh_hosts(existing, "new-user", "fresh-token");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&merged).unwrap();
+        let map = parsed.as_mapping().unwrap();
+        // Other host untouched.
+        let other = map.get("git.example.com").unwrap();
+        assert_eq!(other.get("oauth_token").unwrap().as_str(), Some("keep-me"));
+        // github.com replaced with the new identity/token; no stale data left.
+        let gh = map.get("github.com").unwrap();
+        assert_eq!(gh.get("user").unwrap().as_str(), Some("new-user"));
+        assert_eq!(gh.get("oauth_token").unwrap().as_str(), Some("fresh-token"));
+        assert!(!merged.contains("stale-token"));
+        assert!(!merged.contains("old-user"));
+    }
+
+    #[test]
+    fn gh_hosts_merge_writes_github_into_empty_file() {
+        let merged = merge_gh_hosts("", "ada", "tok");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&merged).unwrap();
+        let gh = parsed.as_mapping().unwrap().get("github.com").unwrap();
+        assert_eq!(gh.get("user").unwrap().as_str(), Some("ada"));
+        assert_eq!(gh.get("oauth_token").unwrap().as_str(), Some("tok"));
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -277,16 +277,16 @@ impl Workspace {
 
     /// Env vars that let the in-workspace `spark-build` wrapper offload a build
     /// for `mission_id` to the Spark via the host endpoint — or `None` when the
-    /// workspace hasn't opted in or the proxy secret isn't available. Only the
-    /// local endpoint URL + the proxy secret it already trusts are exposed;
-    /// Spark credentials stay on the host (see `src/api/spark.rs`).
+    /// workspace hasn't opted in or no signing secret is available. The token
+    /// exposed is a per-mission, scope-bound capability token (NOT the master
+    /// proxy secret): a leak only authorizes spark builds for this one mission,
+    /// never the LLM proxy or another mission. Spark credentials stay on the
+    /// host (see `src/api/spark.rs`).
     pub fn spark_offload_env(&self, mission_id: Uuid) -> Option<HashMap<String, String>> {
         if !self.spark_offload_enabled() {
             return None;
         }
-        let secret = std::env::var("SANDBOXED_PROXY_SECRET")
-            .ok()
-            .filter(|s| !s.trim().is_empty())?;
+        let token = crate::api::spark::build_spark_offload_token(mission_id)?;
         let port = std::env::var("PORT")
             .ok()
             .filter(|s| !s.trim().is_empty())?;
@@ -306,7 +306,11 @@ impl Workspace {
                 port
             ),
         );
-        m.insert("SPARK_OFFLOAD_TOKEN".to_string(), secret);
+        m.insert("SPARK_OFFLOAD_TOKEN".to_string(), token);
+        m.insert(
+            "SPARK_OFFLOAD_MISSION_ID".to_string(),
+            mission_id.to_string(),
+        );
         m.insert(
             "SPARK_WORKSPACE_HOST_DIR".to_string(),
             host_dir.to_string_lossy().to_string(),

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1877,15 +1877,20 @@ fn read_custom_providers_from_file(workspace_root: &Path) -> Vec<AIProvider> {
         if let Ok(contents) = std::fs::read_to_string(path) {
             match serde_json::from_str::<Vec<AIProvider>>(&contents) {
                 Ok(providers) => {
+                    // Include Custom providers and Kimi (which, like Custom, needs
+                    // an explicit OpenCode provider block — it is not a built-in).
                     let custom: Vec<AIProvider> = providers
                         .into_iter()
-                        .filter(|p| p.provider_type == ProviderType::Custom && p.enabled)
+                        .filter(|p| {
+                            matches!(p.provider_type, ProviderType::Custom | ProviderType::Kimi)
+                                && p.enabled
+                        })
                         .collect();
                     if !custom.is_empty() {
                         tracing::debug!(
                             path = %path.display(),
                             count = custom.len(),
-                            "Loaded custom providers from file"
+                            "Loaded custom/Kimi providers from file"
                         );
                         return custom;
                     }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -265,6 +265,56 @@ impl Workspace {
         }
     }
 
+    /// Whether this workspace opted into offloading Lean builds to the DGX
+    /// Spark (`config.spark_offload.enabled == true`).
+    pub fn spark_offload_enabled(&self) -> bool {
+        self.config
+            .get("spark_offload")
+            .and_then(|v| v.get("enabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    /// Env vars that let the in-workspace `spark-build` wrapper offload a build
+    /// for `mission_id` to the Spark via the host endpoint — or `None` when the
+    /// workspace hasn't opted in or the proxy secret isn't available. Only the
+    /// local endpoint URL + the proxy secret it already trusts are exposed;
+    /// Spark credentials stay on the host (see `src/api/spark.rs`).
+    pub fn spark_offload_env(&self, mission_id: Uuid) -> Option<HashMap<String, String>> {
+        if !self.spark_offload_enabled() {
+            return None;
+        }
+        let secret = std::env::var("SANDBOXED_PROXY_SECRET")
+            .ok()
+            .filter(|s| !s.trim().is_empty())?;
+        let port = std::env::var("PORT")
+            .ok()
+            .filter(|s| !s.trim().is_empty())?;
+        let host_dir = mission_workspace_dir_for_root(&self.path, mission_id);
+        let short = &mission_id.to_string()[..8];
+        let guest_dir = if self.workspace_type == WorkspaceType::Container {
+            format!("/workspaces/mission-{}", short)
+        } else {
+            host_dir.to_string_lossy().to_string()
+        };
+        let mut m = HashMap::new();
+        m.insert(
+            "SPARK_OFFLOAD_URL".to_string(),
+            format!(
+                "http://{}:{}/api/spark/offload",
+                self.host_ip_from_workspace(),
+                port
+            ),
+        );
+        m.insert("SPARK_OFFLOAD_TOKEN".to_string(), secret);
+        m.insert(
+            "SPARK_WORKSPACE_HOST_DIR".to_string(),
+            host_dir.to_string_lossy().to_string(),
+        );
+        m.insert("SPARK_WORKSPACE_GUEST_DIR".to_string(), guest_dir);
+        Some(m)
+    }
+
     /// Create the default host workspace.
     pub fn default_host(working_dir: PathBuf) -> Self {
         Self {

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -139,29 +139,50 @@ fn missions_slice() -> Option<String> {
     }
 }
 
-/// Memory caps applied to a mission's transient scopes.
+/// Resource caps applied to a mission's transient scopes (memory + CPU).
 ///
 /// Resolution order (per key): workspace `env_vars` override → API process
 /// env. The workspace override is what makes "boost this one workspace"
 /// possible without touching the global env file or restarting anything.
+///
+/// The CPU caps are what keep one mission's runaway build (e.g. a Lean/proof
+/// fan-out spawning dozens of parallel jobs) from saturating every core and
+/// starving the harness's own response streaming. `missions.slice` carries the
+/// *aggregate* CPU guard (a slice-level `CPUWeight`/`CPUQuota` drop-in, lower
+/// than `system.slice` where the API service lives, so missions yield to the
+/// API tier under contention); these per-scope caps are the *per-mission*
+/// guard inside that envelope. Emitting any CPU property also makes systemd
+/// delegate the `cpu` controller into `missions.slice`, without which a
+/// per-scope `CPUQuota` would silently not be enforced.
 #[derive(Debug, Clone, Default)]
-pub struct MissionMemoryCaps {
+pub struct MissionResourceCaps {
     pub max: Option<String>,
     pub high: Option<String>,
     pub swap_max: Option<String>,
+    /// `CPUWeight` (1..=10000, or "idle"). Relative share under contention.
+    pub cpu_weight: Option<String>,
+    /// `CPUQuota` (e.g. "400%" = 4 cores, or "infinity"). Hard per-mission
+    /// ceiling so a single mission can never take the whole host.
+    pub cpu_quota: Option<String>,
 }
 
-impl MissionMemoryCaps {
-    /// `true` when no MemoryMax is configured — scope wrapping is skipped
-    /// entirely (Docker installs without systemd PID 1, dev hosts, …).
+impl MissionResourceCaps {
+    /// `true` when no cap of any kind is configured — scope wrapping is
+    /// skipped entirely (Docker installs without systemd PID 1, dev hosts, …).
     pub fn is_disabled(&self) -> bool {
         self.max.is_none()
+            && self.high.is_none()
+            && self.swap_max.is_none()
+            && self.cpu_weight.is_none()
+            && self.cpu_quota.is_none()
     }
 
     /// `systemd-run` arguments for a transient scope carrying these caps.
-    /// Returns `None` when caps are disabled.
+    /// Returns `None` when no cap is configured.
     pub(crate) fn scope_run_args(&self, unit: &str) -> Option<Vec<String>> {
-        let max = self.max.as_ref()?;
+        if self.is_disabled() {
+            return None;
+        }
         let mut args = vec![
             "--scope".to_string(),
             "--quiet".to_string(),
@@ -171,35 +192,46 @@ impl MissionMemoryCaps {
         if let Some(slice) = missions_slice() {
             args.push(format!("--slice={slice}"));
         }
-        args.push(format!("--property=MemoryMax={max}"));
+        if let Some(max) = &self.max {
+            args.push(format!("--property=MemoryMax={max}"));
+        }
         if let Some(high) = &self.high {
             args.push(format!("--property=MemoryHigh={high}"));
         }
         if let Some(swap) = &self.swap_max {
             args.push(format!("--property=MemorySwapMax={swap}"));
         }
+        if let Some(weight) = &self.cpu_weight {
+            args.push(format!("--property=CPUWeight={weight}"));
+        }
+        if let Some(quota) = &self.cpu_quota {
+            args.push(format!("--property=CPUQuota={quota}"));
+        }
         Some(args)
     }
 }
 
-/// Build [`MissionMemoryCaps`] from an arbitrary env map (workspace env vars,
+/// Build [`MissionResourceCaps`] from an arbitrary env map (workspace env vars,
 /// `NspawnConfig::env`, …) with process-env fallback.
-pub(crate) fn mission_memory_caps_from_env(env: &HashMap<String, String>) -> MissionMemoryCaps {
-    MissionMemoryCaps {
-        max: resolve_memory_var(env, "MISSION_MEMORY_MAX"),
-        high: resolve_memory_var(env, "MISSION_MEMORY_HIGH"),
-        swap_max: resolve_memory_var(env, "MISSION_MEMORY_SWAP_MAX"),
+pub(crate) fn mission_resource_caps_from_env(env: &HashMap<String, String>) -> MissionResourceCaps {
+    MissionResourceCaps {
+        max: resolve_resource_var(env, "MISSION_MEMORY_MAX"),
+        high: resolve_resource_var(env, "MISSION_MEMORY_HIGH"),
+        swap_max: resolve_resource_var(env, "MISSION_MEMORY_SWAP_MAX"),
+        cpu_weight: resolve_resource_var(env, "MISSION_CPU_WEIGHT"),
+        cpu_quota: resolve_resource_var(env, "MISSION_CPU_QUOTA"),
     }
 }
 
-/// Resolve one memory-cap key: workspace env override first, then process env.
-/// An empty workspace value is treated as "no override" and falls back to the
-/// process default — same as removing the key — so clearing a cap via the raw
-/// env editor and via the Resources "Reset to defaults" button behave
+/// Resolve one resource-cap key: workspace env override first, then process
+/// env. An empty workspace value is treated as "no override" and falls back to
+/// the process default — same as removing the key — so clearing a cap via the
+/// raw env editor and via the Resources "Reset to defaults" button behave
 /// identically, and neither silently drops the mission out of its cgroup scope.
 /// To run a single workspace genuinely uncapped, set the value to `"infinity"`
-/// (which still wraps the mission in a discoverable scope).
-fn resolve_memory_var(workspace_env: &HashMap<String, String>, key: &str) -> Option<String> {
+/// (memory) or `"infinity"`/`10000` (CPU), which still wraps the mission in a
+/// discoverable scope.
+fn resolve_resource_var(workspace_env: &HashMap<String, String>, key: &str) -> Option<String> {
     if let Some(v) = workspace_env.get(key) {
         let v = v.trim();
         if !v.is_empty() {
@@ -703,10 +735,10 @@ impl WorkspaceExec {
         machine_name_for_path(&self.workspace.path)
     }
 
-    /// Memory caps for this workspace's mission scopes (workspace env
-    /// override → process env; see [`resolve_memory_var`]).
-    pub fn mission_memory_caps(&self) -> MissionMemoryCaps {
-        mission_memory_caps_from_env(&self.workspace.env_vars)
+    /// Resource caps (memory + CPU) for this workspace's mission scopes
+    /// (workspace env override → process env; see [`resolve_resource_var`]).
+    pub fn mission_resource_caps(&self) -> MissionResourceCaps {
+        mission_resource_caps_from_env(&self.workspace.env_vars)
     }
 
     /// The boot scope unit name for this workspace's container, when one can
@@ -803,7 +835,7 @@ impl WorkspaceExec {
         // nspawn boot, so shipping this binary is a no-op until the env is
         // enabled (Docker installs without systemd PID 1 stay on the direct
         // path).
-        let caps = self.mission_memory_caps();
+        let caps = self.mission_resource_caps();
         let scope_args = caps.scope_run_args(&mission_scope_unit(&name));
         let mut cmd = if let Some(scope_args) = scope_args {
             let mut c = Command::new("systemd-run");
@@ -978,7 +1010,7 @@ impl WorkspaceExec {
         // own capped transient scope when `MISSION_MEMORY_MAX` is set.
         // The unit embeds the machine name so the API layer can find and
         // retune every scope belonging to one workspace at runtime.
-        let caps = self.mission_memory_caps();
+        let caps = self.mission_resource_caps();
         let exec_unit = format!(
             "sandboxed-exec-{}-{}",
             self.machine_name().unwrap_or_else(|| "unknown".to_string()),
@@ -1456,7 +1488,7 @@ impl WorkspaceExec {
         // on 2026-06-07 despite boot-path caps being deployed. systemd-run
         // --scope keeps the payload as its own foreground child, so PTY
         // semantics and group-kill teardown are preserved.
-        let caps = self.mission_memory_caps();
+        let caps = self.mission_resource_caps();
         let exec_unit = format!(
             "sandboxed-exec-{}-{}",
             self.machine_name().unwrap_or_else(|| "unknown".to_string()),


### PR DESCRIPTION
## Problem

On the control page worker strip (`workers N/M`), worker tab titles overflowed their `max-w-[260px]` chips and rendered on top of each other.

## Cause

Each chip's title span had `truncate` (overflow:hidden + ellipsis), but the flex chain lacked `min-w-0`. A flex item's default `min-width: auto` refuses to shrink below its content size, so the full title overflowed the chip box and bled onto neighboring chips — the ellipsis never engaged.

## Fix

Add `min-w-0` to:
- the chip content wrapper span
- the chip title span
- the back-to-boss pill title span (same latent issue)

## Verification

Confirmed against the live page by injecting the same `min-w-0` classes into the DOM — titles now truncate cleanly with ellipsis in a horizontally scrollable row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (OAuth rotation, Spark offload tokens, unauthenticated `/api/spark`), host filesystem/rsync/SSH, and cgroup/proxy behavior that affects production stability under load.
> 
> **Overview**
> This PR is broader than the worker-strip fix: it adds **mission CPU isolation** (`MISSION_CPU_*`, Resources panel + live `systemctl` retune) alongside existing memory caps, with ops runbooks in `DEBUGGING.md` / `agents.md`.
> 
> **Backend:** **Kimi Code** device OAuth (store upsert, refresh loop, proxy concurrency gate, temperature normalization, quota vs rate-limit cooldowns). **Spark build offload** via scoped per-mission HMAC tokens and `POST /api/spark/offload` (rsync/arbiter/SSH, ancestor workspace authorization). **LLM proxy** gains custom-provider `provider/model` routing and **`QuotaExhausted`** classification. **Control** persists the message queue to SQLite (persist-on-dequeue anti double-run) and restores on startup; **board scheduler** cancels orphaned tasks when the boss mission terminates. **OAuth** centralizes store-account refresh under a lock (Anthropic usage probe uses it). **Ask** strips leaked tool markup on the tools-disabled synthesis pass.
> 
> **Dashboard:** Transcript tail auto-expands (thinking/tools); pen icon for streaming vs brain for reasoning; **ResizeObserver** keeps chat/thoughts pinned when content grows; tab title **`●`** and favicon attention badge when input is pending; Kimi in provider UI with auto-poll OAuth. **Workers strip:** `min-w-0` on chip titles so `truncate` actually ellipsizes long names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8c5eb7ef977efe768664de7eff570701946453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->