### PR TITLE
feat: deliver mid-turn steering by harness capability

### DIFF
--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -26,8 +26,10 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::OnceCell;
 use uuid::Uuid;
 
+use crate::api::control::MissionStatus;
 use crate::api::mission_store::MissionStore;
 use crate::api::proxy_keys::SharedProxyApiKeyStore;
+use crate::api::runners::{effective_mid_turn_kind, MidTurnKind};
 use crate::workspace::SharedWorkspaceStore;
 use crate::workspace_exec::WorkspaceExec;
 
@@ -718,12 +720,12 @@ fn tool_definitions() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "send_to_agent",
-                "description": "Send a steering message to the working agent. Three delivery modes: (default) the message is queued and picked up at the next turn boundary; set immediate=true to inject it INTO the agent's current turn so it is received within a few seconds WITHOUT ending the turn (no cancel — the agent keeps its context and reacts mid-flight); set interrupt=true to cancel the current turn first so it restarts on the message. If the agent is idle, any mode STARTS a new turn. Prefer immediate=true for a quick course-correction while it works; use interrupt=true only when it must stop what it's doing now. Use only when the operator asked you to steer/redirect the agent.",
+                "description": "Send a steering message to the working agent. By default, active missions receive it through the operator-note bridge: Claude Code with stream input and non-goal Codex inject it mid-turn within ~5s without cancelling; other harnesses queue it for the next turn boundary. If the agent is idle, a new turn starts on the message now. Set interrupt=true only to cancel the current turn first and restart on the message, losing in-flight work. Use only when the operator asked you to steer/redirect the agent.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "message": { "type": "string", "description": "The steering instructions for the working agent. Be specific: what to stop doing, what to do instead, and any bounds." },
-                        "immediate": { "type": "boolean", "description": "Inject the message into the agent's current turn (delivered within ~5s, no turn-end, no cancel). Default false. Ignored if the agent is idle (a new turn starts either way)." },
+                        "immediate": { "type": "boolean", "description": "Legacy hint for mid-turn delivery. Non-interrupt sends already use the best available tier: mid-turn for capable active harnesses, next-turn otherwise, or start a turn if idle." },
                         "interrupt": { "type": "boolean", "description": "Cancel the agent's current turn before delivering, so the steer applies now instead of after the turn ends. Default false. Takes precedence over immediate." }
                     },
                     "required": ["message"]
@@ -923,34 +925,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                 return "Error: message is empty".to_string();
             }
             let interrupt = args["interrupt"].as_bool().unwrap_or(false);
-            let immediate = args["immediate"].as_bool().unwrap_or(false);
-            // Immediate mid-turn delivery (no cancel): route through the
-            // operator-note bridge, which the working-agent runner polls every
-            // ~5s and injects into the live turn via stream-json stdin — the
-            // agent sees it within seconds without ending its turn. `interrupt`
-            // wins if both are set (a hard stop is a stronger intent). Sandbox
-            // turns have no live working agent, so the bridge is a no-op there.
-            if immediate && !interrupt {
-                if turn.sandbox {
-                    return "Error: immediate mid-turn delivery isn't available in a sandbox \
-                            (throwaway) Ask thread — there is no live working agent attached."
-                        .to_string();
-                }
-                let body = format_steer_message(&message);
-                if let Err(e) = turn
-                    .ask_store
-                    .enqueue_operator_note(turn.mission_id, &body, Some(turn.thread_id))
-                    .await
-                {
-                    return format!("Error queuing immediate steer: {e}");
-                }
-                return "Steering message queued for immediate delivery. If the working agent is \
-                        mid-turn (stream-json input enabled) it is injected into the CURRENT turn \
-                        within ~5s — no turn-end, no cancel, context preserved. If the agent is \
-                        idle it is delivered when its next turn begins; to START an idle agent, \
-                        resend without immediate."
-                    .to_string();
-            }
+            let _immediate = args["immediate"].as_bool().unwrap_or(false);
             // Track whether the requested interrupt actually landed — a failed
             // cancel (timeout, control error) must not be reported as "delivered
             // after interrupting" when the agent may still be mid-turn.
@@ -964,6 +939,42 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     interrupt_error = Some(e);
                 } else {
                     record_copilot_stop(turn, &format!("steering: {message}")).await;
+                }
+            } else {
+                let mission = match turn.mission_store.get_mission(turn.mission_id).await {
+                    Ok(Some(mission)) => mission,
+                    Ok(None) => return "Error: mission not found".to_string(),
+                    Err(error) => return format!("Error loading mission: {error}"),
+                };
+                if mission.status == MissionStatus::Active {
+                    let content = format_steer_message(&message);
+                    if let Err(error) = turn
+                        .ask_store
+                        .enqueue_operator_note(turn.mission_id, &content, Some(turn.thread_id))
+                        .await
+                    {
+                        return format!("Error queuing steer: {error}");
+                    }
+                    let stream_input_enabled =
+                        crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false);
+                    return match effective_mid_turn_kind(
+                        &mission.backend,
+                        stream_input_enabled,
+                        mission.goal_mode,
+                    ) {
+                        MidTurnKind::StreamJsonStdin | MidTurnKind::CodexAppServer => {
+                            "Steering message queued for active mission delivery — it should be \
+                             injected mid-turn within ~5s without cancelling or losing in-flight \
+                             work."
+                                .to_string()
+                        }
+                        MidTurnKind::None => format!(
+                            "Steering message queued for the next turn — the `{}` harness can't \
+                             receive mid-turn messages in its current mode, so in-flight work is \
+                             preserved and the agent will see it at the next turn boundary.",
+                            mission.backend
+                        ),
+                    };
                 }
             }
             let content = format_steer_message(&message);

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -719,7 +719,7 @@ fn tool_definitions() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "send_to_agent",
-                "description": "Send a steering message to the working agent. By default, active missions receive it through the operator-note bridge: Claude Code with stream input and non-goal Codex inject it mid-turn within ~5s without cancelling; other harnesses queue it for the next turn boundary. If the agent is idle, a new turn starts on the message now. Set interrupt=true only to cancel the current turn first and restart on the message, losing in-flight work. Use only when the operator asked you to steer/redirect the agent.",
+                "description": "Send a steering message to the working agent. By default, when a turn is actually running, Claude Code with stream input injects it mid-turn within ~5s without cancelling; other harnesses queue it for the next turn boundary (in-flight work preserved). If the agent is idle, a new turn starts on the message now. Set interrupt=true only to cancel the current turn first and restart on the message, losing in-flight work. Use only when the operator asked you to steer/redirect the agent.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -26,7 +26,6 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::OnceCell;
 use uuid::Uuid;
 
-use crate::api::control::MissionStatus;
 use crate::api::mission_store::MissionStore;
 use crate::api::proxy_keys::SharedProxyApiKeyStore;
 use crate::api::runners::{effective_mid_turn_kind, MidTurnKind};
