### PR TITLE
fix(dashboard): show "Needs You" when an agent parks on a frontend tool (supersedes #552)

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -366,9 +366,26 @@ function OverviewPageContent() {
     }
   );
 
-  // Build a set of actually running mission IDs from the runtime state
+  // Missions parked on a frontend tool (e.g. AskUserQuestion). The backend
+  // reports them in the running list with run state `waiting_for_tool`, but
+  // they are blocked on the user, so they belong in "Needs You" — not
+  // "Running". Track them separately and keep them out of the running set.
+  const waitingForToolMissionIds = useMemo(() => {
+    return new Set(
+      runningMissions
+        .filter((rm) => rm.state === 'waiting_for_tool')
+        .map((rm) => rm.mission_id)
+    );
+  }, [runningMissions]);
+
+  // Build a set of actually-executing mission IDs from the runtime state
+  // (excluding those merely waiting on a frontend tool).
   const runningMissionIds = useMemo(() => {
-    return new Set(runningMissions.map((rm) => rm.mission_id));
+    return new Set(
+      runningMissions
+        .filter((rm) => rm.state !== 'waiting_for_tool')
+        .map((rm) => rm.mission_id)
+    );
   }, [runningMissions]);
 
   // Build a set of missions with active automations
@@ -387,8 +404,8 @@ function OverviewPageContent() {
 
   // Categorize missions using shared utility
   const categorized = useMemo(
-    () => categorizeMissions(missions, runningLikeMissionIds),
-    [missions, runningLikeMissionIds]
+    () => categorizeMissions(missions, runningLikeMissionIds, waitingForToolMissionIds),
+    [missions, runningLikeMissionIds, waitingForToolMissionIds]
   );
 
   // Set of mission IDs that have at least one child (boss missions)

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -627,7 +627,15 @@ function OverviewPageContent() {
                           runningMissionIds.has(mission.id) ||
                           automationMissionIds.has(mission.id)
                         }
-                        isActuallyRunning={runningMissionIds.has(mission.id)}
+                        isActuallyRunning={
+                          // Offer Cancel (not Delete) whenever the harness is
+                          // still alive — including a mission parked on a
+                          // frontend tool (waiting_for_tool). It shows as
+                          // "Needs You", but its process is live and should be
+                          // cancellable, not deleted outright.
+                          runningMissionIds.has(mission.id) ||
+                          waitingForToolMissionIds.has(mission.id)
+                        }
                         runningMissionIds={runningMissionIds}
                         automationMissionIds={automationMissionIds}
                         onCancel={handleCancel}

--- a/dashboard/src/lib/mission-status.test.ts
+++ b/dashboard/src/lib/mission-status.test.ts
@@ -111,6 +111,15 @@ describe('mission-status', () => {
         expect(categorizeMission('active', false)).toBe('other');
       });
     });
