### PR TITLE
fix(oauth+control): serialize OAuth refresh + circuit-break dead tokens + orchestrator stall-guard

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -39,6 +39,41 @@ use crate::util::{
 static OAUTH_WARN_DEDUP: LazyLock<StdMutex<HashMap<String, Instant>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
+/// Accounts whose stored OAuth refresh token the provider has *permanently*
+/// rejected (`invalid_grant` / "refresh token not found"). Keyed by account id
+/// → the exact dead refresh-token value. The proactive usage-refresh loop
+/// re-attempts a refresh for every account every ~2 min; without this, a single
+/// revoked token (e.g. an Anthropic account the user logged out of) floods the
+/// logs and burns calls forever. We skip re-hitting the OAuth endpoint while the
+/// stored token still equals the dead one; the moment a re-auth rotates the
+/// token (value differs) or any refresh succeeds, the entry is cleared and
+/// refresh resumes automatically. In-memory by design: a restart re-probes once
+/// (a single failure) and then re-trips, which is the desired behavior.
+static OAUTH_REFRESH_DEADLETTER: LazyLock<StdMutex<HashMap<uuid::Uuid, String>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// True when `token` is the exact refresh token already recorded dead for
+/// `account_id` — i.e. re-attempting it would just reproduce `invalid_grant`.
+fn oauth_refresh_token_is_dead(account_id: uuid::Uuid, token: &str) -> bool {
+    OAUTH_REFRESH_DEADLETTER
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&account_id).cloned())
+        .is_some_and(|dead| dead == token)
+}
+
+fn oauth_refresh_mark_token_dead(account_id: uuid::Uuid, token: &str) {
+    if let Ok(mut m) = OAUTH_REFRESH_DEADLETTER.lock() {
+        m.insert(account_id, token.to_string());
+    }
+}
+
+fn oauth_refresh_clear_dead(account_id: uuid::Uuid) {
+    if let Ok(mut m) = OAUTH_REFRESH_DEADLETTER.lock() {
+        m.remove(&account_id);
+    }
+}
+
 const OAUTH_WARN_COOLDOWN: Duration = Duration::from_secs(600);
 
 fn should_warn_oauth(key: &str) -> bool {
@@ -383,6 +418,28 @@ fn parse_grok_device_auth_line(line: &str) -> (Option<String>, Option<String>) {
     };
 
     (auth_url, user_code)
+}
+
+#[cfg(test)]
+mod oauth_deadletter_tests {
+    use super::{
+        oauth_refresh_clear_dead, oauth_refresh_mark_token_dead, oauth_refresh_token_is_dead,
+    };
+
+    #[test]
+    fn deadletter_blocks_same_token_until_rotated_or_cleared() {
+        let acct = uuid::Uuid::new_v4();
+        // Fresh account: not dead.
+        assert!(!oauth_refresh_token_is_dead(acct, "tok-A"));
+        // Mark the current token dead (invalid_grant).
+        oauth_refresh_mark_token_dead(acct, "tok-A");
+        assert!(oauth_refresh_token_is_dead(acct, "tok-A")); // skipped → no flood
+                                                             // A rotated token (re-auth) is NOT blocked → refresh retries.
+        assert!(!oauth_refresh_token_is_dead(acct, "tok-B"));
+        // A successful refresh clears the mark.
+        oauth_refresh_clear_dead(acct);
+        assert!(!oauth_refresh_token_is_dead(acct, "tok-A"));
+    }
 }
 
 #[cfg(test)]