@@ -946,7 +945,28 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     Ok(None) => return "Error: mission not found".to_string(),
                     Err(error) => return format!("Error loading mission: {error}"),
                 };
-                if mission.status == MissionStatus::Active {
+                // Mid-turn injection is only correct when BOTH hold:
+                //   (a) a turn is genuinely in flight for this mission — confirmed
+                //       with the control session, not the DB status, which can lag
+                //       a restart (Active row, no runner) and would otherwise leave
+                //       the note queued with nothing to deliver it; and
+                //   (b) the harness can accept mid-turn input.
+                // The operator-note bridge does not start a turn, so anything else
+                // (idle mission, or a running mission on a harness that can't take
+                // mid-turn input) falls through to the authoritative UserMessage
+                // path below — which starts a turn when idle and queues for the
+                // next boundary when running, and reports honestly either way.
+                let stream_input_enabled =
+                    crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false);
+                let capable = matches!(
+                    effective_mid_turn_kind(
+                        &mission.backend,
+                        stream_input_enabled,
+                        mission.goal_mode,
+                    ),
+                    MidTurnKind::StreamJsonStdin | MidTurnKind::CodexAppServer
+                );
+                if capable && !turn.sandbox && mission_has_live_turn(turn).await {
                     let content = format_steer_message(&message);
                     if let Err(error) = turn
                         .ask_store
@@ -955,35 +975,16 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     {
                         return format!("Error queuing steer: {error}");
                     }
-                    let stream_input_enabled =
-                        crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false);
-                    return match effective_mid_turn_kind(
-                        &mission.backend,
-                        stream_input_enabled,
-                        mission.goal_mode,
-                    ) {
-                        MidTurnKind::StreamJsonStdin | MidTurnKind::CodexAppServer => {
-                            // Capability is the mission-level best case; the
-                            // runner makes the final call per turn (a /goal loop
-                            // or a Claude argv-fallback turn turns mid-turn
-                            // polling off), so promise mid-turn *when possible*
-                            // and name the next-turn fallback rather than
-                            // guaranteeing ~5s injection. Either way the note is
-                            // enqueued and never lost.
-                            "Steering message queued for the active mission. If the current turn \
-                             can accept mid-turn input it is injected within ~5s without cancelling \
-                             or losing in-flight work; otherwise (e.g. a /goal loop or a fallback \
-                             turn) it is delivered at the next turn boundary. No work is lost \
-                             either way."
-                                .to_string()
-                        }
-                        MidTurnKind::None => format!(
-                            "Steering message queued for the next turn — the `{}` harness can't \
-                             receive mid-turn messages in its current mode, so in-flight work is \
-                             preserved and the agent will see it at the next turn boundary.",
-                            mission.backend
-                        ),
-                    };
+                    // Capability is the best case; the runner still makes the
+                    // final per-turn call (a /goal loop or a Claude argv-fallback
+                    // turn disables mid-turn polling), so name the next-turn
+                    // fallback rather than guaranteeing ~5s. No work is lost.
+                    return "Steering message queued for the active mission. If the current turn \
+                            can accept mid-turn input it is injected within ~5s without cancelling \
+                            or losing in-flight work; otherwise (e.g. a /goal loop or a fallback \
+                            turn) it is delivered at the next turn boundary. No work is lost \
+                            either way."
+                        .to_string();
                 }
             }
             let content = format_steer_message(&message);