+
+    describe('waiting for tool takes priority over running', () => {
+      it('categorizes a mission parked on a frontend tool as needs-you', () => {
+        // Backend still reports the mission as running (run state
+        // waiting_for_tool), but it is blocked on the user.
+        expect(categorizeMission('active', true, true)).toBe('needs-you');
+        expect(categorizeMission('active', false, true)).toBe('needs-you');
+      });
+    });
   });
 
   describe('categorizeMissions', () => {
@@ -133,6 +142,21 @@ describe('mission-status', () => {
       expect(result['needs-you'].map(m => m.id)).toEqual(['2']);
       expect(result.finished.map(m => m.id)).toEqual(['3', '4', '5', '6']);
       expect(result.other).toEqual([]);
+    });
+
+    it('puts missions waiting on a frontend tool in needs-you, not running', () => {
+      const missions: TestMission[] = [
+        { id: 'asking', status: 'active' }, // parked on AskUserQuestion
+        { id: 'executing', status: 'active' }, // genuinely running a turn
+      ];
+      // Backend reports both in the running list, but `asking` is waiting_for_tool.
+      const runningIds = new Set(['executing']);
+      const waitingForToolIds = new Set(['asking']);
+
+      const result = categorizeMissions(missions, runningIds, waitingForToolIds);
+
+      expect(result.running.map(m => m.id)).toEqual(['executing']);
+      expect(result['needs-you'].map(m => m.id)).toEqual(['asking']);
     });
 
     it('handles resumed mission correctly (awaiting_user but running)', () => {

--- a/dashboard/src/lib/mission-status.ts
+++ b/dashboard/src/lib/mission-status.ts
@@ -50,15 +50,24 @@ export function finishedTone(status: MissionStatus): FinishedTone {
  * Categorize a mission based on runtime state and stored status.
  *
  * Priority order:
- * 1. Running - mission is actually running (runtime state takes precedence)
- * 2. Needs You - awaiting_user AND not running
- * 3. Finished - completed/acknowledged/failed/interrupted/blocked/not_feasible AND not running
- * 4. Other - anything else (active-but-not-running, pending)
+ * 1. Needs You (waiting for tool) - the agent is parked on a frontend tool
+ *    (e.g. AskUserQuestion). The backend still reports this mission as
+ *    "running" (run state `waiting_for_tool`) because its harness is alive,
+ *    but it is blocked on the user, so it belongs in Needs You — not Running.
+ * 2. Running - mission is actually executing a turn
+ * 3. Needs You - awaiting_user AND not running
+ * 4. Finished - completed/acknowledged/failed/interrupted/blocked/not_feasible AND not running
+ * 5. Other - anything else (active-but-not-running, pending)
  */
 export function categorizeMission(
   status: MissionStatus,
-  isActuallyRunning: boolean
+  isActuallyRunning: boolean,
+  isWaitingForTool = false
 ): MissionCategory {
+  if (isWaitingForTool) {
+    return 'needs-you';
+  }
+
   if (isActuallyRunning) {
     return 'running';
   }
@@ -77,10 +86,15 @@ export function categorizeMission(
 /**
  * Categorize multiple missions into columns for display.
  * Returns missions grouped by category with each mission only in one category.
+ *
+ * `waitingForToolMissionIds` is the subset of running missions parked on a
+ * frontend tool (run state `waiting_for_tool`); they are surfaced as Needs You
+ * rather than Running even though the backend still reports them as running.
  */
 export function categorizeMissions<T extends { id: string; status: MissionStatus }>(
   missions: T[],
-  runningMissionIds: Set<string>
+  runningMissionIds: Set<string>,
+  waitingForToolMissionIds: Set<string> = new Set()
 ): Record<MissionCategory, T[]> {
   const result: Record<MissionCategory, T[]> = {
     running: [],
@@ -90,8 +104,9 @@ export function categorizeMissions<T extends { id: string; status: MissionStatus
   };
 
   for (const mission of missions) {
+    const isWaitingForTool = waitingForToolMissionIds.has(mission.id);
     const isActuallyRunning = runningMissionIds.has(mission.id);
-    const category = categorizeMission(mission.status, isActuallyRunning);
+    const category = categorizeMission(mission.status, isActuallyRunning, isWaitingForTool);
     result[category].push(mission);
   }
 


### PR DESCRIPTION
Supersedes #552 (by @adrienlacombe — original dashboard commit preserved).

## What
A mission parked on a frontend interactive tool reports run-state `waiting_for_tool` while its harness is alive but blocked on the user. It was mis-shown as "Running"; now it shows "Needs You" (kanban).

## Why this supersedes #552
Two changes from the original:

1. **Dropped the unrelated Android upgrade.** #552 also bundled a large Android toolchain/dependency bump (Gradle 8→9.5.1, Kotlin 2.0→2.4, okhttp 4→5, compileSdk 36→37, markdown-renderer API migration — 5 files). That's orthogonal to the dashboard fix and should land on its own; only the 3 dashboard files (`page.tsx`, `mission-status.ts`, `mission-status.test.ts`) are carried over here.
2. **Fixed a Cancel→Delete regression.** Excluding `waiting_for_tool` from the running set also flipped a parked mission's card action from Cancel to Delete, so a live mid-turn mission could be deleted outright. The card now offers Cancel whenever the harness is alive (running **or** parked on a tool).

## Testing
`tsc --noEmit` clean; 27 `mission-status` unit tests pass.

@adrienlacombe — happy to instead split the Android upgrade into its own PR if you'd prefer to keep #552; this just unblocks the dashboard fix cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only display and action logic with unit test coverage; no backend or auth changes.
> 
> **Overview**
> Missions the backend still lists as running with run state **`waiting_for_tool`** (parked on a frontend tool such as AskUserQuestion) now appear in **Needs You** on the Global Monitor kanban instead of **Running**.
> 
> The overview page derives a separate **`waitingForToolMissionIds`** set, omits those IDs from the executing **Running** set, and passes them into **`categorizeMission` / `categorizeMissions`**, where **`isWaitingForTool`** takes priority over “actually running.” Cards in that column no longer use the spinning “running” styling, but **`isActuallyRunning`** still treats a live harness (running or waiting on a tool) as cancellable so users get **Cancel** rather than **Delete**.
> 
> Unit tests cover the new categorization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f201f7d1b834d4a7d2ce63fcf2f06c87c1241f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->