### PR TITLE
fix dashboard sends on non-secure HTTP origins

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -71,6 +71,7 @@ import { getRuntimeApiBase } from "@/lib/settings";
 import { authHeader } from "@/lib/auth";
 import { stripRichFileTagsByName } from "@/lib/rich-tags";
 import { readCachedEvents, writeCachedEvents } from "@/lib/event-cache";
+import { createClientMessageId } from "@/lib/client-message-id";
 import {
   cancelControl,
   postControlMessage,
@@ -8023,7 +8024,7 @@ export default function ControlClient() {
       submittingRef.current = true;
 
       const targetMissionId = viewingMissionIdRef.current;
-      const tempId = crypto.randomUUID();
+      const tempId = createClientMessageId();
       const timestamp = Date.now();
       const hasExistingUserMessages = items.some(
         (item) => item.kind === "user",

--- a/dashboard/src/lib/client-message-id.test.ts
+++ b/dashboard/src/lib/client-message-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { createClientMessageId } from "./client-message-id";
+
+describe("createClientMessageId", () => {
+  it("uses crypto.randomUUID when available", () => {
+    expect(
+      createClientMessageId({
+        randomUUID: () => "11111111-2222-4333-8444-555555555555",
+        getRandomValues: (array) => array,
+      }),
+    ).toBe("11111111-2222-4333-8444-555555555555");
+  });
+
+  it("falls back to a v4 UUID when randomUUID is unavailable", () => {
+    const id = createClientMessageId({
+      getRandomValues: (array) => {
+        array.set([
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+          0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        ]);
+        return array;
+      },
+    });
+
+    expect(id).toBe("00112233-4455-4677-8899-aabbccddeeff");
+  });
+});

--- a/dashboard/src/lib/client-message-id.ts
+++ b/dashboard/src/lib/client-message-id.ts
@@ -1,0 +1,33 @@
+type BrowserCrypto = Pick<Crypto, "getRandomValues"> & {
+  randomUUID?: () => string;
+};
+
+function formatUuidV4(bytes: Uint8Array): string {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
+}
+
+export function createClientMessageId(
+  cryptoImpl: BrowserCrypto | undefined = globalThis.crypto,
+): string {
+  if (typeof cryptoImpl?.randomUUID === "function") {
+    return cryptoImpl.randomUUID();
+  }
+
+  if (typeof cryptoImpl?.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    cryptoImpl.getRandomValues(bytes);
+    return formatUuidV4(bytes);
+  }
+
+  return `client-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}


### PR DESCRIPTION
## Summary

- replace the dashboard's direct `crypto.randomUUID()` call with a client message ID helper
- keep using `crypto.randomUUID()` when available
- fall back to a v4 UUID generated with `crypto.getRandomValues()` for HTTP/non-secure origins

## Why

When the dashboard is served over plain HTTP on a private address, such as a Tailscale IP or MagicDNS host with `:3000`, Chromium does not expose `crypto.randomUUID()`. The message submit handler throws before it can call `POST /api/control/message`, so newly-created missions can be opened but messages are never sent.

## Tests

- `./node_modules/.bin/vitest run src/lib/client-message-id.test.ts`
- Live regression check against a Docker deployment over `http://100.x.y.z:3000`: clicking Send emitted `POST /api/control/message` with a generated `client_message_id`; no `randomUUID` page error was raised.
