### PR TITLE
docs: fix inaccuracies found auditing docs against the code

### DIFF
--- a/ASK_ASSISTANT_DESIGN.md
+++ b/ASK_ASSISTANT_DESIGN.md
@@ -86,7 +86,7 @@ Store: `src/api/ask/store.rs` (`AskStore`). Global singleton via tokio
   `MetadataLlmConfig`; forwards `reasoning_effort` so reasoning models return
   visible content).
 - `mod.rs` — `run_ask_turn`: persist user msg → seed system prompt (recent
-  events + summary) → tool loop (≤6 iterations) → persist assistant answer.
+  events + summary) → tool loop (≤10 iterations) → persist assistant answer.
 - `http.rs` — handlers.
 
 Tools (read-on-demand so the 128K context ceiling never bites):

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,6 @@ systemd-nspawn container isolation.
 | **Platform** | Any OS with Docker | Ubuntu 24.04 LTS |
 | **Setup time** | ~5 minutes | ~30 minutes |
 | **Container workspaces** | Yes (with `privileged: true`) | Yes (native systemd-nspawn) |
-| **Desktop automation** | Yes (headless Xvfb) | Yes (native X11 or Xvfb) |
+| **Desktop automation** | Yes (headless Wayland/Sway) | Yes (native X11 or Xvfb) |
 | **Performance** | Good (slight overhead on macOS) | Best (native Linux) |
 | **Updates** | `docker compose build && up -d` | Git pull + cargo build, or one-click from dashboard |

--- a/PROVIDER_HEALTH_CHECK.md
+++ b/PROVIDER_HEALTH_CHECK.md
@@ -59,7 +59,7 @@ curl -X POST https://YOUR-BACKEND/api/ai/providers/cerebras/health
 
 The health check performs actual API validation for:
 - **Cerebras** - Tests with `llama-3.1-8b` model
-- **Z.AI** - Tests with `glm-4-flash` model
+- **Z.AI** - Tests with `glm-4.7-flash` model
 - **DeepInfra** - Tests with `Meta-Llama-3.1-8B-Instruct` model
 
 For OAuth-based providers (Anthropic, OpenAI, Google), it verifies credentials exist without making test API calls.

--- a/android_dashboard/README.md
+++ b/android_dashboard/README.md
@@ -8,7 +8,7 @@ The Android app is published on Zapstore:
 
 https://zapstore.dev/apps/sh.sandboxed.dashboard
 
-## What's in v0.2.0
+## What's in the app
 
 ### Bottom-tab screens
 
@@ -43,7 +43,7 @@ https://zapstore.dev/apps/sh.sandboxed.dashboard
 | --- | --- |
 | Language | Kotlin 2.0.21 |
 | Build | AGP 8.9.1, Gradle 8.11.1 |
-| SDK | `compileSdk` 36, `targetSdk` 36, `minSdk` 26 (Android 8.0) |
+| SDK | `compileSdk` 36, `targetSdk` 36, `minSdk` 33 (Android 13) |
 | UI | Jetpack Compose (BOM 2024.12.01), Material 3 with `material-icons-extended` |
 | Navigation | `androidx.navigation:navigation-compose` 2.9.8 |
 | State | ViewModel + StateFlow, Compose `collectAsState` |

--- a/backend/STREAMING.md
+++ b/backend/STREAMING.md
@@ -203,4 +203,4 @@ canonical row rather than the op log.
   reference implementation of the continuation rule.
 - `src/api/control_metrics.rs` records p50/p99 SSE chunk sizes so we
   can spot regressions in the streaming contract.
-- `src/api/control.rs::stream()` is the server-side mission filter.
+- `src/api/control/mod.rs::stream()` is the server-side mission filter.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -11,8 +11,8 @@ Developer-focused UI for monitoring and controlling the Sandboxed.sh backend.
 cd dashboard
 bun install
 
