### PR TITLE
[codex] fix container curl bootstrap

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5901,6 +5901,21 @@ fn format_exit_status(status: &std::process::ExitStatus) -> String {
     "code <unknown>".to_string()
 }
 
+fn curl_dependency_error(output: &str) -> Option<&'static str> {
+    let lower = output.to_lowercase();
+    if lower.contains("curl: not found")
+        || lower.contains("curl: command not found")
+        || lower.contains("curl: error while loading shared libraries")
+        || lower.contains("error while loading shared libraries: libcurl")
+    {
+        return Some(
+            "curl is missing or not executable in the workspace. \
+             Rebuild the workspace or install curl and ca-certificates in the workspace template.",
+        );
+    }
+    None
+}
+
 /// Check basic internet connectivity using a reliable public endpoint.
 /// This verifies the workspace has any network access at all.
 async fn check_basic_internet_connectivity(
@@ -5950,7 +5965,9 @@ async fn check_basic_internet_connectivity(
         let stderr = String::from_utf8_lossy(&output.stderr);
         let combined = format!("{}{}", stdout, stderr);
 
-        let err = if combined.contains("Network is unreachable") {
+        let err = if let Some(message) = curl_dependency_error(&combined) {
+            format!("Workspace dependency check failed: {}", message)
+        } else if combined.contains("Network is unreachable") {
             "No internet connectivity: Network is unreachable. \
              The workspace has no network access."
                 .to_string()
@@ -6106,6 +6123,13 @@ async fn check_api_reachability(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{}{}", stdout, stderr);
+
+    if let Some(message) = curl_dependency_error(&combined) {
+        return Err(format!(
+            "Cannot connect to {} API: Workspace dependency check failed: {}",
+            api_name, message
+        ));
+    }
 
     // Check for common error patterns
     if combined.contains("Could not resolve host") {
@@ -8031,18 +8055,18 @@ mod tests {
         codex_final_message_looks_like_progress_update, codex_is_goal_request,
         codex_key_fingerprint, codex_missing_goal_final_response_message,
         codex_tool_stall_should_retry_with_default_model, codex_turn_requires_tool_activity,
-        custom_opencode_provider_definition, ensure_opencode_provider_for_model,
-        extract_codex_reset_window, extract_model_from_message, extract_opencode_session_id,
-        extract_part_text, extract_str, extract_think_content, is_capacity_limited_error,
-        is_codex_chatgpt_account_model_blocked, is_codex_node_wrapper, is_opencode_session_id,
-        is_provider_payload_error, is_rate_limited_error, is_session_corruption_error,
-        is_success_path_auth_error, is_success_path_provider_payload_error,
-        is_success_path_rate_limited_error, is_tool_call_only_output,
-        opencode_goal_terminal_status, opencode_idle_timeout_result_message,
-        opencode_output_needs_fallback, opencode_session_exists_in_data_home,
-        opencode_session_token_from_line, parse_opencode_goal_objective,
-        parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
-        preferred_model_for_cost, record_codex_error_message,
+        curl_dependency_error, custom_opencode_provider_definition,
+        ensure_opencode_provider_for_model, extract_codex_reset_window, extract_model_from_message,
+        extract_opencode_session_id, extract_part_text, extract_str, extract_think_content,
+        is_capacity_limited_error, is_codex_chatgpt_account_model_blocked, is_codex_node_wrapper,
+        is_opencode_session_id, is_provider_payload_error, is_rate_limited_error,
+        is_session_corruption_error, is_success_path_auth_error,
+        is_success_path_provider_payload_error, is_success_path_rate_limited_error,
+        is_tool_call_only_output, opencode_goal_terminal_status,
+        opencode_idle_timeout_result_message, opencode_output_needs_fallback,
+        opencode_session_exists_in_data_home, opencode_session_token_from_line,
+        parse_opencode_goal_objective, parse_opencode_session_token, parse_opencode_sse_event,
+        parse_opencode_stderr_text_part, preferred_model_for_cost, record_codex_error_message,
         replace_filepath_artifact_with_tool_output, running_health, sanitized_opencode_stdout,
         set_codex_account_cooldown, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
         strip_think_tags, summarize_codex_usage_caps, summarize_recent_opencode_stderr,
@@ -8066,6 +8090,28 @@ mod tests {
     use std::fs;
     use std::time::Duration;
     use uuid::Uuid;
+
+    #[test]
+    fn curl_dependency_error_detects_missing_curl() {
+        assert!(curl_dependency_error("/bin/sh: 1: curl: not found").is_some());
+        assert!(curl_dependency_error("curl: command not found").is_some());
+    }
+
+    #[test]
+    fn curl_dependency_error_detects_broken_shared_library() {
+        assert!(
+            curl_dependency_error(
+                "curl: error while loading shared libraries: libcurl.so.4: cannot open shared object file"
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn curl_dependency_error_ignores_network_failures() {
+        assert!(curl_dependency_error("curl: (7) Failed to connect to 1.1.1.1").is_none());
+        assert!(curl_dependency_error("Network is unreachable").is_none());
+    }
 
     #[test]
     fn extract_codex_reset_window_pulls_the_reset_time() {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2549,14 +2549,14 @@ async fn sync_workspace_mcp_binaries(
     working_dir: &Path,
     container_root: &Path,
 ) -> anyhow::Result<()> {
-    // Copy runtime binaries into the container so per-workspace harnesses can
-    // start even when the image lacks the host's developer tooling.
+    // Copy project/runtime binaries into the container so per-workspace
+    // harnesses can start even when the image lacks the host's developer
+    // tooling. Do not copy distro-managed tools such as curl/wget/npm wrappers
+    // from the host: they are often dynamically linked against libraries that
+    // do not exist inside a debootstrap minbase rootfs. The harness bootstrap
+    // installs those from the container distro instead.
     for binary in [
         "opencode",
-        "curl",
-        "wget",
-        "bunx",
-        "npx",
         "workspace-mcp",
         "desktop-mcp",
         "orchestrator-mcp",
@@ -2854,7 +2854,18 @@ export PATH="/root/.bun/bin:/root/.cache/.bun/bin:$PATH"
 #     Without these the rest of this script no-ops (no bun, no npm, no curl)
 #     and the workspace ends up unusable for missions.
 export DEBIAN_FRONTEND=noninteractive
-if ! command -v curl >/dev/null 2>&1; then
+for tool in curl wget; do
+  if command -v "$tool" >/dev/null 2>&1 && ! "$tool" --version >/dev/null 2>&1; then
+    tool_path="$(command -v "$tool" || true)"
+    case "$tool_path" in
+      /usr/local/bin/*)
+        echo "[sandboxed] removing non-functional copied $tool at $tool_path"
+        rm -f "$tool_path" || true
+        ;;
+    esac
+  fi
+done
+if ! command -v curl >/dev/null 2>&1 || ! curl --version >/dev/null 2>&1; then
   echo "[sandboxed] baseline rootfs prereqs: installing curl/ca-certs/gnupg/git/jq/python3/build-essential"
   apt-get update -qq || true
   apt-get install -y -qq --no-install-recommends curl ca-certificates gnupg git jq python3 wget build-essential || true


### PR DESCRIPTION
## Summary

Fix fresh container workspace bootstrap when a host `curl` binary gets copied into a debootstrap minbase rootfs without its shared libraries.

## Root Cause

`sync_workspace_mcp_binaries` copied host-managed tools like `curl`, `wget`, `bunx`, and `npx` into `/usr/local/bin` inside container workspaces. On Docker installs with isolated `ubuntu-noble` workspaces, that copied `curl` can be dynamically linked against host libraries that are absent from the minbase rootfs. The harness bootstrap then sees `curl` in `PATH`, skips installing the distro package, and the mission preflight fails with:

```text
curl: error while loading shared libraries: libcurl.so.4: cannot open shared object file
```

## Changes

- Stop copying host distro-managed tools into container workspaces; keep the sync path for project/runtime MCP binaries.
- Remove broken copied `curl`/`wget` shims from `/usr/local/bin` during harness bootstrap before installing distro packages.
- Treat missing or broken `curl` as a workspace dependency failure instead of reporting it as generic "No internet connectivity".
- Add unit coverage for the broken/missing curl classifier.

## Validation

- `cargo fmt --all`
- `cargo test curl_dependency_error`
- `cargo test --lib`