@@ -9856,6 +9913,18 @@ pub async fn refresh_store_account_oauth_locked(
         .filter(|t| !t.trim().is_empty())
         .unwrap_or_else(|| fallback_refresh_token.to_string());
 
+    // Circuit-breaker: if this exact refresh token was already permanently
+    // rejected (`invalid_grant`), don't re-hit the OAuth endpoint — that's the
+    // 2-min log flood. The block lifts the instant a re-auth rotates the token
+    // (the re-read value above differs from the dead one) or any refresh
+    // succeeds. Surface a permanent-looking error so callers log at debug.
+    if oauth_refresh_token_is_dead(account_id, &refresh_token) {
+        return Err(OAuthRefreshError::InvalidGrant(
+            "invalid_grant (cached): refresh token previously rejected; re-auth required"
+                .to_string(),
+        ));
+    }
+
     // Does this account currently back the shared credential tiers? If there is
     // no tier entry yet (e.g. a freshly connected single account), treat it as
     // the owner so the tiers get populated.
@@ -9864,7 +9933,21 @@ pub async fn refresh_store_account_oauth_locked(
         .map_or(true, |tier_token| tier_token == refresh_token);
 
     let (access, refresh, expires_at) =
-        refresh_oauth_token_internal(&provider_type, &refresh_token).await?;
+        match refresh_oauth_token_internal(&provider_type, &refresh_token).await {
+            Ok(v) => {
+                // Live again — clear any prior dead-letter mark for this account.
+                oauth_refresh_clear_dead(account_id);
+                v
+            }
+            Err(e) => {
+                // A permanently-revoked/expired token: record it so the next
+                // ~2-min cycle skips the doomed retry until re-auth.
+                if matches!(e, OAuthRefreshError::InvalidGrant(_)) {
+                    oauth_refresh_mark_token_dead(account_id, &refresh_token);
+                }
+                return Err(e);
+            }
+        };
 
     // Always update this account's own store record.
     if ai_providers

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -7905,7 +7905,7 @@ fn parse_openai_authorization_input(input: &str) -> (Option<String>, Option<Stri
     (Some(value.to_string()), None)
 }
 
-/// POST /api/ai/providers/:id/oauth/authorize - Initiate OAuth authorization.
+// POST /api/ai/providers/:id/oauth/authorize - Initiate OAuth authorization.
 // ─────────────────────────────────────────────────────────────────────────────
 // Kimi (Moonshot) Code subscription — OAuth 2.0 Device Authorization Grant
 // ─────────────────────────────────────────────────────────────────────────────
@@ -9968,7 +9968,7 @@ pub async fn refresh_store_account_oauth_locked(
     // the owner so the tiers get populated.
     let owns_tiers = read_oauth_token_entry(provider_type)
         .map(|e| e.refresh_token)
-        .map_or(true, |tier_token| tier_token == refresh_token);
+        .is_none_or(|tier_token| tier_token == refresh_token);
 
     let (access, refresh, expires_at) =
         match refresh_oauth_token_internal(&provider_type, &refresh_token).await {

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -74,6 +74,28 @@ fn oauth_refresh_clear_dead(account_id: uuid::Uuid) {
     }
 }
 
+/// Per-provider-type in-process serialization gate for OAuth refresh. The
+/// cross-process file lock (`acquire_oauth_refresh_lock`) is a non-blocking
+/// `try_lock`, so concurrent in-process refreshes (e.g. the proxy firing many
+/// requests at once) sail past it and all consume the SAME rotating refresh
+/// token — Anthropic invalidates it on first use, so every loser of the race
+/// gets `invalid_grant`. This async mutex makes those refreshes wait for each
+/// other; combined with the double-checked expiry below, the first refresh
+/// rotates+persists the token and the rest simply reuse the fresh one.
+static OAUTH_REFRESH_GATES: LazyLock<StdMutex<HashMap<ProviderType, Arc<AsyncMutex<()>>>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+fn oauth_refresh_gate(provider_type: ProviderType) -> Arc<AsyncMutex<()>> {
+    let mut gates = OAUTH_REFRESH_GATES
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    Arc::clone(
+        gates
+            .entry(provider_type)
+            .or_insert_with(|| Arc::new(AsyncMutex::new(()))),
+    )
+}
+
 const OAUTH_WARN_COOLDOWN: Duration = Duration::from_secs(600);
 
 fn should_warn_oauth(key: &str) -> bool {
@@ -9899,16 +9921,32 @@ pub async fn refresh_store_account_oauth_locked(
     provider_type: ProviderType,
     fallback_refresh_token: &str,
 ) -> Result<(String, String, i64), OAuthRefreshError> {
-    // Serialize with every other refresh path for this provider type so a
-    // rotating refresh token is only ever consumed once.
+    // Serialize in-process refreshes for this provider type FIRST. The file
+    // lock below is a non-blocking `try_lock` (cross-process only), so without
+    // this async gate concurrent in-process refreshes race and each consumes the
+    // same rotating refresh token → all but one get `invalid_grant`.
+    let gate = oauth_refresh_gate(provider_type);
+    let _gate = gate.lock().await;
     let _lock = acquire_oauth_refresh_lock(provider_type).ok();
 
-    // Re-read the freshest refresh token now that we hold the lock — another
-    // path may have rotated it while we were waiting.
-    let refresh_token = ai_providers
-        .get(account_id)
-        .await
-        .and_then(|p| p.oauth)
+    // Re-read the freshest credentials now that we're serialized — a concurrent
+    // refresh may have just rotated the token while we waited on the gate.
+    let current_oauth = ai_providers.get(account_id).await.and_then(|p| p.oauth);
+
+    // Double-checked: if a concurrent refresh already produced a still-valid
+    // access token, reuse it instead of consuming the (now-rotated) refresh
+    // token a second time. This is what actually kills the rotating-token race.
+    if let Some(o) = &current_oauth {
+        if !o.refresh_token.trim().is_empty() && !oauth_token_expired(o.expires_at) {
+            return Ok((
+                o.access_token.clone(),
+                o.refresh_token.clone(),
+                o.expires_at,
+            ));
+        }
+    }
+
+    let refresh_token = current_oauth
         .map(|o| o.refresh_token)
         .filter(|t| !t.trim().is_empty())
         .unwrap_or_else(|| fallback_refresh_token.to_string());

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -19516,7 +19516,7 @@ Investigate <service/> failures.
                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        lagged = lagged.saturating_add(n as u64);
+                        lagged = lagged.saturating_add(n);
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -425,6 +425,83 @@ const METADATA_SOURCE_USER: &str = "user";
 const METADATA_VERSION_V1: &str = "v1";
 static MISSION_TITLE_UPDATE_LOCK: std::sync::LazyLock<Mutex<()>> =
     std::sync::LazyLock::new(|| Mutex::new(()));
+
+/// Stall-guard: number of consecutive auto-armed fallback wakeups per mission,
+/// since the last real user message or self-armed automation. Bounds how many
+/// times the server will auto-resume an orchestrator that keeps parking without
+/// scheduling its own wakeup, so a genuinely-finished orchestrator isn't woken
+/// forever (after the cap it's left for a human).
+static STALL_GUARD_CONSECUTIVE_ARMS: std::sync::LazyLock<std::sync::Mutex<HashMap<Uuid, u32>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+const STALL_GUARD_MAX_CONSECUTIVE_ARMS: u32 = 3;
+const STALL_GUARD_WAKEUP_SECONDS: u64 = 1200;
+
+/// Clear a mission's stall-guard counter — called when a real user message
+/// arrives (the operator is steering it) so the guard's budget resets.
+pub(crate) fn reset_stall_guard(mission_id: Uuid) {
+    if let Ok(mut m) = STALL_GUARD_CONSECUTIVE_ARMS.lock() {
+        m.remove(&mission_id);
+    }
+}
+
+/// If an orchestrator mission (one that has spawned child missions) parks in
+/// `AwaitingUser` with no active automation, arm a one-shot fallback wakeup so
+/// it re-checks and continues instead of stalling on an auto-notification that
+/// won't arrive. Leaf missions (no children) are never touched, so a mission
+/// legitimately awaiting a human answer is never auto-resumed. Bounded per
+/// mission; a no-op when the agent already armed its own wakeup.
+async fn maybe_arm_stall_guard_wakeup(mission_store: &Arc<dyn MissionStore>, mission_id: Uuid) {
+    // Only orchestrators are guarded — leaf missions awaiting a human are not.
+    let has_children = mission_store
+        .get_child_missions(mission_id)
+        .await
+        .map(|c| !c.is_empty())
+        .unwrap_or(false);
+    if !has_children {
+        return;
+    }
+    // The agent self-armed a wakeup → it manages its own cadence; reset + skip.
+    if mission_has_active_automation(mission_store, mission_id).await {
+        reset_stall_guard(mission_id);
+        return;
+    }
+    // Bound consecutive auto-arms.
+    let count = {
+        let Ok(mut m) = STALL_GUARD_CONSECUTIVE_ARMS.lock() else {
+            return;
+        };
+        let c = m.entry(mission_id).or_insert(0);
+        if *c >= STALL_GUARD_MAX_CONSECUTIVE_ARMS {
+            return;
+        }
+        *c += 1;
+        *c
+    };
+    tracing::info!(
+        mission_id = %mission_id,
+        arm = count,
+        max = STALL_GUARD_MAX_CONSECUTIVE_ARMS,
+        "Stall-guard: orchestrator parked in awaiting_user with no wakeup armed; arming fallback"
+    );
+    let prompt = "Auto-resume (stall-guard): your previous turn ended in awaiting_user \
+without scheduling a wakeup, but you are an orchestrator with work that may still be in \
+flight. Re-check your workers / board tasks / open PRs + CI and continue. If something is \
+genuinely async (CI, a long build), call ScheduleWakeup so you resume yourself. If \
+everything is truly done, report completion and stop."
+        .to_string();
+    let reason = format!(
+        "stall-guard auto-resume {}/{} (orchestrator parked with no wakeup armed)",
+        count, STALL_GUARD_MAX_CONSECUTIVE_ARMS
+    );
+    crate::api::mission_runner::spawn_claude_builtin_wakeup_automation(
+        mission_id,
+        STALL_GUARD_WAKEUP_SECONDS,
+        prompt,
+        reason,
+    );
+}
+
 struct MetadataRefreshTaskEntry {
     handle: tokio::task::JoinHandle<()>,
     force_refresh: bool,
@@ -3177,6 +3254,11 @@ pub async fn post_message(
     let id = req.client_message_id.unwrap_or_else(Uuid::new_v4);
     let agent = req.agent;
     let target_mission_id = req.mission_id;
+    // A real user message means the operator is steering this mission — reset
+    // its stall-guard budget so future genuine stalls get the full allowance.
+    if let Some(mid) = target_mission_id {
+        reset_stall_guard(mid);
+    }
     let control = control_for_user(&state, &user).await;
     let (queued_tx, queued_rx) = oneshot::channel();
     tracing::info!(
@@ -8216,6 +8298,12 @@ async fn maybe_finalize_terminal_mission(
                     status: new_status,
                     summary: mission_status_summary_for_terminal_reason(reason),
                 });
+
+                // Stall-guard: orchestrators that park in awaiting_user with no
+                // wakeup armed can't resume themselves — arm a bounded fallback.
+                if new_status == MissionStatus::AwaitingUser {
+                    maybe_arm_stall_guard_wakeup(mission_store, mission_id).await;
+                }
             }
         }
         Ok(None) => {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -451,7 +451,12 @@ pub(crate) fn reset_stall_guard(mission_id: Uuid) {
 /// won't arrive. Leaf missions (no children) are never touched, so a mission
 /// legitimately awaiting a human answer is never auto-resumed. Bounded per
 /// mission; a no-op when the agent already armed its own wakeup.
-async fn maybe_arm_stall_guard_wakeup(mission_store: &Arc<dyn MissionStore>, mission_id: Uuid) {
+/// Returns `true` when a fallback wakeup was armed (used by tests; callers may
+/// ignore it).
+async fn maybe_arm_stall_guard_wakeup(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+) -> bool {
     // Only orchestrators are guarded — leaf missions awaiting a human are not.
     let has_children = mission_store
         .get_child_missions(mission_id)
@@ -459,21 +464,21 @@ async fn maybe_arm_stall_guard_wakeup(mission_store: &Arc<dyn MissionStore>, mis
         .map(|c| !c.is_empty())
         .unwrap_or(false);
     if !has_children {
-        return;
+        return false;
     }
     // The agent self-armed a wakeup → it manages its own cadence; reset + skip.
     if mission_has_active_automation(mission_store, mission_id).await {
         reset_stall_guard(mission_id);
-        return;
+        return false;
     }
     // Bound consecutive auto-arms.
     let count = {
         let Ok(mut m) = STALL_GUARD_CONSECUTIVE_ARMS.lock() else {
-            return;
+            return false;
         };
         let c = m.entry(mission_id).or_insert(0);
         if *c >= STALL_GUARD_MAX_CONSECUTIVE_ARMS {
-            return;
+            return false;
         }
         *c += 1;
         *c
@@ -500,6 +505,47 @@ everything is truly done, report completion and stop."
         prompt,
         reason,
     );
+    true
+}
+
+#[cfg(test)]
+mod stall_guard_tests {
+    use super::*;
+
+    async fn mk(store: &Arc<dyn MissionStore>, parent: Option<Uuid>) -> Uuid {
+        store
+            .create_mission_with_parent(Some("m"), None, None, None, None, None, None, parent, None)
+            .await
+            .expect("create")
+            .id
+    }
+
+    #[tokio::test]
+    async fn leaf_mission_is_never_guarded() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let leaf = mk(&store, None).await;
+        // No children → never armed, regardless of how many times it parks.
+        for _ in 0..5 {
+            assert!(!maybe_arm_stall_guard_wakeup(&store, leaf).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn orchestrator_arms_then_caps_then_resets() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let boss = mk(&store, None).await;
+        let _child = mk(&store, Some(boss)).await; // makes `boss` an orchestrator
+        reset_stall_guard(boss);
+        // Arms up to the cap, then stops (leaves it for a human).
+        for _ in 0..STALL_GUARD_MAX_CONSECUTIVE_ARMS {
+            assert!(maybe_arm_stall_guard_wakeup(&store, boss).await);
+        }
+        assert!(!maybe_arm_stall_guard_wakeup(&store, boss).await); // capped
+                                                                    // A real user message resets the budget.
+        reset_stall_guard(boss);
+        assert!(maybe_arm_stall_guard_wakeup(&store, boss).await);
+        reset_stall_guard(boss);
+    }
 }
 
 struct MetadataRefreshTaskEntry {

--- a/src/api/proxy_keys.rs
+++ b/src/api/proxy_keys.rs
@@ -368,6 +368,31 @@ async fn delete_key(
     }
 }
 
+/// Delete (or, with `dry_run`, list) keys that have seen no activity for
+/// `max_age_days` days (default 7).
+async fn cleanup_keys(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CleanupRequest>,
+) -> Result<Json<CleanupResponse>, (StatusCode, String)> {
+    let max_age_days = req.max_age_days.unwrap_or(7);
+    if max_age_days == 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "max_age_days must be at least 1".to_string(),
+        ));
+    }
+    let dry_run = req.dry_run.unwrap_or(false);
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(i64::from(max_age_days));
+    match state.proxy_api_keys.cleanup_unused(cutoff, dry_run).await {
+        Ok(keys) => Ok(Json(CleanupResponse {
+            dry_run,
+            cutoff,
+            keys,
+        })),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,30 +513,5 @@ mod tests {
         );
         // Persisted.
         assert_eq!(store.load_from_disk().unwrap().len(), 3);
-    }
-}
-
-/// Delete (or, with `dry_run`, list) keys that have seen no activity for
-/// `max_age_days` days (default 7).
-async fn cleanup_keys(
-    State(state): State<Arc<AppState>>,
-    Json(req): Json<CleanupRequest>,
-) -> Result<Json<CleanupResponse>, (StatusCode, String)> {
-    let max_age_days = req.max_age_days.unwrap_or(7);
-    if max_age_days == 0 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "max_age_days must be at least 1".to_string(),
-        ));
-    }
-    let dry_run = req.dry_run.unwrap_or(false);
-    let cutoff = chrono::Utc::now() - chrono::Duration::days(i64::from(max_age_days));
-    match state.proxy_api_keys.cleanup_unused(cutoff, dry_run).await {
-        Ok(keys) => Ok(Json(CleanupResponse {
-            dry_run,
-            cutoff,
-            keys,
-        })),
-        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e)),
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1665,6 +1665,54 @@ fn scrub_sensitive_json(value: &mut Value) {
     }
 }
 
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    if std::env::args().any(|arg| arg == "--version" || arg == "-V") {
+        println!("assistant-mcp {SERVER_VERSION}");
+        return;
+    }
+
+    let server = AssistantMcp::new();
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    for line in BufReader::new(stdin.lock()).lines() {
+        let Ok(line) = line else {
+            break;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let request = match serde_json::from_str::<JsonRpcRequest>(&line) {
+            Ok(request) => request,
+            Err(error) => {
+                let response =
+                    JsonRpcResponse::error(Value::Null, -32700, format!("Parse error: {error}"));
+                if let Ok(serialized) = serde_json::to_string(&response) {
+                    let _ = writeln!(stdout, "{serialized}");
+                    let _ = stdout.flush();
+                }
+                continue;
+            }
+        };
+
+        // Notifications (no id), e.g. the `notifications/initialized` the MCP
+        // client sends after `initialize`, expect no reply per JSON-RPC.
+        // Returning a "-32601 Method not found" error here breaks the handshake
+        // with stricter clients.
+        if request.id.is_null() && request.method.starts_with("notifications/") {
+            continue;
+        }
+
+        let response = server.handle_request(request).await;
+        if let Ok(serialized) = serde_json::to_string(&response) {
+            let _ = writeln!(stdout, "{serialized}");
+            let _ = stdout.flush();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1949,53 +1997,5 @@ mod tests {
         assert!(output_dir_for_shared_file(&mission_id, Some("/var/tmp".to_string())).is_err());
         // Relative paths are rejected.
         assert!(output_dir_for_shared_file(&mission_id, Some("tmp/x".to_string())).is_err());
-    }
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    if std::env::args().any(|arg| arg == "--version" || arg == "-V") {
-        println!("assistant-mcp {SERVER_VERSION}");
-        return;
-    }
-
-    let server = AssistantMcp::new();
-    let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout();
-
-    for line in BufReader::new(stdin.lock()).lines() {
-        let Ok(line) = line else {
-            break;
-        };
-        if line.trim().is_empty() {
-            continue;
-        }
-
-        let request = match serde_json::from_str::<JsonRpcRequest>(&line) {
-            Ok(request) => request,
-            Err(error) => {
-                let response =
-                    JsonRpcResponse::error(Value::Null, -32700, format!("Parse error: {error}"));
-                if let Ok(serialized) = serde_json::to_string(&response) {
-                    let _ = writeln!(stdout, "{serialized}");
-                    let _ = stdout.flush();
-                }
-                continue;
-            }
-        };
-
-        // Notifications (no id), e.g. the `notifications/initialized` the MCP
-        // client sends after `initialize`, expect no reply per JSON-RPC.
-        // Returning a "-32601 Method not found" error here breaks the handshake
-        // with stricter clients.
-        if request.id.is_null() && request.method.starts_with("notifications/") {
-            continue;
-        }
-
-        let response = server.handle_request(request).await;
-        if let Ok(serialized) = serde_json::to_string(&response) {
-            let _ = writeln!(stdout, "{serialized}");
-            let _ = stdout.flush();
-        }
     }
 }


### PR DESCRIPTION
Lands the deployed-on-prod fixes onto master:

**OAuth refresh flood (invalid_grant ~40/min on prod):**
- Root cause: `acquire_oauth_refresh_lock` is a non-blocking `try_lock` → concurrent in-process refreshes race on the rotating Anthropic refresh token; every loser gets `invalid_grant`.
- Fix: per-provider-type **async serialization gate** + **double-checked expiry** (first refresh rotates+persists, followers reuse the fresh token), plus a **circuit-breaker** that records a permanently-rejected (`invalid_grant`) token and short-circuits future refreshes of it until re-auth rotates it or one succeeds.

**Orchestrator stall-guard:**
- An orchestrator (mission with children) that parks in `AwaitingUser` with no active automation can't resume itself (e.g. it trusted an auto-notification that never arrives). Arm a bounded one-shot fallback wakeup. Leaf missions (no children) are never touched, so a mission awaiting a human answer is never auto-resumed; capped at 3 consecutive, reset by any user message or self-armed wakeup.

Unit-tested (oauth deadletter; stall-guard leaf-not-guarded / arms-caps-resets). Already validated + running on prod (deployed via cherry-pick).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth credential refresh (rotating tokens, shared tiers) and autonomous mission wakeups; bounded guards limit blast radius but wrong stall-guard triggers could nudge orchestrators unexpectedly.
> 
> **Overview**
> **OAuth refresh** now uses a per-provider in-process async mutex before the existing cross-process file lock, plus a double-check that reuses a still-valid access token after waiting so concurrent callers don’t burn the same rotating refresh token. Permanently rejected refresh tokens (`invalid_grant`) are tracked in memory and skipped until re-auth rotates the token or a refresh succeeds, cutting log/API spam from the proactive refresh loop.
> 
> **Orchestrator stall-guard** arms a bounded fallback wakeup when a mission with child missions lands in `AwaitingUser` without active automation (up to 3 times, ~20 min delay). Leaf missions are untouched; the counter resets on user control messages or when the agent already scheduled its own wakeup.
> 
> Includes unit tests for dead-letter and stall-guard behavior. Minor housekeeping: `cleanup_keys` moved in `proxy_keys.rs`, broadcast lag counter typing fix in control tests, `assistant_mcp` `main` relocated above test module (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45cf27ff52ef8b2661b9e87a19dd723b58aa84ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->