-# If the backend is on :3000, run the dashboard on :3001 to avoid port conflicts.
-PORT=3001 bun dev
+# The dev server runs on :3001 (backend stays on :3000, so no port conflict).
+bun dev
 ```
 
 Configure the backend URL via:
@@ -20,4 +20,4 @@ Configure the backend URL via:
 
 ## Auth
 
-If the backend reports `auth_required=true` from `GET /api/health`, the dashboard will prompt for credentials and store a JWT in `sessionStorage`. In multi-user mode (`auth_mode=multi_user`), it asks for username + password.
+If the backend reports `auth_required=true` from `GET /api/health`, the dashboard will prompt for credentials and store a JWT in `localStorage`. In multi-user mode (`auth_mode=multi_user`), it asks for username + password.

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -91,6 +91,6 @@ vault. Grok accepts `cli_path` to override the CLI binary path.
 ```json
 {
   "ok": true,
-  "message": "Backend configuration updated. Restart Sandboxed.sh to apply runtime changes."
+  "message": "Backend configuration updated."
 }
 ```

--- a/docs/DESKTOP_SETUP.md
+++ b/docs/DESKTOP_SETUP.md
@@ -109,8 +109,8 @@ DESKTOP_ENABLED=true
 # Xvfb resolution (width x height)
 DESKTOP_RESOLUTION=1920x1080
 
-# Starting display number (will increment for concurrent sessions)
-DESKTOP_DISPLAY_START=99
+# X display to use for desktop automation
+DESKTOP_DISPLAY=:99
 ```
 
 ## Manual Testing

--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -12,7 +12,7 @@ assistant stack:
 - `src/api/telegram.rs` owns Telegram webhook routing, trigger filtering,
   per-chat mission creation, file download, streaming edits, Paloma commands,
   proactive mission cards, scheduled messages, workflow relays, and memory.
-- `src/api/control.rs` exposes the Telegram CRUD endpoints and routes webhook
+- `src/api/control/mod.rs` exposes the Telegram CRUD endpoints and routes webhook
   updates into `ControlCommand::UserMessage`.
 - `dashboard/src/app/assistant/page.tsx` is the new top-level UI surface,
   while `dashboard/src/app/settings/telegram/page.tsx` redirects for

--- a/docs/MISSION_API.md
+++ b/docs/MISSION_API.md
@@ -181,7 +181,7 @@ GET /api/control/stream
 Server-Sent Events stream for real-time updates. Events have `event:` and `data:` fields.
 
 **Event types**:
-- `status` — control state changed (`idle`, `running`, `tool_waiting`)
+- `status` — control state changed (`idle`, `running`, `waiting_for_tool`)
 - `user_message` — user message received
 - `assistant_message` — agent response complete
 - `thinking` — agent reasoning (streaming)