@@ -1175,6 +1176,30 @@ async fn cancel_working_agent(turn: &AskTurn) -> Result<(), String> {
         Ok(Ok(result)) => result,
         Ok(Err(_)) => Err("the control session dropped the request".to_string()),
         Err(_) => Err("timed out waiting for the cancellation to be acknowledged".to_string()),
+    }
+}
+
+/// Ask the control session whether this mission has a turn **actually in
+/// flight** right now (main or a parallel runner). This is the authoritative
+/// signal: the DB `MissionStatus::Active` can lag reality — a restart leaves the
+/// row `Active` with no runner attached until autoresume re-attaches — so it must
+/// not be used as a proxy for "a turn is executing" when choosing between
+/// mid-turn injection (needs a live turn to drain the note) and starting a turn.
+/// On any failure we return `false`, degrading to the authoritative UserMessage
+/// path (which starts a turn when idle and queues when running).
+async fn mission_has_live_turn(turn: &AskTurn) -> bool {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    if turn
+        .control_cmd_tx
+        .send(crate::api::control::ControlCommand::ListRunning { respond: tx })
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
+        Ok(Ok(list)) => list.iter().any(|m| m.mission_id == turn.mission_id),
+        _ => false,
     }
 }
 

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -963,9 +963,18 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                         mission.goal_mode,
                     ) {
                         MidTurnKind::StreamJsonStdin | MidTurnKind::CodexAppServer => {
-                            "Steering message queued for active mission delivery — it should be \
-                             injected mid-turn within ~5s without cancelling or losing in-flight \
-                             work."
+                            // Capability is the mission-level best case; the
+                            // runner makes the final call per turn (a /goal loop
+                            // or a Claude argv-fallback turn turns mid-turn
+                            // polling off), so promise mid-turn *when possible*
+                            // and name the next-turn fallback rather than
+                            // guaranteeing ~5s injection. Either way the note is
+                            // enqueued and never lost.
+                            "Steering message queued for the active mission. If the current turn \
+                             can accept mid-turn input it is injected within ~5s without cancelling \
+                             or losing in-flight work; otherwise (e.g. a /goal loop or a fallback \
+                             turn) it is delivered at the next turn boundary. No work is lost \
+                             either way."
                                 .to_string()
                         }
                         MidTurnKind::None => format!(

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1646,23 +1646,28 @@ pub fn run_claudecode_turn<'a>(
                         mission_id,
                         &events_tx,
                         |block| {
+                                // Claude delivery is synchronous: a successful
+                                // blocking write to the live stream-json stdin
+                                // means the frame is handed to the CLI, so the
+                                // returned `bool` is the true outcome.
                                 let msg = serde_json::json!({
                                     "type": "user",
                                     "message": { "role": "user", "content": [{ "type": "text", "text": block }] }
                                 });
-                                if let Some(w) = stdin_writer.as_mut() {
+                                let delivered = if let Some(w) = stdin_writer.as_mut() {
                                     use std::io::Write as _;
-                                    let delivered = writeln!(w, "{}", msg).and_then(|_| w.flush()).is_ok();
-                                    if delivered {
+                                    let ok = writeln!(w, "{}", msg).and_then(|_| w.flush()).is_ok();
+                                    if ok {
                                         tracing::info!(
                                             mission_id = %mission_id,
                                             "Injected operator notes mid-turn via stream-json stdin"
                                         );
                                     }
-                                    delivered
+                                    ok
                                 } else {
                                     false
-                                }
+                                };
+                                std::future::ready(delivered)
                         }
                     ).await;
                 }

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -134,6 +134,7 @@ pub fn run_claudecode_turn<'a>(
     tool_hub: Option<Arc<FrontendToolHub>>,
     status: Option<Arc<RwLock<ControlStatus>>>,
     override_auth: Option<crate::api::ai_providers::ClaudeCodeAuth>,
+    force_argv_prompt: bool,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentResult> + Send + 'a>> {
     Box::pin(async move {
         use crate::api::ai_providers::{
@@ -953,7 +954,8 @@ pub fn run_claudecode_turn<'a>(
         // MID-TURN (picked up after the current tool call completes, like
         // typing in the interactive CLI). The positional prompt is ignored
         // by the CLI in this mode, so it is not added.
-        let stream_input = crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false);
+        let stream_input = crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false)
+            && !force_argv_prompt;
         if stream_input {
             args.push("--input-format".to_string());
             args.push("stream-json".to_string());
@@ -1638,67 +1640,31 @@ pub fn run_claudecode_turn<'a>(
                 // immediately leaves the turn in AwaitingTerminalResult/
                 // AwaitingClaude (not this state), so those stalls remain subject
                 // to the watchdog as before.
-                _ = tokio::time::sleep_until(last_note_poll + Duration::from_secs(5)), if stream_input && stdin_writer.is_some() => {
+                _ = tokio::time::sleep_until(last_note_poll + crate::api::runners::midturn::MID_TURN_POLL), if stream_input && stdin_writer.is_some() => {
                     last_note_poll = Instant::now();
-                    if let Some(store) = crate::api::ask::ask_store_if_initialized() {
-                        match store.take_pending_operator_notes(mission_id).await {
-                            Ok(notes) if !notes.is_empty() => {
-                                let mut block = String::from("<operator-note>\n");
-                                for note in &notes {
-                                    block.push_str(&note.body);
-                                    block.push('\n');
-                                }
-                                block.push_str("</operator-note>");
+                    crate::api::runners::midturn::drain_and_inject(
+                        mission_id,
+                        &events_tx,
+                        |block| {
                                 let msg = serde_json::json!({
                                     "type": "user",
                                     "message": { "role": "user", "content": [{ "type": "text", "text": block }] }
                                 });
-                                let mut delivered = false;
                                 if let Some(w) = stdin_writer.as_mut() {
                                     use std::io::Write as _;
-                                    delivered = writeln!(w, "{}", msg).and_then(|_| w.flush()).is_ok();
-                                }
-                                if delivered {
-                                    tracing::info!(
-                                        mission_id = %mission_id,
-                                        notes = notes.len(),
-                                        "Injected operator notes mid-turn via stream-json stdin"
-                                    );
-                                    let _ = events_tx.send(AgentEvent::UserMessage {
-                                        id: Uuid::new_v4(),
-                                        content: block,
-                                        queued: false,
-                                        mission_id: Some(mission_id),
-                                    });
-                                } else {
-                                    // take_pending_operator_notes already marked them
-                                    // flushed — re-enqueue so they deliver at the next
-                                    // poll or the next turn-prep instead of being lost.
-                                    for note in &notes {
-                                        if let Err(e) = store
-                                            .enqueue_operator_note(
-                                                mission_id,
-                                                &note.body,
-                                                note.source_thread_id,
-                                            )
-                                            .await
-                                        {
-                                            tracing::error!(
-                                                mission_id = %mission_id,
-                                                "Failed to re-enqueue operator note after injection failure: {e}"
-                                            );
-                                        }
+                                    let delivered = writeln!(w, "{}", msg).and_then(|_| w.flush()).is_ok();
+                                    if delivered {
+                                        tracing::info!(
+                                            mission_id = %mission_id,
+                                            "Injected operator notes mid-turn via stream-json stdin"
+                                        );
                                     }
-                                    tracing::warn!(
-                                        mission_id = %mission_id,
-                                        notes = notes.len(),
-                                        "Mid-turn note injection failed; notes re-enqueued for next delivery"
-                                    );
+                                    delivered
+                                } else {
+                                    false
                                 }
-                            }
-                            _ => {}
                         }
-                    }
+                    ).await;
                 }
                 _ = tokio::time::sleep_until(last_heartbeat_at + heartbeat_interval),
                     if saw_non_init_event
@@ -2117,6 +2083,7 @@ pub fn run_claudecode_turn<'a>(
                                                             tool_hub,
                                                             status,
                                                             override_auth_for_continuation,
+                                                            force_argv_prompt,
                                                         ).await;
                                                     }
                                                 }
@@ -2718,6 +2685,16 @@ pub fn run_claudecode_turn<'a>(
     }) // end Box::pin(async move { ... })
 }
 
+fn claudecode_result_is_startup_transport_failure(result: &AgentResult) -> bool {
+    result
+        .data
+        .as_ref()
+        .and_then(|data| data.get("claudecode_transport_failure"))
+        .and_then(|value| value.get("stage"))
+        .and_then(|value| value.as_str())
+        == Some("startup")
+}
+
 /// Claude Code turn with the full recovery orchestration:
 /// transport-failure retries (resume current session, then fresh-session
 /// reset with condensed history), SIGKILL-driven proactive OAuth refresh,
@@ -2772,8 +2749,42 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
         tool_hub.clone(),
         status.clone(),
         None, // override_auth: use default credential resolution
+        false,
     )
     .await;
+
+    let mut force_argv_prompt = false;
+    if crate::util::env_var_bool("SANDBOXED_SH_CLAUDE_STREAM_INPUT", false)
+        && claudecode_result_is_startup_transport_failure(&result)
+        && !cancel.is_cancelled()
+        && !crate::api::routes::is_shutdown_initiated()
+    {
+        force_argv_prompt = true;
+        tracing::warn!(
+            mission_id = %mission_id,
+            "Claude stream-input turn emitted zero usable events; retrying once with argv prompt delivery"
+        );
+        result = run_claudecode_turn(
+            workspace,
+            work_dir,
+            &effective_msg,
+            model,
+            model_effort,
+            agent,
+            mission_id,
+            events_tx.clone(),
+            cancel.clone(),
+            secrets.clone(),
+            app_working_dir,
+            effective_sid.as_deref(),
+            is_continuation,
+            tool_hub.clone(),
+            status.clone(),
+            None,
+            true,
+        )
+        .await;
+    }
 
     loop {
         if cancel.is_cancelled() || crate::api::routes::is_shutdown_initiated() {
@@ -2817,6 +2828,7 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
                     tool_hub.clone(),
                     status.clone(),
                     None,
+                    force_argv_prompt,
                 )
                 .await;
             }
@@ -2882,6 +2894,7 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
                     tool_hub.clone(),
                     status.clone(),
                     None,
+                    force_argv_prompt,
                 )
                 .await;
             }
