### PR TITLE
feat(missions): auto-resume agents when background shell tasks finish (supersedes #550)

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -41,8 +41,8 @@ use uuid::Uuid;
 
 #[allow(unused_imports)]
 use super::supervision::{
-    ack_promotion_loop, cleanup_stale_active_missions_once, recover_server_shutdown_missions,
-    stale_mission_cleanup_loop, stuck_mission_watchdog_loop,
+    ack_promotion_loop, background_task_autoresume_loop, cleanup_stale_active_missions_once,
+    recover_server_shutdown_missions, stale_mission_cleanup_loop, stuck_mission_watchdog_loop,
 };
 use crate::agents::{AgentContext, AgentRef, TerminalReason};
 use crate::config::Config;
@@ -6552,6 +6552,11 @@ fn spawn_control_session(
         mission_search_cache,
     };
 
+    // Shared registry of in-flight Claude Code background shell tasks. Written
+    // by the control actor's ToolResult arm; read by the auto-resume watcher.
+    let background_tasks: super::mission_runner::BackgroundTaskRegistry =
+        Arc::new(RwLock::new(std::collections::HashMap::new()));
+
     // Spawn the main control actor
     tokio::spawn(control_actor_loop(
         config.clone(),
@@ -6573,6 +6578,7 @@ fn spawn_control_session(
         mission_store,
         secrets,
         user_id,
+        Arc::clone(&background_tasks),
     ));
 
     // Recover missions stopped by the previous backend process. Graceful
@@ -6621,6 +6627,27 @@ fn spawn_control_session(
             Arc::clone(&state.mission_store),
             events_tx.clone(),
         ));
+    }
+
+    // Spawn the background-task auto-resume watcher. When a mission agent
+    // launches a `Bash` job with `run_in_background: true` and then ends its
+    // turn, the mission parks in `AwaitingUser` with nothing to wake it when the
+    // job finishes. This watcher polls captured background tasks, detects
+    // completion inside the workspace, and resumes the agent with the output.
+    // Uses an in-memory registry (no persistent store required). Gated by
+    // `BACKGROUND_TASK_AUTORESUME` (default enabled).
+    if super::mission_runner::background_task_autoresume_enabled() {
+        tokio::spawn(background_task_autoresume_loop(
+            Arc::clone(&state.mission_store),
+            state.cmd_tx.clone(),
+            events_tx.clone(),
+            workspaces.clone(),
+            Arc::clone(&background_tasks),
+        ));
+    } else {
+        tracing::info!(
+            "Background-task auto-resume watcher not started (BACKGROUND_TASK_AUTORESUME disabled)"
+        );
     }
 
     // Spawn event logger task (logs all events to SQLite for debugging/replay)