@@ -208,7 +208,6 @@ data: {"id":"uuid","content":"Done!","success":true,"cost_cents":5,"model":"clau
 | `/api/control/missions/:id/tree` | GET | Get agent tree for mission |
 | `/api/control/missions/current` | GET | Get current active mission |
 | `/api/control/missions/:id/resume` | POST | Resume interrupted mission |
-| `/api/control/tree` | GET | Get live agent tree |
 | `/api/control/progress` | GET | Get execution progress |
 
 ## Automations
@@ -240,8 +239,8 @@ POST /api/control/missions/:id/automations
 **Body**:
 ```json
 {
-  "command_source": {"library": {"name": "my-command"}},
-  "trigger": {"interval": {"seconds": 300}},
+  "command_source": {"type": "library", "name": "my-command"},
+  "trigger": {"type": "interval", "seconds": 300},
   "variables": {"key": "value"},
   "retry_config": {
     "max_retries": 3,
@@ -252,14 +251,19 @@ POST /api/control/missions/:id/automations
 }
 ```
 
+Both `command_source` and `trigger` are internally tagged: a `"type"`
+discriminator selects the variant and its fields sit alongside it.
+
 **Trigger types**:
-- `{"interval": {"seconds": 300}}` — Run every N seconds
-- `{"webhook": {"config": {"webhook_id": "optional-uuid"}}}` — Trigger via webhook
-- `"agent_finished"` — Trigger after each agent turn completes
+- `{"type": "interval", "seconds": 300}` — Run every N seconds
+- `{"type": "cron", "expression": "0 8 * * *", "timezone": "Europe/Paris"}` — Cron schedule (timezone defaults to UTC)
+- `{"type": "webhook", "config": {"webhook_id": "optional-uuid"}}` — Trigger via webhook
+- `{"type": "agent_finished"}` — Trigger after each agent turn completes
 
 **Command sources**:
-- `{"library": {"name": "command-name"}}` — Use a library command
-- `{"inline": {"command": "echo hello"}}` — Inline shell command
+- `{"type": "library", "name": "command-name"}` — Use a library command
+- `{"type": "local_file", "path": "scripts/run.sh"}` — Command from a file in the mission workspace
+- `{"type": "inline", "content": "echo hello"}` — Inline shell command
 
 **Response**: `Automation` object.
 
@@ -280,8 +284,8 @@ PATCH /api/control/automations/:id
 **Body** (all fields optional):
 ```json
 {
-  "command_source": {"library": {"name": "new-command"}},
-  "trigger": {"interval": {"seconds": 600}},
+  "command_source": {"type": "library", "name": "new-command"},
+  "trigger": {"type": "interval", "seconds": 600},
   "variables": {"key": "new-value"},
   "retry_config": {"max_retries": 5},
   "active": false
@@ -320,8 +324,8 @@ GET /api/control/missions/:id/automation-executions
 {
   "id": "uuid",
   "mission_id": "uuid",
-  "command_source": {"library": {"name": "my-command"}},
-  "trigger": {"interval": {"seconds": 300}},
+  "command_source": {"type": "library", "name": "my-command"},
+  "trigger": {"type": "interval", "seconds": 300},
   "variables": {"key": "value"},
   "active": true,
   "created_at": "2025-01-13T10:00:00Z",
@@ -345,9 +349,9 @@ GET /api/control/missions/:id/automation-executions
   "trigger_source": "interval",
   "status": "success",
   "webhook_payload": null,
-  "started_at": "2025-01-13T10:05:00Z",
+  "variables_used": {"key": "value"},
   "completed_at": "2025-01-13T10:05:05Z",
-  "result_message": "Command completed successfully",
+  "error": null,
   "retry_count": 0
 }
 ```

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -92,8 +92,8 @@ To route traffic through a home connection:
 3. Use the `tailscale-ubuntu` template (or add Tailscale to your own template).
 
 The template's init script installs Tailscale and creates helper scripts:
-- `sandboxed.sh-network-up` --- brings up the virtual ethernet and DHCP.
-- `sandboxed.sh-tailscale-up` --- connects to your tailnet and sets the exit node.
+- `sandboxed-network-up` --- brings up the virtual ethernet and DHCP.
+- `sandboxed-tailscale-up` --- connects to your tailnet and sets the exit node.
 
 **Host NAT requirement**: isolated networking needs IP forwarding and NAT rules
 on the host. See the installation guide (section 8.3) for the `iptables`
@@ -164,7 +164,7 @@ Templates live in `workspace-template/<name>.json` in your Library repo:
 ### Init Script Best Practices
 
 - Start with `set -euo pipefail` and error trapping.
-- Log to `/var/log/sandboxed.sh-init.log` for debugging.
+- Log to `/var/log/sandboxed-init.log` for debugging.
 - Use `retry()` wrappers for network operations (apt, curl) to handle transient
   failures.
 - Guard installations with `if ! command -v <tool>` so re-running the init

--- a/docs/WORKSPACE_API.md
+++ b/docs/WORKSPACE_API.md
@@ -23,7 +23,6 @@ POST /api/workspaces
   "workspace_type": "host",
   "path": "/path/to/workspace",
   "skills": ["skill-name"],
-  "tools": ["tool-name"],
   "plugins": ["plugin-id"],
   "template": "template-name",
   "distro": "ubuntu-noble",
@@ -38,7 +37,6 @@ POST /api/workspaces
 | `workspace_type` | string | No | `host` or `container` (default: `host`) |
 | `path` | string | No | Custom working directory path |
 | `skills` | string[] | No | Library skill names to sync |
-| `tools` | string[] | No | Library tool names to sync |
 | `plugins` | string[] | No | Plugin identifiers for hooks |
 | `template` | string | No | Template name (forces `container` type) |
 | `distro` | string | No | Linux distro for containers |
@@ -68,7 +66,6 @@ PUT /api/workspaces/:id
 {
   "name": "new-name",
   "skills": ["skill-1", "skill-2"],
-  "tools": ["tool-1"],
   "plugins": ["plugin-id"],
   "template": "template-name",
   "distro": "ubuntu-noble",
@@ -146,8 +143,7 @@ Execute a shell command in the workspace. For container workspaces, runs inside 
   "command": "ls -la",
   "cwd": "subdirectory",
   "timeout_secs": 60,
-  "env": {"MY_VAR": "value"},
-  "stdin": "input data"
+  "env": {"MY_VAR": "value"}
 }
 ```
 
@@ -157,7 +153,6 @@ Execute a shell command in the workspace. For container workspaces, runs inside 
 | `cwd` | string | No | Working directory (relative or absolute) |
 | `timeout_secs` | number | No | Timeout in seconds (default: 300, max: 600) |
 | `env` | object | No | Additional environment variables |
-| `stdin` | string | No | Input to pass to stdin |
 
 **Response**:
 ```json
@@ -259,7 +254,7 @@ Returns detailed information about the container state, useful for understanding
 GET /api/workspaces/:id/init-log
 ```
 
-Reads the init script log from `/var/log/sandboxed.sh-init.log` inside the container.
+Reads the init script log from `/var/log/sandboxed-init.log` inside the container.
 
 **Response**:
 ```json
@@ -267,7 +262,7 @@ Reads the init script log from `/var/log/sandboxed.sh-init.log` inside the conta
   "exists": true,
   "content": "Starting init script\nRunning apt-get update...\n...",
   "total_lines": 1234,
-  "log_path": "/var/log/sandboxed.sh-init.log"
+  "log_path": "/var/log/sandboxed-init.log"
 }
 ```
 
@@ -416,7 +411,6 @@ DELETE /api/library/workspace-template/:name
   "error_message": null,
   "created_at": "2025-01-13T10:00:00Z",
   "skills": ["skill-1"],
-  "tools": ["tool-1"],
   "plugins": ["plugin-id"],
   "template": "nodejs-dev",
   "distro": "ubuntu-noble",

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -58,7 +58,7 @@ By default, workspaces run in host/fallback mode — processes execute directly 
 
 ```yaml
 services:
