### PR TITLE
feat(dashboard): add disk usage to inspect/system view

### DIFF
--- a/dashboard/src/components/system-monitor.tsx
+++ b/dashboard/src/components/system-monitor.tsx
@@ -15,6 +15,9 @@ interface SystemMetrics {
   memory_percent: number;
   network_rx_bytes_per_sec: number;
   network_tx_bytes_per_sec: number;
+  disk_used: number;
+  disk_total: number;
+  disk_percent: number;
   timestamp_ms: number;
 }
 
@@ -384,6 +387,42 @@ function MemoryChart({
   );
 }
 
+// Simple area chart for Disk usage
+function DiskChart({
+  data,
+  percent,
+  used,
+  total,
+  height = 80,
+}: {
+  data: number[];
+  percent: number;
+  used: number;
+  total: number;
+  height?: number;
+}) {
+  return (
+    <AreaChart
+      data={data}
+      gridFractions={MEM_GRID}
+      height={height}
+      topLeft={
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] leading-none font-medium uppercase tracking-wide text-white/50">DISK</span>
+          <span className="text-[10px] leading-none font-semibold tabular-nums text-white/80">
+            {percent.toFixed(0)}%
+          </span>
+        </div>
+      }
+      topRight={
+        <span className="text-[10px] leading-none font-medium tabular-nums text-white/50">
+          {formatBytes(used)} / {formatBytes(total)}
+        </span>
+      }
+    />
+  );
+}
+
 // Network chart with dual lines (rx/tx)
 function NetworkChart({
   rxData,
@@ -566,6 +605,7 @@ export function SystemMonitor({ className, intervalMs = 1000 }: SystemMonitorPro
   const [metrics, setMetrics] = useState<SystemMetrics | null>(null);
   const [coreHistories, setCoreHistories] = useState<number[][]>([]);
   const [memoryHistory, setMemoryHistory] = useState<number[]>([]);
+  const [diskHistory, setDiskHistory] = useState<number[]>([]);
   const [networkRxHistory, setNetworkRxHistory] = useState<number[]>([]);
   const [networkTxHistory, setNetworkTxHistory] = useState<number[]>([]);
   const [containerHistories, setContainerHistories] = useState<Map<string, ContainerHistory>>(new Map());
@@ -636,6 +676,7 @@ export function SystemMonitor({ className, intervalMs = 1000 }: SystemMonitorPro
               setCoreHistories(cores);
 
               setMemoryHistory(historyData.map((m) => m.memory_percent));
+              setDiskHistory(historyData.map((m) => m.disk_percent));
               setNetworkRxHistory(historyData.map((m) => m.network_rx_bytes_per_sec));
               setNetworkTxHistory(historyData.map((m) => m.network_tx_bytes_per_sec));
             }
@@ -708,6 +749,12 @@ export function SystemMonitor({ className, intervalMs = 1000 }: SystemMonitorPro
           // Update memory history
           setMemoryHistory((prev) => {
             const next = [...prev, data.memory_percent];
+            return next.slice(-maxHistory);
+          });
+
+          // Update disk history
+          setDiskHistory((prev) => {
+            const next = [...prev, data.disk_percent];
             return next.slice(-maxHistory);
           });
 
@@ -839,13 +886,20 @@ export function SystemMonitor({ className, intervalMs = 1000 }: SystemMonitorPro
           height={200}
         />
 
-        {/* Memory and Network - Split bottom */}
-        <div className="grid grid-cols-2 gap-3 min-h-0">
+        {/* Memory, Disk and Network - Split bottom */}
+        <div className="grid grid-cols-3 gap-3 min-h-0">
           <MemoryChart
             data={memoryHistory}
             percent={metrics?.memory_percent ?? 0}
             used={metrics?.memory_used ?? 0}
             total={metrics?.memory_total ?? 0}
+            height={150}
+          />
+          <DiskChart
+            data={diskHistory}
+            percent={metrics?.disk_percent ?? 0}
+            used={metrics?.disk_used ?? 0}
+            total={metrics?.disk_total ?? 0}
             height={150}
           />
           <NetworkChart

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -22,7 +22,7 @@ use axum::{
 };
 use futures::{FutureExt, SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use sysinfo::{Networks, System};
+use sysinfo::{Disks, Networks, System};
 use tokio::sync::{broadcast, RwLock};
 
 use super::auth;
@@ -56,6 +56,12 @@ pub struct SystemMetrics {
     pub network_rx_bytes_per_sec: u64,
     /// Network bytes transmitted per second
     pub network_tx_bytes_per_sec: u64,
+    /// Disk space used in bytes (root filesystem)
+    pub disk_used: u64,
+    /// Total disk space in bytes (root filesystem)
+    pub disk_total: u64,
+    /// Disk usage percentage (0-100)
+    pub disk_percent: f32,
     /// Timestamp in milliseconds since epoch
     pub timestamp_ms: u64,
 }
@@ -132,6 +138,33 @@ fn pct(used: u64, total: u64) -> f32 {
         (used as f64 / total as f64 * 100.0) as f32
     } else {
         0.0
+    }
+}
+
+/// Used and total bytes for the filesystem backing `/`, as `(used, total)`.
+///
+/// Falls back to the largest reported filesystem when no `/` mount is exposed
+/// (some container runtimes don't surface it) and to zeros when no disks are
+/// visible.
+fn root_disk_usage(disks: &Disks) -> (u64, u64) {
+    let mut largest: Option<(u64, u64)> = None;
+    for disk in disks.list() {
+        let total = disk.total_space();
+        let available = disk.available_space();
+        if disk.mount_point() == std::path::Path::new("/") {
+            return (total.saturating_sub(available), total);
+        }
+        let is_larger = match largest {
+            Some((t, _)) => total > t,
+            None => true,
+        };
+        if is_larger {
+            largest = Some((total, available));
+        }
+    }
+    match largest {
+        Some((total, available)) => (total.saturating_sub(available), total),
+        None => (0, 0),
     }
 }
 
@@ -329,6 +362,12 @@ impl MonitoringState {
             prev_tx_bytes = current_tx_bytes;
             prev_time = now;
 
+            // Disk usage for the root filesystem (point-in-time gauge, no delta
+            // needed, so a fresh read each tick is fine).
+            let disks = Disks::new_with_refreshed_list();
+            let (disk_used, disk_total) = root_disk_usage(&disks);
+            let disk_percent = pct(disk_used, disk_total);
+
             let metrics = SystemMetrics {
                 cpu_percent,
                 cpu_cores,
@@ -337,6 +376,9 @@ impl MonitoringState {
                 memory_percent,
                 network_rx_bytes_per_sec,
                 network_tx_bytes_per_sec,
+                disk_used,
+                disk_total,
+                disk_percent,
                 timestamp_ms: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()


### PR DESCRIPTION
## Summary
- Collect root-filesystem disk usage (used / total / percent) in the monitoring collector (`src/api/monitoring.rs`) using sysinfo's `Disks`, refreshed each tick alongside the existing CPU/memory/network metrics.
- Surface it as a new **DISK** area chart in the host view of the inspect/system dashboard (`dashboard/src/components/system-monitor.tsx`), placing Memory / Disk / Network in a 3-column row.

## Implementation notes
- `root_disk_usage()` prefers the filesystem mounted at `/`, falls back to the largest reported filesystem when no `/` mount is exposed (some container runtimes don't surface it), and returns zeros when no disks are visible.
- Disk is a point-in-time gauge, so it's read fresh each tick (no delta tracking needed), mirroring the existing network read pattern.
- Dashboard wiring adds `disk_used` / `disk_total` / `disk_percent` to `SystemMetrics`, a `diskHistory` buffer, and the `DiskChart` component reusing the existing `AreaChart` / `formatBytes` helpers.

## Test plan
- [ ] CI builds the Rust backend (no local Rust toolchain available in the authoring environment, so `cargo check` was not run locally).
- [x] Dashboard `eslint` passes on `system-monitor.tsx`.
- [x] Dashboard `tsc --noEmit` shows no new errors from these changes.
- [ ] Manually verify the DISK chart renders in the inspect/system host view and reflects real disk usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)