### PR TITLE
[codex] Add OpenRouter to model routing

### DIFF
--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -727,7 +727,7 @@ export default function ModelRoutingPage() {
 
   const { data: providersData } = useSWR(
     'routing-providers',
-    () => listProviders({ includeAll: true }),
+    () => listProviders({ includeAll: true, includeUnverified: true }),
     { revalidateOnFocus: false }
   );
   const providers = useMemo(

--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -727,6 +727,12 @@ export default function ModelRoutingPage() {
 
   const { data: providersData } = useSWR(
     'routing-providers',
+    // The routing page is a configuration surface: you choose which models to
+    // route to, which can include providers you haven't account-verified yet
+    // (e.g. OpenRouter before a key is set). `includeUnverified` deliberately
+    // surfaces the public catalog for every provider here. Volume stays
+    // bounded: per-provider catalogs are prefix-filtered and OpenRouter is
+    // capped server-side (see MAX_CATALOG_MODELS_PER_PROVIDER).
     () => listProviders({ includeAll: true, includeUnverified: true }),
     { revalidateOnFocus: false }
   );

--- a/dashboard/src/app/model-routing/page.tsx
+++ b/dashboard/src/app/model-routing/page.tsx
@@ -730,9 +730,9 @@ export default function ModelRoutingPage() {
     // The routing page is a configuration surface: you choose which models to
     // route to, which can include providers you haven't account-verified yet
     // (e.g. OpenRouter before a key is set). `includeUnverified` deliberately
-    // surfaces the public catalog for every provider here. Volume stays
-    // bounded: per-provider catalogs are prefix-filtered and OpenRouter is
-    // capped server-side (see MAX_CATALOG_MODELS_PER_PROVIDER).
+    // surfaces the public catalog for every provider here. Per-provider volume
+    // is bounded server-side: prefix-filtered providers stay small, and
+    // OpenRouter is capped (live API + models.dev; see MAX_CATALOG_MODELS_PER_PROVIDER).
     () => listProviders({ includeAll: true, includeUnverified: true }),
     { revalidateOnFocus: false }
   );

--- a/dashboard/src/components/ui/add-provider-modal.tsx
+++ b/dashboard/src/components/ui/add-provider-modal.tsx
@@ -19,6 +19,7 @@ import {
 const providerIcons: Record<string, string> = {
   anthropic: '🧠',
   openai: '🤖',
+  'open-router': '🔀',
   google: '🔮',
   'deep-infra': '🚀',
   cerebras: '🧬',

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -48,6 +48,18 @@ pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] = &[
     "minimax",
 ];
 
+/// Upper bound on the number of live models merged from a single
+/// OpenAI-compatible `/v1/models` response. OpenRouter has no usable prefix
+/// filter and exposes a large, fast-growing catalog; without a bound it can
+/// flood the routing picker (and the cached catalog). Prefix-filtered
+/// providers stay well under this and are left uncapped.
+const MAX_CATALOG_MODELS_PER_PROVIDER: usize = 100;
+
+/// Maximum length (in `char`s) of a model description surfaced from a
+/// `/v1/models` entry. OpenRouter descriptions can run several paragraphs; the
+/// picker only needs a short blurb.
+const MAX_MODEL_DESCRIPTION_CHARS: usize = 200;
+
 /// Where a catalog entry came from.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -679,7 +691,10 @@ fn default_providers_config() -> ProvidersConfig {
                     // OpenRouter model IDs are vendor-prefixed (provider/model).
                     // The live catalog is merged from models.dev and /v1/models
                     // when available; these keep the picker useful before the
-                    // background catalog finishes.
+                    // background catalog finishes. IDs verified against
+                    // OpenRouter's public catalog on 2026-06-17 — treat as
+                    // best-effort seeds that the live catalog supersedes (slugs
+                    // can drift as models are retired).
                     ProviderModel {
                         id: "anthropic/claude-opus-4.8".to_string(),
                         name: "Claude Opus 4.8".to_string(),
@@ -913,6 +928,19 @@ fn model_id_to_display_name(id: &str) -> String {
         .join(" ")
 }
 
+/// Trim a model description to a sane length for the routing picker.
+/// OpenRouter (and some other catalogs) return multi-paragraph descriptions;
+/// keep a short blurb and append an ellipsis when truncated. Operates on
+/// `char` boundaries so multibyte text isn't split mid-codepoint.
+fn truncate_description(description: &str) -> String {
+    let trimmed = description.trim();
+    if trimmed.chars().count() <= MAX_MODEL_DESCRIPTION_CHARS {
+        return trimmed.to_string();
+    }
+    let truncated: String = trimmed.chars().take(MAX_MODEL_DESCRIPTION_CHARS).collect();
+    format!("{}…", truncated.trim_end())
+}
+
 /// Fetch models from an OpenAI-compatible /v1/models endpoint.
 /// Filters results by the given prefix (e.g. "grok-", "glm-").
 /// Returns model IDs and generated display names.
@@ -965,7 +993,8 @@ pub async fn fetch_openai_compatible_models(
             let description = entry
                 .get("description")
                 .and_then(|d| d.as_str())
-                .map(str::to_string);
+                .map(truncate_description)
+                .filter(|d| !d.is_empty());
             Some(ProviderModel {
                 id: id.to_string(),
                 name,
@@ -1275,6 +1304,10 @@ pub async fn fetch_model_catalog(
         provider_id: &'static str,
         base_url: &'static str,
         prefix_filters: Vec<&'static str>,
+        /// Upper bound on models merged from this provider's `/v1/models`.
+        /// Set for prefix-less, large catalogs (OpenRouter) to keep the
+        /// routing picker bounded; `None` means no cap.
+        max_models: Option<usize>,
     }
 
     let targets = vec![
@@ -1283,36 +1316,43 @@ pub async fn fetch_model_catalog(
             provider_id: "openai",
             base_url: "https://api.openai.com/v1",
             prefix_filters: vec!["gpt-", "o1-", "o3-", "o4-", "chatgpt-"],
+            max_models: None,
         },
         FetchTarget {
             provider_type: ProviderType::OpenRouter,
             provider_id: "open-router",
             base_url: "https://openrouter.ai/api/v1",
+            // No usable prefix and a large, fast-growing catalog, so cap it.
             prefix_filters: vec![],
+            max_models: Some(MAX_CATALOG_MODELS_PER_PROVIDER),
         },
         FetchTarget {
             provider_type: ProviderType::Xai,
             provider_id: "xai",
             base_url: "https://api.x.ai/v1",
             prefix_filters: vec!["grok-"],
+            max_models: None,
         },
         FetchTarget {
             provider_type: ProviderType::Cerebras,
             provider_id: "cerebras",
             base_url: "https://api.cerebras.ai/v1",
             prefix_filters: vec![],
+            max_models: None,
         },
         FetchTarget {
             provider_type: ProviderType::Zai,
             provider_id: "zai",
             base_url: "https://open.bigmodel.cn/api/paas/v4",
             prefix_filters: vec!["glm-"],
+            max_models: None,
         },
         FetchTarget {
             provider_type: ProviderType::Minimax,
             provider_id: "minimax",
             base_url: "https://api.minimax.io/v1",
             prefix_filters: vec!["MiniMax-"],
+            max_models: None,
         },
     ];
 
@@ -1371,6 +1411,7 @@ pub async fn fetch_model_catalog(
     for (target, key) in target_keys {
         let provider_id = target.provider_id.to_string();
         let base_url = target.base_url.to_string();
+        let max_models = target.max_models;
         let prefix_filters: Vec<String> = target
             .prefix_filters
             .iter()
@@ -1382,7 +1423,20 @@ pub async fn fetch_model_catalog(
                 Some(api_key) => {
                     let filters: Vec<&str> = prefix_filters.iter().map(|s| s.as_str()).collect();
                     match fetch_openai_compatible_models(&base_url, &api_key, &filters).await {
-                        Ok(models) => {
+                        Ok(mut models) => {
+                            // Bound large catalogs (OpenRouter). Models are
+                            // sorted by id, so truncation is deterministic.
+                            if let Some(limit) = max_models {
+                                if models.len() > limit {
+                                    tracing::info!(
+                                        "Capping {} catalog from {} to {} models",
+                                        provider_id,
+                                        models.len(),
+                                        limit
+                                    );
+                                    models.truncate(limit);
+                                }
+                            }
                             tracing::info!(
                                 "Fetched {} models from {} API",
                                 models.len(),
@@ -2104,6 +2158,24 @@ mod tests {
     fn models_dev_provider_key_maps_openrouter() {
         assert_eq!(models_dev_provider_key("open-router"), "openrouter");
         assert_eq!(models_dev_provider_key("anthropic"), "anthropic");
+    }
+
+    #[test]
+    fn truncate_description_bounds_long_text() {
+        // Short descriptions pass through unchanged (after trimming).
+        assert_eq!(truncate_description("  Short blurb  "), "Short blurb");
+
+        // Long descriptions are capped and get an ellipsis.
+        let long = "x".repeat(MAX_MODEL_DESCRIPTION_CHARS + 50);
+        let out = truncate_description(&long);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), MAX_MODEL_DESCRIPTION_CHARS + 1);
+
+        // Multibyte text isn't split mid-codepoint.
+        let emoji = "🚀".repeat(MAX_MODEL_DESCRIPTION_CHARS + 10);
+        let out = truncate_description(&emoji);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), MAX_MODEL_DESCRIPTION_CHARS + 1);
     }
 
     #[test]

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -48,12 +48,24 @@ pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] = &[
     "minimax",
 ];
 
-/// Upper bound on the number of live models merged from a single
-/// OpenAI-compatible `/v1/models` response. OpenRouter has no usable prefix
-/// filter and exposes a large, fast-growing catalog; without a bound it can
-/// flood the routing picker (and the cached catalog). Prefix-filtered
-/// providers stay well under this and are left uncapped.
+/// Upper bound on models merged for a single provider from live `/v1/models`
+/// and from models.dev. OpenRouter has no usable prefix filter and exposes a
+/// large, fast-growing catalog; without a bound it can flood the routing
+/// picker (and the cached catalog). Prefix-filtered providers stay well under
+/// this and are left uncapped.
 const MAX_CATALOG_MODELS_PER_PROVIDER: usize = 100;
+
+const OPENROUTER_PROVIDER_ID: &str = "open-router";
+
+/// Best-effort seed slugs kept in the default config; prioritized when capping
+/// the models.dev OpenRouter catalog (which has no popularity sort).
+const OPENROUTER_SEED_MODEL_IDS: &[&str] = &[
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-sonnet-4.6",
+    "google/gemini-3.1-pro-preview",
+    "openai/gpt-5.5",
+    "meta-llama/llama-3.3-70b-instruct:free",
+];
 
 /// Maximum length (in `char`s) of a model description surfaced from a
 /// `/v1/models` entry. OpenRouter descriptions can run several paragraphs; the
@@ -305,6 +317,49 @@ fn models_dev_provider_key(provider_id: &str) -> &str {
         "open-router" => "openrouter",
         _ => provider_id,
     }
+}
+
+/// Cap a catalog slice, keeping `priority_ids` first (in that order) then filling
+/// from the remainder in stable id order until `limit`.
+fn cap_catalog_entries(
+    mut entries: Vec<CatalogEntry>,
+    limit: usize,
+    priority_ids: &[&str],
+) -> Vec<CatalogEntry> {
+    if entries.len() <= limit {
+        return entries;
+    }
+
+    let priority_normalized: HashSet<String> = priority_ids
+        .iter()
+        .map(|id| normalize_model_id(id))
+        .collect();
+    let mut priority_entries = Vec::new();
+    let mut rest = Vec::new();
+    for entry in entries.drain(..) {
+        if priority_normalized.contains(&normalize_model_id(&entry.id)) {
+            priority_entries.push(entry);
+        } else {
+            rest.push(entry);
+        }
+    }
+    priority_entries.sort_by_key(|entry| {
+        priority_ids
+            .iter()
+            .position(|id| normalize_model_id(id) == normalize_model_id(&entry.id))
+            .unwrap_or(usize::MAX)
+    });
+    rest.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut capped = priority_entries;
+    for entry in rest {
+        if capped.len() >= limit {
+            break;
+        }
+        capped.push(entry);
+    }
+    capped.truncate(limit);
+    capped
 }
 
 fn merge_catalog_entries(
@@ -944,13 +999,23 @@ fn truncate_description(description: &str) -> String {
 /// Fetch models from an OpenAI-compatible /v1/models endpoint.
 /// Filters results by the given prefix (e.g. "grok-", "glm-").
 /// Returns model IDs and generated display names.
+///
+/// `models_query` is appended after `/models` (e.g. `?sort=most-popular` for
+/// OpenRouter). When `sort_results_by_id` is false the API response order is
+/// preserved (used for server-side popularity sorts).
 pub async fn fetch_openai_compatible_models(
     base_url: &str,
     api_key: &str,
     prefix_filters: &[&str],
+    models_query: Option<&str>,
+    sort_results_by_id: bool,
 ) -> Result<Vec<ProviderModel>, String> {
     let client = reqwest::Client::new();
-    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let base = base_url.trim_end_matches('/');
+    let url = match models_query.filter(|query| !query.is_empty()) {
+        Some(query) => format!("{base}/models{query}"),
+        None => format!("{base}/models"),
+    };
 
     let resp = client
         .get(&url)
@@ -1003,7 +1068,9 @@ pub async fn fetch_openai_compatible_models(
         })
         .collect();
 
-    models.sort_by(|a, b| a.id.cmp(&b.id));
+    if sort_results_by_id {
+        models.sort_by(|a, b| a.id.cmp(&b.id));
+    }
     Ok(models)
 }
 
@@ -1091,22 +1158,41 @@ pub async fn fetch_models_dev_catalog() -> Result<HashMap<String, Vec<CatalogEnt
             continue;
         };
 
-        let entries = models.iter().map(|(model_id, value)| {
-            let name = value
-                .get("name")
-                .and_then(|n| n.as_str())
-                .unwrap_or(model_id)
-                .to_string();
-            CatalogEntry {
-                id: model_id.clone(),
-                name,
-                provider_id: (*provider_id).to_string(),
-                sources: vec![CatalogSource::ModelsDev],
-                availability: CatalogAvailability::Known,
-                last_checked_at: now,
-                description: None,
-            }
-        });
+        let mut entries: Vec<CatalogEntry> = models
+            .iter()
+            .map(|(model_id, value)| {
+                let name = value
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or(model_id)
+                    .to_string();
+                CatalogEntry {
+                    id: model_id.clone(),
+                    name,
+                    provider_id: (*provider_id).to_string(),
+                    sources: vec![CatalogSource::ModelsDev],
+                    availability: CatalogAvailability::Known,
+                    last_checked_at: now,
+                    description: None,
+                }
+            })
+            .collect();
+
+        if *provider_id == OPENROUTER_PROVIDER_ID && entries.len() > MAX_CATALOG_MODELS_PER_PROVIDER
+        {
+            let before = entries.len();
+            entries = cap_catalog_entries(
+                entries,
+                MAX_CATALOG_MODELS_PER_PROVIDER,
+                OPENROUTER_SEED_MODEL_IDS,
+            );
+            tracing::info!(
+                "Capping open-router models.dev catalog from {} to {} models",
+                before,
+                entries.len()
+            );
+        }
+
         merge_catalog_entries(&mut catalog, provider_id, entries);
     }
 
@@ -1304,6 +1390,12 @@ pub async fn fetch_model_catalog(
         provider_id: &'static str,
         base_url: &'static str,
         prefix_filters: Vec<&'static str>,
+        /// Extra query on `/models` (e.g. OpenRouter `?sort=most-popular`).
+        models_query: Option<&'static str>,
+        /// When false, keep the API response order (popularity sorts).
+        sort_results_by_id: bool,
+        /// Fetch even when no API key is configured (public catalog endpoints).
+        allow_unauthenticated: bool,
         /// Upper bound on models merged from this provider's `/v1/models`.
         /// Set for prefix-less, large catalogs (OpenRouter) to keep the
         /// routing picker bounded; `None` means no cap.
@@ -1316,14 +1408,20 @@ pub async fn fetch_model_catalog(
             provider_id: "openai",
             base_url: "https://api.openai.com/v1",
             prefix_filters: vec!["gpt-", "o1-", "o3-", "o4-", "chatgpt-"],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
             max_models: None,
         },
         FetchTarget {
             provider_type: ProviderType::OpenRouter,
             provider_id: "open-router",
             base_url: "https://openrouter.ai/api/v1",
-            // No usable prefix and a large, fast-growing catalog, so cap it.
+            // No usable prefix; ask OpenRouter for weekly token volume order.
             prefix_filters: vec![],
+            models_query: Some("?sort=most-popular"),
+            sort_results_by_id: false,
+            allow_unauthenticated: true,
             max_models: Some(MAX_CATALOG_MODELS_PER_PROVIDER),
         },
         FetchTarget {
@@ -1331,6 +1429,9 @@ pub async fn fetch_model_catalog(
             provider_id: "xai",
             base_url: "https://api.x.ai/v1",
             prefix_filters: vec!["grok-"],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
             max_models: None,
         },
         FetchTarget {
@@ -1338,6 +1439,9 @@ pub async fn fetch_model_catalog(
             provider_id: "cerebras",
             base_url: "https://api.cerebras.ai/v1",
             prefix_filters: vec![],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
             max_models: None,
         },
         FetchTarget {
@@ -1345,6 +1449,9 @@ pub async fn fetch_model_catalog(
             provider_id: "zai",
             base_url: "https://open.bigmodel.cn/api/paas/v4",
             prefix_filters: vec!["glm-"],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
             max_models: None,
         },
         FetchTarget {
@@ -1352,6 +1459,9 @@ pub async fn fetch_model_catalog(
             provider_id: "minimax",
             base_url: "https://api.minimax.io/v1",
             prefix_filters: vec!["MiniMax-"],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
             max_models: None,
         },
     ];
@@ -1412,6 +1522,9 @@ pub async fn fetch_model_catalog(
         let provider_id = target.provider_id.to_string();
         let base_url = target.base_url.to_string();
         let max_models = target.max_models;
+        let models_query = target.models_query.map(str::to_string);
+        let sort_results_by_id = target.sort_results_by_id;
+        let allow_unauthenticated = target.allow_unauthenticated;
         let prefix_filters: Vec<String> = target
             .prefix_filters
             .iter()
@@ -1419,13 +1532,27 @@ pub async fn fetch_model_catalog(
             .collect();
 
         handles.push(tokio::spawn(async move {
-            match key {
+            let api_key = match key {
+                Some(k) if !k.is_empty() => Some(k),
+                _ if allow_unauthenticated => Some(String::new()),
+                _ => None,
+            };
+            match api_key {
                 Some(api_key) => {
                     let filters: Vec<&str> = prefix_filters.iter().map(|s| s.as_str()).collect();
-                    match fetch_openai_compatible_models(&base_url, &api_key, &filters).await {
+                    match fetch_openai_compatible_models(
+                        &base_url,
+                        &api_key,
+                        &filters,
+                        models_query.as_deref(),
+                        sort_results_by_id,
+                    )
+                    .await
+                    {
                         Ok(mut models) => {
-                            // Bound large catalogs (OpenRouter). Models are
-                            // sorted by id, so truncation is deterministic.
+                            // Bound large catalogs (OpenRouter). OpenRouter
+                            // keeps the API's most-popular order; others are
+                            // sorted by id before truncation.
                             if let Some(limit) = max_models {
                                 if models.len() > limit {
                                     tracing::info!(
@@ -1474,7 +1601,7 @@ pub async fn fetch_model_catalog(
         // when present, empty otherwise.
         let api_key = provider.api_key.clone().unwrap_or_default();
         handles.push(tokio::spawn(async move {
-            match fetch_openai_compatible_models(&base_url, &api_key, &[]).await {
+            match fetch_openai_compatible_models(&base_url, &api_key, &[], None, true).await {
                 Ok(models) if !models.is_empty() => {
                     tracing::info!(
                         "Fetched {} models from custom provider {} ({})",
@@ -2161,6 +2288,34 @@ mod tests {
     }
 
     #[test]
+    fn cap_catalog_entries_prioritizes_seeds_then_truncates() {
+        let now = chrono::Utc::now();
+        let make = |id: &str| CatalogEntry {
+            id: id.to_string(),
+            name: id.to_string(),
+            provider_id: OPENROUTER_PROVIDER_ID.to_string(),
+            sources: vec![CatalogSource::ModelsDev],
+            availability: CatalogAvailability::Known,
+            last_checked_at: now,
+            description: None,
+        };
+        let mut entries: Vec<CatalogEntry> = (0..150)
+            .map(|i| make(&format!("vendor/model-{i:03}")))
+            .collect();
+        entries.push(make("anthropic/claude-opus-4.8"));
+        entries.push(make("openai/gpt-5.5"));
+
+        let capped = cap_catalog_entries(
+            entries,
+            MAX_CATALOG_MODELS_PER_PROVIDER,
+            OPENROUTER_SEED_MODEL_IDS,
+        );
+        assert_eq!(capped.len(), MAX_CATALOG_MODELS_PER_PROVIDER);
+        assert_eq!(capped[0].id, "anthropic/claude-opus-4.8");
+        assert!(capped.iter().any(|entry| entry.id == "openai/gpt-5.5"));
+    }
+
+    #[test]
     fn truncate_description_bounds_long_text() {
         // Short descriptions pass through unchanged (after trimming).
         assert_eq!(truncate_description("  Short blurb  "), "Short blurb");
@@ -2411,9 +2566,9 @@ mod tests {
         let mut any_stale = false;
 
         for target in &targets {
-            let api_key = get_api_key_for_provider(target.provider_type, &[]);
-            let api_key = match api_key {
+            let api_key = match get_api_key_for_provider(target.provider_type, &[]) {
                 Some(k) => k,
+                None if target.provider_id == OPENROUTER_PROVIDER_ID => String::new(),
                 None => {
                     eprintln!(
                         "[SKIP] {}: no API key found (set {} or configure in OpenCode auth)",
@@ -2426,11 +2581,24 @@ mod tests {
 
             any_checked = true;
 
+            let (models_query, sort_results_by_id) = if target.provider_id == OPENROUTER_PROVIDER_ID
+            {
+                (Some("?sort=most-popular"), false)
+            } else {
+                (None, true)
+            };
+
             let fetched = if target.is_anthropic {
                 fetch_anthropic_models(&api_key).await
             } else {
-                fetch_openai_compatible_models(target.base_url, &api_key, &target.prefix_filters)
-                    .await
+                fetch_openai_compatible_models(
+                    target.base_url,
+                    &api_key,
+                    &target.prefix_filters,
+                    models_query,
+                    sort_results_by_id,
+                )
+                .await
             };
 
             match fetched {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -40,6 +40,7 @@ const CODEX_MODEL_PROBE_TTL: Duration = Duration::from_secs(10 * 60);
 pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] = &[
     "anthropic",
     "openai",
+    "open-router",
     "google",
     "xai",
     "cerebras",
@@ -284,6 +285,14 @@ fn merge_provider_models(
 
 fn normalize_model_id(id: &str) -> String {
     id.trim().to_ascii_lowercase()
+}
+
+fn models_dev_provider_key(provider_id: &str) -> &str {
+    match provider_id {
+        // Sandboxed/OpenCode use `open-router`; models.dev uses `openrouter`.
+        "open-router" => "openrouter",
+        _ => provider_id,
+    }
 }
 
 fn merge_catalog_entries(
@@ -662,6 +671,43 @@ fn default_providers_config() -> ProvidersConfig {
                 ],
             },
             Provider {
+                id: "open-router".to_string(),
+                name: "OpenRouter (API Key)".to_string(),
+                billing: "pay-per-token".to_string(),
+                description: "Aggregator routing through OpenRouter".to_string(),
+                models: vec![
+                    // OpenRouter model IDs are vendor-prefixed (provider/model).
+                    // The live catalog is merged from models.dev and /v1/models
+                    // when available; these keep the picker useful before the
+                    // background catalog finishes.
+                    ProviderModel {
+                        id: "anthropic/claude-opus-4.8".to_string(),
+                        name: "Claude Opus 4.8".to_string(),
+                        description: Some("Anthropic Claude via OpenRouter".to_string()),
+                    },
+                    ProviderModel {
+                        id: "anthropic/claude-sonnet-4.6".to_string(),
+                        name: "Claude Sonnet 4.6".to_string(),
+                        description: Some("Anthropic Claude via OpenRouter".to_string()),
+                    },
+                    ProviderModel {
+                        id: "google/gemini-3.1-pro-preview".to_string(),
+                        name: "Gemini 3.1 Pro Preview".to_string(),
+                        description: Some("Google Gemini via OpenRouter".to_string()),
+                    },
+                    ProviderModel {
+                        id: "openai/gpt-5.5".to_string(),
+                        name: "GPT-5.5".to_string(),
+                        description: Some("OpenAI GPT via OpenRouter".to_string()),
+                    },
+                    ProviderModel {
+                        id: "meta-llama/llama-3.3-70b-instruct:free".to_string(),
+                        name: "Llama 3.3 70B Instruct (free)".to_string(),
+                        description: Some("Meta Llama via OpenRouter".to_string()),
+                    },
+                ],
+            },
+            Provider {
                 id: "google".to_string(),
                 name: "Google AI (OAuth)".to_string(),
                 billing: "subscription".to_string(),
@@ -910,10 +956,20 @@ pub async fn fetch_openai_compatible_models(
             {
                 return None;
             }
+            let name = entry
+                .get("display_name")
+                .or_else(|| entry.get("name"))
+                .and_then(|n| n.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| model_id_to_display_name(id));
+            let description = entry
+                .get("description")
+                .and_then(|d| d.as_str())
+                .map(str::to_string);
             Some(ProviderModel {
                 id: id.to_string(),
-                name: model_id_to_display_name(id),
-                description: None,
+                name,
+                description,
             })
         })
         .collect();
@@ -999,7 +1055,7 @@ pub async fn fetch_models_dev_catalog() -> Result<HashMap<String, Vec<CatalogEnt
     let mut catalog: HashMap<String, Vec<CatalogEntry>> = HashMap::new();
 
     for provider_id in DEFAULT_CATALOG_PROVIDER_IDS {
-        let Some(provider) = providers.get(*provider_id) else {
+        let Some(provider) = providers.get(models_dev_provider_key(provider_id)) else {
             continue;
         };
         let Some(models) = provider.get("models").and_then(|m| m.as_object()) else {
@@ -1227,6 +1283,12 @@ pub async fn fetch_model_catalog(
             provider_id: "openai",
             base_url: "https://api.openai.com/v1",
             prefix_filters: vec!["gpt-", "o1-", "o3-", "o4-", "chatgpt-"],
+        },
+        FetchTarget {
+            provider_type: ProviderType::OpenRouter,
+            provider_id: "open-router",
+            base_url: "https://openrouter.ai/api/v1",
+            prefix_filters: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Xai,
@@ -2023,6 +2085,28 @@ mod tests {
     }
 
     #[test]
+    fn default_openrouter_catalog_uses_vendor_prefixed_model_ids() {
+        let defaults = default_providers_config();
+        let openrouter = defaults
+            .providers
+            .iter()
+            .find(|provider| provider.id == "open-router")
+            .expect("openrouter provider");
+
+        assert!(openrouter
+            .models
+            .iter()
+            .any(|model| model.id == "anthropic/claude-opus-4.8"));
+        assert!(openrouter.models.iter().all(|model| model.id.contains('/')));
+    }
+
+    #[test]
+    fn models_dev_provider_key_maps_openrouter() {
+        assert_eq!(models_dev_provider_key("open-router"), "openrouter");
+        assert_eq!(models_dev_provider_key("anthropic"), "anthropic");
+    }
+
+    #[test]
     fn default_xai_catalog_includes_grok_build_for_model_routing() {
         let defaults = default_providers_config();
         let xai = defaults
@@ -2215,6 +2299,13 @@ mod tests {
                 is_anthropic: false,
             },
             TestTarget {
+                provider_id: "open-router",
+                provider_type: ProviderType::OpenRouter,
+                base_url: "https://openrouter.ai/api/v1",
+                prefix_filters: vec![],
+                is_anthropic: false,
+            },
+            TestTarget {
                 provider_id: "xai",
                 provider_type: ProviderType::Xai,
                 base_url: "https://api.x.ai/v1",
@@ -2349,7 +2440,7 @@ mod tests {
         if !any_checked {
             eprintln!("\n[INFO] No API keys were available. Set environment variables to check staleness:");
             eprintln!(
-                "  ANTHROPIC_API_KEY, OPENAI_API_KEY, XAI_API_KEY, CEREBRAS_API_KEY, ZHIPU_API_KEY"
+                "  ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, CEREBRAS_API_KEY, ZHIPU_API_KEY"
             );
         }
 


### PR DESCRIPTION
## Summary

Adds OpenRouter as a first-class provider in the Model Routing picker while keeping the existing `open-router` provider id used by credentials and proxy routing.

## Changes

- Adds `open-router` to the routing provider catalog with seeded vendor-prefixed model IDs.
- Maps the app's `open-router` id to the `openrouter` key used by models.dev.
- Enables live OpenRouter `/v1/models` discovery through the existing OpenAI-compatible catalog fetcher.
- Requests unverified public catalog entries on the Model Routing page so OpenRouter models can populate before an account-specific fetch completes.
- Adds an OpenRouter icon in the Add Provider modal.

## Validation

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -q openrouter --lib`
- `cargo test -q api::providers::tests --lib`
- `cd dashboard && bun run lint -- src/app/model-routing/page.tsx src/components/ui/add-provider-modal.tsx`