-  sandboxed.sh:
+  sandboxed-sh:
     # ...
     privileged: true
     cgroup: host
@@ -91,7 +91,7 @@ Two Docker volumes keep data across container restarts:
 
 | Volume | Mount point | Contents |
 |---|---|---|
-| `sandboxed.sh-data` | `/root/.sandboxed-sh` | SQLite database, library, container rootfs, settings |
+| `sandboxed-data` | `/root/.sandboxed-sh` | SQLite database, library, container rootfs, settings |
 | `claude-auth` | `/root/.claude` | Claude Code OAuth credentials |
 
 To back up your data, use `docker volume inspect` to find the volume paths, or bind-mount them to host directories instead.
@@ -100,7 +100,7 @@ To back up your data, use `docker volume inspect` to find the volume paths, or b
 
 The multi-stage build produces a single image with everything pre-installed:
 
-- **Rust backend** — `sandboxed-sh`, `desktop-mcp`, `workspace-mcp` binaries
+- **Rust backend** — `sandboxed-sh`, `desktop-mcp`, `workspace-mcp`, `orchestrator-mcp`, `assistant-mcp` binaries
 - **Next.js dashboard** — standalone build served on port 3001 internally
 - **Caddy** — reverse proxy that unifies backend + dashboard on port 80
 - **Claude Code CLI** — installed via npm
@@ -108,7 +108,7 @@ The multi-stage build produces a single image with everything pre-installed:
 - **Grok CLI** — installed via npm when available
 - **Bun** and **Node.js 20**
 - **systemd-container + debootstrap** — for container workspace isolation
-- **Desktop automation** — Xvfb, i3, Chromium, xdotool, scrot, ImageMagick, Tesseract OCR
+- **Desktop automation** — Sway (Wayland), grim, wtype, wlrctl, wf-recorder, Chromium, ImageMagick, Tesseract OCR
 - **Utilities** — git, curl, jq, SSH client, gnupg
 
 ## Production deployment
@@ -156,7 +156,7 @@ docker compose up -d
 | Permission denied on SSH keys | Ensure `~/.ssh` on the host is readable by your user |
 | Port conflict on 3000 | Change the port mapping (e.g. `"8080:80"`) in `docker-compose.yml` |
 | Build takes too long | Rust compilation is the bottleneck (~5–10 min first time). Subsequent builds use Docker layer caching. |
-| Backend not starting | Check logs with `docker compose logs -f sandboxed.sh` |
+| Backend not starting | Check logs with `docker compose logs -f sandboxed-sh` |
 
 ## Comparison with native installation
 

--- a/docs/install-native.md
+++ b/docs/install-native.md
@@ -616,19 +616,15 @@ tailscale up --advertise-exit-node
 Approve it in the Tailscale admin console (Machines → your node → “Approve exit
 node”).
 
-### 8.2 Use the `residential` workspace template
+### 8.2 Use a Tailscale workspace template
 
-This repo ships a sample template at:
+Create a workspace template that installs Tailscale — manage templates from the
+dashboard under **Config → Workspace Templates**, or store them in your Library
+repo. The template installs Tailscale and adds helper scripts:
 
-```
-library-template/workspace-template/residential.json
-```
-
-It installs Tailscale and adds helper scripts:
-
-- `sandboxed.sh-network-up` (brings up host0 veth + DHCP + DNS)
-- `sandboxed.sh-tailscale-up` (starts tailscaled + sets exit node)
-- `sandboxed.sh-tailscale-check` (prints Tailscale status + public IP)
+- `sandboxed-network-up` (brings up host0 veth + DHCP + DNS)
+- `sandboxed-tailscale-up` (starts tailscaled + sets exit node)
+- `sandboxed-tailscale-check` (prints Tailscale status + public IP)
 
 Set these **workspace env vars** (not global env):
 