@@ -2944,6 +2957,7 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
             tool_hub.clone(),
             status.clone(),
             None,
+            force_argv_prompt,
         )
         .await;
     }
@@ -3000,6 +3014,7 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
                     tool_hub.clone(),
                     status.clone(),
                     Some(alt_auth),
+                    force_argv_prompt,
                 )
                 .await;
                 // Continue rotating on account-specific failures.
@@ -3054,6 +3069,7 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
             tool_hub.clone(),
             status.clone(),
             None,
+            force_argv_prompt,
         )
         .await;
     }

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -884,7 +884,9 @@ pub async fn run_codex_turn(
     };
 
     // Send message streaming
-    let (mut event_rx, _handle) = match backend.send_message_streaming(&session, user_message).await
+    let (mut event_rx, _handle, inject_tx) = match backend
+        .send_message_streaming_with_inject(&session, user_message)
+        .await
     {
         Ok(result) => result,
         Err(e) => {
@@ -930,12 +932,14 @@ pub async fn run_codex_turn(
     // loop and let the post-loop finalization recover whatever it can.
     let mut cancelled = false;
     let mut codex_goal_cancel_deferred = false;
+    let mut last_note_poll = tokio::time::Instant::now();
+    let is_goal_request = codex_is_goal_request(user_message);
 
     loop {
         tokio::select! {
             _ = cancel.cancelled(), if !codex_goal_cancel_deferred => {
                 tracing::info!("Codex turn cancelled for mission {}", mission_id);
-                if codex_is_goal_request(user_message) && !codex_goal_cancel_deferred {
+                if is_goal_request && !codex_goal_cancel_deferred {
                     // Goal-mode cancellation must be handled by the app-server
                     // task because it owns the live thread id needed for
                     // `thread/goal/clear`. Keep draining events until it emits
@@ -947,6 +951,14 @@ pub async fn run_codex_turn(
                 // the event stream task ends.
                 cancelled = true;
                 break;
+            }
+            _ = tokio::time::sleep_until(last_note_poll + crate::api::runners::midturn::MID_TURN_POLL), if !is_goal_request => {
+                last_note_poll = tokio::time::Instant::now();
+                crate::api::runners::midturn::drain_and_inject(
+                    mission_id,
+                    &events_tx,
+                    |block| inject_tx.try_send(block.to_string()).is_ok(),
+                ).await;
             }
             Some(event) = event_rx.recv() => {
                 match event {

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -957,7 +957,21 @@ pub async fn run_codex_turn(
                 crate::api::runners::midturn::drain_and_inject(
                     mission_id,
                     &events_tx,
-                    |block| inject_tx.try_send(block.to_string()).is_ok(),
+                    |block| {
+                        let inject_tx = inject_tx.clone();
+                        async move {
+                            // Delivery is two-stage: enqueue onto the inject
+                            // channel, then wait for the driver task to report
+                            // whether the deferred `turn/start` RPC succeeded.
+                            // Returning the real outcome lets drain_and_inject
+                            // re-enqueue the notes if injection ultimately fails.
+                            let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+                            if inject_tx.try_send((block, ack_tx)).is_err() {
+                                return false;
+                            }
+                            ack_rx.await.unwrap_or(false)
+                        }
+                    },
                 ).await;
             }
             Some(event) = event_rx.recv() => {

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -883,8 +883,13 @@ pub async fn run_codex_turn(
         }
     };
 
-    // Send message streaming
-    let (mut event_rx, _handle, inject_tx) = match backend
+    // Send message streaming. Mid-turn injection (`_inject_tx`) is intentionally
+    // unused: Codex mid-turn steering is disabled because the non-goal driver
+    // ends the mission on the first `turn/completed`, so an injected `turn/start`
+    // would be abandoned. Steers fall back to the authoritative next-turn path
+    // (see effective_mid_turn_kind). Keep the channel so the backend signature is
+    // stable for when injected-turn tracking (or a turn/steer RPC) lands.
+    let (mut event_rx, _handle, _inject_tx) = match backend
         .send_message_streaming_with_inject(&session, user_message)
         .await
     {
@@ -932,7 +937,6 @@ pub async fn run_codex_turn(
     // loop and let the post-loop finalization recover whatever it can.
     let mut cancelled = false;
     let mut codex_goal_cancel_deferred = false;
-    let mut last_note_poll = tokio::time::Instant::now();
     let is_goal_request = codex_is_goal_request(user_message);
 
     loop {
@@ -951,28 +955,6 @@ pub async fn run_codex_turn(
                 // the event stream task ends.
                 cancelled = true;
                 break;
-            }
-            _ = tokio::time::sleep_until(last_note_poll + crate::api::runners::midturn::MID_TURN_POLL), if !is_goal_request => {
-                last_note_poll = tokio::time::Instant::now();
-                crate::api::runners::midturn::drain_and_inject(
-                    mission_id,
-                    &events_tx,
-                    |block| {
-                        let inject_tx = inject_tx.clone();
-                        async move {
-                            // Delivery is two-stage: enqueue onto the inject
-                            // channel, then wait for the driver task to report
-                            // whether the deferred `turn/start` RPC succeeded.
-                            // Returning the real outcome lets drain_and_inject
-                            // re-enqueue the notes if injection ultimately fails.
-                            let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-                            if inject_tx.try_send((block, ack_tx)).is_err() {
-                                return false;
-                            }
-                            ack_rx.await.unwrap_or(false)
-                        }
-                    },
-                ).await;
             }
             Some(event) = event_rx.recv() => {
                 match event {

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -883,15 +883,11 @@ pub async fn run_codex_turn(
         }
     };
 
-    // Send message streaming. Mid-turn injection (`_inject_tx`) is intentionally
-    // unused: Codex mid-turn steering is disabled because the non-goal driver
-    // ends the mission on the first `turn/completed`, so an injected `turn/start`
-    // would be abandoned. Steers fall back to the authoritative next-turn path
-    // (see effective_mid_turn_kind). Keep the channel so the backend signature is
-    // stable for when injected-turn tracking (or a turn/steer RPC) lands.
-    let (mut event_rx, _handle, _inject_tx) = match backend
-        .send_message_streaming_with_inject(&session, user_message)
-        .await
+    // Send message streaming. Codex has no mid-turn injection: the non-goal
+    // driver ends the mission on the first `turn/completed`, so an injected
+    // `turn/start` would be abandoned. Steers fall back to the authoritative
+    // next-turn path (see effective_mid_turn_kind).
+    let (mut event_rx, _handle) = match backend.send_message_streaming(&session, user_message).await
     {
         Ok(result) => result,
         Err(e) => {

--- a/src/api/runners/midturn.rs
+++ b/src/api/runners/midturn.rs
@@ -1,0 +1,141 @@
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use crate::api::control::AgentEvent;
+
+pub(crate) const MID_TURN_POLL: Duration = Duration::from_secs(5);
+
+pub(crate) async fn drain_and_inject<F>(
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    inject: F,
+) where
+    F: FnOnce(&str) -> bool,
+{
+    let Some(store) = crate::api::ask::ask_store_if_initialized() else {
+        return;
+    };
+    drain_and_inject_from_store(store, mission_id, events_tx, inject).await;
+}
+
+async fn drain_and_inject_from_store<F>(
+    store: std::sync::Arc<crate::api::ask::AskStore>,
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    inject: F,
+) where
+    F: FnOnce(&str) -> bool,
+{
+    let notes = match store.take_pending_operator_notes(mission_id).await {
+        Ok(notes) if !notes.is_empty() => notes,
+        Ok(_) => return,
+        Err(error) => {
+            tracing::warn!(
+                mission_id = %mission_id,
+                "Failed to drain operator notes for mid-turn injection: {error}"
+            );
+            return;
+        }
+    };
+
+    let mut block = String::from("<operator-note>\n");
+    for note in &notes {
+        block.push_str(&note.body);
+        block.push('\n');
+    }
+    block.push_str("</operator-note>");
+
+    if inject(&block) {
+        tracing::info!(
+            mission_id = %mission_id,
+            notes = notes.len(),
+            "Injected operator notes mid-turn"
+        );
+        let _ = events_tx.send(AgentEvent::UserMessage {
+            id: Uuid::new_v4(),
+            content: block,
+            queued: false,
+            mission_id: Some(mission_id),
+        });
+        return;
+    }
+
+    for note in &notes {
+        if let Err(error) = store
+            .enqueue_operator_note(mission_id, &note.body, note.source_thread_id)
+            .await
+        {
+            tracing::error!(
+                mission_id = %mission_id,
+                "Failed to re-enqueue operator note after injection failure: {error}"
+            );
+        }
+    }
+    tracing::warn!(
+        mission_id = %mission_id,
+        notes = notes.len(),
+        "Mid-turn note injection failed; notes re-enqueued for next delivery"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::api::ask::AskStore;
+
+    async fn temp_store() -> Arc<AskStore> {
+        let path = std::env::temp_dir().join(format!("midturn-{}.db", Uuid::new_v4()));
+        Arc::new(AskStore::open(path).await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn drain_and_inject_emits_event_on_success_and_requeues_on_failure() {
+        let mission_id = Uuid::new_v4();
+        let store = temp_store().await;
+        let (events_tx, mut events_rx) = broadcast::channel(8);
+        store
+            .enqueue_operator_note(mission_id, "first note", None)
+            .await
+            .unwrap();
+        store
+            .enqueue_operator_note(mission_id, "second note", None)
+            .await
+            .unwrap();
+
+        let captured = Arc::new(Mutex::new(String::new()));
+        let captured_for_inject = Arc::clone(&captured);
+        drain_and_inject_from_store(Arc::clone(&store), mission_id, &events_tx, |block| {
+            *captured_for_inject.lock().unwrap() = block.to_string();
+            true
+        })
+        .await;
+
+        let block = captured.lock().unwrap().clone();
+        assert!(block.starts_with("<operator-note>"));
+        assert!(block.contains("first note"));
+        assert!(block.contains("second note"));
+        assert!(matches!(
+            events_rx.try_recv().unwrap(),
+            AgentEvent::UserMessage { queued: false, .. }
+        ));
+        assert!(store
+            .take_pending_operator_notes(mission_id)
+            .await
+            .unwrap()
+            .is_empty());
+
+        store
+            .enqueue_operator_note(mission_id, "retry me", None)
+            .await
+            .unwrap();
+        drain_and_inject_from_store(Arc::clone(&store), mission_id, &events_tx, |_| false).await;
+
+        let pending = store.take_pending_operator_notes(mission_id).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].body, "retry me");
+    }
+}

--- a/src/api/runners/midturn.rs
+++ b/src/api/runners/midturn.rs
@@ -7,12 +7,13 @@ use crate::api::control::AgentEvent;
 
 pub(crate) const MID_TURN_POLL: Duration = Duration::from_secs(5);
 
-pub(crate) async fn drain_and_inject<F>(
+pub(crate) async fn drain_and_inject<F, Fut>(
     mission_id: Uuid,
     events_tx: &broadcast::Sender<AgentEvent>,
     inject: F,
 ) where
-    F: FnOnce(&str) -> bool,
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = bool>,
 {
     let Some(store) = crate::api::ask::ask_store_if_initialized() else {
         return;
@@ -20,13 +21,20 @@ pub(crate) async fn drain_and_inject<F>(
     drain_and_inject_from_store(store, mission_id, events_tx, inject).await;
 }
 
-async fn drain_and_inject_from_store<F>(
+// The injection closure is `async` and its `bool` MUST mean the note block was
+// *actually accepted by the backend* — not merely queued for delivery. Backends
+// whose delivery is deferred (e.g. Codex enqueues onto an inject channel that a
+// driver task later turns into a `turn/start` RPC) must therefore await the real
+// outcome before returning, so a failed RPC re-enqueues the notes here instead
+// of silently dropping them after we already took them off the queue.
+async fn drain_and_inject_from_store<F, Fut>(
     store: std::sync::Arc<crate::api::ask::AskStore>,
     mission_id: Uuid,
     events_tx: &broadcast::Sender<AgentEvent>,
     inject: F,
 ) where
-    F: FnOnce(&str) -> bool,
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = bool>,
 {
     let notes = match store.take_pending_operator_notes(mission_id).await {
         Ok(notes) if !notes.is_empty() => notes,
@@ -47,7 +55,7 @@ async fn drain_and_inject_from_store<F>(
     }
     block.push_str("</operator-note>");
 
-    if inject(&block) {
+    if inject(block.clone()).await {
         tracing::info!(
             mission_id = %mission_id,
             notes = notes.len(),
@@ -109,8 +117,11 @@ mod tests {
         let captured = Arc::new(Mutex::new(String::new()));
         let captured_for_inject = Arc::clone(&captured);
         drain_and_inject_from_store(Arc::clone(&store), mission_id, &events_tx, |block| {
-            *captured_for_inject.lock().unwrap() = block.to_string();
-            true
+            let captured_for_inject = Arc::clone(&captured_for_inject);
+            async move {
+                *captured_for_inject.lock().unwrap() = block.clone();
+                true
+            }
         })
         .await;
 
@@ -132,7 +143,10 @@ mod tests {
             .enqueue_operator_note(mission_id, "retry me", None)
             .await
             .unwrap();
-        drain_and_inject_from_store(Arc::clone(&store), mission_id, &events_tx, |_| false).await;
+        drain_and_inject_from_store(Arc::clone(&store), mission_id, &events_tx, |_| async {
+            false
+        })
+        .await;
 
         let pending = store.take_pending_operator_notes(mission_id).await.unwrap();
         assert_eq!(pending.len(), 1);

--- a/src/api/runners/mod.rs
+++ b/src/api/runners/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod codex;
 pub(crate) mod errors;
 pub(crate) mod gemini;
 pub(crate) mod grok;
+pub(crate) mod midturn;
 pub(crate) mod opencode;
 
 use std::future::Future;
@@ -72,10 +73,20 @@ pub(crate) enum TurnExtras<'a> {
 /// reintroduces the async stack overflow this codebase already fixed once.
 pub(crate) trait HarnessRunner: Send + Sync {
     fn name(&self) -> &'static str;
+    fn mid_turn_kind(&self) -> MidTurnKind {
+        MidTurnKind::None
+    }
     fn run_turn<'a>(
         &'a self,
         ctx: TurnContext<'a>,
     ) -> Pin<Box<dyn Future<Output = AgentResult> + Send + 'a>>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MidTurnKind {
+    None,
+    StreamJsonStdin,
+    CodexAppServer,
 }
 
 pub(crate) struct ClaudeCodeRunner;
@@ -87,6 +98,9 @@ pub(crate) struct GeminiRunner;
 impl HarnessRunner for ClaudeCodeRunner {
     fn name(&self) -> &'static str {
         "claudecode"
+    }
+    fn mid_turn_kind(&self) -> MidTurnKind {
+        MidTurnKind::StreamJsonStdin
     }
     fn run_turn<'a>(
         &'a self,
@@ -155,6 +169,9 @@ impl HarnessRunner for OpenCodeRunner {
 impl HarnessRunner for CodexRunner {
     fn name(&self) -> &'static str {
         "codex"
+    }
+    fn mid_turn_kind(&self) -> MidTurnKind {
+        MidTurnKind::CodexAppServer
     }
     fn run_turn<'a>(
         &'a self,
@@ -236,6 +253,20 @@ pub(crate) fn runner_for(backend_id: &str) -> Option<&'static dyn HarnessRunner>
     }
 }
 
+pub(crate) fn effective_mid_turn_kind(
+    backend_id: &str,
+    stream_input_enabled: bool,
+    is_goal: bool,
+) -> MidTurnKind {
+    match backend_id {
+        "claudecode" if !stream_input_enabled => MidTurnKind::None,
+        "codex" if is_goal => MidTurnKind::None,
+        _ => runner_for(backend_id)
+            .map(|runner| runner.mid_turn_kind())
+            .unwrap_or(MidTurnKind::None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,5 +279,40 @@ mod tests {
         }
         assert!(runner_for("unknown").is_none());
         assert!(runner_for("").is_none());
+
+        assert_eq!(
+            runner_for("claudecode").unwrap().mid_turn_kind(),
+            MidTurnKind::StreamJsonStdin
+        );
+        assert_eq!(
+            runner_for("codex").unwrap().mid_turn_kind(),
+            MidTurnKind::CodexAppServer
+        );
+        for backend in ["opencode", "grok", "gemini"] {
+            assert_eq!(
+                runner_for(backend).unwrap().mid_turn_kind(),
+                MidTurnKind::None
+            );
+        }
+        assert_eq!(
+            effective_mid_turn_kind("claudecode", true, false),
+            MidTurnKind::StreamJsonStdin
+        );
+        assert_eq!(
+            effective_mid_turn_kind("claudecode", false, false),
+            MidTurnKind::None
+        );
+        assert_eq!(
+            effective_mid_turn_kind("codex", true, false),
+            MidTurnKind::CodexAppServer
+        );
+        assert_eq!(
+            effective_mid_turn_kind("codex", true, true),
+            MidTurnKind::None
+        );
+        assert_eq!(
+            effective_mid_turn_kind("opencode", true, false),
+            MidTurnKind::None
+        );
     }
 }

--- a/src/api/runners/mod.rs
+++ b/src/api/runners/mod.rs
@@ -171,6 +171,12 @@ impl HarnessRunner for CodexRunner {
         "codex"
     }
     fn mid_turn_kind(&self) -> MidTurnKind {
+        // Raw backend capability: the app-server accepts a second `turn/start`
+        // on the live thread. NOTE: this is gated OFF in
+        // `effective_mid_turn_kind` — the non-goal driver marks the turn
+        // terminal on the first `turn/completed` (see codex/mod.rs), so an
+        // injected turn would be abandoned. Re-enable once the driver tracks
+        // injected turns (or a `turn/steer`-style append RPC is wired).
         MidTurnKind::CodexAppServer
     }
     fn run_turn<'a>(
@@ -258,9 +264,17 @@ pub(crate) fn effective_mid_turn_kind(
     stream_input_enabled: bool,
     is_goal: bool,
 ) -> MidTurnKind {
+    // `is_goal` is retained for API stability / future re-enable; Codex is
+    // currently gated off entirely (see below), so it is unused for now.
+    let _ = is_goal;
     match backend_id {
         "claudecode" if !stream_input_enabled => MidTurnKind::None,
-        "codex" if is_goal => MidTurnKind::None,
+        // Codex mid-turn injection is disabled: the app-server can start a
+        // second turn, but the non-goal driver ends the mission on the first
+        // `turn/completed`, so the injected turn is abandoned and the steer
+        // never reaches the model. Fall back to the authoritative next-turn
+        // path until the driver can consume an injected turn.
+        "codex" => MidTurnKind::None,
         _ => runner_for(backend_id)
             .map(|runner| runner.mid_turn_kind())
             .unwrap_or(MidTurnKind::None),
@@ -302,9 +316,12 @@ mod tests {
             effective_mid_turn_kind("claudecode", false, false),
             MidTurnKind::None
         );
+        // Codex is gated off in effective_mid_turn_kind (driver can't consume
+        // an injected turn yet) even though its raw mid_turn_kind is
+        // CodexAppServer — regardless of goal mode.
         assert_eq!(
             effective_mid_turn_kind("codex", true, false),
-            MidTurnKind::CodexAppServer
+            MidTurnKind::None
         );
         assert_eq!(
             effective_mid_turn_kind("codex", true, true),

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -62,6 +62,23 @@ impl CodexBackend {
     pub async fn get_config(&self) -> CodexConfig {
         self.config.read().await.clone()
     }
+
+    pub(crate) async fn send_message_streaming_with_inject(
+        &self,
+        session: &Session,
+        message: &str,
+    ) -> Result<
+        (
+            mpsc::Receiver<ExecutionEvent>,
+            JoinHandle<()>,
+            mpsc::Sender<String>,
+        ),
+        Error,
+    > {
+        let config = self.config.read().await.clone();
+        send_message_streaming_app_server(config, session, message, self.workspace_exec.as_ref())
+            .await
+    }
 }
 
 impl Default for CodexBackend {
@@ -111,13 +128,14 @@ impl Backend for CodexBackend {
         session: &Session,
         message: &str,
     ) -> Result<(mpsc::Receiver<ExecutionEvent>, JoinHandle<()>), Error> {
-        let config = self.config.read().await.clone();
         // All codex missions go through app-server now (Path A). The legacy
         // `codex exec` branch was removed because it can't parse slash
         // commands, never arms goals.rs, and the new path covers both
         // regular and goal missions.
-        send_message_streaming_app_server(config, session, message, self.workspace_exec.as_ref())
-            .await
+        let (rx, handle, _inject_tx) = self
+            .send_message_streaming_with_inject(session, message)
+            .await?;
+        Ok((rx, handle))
     }
 }
 
@@ -196,7 +214,14 @@ async fn send_message_streaming_app_server(
     session: &Session,
     message: &str,
     workspace_exec: Option<&crate::workspace_exec::WorkspaceExec>,
-) -> Result<(mpsc::Receiver<ExecutionEvent>, JoinHandle<()>), Error> {
+) -> Result<
+    (
+        mpsc::Receiver<ExecutionEvent>,
+        JoinHandle<()>,
+        mpsc::Sender<String>,
+    ),
+    Error,
+> {
     use app_server::{
         AppServerConfig, AppServerSession, GoalSetParams, InboundMessage, ThreadStartParams,
         TurnStartParams, UserInputItem,
@@ -288,6 +313,7 @@ async fn send_message_streaming_app_server(
     };
 
     let (tx, rx) = mpsc::channel::<ExecutionEvent>(256);
+    let (inject_tx, mut inject_rx) = mpsc::channel::<String>(8);
 
     // Take the inbound channel before issuing any further RPC — `goal/set`
     // and `turn/start` start emitting notifications before they return.
@@ -443,6 +469,22 @@ async fn send_message_streaming_app_server(
                         Some(m) => m,
                         None => break, // inner loop → check whether to reconnect
                     },
+                    Some(text) = inject_rx.recv(), if !is_goal_mission => {
+                        if let Err(e) = session_arc
+                            .turn_start(TurnStartParams {
+                                thread_id: thread_id.clone(),
+                                input: vec![UserInputItem::Text { text }],
+                            })
+                            .await
+                        {
+                            tracing::warn!(
+                                thread_id = %thread_id,
+                                "codex app-server mid-turn injection failed: {}",
+                                e
+                            );
+                        }
+                        continue;
+                    }
                 };
 
                 match msg {
@@ -601,7 +643,7 @@ async fn send_message_streaming_app_server(
         let _ = session_arc.shutdown().await;
     });
 
-    Ok((rx, handle))
+    Ok((rx, handle, inject_tx))
 }
 
 /// Auto-approve any server-initiated elicitation. Matches exec-mode's

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -13,6 +13,12 @@ use crate::backend::{AgentInfo, Backend, Session, SessionConfig};
 
 use client::CodexConfig;
 
+/// Mid-turn injection request: the note block plus a one-shot the driver task
+/// uses to report whether the deferred `turn/start` RPC actually succeeded. The
+/// caller awaits this ack so a failed injection re-enqueues the notes instead of
+/// dropping them (they were already taken off the operator-note queue).
+pub(crate) type InjectRequest = (String, tokio::sync::oneshot::Sender<bool>);
+
 /// Codex backend that spawns the Codex CLI for mission execution.
 pub struct CodexBackend {
     id: String,
@@ -71,7 +77,7 @@ impl CodexBackend {
         (
             mpsc::Receiver<ExecutionEvent>,
             JoinHandle<()>,
-            mpsc::Sender<String>,
+            mpsc::Sender<InjectRequest>,
         ),
         Error,
     > {
@@ -218,7 +224,7 @@ async fn send_message_streaming_app_server(
     (
         mpsc::Receiver<ExecutionEvent>,
         JoinHandle<()>,
-        mpsc::Sender<String>,
+        mpsc::Sender<InjectRequest>,
     ),
     Error,
 > {
@@ -313,7 +319,7 @@ async fn send_message_streaming_app_server(
     };
 
     let (tx, rx) = mpsc::channel::<ExecutionEvent>(256);
-    let (inject_tx, mut inject_rx) = mpsc::channel::<String>(8);
+    let (inject_tx, mut inject_rx) = mpsc::channel::<InjectRequest>(8);
 
     // Take the inbound channel before issuing any further RPC — `goal/set`
     // and `turn/start` start emitting notifications before they return.
@@ -469,20 +475,27 @@ async fn send_message_streaming_app_server(
                         Some(m) => m,
                         None => break, // inner loop → check whether to reconnect
                     },
-                    Some(text) = inject_rx.recv(), if !is_goal_mission => {
-                        if let Err(e) = session_arc
+                    Some((text, ack)) = inject_rx.recv(), if !is_goal_mission => {
+                        let delivered = match session_arc
                             .turn_start(TurnStartParams {
                                 thread_id: thread_id.clone(),
                                 input: vec![UserInputItem::Text { text }],
                             })
                             .await
                         {
-                            tracing::warn!(
-                                thread_id = %thread_id,
-                                "codex app-server mid-turn injection failed: {}",
-                                e
-                            );
-                        }
+                            Ok(_) => true,
+                            Err(e) => {
+                                tracing::warn!(
+                                    thread_id = %thread_id,
+                                    "codex app-server mid-turn injection failed: {}",
+                                    e
+                                );
+                                false
+                            }
+                        };
+                        // Report the real RPC outcome so the caller re-enqueues
+                        // the notes when delivery failed.
+                        let _ = ack.send(delivered);
                         continue;
                     }
                 };

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -13,12 +13,6 @@ use crate::backend::{AgentInfo, Backend, Session, SessionConfig};
 
 use client::CodexConfig;
 
-/// Mid-turn injection request: the note block plus a one-shot the driver task
-/// uses to report whether the deferred `turn/start` RPC actually succeeded. The
-/// caller awaits this ack so a failed injection re-enqueues the notes instead of
-/// dropping them (they were already taken off the operator-note queue).
-pub(crate) type InjectRequest = (String, tokio::sync::oneshot::Sender<bool>);
-
 /// Codex backend that spawns the Codex CLI for mission execution.
 pub struct CodexBackend {
     id: String,
@@ -67,23 +61,6 @@ impl CodexBackend {
     /// Get the current configuration.
     pub async fn get_config(&self) -> CodexConfig {
         self.config.read().await.clone()
-    }
-
-    pub(crate) async fn send_message_streaming_with_inject(
-        &self,
-        session: &Session,
-        message: &str,
-    ) -> Result<
-        (
-            mpsc::Receiver<ExecutionEvent>,
-            JoinHandle<()>,
-            mpsc::Sender<InjectRequest>,
-        ),
-        Error,
-    > {
-        let config = self.config.read().await.clone();
-        send_message_streaming_app_server(config, session, message, self.workspace_exec.as_ref())
-            .await
     }
 }
 
@@ -138,10 +115,9 @@ impl Backend for CodexBackend {
         // `codex exec` branch was removed because it can't parse slash
         // commands, never arms goals.rs, and the new path covers both
         // regular and goal missions.
-        let (rx, handle, _inject_tx) = self
-            .send_message_streaming_with_inject(session, message)
-            .await?;
-        Ok((rx, handle))
+        let config = self.config.read().await.clone();
+        send_message_streaming_app_server(config, session, message, self.workspace_exec.as_ref())
+            .await
     }
 }
 
@@ -220,14 +196,7 @@ async fn send_message_streaming_app_server(
     session: &Session,
     message: &str,
     workspace_exec: Option<&crate::workspace_exec::WorkspaceExec>,
-) -> Result<
-    (
-        mpsc::Receiver<ExecutionEvent>,
-        JoinHandle<()>,
-        mpsc::Sender<InjectRequest>,
-    ),
-    Error,
-> {
+) -> Result<(mpsc::Receiver<ExecutionEvent>, JoinHandle<()>), Error> {
     use app_server::{
         AppServerConfig, AppServerSession, GoalSetParams, InboundMessage, ThreadStartParams,
         TurnStartParams, UserInputItem,
@@ -319,7 +288,6 @@ async fn send_message_streaming_app_server(
     };
 
     let (tx, rx) = mpsc::channel::<ExecutionEvent>(256);
-    let (inject_tx, mut inject_rx) = mpsc::channel::<InjectRequest>(8);
 
     // Take the inbound channel before issuing any further RPC — `goal/set`
     // and `turn/start` start emitting notifications before they return.
@@ -475,37 +443,6 @@ async fn send_message_streaming_app_server(
                         Some(m) => m,
                         None => break, // inner loop → check whether to reconnect
                     },
-                    Some((text, ack)) = inject_rx.recv() => {
-                        // Always consume the inject channel and ack so the caller
-                        // (which awaits this ack to decide whether to flush or
-                        // re-enqueue the operator notes) can never block. Goal
-                        // turns own a persistent thread that must not receive an
-                        // extra turn/start, so they ack `false` → the notes are
-                        // re-enqueued for next-turn delivery.
-                        let delivered = if is_goal_mission {
-                            false
-                        } else {
-                            match session_arc
-                                .turn_start(TurnStartParams {
-                                    thread_id: thread_id.clone(),
-                                    input: vec![UserInputItem::Text { text }],
-                                })
-                                .await
-                            {
-                                Ok(_) => true,
-                                Err(e) => {
-                                    tracing::warn!(
-                                        thread_id = %thread_id,
-                                        "codex app-server mid-turn injection failed: {}",
-                                        e
-                                    );
-                                    false
-                                }
-                            }
-                        };
-                        let _ = ack.send(delivered);
-                        continue;
-                    }
                 };
 
                 match msg {
@@ -664,7 +601,7 @@ async fn send_message_streaming_app_server(
         let _ = session_arc.shutdown().await;
     });
 
-    Ok((rx, handle, inject_tx))
+    Ok((rx, handle))
 }
 
 /// Auto-approve any server-initiated elicitation. Matches exec-mode's

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -475,26 +475,34 @@ async fn send_message_streaming_app_server(
                         Some(m) => m,
                         None => break, // inner loop → check whether to reconnect
                     },
-                    Some((text, ack)) = inject_rx.recv(), if !is_goal_mission => {
-                        let delivered = match session_arc
-                            .turn_start(TurnStartParams {
-                                thread_id: thread_id.clone(),
-                                input: vec![UserInputItem::Text { text }],
-                            })
-                            .await
-                        {
-                            Ok(_) => true,
-                            Err(e) => {
-                                tracing::warn!(
-                                    thread_id = %thread_id,
-                                    "codex app-server mid-turn injection failed: {}",
-                                    e
-                                );
-                                false
+                    Some((text, ack)) = inject_rx.recv() => {
+                        // Always consume the inject channel and ack so the caller
+                        // (which awaits this ack to decide whether to flush or
+                        // re-enqueue the operator notes) can never block. Goal
+                        // turns own a persistent thread that must not receive an
+                        // extra turn/start, so they ack `false` → the notes are
+                        // re-enqueued for next-turn delivery.
+                        let delivered = if is_goal_mission {
+                            false
+                        } else {
+                            match session_arc
+                                .turn_start(TurnStartParams {
+                                    thread_id: thread_id.clone(),
+                                    input: vec![UserInputItem::Text { text }],
+                                })
+                                .await
+                            {
+                                Ok(_) => true,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        thread_id = %thread_id,
+                                        "codex app-server mid-turn injection failed: {}",
+                                        e
+                                    );
+                                    false
+                                }
                             }
                         };
-                        // Report the real RPC outcome so the caller re-enqueues
-                        // the notes when delivery failed.
                         let _ = ack.send(delivered);
                         continue;
                     }


### PR DESCRIPTION
## Summary
- add a shared harness capability model for mid-turn operator-note delivery
- factor operator-note draining/requeue safety into `api::runners::midturn`
- wire Claude stream-json stdin and Codex app-server second-turn injection through the shared helper
- make Ask `send_to_agent` tier-honest: active missions enqueue operator notes with mid-turn/next-turn reporting, idle missions still start a turn, interrupt remains a hard cancel/restart path
- add Claude stream-input zero-event fallback to retry once with argv prompt delivery

## Verification
- `cargo fmt`
- `cargo test --lib` (1071 passed, 1 ignored)
- `cargo test drain_and_inject_emits_event_on_success_and_requeues_on_failure --lib`
- `cargo test runner_for_maps_every_backend --lib`
- `cargo clippy --all-targets -- -D clippy::all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission steering and Claude turn startup/recovery paths; mis-routing could queue steers without delivery, though failures degrade to UserMessage and note re-enqueue limits loss.
> 
> **Overview**
> **Ask `send_to_agent`** no longer treats `immediate=true` as the only mid-turn path. Non-interrupt steers enqueue operator notes when the backend is mid-turn-capable (Claude stream-json with stream input enabled), the mission has a **live turn** per `ListRunning` (not DB `Active`), and the thread isn’t sandboxed; otherwise they still go through `UserMessage` (start if idle, queue at next boundary). Tool docs and user-facing copy are updated; `immediate` is a legacy no-op.
> 
> **Runners** gain `MidTurnKind` on harnesses plus `effective_mid_turn_kind` (stream input off → none for Claude; **Codex forced to none** until the driver can consume injected turns). Shared **`midturn::drain_and_inject`** handles poll interval, success events, and re-queue on failed injection; Claude’s inline loop delegates to it.
> 
> **Claude Code** adds `force_argv_prompt` to disable stream-json stdin; on **startup** transport failure with zero usable events, it retries once with argv prompt delivery and keeps that mode through recovery/rotation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c297e797209d43ee634e81ee2a6c3624d1660b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->