@@ -8448,6 +8475,9 @@ async fn control_actor_loop(
     mission_store: Arc<dyn MissionStore>,
     secrets: Option<Arc<SecretsStore>>,
     session_user_id: String,
+    // Shared registry of in-flight Claude Code background shell tasks. Written
+    // here from the `ToolResult` event arm; read by the auto-resume watcher.
+    background_tasks: super::mission_runner::BackgroundTaskRegistry,
 ) {
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
@@ -8492,6 +8522,16 @@ async fn control_actor_loop(
         Uuid,
         super::mission_runner::MissionRunner,
     > = std::collections::HashMap::new();
+
+    // Correlate Bash `tool_call_id` -> command string so that when the matching
+    // `Bash` ToolResult carries a background-start marker we can record the
+    // launched command in the background-task registry. Capped to avoid
+    // unbounded growth if a result is ever dropped; entries are removed when
+    // the matching result arrives. Only `Bash` calls are tracked.
+    let mut pending_bash_commands: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    const MAX_PENDING_BASH_COMMANDS: usize = 256;
+    let background_autoresume_enabled = super::mission_runner::background_task_autoresume_enabled();
 
     // Task-board scheduler cadence: the 100ms tick is far too hot for store
     // scans, so passes run every few seconds. Each pass spawns ready workers,
@@ -8564,6 +8604,28 @@ async fn control_actor_loop(
         if let Some(raw) = result.as_str() {
             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(raw) {
                 return Some(parsed);
+            }
+        }
+        None
+    }
+
+    /// Extract the human-readable text from a tool result `Value`.
+    ///
+    /// The Claude Code runner emits either a plain string or an object of the
+    /// form `{ "content": ..., "stdout": ..., "stderr": ..., "is_error": ... }`
+    /// (see `runners::claudecode`). We prefer `content`, falling back to
+    /// `stdout`, then the whole string. Returns `None` when no text is present.
+    fn tool_result_text(result: &serde_json::Value) -> Option<String> {
+        if let Some(s) = result.as_str() {
+            return Some(s.to_string());
+        }
+        if let Some(obj) = result.as_object() {
+            for key in ["content", "stdout"] {
+                if let Some(s) = obj.get(key).and_then(|v| v.as_str()) {
+                    if !s.is_empty() {
+                        return Some(s.to_string());
+                    }
+                }
             }
         }
         None
@@ -8946,17 +9008,23 @@ async fn control_actor_loop(
                             }
                         }
 
-                        // Strict (control-plane) messages must reach their exact
-                        // target via Case 1/2 only. If we got here, the target
-                        // wasn't deliverable (e.g. capacity, or no target) — drop
-                        // it rather than fall through to the main session, which
-                        // would leak a board wake / worker dispatch into an
-                        // unrelated mission. The scheduler re-issues on its next
-                        // pass (wake) or via the zombie sweep (worker spawn).
-                        if strict {
+                        // Strict (control-plane) messages must never leak into an
+                        // *unrelated* mission. If the target is some OTHER mission
+                        // than the main session's and we got here, Case 1/2 (queue
+                        // to / start a parallel runner) didn't fire — drop rather
+                        // than fall through to the main session, which would land a
+                        // board wake / bg-autoresume / worker dispatch in the wrong
+                        // mission. The scheduler re-issues on its next pass.
+                        //
+                        // When the target IS the main session's mission, there is
+                        // no leak: Case 3 below is exactly where we want it — it
+                        // activates an idle/AwaitingUser main mission and starts a
+                        // fresh turn (e.g. the bg-task auto-resume waking a mission
+                        // that parked on the user while a background job ran).
+                        if strict && !target_is_main {
                             tracing::warn!(
                                 target = ?effective_target,
-                                "Dropping strict control-plane message: target not deliverable this pass"
+                                "Dropping strict control-plane message: non-main target not deliverable this pass"
                             );
                             let _ = respond.send(UserMessageAck::Dropped);
                             continue;
@@ -11289,6 +11357,21 @@ async fn control_actor_loop(
                                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                                 }
 
+                                // Background-task auto-resume: stash the command
+                                // for any `Bash` call so the matching ToolResult
+                                // can attach it to a captured background task.
+                                if background_autoresume_enabled
+                                    && name == "Bash"
+                                    && pending_bash_commands.len() < MAX_PENDING_BASH_COMMANDS
+                                {
+                                    if let Some(cmd) =
+                                        args.get("command").and_then(|v| v.as_str())
+                                    {
+                                        pending_bash_commands
+                                            .insert(tool_call_id.clone(), cmd.to_string());
+                                    }
+                                }
+
                                 // Emit activity event for real-time SSE
                                 let _ = events_tx.send(AgentEvent::MissionActivity {
                                     label,
@@ -11472,6 +11555,63 @@ async fn control_actor_loop(
                             }
                         }
                         _ => {}
+                    }
+
+                    // Background-task auto-resume capture: when a `Bash` tool
+                    // result is the CLI's background-launch confirmation, record
+                    // the task so the watcher can wake the agent once it finishes.
+                    // (Must run before the desktop block below, which `continue`s
+                    // past non-desktop tool results.)
+                    if background_autoresume_enabled {
+                        if let AgentEvent::ToolResult {
+                            tool_call_id,
+                            name,
+                            result,
+                            mission_id,
+                        } = &event
+                        {
+                            // Always reclaim the correlated command, even if this
+                            // isn't a background start, so the map can't leak.
+                            let command = pending_bash_commands.remove(tool_call_id);
+                            if name == "Bash" {
+                                if let (Some(mid), Some(text)) =
+                                    (mission_id, tool_result_text(result))
+                                {
+                                    if let Some((task_id, output_path)) =
+                                        super::runners::claudecode::parse_background_task_start(
+                                            &text,
+                                        )
+                                    {
+                                        let task = super::mission_runner::BackgroundTask {
+                                            id: task_id.clone(),
+                                            output_path: output_path.clone(),
+                                            command: command.unwrap_or_default(),
+                                            started_at: std::time::Instant::now(),
+                                        };
+                                        tracing::info!(
+                                            mission_id = %mid,
+                                            background_task_id = %task_id,
+                                            output_path = %output_path,
+                                            "Captured Claude Code background task; \
+                                             scheduling auto-resume on completion"
+                                        );
+                                        // Mirror onto the runner (informational).
+                                        if let Some(runner) = parallel_runners.get_mut(mid) {
+                                            runner
+                                                .background_tasks
+                                                .insert(task_id.clone(), task.clone());
+                                        }
+                                        // Source of truth: the shared registry.
+                                        background_tasks
+                                            .write()
+                                            .await
+                                            .entry(*mid)
+                                            .or_default()
+                                            .insert(task_id, task);
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     // Track desktop sessions for mission reconnect/resume.

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2469,6 +2469,49 @@ pub struct QueuedMessage {
     pub agent: Option<String>,
 }
 
+/// Environment flag gating the background-task auto-resume feature.
+///
+/// Default enabled; set `BACKGROUND_TASK_AUTORESUME=0` (or `false`/`no`/`off`)
+/// to disable. When disabled, capture and the watcher both no-op.
+pub const BACKGROUND_TASK_AUTORESUME_ENV: &str = "BACKGROUND_TASK_AUTORESUME";
+
+/// Whether the background-task auto-resume feature is enabled.
+pub fn background_task_autoresume_enabled() -> bool {
+    crate::util::env_var_bool(BACKGROUND_TASK_AUTORESUME_ENV, true)
+}
+
+/// An in-flight Claude Code background shell task (`Bash` tool with
+/// `run_in_background: true`).
+///
+/// Recorded when the CLI emits the background-start marker (see
+/// `crate::api::runners::claudecode::parse_background_task_start`) and consumed
+/// by the auto-resume watcher (`crate::api::supervision::bg_autoresume`), which
+/// which polls for completion and wakes the agent with the output once the job
+/// finishes.
+#[derive(Debug, Clone)]
+pub struct BackgroundTask {
+    /// CLI-assigned background id (e.g. `bash_1`).
+    pub id: String,
+    /// Path the CLI writes the job's combined output to (inside the workspace).
+    pub output_path: String,
+    /// The shell command that was launched, for the resume message. Best-effort
+    /// (empty if the matching tool_call wasn't observed).
+    pub command: String,
+    /// When we first observed the task start. Used for the overall timeout.
+    pub started_at: Instant,
+}
+
+/// Shared, cross-task registry of in-flight background tasks per mission.
+///
+/// The control actor (writer) records tasks here from the `ToolResult` event
+/// arm, and the supervision watcher (reader) polls and resumes from it. A
+/// shared registry is required because a mission's [`MissionRunner`] is torn
+/// down once its turn ends and the mission parks in `AwaitingUser` — exactly
+/// when the watcher needs to act — so per-runner state alone would not survive.
+///
+/// Keyed by mission id, then by background-task id.
+pub type BackgroundTaskRegistry = Arc<RwLock<HashMap<Uuid, HashMap<String, BackgroundTask>>>>;
+
 /// Isolated runner for a single mission.
 /// Info about a tracked subtask (from delegate_task/Task tool calls).
 #[derive(Debug, Clone)]
@@ -2553,6 +2596,15 @@ pub struct MissionRunner {
     /// Shared with the turn loops via Arc so they can increment/decrement
     /// without holding the runner's outer lock.
     pub active_tool_calls: Arc<std::sync::atomic::AtomicUsize>,
+
+    /// In-flight background shell tasks started this mission (`Bash` with
+    /// `run_in_background: true`), keyed by background-task id.
+    ///
+    /// This mirrors the shared [`BackgroundTaskRegistry`], which is the source
+    /// of truth used by the auto-resume watcher (the runner is torn down when
+    /// the mission parks in `AwaitingUser`, so this field is informational and
+    /// for in-process inspection only).
+    pub background_tasks: HashMap<String, BackgroundTask>,
 }
 
 impl MissionRunner {
@@ -2592,6 +2644,7 @@ impl MissionRunner {
             working_directory: None,
             user_id: None,
             active_tool_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            background_tasks: HashMap::new(),
         }
     }
 

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -46,6 +46,72 @@ fn claude_thinking_budget(effort: &str) -> u32 {
     }
 }
 
+/// Marker emitted by Claude Code's `Bash` tool when invoked with
+/// `run_in_background: true`. The CLI handles the launch locally and returns a
+/// confirmation `tool_result` of the exact form:
+///
+/// `Command running in background with ID: <id>. Output is being written to: <path>`
+///
+/// In `--print` (non-interactive) mode no further re-invocation happens when the
+/// job finishes, so nothing wakes the agent — the background-task auto-resume
+/// watcher (see `supervision::background_task_autoresume_loop`) closes that gap.
+const BACKGROUND_TASK_ID_MARKER: &str = "Command running in background with ID:";
+const BACKGROUND_TASK_OUTPUT_MARKER: &str = "Output is being written to:";
+
+/// Pure parser for the Claude Code background-start marker.
+///
+/// Given a `Bash` tool_result's textual content, returns `Some((id, output_path))`
+/// when the content is a background-launch confirmation, or `None` otherwise.
+///
+/// The marker format is:
+/// `Command running in background with ID: <id>. Output is being written to: <path>`
+///
+/// We locate both labels by substring (rather than a strict full-string match)
+/// so leading/trailing whitespace or a trailing newline in the CLI payload does
+/// not break detection.
+///
+/// Both the id and the output path are single whitespace-free tokens. The real
+/// marker continues with explanatory prose after the path
+/// (`... tasks/bokwqyjak.output. You will be notified when it completes. ...`),
+/// so for each label we take only the **first whitespace-delimited token** and
+/// strip a single trailing `.` (the sentence separator). This prevents the
+/// trailing marker sentence from being captured as part of the path.
+pub fn parse_background_task_start(content: &str) -> Option<(String, String)> {
+    let id_label = content.find(BACKGROUND_TASK_ID_MARKER)?;
+    let after_id = &content[id_label + BACKGROUND_TASK_ID_MARKER.len()..];
+
+    // The output label must come *after* the id label.
+    let out_rel = after_id.find(BACKGROUND_TASK_OUTPUT_MARKER)?;
+    let id_segment = &after_id[..out_rel];
+    let after_out = &after_id[out_rel + BACKGROUND_TASK_OUTPUT_MARKER.len()..];
+
+    // The id is the first whitespace-delimited token between the two labels,
+    // terminated by the literal "." that precedes the output label. Strip a
+    // single trailing period.
+    let id = id_segment
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('.')
+        .to_string();
+
+    // The path is the first whitespace-delimited token after the output label
+    // (paths contain no spaces). Strip a single trailing "." (sentence
+    // separator) so the trailing marker prose
+    // ("... .output. You will be notified ...") is not captured.
+    let path = after_out
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('.')
+        .to_string();
+
+    if id.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some((id, path))
+}
+
 /// Execute a turn using Claude Code CLI backend.
 ///
 /// For Host workspaces: spawns the CLI directly on the host.
@@ -2986,4 +3052,67 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
     }
 
     result
+}
+
+#[cfg(test)]
+mod background_task_tests {
+    use super::parse_background_task_start;
+
+    #[test]
+    fn parses_real_marker() {
+        let content = "Command running in background with ID: bash_1. \
+             Output is being written to: /tmp/claude-bg/bash_1.log";
+        let (id, path) = parse_background_task_start(content).expect("should parse marker");
+        assert_eq!(id, "bash_1");
+        assert_eq!(path, "/tmp/claude-bg/bash_1.log");
+    }
+
+    #[test]
+    fn parses_real_marker_with_trailing_prose() {
+        // Exact marker emitted by the Claude CLI: the path is followed by
+        // explanatory prose on the same line. Only the path token must be
+        // captured (no trailing sentence).
+        let content = "Command running in background with ID: bokwqyjak. \
+             Output is being written to: \
+             /tmp/claude-0/-workspaces-mission-20b6ee43/3cd99fa9-c3f8-4127-954a-d3be352221bf/tasks/bokwqyjak.output. \
+             You will be notified when it completes. To check interim output, use Read on that file path.";
+        let (id, path) = parse_background_task_start(content).expect("should parse real marker");
+        assert_eq!(id, "bokwqyjak");
+        assert_eq!(
+            path,
+            "/tmp/claude-0/-workspaces-mission-20b6ee43/3cd99fa9-c3f8-4127-954a-d3be352221bf/tasks/bokwqyjak.output"
+        );
+    }
+
+    #[test]
+    fn parses_marker_with_surrounding_whitespace_and_newline() {
+        let content = "  Command running in background with ID: abc-123. \
+             Output is being written to: /var/tmp/out.log\n";
+        let (id, path) = parse_background_task_start(content).expect("should tolerate whitespace");
+        assert_eq!(id, "abc-123");
+        assert_eq!(path, "/var/tmp/out.log");
+    }
+
+    #[test]
+    fn returns_none_for_unrelated_content() {
+        assert!(parse_background_task_start("total 0\n-rw-r--r-- 1 root root 0 file").is_none());
+        assert!(parse_background_task_start("").is_none());
+    }
+
+    #[test]
+    fn returns_none_when_only_id_label_present() {
+        // Malformed: id label but no output label.
+        assert!(parse_background_task_start("Command running in background with ID: x").is_none());
+    }
+
+    #[test]
+    fn returns_none_when_id_or_path_empty() {
+        // Output label present but path missing.
+        let content = "Command running in background with ID: bash_2. Output is being written to:";
+        assert!(parse_background_task_start(content).is_none());
+        // Id missing.
+        let content = "Command running in background with ID: . \
+             Output is being written to: /tmp/x.log";
+        assert!(parse_background_task_start(content).is_none());
+    }
 }

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -9,6 +9,8 @@
 //!   detection of silent/orphaned runners (incl. OOM-kill reporting).
 //! - [`stale_mission_cleanup_loop`] — hour-scale cleanup of abandoned
 //!   missions.
+//! - [`background_task_autoresume_loop`] — wakes missions parked in
+//!   `AwaitingUser` when Claude Code background shell tasks finish.
 //!
 //! TODO(Phase 5b): replace their three independent "is this mission alive?"
 //! heuristics with one per-mission LivenessState fed by the event stream —
@@ -27,6 +29,10 @@ use super::control::MissionStatus;
 #[allow(unused_imports)]
 use super::control::*;
 use super::mission_store::MissionStore;
+
+mod bg_autoresume;
+
+pub(crate) use bg_autoresume::background_task_autoresume_loop;
 
 pub(crate) async fn recover_server_shutdown_missions(
     mission_store: Arc<dyn MissionStore>,

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -1,0 +1,801 @@
+//! Background-task auto-resume watcher for Claude Code `Bash run_in_background`.
+//!
+//! When a mission agent launches a background shell job and parks in
+//! `AwaitingUser`, this module polls for completion inside the workspace and
+//! wakes the agent with the output.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{broadcast, mpsc, oneshot};
+use uuid::Uuid;
+
+use crate::workspace;
+use crate::workspace_exec::WorkspaceExec;
+
+use super::super::control::{AgentEvent, ControlCommand, MissionStatus, UserMessageAck};
+use super::super::mission_runner::{BackgroundTask, BackgroundTaskRegistry};
+use super::super::mission_store::MissionStore;
+
+/// How often the watcher polls in-flight background tasks for completion.
+const BG_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Once a probe reports the launched process gone (`busy == false`), it must
+/// stay gone for at least this long before we treat the task as finished. This
+/// absorbs a transient single-probe `pgrep` miss (e.g. the process briefly not
+/// matching while it forks/execs a child).
+const BG_IDLE_STABLE_SECS: u64 = 15;
+
+/// Grace period after a task starts during which a not-busy probe is NOT
+/// trusted on its own. A task that finished before our very first probe never
+/// shows as busy, so we only trust "not busy" once either (a) we have seen it
+/// busy at least once, or (b) it has existed at least this long (so a probe
+/// that simply raced the launch can't immediately declare it finished).
+const BG_START_GRACE_SECS: u64 = 20;
+
+/// Hard cap on how long we track a single background task before treating it as
+/// done regardless of the completion heuristic. Prevents a task whose process
+/// we can't observe (exotic shell, missing pgrep) from being watched forever.
+const BG_OVERALL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Max number of trailing bytes of the output file to include in the resume
+/// message, so we never blow up a turn's context with a huge log.
+const BG_OUTPUT_TAIL_BYTES: usize = 4000;
+
+/// Cap on completion-check commands per tick to bound work even if a misbehaving
+/// agent spawns hundreds of background jobs.
+const BG_MAX_CHECKS_PER_TICK: usize = 64;
+
+/// Outcome of a single workspace completion probe.
+///
+/// The probe keys completion off the launched **process** (`busy`), not the
+/// output file: Claude Code's background-task output file is ephemeral and is
+/// usually gone by the time we probe (the turn has already ended). `exists`
+/// and `mtime_epoch` are kept only so we can tail the output when it happens to
+/// still be present.
+#[derive(Debug, PartialEq, Eq)]
+enum BgProbe {
+    /// A probe result. `exists` reflects whether the output file is present
+    /// (for tailing); `busy` is true while the launched command's process is
+    /// still running; `mtime_epoch` is the output file mtime (0 when absent).
+    /// `pgrep_available` is false when `pgrep` is missing from the workspace —
+    /// the watcher must not trust `busy` in that case (fail closed).
+    Observed {
+        exists: bool,
+        mtime_epoch: u64,
+        busy: bool,
+        pgrep_available: bool,
+    },
+    /// The probe could not be run / parsed (WorkspaceExec error, bad output).
+    /// We skip this task this tick and retry next pass. `reason` carries the
+    /// underlying WorkspaceExec error (when the probe failed to exec) purely for
+    /// diagnostic logging; it is `None` for a parse failure.
+    Unknown { reason: Option<String> },
+}
+
+/// Per-task bookkeeping the watcher keeps across ticks.
+#[derive(Debug, Clone)]
+struct BgWatch {
+    /// True once any probe has reported the launched process running. Lets us
+    /// trust a later "not busy" reading even if the task finished quickly.
+    was_busy: bool,
+    /// Wall-clock instant at which we *first* observed the task not busy in the
+    /// current not-busy streak. Reset whenever a probe reports busy. Used to
+    /// require the process stay gone for `BG_IDLE_STABLE_SECS`.
+    idle_since: Option<Instant>,
+}
+
+/// Pure completion decision for one probe, factored out so it is unit-testable
+/// without a real filesystem or process table.
+fn bg_decide_finished(
+    prev: Option<&BgWatch>,
+    busy: bool,
+    task_age_secs: u64,
+    now: Instant,
+) -> (bool, BgWatch) {
+    let prev_was_busy = prev.map(|w| w.was_busy).unwrap_or(false);
+
+    if busy {
+        return (
+            false,
+            BgWatch {
+                was_busy: true,
+                idle_since: None,
+            },
+        );
+    }
+
+    let idle_since = prev.and_then(|w| w.idle_since).unwrap_or(now);
+    let idle_secs = now.duration_since(idle_since).as_secs();
+
+    let trust_not_busy = prev_was_busy || task_age_secs >= BG_START_GRACE_SECS;
+    let finished = trust_not_busy && idle_secs >= BG_IDLE_STABLE_SECS;
+
+    (
+        finished,
+        BgWatch {
+            was_busy: prev_was_busy,
+            idle_since: Some(idle_since),
+        },
+    )
+}
+
+/// Watcher that auto-resumes missions whose background shell tasks have finished.
+///
+/// Uses an in-memory [`BackgroundTaskRegistry`] shared with the control actor.
+/// A persistent mission store is **not** required — only
+/// [`MissionStore::get_mission`] must work (including in-memory dev stores).
+pub(crate) async fn background_task_autoresume_loop(
+    mission_store: Arc<dyn MissionStore>,
+    cmd_tx: mpsc::Sender<ControlCommand>,
+    events_tx: broadcast::Sender<AgentEvent>,
+    workspaces: workspace::SharedWorkspaceStore,
+    background_tasks: BackgroundTaskRegistry,
+) {
+    tracing::info!(
+        "Background-task auto-resume watcher started: poll {}s, start-grace {}s, idle-stable {}s, \
+         timeout {}s",
+        BG_POLL_INTERVAL.as_secs(),
+        BG_START_GRACE_SECS,
+        BG_IDLE_STABLE_SECS,
+        BG_OVERALL_TIMEOUT.as_secs(),
+    );
+
+    let mut watches: HashMap<(Uuid, String), BgWatch> = HashMap::new();
+
+    loop {
+        tokio::time::sleep(BG_POLL_INTERVAL).await;
+
+        let snapshot: Vec<(Uuid, BackgroundTask)> = {
+            let guard = background_tasks.read().await;
+            guard
+                .iter()
+                .flat_map(|(mid, tasks)| tasks.values().map(move |t| (*mid, t.clone())))
+                .collect()
+        };
+
+        if snapshot.is_empty() {
+            watches.clear();
+            continue;
+        }
+
+        {
+            let live: HashSet<(Uuid, String)> =
+                snapshot.iter().map(|(m, t)| (*m, t.id.clone())).collect();
+            watches.retain(|k, _| live.contains(k));
+        }
+
+        let mut checks_done = 0usize;
+        for (mission_id, task) in snapshot {
+            if checks_done >= BG_MAX_CHECKS_PER_TICK {
+                break;
+            }
+
+            let mission = match mission_store.get_mission(mission_id).await {
+                Ok(Some(m)) => m,
+                Ok(None) => {
+                    remove_background_task(&background_tasks, mission_id, &task.id).await;
+                    continue;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        mission_id = %mission_id,
+                        "bg-autoresume: get_mission failed: {}; retrying next tick",
+                        e
+                    );
+                    continue;
+                }
+            };
+            if mission.status != MissionStatus::AwaitingUser {
+                let terminal = matches!(
+                    mission.status,
+                    MissionStatus::Completed | MissionStatus::Failed | MissionStatus::NotFeasible
+                );
+                let age_secs = task.started_at.elapsed().as_secs();
+                let prev = watches.get(&(mission_id, task.id.clone()));
+                tracing::debug!(
+                    mission_id = %mission_id,
+                    task = %task.id,
+                    mission_status = ?mission.status,
+                    exists = tracing::field::Empty,
+                    mtime_epoch = tracing::field::Empty,
+                    busy = tracing::field::Empty,
+                    was_busy = prev.map(|w| w.was_busy).unwrap_or(false),
+                    age_secs,
+                    idle_secs = tracing::field::Empty,
+                    decision = "skipped_not_awaiting_user",
+                    "bg-autoresume: probe",
+                );
+                if terminal || task.started_at.elapsed() >= BG_OVERALL_TIMEOUT {
+                    remove_background_task(&background_tasks, mission_id, &task.id).await;
+                }
+                continue;
+            }
+
+            let timed_out = task.started_at.elapsed() >= BG_OVERALL_TIMEOUT;
+
+            let workspace = match workspaces.get(mission.workspace_id).await {
+                Some(ws) => ws,
+                None => {
+                    tracing::debug!(
+                        mission_id = %mission_id,
+                        workspace_id = %mission.workspace_id,
+                        "bg-autoresume: workspace not found; skipping"
+                    );
+                    continue;
+                }
+            };
+            let exec = WorkspaceExec::new(workspace.clone());
+
+            let mut output_exists = timed_out;
+            let mut finished = timed_out;
+            let age_secs = task.started_at.elapsed().as_secs();
+            if timed_out {
+                let prev = watches.get(&(mission_id, task.id.clone()));
+                tracing::debug!(
+                    mission_id = %mission_id,
+                    task = %task.id,
+                    mission_status = ?mission.status,
+                    exists = tracing::field::Empty,
+                    mtime_epoch = tracing::field::Empty,
+                    busy = tracing::field::Empty,
+                    was_busy = prev.map(|w| w.was_busy).unwrap_or(false),
+                    age_secs,
+                    idle_secs = tracing::field::Empty,
+                    decision = "timeout",
+                    "bg-autoresume: probe",
+                );
+            } else {
+                checks_done += 1;
+                match probe_background_task(&exec, &workspace.path, &task).await {
+                    BgProbe::Observed {
+                        exists,
+                        mtime_epoch,
+                        busy,
+                        pgrep_available,
+                    } => {
+                        if !pgrep_available {
+                            let prev = watches.get(&(mission_id, task.id.clone()));
+                            tracing::warn!(
+                                mission_id = %mission_id,
+                                task = %task.id,
+                                "bg-autoresume: pgrep unavailable in workspace; \
+                                 cannot detect completion (will retry until timeout)"
+                            );
+                            tracing::debug!(
+                                mission_id = %mission_id,
+                                task = %task.id,
+                                mission_status = ?mission.status,
+                                exists = tracing::field::Empty,
+                                mtime_epoch = tracing::field::Empty,
+                                busy = tracing::field::Empty,
+                                was_busy = prev.map(|w| w.was_busy).unwrap_or(false),
+                                age_secs,
+                                idle_secs = tracing::field::Empty,
+                                decision = "pgrep_unavailable",
+                                "bg-autoresume: probe",
+                            );
+                            continue;
+                        }
+
+                        output_exists = exists;
+                        let key = (mission_id, task.id.clone());
+                        let now = Instant::now();
+                        let was_busy = watches.get(&key).map(|w| w.was_busy).unwrap_or(false);
+                        let (is_finished, next) =
+                            bg_decide_finished(watches.get(&key), busy, age_secs, now);
+                        let idle_secs = next
+                            .idle_since
+                            .map(|s| now.duration_since(s).as_secs())
+                            .unwrap_or(0);
+                        watches.insert(key, next);
+                        finished = is_finished;
+                        tracing::debug!(
+                            mission_id = %mission_id,
+                            task = %task.id,
+                            mission_status = ?mission.status,
+                            exists,
+                            mtime_epoch,
+                            busy,
+                            was_busy,
+                            age_secs,
+                            idle_secs,
+                            decision = if is_finished { "finished" } else { "waiting" },
+                            "bg-autoresume: probe",
+                        );
+                    }
+                    BgProbe::Unknown { reason } => {
+                        let prev = watches.get(&(mission_id, task.id.clone()));
+                        tracing::debug!(
+                            mission_id = %mission_id,
+                            task = %task.id,
+                            mission_status = ?mission.status,
+                            exists = tracing::field::Empty,
+                            mtime_epoch = tracing::field::Empty,
+                            busy = tracing::field::Empty,
+                            was_busy = prev.map(|w| w.was_busy).unwrap_or(false),
+                            age_secs,
+                            idle_secs = tracing::field::Empty,
+                            decision = "probe_unknown",
+                            error = reason.as_deref().unwrap_or("(parse failure)"),
+                            "bg-autoresume: probe",
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            if !finished {
+                continue;
+            }
+
+            let tail = if output_exists {
+                read_output_tail(&exec, &workspace.path, &task.output_path)
+                    .await
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+            let command_display = if task.command.trim().is_empty() {
+                "(command unavailable)".to_string()
+            } else {
+                task.command.clone()
+            };
+            let content = if tail.is_empty() {
+                let note = if timed_out {
+                    " (reported finished after the 30-minute watcher timeout; it may \
+                     still be running.)"
+                } else {
+                    ""
+                };
+                format!(
+                    "Background task `{}` (`{}`) finished. (No captured output was \
+                     available.){}\n\nContinue from here.",
+                    task.id, command_display, note,
+                )
+            } else {
+                let note = if timed_out {
+                    "\n\n(Note: reported as finished after the 30-minute watcher timeout; \
+                     it may still be running.)"
+                } else {
+                    ""
+                };
+                format!(
+                    "Background task `{}` (`{}`) finished. Output:\n\n```\n{}\n```{}\n\nContinue from here.",
+                    task.id, command_display, tail, note,
+                )
+            };
+
+            let _ = events_tx.send(AgentEvent::MissionActivity {
+                label: format!("Resuming: background task `{}` finished", task.id),
+                tool_name: "background_task_autoresume".to_string(),
+                mission_id: Some(mission_id),
+            });
+
+            let (ack_tx, ack_rx) = oneshot::channel();
+            let send_res = cmd_tx
+                .send(ControlCommand::UserMessage {
+                    id: Uuid::new_v4(),
+                    content,
+                    agent: None,
+                    target_mission_id: Some(mission_id),
+                    strict: true,
+                    respond: ack_tx,
+                })
+                .await;
+            if let Err(e) = send_res {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    task = %task.id,
+                    "bg-autoresume: control channel closed; exiting watcher: {}",
+                    e
+                );
+                return;
+            }
+
+            match ack_rx.await {
+                Ok(UserMessageAck::Dropped) => {
+                    tracing::info!(
+                        mission_id = %mission_id,
+                        task = %task.id,
+                        "bg-autoresume: resume dropped (not deliverable this pass); will retry"
+                    );
+                    continue;
+                }
+                Ok(_) => {
+                    tracing::info!(
+                        mission_id = %mission_id,
+                        task = %task.id,
+                        timed_out = timed_out,
+                        "bg-autoresume: resumed mission with background task output"
+                    );
+                }
+                Err(_) => {
+                    // Actor dropped the responder without sending an ack — the
+                    // delivery outcome is unknown. Keep the task in the registry
+                    // and retry next tick rather than dropping the wake.
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        task = %task.id,
+                        "bg-autoresume: resume ack channel closed before ack; will retry"
+                    );
+                    continue;
+                }
+            }
+
+            let prev = watches.get(&(mission_id, task.id.clone()));
+            tracing::debug!(
+                mission_id = %mission_id,
+                task = %task.id,
+                mission_status = ?mission.status,
+                exists = output_exists,
+                mtime_epoch = tracing::field::Empty,
+                busy = tracing::field::Empty,
+                was_busy = prev.map(|w| w.was_busy).unwrap_or(false),
+                age_secs = task.started_at.elapsed().as_secs(),
+                idle_secs = tracing::field::Empty,
+                decision = "resumed",
+                "bg-autoresume: probe",
+            );
+
+            remove_background_task(&background_tasks, mission_id, &task.id).await;
+            watches.remove(&(mission_id, task.id.clone()));
+        }
+    }
+}
+
+async fn remove_background_task(
+    background_tasks: &BackgroundTaskRegistry,
+    mission_id: Uuid,
+    task_id: &str,
+) {
+    let mut guard = background_tasks.write().await;
+    if let Some(tasks) = guard.get_mut(&mission_id) {
+        tasks.remove(task_id);
+        if tasks.is_empty() {
+            guard.remove(&mission_id);
+        }
+    }
+}
+
+/// Choose a `pgrep -f` pattern for a background task.
+///
+/// Match on the launched **command**, not Claude's task id. The task id (and
+/// the output-file path) do NOT appear in the launched process's command line:
+/// Claude runs the job as `/bin/bash -c '… eval <command> …'` and redirects its
+/// output to the task file via an fd from its parent, so the only
+/// task-identifying text in the process table is the command itself. Verified
+/// live against the deployed harness — grepping every process cmdline for the
+/// task id / output path matched nothing. Matching the id would never match,
+/// `busy` would stay false, and the watcher would resume prematurely (the
+/// original footgun). The `/proc/$$/cmdline` self-match guard in the probe
+/// keeps the command pattern from matching the probe shell itself.
+///
+/// The id / output-file stem are kept only as a last-resort fallback for the
+/// (unexpected) case where the command is empty.
+fn pgrep_pattern_for_task(task: &BackgroundTask) -> String {
+    let cmd = truncate_for_pgrep(&task.command);
+    if !cmd.is_empty() {
+        return cmd;
+    }
+    if !task.id.is_empty() {
+        return task.id.clone();
+    }
+    Path::new(&task.output_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|name| name.strip_suffix(".output").unwrap_or(name).to_string())
+        .unwrap_or_default()
+}
+
+async fn probe_background_task(exec: &WorkspaceExec, cwd: &Path, task: &BackgroundTask) -> BgProbe {
+    let out_path = shell_single_quote(&task.output_path);
+    let task_pattern = shell_single_quote(&pgrep_pattern_for_task(task));
+    let script = format!(
+        r#"
+set -u
+P={out_path}
+PAT={task_pattern}
+EXISTS=0
+M=0
+if [ -e "$P" ]; then
+  EXISTS=1
+  M=$(stat -c %Y "$P" 2>/dev/null) || M=$(stat -f %m "$P" 2>/dev/null) || M=0
+fi
+BUSY=0
+HAS_PGREP=0
+SELF=$$
+# This script embeds the command pattern, so the probe shell (and the subshells
+# it forks for $(…), which share its argv) match `pgrep -f $PAT` themselves.
+# Skip our own pid and every pid whose /proc cmdline equals ours. Linux-only:
+# /proc is absent on macOS host workspaces, so SELFCMD stays empty and only $$
+# is skipped there. Production nspawn containers are Linux and get the full guard.
+SELFCMD=$(tr '\0' ' ' < /proc/$$/cmdline 2>/dev/null)
+if [ -n "$PAT" ] && command -v pgrep >/dev/null 2>&1; then
+  HAS_PGREP=1
+  for pid in $(pgrep -f -- "$PAT" 2>/dev/null); do
+    [ "$pid" = "$SELF" ] && continue
+    PIDCMD=$(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)
+    [ -n "$SELFCMD" ] && [ "$PIDCMD" = "$SELFCMD" ] && continue
+    BUSY=1
+    break
+  done
+fi
+if [ "$BUSY" = "0" ] && [ "$EXISTS" = "1" ] && command -v fuser >/dev/null 2>&1; then
+  if fuser "$P" >/dev/null 2>&1; then BUSY=1; fi
+fi
+echo "BG $EXISTS $M $BUSY $HAS_PGREP"
+"#,
+    );
+
+    let args = vec!["-c".to_string(), script];
+    let output = match exec.output(cwd, "/bin/sh", &args, HashMap::new()).await {
+        Ok(o) => o,
+        Err(e) => {
+            return BgProbe::Unknown {
+                reason: Some(e.to_string()),
+            };
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_probe_line(&stdout)
+}
+
+/// Parse the `BG <exists> <mtime> <busy> [<pgrep_ok>]` line from the probe.
+fn parse_probe_line(stdout: &str) -> BgProbe {
+    for line in stdout.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("BG ") {
+            let mut parts = rest.split_whitespace();
+            let exists = parts.next().and_then(|s| s.parse::<u8>().ok());
+            let mtime = parts.next().and_then(|s| s.parse::<u64>().ok());
+            let busy = parts.next().and_then(|s| s.parse::<u8>().ok());
+            let pgrep_ok = parts
+                .next()
+                .and_then(|s| s.parse::<u8>().ok())
+                .map(|v| v != 0);
+            return match (exists, mtime, busy) {
+                (Some(e), Some(m), Some(b)) => BgProbe::Observed {
+                    exists: e != 0,
+                    mtime_epoch: m,
+                    busy: b != 0,
+                    // Fail closed: without an explicit pgrep_ok=1 we do not trust busy.
+                    pgrep_available: pgrep_ok.unwrap_or(false),
+                },
+                _ => BgProbe::Unknown { reason: None },
+            };
+        }
+    }
+    BgProbe::Unknown { reason: None }
+}
+
+async fn read_output_tail(exec: &WorkspaceExec, cwd: &Path, output_path: &str) -> Option<String> {
+    let out_path = shell_single_quote(output_path);
+    let bytes = BG_OUTPUT_TAIL_BYTES;
+    let script = format!(
+        r#"set -u; P={out_path}; [ -f "$P" ] && tail -c {bytes} "$P" 2>/dev/null || true"#,
+    );
+    let args = vec!["-c".to_string(), script];
+    let output = exec
+        .output(cwd, "/bin/sh", &args, HashMap::new())
+        .await
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout).to_string();
+    let trimmed = text.trim_end_matches('\n');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn shell_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Fallback when task id and output-path stem are both unavailable.
+fn truncate_for_pgrep(command: &str) -> String {
+    const MAX: usize = 120;
+    let trimmed = command.trim();
+    if trimmed.len() <= MAX {
+        trimmed.to_string()
+    } else {
+        let mut end = MAX;
+        while !trimmed.is_char_boundary(end) {
+            end -= 1;
+        }
+        trimmed[..end].to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bg_decide_finished, parse_probe_line, pgrep_pattern_for_task, shell_single_quote,
+        truncate_for_pgrep, BackgroundTask, BgProbe, BgWatch, BG_IDLE_STABLE_SECS,
+        BG_START_GRACE_SECS,
+    };
+    use std::time::{Duration, Instant};
+
+    fn sample_task(id: &str, output_path: &str, command: &str) -> BackgroundTask {
+        BackgroundTask {
+            id: id.to_string(),
+            output_path: output_path.to_string(),
+            command: command.to_string(),
+            started_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn pgrep_pattern_prefers_command() {
+        // The command is the only task-identifying text in the launched
+        // process's cmdline (the id / output path are not), so it must win.
+        let task = sample_task("bokwqyjak", "/tmp/tasks/bokwqyjak.output", "sleep 40");
+        assert_eq!(pgrep_pattern_for_task(&task), "sleep 40");
+    }
+
+    #[test]
+    fn pgrep_pattern_falls_back_to_task_id_when_command_empty() {
+        let task = sample_task("bokwqyjak", "/tmp/tasks/bokwqyjak.output", "");
+        assert_eq!(pgrep_pattern_for_task(&task), "bokwqyjak");
+    }
+
+    #[test]
+    fn pgrep_pattern_falls_back_to_output_stem_when_command_and_id_empty() {
+        let task = sample_task("", "/tmp/tasks/bokwqyjak.output", "");
+        assert_eq!(pgrep_pattern_for_task(&task), "bokwqyjak");
+    }
+
+    #[test]
+    fn parse_probe_exists_idle_with_pgrep() {
+        match parse_probe_line("BG 1 1700000000 0 1\n") {
+            BgProbe::Observed {
+                exists,
+                mtime_epoch,
+                busy,
+                pgrep_available,
+            } => {
+                assert!(exists);
+                assert_eq!(mtime_epoch, 1_700_000_000);
+                assert!(!busy);
+                assert!(pgrep_available);
+            }
+            other => panic!("expected Observed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_busy_with_pgrep() {
+        match parse_probe_line("noise\nBG 1 42 1 1") {
+            BgProbe::Observed {
+                busy,
+                pgrep_available,
+                ..
+            } => {
+                assert!(busy);
+                assert!(pgrep_available);
+            }
+            other => panic!("expected Observed busy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_without_pgrep_field_fails_closed() {
+        match parse_probe_line("BG 0 0 0") {
+            BgProbe::Observed {
+                pgrep_available, ..
+            } => assert!(!pgrep_available),
+            other => panic!("expected Observed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_pgrep_unavailable_flag() {
+        match parse_probe_line("BG 0 0 0 0") {
+            BgProbe::Observed {
+                pgrep_available, ..
+            } => assert!(!pgrep_available),
+            other => panic!("expected Observed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_file_absent_is_still_observed() {
+        match parse_probe_line("BG 0 0 0 1") {
+            BgProbe::Observed {
+                exists,
+                mtime_epoch,
+                busy,
+                pgrep_available,
+            } => {
+                assert!(!exists);
+                assert_eq!(mtime_epoch, 0);
+                assert!(!busy);
+                assert!(pgrep_available);
+            }
+            other => panic!("expected Observed (absent file), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_unknown() {
+        assert!(matches!(
+            parse_probe_line("garbage"),
+            BgProbe::Unknown { .. }
+        ));
+        assert!(matches!(
+            parse_probe_line("BG 1 x y"),
+            BgProbe::Unknown { .. }
+        ));
+    }
+
+    fn watch(was_busy: bool, idle_since: Option<Instant>) -> BgWatch {
+        BgWatch {
+            was_busy,
+            idle_since,
+        }
+    }
+
+    #[test]
+    fn busy_is_never_finished_and_records_was_busy() {
+        let now = Instant::now();
+        let (finished, next) = bg_decide_finished(None, true, 999, now);
+        assert!(!finished);
+        assert!(next.was_busy);
+        assert!(next.idle_since.is_none());
+    }
+
+    #[test]
+    fn first_probe_not_busy_within_grace_waits() {
+        let now = Instant::now();
+        let (finished, next) = bg_decide_finished(None, false, BG_START_GRACE_SECS - 1, now);
+        assert!(!finished);
+        assert!(next.idle_since.is_some());
+        assert!(!next.was_busy);
+    }
+
+    #[test]
+    fn finished_before_first_probe_trusted_after_grace_and_idle_window() {
+        let idle_start = Instant::now();
+        let prev = watch(false, Some(idle_start));
+        let now = idle_start + Duration::from_secs(BG_IDLE_STABLE_SECS);
+        let (finished, _next) =
+            bg_decide_finished(Some(&prev), false, BG_START_GRACE_SECS + 5, now);
+        assert!(finished);
+    }
+
+    #[test]
+    fn was_busy_then_idle_stable_finishes_even_before_grace() {
+        let idle_start = Instant::now();
+        let prev = watch(true, Some(idle_start));
+        let now = idle_start + Duration::from_secs(BG_IDLE_STABLE_SECS);
+        let (finished, _next) = bg_decide_finished(Some(&prev), false, 1, now);
+        assert!(finished);
+    }
+
+    #[test]
+    fn shell_quoting_escapes_single_quotes() {
+        assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn pgrep_truncation_is_char_safe() {
+        let long = "é".repeat(200);
+        let t = truncate_for_pgrep(&long);
+        assert!(t.len() <= 120);
+        assert!(long.starts_with(&t));
+    }
+}

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -37,8 +37,14 @@ const BG_START_GRACE_SECS: u64 = 20;
 
 /// Hard cap on how long we track a single background task before treating it as
 /// done regardless of the completion heuristic. Prevents a task whose process
-/// we can't observe (exotic shell, missing pgrep) from being watched forever.
+/// we can't observe (no readable /proc, e.g. a macOS host workspace) from being
+/// watched forever.
 const BG_OVERALL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Per-probe timeout. The watcher checks tasks serially, so a single probe that
+/// blocks (a wedged/OOM-throttled container, an nspawn boot lock, a hung `fuser`)
+/// must not freeze completion detection for every other mission's tasks.
+const BG_PROBE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Max number of trailing bytes of the output file to include in the resume
 /// message, so we never blow up a turn's context with a huge log.
@@ -307,7 +313,19 @@ pub(crate) async fn background_task_autoresume_loop(
                         );
                     }
                     BgProbe::Unknown { reason } => {
-                        let prev = watches.get(&(mission_id, task.id.clone()));
+                        let key = (mission_id, task.id.clone());
+                        let was_busy = watches.get(&key).map(|w| w.was_busy).unwrap_or(false);
+                        // Reset the idle clock: a probe we couldn't observe must
+                        // not let `BG_IDLE_STABLE_SECS` accumulate across the gap
+                        // (the process could have been running the whole time).
+                        // We require a fresh stable not-busy window afterwards.
+                        watches.insert(
+                            key,
+                            BgWatch {
+                                was_busy,
+                                idle_since: None,
+                            },
+                        );
                         tracing::debug!(
                             mission_id = %mission_id,
                             task = %task.id,
@@ -315,7 +333,7 @@ pub(crate) async fn background_task_autoresume_loop(
                             exists = tracing::field::Empty,
                             mtime_epoch = tracing::field::Empty,
                             busy = tracing::field::Empty,
-                            was_busy = prev.map(|w| w.was_busy).unwrap_or(false),
+                            was_busy,
                             age_secs,
                             idle_secs = tracing::field::Empty,
                             decision = "probe_unknown",
@@ -507,20 +525,30 @@ fi
 BUSY=0
 HAS_PGREP=0
 SELF=$$
-# This script embeds the command pattern, so the probe shell (and the subshells
-# it forks for $(…), which share its argv) match `pgrep -f $PAT` themselves.
-# Skip our own pid and every pid whose /proc cmdline equals ours. Linux-only:
-# /proc is absent on macOS host workspaces, so SELFCMD stays empty and only $$
-# is skipped there. Production nspawn containers are Linux and get the full guard.
+# Match the launched command LITERALLY against each process's /proc cmdline.
+# (This used `pgrep -f -- "$PAT"`, but `pgrep -f` treats PAT as an EXTENDED
+# REGEX. Real commands contain (), [], ., *, +, | and the 120-char truncation
+# can split a regex group — so the pattern often fails to match or errors, BUSY
+# stays 0, and the watcher resumes the agent while the build is still running.
+# A quoted shell `case` glob (*"$PAT"*) is a literal substring test, and a
+# truncated PAT is just a prefix, which still matches.)
+# The probe shell and its $(…) subshells embed PAT in their own argv, so skip
+# our own pid and any pid whose cmdline equals ours. Linux-only (/proc): on a
+# macOS host workspace /proc is absent, so detection is reported unavailable
+# (HAS_PGREP=0) and the watcher fail-closes to the overall timeout — it never
+# resumes prematurely there. Production nspawn containers are Linux.
 SELFCMD=$(tr '\0' ' ' < /proc/$$/cmdline 2>/dev/null)
-if [ -n "$PAT" ] && command -v pgrep >/dev/null 2>&1; then
+if [ -n "$PAT" ] && [ -r /proc/$$/cmdline ]; then
   HAS_PGREP=1
-  for pid in $(pgrep -f -- "$PAT" 2>/dev/null); do
+  for d in /proc/[0-9]*; do
+    pid=$(basename "$d")
     [ "$pid" = "$SELF" ] && continue
-    PIDCMD=$(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null)
-    [ -n "$SELFCMD" ] && [ "$PIDCMD" = "$SELFCMD" ] && continue
-    BUSY=1
-    break
+    CMD=$(tr '\0' ' ' < "$d/cmdline" 2>/dev/null) || continue
+    [ -z "$CMD" ] && continue
+    [ -n "$SELFCMD" ] && [ "$CMD" = "$SELFCMD" ] && continue
+    case "$CMD" in
+      *"$PAT"*) BUSY=1; break ;;
+    esac
   done
 fi
 if [ "$BUSY" = "0" ] && [ "$EXISTS" = "1" ] && command -v fuser >/dev/null 2>&1; then
@@ -531,11 +559,20 @@ echo "BG $EXISTS $M $BUSY $HAS_PGREP"
     );
 
     let args = vec!["-c".to_string(), script];
-    let output = match exec.output(cwd, "/bin/sh", &args, HashMap::new()).await {
-        Ok(o) => o,
-        Err(e) => {
+    let probe = exec.output(cwd, "/bin/sh", &args, HashMap::new());
+    let output = match tokio::time::timeout(BG_PROBE_TIMEOUT, probe).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
             return BgProbe::Unknown {
                 reason: Some(e.to_string()),
+            };
+        }
+        Err(_) => {
+            return BgProbe::Unknown {
+                reason: Some(format!(
+                    "probe timed out after {}s",
+                    BG_PROBE_TIMEOUT.as_secs()
+                )),
             };
         }
     };
@@ -579,9 +616,10 @@ async fn read_output_tail(exec: &WorkspaceExec, cwd: &Path, output_path: &str) -
         r#"set -u; P={out_path}; [ -f "$P" ] && tail -c {bytes} "$P" 2>/dev/null || true"#,
     );
     let args = vec!["-c".to_string(), script];
-    let output = exec
-        .output(cwd, "/bin/sh", &args, HashMap::new())
+    let read = exec.output(cwd, "/bin/sh", &args, HashMap::new());
+    let output = tokio::time::timeout(BG_PROBE_TIMEOUT, read)
         .await
+        .ok()?
         .ok()?;
     let text = String::from_utf8_lossy(&output.stdout).to_string();
     let trimmed = text.trim_end_matches('\n');
@@ -756,6 +794,19 @@ mod tests {
         assert!(!finished);
         assert!(next.was_busy);
         assert!(next.idle_since.is_none());
+    }
+
+    #[test]
+    fn idle_clock_restarts_after_unknown_reset() {
+        // The Unknown-probe path keeps `was_busy` but clears `idle_since`. A
+        // single not-busy probe afterwards must NOT immediately finish — a fresh
+        // BG_IDLE_STABLE_SECS window is required, so an unobserved gap can't be
+        // counted as confirmed-idle time.
+        let now = Instant::now();
+        let reset = watch(true, None);
+        let (finished, next) = bg_decide_finished(Some(&reset), false, 9_999, now);
+        assert!(!finished, "must require a fresh idle window after a reset");
+        assert!(next.idle_since.is_some());
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #550 (by @adrienlacombe — original commit preserved) with review fixes applied before merge.

## What
Auto-resume a mission's agent when a backgrounded shell/build task finishes, so an agent that ends a turn waiting on a long build doesn't stall in `awaiting_user` forever.

## Why this supersedes #550
Review found correctness/availability bugs in the completion-detection probe. Rather than block, the original commit is kept as-is and a follow-up fix commit addresses them:

- **[HIGH] Premature resume from regex/truncation.** The probe matched the launched command with `pgrep -f`, which treats the pattern as an *extended regex*. Real commands contain `()[].*+|` and the 120-char truncation can split a regex group → the pattern fails to match, `busy` stays `0`, and the agent is resumed **while the build is still running**. Replaced with a literal `/proc/<pid>/cmdline` substring scan (a quoted shell `case`); a truncated pattern is now a prefix, which still matches. Fail-closed where `/proc` is unreadable (macOS host) so it never resumes prematurely.
- **[HIGH] One stuck probe froze all detection.** The probe `exec.output` had no timeout and the watcher is serial — a wedged/OOM-throttled container or hung `fuser` blocked completion detection for every mission. Probe + output-tail reads now have a 20s timeout.
- **[MEDIUM] Idle clock leaked across unobserved gaps.** An `Unknown` probe left `idle_since` intact, so the idle-stable window could accumulate during a gap when the process may still have been running. The clock now resets on `Unknown` (+ test).

## Known / accepted (low)
- The 30-min overall timeout still reports a genuinely-longer build as "finished (may still be running)" and stops watching it. Acceptable for now; tune `BG_OVERALL_TIMEOUT` if Lean/SPHINCS builds need longer.
- The output tail is auto-injected into the resume prompt; its content is whatever the job wrote (same trust as the agent reading the file itself).

## Testing
`cargo build`, `cargo fmt`, and 16 `bg_autoresume` unit tests pass (incl. the new idle-reset test).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission control routing and injects automated user messages that resume agents; completion detection relies on workspace process probing with fail-closed behavior on missing `/proc`, but a wrong “finished” decision could still resume too early or too late.
> 
> **Overview**
> **Background-task auto-resume** closes the gap where a mission agent starts a Claude Code `Bash` job with `run_in_background: true`, ends its turn in `AwaitingUser`, and never gets woken when the job completes in non-interactive mode.
> 
> The control actor now correlates `Bash` tool calls with results, parses the CLI’s background-start marker (`parse_background_task_start`), and writes tasks into a shared in-memory **`BackgroundTaskRegistry`** (default on via `BACKGROUND_TASK_AUTORESUME`). A new **`background_task_autoresume_loop`** polls every 10s, probes the workspace for process completion (literal `/proc` cmdline substring match instead of `pgrep -f` regex, 20s probe timeouts, idle-stable and start-grace heuristics), tails output when available, and sends a **strict** `UserMessage` to resume the target mission.
> 
> **Control-plane routing** is tightened so strict messages only drop when the target is a *non-main* mission that couldn’t be delivered; strict wakes for the main session (including bg auto-resume) may fall through to Case 3 and start a new turn on an idle/`AwaitingUser` main mission.
> 
> Unit tests cover marker parsing, probe parsing, completion decisions, and pgrep pattern selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df41f54a7d2925ea12b7a3cbd7832ad3e9f2e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->