### PR TITLE
feat(dashboard): responsive mobile layout (desktop unchanged)

### DIFF
--- a/dashboard/src/app/config/commands/page.tsx
+++ b/dashboard/src/app/config/commands/page.tsx
@@ -185,7 +185,7 @@ Describe what this command does.
   }
 
   return (
-    <div className="h-screen flex flex-col p-6 gap-4 overflow-hidden">
+    <div className="h-[calc(100vh-3rem)] lg:h-screen flex flex-col p-6 gap-4 overflow-hidden">
       {libraryUnavailable ? (
         <LibraryUnavailable message={libraryUnavailableMessage} onConfigured={refresh} />
       ) : (

--- a/dashboard/src/app/config/settings/page.tsx
+++ b/dashboard/src/app/config/settings/page.tsx
@@ -759,7 +759,7 @@ export default function SettingsPage() {
 
   if (loading && !fileContent) {
     return (
-      <div className="h-screen flex flex-col p-6 gap-4 overflow-hidden">
+      <div className="h-[calc(100vh-3rem)] lg:h-screen flex flex-col p-6 gap-4 overflow-hidden">
         <div className="h-16 rounded-xl bg-white/[0.02] border border-white/[0.06]" />
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
@@ -786,7 +786,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="h-screen flex flex-col p-6 gap-4 overflow-hidden">
+    <div className="h-[calc(100vh-3rem)] lg:h-screen flex flex-col p-6 gap-4 overflow-hidden">
       {/* Git Status Bar */}
       {status && (
         <div className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.06]">

--- a/dashboard/src/app/config/settings/page.tsx
+++ b/dashboard/src/app/config/settings/page.tsx
@@ -769,14 +769,14 @@ export default function SettingsPage() {
           </div>
           <div className="h-10 w-40 rounded-lg bg-white/[0.04] border border-white/[0.06]" />
         </div>
-        <div className="flex gap-4 flex-1 min-h-0">
-          <div className="w-64 flex-shrink-0 rounded-xl bg-white/[0.02] border border-white/[0.06] p-4 space-y-3">
+        <div className="flex flex-1 min-h-0 flex-col gap-4 lg:flex-row">
+          <div className="w-full flex-shrink-0 rounded-xl bg-white/[0.02] border border-white/[0.06] p-4 space-y-3 max-lg:h-56 lg:w-64">
             <div className="h-4 w-28 rounded bg-white/[0.06]" />
             {Array.from({ length: 7 }).map((_, index) => (
               <div key={index} className="h-12 rounded-lg bg-white/[0.04]" />
             ))}
           </div>
-          <div className="flex-1 rounded-xl bg-white/[0.02] border border-white/[0.06] p-5 space-y-4">
+          <div className="flex-1 min-h-0 rounded-xl bg-white/[0.02] border border-white/[0.06] p-5 space-y-4">
             <div className="h-6 w-48 rounded bg-white/[0.06]" />
             <div className="code-block h-full min-h-0 p-0" />
           </div>
@@ -893,9 +893,9 @@ export default function SettingsPage() {
       )}
 
       {/* Harness Tabs and Profile Selector */}
-      <div className="flex items-center justify-between mb-2">
+      <div className="mb-2 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         {/* Harness Tabs - Left */}
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {enabledHarnesses.map((harnessId) => (
             <button
               key={harnessId}
@@ -913,10 +913,10 @@ export default function SettingsPage() {
         </div>
 
         {/* Profile Selector - Right */}
-        <div className="relative" ref={profileDropdownRef}>
+        <div className="relative w-full lg:w-auto" ref={profileDropdownRef}>
           <button
             onClick={() => setShowProfileDropdown(!showProfileDropdown)}
-            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium border border-white/[0.08] bg-white/[0.04] hover:bg-white/[0.06] text-white/80 transition-colors"
+            className="flex w-full items-center justify-between gap-2 px-3 py-2 rounded-lg text-sm font-medium border border-white/[0.08] bg-white/[0.04] hover:bg-white/[0.06] text-white/80 transition-colors lg:w-auto lg:justify-start"
           >
             <Layers className="h-4 w-4 text-white/50" />
             <span>{selectedProfile}</span>
@@ -925,7 +925,7 @@ export default function SettingsPage() {
 
           {/* Profile Dropdown */}
           {showProfileDropdown && (
-            <div className="absolute right-0 top-full mt-1 w-56 rounded-lg border border-white/[0.08] bg-[#1a1a1f] shadow-xl z-50">
+            <div className="absolute left-0 right-0 top-full mt-1 rounded-lg border border-white/[0.08] bg-[#1a1a1f] shadow-xl z-50 lg:left-auto lg:w-56">
               <div className="p-1">
                 {profiles.map((profile) => (
                   <button
@@ -1039,9 +1039,9 @@ export default function SettingsPage() {
       )}
 
       {/* Main Content: File Browser + Editor */}
-      <div className="flex gap-4 flex-1 min-h-0">
+      <div className="flex flex-1 min-h-0 flex-col gap-4 lg:flex-row">
         {/* File Browser Sidebar */}
-        <div className="w-64 flex-shrink-0 rounded-xl bg-white/[0.02] border border-white/[0.06] p-4 flex flex-col">
+        <div className="flex w-full flex-shrink-0 flex-col rounded-xl bg-white/[0.02] border border-white/[0.06] p-4 max-lg:h-56 lg:w-64">
           <div className="flex items-center gap-2 mb-4">
             <FolderOpen className="h-4 w-4 text-white/50" />
             <span className="text-sm font-medium text-white">{harnessConfig.dir}/</span>
@@ -1108,7 +1108,7 @@ export default function SettingsPage() {
         </div>
 
         {/* Editor */}
-        <div className="flex-1 flex flex-col min-h-0">
+        <div className="flex-1 min-w-0 flex flex-col min-h-0">
           {/* Editor Header */}
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-3">

--- a/dashboard/src/app/config/skills/page.tsx
+++ b/dashboard/src/app/config/skills/page.tsx
@@ -1115,7 +1115,7 @@ Describe what this skill does.
   }
 
   return (
-    <div className="h-screen flex flex-col p-6 gap-4 overflow-hidden">
+    <div className="h-[calc(100vh-3rem)] lg:h-screen flex flex-col p-6 gap-4 overflow-hidden">
       {/* Git Status Bar */}
       {status && (
         <div className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.06]">

--- a/dashboard/src/app/config/workspace-templates/page.tsx
+++ b/dashboard/src/app/config/workspace-templates/page.tsx
@@ -550,7 +550,7 @@ set -e
   }
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden p-6 max-w-7xl mx-auto space-y-4">
+    <div className="h-[calc(100vh-3rem)] lg:h-screen flex flex-col overflow-hidden p-6 max-w-7xl mx-auto space-y-4">
       {/* Git Status Bar */}
       {status && (
         <div className="p-4 rounded-xl bg-white/[0.02] border border-white/[0.06]">

--- a/dashboard/src/app/console/console-client.tsx
+++ b/dashboard/src/app/console/console-client.tsx
@@ -1778,7 +1778,7 @@ export default function ConsoleClient() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col p-4">
+    <div className="flex min-h-[calc(100vh-3rem)] flex-col p-4 lg:min-h-screen">
       {/* Main panel with integrated tab bar */}
       <div className="relative flex-1 min-h-0 flex flex-col rounded-lg border border-white/10 bg-[#0d0d0d] overflow-hidden">
         {/* Tab bar - inside the panel */}

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -9080,7 +9080,7 @@ export default function ControlClient() {
 
   return (
     <NowTickProvider>
-      <div className="flex h-screen flex-col p-6">
+      <div className="flex h-[calc(100vh-3rem)] flex-col p-6 lg:h-screen">
         {/* Always-on debug overlay so any OOM-style crash leaves a trail
           we can reconstruct from sessionStorage after reload. Cheap:
           a polling tick every 2s that reads performance.memory and
@@ -9716,7 +9716,7 @@ export default function ControlClient() {
         </div>
 
         {/* Main content area - Chat and Desktop stream side by side */}
-        <div className="flex-1 min-h-0 flex gap-4">
+        <div className="flex-1 min-h-0 flex flex-col gap-4 lg:flex-row max-lg:overflow-y-auto">
           {/* Chat container. We intentionally do NOT animate flex-grow when
           side panels (Workers / Workbench / Thinking) open: animating layout
           properties like `flex-grow` re-flows the entire (potentially huge)
@@ -9726,7 +9726,7 @@ export default function ControlClient() {
           snap to its new width in a single layout pass. */}
           <div
             className={cn(
-              "flex-1 min-h-0 flex flex-col rounded-2xl glass-panel border border-white/[0.06] overflow-hidden relative",
+              "flex-1 min-h-0 flex flex-col rounded-2xl glass-panel border border-white/[0.06] overflow-hidden relative max-lg:min-h-[60vh]",
               showDesktopStream && "flex-[2]",
             )}
           >
@@ -10265,7 +10265,9 @@ export default function ControlClient() {
                 // `transition-all duration-300` that was animating width on
                 // mount (the width change is what caused the chat-side reflow
                 // freeze when toggling the Workers panel).
-                "min-h-0 flex flex-col gap-4 animate-fade-in shrink-0",
+                // Below lg the side panel stacks under the chat at full width
+                // with a capped height instead of competing for horizontal room.
+                "min-h-0 flex flex-col gap-4 animate-fade-in shrink-0 max-lg:w-full max-lg:min-w-0 max-lg:max-w-none max-lg:max-h-none max-lg:h-[60vh] max-lg:resize-none",
                 showDesktopStream
                   ? "basis-auto w-[clamp(400px,44vw,820px)] h-[min(720px,calc(100vh-7rem))] min-h-[420px] min-w-[360px] max-h-[calc(100vh-7rem)] max-w-[820px] resize overflow-hidden"
                   : "w-80",

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -10269,8 +10269,8 @@ export default function ControlClient() {
                 // with a capped height instead of competing for horizontal room.
                 "min-h-0 flex flex-col gap-4 animate-fade-in shrink-0 max-lg:w-full max-lg:min-w-0 max-lg:max-w-none max-lg:max-h-none max-lg:h-[60vh] max-lg:resize-none",
                 showDesktopStream
-                  ? "basis-auto w-[clamp(400px,44vw,820px)] h-[min(720px,calc(100vh-7rem))] min-h-[420px] min-w-[360px] max-h-[calc(100vh-7rem)] max-w-[820px] resize overflow-hidden"
-                  : "w-80",
+                  ? "lg:basis-auto lg:w-[clamp(400px,44vw,820px)] lg:h-[min(720px,calc(100vh-7rem))] lg:min-h-[420px] lg:min-w-[360px] lg:max-h-[calc(100vh-7rem)] lg:max-w-[820px] lg:resize overflow-hidden"
+                  : "lg:w-80",
               )}
             >
               {showWorkbenchPanel && (

--- a/dashboard/src/app/inspect/page.tsx
+++ b/dashboard/src/app/inspect/page.tsx
@@ -306,7 +306,7 @@ function ServerCard() {
 
 export default function InspectPage() {
   return (
-    <div className="min-h-screen flex flex-col p-6 max-w-4xl mx-auto space-y-6">
+    <div className="min-h-[calc(100vh-3rem)] lg:min-h-screen flex flex-col p-6 max-w-4xl mx-auto space-y-6">
       <div>
         <h1 className="text-2xl font-semibold text-white">Inspect</h1>
         <p className="text-sm text-white/60 mt-1">

--- a/dashboard/src/app/inspect/system/page.tsx
+++ b/dashboard/src/app/inspect/system/page.tsx
@@ -152,14 +152,14 @@ function ServerInfoCard() {
 
 export default function MonitoringPage() {
   return (
-    <div className="flex gap-4 p-6 h-screen">
+    <div className="flex flex-col gap-4 p-6 lg:flex-row lg:h-screen">
       {/* Server Info - Left column */}
-      <div className="w-[200px] shrink-0">
+      <div className="w-full shrink-0 lg:w-[200px]">
         <ServerInfoCard />
       </div>
 
       {/* System Monitor - Right column */}
-      <div className="flex-1 rounded-xl bg-white/[0.02] border border-white/[0.04] p-4 min-w-0 overflow-hidden">
+      <div className="flex-1 rounded-xl bg-white/[0.02] border border-white/[0.04] p-4 min-w-0 overflow-hidden max-lg:flex-none max-lg:h-[560px]">
         <SystemMonitor className="w-full h-full" />
       </div>
     </div>

--- a/dashboard/src/app/inspect/tools/page.tsx
+++ b/dashboard/src/app/inspect/tools/page.tsx
@@ -105,7 +105,7 @@ export default function ToolsPage() {
   }, [tools]);
 
   return (
-    <div className="mx-auto flex min-h-screen max-w-6xl flex-col space-y-4 p-6">
+    <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-6xl flex-col space-y-4 p-6 lg:min-h-screen">
       <div>
         <h1 className="text-2xl font-semibold text-white">Tools</h1>
         <p className="mt-1 text-sm text-white/60">

--- a/dashboard/src/app/inspect/tools/page.tsx
+++ b/dashboard/src/app/inspect/tools/page.tsx
@@ -6,6 +6,9 @@ import { Wrench } from 'lucide-react';
 import { listTools, type ToolInfo } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
+const DESKTOP_TOOL_GRID =
+  'lg:grid lg:grid-cols-[minmax(180px,1.1fr)_minmax(160px,0.8fr)_minmax(280px,2fr)_minmax(110px,0.6fr)] lg:gap-4';
+
 function formatToolSource(source: ToolInfo['source']): string {
   if (source === 'builtin') return 'Built-in';
   if (typeof source === 'object' && source && 'mcp' in source) {
@@ -19,12 +22,82 @@ function formatToolSource(source: ToolInfo['source']): string {
   return 'Unknown';
 }
 
+function ToolStatusBadge({ enabled }: { enabled: boolean }) {
+  return (
+    <span
+      className={cn(
+        'text-xs font-medium',
+        enabled ? 'text-emerald-400' : 'text-white/40',
+      )}
+    >
+      {enabled ? 'Enabled' : 'Disabled'}
+    </span>
+  );
+}
+
+function ToolRow({ tool }: { tool: ToolInfo }) {
+  const sourceLabel = formatToolSource(tool.source);
+
+  return (
+    <>
+      <div className="space-y-2 border-b border-white/[0.04] px-4 py-3 lg:hidden">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 font-medium text-white">{tool.name}</div>
+          <ToolStatusBadge enabled={tool.enabled} />
+        </div>
+        <div className="text-xs text-white/60">{sourceLabel}</div>
+        {tool.description ? (
+          <div className="text-xs text-white/50">{tool.description}</div>
+        ) : null}
+      </div>
+
+      <div
+        className={cn(
+          'hidden border-b border-white/[0.04] px-4 py-3 text-sm lg:grid',
+          DESKTOP_TOOL_GRID,
+        )}
+      >
+        <div className="truncate font-medium text-white">{tool.name}</div>
+        <div className="truncate text-xs text-white/60">{sourceLabel}</div>
+        <div className="line-clamp-2 text-xs text-white/50">{tool.description}</div>
+        <ToolStatusBadge enabled={tool.enabled} />
+      </div>
+    </>
+  );
+}
+
+function ToolRowSkeleton({ index }: { index: number }) {
+  return (
+    <>
+      <div
+        key={`mobile-${index}`}
+        className="space-y-2 border-b border-white/[0.04] px-4 py-3 lg:hidden"
+      >
+        <div className="h-4 w-32 rounded bg-white/[0.06]" />
+        <div className="h-4 w-24 rounded bg-white/[0.04]" />
+        <div className="h-4 w-full rounded bg-white/[0.04]" />
+      </div>
+      <div
+        key={`desktop-${index}`}
+        className={cn(
+          'hidden border-b border-white/[0.04] px-4 py-3 lg:grid',
+          DESKTOP_TOOL_GRID,
+        )}
+      >
+        <div className="h-4 w-32 rounded bg-white/[0.06]" />
+        <div className="h-4 w-24 rounded bg-white/[0.04]" />
+        <div className="h-4 w-full rounded bg-white/[0.04]" />
+        <div className="h-4 w-16 rounded bg-white/[0.04]" />
+      </div>
+    </>
+  );
+}
+
 export default function ToolsPage() {
-  // SWR: fetch tools list
   const { data: tools = [], isLoading: loading } = useSWR(
     'tools',
     listTools,
-    { revalidateOnFocus: false }
+    { revalidateOnFocus: false },
   );
 
   const sortedTools = useMemo(() => {
@@ -32,16 +105,21 @@ export default function ToolsPage() {
   }, [tools]);
 
   return (
-    <div className="min-h-screen flex flex-col p-6 max-w-6xl mx-auto space-y-4">
+    <div className="mx-auto flex min-h-screen max-w-6xl flex-col space-y-4 p-6">
       <div>
         <h1 className="text-2xl font-semibold text-white">Tools</h1>
-        <p className="text-sm text-white/60 mt-1">
+        <p className="mt-1 text-sm text-white/60">
           Read-only inventory of tools available to agents, including their source.
         </p>
       </div>
 
-      <div className="rounded-xl bg-white/[0.02] border border-white/[0.06] overflow-hidden">
-        <div className="grid grid-cols-[minmax(180px,1.1fr)_minmax(160px,0.8fr)_minmax(280px,2fr)_minmax(110px,0.6fr)] gap-4 px-4 py-3 text-[11px] uppercase tracking-wider text-white/40 border-b border-white/[0.06]">
+      <div className="overflow-hidden rounded-xl border border-white/[0.06] bg-white/[0.02]">
+        <div
+          className={cn(
+            'hidden border-b border-white/[0.06] px-4 py-3 text-[11px] uppercase tracking-wider text-white/40 lg:grid',
+            DESKTOP_TOOL_GRID,
+          )}
+        >
           <span>Name</span>
           <span>Source</span>
           <span>Description</span>
@@ -49,47 +127,21 @@ export default function ToolsPage() {
         </div>
 
         {loading ? (
-          <div className="divide-y divide-white/[0.04]">
+          <div>
             {Array.from({ length: 10 }).map((_, index) => (
-              <div
-                key={index}
-                className="grid grid-cols-[minmax(180px,1.1fr)_minmax(160px,0.8fr)_minmax(280px,2fr)_minmax(110px,0.6fr)] gap-4 px-4 py-3"
-              >
-                <div className="h-4 w-32 rounded bg-white/[0.06]" />
-                <div className="h-4 w-24 rounded bg-white/[0.04]" />
-                <div className="h-4 w-full rounded bg-white/[0.04]" />
-                <div className="h-4 w-16 rounded bg-white/[0.04]" />
-              </div>
+              <ToolRowSkeleton key={index} index={index} />
             ))}
           </div>
         ) : sortedTools.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 text-white/40">
-            <Wrench className="h-10 w-10 mb-3 text-white/20" />
+            <Wrench className="mb-3 h-10 w-10 text-white/20" />
             <p className="text-sm">No tools available</p>
           </div>
         ) : (
-          <div className="divide-y divide-white/[0.04]">
-            {sortedTools.map((tool) => {
-              const sourceLabel = formatToolSource(tool.source);
-              return (
-                <div
-                  key={tool.name}
-                  className="grid grid-cols-[minmax(180px,1.1fr)_minmax(160px,0.8fr)_minmax(280px,2fr)_minmax(110px,0.6fr)] gap-4 px-4 py-3 text-sm"
-                >
-                  <div className="font-medium text-white truncate">{tool.name}</div>
-                  <div className="text-xs text-white/60 truncate">{sourceLabel}</div>
-                  <div className="text-xs text-white/50 line-clamp-2">{tool.description}</div>
-                  <div
-                    className={cn(
-                      'text-xs font-medium',
-                      tool.enabled ? 'text-emerald-400' : 'text-white/40'
-                    )}
-                  >
-                    {tool.enabled ? 'Enabled' : 'Disabled'}
-                  </div>
-                </div>
-              );
-            })}
+          <div>
+            {sortedTools.map((tool) => (
+              <ToolRow key={tool.name} tool={tool} />
+            ))}
           </div>
         )}
       </div>

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
-import { Sidebar } from "@/components/sidebar";
+import { AppShell } from "@/components/app-shell";
 import { AuthGate } from "@/components/auth-gate";
 import { LibraryProvider } from "@/contexts/library-context";
 import { MissionSwitcherProvider } from "@/contexts/mission-switcher-context";
@@ -26,6 +26,11 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.svg",
   },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({
@@ -68,8 +73,7 @@ export default function RootLayout({
           <ToastProvider>
             <LibraryProvider>
               <MissionSwitcherProvider>
-                <Sidebar />
-                <main className="ml-56 min-h-screen">{children}</main>
+                <AppShell>{children}</AppShell>
               </MissionSwitcherProvider>
             </LibraryProvider>
           </ToastProvider>

--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -1028,7 +1028,7 @@ export default function ModelRoutingPage() {
           {/* Create form */}
           {showCreate && (
             <div className="mb-4 rounded-lg border border-indigo-500/20 bg-indigo-500/[0.03] p-4 space-y-3">
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <label className="text-xs text-white/40 mb-1 block">Chain ID</label>
                   <input

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -538,7 +538,7 @@ function OverviewPageContent() {
   );
 
   return (
-    <div className="flex h-screen overflow-hidden">
+    <div className="flex flex-col lg:flex-row lg:h-screen lg:overflow-hidden">
       {/* Main content */}
       <div className="flex-1 flex flex-col p-6 min-h-0">
         {/* Header */}
@@ -571,8 +571,8 @@ function OverviewPageContent() {
           />
         </div>
 
-        {/* Compact Kanban Board - 3 columns, fills available space */}
-        <div className="flex-1 min-h-0 grid grid-cols-3 gap-4 mb-4">
+        {/* Compact Kanban Board - 3 columns on desktop; stacks on mobile. */}
+        <div className="grid grid-cols-1 gap-4 mb-4 lg:flex-1 lg:min-h-0 lg:grid-cols-3">
           {columnData.map((col) => {
             const ColIcon = col.icon;
             return (
@@ -674,7 +674,7 @@ function OverviewPageContent() {
 
       {/* Right sidebar - no glass panel wrapper, just border. Flex column so
           the automations panel stretches into the remaining vertical space. */}
-      <div className="flex h-screen w-72 flex-col gap-4 overflow-y-auto border-l border-white/[0.06] p-4">
+      <div className="flex w-full flex-col gap-4 overflow-y-auto border-t border-white/[0.06] p-4 lg:h-screen lg:w-72 lg:border-t-0 lg:border-l">
         <div className="flex-shrink-0">
           <LastDaySummary
             missions={missions}

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -571,14 +571,18 @@ function OverviewPageContent() {
           />
         </div>
 
-        {/* Compact Kanban Board - 3 columns on desktop; stacks on mobile. */}
+        {/* Compact Kanban Board - 3 columns on desktop; stacks on mobile.
+            Below lg the grid contributes no height, so the column's clip +
+            inner scroll are gated behind lg: as well — otherwise the
+            flex-1/overflow-hidden body collapses toward zero and clips cards.
+            On mobile columns grow to fit their cards and the page scrolls. */}
         <div className="grid grid-cols-1 gap-4 mb-4 lg:flex-1 lg:min-h-0 lg:grid-cols-3">
           {columnData.map((col) => {
             const ColIcon = col.icon;
             return (
               <div
                 key={col.id}
-                className="flex flex-col min-h-0 rounded-xl bg-white/[0.01] border border-white/[0.04] overflow-hidden"
+                className="flex flex-col rounded-xl bg-white/[0.01] border border-white/[0.04] lg:min-h-0 lg:overflow-hidden"
               >
                 <div className="flex items-center justify-between px-3 py-2.5 border-b border-white/[0.04]">
                   <div className="flex items-center gap-2">
@@ -591,7 +595,7 @@ function OverviewPageContent() {
                     </span>
                   )}
                 </div>
-                <div className="flex-1 overflow-y-auto p-2 space-y-2">
+                <div className="p-2 space-y-2 lg:flex-1 lg:overflow-y-auto">
                   {col.missions.length === 0 ? (
                     <div className="flex flex-col items-center justify-center py-10 text-center">
                       <p className="text-[10px] text-white/20">

--- a/dashboard/src/app/settings/layout.tsx
+++ b/dashboard/src/app/settings/layout.tsx
@@ -4,7 +4,7 @@ export default function SettingsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="h-screen flex flex-col overflow-hidden">
+    <div className="h-[calc(100vh-3rem)] lg:h-screen flex flex-col overflow-hidden">
       {children}
     </div>
   );

--- a/dashboard/src/app/workspaces/page.tsx
+++ b/dashboard/src/app/workspaces/page.tsx
@@ -454,7 +454,7 @@ export default function WorkspacesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[calc(100vh-4rem)]">
+      <div className="flex items-center justify-center min-h-[calc(100vh-3rem)] lg:min-h-screen">
         <Loader className="h-8 w-8 animate-spin text-white/40" />
       </div>
     );
@@ -462,7 +462,7 @@ export default function WorkspacesPage() {
 
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-white">Workspaces</h1>
           <p className="text-sm text-white/60 mt-1">
@@ -471,7 +471,7 @@ export default function WorkspacesPage() {
         </div>
         <button
           onClick={() => setShowNewWorkspaceDialog(true)}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 rounded-lg transition-colors"
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 rounded-lg transition-colors max-lg:self-start"
         >
           <Plus className="h-4 w-4" />
           New Workspace
@@ -1036,7 +1036,7 @@ export default function WorkspacesPage() {
                       <p className="text-xs text-white/50 font-medium">Save as Template</p>
                     </div>
                     <div className="p-4 space-y-4">
-                      <div className="grid grid-cols-2 gap-3">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         <div>
                           <label className="text-xs text-white/40 block mb-2">Template Name</label>
                           <input

--- a/dashboard/src/components/app-shell.tsx
+++ b/dashboard/src/components/app-shell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { List } from '@phosphor-icons/react';
 import { Sidebar } from '@/components/sidebar';
@@ -11,11 +11,16 @@ import { BrainLogo } from '@/components/icons';
  * layout: a fixed sidebar plus a left-margined <main>. Below lg the sidebar
  * collapses into an off-canvas drawer toggled from a mobile top bar, so the
  * 224px sidebar no longer permanently eats the viewport on phones.
+ *
+ * Mobile top bar height is `h-12` (3rem) — see `MOBILE_TOP_BAR_HEIGHT` in
+ * `@/lib/responsive-layout`.
  */
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [navOpen, setNavOpen] = useState(false);
   const pathname = usePathname();
   const [lastPathname, setLastPathname] = useState(pathname);
+
+  const closeNav = () => setNavOpen(false);
 
   // Close the drawer whenever the route changes so navigating from it doesn't
   // leave the overlay covering the destination page. Adjusting state during
@@ -26,6 +31,29 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     setNavOpen(false);
   }
 
+  // Prevent the page behind the drawer from scrolling (especially on iOS).
+  useEffect(() => {
+    if (!navOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [navOpen]);
+
+  // Close the drawer on Escape from anywhere in the app.
+  useEffect(() => {
+    if (!navOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeNav();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [navOpen]);
+
   return (
     <>
       {/* Mobile top bar — never rendered at lg+, so desktop is untouched. */}
@@ -34,6 +62,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           type="button"
           onClick={() => setNavOpen(true)}
           aria-label="Open navigation"
+          aria-expanded={navOpen}
+          aria-controls="app-sidebar"
           className="flex h-8 w-8 items-center justify-center rounded-lg text-white/70 transition-colors hover:bg-white/[0.06] hover:text-white"
         >
           <List className="h-5 w-5" />
@@ -46,12 +76,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       {navOpen && (
         <div
           className="lg:hidden fixed inset-0 z-30 bg-black/50 backdrop-blur-sm"
-          onClick={() => setNavOpen(false)}
+          onClick={closeNav}
           aria-hidden="true"
         />
       )}
 
-      <Sidebar open={navOpen} onClose={() => setNavOpen(false)} />
+      <Sidebar id="app-sidebar" open={navOpen} onClose={closeNav} />
 
       <main className="lg:ml-56 min-h-[calc(100vh-3rem)] lg:min-h-screen">
         {children}

--- a/dashboard/src/components/app-shell.tsx
+++ b/dashboard/src/components/app-shell.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { List } from '@phosphor-icons/react';
+import { Sidebar } from '@/components/sidebar';
+import { BrainLogo } from '@/components/icons';
+
+/**
+ * Authenticated app shell. On desktop (lg+) it renders exactly the original
+ * layout: a fixed sidebar plus a left-margined <main>. Below lg the sidebar
+ * collapses into an off-canvas drawer toggled from a mobile top bar, so the
+ * 224px sidebar no longer permanently eats the viewport on phones.
+ */
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const [navOpen, setNavOpen] = useState(false);
+  const pathname = usePathname();
+  const [lastPathname, setLastPathname] = useState(pathname);
+
+  // Close the drawer whenever the route changes so navigating from it doesn't
+  // leave the overlay covering the destination page. Adjusting state during
+  // render (rather than in an effect) avoids an extra commit and satisfies the
+  // react-hooks/set-state-in-effect rule.
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname);
+    setNavOpen(false);
+  }
+
+  return (
+    <>
+      {/* Mobile top bar — never rendered at lg+, so desktop is untouched. */}
+      <div className="lg:hidden sticky top-0 z-30 flex h-12 items-center gap-3 border-b border-white/[0.06] glass-panel px-4">
+        <button
+          type="button"
+          onClick={() => setNavOpen(true)}
+          aria-label="Open navigation"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-white/70 transition-colors hover:bg-white/[0.06] hover:text-white"
+        >
+          <List className="h-5 w-5" />
+        </button>
+        <BrainLogo size={24} />
+        <span className="text-sm font-medium text-white">Sandboxed.sh</span>
+      </div>
+
+      {/* Backdrop behind the open drawer (mobile only). */}
+      {navOpen && (
+        <div
+          className="lg:hidden fixed inset-0 z-30 bg-black/50 backdrop-blur-sm"
+          onClick={() => setNavOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      <Sidebar open={navOpen} onClose={() => setNavOpen(false)} />
+
+      <main className="lg:ml-56 min-h-[calc(100vh-3rem)] lg:min-h-screen">
+        {children}
+      </main>
+    </>
+  );
+}

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -368,7 +368,7 @@ export function AskPanel({
 
   return (
     <div
-      className="@container relative flex h-full shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl"
+      className="@container relative flex h-full shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl max-lg:max-w-full max-lg:h-[60vh]"
       style={{ width: panelWidth }}
     >
       {/* Drag the left edge to trade width between the chat and the co-pilot. */}

--- a/dashboard/src/components/ask-panel.tsx
+++ b/dashboard/src/components/ask-panel.tsx
@@ -26,6 +26,8 @@ import {
   type AskMessage,
 } from "@/lib/api";
 import { LazyMarkdownContent } from "@/components/markdown-content";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { LG_MEDIA_QUERY } from "@/lib/responsive-layout";
 import { cn } from "@/lib/utils";
 
 interface AskPanelProps {
@@ -365,17 +367,21 @@ export function AskPanel({
   const copilot = "text-[rgb(var(--copilot))]";
   const ctrl =
     "border border-[rgb(var(--foreground)/0.1)] bg-[rgb(var(--foreground)/0.04)] text-[rgb(var(--foreground)/0.6)] hover:bg-[rgb(var(--foreground)/0.07)] hover:text-[rgb(var(--foreground)/0.85)]";
+  const isDesktop = useMediaQuery(LG_MEDIA_QUERY);
 
   return (
     <div
-      className="@container relative flex h-full shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl max-lg:max-w-full max-lg:h-[60vh]"
-      style={{ width: panelWidth }}
+      className={cn(
+        "@container relative flex h-full shrink-0 flex-col rounded-2xl border border-[rgb(var(--copilot)/0.25)] bg-[rgb(var(--background-elevated)/0.72)] backdrop-blur-xl",
+        !isDesktop && "w-full max-lg:h-[60vh]",
+      )}
+      style={isDesktop ? { width: panelWidth } : undefined}
     >
       {/* Drag the left edge to trade width between the chat and the co-pilot. */}
       <div
         role="separator"
         aria-orientation="vertical"
-        className="absolute -left-1 top-0 z-10 h-full w-2 cursor-col-resize hover:bg-[rgb(var(--copilot)/0.25)]"
+        className="absolute -left-1 top-0 z-10 hidden h-full w-2 cursor-col-resize hover:bg-[rgb(var(--copilot)/0.25)] lg:block"
         onPointerDown={(e) => {
           e.preventDefault();
           const startX = e.clientX;

--- a/dashboard/src/components/assistant/assistant-page.tsx
+++ b/dashboard/src/components/assistant/assistant-page.tsx
@@ -694,7 +694,7 @@ export default function AssistantPage() {
 
   return (
     <div className="flex-1 flex flex-col items-center p-6 overflow-auto">
-      <div className="w-full min-w-[720px] max-w-5xl space-y-6">
+      <div className="w-full min-w-[720px] max-w-5xl space-y-6 max-lg:min-w-0">
         {/* Header */}
         <header className="flex flex-wrap items-center justify-between gap-3">
           <div className="min-w-0">

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -86,7 +86,13 @@ const navigation: NavItem[] = [
   },
 ];
 
-export const Sidebar = memo(function Sidebar() {
+export const Sidebar = memo(function Sidebar({
+  open = false,
+  onClose,
+}: {
+  open?: boolean;
+  onClose?: () => void;
+}) {
   const pathname = usePathname();
   const [currentMission, setCurrentMission] = useState<Mission | null>(null);
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
@@ -160,7 +166,15 @@ export const Sidebar = memo(function Sidebar() {
         : 'text-white/40';
 
   return (
-    <aside className="fixed left-0 top-0 z-40 flex h-screen w-56 flex-col glass-panel border-r border-white/[0.06]">
+    <aside
+      className={cn(
+        'fixed left-0 top-0 z-40 flex h-screen w-56 flex-col glass-panel border-r border-white/[0.06]',
+        // Off-canvas drawer below lg; always docked at lg+ so desktop is
+        // unchanged (lg:translate-x-0 wins regardless of `open`).
+        'transition-transform duration-200 lg:translate-x-0',
+        open ? 'translate-x-0' : '-translate-x-full',
+      )}
+    >
       {/* Header */}
       <div className="flex h-16 items-center gap-2 border-b border-white/[0.06] px-4">
         <BrainLogo size={32} />
@@ -220,6 +234,7 @@ export const Sidebar = memo(function Sidebar() {
                         <Link
                           key={child.name}
                           href={child.href}
+                          onClick={onClose}
                           className={cn(
                             'flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-all',
                             isChildCurrent
@@ -243,6 +258,7 @@ export const Sidebar = memo(function Sidebar() {
             <Link
               key={item.name}
               href={item.href}
+              onClick={onClose}
               className={cn(
                 'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all relative',
                 isCurrentPath
@@ -264,8 +280,9 @@ export const Sidebar = memo(function Sidebar() {
 
       {/* Current Mission Status */}
       {currentMission && (
-        <Link 
+        <Link
           href={`/control?mission=${currentMission.id}`}
+          onClick={onClose}
           className="mx-3 mb-3 p-3 rounded-xl bg-white/[0.02] border border-white/[0.04] hover:bg-white/[0.04] transition-colors"
         >
           <div className="flex items-center gap-2 mb-1.5">

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
+import { LG_MEDIA_QUERY } from '@/lib/responsive-layout';
+import { useMediaQuery } from '@/hooks/use-media-query';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -87,15 +89,53 @@ const navigation: NavItem[] = [
 ];
 
 export const Sidebar = memo(function Sidebar({
+  id,
   open = false,
   onClose,
 }: {
+  id?: string;
   open?: boolean;
   onClose?: () => void;
 }) {
   const pathname = usePathname();
+  const asideRef = useRef<HTMLElement>(null);
+  const isDesktop = useMediaQuery(LG_MEDIA_QUERY);
   const [currentMission, setCurrentMission] = useState<Mission | null>(null);
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+
+  // Trap focus inside the off-canvas drawer while it is open on mobile.
+  useEffect(() => {
+    if (!open || isDesktop) return;
+    const root = asideRef.current;
+    if (!root) return;
+
+    const focusables = root.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusables.length === 0) return;
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    first.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+      if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    root.addEventListener('keydown', onKeyDown);
+    return () => root.removeEventListener('keydown', onKeyDown);
+  }, [open, isDesktop]);
 
   // Auto-expand sections if we're on their subpages
   useEffect(() => {
@@ -167,6 +207,9 @@ export const Sidebar = memo(function Sidebar({
 
   return (
     <aside
+      ref={asideRef}
+      id={id}
+      aria-label="Main navigation"
       className={cn(
         'fixed left-0 top-0 z-40 flex h-screen w-56 flex-col glass-panel border-r border-white/[0.06]',
         // Off-canvas drawer below lg; always docked at lg+ so desktop is

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -204,12 +204,15 @@ export const Sidebar = memo(function Sidebar({
       : currentMission?.status === 'failed' 
         ? 'text-red-400' 
         : 'text-white/40';
+  const hideClosedMobileNav = !open && !isDesktop;
 
   return (
     <aside
       ref={asideRef}
       id={id}
       aria-label="Main navigation"
+      aria-hidden={hideClosedMobileNav ? true : undefined}
+      inert={hideClosedMobileNav ? true : undefined}
       className={cn(
         'fixed left-0 top-0 z-40 flex h-screen w-56 flex-col glass-panel border-r border-white/[0.06]',
         // Off-canvas drawer below lg; always docked at lg+ so desktop is

--- a/dashboard/src/components/system-monitor.tsx
+++ b/dashboard/src/components/system-monitor.tsx
@@ -840,7 +840,7 @@ export function SystemMonitor({ className, intervalMs = 1000 }: SystemMonitorPro
         />
 
         {/* Memory and Network - Split bottom */}
-        <div className="grid grid-cols-2 gap-3 min-h-0">
+        <div className="grid grid-cols-1 gap-3 min-h-0 sm:grid-cols-2">
           <MemoryChart
             data={memoryHistory}
             percent={metrics?.memory_percent ?? 0}

--- a/dashboard/src/hooks/use-media-query.ts
+++ b/dashboard/src/hooks/use-media-query.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribe to a CSS media query. Returns `false` during SSR and until the first
+ * client match so layout doesn't flash incorrectly on hydration.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const sync = () => setMatches(media.matches);
+    sync();
+    media.addEventListener("change", sync);
+    return () => media.removeEventListener("change", sync);
+  }, [query]);
+
+  return matches;
+}

--- a/dashboard/src/lib/responsive-layout.ts
+++ b/dashboard/src/lib/responsive-layout.ts
@@ -1,0 +1,11 @@
+/** Matches Tailwind `lg` (1024px). Keep in sync with dashboard breakpoints. */
+export const LG_MEDIA_QUERY = "(min-width: 1024px)";
+
+/** Height of the mobile top bar (`AppShell` uses `h-12`). Used in `calc(100vh - …)` page shells. */
+export const MOBILE_TOP_BAR_HEIGHT = "3rem";
+
+/** Stacked panel height below `lg` (Mission/Control side panels, Ask co-pilot). */
+export const MOBILE_STACKED_PANEL_HEIGHT = "60vh";
+
+/** Fixed height for the system monitor chart area below `lg` so SVGs don't collapse. */
+export const MOBILE_SYSTEM_MONITOR_HEIGHT = "560px";


### PR DESCRIPTION
## Summary

Makes the web dashboard usable on mobile while leaving the desktop (≥1024px / `lg`) experience **unchanged**. Previously the shell never adapted: a fixed `w-56` sidebar plus `ml-56` main, several `h-screen overflow-hidden` pages, hard `grid-cols-3` columns, fixed-width rails, and a `min-w-[720px]` assistant view made the app unusable below ~1024px.

### Approach (desktop-safe by construction)
- **`lg:` to restore, `max-lg:` to add.** Where the original applied a value at all widths, the desktop value is re-pinned behind `lg:`. Net-new mobile-only properties use `max-lg:` so no desktop class value changes.
- **New `AppShell`** (`dashboard/src/components/app-shell.tsx`) wraps the sidebar. At `lg+` it renders the original docked sidebar + `lg:ml-56` main. Below `lg` the sidebar becomes an off-canvas drawer (`-translate-x-full` → `translate-x-0`, always `lg:translate-x-0`) toggled from a new sticky mobile top bar (`lg:hidden`, 3rem tall) with a backdrop. The drawer closes on route change.
- **`layout.tsx`** gains a `viewport` export (`width=device-width, initialScale=1`).

### Per-view changes
- **Overview** — stacks the kanban (`grid-cols-1` → `lg:grid-cols-3`) and right rail; scrolls instead of `h-screen overflow-hidden`.
- **Inspect/System** — info column + monitor stack; the system monitor gets a definite height below `lg` (`max-lg:flex-none max-lg:h-[560px]`) so the `h-full` SVG charts don't collapse to zero, and the MEM/NET grid drops to one column on phones.
- **Assistant** — `max-lg:min-w-0` removes the `min-w-[720px]` horizontal overflow.
- **Mission/Control** — main row stacks and the resizable side panel/ask-panel cap their width and disable resize below `lg`. *Conservative stacking treatment on a large, complex resizable view — worth a design eye (see below).*
- **Root `h-screen` pages** (config: commands/skills/settings/workspace-templates, settings layout) → `h-[calc(100vh-3rem)] lg:h-screen` so the mobile top bar doesn't clip them.

## Validation
- `eslint` clean; `tsc --noEmit` shows no new errors (the 2 pre-existing errors are in an unrelated test file, `client-message-id.test.ts`, untouched here).
- Ran the dev server and verified in a real browser (Chrome, headless):
  - **Mobile (390×844):** drawer opens/closes, every view stacks and scrolls, **0 horizontal overflow** on Overview / Assistant / Control / config / settings; `h-screen` pages sit exactly below the 48px top bar (root `top=48`, `bottom=844`).
  - **Desktop (1440×900):** mobile top bar `display:none`, sidebar docked at `left:0 width:224`, no transform, `main` `margin-left:224px`, 0 overflow — i.e. **identical to today**.

## Review notes
- The Mission/Control view (`control-client.tsx`) is a ~10k-line resizable layout; the mobile treatment here is a pragmatic vertical stack and would benefit from a design review for UX polish.
- Tested against a stubbed/unreachable backend, so this verifies **layout**, not data-bound rendering. Please give it a human review and a sanity check against a live instance before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)