### PR TITLE
fix dashboard sends on non-secure HTTP origins

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -71,6 +71,7 @@ import { getRuntimeApiBase } from "@/lib/settings";
 import { authHeader } from "@/lib/auth";
 import { stripRichFileTagsByName } from "@/lib/rich-tags";
 import { readCachedEvents, writeCachedEvents } from "@/lib/event-cache";
+import { createClientMessageId } from "@/lib/client-message-id";
 import {
   cancelControl,
   postControlMessage,
@@ -8023,7 +8024,7 @@ export default function ControlClient() {
       submittingRef.current = true;
 
       const targetMissionId = viewingMissionIdRef.current;
-      const tempId = crypto.randomUUID();
+      const tempId = createClientMessageId();
       const timestamp = Date.now();
       const hasExistingUserMessages = items.some(
         (item) => item.kind === "user",

--- a/dashboard/src/lib/client-message-id.test.ts
+++ b/dashboard/src/lib/client-message-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { createClientMessageId } from "./client-message-id";
+
+describe("createClientMessageId", () => {
+  it("uses crypto.randomUUID when available", () => {
+    expect(
+      createClientMessageId({
+        randomUUID: () => "11111111-2222-4333-8444-555555555555",
+        getRandomValues: (array) => array,
+      }),
+    ).toBe("11111111-2222-4333-8444-555555555555");
+  });
+
+  it("falls back to a v4 UUID when randomUUID is unavailable", () => {
+    const id = createClientMessageId({
+      getRandomValues: (array) => {
+        array.set([
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+          0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        ]);
+        return array;
+      },
+    });
+
+    expect(id).toBe("00112233-4455-4677-8899-aabbccddeeff");
+  });
+});

--- a/dashboard/src/lib/client-message-id.test.ts
+++ b/dashboard/src/lib/client-message-id.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createClientMessageId } from "./client-message-id";
 
 describe("createClientMessageId", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("uses crypto.randomUUID when available", () => {
     expect(
       createClientMessageId({
@@ -24,5 +28,18 @@ describe("createClientMessageId", () => {
     });
 
     expect(id).toBe("00112233-4455-4677-8899-aabbccddeeff");
+  });
+
+  it("falls back to a Math.random v4 UUID when no crypto source exists", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const id = createClientMessageId(
+      {} as Parameters<typeof createClientMessageId>[0],
+    );
+
+    expect(id).toBe("00000000-0000-4000-8000-000000000000");
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 });

--- a/dashboard/src/lib/client-message-id.ts
+++ b/dashboard/src/lib/client-message-id.ts
@@ -1,0 +1,33 @@
+type BrowserCrypto = Pick<Crypto, "getRandomValues"> & {
+  randomUUID?: () => string;
+};
+
+function formatUuidV4(bytes: Uint8Array): string {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
+}
+
+export function createClientMessageId(
+  cryptoImpl: BrowserCrypto | undefined = globalThis.crypto,
+): string {
+  if (typeof cryptoImpl?.randomUUID === "function") {
+    return cryptoImpl.randomUUID();
+  }
+
+  if (typeof cryptoImpl?.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    cryptoImpl.getRandomValues(bytes);
+    return formatUuidV4(bytes);
+  }
+
+  return `client-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}

--- a/dashboard/src/lib/client-message-id.ts
+++ b/dashboard/src/lib/client-message-id.ts
@@ -2,6 +2,13 @@ type BrowserCrypto = Pick<Crypto, "getRandomValues"> & {
   randomUUID?: () => string;
 };
 
+function fillRandomBytes(bytes: Uint8Array): Uint8Array {
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return bytes;
+}
+
 function formatUuidV4(bytes: Uint8Array): string {
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
@@ -23,11 +30,14 @@ export function createClientMessageId(
     return cryptoImpl.randomUUID();
   }
 
+  const bytes = new Uint8Array(16);
   if (typeof cryptoImpl?.getRandomValues === "function") {
-    const bytes = new Uint8Array(16);
     cryptoImpl.getRandomValues(bytes);
     return formatUuidV4(bytes);
   }
 
-  return `client-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+  // The message id is sent as `client_message_id`, which the backend parses as
+  // a UUID. When no crypto source is available, fall back to a Math.random v4
+  // UUID so the value still deserializes server-side.
+  return formatUuidV4(fillRandomBytes(bytes));
 }


### PR DESCRIPTION
Supersedes #546. Includes the original commit by @adrienlacombe and adds a follow-up fix for a remaining issue.

## Summary

- replace the dashboard's direct `crypto.randomUUID()` call with a `createClientMessageId()` helper (from #546)
- keep using `crypto.randomUUID()` when available; fall back to a v4 UUID built from `crypto.getRandomValues()` on HTTP/non-secure origins (from #546)
- **new:** make the last-resort fallback emit a valid v4 UUID instead of a `client-<base36>` string, and add a deterministic test for it

## Why

When the dashboard is served over plain HTTP on a private address (Tailscale IP / MagicDNS host with `:3000`), Chromium does not expose `crypto.randomUUID()`. The submit handler threw before calling `POST /api/control/message`, so messages were never sent.

The remaining issue addressed here: `tempId` is sent as `client_message_id`, which the backend deserializes as `Option<Uuid>` (`src/api/control/mod.rs`). The previous last-resort fallback returned a non-UUID `client-...` string, so if that branch were ever reached the request would fail server-side, re-breaking sends. It now returns a `Math.random`-backed v4 UUID that deserializes correctly. (In practice this branch is rarely hit because `getRandomValues` is available on insecure origins, but it's no longer a latent landmine.)

## Tests

- `bun run test:unit` — `src/lib/client-message-id.test.ts` (3 tests pass), including the new no-crypto fallback case asserting `00000000-0000-4000-8000-000000000000`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to optimistic message ID generation with tests; no auth or server logic changes.
> 
> **Overview**
> Fixes control chat sends failing on plain HTTP (e.g. Tailscale `:3000`) where **`crypto.randomUUID()`** is missing and the submit path threw before **`POST /api/control/message`**.
> 
> The control client now uses **`createClientMessageId()`** instead of calling **`randomUUID()`** directly. The helper prefers **`crypto.randomUUID()`**, then builds a v4 UUID from **`crypto.getRandomValues()`**, and as a last resort uses **`Math.random`** with proper v4 formatting so **`client_message_id`** always parses as a UUID on the backend (replacing a non-UUID **`client-...`** fallback that could fail deserialization).
> 
> Unit tests cover all three branches, including the no-crypto fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ea97ded0d588a47a090a7710a36d3cdc8db52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->