@@ -640,8 +636,8 @@ Set these **workspace env vars** (not global env):
 Then inside the workspace:
 
 ```bash
-sandboxed.sh-tailscale-up
-sandboxed.sh-tailscale-check
+sandboxed-tailscale-up
+sandboxed-tailscale-check
 ```
 
 If the public IP matches your home ISP, the exit node is working.
@@ -950,7 +946,7 @@ bun install
 NEXT_PUBLIC_API_URL=https://agent.yourdomain.com bun dev
 ```
 
-Then open `http://localhost:3000`.
+Then open `http://localhost:3001` (the dev server runs on port 3001).
 
 ### 12.3 iOS App
 

--- a/mobile-app-reliability.md
+++ b/mobile-app-reliability.md
@@ -313,7 +313,7 @@ Use simulator tests for:
 ## Source Notes
 
 - `backend/STREAMING.md` is the repo's canonical stream contract.
-- `src/api/control.rs` confirms SSE keepalives and WS heartbeat/resume support.
+- `src/api/control/mod.rs` confirms SSE keepalives and WS heartbeat/resume support.
 - `dashboard/src/lib/api.ts` already has stream diagnostics and opt-in WS logic
   worth mirroring in iOS.
 - Apple documents


### PR DESCRIPTION
## Summary

Audited the repository documentation against the current code and fixed concrete, verifiable inaccuracies (commands, paths, env vars, ports, API endpoints/shapes, version/SDK numbers, binary/stack names, and stale module paths). Scope was limited to factual corrections — design intent, roadmap, and historical/log artifacts were left untouched.

## Changes by file

- **docs/MISSION_API.md** — SSE status `tool_waiting` → `waiting_for_tool`; removed a non-existent `GET /api/control/tree` row; rewrote `command_source`/`trigger` to the internally-tagged serde form (`{"type":"library","name":...}`, `{"type":"interval","seconds":...}`, `{"type":"inline","content":...}`) with cron + local_file examples; `AutomationExecution` fields `started_at`/`result_message` → `variables_used`/`error`.
- **docs/WORKSPACE_API.md** — removed the non-existent `tools` field (create/update/object/table) and `stdin` from exec; init log path `sandboxed.sh-init.log` → `sandboxed-init.log`.
- **docs/WORKSPACES.md** — hyphenated helper script names (`sandboxed-network-up`, `sandboxed-tailscale-up`); log path fix.
- **docs/BACKEND_API.md** — corrected the config-update response message to match `src/api/backends.rs`.
- **docs/install-docker.md** — service name `sandboxed-sh`, volume `sandboxed-data`; added `orchestrator-mcp`/`assistant-mcp` to the binary list; Docker desktop stack Xvfb/i3/xdotool/scrot → Sway/grim/wtype/wlrctl/wf-recorder (Wayland, per Dockerfile); logs command service name.
- **docs/install-native.md** — removed a false "sample template ships at library-template/..." claim; fixed helper script names; dev port `3000` → `3001`.
- **docs/DESKTOP_SETUP.md** — `DESKTOP_DISPLAY_START=99` → `DESKTOP_DISPLAY=:99` (matches the env var the code reads).
- **INSTALL.md** — comparison table: Docker desktop automation "headless Xvfb" → "headless Wayland/Sway" (Dockerfile uses Wayland; native correctly stays X11/Xvfb).
- **dashboard/README.md** — JWT stored in `localStorage` (not `sessionStorage`); `bun dev` (the dev script hardcodes `--port 3001`).
- **android_dashboard/README.md** — `minSdk 26` → `minSdk 33`; stale version heading generalized.
- **PROVIDER_HEALTH_CHECK.md** — `glm-4-flash` → `glm-4.7-flash`.
- **backend/STREAMING.md, docs/HERMES_ASSISTANT_MIGRATION.md, mobile-app-reliability.md** — `src/api/control.rs` → `src/api/control/mod.rs` (the file became a module directory).
- **ASK_ASSISTANT_DESIGN.md** — tool loop "≤6 iterations" → "≤10 iterations" (matches `MAX_ITERATIONS`).

## Test plan

- [ ] Maintainer review of each correction against current code/config
- [ ] Confirm desktop-automation phrasing (Docker = Wayland, native = X11) matches intended deployment story