### PR TITLE
fix(control,codex): isolate mission streams and codex state

### DIFF
--- a/dashboard/src/app/control/control-client.item-views.test.ts
+++ b/dashboard/src/app/control/control-client.item-views.test.ts
@@ -69,7 +69,11 @@ describe("deriveItemViews", () => {
       endTime: 3,
     };
 
-    const views = deriveItemViews([completedStream, assistantItem], true, false);
+    const views = deriveItemViews(
+      [completedStream, assistantItem],
+      true,
+      false,
+    );
 
     expect(views.thinkingItems).toEqual([completedStream]);
     expect(views.groupedItems).toEqual([assistantItem]);
@@ -239,6 +243,30 @@ describe("appendUnpersistedLiveTail", () => {
     );
 
     expect(views).toEqual([missionBUser]);
+  });
+
+  it("uses the viewed mission user as the live tail anchor", () => {
+    const missionAUser: Extract<ChatItem, { kind: "user" }> = {
+      ...userItem,
+      missionId: "mission-a",
+    };
+    const missionAStream: Extract<ChatItem, { kind: "stream" }> = {
+      ...streamItem,
+      missionId: "mission-a",
+    };
+    const missionBUser: Extract<ChatItem, { kind: "user" }> = {
+      ...userItem,
+      id: "user-b",
+      missionId: "mission-b",
+    };
+
+    const views = appendUnpersistedLiveTail(
+      [missionAUser],
+      [missionAUser, missionAStream, missionBUser],
+      "mission-a",
+    );
+
+    expect(views).toEqual([missionAUser, missionAStream]);
   });
 
   it("carries over a failed user row not present in server history", () => {

--- a/dashboard/src/app/control/control-client.item-views.test.ts
+++ b/dashboard/src/app/control/control-client.item-views.test.ts
@@ -217,6 +217,30 @@ describe("appendUnpersistedLiveTail", () => {
     expect(views).toEqual([userItem, streamItem]);
   });
 
+  it("does not carry a live stream from another mission", () => {
+    const missionAUser: Extract<ChatItem, { kind: "user" }> = {
+      ...userItem,
+      missionId: "mission-a",
+    };
+    const missionAStream: Extract<ChatItem, { kind: "stream" }> = {
+      ...streamItem,
+      missionId: "mission-a",
+    };
+    const missionBUser: Extract<ChatItem, { kind: "user" }> = {
+      ...userItem,
+      id: "user-b",
+      missionId: "mission-b",
+    };
+
+    const views = appendUnpersistedLiveTail(
+      [missionBUser],
+      [missionAUser, missionAStream],
+      "mission-b",
+    );
+
+    expect(views).toEqual([missionBUser]);
+  });
+
   it("carries over a failed user row not present in server history", () => {
     const failed: Extract<ChatItem, { kind: "user" }> = {
       id: "user-failed",

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6558,6 +6558,51 @@ export default function ControlClient() {
     ],
   );
 
+  // Rename any mission by id from the Cmd+K switcher. Optimistic across the
+  // three places a mission title is mirrored (recent list, current, viewing);
+  // reverts on failure.
+  const handleRenameMissionById = useCallback(
+    async (missionId: string, nextTitle: string) => {
+      const trimmed = nextTitle.trim();
+      if (!trimmed) return;
+      const previousById = new Map<string, string | null | undefined>();
+      previousById.set(missionId, recentMissions.find((m) => m.id === missionId)?.title);
+
+      const applyTitle = (mission: Mission | null) =>
+        mission?.id === missionId ? { ...mission, title: trimmed } : mission;
+
+      setRecentMissions((prev) =>
+        prev.map((mission) =>
+          mission.id === missionId ? { ...mission, title: trimmed } : mission,
+        ),
+      );
+      setCurrentMission(applyTitle);
+      setViewingMission(applyTitle);
+
+      try {
+        await updateMissionTitle(missionId, trimmed);
+      } catch (error) {
+        console.error("Failed to rename mission:", error);
+        toast.error("Failed to rename mission");
+        const restore = (mission: Mission | null) =>
+          mission?.id === missionId
+            ? { ...mission, title: previousById.get(missionId) ?? null }
+            : mission;
+        setRecentMissions((prev) =>
+          prev.map((mission) =>
+            mission.id === missionId
+              ? { ...mission, title: previousById.get(missionId) ?? null }
+              : mission,
+          ),
+        );
+        setCurrentMission(restore);
+        setViewingMission(restore);
+        throw error;
+      }
+    },
+    [recentMissions],
+  );
+
   // Debouncing for thinking updates to reduce re-renders during streaming
   const pendingThinkingRef = useRef<{
     content: string;
@@ -7295,6 +7340,7 @@ export default function ControlClient() {
         const bubbleId = String(data["bubble_id"] ?? "text-op-latest");
         const rawOps = Array.isArray(data["ops"]) ? data["ops"] : [];
         const now = Date.now();
+        const acceptedMissionId = eventMissionId ?? viewingId ?? undefined;
 
         setItems((prev) => {
           const filtered = prev.filter((it) => it.kind !== "phase");
@@ -7340,6 +7386,7 @@ export default function ControlClient() {
               ...existing,
               content,
               done: finalized,
+              missionId: acceptedMissionId ?? existing.missionId,
               endTime: finalized ? now : undefined,
             };
             return updated;
@@ -7352,6 +7399,7 @@ export default function ControlClient() {
               id: bubbleId,
               content,
               done: finalized,
+              missionId: acceptedMissionId,
               startTime: now,
               endTime: finalized ? now : undefined,
             },
@@ -9225,6 +9273,7 @@ export default function ControlClient() {
           onResumeMission={handleResumeMissionById}
           onOpenFailingToolCall={handleOpenFailingToolCallById}
           onFollowUpMission={handleFollowUpMissionById}
+          onRenameMission={handleRenameMissionById}
           onRefresh={refreshRecentMissions}
         />
 

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -6565,8 +6565,21 @@ export default function ControlClient() {
     async (missionId: string, nextTitle: string) => {
       const trimmed = nextTitle.trim();
       if (!trimmed) return;
+      // Capture the pre-rename title from whichever source currently holds the
+      // mission. It may be open in current/viewing but absent from the recent
+      // list, in which case restoring from `recentMissions` alone would wipe the
+      // title to null on a failed API call.
+      const previousTitle =
+        recentMissions.find((m) => m.id === missionId)?.title ??
+        (currentMissionRef.current?.id === missionId
+          ? currentMissionRef.current.title
+          : undefined) ??
+        (viewingMissionRef.current?.id === missionId
+          ? viewingMissionRef.current.title
+          : undefined) ??
+        null;
       const previousById = new Map<string, string | null | undefined>();
-      previousById.set(missionId, recentMissions.find((m) => m.id === missionId)?.title);
+      previousById.set(missionId, previousTitle);
 
       const applyTitle = (mission: Mission | null) =>
         mission?.id === missionId ? { ...mission, title: trimmed } : mission;

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -250,6 +250,12 @@ function isRetriableSendError(error: unknown): boolean {
   );
 }
 
+function chatItemMatchesMission(item: ChatItem, missionId?: string): boolean {
+  if (!missionId) return true;
+  if (!("missionId" in item)) return true;
+  return item.missionId == null || item.missionId === missionId;
+}
+
 export function appendUnpersistedLiveTail(
   historyItems: ChatItem[],
   liveItems: ChatItem[],
@@ -258,7 +264,7 @@ export function appendUnpersistedLiveTail(
   if (liveItems.length === 0) return historyItems;
 
   const lastLiveUserIdx = liveItems.findLastIndex(
-    (item) => item.kind === "user",
+    (item) => item.kind === "user" && chatItemMatchesMission(item, missionId),
   );
   if (lastLiveUserIdx === -1) return historyItems;
 
@@ -283,14 +289,7 @@ export function appendUnpersistedLiveTail(
   const unpersistedTail = liveItems
     .slice(lastLiveUserIdx + 1)
     .filter((item) => {
-      if (
-        missionId &&
-        "missionId" in item &&
-        item.missionId != null &&
-        item.missionId !== missionId
-      ) {
-        return false;
-      }
+      if (!chatItemMatchesMission(item, missionId)) return false;
       if (existingIds.has(item.id)) return false;
       if (item.kind === "assistant") {
         const content = item.content.trim();
@@ -310,9 +309,7 @@ export function appendUnpersistedLiveTail(
   const lastLiveUser = liveItems[lastLiveUserIdx];
   const carryUnpersistedUser =
     lastLiveUser.kind === "user" &&
-    (!missionId ||
-      lastLiveUser.missionId == null ||
-      lastLiveUser.missionId === missionId) &&
+    chatItemMatchesMission(lastLiveUser, missionId) &&
     !existingIds.has(lastLiveUser.id) &&
     (lastLiveUser.sendStatus === "failed" ||
       lastLiveUser.sendStatus === "sending");
@@ -3113,7 +3110,10 @@ export default function ControlClient() {
   const [items, setItems] = useControlItemsStore();
   // Agent task board + next-wakeup marker for the Workbench panel, derived
   // from the same chat items the transcript renders (single source of truth).
-  const workbenchMissionState = useMemo(() => extractMissionState(items), [items]);
+  const workbenchMissionState = useMemo(
+    () => extractMissionState(items),
+    [items],
+  );
   const itemsRef = useRef<ChatItem[]>([]);
   const [input, setInput] = useState(() => loadControlDraftForMission(null));
   const [canSubmitInput, setCanSubmitInput] = useState(false);
@@ -7101,7 +7101,20 @@ export default function ControlClient() {
         };
 
         // Get or create stable ID for current thinking session
-        const existingPending = pendingThinkingRef.current;
+        let existingPending = pendingThinkingRef.current;
+        const pendingMissionChanged = Boolean(
+          existingPending?.missionId &&
+          acceptedMissionId &&
+          existingPending.missionId !== acceptedMissionId,
+        );
+        if (pendingMissionChanged) {
+          pendingThinkingRef.current = {
+            ...existingPending!,
+            done: true,
+          };
+          flushThinking();
+          existingPending = null;
+        }
         const existingContent = existingPending?.content ?? "";
         // P1-#8: tolerant continuation check (see stream-continuation.ts).
         const isContinuation = isStreamContinuation(content, existingContent);
@@ -7238,7 +7251,17 @@ export default function ControlClient() {
           });
         };
 
-        const existingPending = pendingStreamRef.current;
+        let existingPending = pendingStreamRef.current;
+        const pendingMissionChanged = Boolean(
+          existingPending?.missionId &&
+          acceptedMissionId &&
+          existingPending.missionId !== acceptedMissionId,
+        );
+        if (pendingMissionChanged) {
+          flushStream();
+          pendingStreamRef.current = null;
+          existingPending = null;
+        }
         const existingContent = existingPending?.content ?? "";
         // P1-#8: tolerant continuation check (see stream-continuation.ts).
         const isContinuation = isStreamContinuation(content, existingContent);
@@ -9061,7 +9084,10 @@ export default function ControlClient() {
   useFaviconStatus(faviconStatus, viewingMissionIsRunning, hasPendingUserInput);
 
   useEffect(() => {
-    document.title = formatMissionDocumentTitle(activeMission, hasPendingUserInput);
+    document.title = formatMissionDocumentTitle(
+      activeMission,
+      hasPendingUserInput,
+    );
     return () => {
       document.title = DEFAULT_DOCUMENT_TITLE;
     };

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -200,6 +200,18 @@ const MAX_MISSION_DRAFT_CACHE_BYTES = 64 * 1024;
 const MAX_MISSION_DRAFT_CACHE_ENTRIES = 50;
 const DEFAULT_DOCUMENT_TITLE = "Sandboxed.sh";
 const MAX_DOCUMENT_MISSION_TITLE_LENGTH = 80;
+const CONTROL_MISSION_SCOPED_EVENT_TYPES = new Set([
+  "user_message",
+  "assistant_message",
+  "thinking",
+  "text_delta",
+  "text_op",
+  "tool_call",
+  "tool_result",
+  "phase",
+  "goal_iteration",
+  "goal_status",
+]);
 
 type EventsWorkerRequest = {
   id: number;
@@ -241,6 +253,7 @@ function isRetriableSendError(error: unknown): boolean {
 export function appendUnpersistedLiveTail(
   historyItems: ChatItem[],
   liveItems: ChatItem[],
+  missionId?: string,
 ): ChatItem[] {
   if (liveItems.length === 0) return historyItems;
 
@@ -270,6 +283,14 @@ export function appendUnpersistedLiveTail(
   const unpersistedTail = liveItems
     .slice(lastLiveUserIdx + 1)
     .filter((item) => {
+      if (
+        missionId &&
+        "missionId" in item &&
+        item.missionId != null &&
+        item.missionId !== missionId
+      ) {
+        return false;
+      }
       if (existingIds.has(item.id)) return false;
       if (item.kind === "assistant") {
         const content = item.content.trim();
@@ -289,6 +310,9 @@ export function appendUnpersistedLiveTail(
   const lastLiveUser = liveItems[lastLiveUserIdx];
   const carryUnpersistedUser =
     lastLiveUser.kind === "user" &&
+    (!missionId ||
+      lastLiveUser.missionId == null ||
+      lastLiveUser.missionId === missionId) &&
     !existingIds.has(lastLiveUser.id) &&
     (lastLiveUser.sendStatus === "failed" ||
       lastLiveUser.sendStatus === "sending");
@@ -6539,6 +6563,7 @@ export default function ControlClient() {
     content: string;
     done: boolean;
     id: string;
+    missionId?: string;
     startTime: number;
   } | null>(null);
   const thinkingFlushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -6549,6 +6574,7 @@ export default function ControlClient() {
 
   const pendingStreamRef = useRef<{
     content: string;
+    missionId?: string;
     startTime: number;
   } | null>(null);
   const streamFlushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -6619,7 +6645,9 @@ export default function ControlClient() {
           // CLOSED and drop it — history catch-up backfills it on the next
           // sync — rather than risk rendering a main-session message inside an
           // unrelated parallel mission's view (cross-mission leak).
-          if (viewingId !== currentMissionId) {
+          if (CONTROL_MISSION_SCOPED_EVENT_TYPES.has(event.type)) {
+            filterReason = "mission-scoped event has no mission_id";
+          } else if (viewingId !== currentMissionId) {
             if (event.type !== "status") {
               filterReason = currentMissionId
                 ? "event has no mission_id for parallel mission"
@@ -6974,6 +7002,7 @@ export default function ControlClient() {
         const content = String(data["content"] ?? "");
         const done = Boolean(data["done"]);
         const now = Date.now();
+        const acceptedMissionId = eventMissionId ?? viewingId ?? undefined;
 
         // Debounced thinking updates to reduce re-renders during streaming
         const flushThinking = () => {
@@ -6984,12 +7013,20 @@ export default function ControlClient() {
             // Remove phase items when thinking starts
             const filtered = prev.filter((it) => it.kind !== "phase");
             let existingIdx = filtered.findIndex(
-              (it) => it.kind === "thinking" && !it.done,
+              (it) =>
+                it.kind === "thinking" &&
+                !it.done &&
+                (pending.missionId == null ||
+                  it.missionId == null ||
+                  it.missionId === pending.missionId),
             );
             if (existingIdx < 0) {
               existingIdx = filtered.findLastIndex(
                 (it) =>
                   it.kind === "thinking" &&
+                  (pending.missionId == null ||
+                    it.missionId == null ||
+                    it.missionId === pending.missionId) &&
                   isStreamContinuation(pending.content, it.content),
               );
             }
@@ -7014,6 +7051,7 @@ export default function ControlClient() {
                   ),
                   done: pending.done,
                   endTime: pending.done ? now : existing.endTime,
+                  missionId: pending.missionId ?? existing.missionId,
                 };
                 if (pending.done) {
                   pendingThinkingRef.current = null;
@@ -7037,6 +7075,7 @@ export default function ControlClient() {
                   id: pending.id,
                   content: pending.content,
                   done: pending.done,
+                  missionId: pending.missionId,
                   startTime: pending.startTime,
                   endTime: pending.done ? now : undefined,
                 },
@@ -7052,6 +7091,7 @@ export default function ControlClient() {
                   id: pending.id,
                   content: pending.content,
                   done: pending.done,
+                  missionId: pending.missionId,
                   startTime: pending.startTime,
                   endTime: pending.done ? now : undefined,
                 },
@@ -7077,6 +7117,7 @@ export default function ControlClient() {
             id:
               existingPending?.id ??
               `thinking-${thinkingIdCounterRef.current++}`,
+            missionId: existingPending?.missionId ?? acceptedMissionId,
             startTime: existingPending?.startTime ?? now,
           };
           flushThinking();
@@ -7095,6 +7136,7 @@ export default function ControlClient() {
           content: content || existingPending?.content || "",
           done,
           id: thinkingId,
+          missionId: acceptedMissionId,
           startTime,
         };
 
@@ -7135,6 +7177,7 @@ export default function ControlClient() {
         const content = String(data["content"] ?? "");
         const now = Date.now();
         if (!content.trim()) return;
+        const acceptedMissionId = eventMissionId ?? viewingId ?? undefined;
 
         // Debounced stream updates to reduce re-renders during rapid delta streaming.
         const flushStream = () => {
@@ -7146,7 +7189,12 @@ export default function ControlClient() {
             const filtered = prev.filter((it) => it.kind !== "phase");
             const streamId = "text_delta_latest";
             const existingIdx = filtered.findIndex(
-              (it) => it.kind === "stream" && it.id === streamId,
+              (it) =>
+                it.kind === "stream" &&
+                it.id === streamId &&
+                (pending.missionId == null ||
+                  it.missionId == null ||
+                  it.missionId === pending.missionId),
             );
             if (existingIdx >= 0) {
               const updated = [...filtered];
@@ -7164,6 +7212,7 @@ export default function ControlClient() {
                 ...existing,
                 content: pending.content || existing.content,
                 done: false,
+                missionId: pending.missionId ?? existing.missionId,
                 startTime:
                   isContinuation && !existing.done
                     ? existing.startTime
@@ -7181,6 +7230,7 @@ export default function ControlClient() {
                 id: "text_delta_latest",
                 content: pending.content,
                 done: false,
+                missionId: pending.missionId,
                 startTime: pending.startTime,
                 endTime: undefined,
               },
@@ -7195,6 +7245,7 @@ export default function ControlClient() {
 
         pendingStreamRef.current = {
           content: mergeStreamFragment(existingContent, content),
+          missionId: acceptedMissionId,
           startTime: isContinuation ? (existingPending?.startTime ?? now) : now,
         };
 
@@ -8644,6 +8695,7 @@ export default function ControlClient() {
         historyItems = appendUnpersistedLiveTail(
           historyItems,
           itemsRef.current,
+          missionId,
         );
 
         // Pre-queue length: pagination uses this to find the live tail

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -7357,8 +7357,17 @@ export default function ControlClient() {
 
         setItems((prev) => {
           const filtered = prev.filter((it) => it.kind !== "phase");
+          // Match the live row by id AND mission scope, mirroring the
+          // text_delta flush. Without the mission guard a shared bubble id
+          // (e.g. the "text-op-latest" default) could merge a text_op into
+          // another mission's stream bubble.
           const existingIdx = filtered.findIndex(
-            (it) => it.kind === "stream" && it.id === bubbleId,
+            (it) =>
+              it.kind === "stream" &&
+              it.id === bubbleId &&
+              (acceptedMissionId == null ||
+                it.missionId == null ||
+                it.missionId === acceptedMissionId),
           );
           const existing =
             existingIdx >= 0 && filtered[existingIdx]?.kind === "stream"

--- a/dashboard/src/app/control/events-reducer.ts
+++ b/dashboard/src/app/control/events-reducer.ts
@@ -61,6 +61,7 @@ export type ChatItem =
       done: boolean;
       startTime: number;
       endTime?: number;
+      missionId?: string;
     }
   | {
       kind: "stream";
@@ -69,6 +70,7 @@ export type ChatItem =
       done: boolean;
       startTime: number;
       endTime?: number;
+      missionId?: string;
     }
   | {
       kind: "tool";

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -13,12 +13,14 @@ import {
   ChevronRight,
   ChevronDown,
   Pin,
+  Pencil,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { searchMissions, type Mission, type RunningMissionInfo } from '@/lib/api';
 import { getMissionShortName } from '@/lib/mission-display';
 import { STATUS_LABELS, getMissionDotColor, getMissionTitle } from '@/lib/mission-status';
 import { AsyncButton } from '@/components/ui/async-button';
+import { getStatusIcon } from '@/components/ui/status-icons';
 
 interface MissionSwitcherProps {
   open: boolean;
@@ -33,6 +35,7 @@ interface MissionSwitcherProps {
   onResumeMission?: (missionId: string) => Promise<void> | void;
   onOpenFailingToolCall?: (missionId: string) => Promise<void> | void;
   onFollowUpMission?: (missionId: string) => Promise<void> | void;
+  onRenameMission?: (missionId: string, title: string) => Promise<void> | void;
   onRefresh?: () => void;
 }
 
@@ -155,6 +158,54 @@ function getMissionBackendLabel(mission: Mission): string {
 
 function getMissionStatusLabel(mission: Mission): string {
   return STATUS_LABELS[mission.status] ?? mission.status ?? 'Unknown';
+}
+
+function getMissionStatusToneClass(status: string | undefined, isRunning: boolean): string {
+  if (isRunning && status !== 'waiting_for_tool') return 'text-indigo-300/85';
+  switch (status) {
+    case 'waiting_for_tool':
+    case 'awaiting_user':
+    case 'pending':
+      return 'text-amber-300/90';
+    case 'completed':
+    case 'acknowledged':
+      return 'text-emerald-300/85';
+    case 'failed':
+    case 'interrupted':
+    case 'blocked':
+    case 'not_feasible':
+      return 'text-rose-300/85';
+    default:
+      return 'text-white/40';
+  }
+}
+
+// Render the status as a small color-coded glyph instead of a word — the icon
+// (Bell = Needs You, spinner = running, check = done, ✕ = failed) reads as fast
+// as text in a fraction of the width, and the full label rides along in the
+// tooltip. The left dot still carries the same color for redundancy.
+function getMissionStatusDisplay(
+  mission: Mission | undefined,
+  isRunning: boolean,
+  runningState?: string
+): { Icon: ReturnType<typeof getStatusIcon>; tone: string; label: string; spin: boolean } | null {
+  if (isRunning) {
+    const waiting = runningState === 'waiting_for_tool';
+    const statusKey = waiting ? 'awaiting_user' : 'running';
+    return {
+      Icon: getStatusIcon(statusKey),
+      tone: getMissionStatusToneClass(runningState, true),
+      label: waiting ? 'Needs You' : (runningState || 'running').replace(/_/g, ' '),
+      spin: !waiting,
+    };
+  }
+  if (!mission) return null;
+  return {
+    Icon: getStatusIcon(mission.status),
+    tone: getMissionStatusToneClass(mission.status, false),
+    label: getMissionStatusLabel(mission),
+    spin: false,
+  };
 }
 
 export interface MissionQuickAction {
@@ -641,6 +692,7 @@ export function MissionSwitcher({
   onResumeMission,
   onOpenFailingToolCall,
   onFollowUpMission,
+  onRenameMission,
   onRefresh,
 }: MissionSwitcherProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -683,6 +735,44 @@ export function MissionSwitcher({
     }
     return map;
   }, [missions]);
+
+  // Inline rename state. Only one row edits at a time; `renameValue` is the
+  // working draft. The id is mirrored in a ref so commit/cancel stay idempotent:
+  // Enter (or a pencil click) commits and unmounts the input, and the unmount
+  // blur fires a second commit — the ref short-circuits it so we never
+  // double-call the API.
+  const [renamingMissionId, setRenamingMissionId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renamingIdRef = useRef<string | null>(null);
+
+  const startRename = useCallback((mission: Mission | undefined, missionId: string) => {
+    if (!onRenameMission || !mission) return;
+    renamingIdRef.current = missionId;
+    setRenameValue(mission.title?.trim() ?? '');
+    setRenamingMissionId(missionId);
+  }, [onRenameMission]);
+
+  const cancelRename = useCallback(() => {
+    renamingIdRef.current = null;
+    setRenamingMissionId(null);
+  }, []);
+
+  const commitRename = useCallback(
+    async (missionId: string, rawValue: string) => {
+      if (renamingIdRef.current !== missionId) return;
+      renamingIdRef.current = null;
+      setRenamingMissionId(null);
+      const next = rawValue.trim();
+      const current = missionById.get(missionId)?.title?.trim() ?? '';
+      if (!next || next === current) return;
+      try {
+        await onRenameMission?.(missionId, next);
+      } catch (error) {
+        console.error('Failed to rename mission:', error);
+      }
+    },
+    [missionById, onRenameMission]
+  );
 
   // Handle mission selection with loading state
   const handleSelect = useCallback(async (missionId: string) => {
@@ -980,6 +1070,12 @@ export function MissionSwitcher({
   const rowVirtualizer = useVirtualizer({
     count: renderedRows.length,
     getScrollElement: () => listRef.current,
+    // Key measurements by stable row id, not array index. When pinning
+    // reorders the list, a tall row (title + description + activity) can land
+    // on an index whose cached height was a short row — index-keyed caches
+    // then stack rows on top of each other until the async re-measure lands.
+    // Keying by id makes each row carry its own measured height across reorders.
+    getItemKey: (index) => renderedRows[index]?.id ?? index,
     estimateSize: (index) => {
       const row = renderedRows[index];
       if (row?.kind === 'section') return 34;
@@ -1094,8 +1190,21 @@ export function MissionSwitcher({
         }
         return;
       }
-      
+
+      // While an inline rename is open, the row's <input> owns the keyboard
+      // (Enter saves, Escape cancels, arrows move the caret). Its own handler
+      // stops propagation, but guard here too in case focus drifts.
+      if (renamingMissionId) return;
+
       switch (e.key) {
+        case 'F2': {
+          const selected = orderedItems[selectedIndex];
+          if (onRenameMission && selected?.mission && !selected.isWorkerOf) {
+            e.preventDefault();
+            startRename(selected.mission, selected.id);
+          }
+          break;
+        }
         case 'Escape':
           e.preventDefault();
           onClose();
@@ -1166,6 +1275,9 @@ export function MissionSwitcher({
     bossesWithGroupedWorkers,
     expandedBossIds,
     toggleBossExpansion,
+    renamingMissionId,
+    onRenameMission,
+    startRename,
   ]);
 
   // Scroll selected item into view — only when the user actually navigates
@@ -1361,15 +1473,22 @@ export function MissionSwitcher({
                         <span className="rounded bg-cyan-500/10 border border-cyan-500/20 px-1 py-0.5 text-[8px] font-medium text-cyan-400 shrink-0">
                           W
                         </span>
-                        <span className="text-[9px] text-white/30 shrink-0">
-                          {isLoading
-                            ? 'Loading...'
-                            : isRunning
-                              ? runningInfo?.state || 'running'
-                              : mission
-                                ? getMissionStatusLabel(mission)
-                                : ''}
-                        </span>
+                        {isLoading ? (
+                          <Loader2 className="h-3 w-3 animate-spin text-indigo-400 shrink-0" />
+                        ) : (() => {
+                          const status = getMissionStatusDisplay(
+                            mission,
+                            isRunning,
+                            runningInfo?.state
+                          );
+                          if (!status) return null;
+                          const { Icon, tone, label, spin } = status;
+                          return (
+                            <span title={label} aria-label={label} className={cn('shrink-0', tone)}>
+                              <Icon className={cn('h-3 w-3', spin && 'animate-spin')} />
+                            </span>
+                          );
+                        })()}
                         {isViewing && !isLoading && (
                           <Check className="h-3 w-3 text-indigo-400 shrink-0" />
                         )}
@@ -1438,11 +1557,42 @@ export function MissionSwitcher({
                       {/* Mission info */}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <span className={cn("font-medium truncate", isWorkerItem ? "text-[13px]" : "text-sm")}>
-                            {mission
-                              ? getMissionDisplayName(mission)
-                              : getMissionShortName(item.id)}
-                          </span>
+                          {renamingMissionId === item.id ? (
+                            <input
+                              autoFocus
+                              value={renameValue}
+                              onChange={(e) => setRenameValue(e.target.value)}
+                              onFocus={(e) => e.currentTarget.select()}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                              onMouseDown={(e) => e.stopPropagation()}
+                              onBlur={() => commitRename(item.id, renameValue)}
+                              onKeyDown={(e) => {
+                                // Keep Enter/Escape/arrows inside the editor.
+                                e.stopPropagation();
+                                if (e.key === 'Enter') {
+                                  e.preventDefault();
+                                  commitRename(item.id, renameValue);
+                                } else if (e.key === 'Escape') {
+                                  e.preventDefault();
+                                  cancelRename();
+                                }
+                              }}
+                              placeholder={getMissionShortName(item.id)}
+                              className={cn(
+                                'min-w-0 flex-1 rounded border border-indigo-400/50 bg-white/[0.08] px-1.5 py-0.5 font-medium text-white outline-none placeholder:text-white/30 focus:border-indigo-400',
+                                isWorkerItem ? 'text-[13px]' : 'text-sm'
+                              )}
+                            />
+                          ) : (
+                            <span className={cn("font-medium truncate min-w-0", isWorkerItem ? "text-[13px]" : "text-sm")}>
+                              {mission
+                                ? getMissionDisplayName(mission)
+                                : getMissionShortName(item.id)}
+                            </span>
+                          )}
                           {mission && (() => {
                             const ws = getWorkspaceLabel(mission, workspaceNameById);
                             return ws ? (
@@ -1516,16 +1666,46 @@ export function MissionSwitcher({
                         )}
                       </div>
 
-                      {/* Status label or loading text */}
-                      <span className="text-[10px] text-white/30 shrink-0">
-                        {isLoading
-                          ? 'Loading...'
-                          : isRunning
-                          ? runningInfo?.state || 'running'
-                          : mission
-                          ? `${getMissionStatusLabel(mission)} · ${getMissionBackendLabel(mission)}`
-                          : ''}
-                      </span>
+                      {/* Status glyph — an icon in place of the old
+                          "Needs You · claudecode" text. Frees the row width for
+                          the title; the full label rides in the tooltip and the
+                          backend stays searchable + shown on the mission page. */}
+                      {isLoading ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-indigo-400 shrink-0" />
+                      ) : (() => {
+                        const status = getMissionStatusDisplay(
+                          mission,
+                          isRunning,
+                          runningInfo?.state
+                        );
+                        if (!status) return null;
+                        const { Icon, tone, label, spin } = status;
+                        return (
+                          <span
+                            title={label}
+                            aria-label={label}
+                            className={cn('shrink-0', tone)}
+                          >
+                            <Icon className={cn('h-4 w-4', spin && 'animate-spin')} />
+                          </span>
+                        );
+                      })()}
+
+                      {onRenameMission && mission && renamingMissionId !== item.id && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            startRename(mission, item.id);
+                          }}
+                          className="p-1 rounded transition-all shrink-0 hover:bg-white/[0.08] text-white/25 opacity-0 group-hover:opacity-100 hover:text-white/60"
+                          title="Rename mission (F2)"
+                          aria-label="Rename mission"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                      )}
 
                       <button
                         type="button"
@@ -1592,18 +1772,18 @@ export function MissionSwitcher({
                                 onClose();
                               }
                             }}
-                            spinnerClassName="h-3 w-3"
-                            className="px-1.5 py-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-white/[0.08] text-[10px] text-white/40 hover:text-emerald-300 transition-all shrink-0 inline-flex items-center gap-1 data-[busy=true]:opacity-100"
-                            title={action.title}
+                            spinnerClassName="h-3.5 w-3.5"
+                            className="p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-white/[0.08] text-white/40 hover:text-emerald-300 transition-all shrink-0 inline-flex items-center justify-center data-[busy=true]:opacity-100"
+                            title={`${action.label} — ${action.title}`}
+                            aria-label={action.label}
                           >
                             {action.action === 'resume' ? (
-                              <RotateCcw className="h-3 w-3" />
+                              <RotateCcw className="h-3.5 w-3.5" />
                             ) : action.action === 'open_failure' ? (
-                              <AlertTriangle className="h-3 w-3" />
+                              <AlertTriangle className="h-3.5 w-3.5" />
                             ) : (
-                              <MessageSquarePlus className="h-3 w-3" />
+                              <MessageSquarePlus className="h-3.5 w-3.5" />
                             )}
-                            {action.label}
                           </AsyncButton>
                         ))}
                     </a>

--- a/dashboard/src/contexts/mission-switcher-context.tsx
+++ b/dashboard/src/contexts/mission-switcher-context.tsx
@@ -13,6 +13,7 @@ import {
   resumeMission,
   createMission,
   getMission,
+  updateMissionTitle,
   type Mission,
   type RunningMissionInfo,
 } from '@/lib/api';
@@ -147,6 +148,32 @@ export function MissionSwitcherProvider({ children }: { children: React.ReactNod
     }
   }, [missions, mutateMissions, mutateRunningMissions, router]);
 
+  const handleRenameMission = useCallback(async (missionId: string, nextTitle: string) => {
+    const trimmed = nextTitle.trim();
+    if (!trimmed) return;
+    const applyTitle = (list: Mission[] = []) =>
+      list.map((mission) =>
+        mission.id === missionId ? { ...mission, title: trimmed } : mission
+      );
+    try {
+      // Optimistic: patch the cached list immediately, then persist and
+      // revalidate. On failure SWR rolls back to the server value.
+      await mutateMissions(
+        async () => {
+          await updateMissionTitle(missionId, trimmed);
+          return listMissions();
+        },
+        {
+          optimisticData: applyTitle,
+          rollbackOnError: true,
+          revalidate: true,
+        }
+      );
+    } catch {
+      toast.error('Failed to rename mission');
+    }
+  }, [mutateMissions]);
+
   const contextValue = useMemo(() => ({
     open: () => setIsOpen(true),
     close: () => setIsOpen(false),
@@ -170,6 +197,7 @@ export function MissionSwitcherProvider({ children }: { children: React.ReactNod
           onResumeMission={handleResumeMission}
           onOpenFailingToolCall={handleOpenFailingToolCall}
           onFollowUpMission={handleFollowUpMission}
+          onRenameMission={handleRenameMission}
           onRefresh={handleRefresh}
         />
       )}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -828,6 +828,19 @@ const ORCHESTRATOR_WIDE_EVENT_TYPES = new Set([
   "stream_lagged",
 ]);
 
+const MISSION_SCOPED_EVENT_TYPES = new Set([
+  "user_message",
+  "assistant_message",
+  "thinking",
+  "text_delta",
+  "text_op",
+  "tool_call",
+  "tool_result",
+  "phase",
+  "goal_iteration",
+  "goal_status",
+]);
+
 function shouldDropForMission(
   data: unknown,
   expectedMissionId: string | undefined,
@@ -837,7 +850,13 @@ function shouldDropForMission(
   if (ORCHESTRATOR_WIDE_EVENT_TYPES.has(eventType)) return false;
   if (!data || typeof data !== "object") return false;
   const evMissionId = (data as { mission_id?: unknown }).mission_id;
-  if (evMissionId === undefined || evMissionId === null) return false;
+  if (evMissionId === undefined || evMissionId === null) {
+    // A mission-scoped stream can receive an unattributed first event during
+    // backend fallback/race paths. Content-bearing events without a mission id
+    // are not safe to render into a specific mission view; history catch-up can
+    // backfill the correct rows once they are persisted.
+    return MISSION_SCOPED_EVENT_TYPES.has(eventType);
+  }
   if (typeof evMissionId !== "string") return false;
   return evMissionId !== expectedMissionId;
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -554,6 +554,7 @@ export interface QueuedMessage {
   content: string;
   agent: string | null;
   mission_id: string | null;
+  source?: string | null;
 }
 
 export async function getQueue(): Promise<QueuedMessage[]> {

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -59,6 +59,8 @@ export interface Mission {
   created_at: string;
   updated_at: string;
   interrupted_at?: string;
+  /** FLEET-004: when this mission was last paused (set while status is `paused`). */
+  paused_at?: string;
   /**
    * Timestamp of the user's first open since this mission last entered
    * `awaiting_user`. Drives the 1h ack grace timer (backend) and the

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -997,6 +997,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     agent: None,
                     target_mission_id: Some(turn.mission_id),
                     strict: false,
+                    source: None,
                     respond: tx,
                 })
                 .await;
@@ -1126,6 +1127,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     agent: None,
                     target_mission_id: Some(mission.id),
                     strict: false,
+                    source: None,
                     respond: tx2,
                 })
                 .await;

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1102,6 +1102,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     config_profile: None,
                     parent_mission_id: None,
                     working_directory: None,
+                    scheduling: Default::default(),
                     respond: tx,
                 })
                 .await

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -336,3 +336,248 @@ pub async fn update_backend_config(
         "message": "Backend configuration updated."
     })))
 }
+
+// ---- FLEET-003: normalized backend quota ----
+
+/// A vendor-neutral quota snapshot for one provider account serving a backend.
+///
+/// Providers expose rate-limit state through different header families
+/// (Anthropic input/output token windows, OpenAI request/token windows, …).
+/// This struct presents a single normalized shape so callers don't branch on
+/// the vendor. `raw` carries the untouched [`RateLimitSnapshot`] for anyone
+/// who needs the provider-specific detail.
+#[derive(Debug, Clone, Serialize)]
+pub struct BackendQuota {
+    pub backend_id: String,
+    pub provider_id: String,
+    /// Account-scoped health id the snapshot came from.
+    pub account_id: uuid::Uuid,
+    /// Amount consumed in the reported window (`limit - remaining`), if both known.
+    pub used: Option<u64>,
+    /// Amount left in the reported window.
+    pub remaining: Option<u64>,
+    /// Window maximum.
+    pub limit: Option<u64>,
+    /// When the reported window resets.
+    pub reset_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Which window the normalized numbers describe
+    /// (`input_tokens` | `tokens` | `requests`).
+    pub window_kind: String,
+    /// Untouched provider snapshot for vendor-specific detail.
+    pub raw: serde_json::Value,
+}
+
+/// The normalized window extracted from a provider snapshot.
+struct NormalizedQuota {
+    used: Option<u64>,
+    remaining: Option<u64>,
+    limit: Option<u64>,
+    reset_at: Option<chrono::DateTime<chrono::Utc>>,
+    window_kind: &'static str,
+}
+
+type QuotaNormalizer = fn(&crate::provider_health::RateLimitSnapshot) -> NormalizedQuota;
+
+fn build_window(
+    remaining: Option<u64>,
+    limit: Option<u64>,
+    reset: Option<chrono::DateTime<chrono::Utc>>,
+    window_kind: &'static str,
+) -> NormalizedQuota {
+    let used = match (limit, remaining) {
+        (Some(l), Some(r)) => Some(l.saturating_sub(r)),
+        _ => None,
+    };
+    NormalizedQuota {
+        used,
+        remaining,
+        limit,
+        reset_at: reset,
+        window_kind,
+    }
+}
+
+/// Anthropic reports per-input/output token windows; prefer the input window
+/// and fall back to the combined token window.
+fn normalize_anthropic(s: &crate::provider_health::RateLimitSnapshot) -> NormalizedQuota {
+    if s.input_tokens_limit.is_some() || s.input_tokens_remaining.is_some() {
+        build_window(
+            s.input_tokens_remaining,
+            s.input_tokens_limit,
+            s.tokens_reset,
+            "input_tokens",
+        )
+    } else {
+        build_window(s.tokens_remaining, s.tokens_limit, s.tokens_reset, "tokens")
+    }
+}
+
+/// OpenAI reports request and token windows; prefer the token window.
+fn normalize_openai(s: &crate::provider_health::RateLimitSnapshot) -> NormalizedQuota {
+    if s.tokens_limit.is_some() || s.tokens_remaining.is_some() {
+        build_window(s.tokens_remaining, s.tokens_limit, s.tokens_reset, "tokens")
+    } else {
+        build_window(
+            s.requests_remaining,
+            s.requests_limit,
+            s.requests_reset,
+            "requests",
+        )
+    }
+}
+
+/// Generic fallback: take whichever window the provider populated.
+fn normalize_generic(s: &crate::provider_health::RateLimitSnapshot) -> NormalizedQuota {
+    if s.tokens_limit.is_some() || s.tokens_remaining.is_some() {
+        build_window(s.tokens_remaining, s.tokens_limit, s.tokens_reset, "tokens")
+    } else if s.requests_limit.is_some() || s.requests_remaining.is_some() {
+        build_window(
+            s.requests_remaining,
+            s.requests_limit,
+            s.requests_reset,
+            "requests",
+        )
+    } else {
+        build_window(
+            s.input_tokens_remaining,
+            s.input_tokens_limit,
+            s.tokens_reset,
+            "input_tokens",
+        )
+    }
+}
+
+/// Select the per-provider normalizer. A small dispatch table keeps the
+/// vendor-specific logic in named functions instead of one sprawling match.
+fn normalizer_for(provider_id: &str) -> QuotaNormalizer {
+    match provider_id {
+        "anthropic" => normalize_anthropic,
+        "openai" => normalize_openai,
+        _ => normalize_generic,
+    }
+}
+
+/// GET /api/backends/:id/quota — normalized quota snapshot(s) for the
+/// provider account(s) that serve this backend (FLEET-003).
+///
+/// A backend maps to one or more providers via each provider's
+/// `use_for_backends`. For every such provider account that has reported
+/// rate-limit headers, we emit one normalized [`BackendQuota`]. Returns an
+/// empty list (200) for a known backend with no quota data yet, and 404 for
+/// an unknown backend.
+pub async fn get_backend_quota(
+    State(state): State<Arc<AppState>>,
+    Extension(_user): Extension<AuthUser>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<BackendQuota>>, (StatusCode, String)> {
+    {
+        let registry = state.backend_registry.read().await;
+        if registry.get(&id).is_none() {
+            return Err((StatusCode::NOT_FOUND, format!("Backend {} not found", id)));
+        }
+    }
+
+    // Provider type ids whose `use_for_backends` includes this backend.
+    let provider_ids: std::collections::HashSet<String> = state
+        .ai_providers
+        .list()
+        .await
+        .into_iter()
+        .filter(|p| p.enabled)
+        .filter(|p| {
+            p.use_for_backends
+                .as_ref()
+                .map(|bs| bs.iter().any(|b| b == &id))
+                .unwrap_or(false)
+        })
+        .map(|p| p.provider_type.id().to_string())
+        .collect();
+
+    if provider_ids.is_empty() {
+        return Ok(Json(Vec::new()));
+    }
+
+    let mut quotas = Vec::new();
+    for health in state.health_tracker.get_all_health().await {
+        let Some(provider_id) = health.provider_id.clone() else {
+            continue;
+        };
+        if !provider_ids.contains(&provider_id) {
+            continue;
+        }
+        let Some(snapshot) = health.rate_limit_snapshot.as_ref() else {
+            continue;
+        };
+        let normalized = normalizer_for(&provider_id)(snapshot);
+        quotas.push(BackendQuota {
+            backend_id: id.clone(),
+            provider_id,
+            account_id: health.account_id,
+            used: normalized.used,
+            remaining: normalized.remaining,
+            limit: normalized.limit,
+            reset_at: normalized.reset_at,
+            window_kind: normalized.window_kind.to_string(),
+            raw: serde_json::to_value(snapshot).unwrap_or(serde_json::Value::Null),
+        });
+    }
+
+    Ok(Json(quotas))
+}
+
+#[cfg(test)]
+mod quota_tests {
+    use super::*;
+    use crate::provider_health::RateLimitSnapshot;
+
+    /// FLEET-003: Anthropic snapshots normalize off the input-token window and
+    /// derive `used` as `limit - remaining`.
+    #[test]
+    fn test_anthropic_quota_normalization() {
+        let snap = RateLimitSnapshot {
+            input_tokens_limit: Some(1000),
+            input_tokens_remaining: Some(250),
+            tokens_reset: chrono::DateTime::parse_from_rfc3339("2026-06-24T12:00:00Z")
+                .ok()
+                .map(|t| t.with_timezone(&chrono::Utc)),
+            ..Default::default()
+        };
+        let n = normalize_anthropic(&snap);
+        assert_eq!(n.window_kind, "input_tokens");
+        assert_eq!(n.limit, Some(1000));
+        assert_eq!(n.remaining, Some(250));
+        assert_eq!(n.used, Some(750));
+        assert!(n.reset_at.is_some());
+    }
+
+    /// FLEET-003: OpenAI snapshots prefer the token window; `used` is absent
+    /// when the limit is unknown.
+    #[test]
+    fn test_openai_quota_normalization() {
+        let snap = RateLimitSnapshot {
+            tokens_remaining: Some(500),
+            requests_remaining: Some(9),
+            requests_limit: Some(10),
+            ..Default::default()
+        };
+        let n = normalize_openai(&snap);
+        assert_eq!(n.window_kind, "tokens");
+        assert_eq!(n.remaining, Some(500));
+        assert_eq!(n.limit, None);
+        assert_eq!(n.used, None);
+    }
+
+    /// FLEET-003: the dispatch table routes by provider id and falls back to
+    /// the generic normalizer for unknown providers.
+    #[test]
+    fn test_normalizer_dispatch() {
+        let snap = RateLimitSnapshot {
+            requests_limit: Some(100),
+            requests_remaining: Some(40),
+            ..Default::default()
+        };
+        let n = normalizer_for("some-unknown-provider")(&snap);
+        assert_eq!(n.window_kind, "requests");
+        assert_eq!(n.used, Some(60));
+    }
+}

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -397,6 +397,10 @@ pub async fn scheduler_pass(
                     // Runner may exist in another control session or be mid-start;
                     // leave it alone.
                 }
+                MissionStatus::Paused => {
+                    // Operator-paused worker: leave it alone, the dispatcher will
+                    // resume it when unpaused.
+                }
             }
         }
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -201,6 +201,7 @@ fn self_send_message(
         agent: None,
         target_mission_id: Some(target_mission_id),
         strict: true,
+        source: None,
         respond,
     }) {
         Ok(()) => true,

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -27,6 +27,11 @@ pub enum AgentEvent {
         /// Mission this message belongs to (for parallel execution)
         #[serde(skip_serializing_if = "Option::is_none")]
         mission_id: Option<Uuid>,
+        /// Origin of this message for audit/attribution (e.g. `api:<user_id>`,
+        /// `task-board`, `telegram`, `relay`). None for internally-generated
+        /// control messages.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
     },
     AssistantMessage {
         id: Uuid,
@@ -369,6 +374,10 @@ pub enum ControlCommand {
         /// can't reach its exact target it is dropped, never delivered elsewhere.
         /// This keeps the control plane from leaking into unrelated missions.
         strict: bool,
+        /// Origin of this message for audit/attribution (e.g. `api:<user_id>`,
+        /// `task-board`, `telegram`, `relay`). None for internally-generated
+        /// control messages.
+        source: Option<String>,
         /// Respond with the delivery outcome (queued / delivered / dropped).
         respond: oneshot::Sender<UserMessageAck>,
     },

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -457,6 +457,17 @@ pub enum ControlCommand {
         min_idle: Option<std::time::Duration>,
         respond: oneshot::Sender<Result<(), String>>,
     },
+    /// Pause a mission (FLEET-004). Stops any in-flight runner (main or
+    /// parallel) for the mission, then sets its status to `Paused`. Unlike
+    /// `CancelMission` (which lands on `Interrupted`), this lands on `Paused`
+    /// so the dispatcher skips it until an explicit resume. Routing through the
+    /// control loop guarantees the active turn is actually signalled to stop —
+    /// a bare store update would leave the runner executing and let its
+    /// completion overwrite the paused status.
+    PauseMission {
+        mission_id: Uuid,
+        respond: oneshot::Sender<Result<(), String>>,
+    },
     /// List currently running missions
     ListRunning {
         respond: oneshot::Sender<Vec<crate::api::mission_runner::RunningMissionInfo>>,

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -413,6 +413,8 @@ pub enum ControlCommand {
         parent_mission_id: Option<Uuid>,
         /// Working directory override (for git worktrees etc.)
         working_directory: Option<String>,
+        /// FLEET-001 scheduling metadata (priority, not_before, deadline).
+        scheduling: crate::api::mission_store::MissionScheduling,
         respond: oneshot::Sender<Result<Mission, String>>,
     },
     /// Update mission status
@@ -513,6 +515,10 @@ pub enum MissionStatus {
     Blocked,
     /// Mission not feasible as specified (wrong assumptions in request)
     NotFeasible,
+    /// Mission explicitly paused by an operator. Unlike `Blocked` this is
+    /// NOT terminal: the dispatcher skips it while paused but can resume it
+    /// back to `Pending` on demand (see FLEET-004).
+    Paused,
 }
 
 impl std::fmt::Display for MissionStatus {
@@ -527,6 +533,29 @@ impl std::fmt::Display for MissionStatus {
             Self::Blocked => write!(f, "blocked"),
             Self::NotFeasible => write!(f, "not_feasible"),
             Self::Interrupted => write!(f, "interrupted"),
+            Self::Paused => write!(f, "paused"),
         }
     }
+}
+
+impl MissionStatus {
+    /// Whether this status is terminal — the mission has reached a final
+    /// resting state and the dispatcher will never auto-run it again.
+    ///
+    /// NOTE: `Paused` is deliberately NOT terminal. A paused mission is parked
+    /// by an operator and can be resumed back to `Pending` (FLEET-004); the
+    /// dispatcher simply skips it while paused. `Blocked` is treated as
+    /// terminal here because, unlike `Paused`, it requires external resolution.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Interrupted | Self::Blocked | Self::NotFeasible
+        )
+    }
+}
+
+/// Free-function alias for [`MissionStatus::is_terminal`], kept for call sites
+/// that read more clearly as `mission_status_is_terminal(status)`.
+pub fn mission_status_is_terminal(status: MissionStatus) -> bool {
+    status.is_terminal()
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11975,19 +11975,23 @@ async fn control_actor_loop(
                                     live.push(m);
                                 }
                             }
-                            // 2. Dispatch the next runnable mission. Only when the
-                            //    main session is idle AND there is a free parallel slot
-                            //    — an explicitly-targeted message starts a parallel
-                            //    runner (Case 2), which DROPS at capacity, so dispatching
-                            //    without a slot would surface a spurious error.
+                            // 2. Dispatch the next runnable mission when there is spare
+                            //    concurrency. The targeted scheduler message starts a
+                            //    parallel runner (Case 2, explicit target => force
+                            //    parallel), which DROPS at capacity — so mirror its check
+                            //    (main + parallel < max_parallel) rather than requiring the
+                            //    main session to be idle, otherwise eligible scheduled
+                            //    missions stall behind a busy main runner.
                             let parallel_running = parallel_runners
                                 .values()
                                 .filter(|r| r.is_running())
                                 .count();
+                            let total_running =
+                                parallel_running + if running.is_some() { 1 } else { 0 };
                             let max_parallel = crate::settings::max_parallel_missions_cached_or(
                                 config.max_parallel_missions,
                             );
-                            if running.is_none() && parallel_running < max_parallel {
+                            if total_running < max_parallel {
                                 if let Some(next) =
                                     super::mission_store::select_next_runnable_mission(&live, now)
                                 {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -578,6 +578,28 @@ mod stall_guard_tests {
             .expect("delete after resume");
         assert!(store.get_mission(mid).await.expect("get").is_none());
     }
+
+    #[test]
+    fn resolve_actor_prefers_explicit_then_falls_back_to_user() {
+        let user = AuthUser {
+            id: "u-123".to_string(),
+            username: "thomas".to_string(),
+        };
+        // Explicit override wins (trimmed).
+        assert_eq!(
+            resolve_actor(Some("  system:fleet-watcher ".to_string()), &user),
+            "system:fleet-watcher"
+        );
+        // Blank override is ignored → falls back to the user.
+        assert_eq!(resolve_actor(Some("   ".to_string()), &user), "user:thomas");
+        assert_eq!(resolve_actor(None, &user), "user:thomas");
+        // No username → fall back to the id.
+        let anon = AuthUser {
+            id: "u-123".to_string(),
+            username: String::new(),
+        };
+        assert_eq!(resolve_actor(None, &anon), "user:u-123");
+    }
 }
 
 struct MetadataRefreshTaskEntry {
@@ -5654,6 +5676,14 @@ pub async fn cancel_mission(
         .map_err(|e| (StatusCode::NOT_FOUND, e))
 }
 
+/// Optional body for the pause endpoint (FLEET-004). Carries attribution only.
+#[derive(Debug, Default, Deserialize)]
+pub struct PauseMissionRequest {
+    /// Optional attribution override (e.g. `"system:fleet-watcher"`).
+    #[serde(default)]
+    pub actor: Option<String>,
+}
+
 /// Pause a mission (FLEET-004). Sets the mission to `Paused`, a non-terminal
 /// state the dispatcher deliberately skips when selecting the next runnable
 /// mission. Resume via `POST /missions/:id/resume`, which transitions a
@@ -5665,7 +5695,9 @@ pub async fn pause_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
     Path(mission_id): Path<Uuid>,
+    body: Option<Json<PauseMissionRequest>>,
 ) -> Result<Json<Mission>, (StatusCode, String)> {
+    let actor = resolve_actor(body.and_then(|b| b.0.actor), &user);
     let control = control_for_user(&state, &user).await;
     let mission = control
         .mission_store
@@ -5710,6 +5742,7 @@ pub async fn pause_mission(
     rx.await
         .map_err(recv_failed)?
         .map_err(|e| (StatusCode::CONFLICT, e))?;
+    tracing::info!(mission_id = %mission_id, actor = %actor, "FLEET-004 mission paused");
 
     let updated = control
         .mission_store
@@ -5725,6 +5758,24 @@ pub async fn pause_mission(
     Ok(Json(updated))
 }
 
+/// Resolve the acting principal for a FLEET control action. An explicit
+/// `actor` override (e.g. `"system:fleet-watcher"`) wins; otherwise we attribute
+/// it to the authenticated user. Recorded in structured logs so a post-mortem
+/// can answer "who paused/cloned/resumed this mission?".
+fn resolve_actor(explicit: Option<String>, user: &AuthUser) -> String {
+    explicit
+        .map(|a| a.trim().to_string())
+        .filter(|a| !a.is_empty())
+        .unwrap_or_else(|| {
+            let who = if user.username.is_empty() {
+                &user.id
+            } else {
+                &user.username
+            };
+            format!("user:{}", who)
+        })
+}
+
 /// Overrides accepted when cloning a mission (FLEET-002). Any field left unset
 /// inherits from the source mission.
 #[derive(Debug, Default, Deserialize)]
@@ -5737,6 +5788,17 @@ pub struct CloneMissionRequest {
     pub model_effort: Option<String>,
     #[serde(default)]
     pub model_override: Option<String>,
+    /// When true, copy the source mission's conversation history into the clone
+    /// (retry-with-context). Default false — the clone starts fresh.
+    #[serde(default)]
+    pub clone_messages: bool,
+    /// Optional parent to record on the clone for lineage tracing in the UI.
+    /// Left unset, the clone has no parent (independent mission).
+    #[serde(default)]
+    pub parent_mission_id: Option<Uuid>,
+    /// Optional attribution override (e.g. `"system:fleet-watcher"`).
+    #[serde(default)]
+    pub actor: Option<String>,
 }
 
 /// Clone an existing mission's configuration into a fresh `Pending` mission
@@ -5752,6 +5814,9 @@ pub async fn clone_mission(
     body: Option<Json<CloneMissionRequest>>,
 ) -> Result<Json<Mission>, (StatusCode, String)> {
     let overrides = body.map(|b| b.0).unwrap_or_default();
+    let actor = resolve_actor(overrides.actor.clone(), &user);
+    let clone_messages = overrides.clone_messages;
+    let parent_mission_id = overrides.parent_mission_id;
 
     let control = control_for_user(&state, &user).await;
     let source = control
@@ -5778,14 +5843,37 @@ pub async fn clone_mission(
             .or_else(|| source.model_effort.clone()),
         config_profile: source.config_profile.clone(),
         backend: overrides.backend.or_else(|| Some(source.backend.clone())),
-        parent_mission_id: None,
+        parent_mission_id,
         working_directory: source.working_directory.clone(),
         priority: None,
         not_before: None,
         deadline: None,
     };
 
-    create_mission(State(state), Extension(user), Some(Json(req))).await
+    let cloned = create_mission(State(state), Extension(user), Some(Json(req))).await?;
+    let clone_id = cloned.0.id;
+
+    // Optionally seed the clone with the source's conversation history
+    // (retry-with-context). `control` still holds the store handle after the
+    // create above moved `state`.
+    if clone_messages && !source.history.is_empty() {
+        control
+            .mission_store
+            .update_mission_history(clone_id, &source.history)
+            .await
+            .map_err(internal_error)?;
+    }
+
+    tracing::info!(
+        source_mission = %mission_id,
+        clone_mission = %clone_id,
+        actor = %actor,
+        clone_messages,
+        parent = ?parent_mission_id,
+        "FLEET-002 mission cloned"
+    );
+
+    Ok(cloned)
 }
 
 /// Request body for resuming a mission
@@ -5798,6 +5886,9 @@ pub struct ResumeMissionRequest {
     /// Useful when the user is about to send their own custom message.
     #[serde(default)]
     pub skip_message: bool,
+    /// Optional attribution override (e.g. `"system:fleet-watcher"`).
+    #[serde(default)]
+    pub actor: Option<String>,
 }
 
 /// Resume an interrupted mission.
@@ -5808,11 +5899,16 @@ pub async fn resume_mission(
     Path(mission_id): Path<Uuid>,
     body: Option<Json<ResumeMissionRequest>>,
 ) -> Result<Json<Mission>, (StatusCode, String)> {
-    let (clean_workspace, skip_message) = body
-        .map(|b| (b.clean_workspace, b.skip_message))
-        .unwrap_or((false, false));
+    let (clean_workspace, skip_message, actor_override) = body
+        .map(|b| {
+            let r = b.0;
+            (r.clean_workspace, r.skip_message, r.actor)
+        })
+        .unwrap_or((false, false, None));
+    let actor = resolve_actor(actor_override, &user);
 
     let control = control_for_user(&state, &user).await;
+    tracing::info!(mission_id = %mission_id, actor = %actor, "FLEET-004 mission resume requested");
 
     // FLEET-004: a Paused mission resumes its *prior work* from history, so it
     // first transitions to Interrupted (the status `resume_mission_impl`

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5657,16 +5657,21 @@ pub async fn pause_mission(
         ));
     }
 
+    // Route through the control loop so any in-flight runner is actually
+    // stopped before the mission is parked. A bare store update would leave the
+    // active turn executing and let its completion overwrite `Paused`.
+    let (tx, rx) = oneshot::channel();
     control
-        .mission_store
-        .update_mission_status(mission_id, MissionStatus::Paused)
+        .cmd_tx
+        .send(ControlCommand::PauseMission {
+            mission_id,
+            respond: tx,
+        })
         .await
-        .map_err(internal_error)?;
-    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
-        mission_id,
-        status: MissionStatus::Paused,
-        summary: None,
-    });
+        .map_err(session_unavailable)?;
+    rx.await
+        .map_err(recv_failed)?
+        .map_err(|e| (StatusCode::CONFLICT, e))?;
 
     let updated = control
         .mission_store
@@ -10337,6 +10342,62 @@ async fn control_actor_loop(
                                 }
                             } else {
                                 let _ = respond.send(Err(format!("Mission {} not found", mission_id)));
+                            }
+                        }
+                    }
+                    ControlCommand::PauseMission { mission_id, respond } => {
+                        // Stop any in-flight runner before parking the mission so
+                        // the agent turn can't keep executing (and overwrite the
+                        // paused status on completion). Mirrors CancelMission's
+                        // stop logic but lands on `Paused` instead of `Interrupted`.
+                        if let Some(runner) = parallel_runners.get_mut(&mission_id) {
+                            runner.cancel();
+                            parallel_runners.remove(&mission_id);
+                            close_mission_desktop_sessions(
+                                &mission_store,
+                                mission_id,
+                                &config.working_dir,
+                            )
+                            .await;
+                        } else if running_mission_id == Some(mission_id) {
+                            if let Some(token) = &running_cancel {
+                                token.cancel();
+                                // Arm the force-clear deadline so a zombie runner
+                                // that never observes the cancel still gets torn
+                                // down (matches CancelMission).
+                                runner_force_clear_deadline = Some(
+                                    tokio::time::Instant::now() + RUNNER_FORCE_CLEAR_GRACE,
+                                );
+                            }
+                            close_mission_desktop_sessions(
+                                &mission_store,
+                                mission_id,
+                                &config.working_dir,
+                            )
+                            .await;
+                        }
+
+                        // Set Paused last so it survives the runner teardown above.
+                        // maybe_finalize_terminal_mission skips non-Active/Pending/
+                        // Interrupted statuses, so the cancelled turn's completion
+                        // won't promote this back out of Paused.
+                        match mission_store
+                            .update_mission_status(mission_id, MissionStatus::Paused)
+                            .await
+                        {
+                            Ok(()) => {
+                                let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                    mission_id,
+                                    status: MissionStatus::Paused,
+                                    summary: None,
+                                });
+                                let _ = respond.send(Ok(()));
+                            }
+                            Err(e) => {
+                                let _ = respond.send(Err(format!(
+                                    "Failed to pause mission {}: {}",
+                                    mission_id, e
+                                )));
                             }
                         }
                     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9427,9 +9427,25 @@ async fn control_actor_loop(
 
                         let was_running = running.is_some();
                         let content_clone = content.clone();
-                        // Capture the target mission ID once, before queuing
-                        // This ensures we use the same mission_id for events and execution
-                        let target_mission_id = *current_mission.read().await;
+                        // Capture the target mission ID once, before queuing.
+                        // This ensures we use the same mission_id for events and execution.
+                        //
+                        // Honor the message's EXPLICIT target; fall back to the session
+                        // `current_mission` pointer only for untargeted messages. We only
+                        // reach Case 3 when the target is absent or equals the main mission
+                        // (`target_is_main`), so an explicit `effective_target` here is the
+                        // main mission the runner is on — and its history is already what
+                        // the next turn will use. Previously this read `*current_mission`
+                        // unconditionally: when the runner was busy on one mission
+                        // (`running_mission_id`) while the session pointer had drifted to
+                        // another (e.g. the dashboard/MCP moved it), an explicitly-targeted
+                        // follow-up got silently re-pinned to the drifted mission and
+                        // executed there. (Prod 2026-06-23: a Hermes follow-up for mission
+                        // 91f7… ran in the unrelated 4f3f… instead.)
+                        let target_mission_id = match effective_target {
+                            Some(tid) => Some(tid),
+                            None => *current_mission.read().await,
+                        };
                         queue.push_back((id, content, msg_agent, target_mission_id));
                         let status_mission_id = if running.is_some() {
                             running_mission_id

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4183,6 +4183,14 @@ pub struct CreateMissionRequest {
     pub parent_mission_id: Option<Uuid>,
     /// Working directory override (for git worktrees etc.)
     pub working_directory: Option<String>,
+    /// FLEET-001 scheduling hint: dispatch priority (higher = more important,
+    /// default 0). The dispatcher prefers higher-priority Pending missions,
+    /// FIFO within the same priority.
+    pub priority: Option<i32>,
+    /// FLEET-001 scheduling hint: do not dispatch before this timestamp.
+    pub not_before: Option<chrono::DateTime<chrono::Utc>>,
+    /// FLEET-001 scheduling hint: soft deadline for observability/enforcement.
+    pub deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 fn deserialize_string_patch<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
@@ -4281,6 +4289,9 @@ pub async fn create_mission(
         backend: None,
         parent_mission_id: None,
         working_directory: None,
+        priority: None,
+        not_before: None,
+        deadline: None,
     });
 
     let title = req.title.clone();
@@ -4411,6 +4422,11 @@ pub async fn create_mission(
             config_profile: effective_config_profile,
             parent_mission_id: req.parent_mission_id,
             working_directory: req.working_directory,
+            scheduling: crate::api::mission_store::MissionScheduling {
+                priority: req.priority.unwrap_or(0),
+                not_before: req.not_before.map(|t| t.to_rfc3339()),
+                deadline: req.deadline.map(|t| t.to_rfc3339()),
+            },
             respond: tx,
         })
         .await
@@ -5600,6 +5616,72 @@ pub async fn cancel_mission(
         .map_err(|e| (StatusCode::NOT_FOUND, e))
 }
 
+/// Pause a mission (FLEET-004). Sets the mission to `Paused`, a non-terminal
+/// state the dispatcher deliberately skips when selecting the next runnable
+/// mission. Resume via `POST /missions/:id/resume`, which transitions a
+/// `Paused` mission back to `Pending` so the dispatcher re-queues it.
+///
+/// Rejects missions that are already terminal (nothing to pause) or already
+/// paused (no-op kept explicit for the operator).
+pub async fn pause_mission(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(mission_id): Path<Uuid>,
+) -> Result<Json<Mission>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let mission = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Mission {} not found", mission_id),
+            )
+        })?;
+
+    if mission.status == MissionStatus::Paused {
+        return Err((
+            StatusCode::CONFLICT,
+            "Mission is already paused".to_string(),
+        ));
+    }
+    if mission_status_is_terminal(mission.status) {
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "Cannot pause a terminal mission (status: {})",
+                mission.status
+            ),
+        ));
+    }
+
+    control
+        .mission_store
+        .update_mission_status(mission_id, MissionStatus::Paused)
+        .await
+        .map_err(internal_error)?;
+    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id,
+        status: MissionStatus::Paused,
+        summary: None,
+    });
+
+    let updated = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Mission {} not found", mission_id),
+            )
+        })?;
+    Ok(Json(updated))
+}
+
 /// Request body for resuming a mission
 #[derive(Debug, Deserialize, Default)]
 pub struct ResumeMissionRequest {
@@ -5623,9 +5705,41 @@ pub async fn resume_mission(
     let (clean_workspace, skip_message) = body
         .map(|b| (b.clean_workspace, b.skip_message))
         .unwrap_or((false, false));
-    let (tx, rx) = oneshot::channel();
 
     let control = control_for_user(&state, &user).await;
+
+    // FLEET-004: a Paused mission resumes by returning to the dispatcher queue
+    // (Paused → Pending) rather than going through the interrupted-mission
+    // context-reconstruction path below. The dispatcher re-selects it on its
+    // next pass, honoring priority/not_before ordering (FLEET-001).
+    if let Ok(Some(mission)) = control.mission_store.get_mission(mission_id).await {
+        if mission.status == MissionStatus::Paused {
+            control
+                .mission_store
+                .update_mission_status(mission_id, MissionStatus::Pending)
+                .await
+                .map_err(internal_error)?;
+            let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                mission_id,
+                status: MissionStatus::Pending,
+                summary: None,
+            });
+            let updated = control
+                .mission_store
+                .get_mission(mission_id)
+                .await
+                .map_err(internal_error)?
+                .ok_or_else(|| {
+                    (
+                        StatusCode::NOT_FOUND,
+                        format!("Mission {} not found", mission_id),
+                    )
+                })?;
+            return Ok(Json(updated));
+        }
+    }
+
+    let (tx, rx) = oneshot::channel();
     control
         .cmd_tx
         .send(ControlCommand::ResumeMission {
@@ -8892,11 +9006,13 @@ async fn control_actor_loop(
             None,
             None,
             None,
+            crate::api::mission_store::MissionScheduling::default(),
         )
         .await
     }
 
     // Helper to create a new mission with title
+    #[allow(clippy::too_many_arguments)]
     async fn create_new_mission_with_title(
         mission_store: &Arc<dyn MissionStore>,
         title: Option<&str>,
@@ -8908,8 +9024,9 @@ async fn control_actor_loop(
         config_profile: Option<&str>,
         parent_mission_id: Option<Uuid>,
         working_directory: Option<&str>,
+        scheduling: crate::api::mission_store::MissionScheduling,
     ) -> Result<Mission, String> {
-        mission_store
+        let mut mission = mission_store
             .create_mission_with_parent(
                 title,
                 workspace_id,
@@ -8921,7 +9038,16 @@ async fn control_actor_loop(
                 parent_mission_id,
                 working_directory,
             )
-            .await
+            .await?;
+        // FLEET-001: persist scheduling metadata as a focused follow-up write so
+        // the wide `create_mission_with_parent` signature stays untouched.
+        if scheduling != crate::api::mission_store::MissionScheduling::default() {
+            mission_store
+                .set_mission_scheduling(mission.id, &scheduling)
+                .await?;
+            mission.scheduling = scheduling;
+        }
+        Ok(mission)
     }
 
     // Helper to validate and prepare an interrupted or blocked mission for resume.
@@ -9691,7 +9817,7 @@ async fn control_actor_loop(
                             }
                         }
                     }
-                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, backend, config_profile, parent_mission_id, working_directory, respond } => {
+                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, backend, config_profile, parent_mission_id, working_directory, scheduling, respond } => {
                         // First persist current mission history
                         persist_mission_history(
                             &mission_store,
@@ -9713,6 +9839,7 @@ async fn control_actor_loop(
                             config_profile.as_deref(),
                             parent_mission_id,
                             working_directory.as_deref(),
+                            scheduling,
                         )
                         .await {
                             Ok(mission) => {
@@ -18286,6 +18413,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
         let weak = Mission {
             id: Uuid::new_v4(),
@@ -18317,6 +18445,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
 
         let strong_score = mission_search_relevance_score(
@@ -18363,6 +18492,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
 
         let score = mission_search_relevance_score(
@@ -18406,6 +18536,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
 
         let score = mission_search_relevance_score(
@@ -18449,6 +18580,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
 
         let score = mission_search_relevance_score(
@@ -18492,6 +18624,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
 
         let score = mission_search_relevance_score(
@@ -18619,6 +18752,7 @@ And the report:
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
         let before = mission_search_freshness_key(
             &[MissionSearchCandidate {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -551,6 +551,33 @@ mod stall_guard_tests {
         assert!(maybe_arm_stall_guard_wakeup(&store, boss).await);
         reset_stall_guard(boss);
     }
+
+    #[tokio::test]
+    async fn delete_rejects_paused_mission_until_resumed_or_cancelled() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mid = mk(&store, None).await;
+        store
+            .update_mission_status(mid, MissionStatus::Paused)
+            .await
+            .expect("pause");
+
+        // Deleting a paused mission is refused with 409 and leaves it intact.
+        let err = delete_mission_with_children(&store, mid, &[])
+            .await
+            .expect_err("paused delete should be refused");
+        assert_eq!(err.0, StatusCode::CONFLICT);
+        assert!(store.get_mission(mid).await.expect("get").is_some());
+
+        // Once it leaves Paused (e.g. resumed → Interrupted), delete succeeds.
+        store
+            .update_mission_status(mid, MissionStatus::Interrupted)
+            .await
+            .expect("resume");
+        delete_mission_with_children(&store, mid, &[])
+            .await
+            .expect("delete after resume");
+        assert!(store.get_mission(mid).await.expect("get").is_none());
+    }
 }
 
 struct MetadataRefreshTaskEntry {
@@ -5916,13 +5943,26 @@ async fn delete_mission_with_children(
     mission_id: Uuid,
     running: &[super::mission_runner::RunningMissionInfo],
 ) -> Result<Vec<Uuid>, (StatusCode, String)> {
-    let Some(_) = mission_store
+    let Some(target) = mission_store
         .get_mission(mission_id)
         .await
         .map_err(internal_error)?
     else {
         return Err((StatusCode::NOT_FOUND, "Mission not found".to_string()));
     };
+
+    // FLEET-004: a Paused mission is deliberately parked for later resume —
+    // deleting it would silently discard work the operator chose to keep. Require
+    // an explicit resume-or-cancel first (mirrors the pause endpoint's 409s).
+    if target.status == MissionStatus::Paused {
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "Cannot delete a paused mission ({}). Resume or cancel it first.",
+                mission_id
+            ),
+        ));
+    }
 
     let child_ids = collect_child_mission_ids(mission_store, mission_id).await?;
     let mut ids_to_delete = Vec::with_capacity(child_ids.len() + 1);

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4193,12 +4193,14 @@ pub struct CreateMissionRequest {
     /// Working directory override (for git worktrees etc.)
     pub working_directory: Option<String>,
     /// FLEET-001 scheduling hint: dispatch priority (higher = more important,
-    /// default 0). The dispatcher prefers higher-priority Pending missions,
-    /// FIFO within the same priority.
+    /// default 0). The scheduler dispatches higher-priority scheduled missions
+    /// first, FIFO within the same priority.
     pub priority: Option<i32>,
-    /// FLEET-001 scheduling hint: do not dispatch before this timestamp.
+    /// FLEET-001 scheduling hint: do not dispatch before this timestamp. The
+    /// mission's first message is held (as `deferred_goal`) until then.
     pub not_before: Option<chrono::DateTime<chrono::Utc>>,
-    /// FLEET-001 scheduling hint: soft deadline for observability/enforcement.
+    /// FLEET-001 scheduling hint: deadline. A scheduled mission that never
+    /// dispatches before this is failed with reason `deadline_exceeded`.
     pub deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
@@ -5785,22 +5787,22 @@ pub async fn resume_mission(
 
     let control = control_for_user(&state, &user).await;
 
-    // FLEET-004: a Paused mission first returns to Pending, then falls through to
-    // the ResumeMission path below to actually rebuild context and start the
-    // runner. The FLEET-001 priority/not_before dispatcher that would otherwise
-    // re-select a Pending mission is not yet wired in production, so resuming has
-    // to start the mission directly rather than parking it in Pending — otherwise
-    // the agent never runs again from the resume API alone.
+    // FLEET-004: a Paused mission resumes its *prior work* from history, so it
+    // first transitions to Interrupted (the status `resume_mission_impl`
+    // accepts) and then falls through to the ResumeMission path below to rebuild
+    // context and restart the runner. (Pending would be wrong here: the FLEET-001
+    // dispatcher only dispatches `not_before`-scheduled missions that carry a
+    // fresh `deferred_goal`, not paused missions continuing from history.)
     if let Ok(Some(mission)) = control.mission_store.get_mission(mission_id).await {
         if mission.status == MissionStatus::Paused {
             control
                 .mission_store
-                .update_mission_status(mission_id, MissionStatus::Pending)
+                .update_mission_status(mission_id, MissionStatus::Interrupted)
                 .await
                 .map_err(internal_error)?;
             let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
                 mission_id,
-                status: MissionStatus::Pending,
+                status: MissionStatus::Interrupted,
                 summary: None,
             });
             // fall through to ResumeMission below
@@ -8955,6 +8957,12 @@ async fn control_actor_loop(
     // sweeps zombies, and wakes idle bosses whose board needs a decision.
     const BOARD_PASS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
     let mut last_board_pass = tokio::time::Instant::now();
+    // FLEET-001 scheduling dispatch cadence: same throttling rationale as the
+    // board pass — a store scan on every 100ms tick is wasteful. Each pass
+    // expires past-deadline scheduled missions and, when the main session is
+    // idle, dispatches the highest-priority dispatchable one.
+    const SCHEDULER_PASS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+    let mut last_scheduler_pass = tokio::time::Instant::now();
     // Per-boss "wake outstanding" flags, coalescing board wakes across passes.
     let mut board_wake_state: std::collections::HashMap<Uuid, bool> =
         std::collections::HashMap::new();
@@ -9276,6 +9284,66 @@ async fn control_actor_loop(
                                     });
                                     let _ = respond.send(UserMessageAck::Dropped);
                                     continue;
+                                }
+                            }
+                        }
+
+                        // FLEET-001 scheduled-mission deferral: if the target is a
+                        // Pending mission whose `not_before` is still in the future
+                        // and it isn't already running, stash the goal and leave it
+                        // Pending. The scheduler tick re-injects it as a normal user
+                        // message once the dispatch window opens. Strict control-plane
+                        // messages are operational and never deferred.
+                        if !strict {
+                            if let Some(tid) = effective_target {
+                                let target_running =
+                                    target_in_parallel || running_mid == Some(tid);
+                                if !target_running {
+                                    if let Ok(Some(m)) = mission_store.get_mission(tid).await {
+                                        let now = chrono::Utc::now();
+                                        if m.status == MissionStatus::Pending
+                                            && !m.is_dispatchable_at(now)
+                                        {
+                                            // Append to any previously-stashed goal so
+                                            // multiple pre-dispatch messages aren't lost.
+                                            let combined = match mission_store
+                                                .get_deferred_goal(tid)
+                                                .await
+                                                .ok()
+                                                .flatten()
+                                            {
+                                                Some(prev) if !prev.is_empty() => {
+                                                    format!("{prev}\n{content}")
+                                                }
+                                                _ => content.clone(),
+                                            };
+                                            if let Err(e) = mission_store
+                                                .set_deferred_goal(tid, Some(combined))
+                                                .await
+                                            {
+                                                tracing::warn!(
+                                                    mission_id = %tid,
+                                                    "Failed to stash deferred goal: {e}"
+                                                );
+                                            }
+                                            // Surface the queued goal so the UI shows it
+                                            // as pending until dispatch.
+                                            let _ = events_tx.send(AgentEvent::UserMessage {
+                                                id,
+                                                content: content.clone(),
+                                                queued: true,
+                                                mission_id: Some(tid),
+                                                source: source.clone(),
+                                            });
+                                            tracing::info!(
+                                                mission_id = %tid,
+                                                not_before = ?m.scheduling.not_before,
+                                                "Deferred scheduled mission: goal stashed until dispatch window"
+                                            );
+                                            let _ = respond.send(UserMessageAck::Queued);
+                                            continue;
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -11814,6 +11882,118 @@ async fn control_actor_loop(
                         &mut board_wake_state,
                     )
                     .await;
+                }
+
+                // FLEET-001 scheduling dispatch: expire past-deadline scheduled
+                // missions, then start the highest-priority dispatchable one when
+                // the main session is idle. Throttled like the board pass.
+                if last_scheduler_pass.elapsed() >= SCHEDULER_PASS_INTERVAL {
+                    last_scheduler_pass = tokio::time::Instant::now();
+                    match mission_store.get_scheduled_pending_missions().await {
+                        Ok(pending) => {
+                            let now = chrono::Utc::now();
+                            // 1. Expire any scheduled mission whose deadline elapsed
+                            //    before it ever dispatched.
+                            let mut live: Vec<Mission> = Vec::with_capacity(pending.len());
+                            for m in pending {
+                                if m.is_past_deadline(now) {
+                                    tracing::info!(
+                                        mission_id = %m.id,
+                                        deadline = ?m.scheduling.deadline,
+                                        "Scheduler: expiring scheduled mission past deadline"
+                                    );
+                                    let _ = mission_store.set_deferred_goal(m.id, None).await;
+                                    if let Err(e) = mission_store
+                                        .update_mission_status_with_reason(
+                                            m.id,
+                                            MissionStatus::Failed,
+                                            Some("deadline_exceeded"),
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            mission_id = %m.id,
+                                            "Scheduler: failed to expire mission: {e}"
+                                        );
+                                    } else {
+                                        maybe_schedule_mission_metadata_refresh_for_status(
+                                            &mission_store,
+                                            &events_tx,
+                                            m.id,
+                                            MissionStatus::Failed,
+                                        );
+                                        let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                            mission_id: m.id,
+                                            status: MissionStatus::Failed,
+                                            summary: Some(
+                                                "Scheduled mission expired: deadline passed before dispatch"
+                                                    .to_string(),
+                                            ),
+                                        });
+                                    }
+                                } else {
+                                    live.push(m);
+                                }
+                            }
+                            // 2. Dispatch the next runnable mission. Only when the
+                            //    main session is idle AND there is a free parallel slot
+                            //    — an explicitly-targeted message starts a parallel
+                            //    runner (Case 2), which DROPS at capacity, so dispatching
+                            //    without a slot would surface a spurious error.
+                            let parallel_running = parallel_runners
+                                .values()
+                                .filter(|r| r.is_running())
+                                .count();
+                            let max_parallel = crate::settings::max_parallel_missions_cached_or(
+                                config.max_parallel_missions,
+                            );
+                            if running.is_none() && parallel_running < max_parallel {
+                                if let Some(next) =
+                                    super::mission_store::select_next_runnable_mission(&live, now)
+                                {
+                                    let mission_id = next.id;
+                                    let priority = next.scheduling.priority;
+                                    if let Ok(Some(goal)) =
+                                        mission_store.get_deferred_goal(mission_id).await
+                                    {
+                                        // Deliberately do NOT clear the goal here. The
+                                        // Pending->Active transition that the dispatched
+                                        // message triggers is what removes the mission from
+                                        // `get_scheduled_pending_missions` (status filter),
+                                        // so it can't be re-dispatched. Leaving the goal in
+                                        // place means a rare dispatch drop (capacity race)
+                                        // simply retries on the next pass instead of losing
+                                        // the scheduled work.
+                                        let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
+                                        match self_cmd_tx.try_send(ControlCommand::UserMessage {
+                                            id: Uuid::new_v4(),
+                                            content: goal,
+                                            agent: None,
+                                            target_mission_id: Some(mission_id),
+                                            strict: false,
+                                            source: Some("scheduler".to_string()),
+                                            respond: ack_tx,
+                                        }) {
+                                            Ok(()) => tracing::info!(
+                                                mission_id = %mission_id,
+                                                priority,
+                                                "Scheduler: dispatching scheduled mission"
+                                            ),
+                                            Err(e) => tracing::warn!(
+                                                mission_id = %mission_id,
+                                                "Scheduler: dispatch enqueue failed; will retry: {e}"
+                                            ),
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Scheduler: failed to list scheduled pending missions: {e}"
+                            );
+                        }
+                    }
                 }
             }
             // Force-reap a runner whose cancel was fired but whose

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2583,20 +2583,26 @@ pub struct QueuedMessage {
     pub agent: Option<String>,
     /// Which mission this queued message belongs to
     pub mission_id: Option<Uuid>,
+    /// Attribution for the message (e.g. `api:<user_id>`, `telegram`). Persisted
+    /// so a queued message keeps its source after a restart. Defaults to `None`
+    /// for snapshots written before this field existed.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 /// Serialize the control session queue to a stable JSON snapshot for
 /// persistence across restarts (see `MissionStore::save_control_queue`).
 fn serialize_queue_snapshot(
-    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
 ) -> String {
     let items: Vec<QueuedMessage> = queue
         .iter()
-        .map(|(id, content, agent, target_mid)| QueuedMessage {
+        .map(|(id, content, agent, target_mid, source)| QueuedMessage {
             id: *id,
             content: content.clone(),
             agent: agent.clone(),
             mission_id: *target_mid,
+            source: source.clone(),
         })
         .collect();
     serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
@@ -2614,7 +2620,7 @@ fn serialize_queue_snapshot(
 async fn persist_control_queue_if_changed(
     mission_store: &Arc<dyn MissionStore>,
     session_user_id: &str,
-    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
     last_persisted: &mut String,
 ) {
     let snapshot = serialize_queue_snapshot(queue);
@@ -7790,7 +7796,7 @@ struct RoutedAutomationMessage {
 }
 
 fn enqueue_agent_finished_messages(
-    queue: &mut VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+    queue: &mut VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
     messages: Vec<RoutedAutomationMessage>,
 ) {
     for message in messages {
@@ -7799,6 +7805,7 @@ fn enqueue_agent_finished_messages(
             message.content,
             None,
             Some(message.target_mission_id),
+            Some("automation".to_string()),
         ));
     }
 }
@@ -8077,12 +8084,12 @@ async fn post_turn_handle_grok_goal(
 }
 
 fn queue_has_pending_target_mission(
-    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>)>,
+    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
     mission_id: Uuid,
 ) -> bool {
     queue
         .iter()
-        .any(|(_id, _msg, _agent, target_mid)| *target_mid == Some(mission_id))
+        .any(|(_id, _msg, _agent, target_mid, _source)| *target_mid == Some(mission_id))
 }
 
 fn accept_user_message_id(accepted: &mut HashSet<Uuid>, id: Uuid) -> bool {
@@ -8850,7 +8857,8 @@ async fn control_actor_loop(
 ) {
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
-    let mut queue: VecDeque<(Uuid, String, Option<String>, Option<Uuid>)> = VecDeque::new();
+    let mut queue: VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)> =
+        VecDeque::new();
     // Re-drive any messages that were queued before the last restart. They are
     // persisted as a JSON snapshot (see `persist_control_queue_if_changed`) so a
     // restart doesn't lose pending work. We re-inject them through the normal
@@ -8873,7 +8881,7 @@ async fn control_actor_loop(
                             agent: it.agent,
                             target_mission_id: it.mission_id,
                             strict: false,
-                            source: None,
+                            source: it.source,
                             respond: ack_tx,
                         }) {
                             tracing::warn!("Failed to re-queue restored control message: {e}");
@@ -9640,7 +9648,7 @@ async fn control_actor_loop(
                             Some(tid) => Some(tid),
                             None => *current_mission.read().await,
                         };
-                        queue.push_back((id, content, msg_agent, target_mission_id));
+                        queue.push_back((id, content, msg_agent, target_mission_id, source.clone()));
                         let status_mission_id = if running.is_some() {
                             running_mission_id
                         } else {
@@ -9663,7 +9671,7 @@ async fn control_actor_loop(
                             });
                         }
                         if running.is_none() {
-                            if let Some((mid, msg, per_msg_agent, msg_target_mid)) = queue.pop_front() {
+                            if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                                 // Persist the dequeue before the awaits that start
                                 // the run, so a crash here can't restore + re-run it.
                                 persist_control_queue_if_changed(
@@ -9680,7 +9688,7 @@ async fn control_actor_loop(
                                     queue.len(),
                                     msg_target_mid,
                                 ).await;
-                                let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid, source: source.clone() });
+                                let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid, source: msg_source.clone() });
 
                                 // Immediately persist user message so it's visible when loading mission
                                 history.push(("user".to_string(), msg.clone()));
@@ -10621,12 +10629,18 @@ async fn control_actor_loop(
                                 // Skip if the caller just wants to update the status (e.g., before sending a custom message)
                                 if !skip_message {
                                     let msg_id = Uuid::new_v4();
-                                    queue.push_back((msg_id, resume_prompt, None, Some(mission_id)));
+                                    queue.push_back((
+                                        msg_id,
+                                        resume_prompt,
+                                        None,
+                                        Some(mission_id),
+                                        Some("system:resume".to_string()),
+                                    ));
                                 }
 
                                 // Start execution if not already running
                                 if running.is_none() {
-                                    if let Some((mid, msg, _per_msg_agent, msg_target_mid)) = queue.pop_front() {
+                                    if let Some((mid, msg, _per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                                         // Persist the dequeue before the awaits that
                                         // start the run, so a crash here can't
                                         // restore + re-run it.
@@ -10645,7 +10659,7 @@ async fn control_actor_loop(
                                             queue.len(),
                                             Some(target_mid),
                                         ).await;
-                                        let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: Some(target_mid), source: None });
+                                        let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: Some(target_mid), source: msg_source.clone() });
                                         let cfg = config.clone();
                                         let agent = Arc::clone(&root_agent);
                                         let mcp_ref = Arc::clone(&mcp);
@@ -10823,11 +10837,12 @@ async fn control_actor_loop(
                         // Collect queued messages from main runner with their target mission IDs
                         let mut queued: Vec<QueuedMessage> = queue
                             .iter()
-                            .map(|(id, content, agent, target_mid)| QueuedMessage {
+                            .map(|(id, content, agent, target_mid, source)| QueuedMessage {
                                 id: *id,
                                 content: content.clone(),
                                 agent: agent.clone(),
                                 mission_id: *target_mid,
+                                source: source.clone(),
                             })
                             .collect();
                         // Also collect queued messages from parallel runners
@@ -10838,6 +10853,7 @@ async fn control_actor_loop(
                                     content: qm.content.clone(),
                                     agent: qm.agent.clone(),
                                     mission_id: Some(*mid),
+                                    source: None,
                                 });
                             }
                         }
@@ -10848,7 +10864,7 @@ async fn control_actor_loop(
 
                         // Try to remove from main queue
                         let before_len = queue.len();
-                        queue.retain(|(id, _, _, _)| *id != message_id);
+                        queue.retain(|(id, _, _, _, _)| *id != message_id);
                         if queue.len() < before_len {
                             removed = true;
                             // Emit event for main queue change
@@ -10906,7 +10922,7 @@ async fn control_actor_loop(
                                 // from one mission's view must not wipe other
                                 // missions' queues.
                                 let before_len = queue.len();
-                                queue.retain(|(_, _, _, target_mid)| *target_mid != Some(target));
+                                queue.retain(|(_, _, _, target_mid, _)| *target_mid != Some(target));
                                 let main_removed = before_len - queue.len();
                                 cleared += main_removed;
                                 if main_removed > 0 {
@@ -11338,7 +11354,7 @@ async fn control_actor_loop(
                         );
                         let already_queued_for_mission = queue
                             .iter()
-                            .any(|(_id, _msg, _agent, target_mid)| *target_mid == Some(mission_id));
+                            .any(|(_id, _msg, _agent, target_mid, _source)| *target_mid == Some(mission_id));
 
                         // Grok `/goal` post-turn: parse the sentinel from the
                         // assistant's last text and either disable the goal
@@ -11389,7 +11405,7 @@ async fn control_actor_loop(
                 }
 
                 // Start next queued message, if any.
-                if let Some((mid, msg, per_msg_agent, msg_target_mid)) = queue.pop_front() {
+                if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                     // Persist the dequeue before the awaits that start the run, so
                     // a crash here can't restore + re-run it.
                     persist_control_queue_if_changed(
@@ -11406,7 +11422,7 @@ async fn control_actor_loop(
                         queue.len(),
                         msg_target_mid,
                     ).await;
-                    let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid, source: None });
+                    let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid, source: msg_source.clone() });
 
                     // Immediately persist user message so it's visible when loading mission
                     history.push(("user".to_string(), msg.clone()));
@@ -11670,6 +11686,7 @@ async fn control_actor_loop(
                                         message.content,
                                         None,
                                         Some(message.target_mission_id),
+                                        Some("automation".to_string()),
                                     ));
                                 }
                             }
@@ -19024,6 +19041,7 @@ Investigate <service/> failures.
             "queued user message".to_string(),
             None,
             Some(existing_target),
+            Some("api:test-user".to_string()),
         )]);
 
         enqueue_agent_finished_messages(
@@ -19042,7 +19060,7 @@ Investigate <service/> failures.
 
         let ordered: Vec<(String, Option<Uuid>)> = queue
             .into_iter()
-            .map(|(_, content, _, mission_id)| (content, mission_id))
+            .map(|(_, content, _, mission_id, _)| (content, mission_id))
             .collect();
         assert_eq!(
             ordered,
@@ -19064,12 +19082,14 @@ Investigate <service/> failures.
                 "other mission".to_string(),
                 None,
                 Some(other_mission_id),
+                None,
             ),
             (
                 Uuid::new_v4(),
                 "current mission".to_string(),
                 None,
                 Some(mission_id),
+                None,
             ),
         ]);
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5793,38 +5793,61 @@ pub async fn resume_mission(
     // context and restart the runner. (Pending would be wrong here: the FLEET-001
     // dispatcher only dispatches `not_before`-scheduled missions that carry a
     // fresh `deferred_goal`, not paused missions continuing from history.)
-    if let Ok(Some(mission)) = control.mission_store.get_mission(mission_id).await {
-        if mission.status == MissionStatus::Paused {
-            control
-                .mission_store
-                .update_mission_status(mission_id, MissionStatus::Interrupted)
-                .await
-                .map_err(internal_error)?;
-            let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
-                mission_id,
-                status: MissionStatus::Interrupted,
-                summary: None,
-            });
-            // fall through to ResumeMission below
-        }
+    let was_paused = matches!(
+        control.mission_store.get_mission(mission_id).await,
+        Ok(Some(ref m)) if m.status == MissionStatus::Paused
+    );
+    if was_paused {
+        control
+            .mission_store
+            .update_mission_status(mission_id, MissionStatus::Interrupted)
+            .await
+            .map_err(internal_error)?;
+        let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+            mission_id,
+            status: MissionStatus::Interrupted,
+            summary: None,
+        });
     }
 
-    let (tx, rx) = oneshot::channel();
-    control
-        .cmd_tx
-        .send(ControlCommand::ResumeMission {
-            mission_id,
-            clean_workspace,
-            skip_message,
-            respond: tx,
-        })
-        .await
-        .map_err(session_unavailable)?;
+    let outcome: Result<Mission, (StatusCode, String)> = async {
+        let (tx, rx) = oneshot::channel();
+        control
+            .cmd_tx
+            .send(ControlCommand::ResumeMission {
+                mission_id,
+                clean_workspace,
+                skip_message,
+                respond: tx,
+            })
+            .await
+            .map_err(session_unavailable)?;
+        rx.await
+            .map_err(recv_failed)?
+            .map_err(|e| (StatusCode::BAD_REQUEST, e))
+    }
+    .await;
 
-    rx.await
-        .map_err(recv_failed)?
-        .map(Json)
-        .map_err(|e| (StatusCode::BAD_REQUEST, e))
+    match outcome {
+        Ok(mission) => Ok(Json(mission)),
+        Err(err) => {
+            // A failed resume must not leave a paused mission stranded in
+            // Interrupted: restore the operator-visible Paused state (best
+            // effort) before surfacing the error.
+            if was_paused {
+                let _ = control
+                    .mission_store
+                    .update_mission_status(mission_id, MissionStatus::Paused)
+                    .await;
+                let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    mission_id,
+                    status: MissionStatus::Paused,
+                    summary: None,
+                });
+            }
+            Err(err)
+        }
+    }
 }
 
 /// Delete a mission by ID.
@@ -8963,6 +8986,14 @@ async fn control_actor_loop(
     // idle, dispatches the highest-priority dispatchable one.
     const SCHEDULER_PASS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
     let mut last_scheduler_pass = tokio::time::Instant::now();
+    // Guards against double-dispatch: a scheduled mission stays Pending (with its
+    // goal) until the dispatched message is processed and flips it to Active. If
+    // the actor is slow or the start is dropped, that window can exceed one pass,
+    // so we record each dispatch and skip re-dispatching the same mission until
+    // this cooldown elapses (after which a still-Pending mission is retried).
+    const SCHEDULER_DISPATCH_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
+    let mut scheduler_inflight: std::collections::HashMap<Uuid, tokio::time::Instant> =
+        std::collections::HashMap::new();
     // Per-boss "wake outstanding" flags, coalescing board wakes across passes.
     let mut board_wake_state: std::collections::HashMap<Uuid, bool> =
         std::collections::HashMap::new();
@@ -11889,11 +11920,17 @@ async fn control_actor_loop(
                 // the main session is idle. Throttled like the board pass.
                 if last_scheduler_pass.elapsed() >= SCHEDULER_PASS_INTERVAL {
                     last_scheduler_pass = tokio::time::Instant::now();
+                    // Drop cooldown records that have aged out so a still-Pending
+                    // (dropped) mission becomes eligible for retry.
+                    scheduler_inflight
+                        .retain(|_, at| at.elapsed() < SCHEDULER_DISPATCH_COOLDOWN);
                     match mission_store.get_scheduled_pending_missions().await {
                         Ok(pending) => {
                             let now = chrono::Utc::now();
                             // 1. Expire any scheduled mission whose deadline elapsed
-                            //    before it ever dispatched.
+                            //    before it ever dispatched. Missions still within the
+                            //    dispatch cooldown are skipped (not added to `live`) so
+                            //    a slow/lost start can't trigger a duplicate dispatch.
                             let mut live: Vec<Mission> = Vec::with_capacity(pending.len());
                             for m in pending {
                                 if m.is_past_deadline(now) {
@@ -11931,6 +11968,9 @@ async fn control_actor_loop(
                                             ),
                                         });
                                     }
+                                } else if scheduler_inflight.contains_key(&m.id) {
+                                    // A dispatch for this mission is still settling;
+                                    // skip until the cooldown record ages out.
                                 } else {
                                     live.push(m);
                                 }
@@ -11974,11 +12014,21 @@ async fn control_actor_loop(
                                             source: Some("scheduler".to_string()),
                                             respond: ack_tx,
                                         }) {
-                                            Ok(()) => tracing::info!(
-                                                mission_id = %mission_id,
-                                                priority,
-                                                "Scheduler: dispatching scheduled mission"
-                                            ),
+                                            Ok(()) => {
+                                                // Record the dispatch so the next passes
+                                                // skip this mission until it flips to
+                                                // Active (or the cooldown lets a dropped
+                                                // start retry).
+                                                scheduler_inflight.insert(
+                                                    mission_id,
+                                                    tokio::time::Instant::now(),
+                                                );
+                                                tracing::info!(
+                                                    mission_id = %mission_id,
+                                                    priority,
+                                                    "Scheduler: dispatching scheduled mission"
+                                                );
+                                            }
                                             Err(e) => tracing::warn!(
                                                 mission_id = %mission_id,
                                                 "Scheduler: dispatch enqueue failed; will retry: {e}"

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5682,6 +5682,69 @@ pub async fn pause_mission(
     Ok(Json(updated))
 }
 
+/// Overrides accepted when cloning a mission (FLEET-002). Any field left unset
+/// inherits from the source mission.
+#[derive(Debug, Default, Deserialize)]
+pub struct CloneMissionRequest {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub backend: Option<String>,
+    #[serde(default)]
+    pub model_effort: Option<String>,
+    #[serde(default)]
+    pub model_override: Option<String>,
+}
+
+/// Clone an existing mission's configuration into a fresh `Pending` mission
+/// (FLEET-002). Copies title, workspace, agent, config profile, working
+/// directory and model settings; the optional body overrides
+/// title/backend/model_effort/model_override. Conversation history is **not**
+/// copied — the clone starts fresh. Reuses the standard create path so all
+/// backend/agent/model validation applies identically.
+pub async fn clone_mission(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(mission_id): Path<Uuid>,
+    body: Option<Json<CloneMissionRequest>>,
+) -> Result<Json<Mission>, (StatusCode, String)> {
+    let overrides = body.map(|b| b.0).unwrap_or_default();
+
+    let control = control_for_user(&state, &user).await;
+    let source = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Mission {} not found", mission_id),
+            )
+        })?;
+
+    let req = CreateMissionRequest {
+        title: overrides.title.or_else(|| source.title.clone()),
+        workspace_id: Some(source.workspace_id),
+        agent: source.agent.clone(),
+        model_override: overrides
+            .model_override
+            .or_else(|| source.model_override.clone()),
+        model_effort: overrides
+            .model_effort
+            .or_else(|| source.model_effort.clone()),
+        config_profile: source.config_profile.clone(),
+        backend: overrides.backend.or_else(|| Some(source.backend.clone())),
+        parent_mission_id: None,
+        working_directory: source.working_directory.clone(),
+        priority: None,
+        not_before: None,
+        deadline: None,
+    };
+
+    create_mission(State(state), Extension(user), Some(Json(req))).await
+}
+
 /// Request body for resuming a mission
 #[derive(Debug, Deserialize, Default)]
 pub struct ResumeMissionRequest {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5926,6 +5926,11 @@ pub async fn resume_mission(
             .update_mission_status(mission_id, MissionStatus::Interrupted)
             .await
             .map_err(internal_error)?;
+        // FLEET-004: leaving Paused clears the pause timestamp.
+        let _ = control
+            .mission_store
+            .set_mission_paused_at(mission_id, None)
+            .await;
         let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
             mission_id,
             status: MissionStatus::Interrupted,
@@ -10643,6 +10648,13 @@ async fn control_actor_loop(
                             .await
                         {
                             Ok(()) => {
+                                // FLEET-004: stamp the pause time for UI pause-age.
+                                let _ = mission_store
+                                    .set_mission_paused_at(
+                                        mission_id,
+                                        Some(chrono::Utc::now().to_rfc3339()),
+                                    )
+                                    .await;
                                 let _ = events_tx.send(AgentEvent::MissionStatusChanged {
                                     mission_id,
                                     status: MissionStatus::Paused,
@@ -18928,6 +18940,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now.clone(),
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,
@@ -18960,6 +18973,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,
@@ -19007,6 +19021,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,
@@ -19051,6 +19066,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,
@@ -19095,6 +19111,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,
@@ -19139,6 +19156,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,
@@ -19267,6 +19285,7 @@ And the report:
             created_at: now.clone(),
             updated_at: now.clone(),
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3324,6 +3324,7 @@ pub async fn post_message(
             agent,
             target_mission_id,
             strict: false,
+            source: Some(format!("api:{}", user.id)),
             respond: queued_tx,
         })
         .await
@@ -3545,6 +3546,7 @@ pub async fn board_task_verdict(
                         agent: None,
                         target_mission_id: Some(worker_id),
                         strict: false,
+                        source: Some("task-board".to_string()),
                         respond: tx,
                     })
                     .await
@@ -5976,6 +5978,11 @@ fn stored_event_to_agent_event(event: &mission_store::StoredEvent) -> Option<Age
             content: event.content.clone(),
             queued: false,
             mission_id,
+            source: event
+                .metadata
+                .get("source")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
         }),
         "assistant_message" => {
             let meta = event.metadata.as_object();
@@ -7412,6 +7419,7 @@ async fn automation_scheduler_loop(
                         agent: None,
                         target_mission_id: Some(mission.id),
                         strict: false,
+                        source: None,
                         respond: respond_tx,
                     })
                     .await;
@@ -8683,6 +8691,7 @@ async fn control_actor_loop(
                             agent: it.agent,
                             target_mission_id: it.mission_id,
                             strict: false,
+                            source: None,
                             respond: ack_tx,
                         }) {
                             tracing::warn!("Failed to re-queue restored control message: {e}");
@@ -8979,7 +8988,7 @@ async fn control_actor_loop(
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else { break };
                 match cmd {
-                    ControlCommand::UserMessage { id, content, agent: msg_agent, target_mission_id, strict, respond } => {
+                    ControlCommand::UserMessage { id, content, agent: msg_agent, target_mission_id, strict, source, respond } => {
                         if !accept_user_message_id(&mut accepted_user_message_ids, id) {
                             let status_snapshot = status.read().await;
                             let _ = respond.send(if status_snapshot.state != ControlRunState::Idle {
@@ -9090,6 +9099,7 @@ async fn control_actor_loop(
                                         content: content.clone(),
                                         queued: was_running,
                                         mission_id: Some(tid),
+                                        source: source.clone(),
                                     });
                                     // Surface the parallel queue growth to all
                                     // clients (Status events otherwise only
@@ -9207,6 +9217,7 @@ async fn control_actor_loop(
                                                 content: content.clone(),
                                                 queued: false,
                                                 mission_id: Some(tid),
+                                                source: source.clone(),
                                             });
                                             // Start execution
                                             runner.start_next(
@@ -9438,6 +9449,7 @@ async fn control_actor_loop(
                                 content: content_clone,
                                 queued: true,
                                 mission_id: target_mission_id,
+                                source: source.clone(),
                             });
                         }
                         if running.is_none() {
@@ -9458,7 +9470,7 @@ async fn control_actor_loop(
                                     queue.len(),
                                     msg_target_mid,
                                 ).await;
-                                let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid });
+                                let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid, source: source.clone() });
 
                                 // Immediately persist user message so it's visible when loading mission
                                 history.push(("user".to_string(), msg.clone()));
@@ -9852,6 +9864,7 @@ async fn control_actor_loop(
                                         content: handoff,
                                         queued: false,
                                         mission_id: Some(id),
+                                        source: None,
                                     };
                                     if let Err(e) = mission_store.log_event(id, &event).await {
                                         tracing::warn!(
@@ -10365,7 +10378,7 @@ async fn control_actor_loop(
                                             queue.len(),
                                             Some(target_mid),
                                         ).await;
-                                        let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: Some(target_mid) });
+                                        let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: Some(target_mid), source: None });
                                         let cfg = config.clone();
                                         let agent = Arc::clone(&root_agent);
                                         let mcp_ref = Arc::clone(&mcp);
@@ -11126,7 +11139,7 @@ async fn control_actor_loop(
                         queue.len(),
                         msg_target_mid,
                     ).await;
-                    let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid });
+                    let _ = events_tx.send(AgentEvent::UserMessage { id: mid, content: msg.clone(), queued: false, mission_id: msg_target_mid, source: None });
 
                     // Immediately persist user message so it's visible when loading mission
                     history.push(("user".to_string(), msg.clone()));
@@ -12820,6 +12833,7 @@ pub async fn create_automation(
                     agent: None,
                     target_mission_id: Some(target_mission_id),
                     strict: false,
+                    source: None,
                     respond: respond_tx,
                 })
                 .await;
@@ -14070,6 +14084,7 @@ pub async fn webhook_receiver(
             agent: None,
             target_mission_id: Some(mission.id),
             strict: false,
+            source: None,
             respond: respond_tx,
         })
         .await;
@@ -15224,6 +15239,7 @@ pub async fn send_telegram_message_api(
                     agent: None,
                     target_mission_id: Some(mapping.mission_id),
                     strict: false,
+                    source: Some("telegram".to_string()),
                     respond: tx,
                 })
                 .await;

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -63,6 +63,11 @@ use super::routes::AppState;
 pub(crate) const SERVER_SHUTDOWN_AUTO_RESUME_MAX_AGE_HOURS: u64 = 48;
 const INTERRUPTED_RESUME_PROMPT: &str = "You were interrupted, resume your work.";
 
+/// One entry in the main control queue: (message id, content, optional per-message
+/// agent override, target mission id, source). Aliased to keep signatures under
+/// clippy's `type_complexity` threshold.
+type ControlQueueEntry = (Uuid, String, Option<String>, Option<Uuid>, Option<String>);
+
 /// Silence threshold before declaring a mission stuck. Conservative so
 /// legitimately long codex turns (Lean compiles, CI polls) don't trigger
 /// false positives. Shared between the watchdog loop and the actor's
@@ -2592,9 +2597,7 @@ pub struct QueuedMessage {
 
 /// Serialize the control session queue to a stable JSON snapshot for
 /// persistence across restarts (see `MissionStore::save_control_queue`).
-fn serialize_queue_snapshot(
-    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
-) -> String {
+fn serialize_queue_snapshot(queue: &VecDeque<ControlQueueEntry>) -> String {
     let items: Vec<QueuedMessage> = queue
         .iter()
         .map(|(id, content, agent, target_mid, source)| QueuedMessage {
@@ -2620,7 +2623,7 @@ fn serialize_queue_snapshot(
 async fn persist_control_queue_if_changed(
     mission_store: &Arc<dyn MissionStore>,
     session_user_id: &str,
-    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
+    queue: &VecDeque<ControlQueueEntry>,
     last_persisted: &mut String,
 ) {
     let snapshot = serialize_queue_snapshot(queue);
@@ -5782,10 +5785,12 @@ pub async fn resume_mission(
 
     let control = control_for_user(&state, &user).await;
 
-    // FLEET-004: a Paused mission resumes by returning to the dispatcher queue
-    // (Paused → Pending) rather than going through the interrupted-mission
-    // context-reconstruction path below. The dispatcher re-selects it on its
-    // next pass, honoring priority/not_before ordering (FLEET-001).
+    // FLEET-004: a Paused mission first returns to Pending, then falls through to
+    // the ResumeMission path below to actually rebuild context and start the
+    // runner. The FLEET-001 priority/not_before dispatcher that would otherwise
+    // re-select a Pending mission is not yet wired in production, so resuming has
+    // to start the mission directly rather than parking it in Pending — otherwise
+    // the agent never runs again from the resume API alone.
     if let Ok(Some(mission)) = control.mission_store.get_mission(mission_id).await {
         if mission.status == MissionStatus::Paused {
             control
@@ -5798,18 +5803,7 @@ pub async fn resume_mission(
                 status: MissionStatus::Pending,
                 summary: None,
             });
-            let updated = control
-                .mission_store
-                .get_mission(mission_id)
-                .await
-                .map_err(internal_error)?
-                .ok_or_else(|| {
-                    (
-                        StatusCode::NOT_FOUND,
-                        format!("Mission {} not found", mission_id),
-                    )
-                })?;
-            return Ok(Json(updated));
+            // fall through to ResumeMission below
         }
     }
 
@@ -7796,7 +7790,7 @@ struct RoutedAutomationMessage {
 }
 
 fn enqueue_agent_finished_messages(
-    queue: &mut VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
+    queue: &mut VecDeque<ControlQueueEntry>,
     messages: Vec<RoutedAutomationMessage>,
 ) {
     for message in messages {
@@ -8083,10 +8077,7 @@ async fn post_turn_handle_grok_goal(
     }
 }
 
-fn queue_has_pending_target_mission(
-    queue: &VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)>,
-    mission_id: Uuid,
-) -> bool {
+fn queue_has_pending_target_mission(queue: &VecDeque<ControlQueueEntry>, mission_id: Uuid) -> bool {
     queue
         .iter()
         .any(|(_id, _msg, _agent, target_mid, _source)| *target_mid == Some(mission_id))
@@ -8857,8 +8848,7 @@ async fn control_actor_loop(
 ) {
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
-    let mut queue: VecDeque<(Uuid, String, Option<String>, Option<Uuid>, Option<String>)> =
-        VecDeque::new();
+    let mut queue: VecDeque<ControlQueueEntry> = VecDeque::new();
     // Re-drive any messages that were queued before the last restart. They are
     // persisted as a JSON snapshot (see `persist_control_queue_if_changed`) so a
     // restart doesn't lose pending work. We re-inject them through the normal
@@ -9295,7 +9285,7 @@ async fn control_actor_loop(
                             if target_in_parallel {
                                 if let Some(runner) = parallel_runners.get_mut(&tid) {
                                     let was_running = runner.is_running();
-                                    runner.queue_message(id, content.clone(), msg_agent);
+                                    runner.queue_message(id, content.clone(), msg_agent, source.clone());
                                     let _ = events_tx.send(AgentEvent::UserMessage {
                                         id,
                                         content: content.clone(),
@@ -9412,7 +9402,7 @@ async fn control_actor_loop(
                                                 runner.history.push((entry.role.clone(), entry.content.clone()));
                                             }
                                             // Queue the message
-                                            runner.queue_message(id, content.clone(), msg_agent);
+                                            runner.queue_message(id, content.clone(), msg_agent, source.clone());
                                             // Emit user message event
                                             let _ = events_tx.send(AgentEvent::UserMessage {
                                                 id,
@@ -10151,7 +10141,7 @@ async fn control_actor_loop(
                             }
 
                             // Queue the initial message (no per-message agent override for parallel start)
-                            runner.queue_message(Uuid::new_v4(), content, None);
+                            runner.queue_message(Uuid::new_v4(), content, None, None);
 
                             // Start execution
                             let started = runner.start_next(
@@ -10534,7 +10524,7 @@ async fn control_actor_loop(
                                             .history
                                             .push((entry.role.clone(), entry.content.clone()));
                                     }
-                                    runner.queue_message(Uuid::new_v4(), resume_prompt, None);
+                                    runner.queue_message(Uuid::new_v4(), resume_prompt, None, None);
 
                                     let started = runner.start_next(
                                         config.clone(),
@@ -10853,7 +10843,7 @@ async fn control_actor_loop(
                                     content: qm.content.clone(),
                                     agent: qm.agent.clone(),
                                     mission_id: Some(*mid),
-                                    source: None,
+                                    source: qm.source.clone(),
                                 });
                             }
                         }
@@ -11675,7 +11665,7 @@ async fn control_actor_loop(
                                 .await;
                                 for message in messages {
                                     if message.target_mission_id == *mission_id {
-                                        runner.queue_message(Uuid::new_v4(), message.content, None);
+                                        runner.queue_message(Uuid::new_v4(), message.content, None, None);
                                         continue;
                                     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -9360,6 +9360,21 @@ async fn control_actor_loop(
                                     // Load mission and start in parallel
                                     match load_mission_record(&mission_store, tid).await {
                                         Ok(mission) => {
+                                            // A paused mission must not be auto-started by an
+                                            // incoming message — respect the pause. The user
+                                            // resumes it explicitly via the resume API.
+                                            if mission.status == MissionStatus::Paused {
+                                                let _ = events_tx.send(AgentEvent::Error {
+                                                    message: format!(
+                                                        "Mission {} is paused; resume it before sending messages",
+                                                        tid
+                                                    ),
+                                                    mission_id: Some(tid),
+                                                    resumable: true,
+                                                });
+                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                continue;
+                                            }
                                             // Activate mission: if pending, interrupted, blocked, completed, or failed, update status to active
                                             if matches!(
                                                 mission.status,
@@ -10120,6 +10135,15 @@ async fn control_actor_loop(
                                     continue;
                                 }
                             };
+
+                            // Don't start a paused mission — resume it explicitly first.
+                            if mission.status == MissionStatus::Paused {
+                                let _ = respond.send(Err(format!(
+                                    "Mission {} is paused; resume it before starting",
+                                    mission_id
+                                )));
+                                continue;
+                            }
 
                             // Create a new MissionRunner
                             let mut runner = super::mission_runner::MissionRunner::new(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -12556,6 +12556,24 @@ pub async fn create_automation(
 ) -> Result<Json<mission_store::Automation>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
 
+    if control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(internal_error)?
+        .is_none()
+    {
+        tracing::warn!(
+            mission_id = %mission_id,
+            user_id = %user.id,
+            "Rejecting automation create for missing mission"
+        );
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Mission {} not found; cannot create automation", mission_id),
+        ));
+    }
+
     // Validate the command exists in the library if CommandSource::Library
     if let mission_store::CommandSource::Library { ref name } = req.command_source {
         validate_library_command(&state, name).await?;
@@ -12639,6 +12657,16 @@ pub async fn create_automation(
         .get("__wakeup_source")
         .map(String::as_str)
         == Some("claude-builtin");
+
+    tracing::info!(
+        mission_id = %mission_id,
+        automation_id = %automation.id,
+        command_source = ?automation.command_source,
+        trigger = ?automation.trigger,
+        fresh_session = ?automation.fresh_session,
+        is_builtin_wakeup,
+        "Creating mission automation"
+    );
 
     let mut automation = control
         .mission_store

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2809,6 +2809,7 @@ impl MissionRunner {
         let user_id = self.user_id.clone();
         let user_message = msg.content.clone();
         let msg_id = msg.id;
+        let msg_source = msg.source.clone();
         tracing::info!(
             mission_id = %mission_id,
             workspace_id = %workspace_id,
@@ -2824,13 +2825,14 @@ impl MissionRunner {
             cmd_tx: mission_cmd_tx,
         };
 
-        // Emit user message event with mission context
+        // Emit user message event with mission context, preserving the original
+        // attribution (api:/telegram/…) stored on the queued message.
         let _ = events_tx.send(AgentEvent::UserMessage {
             id: msg_id,
             content: user_message.clone(),
             queued: false,
             mission_id: Some(mission_id),
-            source: None,
+            source: msg_source,
         });
 
         let handle = tokio::spawn(async move {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2467,6 +2467,9 @@ pub struct QueuedMessage {
     pub content: String,
     /// Optional agent override for this specific message (e.g., from @agent mention)
     pub agent: Option<String>,
+    /// Origin of the message (e.g. `api:<user_id>`, `telegram`) for audit. None
+    /// for system-generated messages (resume prompts, board wakeups).
+    pub source: Option<String>,
 }
 
 /// Environment flag gating the background-task auto-resume feature.
@@ -2720,8 +2723,19 @@ impl MissionRunner {
     }
 
     /// Queue a message for this mission.
-    pub fn queue_message(&mut self, id: Uuid, content: String, agent: Option<String>) {
-        self.queue.push_back(QueuedMessage { id, content, agent });
+    pub fn queue_message(
+        &mut self,
+        id: Uuid,
+        content: String,
+        agent: Option<String>,
+        source: Option<String>,
+    ) {
+        self.queue.push_back(QueuedMessage {
+            id,
+            content,
+            agent,
+            source,
+        });
     }
 
     /// Cancel the current execution.

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2816,6 +2816,7 @@ impl MissionRunner {
             content: user_message.clone(),
             queued: false,
             mission_id: Some(mission_id),
+            source: None,
         });
 
         let handle = tokio::spawn(async move {

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -165,6 +165,7 @@ impl MissionStore for FileMissionStore {
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: Some(Uuid::new_v4().to_string()),
@@ -551,6 +552,19 @@ impl MissionStore for FileMissionStore {
 
     async fn get_deferred_goal(&self, mission_id: Uuid) -> Result<Option<String>, String> {
         Ok(self.deferred_goals.read().await.get(&mission_id).cloned())
+    }
+
+    async fn set_mission_paused_at(
+        &self,
+        mission_id: Uuid,
+        paused_at: Option<String>,
+    ) -> Result<(), String> {
+        {
+            if let Some(m) = self.missions.write().await.get_mut(&mission_id) {
+                m.paused_at = paused_at;
+            }
+        }
+        self.persist().await
     }
 
     async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String> {

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -21,6 +21,10 @@ const METADATA_SOURCE_USER: &str = "user";
 struct MissionStoreSnapshot {
     missions: HashMap<Uuid, Mission>,
     trees: HashMap<Uuid, AgentTreeNode>,
+    /// FLEET-001 scheduling: deferred goals held outside the Mission struct
+    /// (mirrors the sqlite `deferred_goal` column).
+    #[serde(default)]
+    deferred_goals: HashMap<Uuid, String>,
 }
 
 #[derive(Clone)]
@@ -28,6 +32,7 @@ pub struct FileMissionStore {
     path: PathBuf,
     missions: Arc<RwLock<HashMap<Uuid, Mission>>>,
     trees: Arc<RwLock<HashMap<Uuid, AgentTreeNode>>>,
+    deferred_goals: Arc<RwLock<HashMap<Uuid, String>>>,
     persist_lock: Arc<Mutex<()>>,
 }
 
@@ -59,6 +64,7 @@ impl FileMissionStore {
             path,
             missions: Arc::new(RwLock::new(snapshot.missions)),
             trees: Arc::new(RwLock::new(snapshot.trees)),
+            deferred_goals: Arc::new(RwLock::new(snapshot.deferred_goals)),
             persist_lock: Arc::new(Mutex::new(())),
         })
     }
@@ -68,6 +74,7 @@ impl FileMissionStore {
         let snapshot = MissionStoreSnapshot {
             missions: self.missions.read().await.clone(),
             trees: self.trees.read().await.clone(),
+            deferred_goals: self.deferred_goals.read().await.clone(),
         };
         let data = serde_json::to_vec_pretty(&snapshot)
             .map_err(|e| format!("Failed to serialize mission store: {}", e))?;
@@ -520,6 +527,43 @@ impl MissionStore for FileMissionStore {
             .filter(|m| m.status == MissionStatus::Active)
             .cloned()
             .collect();
+        Ok(missions)
+    }
+
+    async fn set_deferred_goal(
+        &self,
+        mission_id: Uuid,
+        goal: Option<String>,
+    ) -> Result<(), String> {
+        {
+            let mut goals = self.deferred_goals.write().await;
+            match goal {
+                Some(g) => {
+                    goals.insert(mission_id, g);
+                }
+                None => {
+                    goals.remove(&mission_id);
+                }
+            }
+        }
+        self.persist().await
+    }
+
+    async fn get_deferred_goal(&self, mission_id: Uuid) -> Result<Option<String>, String> {
+        Ok(self.deferred_goals.read().await.get(&mission_id).cloned())
+    }
+
+    async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String> {
+        let goals = self.deferred_goals.read().await;
+        let mut missions: Vec<Mission> = self
+            .missions
+            .read()
+            .await
+            .values()
+            .filter(|m| m.status == MissionStatus::Pending && goals.contains_key(&m.id))
+            .cloned()
+            .collect();
+        missions.sort_by(|a, b| a.created_at.cmp(&b.created_at));
         Ok(missions)
     }
 

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -168,6 +168,7 @@ impl MissionStore for FileMissionStore {
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
         self.missions
             .write()

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -19,6 +19,9 @@ pub struct InMemoryMissionStore {
     missions: Arc<RwLock<HashMap<Uuid, Mission>>>,
     trees: Arc<RwLock<HashMap<Uuid, AgentTreeNode>>>,
     board_tasks: Arc<RwLock<HashMap<Uuid, BoardTask>>>,
+    /// FLEET-001 scheduling: deferred goals held outside the Mission struct
+    /// (mirrors the sqlite `deferred_goal` column).
+    deferred_goals: Arc<RwLock<HashMap<Uuid, String>>>,
 }
 
 impl InMemoryMissionStore {
@@ -27,6 +30,7 @@ impl InMemoryMissionStore {
             missions: Arc::new(RwLock::new(HashMap::new())),
             trees: Arc::new(RwLock::new(HashMap::new())),
             board_tasks: Arc::new(RwLock::new(HashMap::new())),
+            deferred_goals: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -455,6 +459,41 @@ impl MissionStore for InMemoryMissionStore {
             .filter(|m| m.status == MissionStatus::Active)
             .cloned()
             .collect();
+        Ok(missions)
+    }
+
+    async fn set_deferred_goal(
+        &self,
+        mission_id: Uuid,
+        goal: Option<String>,
+    ) -> Result<(), String> {
+        let mut goals = self.deferred_goals.write().await;
+        match goal {
+            Some(g) => {
+                goals.insert(mission_id, g);
+            }
+            None => {
+                goals.remove(&mission_id);
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_deferred_goal(&self, mission_id: Uuid) -> Result<Option<String>, String> {
+        Ok(self.deferred_goals.read().await.get(&mission_id).cloned())
+    }
+
+    async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String> {
+        let goals = self.deferred_goals.read().await;
+        let mut missions: Vec<Mission> = self
+            .missions
+            .read()
+            .await
+            .values()
+            .filter(|m| m.status == MissionStatus::Pending && goals.contains_key(&m.id))
+            .cloned()
+            .collect();
+        missions.sort_by(|a, b| a.created_at.cmp(&b.created_at));
         Ok(missions)
     }
 

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -117,6 +117,7 @@ impl MissionStore for InMemoryMissionStore {
             created_at: now.clone(),
             updated_at: now,
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: Some(Uuid::new_v4().to_string()),
@@ -481,6 +482,17 @@ impl MissionStore for InMemoryMissionStore {
 
     async fn get_deferred_goal(&self, mission_id: Uuid) -> Result<Option<String>, String> {
         Ok(self.deferred_goals.read().await.get(&mission_id).cloned())
+    }
+
+    async fn set_mission_paused_at(
+        &self,
+        mission_id: Uuid,
+        paused_at: Option<String>,
+    ) -> Result<(), String> {
+        if let Some(m) = self.missions.write().await.get_mut(&mission_id) {
+            m.paused_at = paused_at;
+        }
+        Ok(())
     }
 
     async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String> {

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -123,6 +123,7 @@ impl MissionStore for InMemoryMissionStore {
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
         self.missions
             .write()

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -33,10 +33,12 @@ pub struct MissionScheduling {
     /// Dispatch priority; higher wins. FIFO (by `created_at`) within a tier.
     #[serde(default)]
     pub priority: i32,
-    /// Do not dispatch before this RFC3339 timestamp.
+    /// Do not dispatch before this RFC3339 timestamp. The scheduler holds the
+    /// mission's goal in `deferred_goal` and only dispatches once `now` passes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub not_before: Option<String>,
-    /// Soft deadline (RFC3339) for observability/enforcement.
+    /// Deadline (RFC3339). The scheduler fails a still-undispatched scheduled
+    /// mission with reason `deadline_exceeded` once this passes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deadline: Option<String>,
 }
@@ -1465,6 +1467,19 @@ pub trait MissionStore: Send + Sync {
     /// Get all missions currently in active status (for startup recovery).
     async fn get_all_active_missions(&self) -> Result<Vec<Mission>, String>;
 
+    /// FLEET-001 scheduling: persist (or clear, with `None`) the deferred goal a
+    /// `not_before`-scheduled mission will run once the dispatcher picks it up.
+    async fn set_deferred_goal(&self, mission_id: Uuid, goal: Option<String>)
+        -> Result<(), String>;
+
+    /// FLEET-001 scheduling: read the deferred goal for a mission, if any.
+    async fn get_deferred_goal(&self, mission_id: Uuid) -> Result<Option<String>, String>;
+
+    /// FLEET-001 scheduling: all `Pending` missions that carry a deferred goal
+    /// (i.e. are armed for scheduled dispatch). Scheduling fields are populated
+    /// so the dispatcher can order/expire them; history is not loaded.
+    async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String>;
+
     /// Record the first time the user opened this mission, if not already set.
     /// Returns `Some(timestamp)` if the field was set by this call, or `None`
     /// if it was already populated (no-op). Used by the new
@@ -2888,6 +2903,73 @@ mod tests {
             active_missions.is_empty(),
             "Pending missions should not appear in active missions list"
         );
+    }
+
+    /// FLEET-001: a Pending mission appears in the scheduled-pending list only
+    /// while it carries a deferred goal, and disappears once dispatched (Active)
+    /// or the goal is cleared.
+    #[tokio::test]
+    async fn test_scheduled_pending_missions_track_deferred_goal() {
+        let store = InMemoryMissionStore::new();
+        let mission = store
+            .create_mission(Some("Scheduled"), None, None, None, None, None, None)
+            .await
+            .expect("create mission");
+
+        // No goal yet -> not scheduled-pending.
+        assert!(store
+            .get_scheduled_pending_missions()
+            .await
+            .expect("list")
+            .is_empty());
+
+        // Stash a goal -> appears, with the goal readable.
+        store
+            .set_deferred_goal(mission.id, Some("do the thing".to_string()))
+            .await
+            .expect("set goal");
+        assert_eq!(
+            store
+                .get_deferred_goal(mission.id)
+                .await
+                .expect("get goal")
+                .as_deref(),
+            Some("do the thing")
+        );
+        let pending = store.get_scheduled_pending_missions().await.expect("list");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, mission.id);
+
+        // Dispatched (Active) -> no longer scheduled-pending even with goal set.
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .expect("activate");
+        assert!(store
+            .get_scheduled_pending_missions()
+            .await
+            .expect("list")
+            .is_empty());
+
+        // Back to Pending but goal cleared -> still not scheduled-pending.
+        store
+            .update_mission_status(mission.id, MissionStatus::Pending)
+            .await
+            .expect("repend");
+        store
+            .set_deferred_goal(mission.id, None)
+            .await
+            .expect("clear goal");
+        assert!(store
+            .get_deferred_goal(mission.id)
+            .await
+            .expect("get goal")
+            .is_none());
+        assert!(store
+            .get_scheduled_pending_missions()
+            .await
+            .expect("list")
+            .is_empty());
     }
 
     /// Test that missions transition correctly from Pending to Active.

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -21,6 +21,26 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use uuid::Uuid;
 
+/// FLEET-001 scheduling metadata for a mission. Flattened into [`Mission`] so
+/// the fields surface at the top level of API responses (the fleet watcher
+/// reads `priority`/`not_before`/`deadline` directly) while keeping the
+/// scheduler inputs grouped in one place.
+///
+/// Timestamps are stored as RFC3339 strings to match the rest of the mission
+/// row (`created_at`/`updated_at`) and the underlying TEXT columns.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissionScheduling {
+    /// Dispatch priority; higher wins. FIFO (by `created_at`) within a tier.
+    #[serde(default)]
+    pub priority: i32,
+    /// Do not dispatch before this RFC3339 timestamp.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<String>,
+    /// Soft deadline (RFC3339) for observability/enforcement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<String>,
+}
+
 /// A mission (persistent goal-oriented session).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Mission {
@@ -103,6 +123,10 @@ pub struct Mission {
     /// Active via a new user message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub first_viewed_at: Option<String>,
+    /// FLEET-001 scheduling metadata (priority, not_before, deadline).
+    /// Flattened so the fields appear top-level in serialized output.
+    #[serde(default, flatten)]
+    pub scheduling: MissionScheduling,
 }
 
 /// Aggregate mission counts by status.
@@ -120,6 +144,55 @@ fn default_backend() -> String {
 
 fn default_workspace_id() -> Uuid {
     crate::workspace::DEFAULT_WORKSPACE_ID
+}
+
+impl Mission {
+    /// True when the `not_before` constraint (if any) is satisfied at `now`.
+    /// An unset or unparseable timestamp never blocks dispatch.
+    pub fn is_dispatchable_at(&self, now: chrono::DateTime<Utc>) -> bool {
+        match self.scheduling.not_before.as_deref() {
+            Some(ts) => chrono::DateTime::parse_from_rfc3339(ts)
+                .map(|t| t.with_timezone(&Utc) <= now)
+                .unwrap_or(true),
+            None => true,
+        }
+    }
+
+    /// True when a `deadline` is set and has already elapsed at `now`.
+    pub fn is_past_deadline(&self, now: chrono::DateTime<Utc>) -> bool {
+        match self.scheduling.deadline.as_deref() {
+            Some(ts) => chrono::DateTime::parse_from_rfc3339(ts)
+                .map(|t| t.with_timezone(&Utc) < now)
+                .unwrap_or(false),
+            None => false,
+        }
+    }
+}
+
+/// FLEET-001: select the next mission to dispatch from a candidate set.
+///
+/// A mission is *runnable* when it is `Pending` (which excludes `Paused`,
+/// terminal, and in-flight states) and its `not_before` constraint is
+/// satisfied at `now`. Among runnable missions the highest `priority` wins,
+/// with ties broken by oldest `created_at` (FIFO). Returns `None` when
+/// nothing is runnable.
+///
+/// This is a pure function so the dispatch ordering has a single, unit-tested
+/// source of truth independent of any storage backend.
+pub fn select_next_runnable_mission(
+    missions: &[Mission],
+    now: chrono::DateTime<Utc>,
+) -> Option<&Mission> {
+    missions
+        .iter()
+        .filter(|m| m.status == MissionStatus::Pending)
+        .filter(|m| m.is_dispatchable_at(now))
+        .max_by(|a, b| {
+            a.scheduling
+                .priority
+                .cmp(&b.scheduling.priority)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        })
 }
 
 /// A single entry in the mission history.
@@ -1286,6 +1359,17 @@ pub trait MissionStore: Send + Sync {
 
     /// Update mission status.
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String>;
+
+    /// Persist FLEET-001 scheduling metadata (priority, not_before, deadline)
+    /// for a mission. Default is a no-op so non-persistent stores can ignore it;
+    /// the SQLite store overrides it to write the dedicated columns.
+    async fn set_mission_scheduling(
+        &self,
+        _id: Uuid,
+        _scheduling: &MissionScheduling,
+    ) -> Result<(), String> {
+        Ok(())
+    }
 
     /// Update mission status with terminal reason (for failed/completed missions).
     async fn update_mission_status_with_reason(
@@ -2905,5 +2989,131 @@ mod tests {
         assert_eq!(format!("{}", MissionStatus::Active), "active");
         assert_eq!(format!("{}", MissionStatus::Completed), "completed");
         assert_eq!(format!("{}", MissionStatus::Interrupted), "interrupted");
+    }
+
+    // ---- FLEET-001 / FLEET-004 scheduling tests ----
+
+    /// Build a minimal Pending mission with the given scheduling inputs for
+    /// the dispatcher tests.
+    fn scheduling_mission(
+        created_at: &str,
+        priority: i32,
+        not_before: Option<&str>,
+        status: MissionStatus,
+    ) -> Mission {
+        Mission {
+            id: Uuid::new_v4(),
+            status,
+            title: None,
+            short_description: None,
+            metadata_updated_at: None,
+            metadata_source: None,
+            metadata_model: None,
+            metadata_version: None,
+            workspace_id: default_workspace_id(),
+            workspace_name: None,
+            agent: None,
+            model_override: None,
+            model_effort: None,
+            backend: default_backend(),
+            config_profile: None,
+            history: vec![],
+            created_at: created_at.to_string(),
+            updated_at: created_at.to_string(),
+            interrupted_at: None,
+            resumable: false,
+            desktop_sessions: Vec::new(),
+            session_id: None,
+            terminal_reason: None,
+            parent_mission_id: None,
+            working_directory: None,
+            mission_mode: MissionMode::default(),
+            goal_mode: false,
+            goal_objective: None,
+            first_viewed_at: None,
+            scheduling: MissionScheduling {
+                priority,
+                not_before: not_before.map(|s| s.to_string()),
+                deadline: None,
+            },
+        }
+    }
+
+    /// FLEET-004: Paused is a non-terminal status (unlike Blocked), so a paused
+    /// mission can later be resumed.
+    #[test]
+    fn test_paused_not_terminal() {
+        use crate::api::control::mission_status_is_terminal;
+        assert!(!mission_status_is_terminal(MissionStatus::Paused));
+        // Sanity: a genuinely terminal status still reports terminal.
+        assert!(mission_status_is_terminal(MissionStatus::Completed));
+        assert!(mission_status_is_terminal(MissionStatus::Blocked));
+    }
+
+    /// FLEET-001: higher priority wins; ties broken by oldest created_at (FIFO).
+    #[test]
+    fn test_priority_sorting() {
+        let now = Utc::now();
+        let missions = vec![
+            scheduling_mission("2026-01-01T00:00:00Z", 0, None, MissionStatus::Pending),
+            scheduling_mission("2026-01-01T01:00:00Z", 5, None, MissionStatus::Pending),
+            scheduling_mission("2026-01-01T02:00:00Z", 5, None, MissionStatus::Pending),
+        ];
+        let next = select_next_runnable_mission(&missions, now).expect("a runnable mission");
+        // Highest priority is 5; between the two priority-5 missions the older
+        // (01:00) wins over the newer (02:00).
+        assert_eq!(next.scheduling.priority, 5);
+        assert_eq!(next.created_at, "2026-01-01T01:00:00Z");
+    }
+
+    /// FLEET-001: missions with `not_before` in the future are not runnable;
+    /// `Paused` missions are excluded even when otherwise eligible.
+    #[test]
+    fn test_not_before_filtering() {
+        let now = Utc::now();
+        let future = (now + chrono::Duration::hours(1)).to_rfc3339();
+        let past = (now - chrono::Duration::hours(1)).to_rfc3339();
+
+        // Only a future not_before -> nothing runnable.
+        let blocked = vec![scheduling_mission(
+            "2026-01-01T00:00:00Z",
+            10,
+            Some(&future),
+            MissionStatus::Pending,
+        )];
+        assert!(select_next_runnable_mission(&blocked, now).is_none());
+
+        // A past not_before is runnable; a higher-priority Paused mission is
+        // skipped; a higher-priority future mission is skipped.
+        let mixed = vec![
+            scheduling_mission(
+                "2026-01-01T00:00:00Z",
+                1,
+                Some(&past),
+                MissionStatus::Pending,
+            ),
+            scheduling_mission("2026-01-01T00:00:00Z", 99, None, MissionStatus::Paused),
+            scheduling_mission(
+                "2026-01-01T00:00:00Z",
+                99,
+                Some(&future),
+                MissionStatus::Pending,
+            ),
+        ];
+        let next = select_next_runnable_mission(&mixed, now).expect("the past-eligible mission");
+        assert_eq!(next.scheduling.priority, 1);
+        assert!(next.is_dispatchable_at(now));
+    }
+
+    /// FLEET-001: deadline helper reports elapsed deadlines and ignores unset.
+    #[test]
+    fn test_deadline_detection() {
+        let now = Utc::now();
+        let mut m = scheduling_mission("2026-01-01T00:00:00Z", 0, None, MissionStatus::Pending);
+        assert!(!m.is_past_deadline(now));
+        m.scheduling.deadline = Some((now - chrono::Duration::minutes(1)).to_rfc3339());
+        assert!(m.is_past_deadline(now));
+        m.scheduling.deadline = Some((now + chrono::Duration::minutes(1)).to_rfc3339());
+        assert!(!m.is_past_deadline(now));
     }
 }

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -86,6 +86,10 @@ pub struct Mission {
     /// When this mission was interrupted (if status is Interrupted)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interrupted_at: Option<String>,
+    /// FLEET-004: when this mission was last paused (if status is Paused). RFC3339.
+    /// Lets the UI show pause age and enables future zombie-pause cleanup.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused_at: Option<String>,
     /// Whether this mission can be resumed
     #[serde(default)]
     pub resumable: bool,
@@ -1479,6 +1483,14 @@ pub trait MissionStore: Send + Sync {
     /// (i.e. are armed for scheduled dispatch). Scheduling fields are populated
     /// so the dispatcher can order/expire them; history is not loaded.
     async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String>;
+
+    /// FLEET-004: set (or clear, with `None`) the timestamp at which a mission
+    /// was paused. Set on pause, cleared on resume.
+    async fn set_mission_paused_at(
+        &self,
+        mission_id: Uuid,
+        paused_at: Option<String>,
+    ) -> Result<(), String>;
 
     /// Record the first time the user opened this mission, if not already set.
     /// Returns `Some(timestamp)` if the field was set by this call, or `None`
@@ -2972,6 +2984,44 @@ mod tests {
             .is_empty());
     }
 
+    /// FLEET-004: paused_at round-trips through the store (set on pause, read
+    /// back on the mission, cleared on resume).
+    #[tokio::test]
+    async fn test_paused_at_round_trip() {
+        let store = InMemoryMissionStore::new();
+        let mission = store
+            .create_mission(Some("Pausable"), None, None, None, None, None, None)
+            .await
+            .expect("create");
+        assert!(mission.paused_at.is_none());
+
+        store
+            .set_mission_paused_at(mission.id, Some("2026-06-25T05:00:00+00:00".to_string()))
+            .await
+            .expect("set paused_at");
+        let loaded = store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("some");
+        assert_eq!(
+            loaded.paused_at.as_deref(),
+            Some("2026-06-25T05:00:00+00:00")
+        );
+
+        store
+            .set_mission_paused_at(mission.id, None)
+            .await
+            .expect("clear paused_at");
+        assert!(store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("some")
+            .paused_at
+            .is_none());
+    }
+
     /// Test that missions transition correctly from Pending to Active.
     #[tokio::test]
     async fn test_mission_status_transition_pending_to_active() {
@@ -3103,6 +3153,7 @@ mod tests {
             created_at: created_at.to_string(),
             updated_at: created_at.to_string(),
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: None,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3,7 +3,7 @@
 use super::{
     now_string, sanitize_filename, Automation, AutomationExecution, BoardTask, BoardTaskOutcome,
     BoardTaskStatus, CommandSource, DailyUsageStats, ExecutionStatus, FreshSession,
-    HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode, MissionStatus,
+    HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode, MissionScheduling, MissionStatus,
     MissionStatusCounts, MissionStore, ModelUsageStats, NewBoardTask, PalomaCooldownState,
     PalomaDecision, PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig,
     StopPolicy, StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
@@ -491,7 +491,10 @@ CREATE TABLE IF NOT EXISTS missions (
     resumable INTEGER NOT NULL DEFAULT 0,
     desktop_sessions TEXT,
     terminal_reason TEXT,
-    first_viewed_at TEXT
+    first_viewed_at TEXT,
+    priority INTEGER NOT NULL DEFAULT 0,
+    not_before TEXT,
+    deadline TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -2017,6 +2020,44 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add first_viewed_at column: {}", e))?;
         }
 
+        // FLEET-001 scheduling columns: priority (dispatch ordering), not_before
+        // (earliest dispatch time), deadline (soft deadline for observability).
+        let has_priority_column: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'priority'")
+            .map_err(|e| format!("Failed to check for priority column: {}", e))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {}", e))?;
+        if !has_priority_column {
+            tracing::info!("Running migration: adding 'priority' column to missions table");
+            conn.execute(
+                "ALTER TABLE missions ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
+                [],
+            )
+            .map_err(|e| format!("Failed to add priority column: {}", e))?;
+        }
+
+        let has_not_before_column: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'not_before'")
+            .map_err(|e| format!("Failed to check for not_before column: {}", e))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {}", e))?;
+        if !has_not_before_column {
+            tracing::info!("Running migration: adding 'not_before' column to missions table");
+            conn.execute("ALTER TABLE missions ADD COLUMN not_before TEXT", [])
+                .map_err(|e| format!("Failed to add not_before column: {}", e))?;
+        }
+
+        let has_deadline_column: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'deadline'")
+            .map_err(|e| format!("Failed to check for deadline column: {}", e))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {}", e))?;
+        if !has_deadline_column {
+            tracing::info!("Running migration: adding 'deadline' column to missions table");
+            conn.execute("ALTER TABLE missions ADD COLUMN deadline TEXT", [])
+                .map_err(|e| format!("Failed to add deadline column: {}", e))?;
+        }
+
         Ok(())
     }
 
@@ -2279,6 +2320,7 @@ fn parse_status(s: &str) -> MissionStatus {
         "interrupted" => MissionStatus::Interrupted,
         "blocked" => MissionStatus::Blocked,
         "not_feasible" => MissionStatus::NotFeasible,
+        "paused" => MissionStatus::Paused,
         _ => MissionStatus::Pending,
     }
 }
@@ -2294,6 +2336,7 @@ fn status_to_string(status: MissionStatus) -> &'static str {
         MissionStatus::Interrupted => "interrupted",
         MissionStatus::Blocked => "blocked",
         MissionStatus::NotFeasible => "not_feasible",
+        MissionStatus::Paused => "paused",
     }
 }
 
@@ -2315,7 +2358,8 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode,
-                            COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at
+                            COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
+                            COALESCE(priority, 0) as priority, not_before, deadline
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2368,6 +2412,11 @@ impl MissionStore for SqliteMissionStore {
                             goal_mode: row.get::<_, i32>(25).unwrap_or(0) != 0,
                             goal_objective: row.get(26).ok().flatten(),
                             first_viewed_at: row.get(27).ok().flatten(),
+                            scheduling: MissionScheduling {
+                                priority: row.get::<_, i32>(28).unwrap_or(0),
+                                not_before: row.get(29).ok().flatten(),
+                                deadline: row.get(30).ok().flatten(),
+                            },
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2427,7 +2476,8 @@ impl MissionStore for SqliteMissionStore {
                             created_at, updated_at, interrupted_at, resumable, desktop_sessions,
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
-                            COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at FROM missions WHERE id = ?1",
+                            COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
+                            COALESCE(priority, 0) as priority, not_before, deadline FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -2477,6 +2527,11 @@ impl MissionStore for SqliteMissionStore {
                             goal_mode: row.get::<_, i32>(25).unwrap_or(0) != 0,
                             goal_objective: row.get(26).ok().flatten(),
                             first_viewed_at: row.get(27).ok().flatten(),
+                            scheduling: MissionScheduling {
+                                priority: row.get::<_, i32>(28).unwrap_or(0),
+                                not_before: row.get(29).ok().flatten(),
+                                deadline: row.get(30).ok().flatten(),
+                            },
                     })
                 })
                 .optional()
@@ -2596,6 +2651,7 @@ impl MissionStore for SqliteMissionStore {
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         };
 
         let m = mission.clone();
@@ -2685,6 +2741,7 @@ impl MissionStore for SqliteMissionStore {
                             goal_mode: row.get::<_, i32>(23).unwrap_or(0) != 0,
                             goal_objective: row.get(24).ok().flatten(),
                             first_viewed_at: None,
+                            scheduling: Default::default(),
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2699,6 +2756,29 @@ impl MissionStore for SqliteMissionStore {
     async fn update_mission_status(&self, id: Uuid, status: MissionStatus) -> Result<(), String> {
         self.update_mission_status_with_reason(id, status, None)
             .await
+    }
+
+    async fn set_mission_scheduling(
+        &self,
+        id: Uuid,
+        scheduling: &MissionScheduling,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let priority = scheduling.priority;
+        let not_before = scheduling.not_before.clone();
+        let deadline = scheduling.deadline.clone();
+        let now = now_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET priority = ?1, not_before = ?2, deadline = ?3, updated_at = ?4 WHERE id = ?5",
+                params![priority, not_before, deadline, now, id.to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
     }
 
     async fn update_mission_status_with_reason(
@@ -3341,6 +3421,7 @@ impl MissionStore for SqliteMissionStore {
                         goal_mode: false,
                         goal_objective: None,
                         first_viewed_at: None,
+                        scheduling: Default::default(),
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -3415,6 +3496,7 @@ impl MissionStore for SqliteMissionStore {
                         goal_mode: row.get::<_, i32>(14).unwrap_or(0) != 0,
                         goal_objective: row.get(15).ok().flatten(),
                         first_viewed_at: None,
+                        scheduling: Default::default(),
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -5839,6 +5921,7 @@ impl MissionStore for SqliteMissionStore {
                         goal_mode: false,
                         goal_objective: None,
                         first_viewed_at: None,
+                        scheduling: Default::default(),
                     })
                 })
                 .map_err(|e| e.to_string())?

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -494,7 +494,8 @@ CREATE TABLE IF NOT EXISTS missions (
     first_viewed_at TEXT,
     priority INTEGER NOT NULL DEFAULT 0,
     not_before TEXT,
-    deadline TEXT
+    deadline TEXT,
+    deferred_goal TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -2058,6 +2059,21 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add deadline column: {}", e))?;
         }
 
+        // FLEET-001 scheduling dispatch: the goal a not_before-deferred mission
+        // will run once the scheduler dispatches it. Held here (rather than in
+        // mission history) so a Pending mission carries dispatchable work
+        // without prematurely appearing as a committed turn.
+        let has_deferred_goal_column: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'deferred_goal'")
+            .map_err(|e| format!("Failed to check for deferred_goal column: {}", e))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {}", e))?;
+        if !has_deferred_goal_column {
+            tracing::info!("Running migration: adding 'deferred_goal' column to missions table");
+            conn.execute("ALTER TABLE missions ADD COLUMN deferred_goal TEXT", [])
+                .map_err(|e| format!("Failed to add deferred_goal column: {}", e))?;
+        }
+
         Ok(())
     }
 
@@ -3497,6 +3513,122 @@ impl MissionStore for SqliteMissionStore {
                         goal_objective: row.get(15).ok().flatten(),
                         first_viewed_at: None,
                         scheduling: Default::default(),
+                    })
+                })
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+
+            Ok(missions)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn set_deferred_goal(
+        &self,
+        mission_id: Uuid,
+        goal: Option<String>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let id = mission_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET deferred_goal = ?1 WHERE id = ?2",
+                params![goal, id],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok::<(), String>(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn get_deferred_goal(&self, mission_id: Uuid) -> Result<Option<String>, String> {
+        let conn = self.conn.clone();
+        let id = mission_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                "SELECT deferred_goal FROM missions WHERE id = ?1",
+                params![id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, status, title, workspace_id, workspace_name, agent, model_override,
+                            created_at, updated_at, interrupted_at, resumable, desktop_sessions,
+                            COALESCE(backend, 'opencode') as backend,
+                            COALESCE(mission_mode, 'task') as mission_mode,
+                            COALESCE(goal_mode, 0) as goal_mode,
+                            goal_objective,
+                            COALESCE(priority, 0) as priority, not_before, deadline
+                     FROM missions
+                     WHERE status = 'pending' AND deferred_goal IS NOT NULL
+                     ORDER BY created_at ASC",
+                )
+                .map_err(|e| e.to_string())?;
+
+            let missions = stmt
+                .query_map(params![], |row| {
+                    let id_str: String = row.get(0)?;
+                    let status_str: String = row.get(1)?;
+                    let workspace_id_str: String = row.get(3)?;
+                    let desktop_sessions_json: Option<String> = row.get(11)?;
+                    let backend: String = row.get(12)?;
+
+                    Ok(Mission {
+                        id: parse_uuid_or_nil(&id_str),
+                        status: parse_status(&status_str),
+                        title: row.get(2)?,
+                        short_description: None,
+                        metadata_updated_at: None,
+                        metadata_source: None,
+                        metadata_model: None,
+                        metadata_version: None,
+                        workspace_id: Uuid::parse_str(&workspace_id_str)
+                            .unwrap_or(crate::workspace::DEFAULT_WORKSPACE_ID),
+                        workspace_name: row.get(4)?,
+                        agent: row.get(5)?,
+                        model_override: row.get(6)?,
+                        model_effort: None,
+                        backend,
+                        config_profile: None,
+                        history: vec![],
+                        created_at: row.get(7)?,
+                        updated_at: row.get(8)?,
+                        interrupted_at: row.get(9)?,
+                        resumable: row.get::<_, i32>(10)? != 0,
+                        desktop_sessions: desktop_sessions_json
+                            .and_then(|s| serde_json::from_str(&s).ok())
+                            .unwrap_or_default(),
+                        session_id: None,
+                        terminal_reason: None,
+                        parent_mission_id: None,
+                        working_directory: None,
+                        mission_mode: row
+                            .get::<_, Option<String>>(13)?
+                            .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok())
+                            .unwrap_or_default(),
+                        goal_mode: row.get::<_, i32>(14).unwrap_or(0) != 0,
+                        goal_objective: row.get(15).ok().flatten(),
+                        first_viewed_at: None,
+                        scheduling: MissionScheduling {
+                            priority: row.get::<_, i32>(16).unwrap_or(0),
+                            not_before: row.get(17).ok().flatten(),
+                            deadline: row.get(18).ok().flatten(),
+                        },
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -13685,5 +13817,81 @@ mod tests {
             .expect("get")
             .expect("some");
         assert_eq!(fetched.task_key, "t2");
+    }
+
+    /// FLEET-001: deferred goals round-trip and the scheduled-pending query
+    /// surfaces only Pending missions that carry a goal, with scheduling fields
+    /// populated (verifies the SELECT column indices).
+    #[tokio::test]
+    async fn deferred_goal_and_scheduled_pending_round_trip() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Scheduled"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+        store
+            .set_mission_scheduling(
+                mission.id,
+                &crate::api::mission_store::MissionScheduling {
+                    priority: 7,
+                    not_before: Some("2099-01-01T00:00:00Z".to_string()),
+                    deadline: Some("2099-02-01T00:00:00Z".to_string()),
+                },
+            )
+            .await
+            .expect("set scheduling");
+
+        // No goal yet -> not scheduled-pending.
+        assert!(store
+            .get_scheduled_pending_missions()
+            .await
+            .expect("list")
+            .is_empty());
+
+        store
+            .set_deferred_goal(mission.id, Some("run the report".to_string()))
+            .await
+            .expect("set goal");
+        assert_eq!(
+            store
+                .get_deferred_goal(mission.id)
+                .await
+                .expect("get")
+                .as_deref(),
+            Some("run the report")
+        );
+
+        let pending = store.get_scheduled_pending_missions().await.expect("list");
+        assert_eq!(pending.len(), 1);
+        let m = &pending[0];
+        assert_eq!(m.id, mission.id);
+        assert_eq!(m.scheduling.priority, 7);
+        assert_eq!(
+            m.scheduling.not_before.as_deref(),
+            Some("2099-01-01T00:00:00Z")
+        );
+        assert_eq!(
+            m.scheduling.deadline.as_deref(),
+            Some("2099-02-01T00:00:00Z")
+        );
+
+        // Clearing the goal removes it from the scheduled-pending set.
+        store
+            .set_deferred_goal(mission.id, None)
+            .await
+            .expect("clear");
+        assert!(store
+            .get_deferred_goal(mission.id)
+            .await
+            .expect("get")
+            .is_none());
+        assert!(store
+            .get_scheduled_pending_missions()
+            .await
+            .expect("list")
+            .is_empty());
     }
 }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -495,7 +495,8 @@ CREATE TABLE IF NOT EXISTS missions (
     priority INTEGER NOT NULL DEFAULT 0,
     not_before TEXT,
     deadline TEXT,
-    deferred_goal TEXT
+    deferred_goal TEXT,
+    paused_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -2074,6 +2075,19 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add deferred_goal column: {}", e))?;
         }
 
+        // FLEET-004: when a mission was last paused (status Paused). Drives pause
+        // age in the UI and future zombie-pause cleanup.
+        let has_paused_at_column: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'paused_at'")
+            .map_err(|e| format!("Failed to check for paused_at column: {}", e))?
+            .exists([])
+            .map_err(|e| format!("Failed to query table info: {}", e))?;
+        if !has_paused_at_column {
+            tracing::info!("Running migration: adding 'paused_at' column to missions table");
+            conn.execute("ALTER TABLE missions ADD COLUMN paused_at TEXT", [])
+                .map_err(|e| format!("Failed to add paused_at column: {}", e))?;
+        }
+
         Ok(())
     }
 
@@ -2375,7 +2389,7 @@ impl MissionStore for SqliteMissionStore {
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode,
                             COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
-                            COALESCE(priority, 0) as priority, not_before, deadline
+                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2414,6 +2428,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(13)?,
                         updated_at: row.get(14)?,
                         interrupted_at: row.get(15)?,
+                        paused_at: row.get(31).ok().flatten(),
                         resumable: row.get::<_, i32>(16)? != 0,
                         desktop_sessions: desktop_sessions_json
                             .and_then(|s| serde_json::from_str(&s).ok())
@@ -2493,7 +2508,7 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
-                            COALESCE(priority, 0) as priority, not_before, deadline FROM missions WHERE id = ?1",
+                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -2529,6 +2544,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(13)?,
                         updated_at: row.get(14)?,
                         interrupted_at: row.get(15)?,
+                        paused_at: row.get(31).ok().flatten(),
                         resumable: row.get::<_, i32>(16)? != 0,
                         desktop_sessions: desktop_sessions_json
                             .and_then(|s| serde_json::from_str(&s).ok())
@@ -2657,6 +2673,7 @@ impl MissionStore for SqliteMissionStore {
             created_at: now.clone(),
             updated_at: now.clone(),
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: Vec::new(),
             session_id: Some(session_id.clone()),
@@ -2745,6 +2762,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(14)?,
                         updated_at: row.get(15)?,
                         interrupted_at: row.get(16)?,
+                        paused_at: None,
                         resumable: row.get::<_, i32>(17)? != 0,
                         desktop_sessions: Vec::new(),
                         session_id: row.get(18)?,
@@ -3425,6 +3443,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(7)?,
                         updated_at: row.get(8)?,
                         interrupted_at: row.get(9)?,
+                        paused_at: None,
                         resumable: row.get::<_, i32>(10)? != 0,
                         desktop_sessions: desktop_sessions_json
                             .and_then(|s| serde_json::from_str(&s).ok())
@@ -3497,6 +3516,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(7)?,
                         updated_at: row.get(8)?,
                         interrupted_at: row.get(9)?,
+                        paused_at: None,
                         resumable: row.get::<_, i32>(10)? != 0,
                         desktop_sessions: desktop_sessions_json
                             .and_then(|s| serde_json::from_str(&s).ok())
@@ -3561,6 +3581,26 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn set_mission_paused_at(
+        &self,
+        mission_id: Uuid,
+        paused_at: Option<String>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let id = mission_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET paused_at = ?1 WHERE id = ?2",
+                params![paused_at, id],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok::<(), String>(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn get_scheduled_pending_missions(&self) -> Result<Vec<Mission>, String> {
         let conn = self.conn.clone();
         tokio::task::spawn_blocking(move || {
@@ -3609,6 +3649,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(7)?,
                         updated_at: row.get(8)?,
                         interrupted_at: row.get(9)?,
+                        paused_at: None,
                         resumable: row.get::<_, i32>(10)? != 0,
                         desktop_sessions: desktop_sessions_json
                             .and_then(|s| serde_json::from_str(&s).ok())
@@ -6042,6 +6083,7 @@ impl MissionStore for SqliteMissionStore {
                         created_at: row.get(6).unwrap_or_default(),
                         updated_at: row.get(7).unwrap_or_default(),
                         interrupted_at: None,
+                        paused_at: None,
                         resumable: false,
                         desktop_sessions: vec![],
                         session_id: None,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -11682,7 +11682,15 @@ mod tests {
             .await
             .expect("sqlite store");
         let mission = store
-            .create_mission(Some("source attribution"), None, None, None, None, None, None)
+            .create_mission(
+                Some("source attribution"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .await
             .expect("mission");
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3636,6 +3636,7 @@ impl MissionStore for SqliteMissionStore {
                 id,
                 content,
                 queued,
+                source,
                 ..
             } => (
                 "user_message",
@@ -3643,7 +3644,17 @@ impl MissionStore for SqliteMissionStore {
                 None,
                 None,
                 content.clone(),
-                serde_json::json!({ "queued": queued }),
+                {
+                    // Always record `queued`; record `source` only when present so
+                    // the persisted metadata is the forensic record of who/what
+                    // posted this message (audit/attribution).
+                    let mut meta = serde_json::Map::new();
+                    meta.insert("queued".to_string(), serde_json::json!(queued));
+                    if let Some(src) = source {
+                        meta.insert("source".to_string(), serde_json::json!(src));
+                    }
+                    serde_json::Value::Object(meta)
+                },
             ),
             AgentEvent::AssistantMessage {
                 id,
@@ -11559,6 +11570,7 @@ mod tests {
                     content: "B".to_string(),
                     queued: true,
                     mission_id: Some(mission.id),
+                    source: None,
                 },
             )
             .await
@@ -11581,6 +11593,7 @@ mod tests {
                     content: "A".to_string(),
                     queued: false,
                     mission_id: Some(mission.id),
+                    source: None,
                 },
             )
             .await
@@ -11613,6 +11626,7 @@ mod tests {
                     content: "B".to_string(),
                     queued: false,
                     mission_id: Some(mission.id),
+                    source: None,
                 },
             )
             .await
@@ -11656,6 +11670,51 @@ mod tests {
                 ("user".to_string(), "B".to_string()),
                 ("assistant".to_string(), "reply B".to_string()),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn user_message_source_is_persisted_in_metadata() {
+        use crate::api::control::AgentEvent;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("source attribution"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        store
+            .log_event(
+                mission.id,
+                &AgentEvent::UserMessage {
+                    id: Uuid::new_v4(),
+                    content: "hello".to_string(),
+                    queued: false,
+                    mission_id: Some(mission.id),
+                    source: Some("api:user-123".to_string()),
+                },
+            )
+            .await
+            .expect("user message with source");
+
+        let events = store
+            .get_events(mission.id, None, None, None)
+            .await
+            .expect("events");
+        let user_event = events
+            .iter()
+            .find(|e| e.event_type == "user_message")
+            .expect("user_message row");
+        // The persisted metadata JSON is the forensic record of who/what posted
+        // this message — it must carry the attribution source.
+        assert_eq!(
+            user_event.metadata.get("source").and_then(|v| v.as_str()),
+            Some("api:user-123"),
+            "persisted metadata should contain the attribution source, got {}",
+            user_event.metadata
         );
     }
 
@@ -12750,6 +12809,7 @@ mod tests {
                         content: format!("msg {i}"),
                         queued: false,
                         mission_id: Some(mission.id),
+                        source: None,
                     },
                 )
                 .await
@@ -12849,6 +12909,7 @@ mod tests {
                         content: format!("msg {i}"),
                         queued: false,
                         mission_id: Some(mission.id),
+                        source: None,
                     },
                 )
                 .await

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -270,6 +270,7 @@ mod tests {
             created_at: "2026-05-24T00:00:00Z".to_string(),
             updated_at: "2026-05-24T00:00:00Z".to_string(),
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: vec![],
             session_id: None,

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -79,6 +79,7 @@ pub fn status_emoji(status: MissionStatus) -> &'static str {
         MissionStatus::Interrupted => "⏸️",
         MissionStatus::NotFeasible => "🚫",
         MissionStatus::Acknowledged => "☑️",
+        MissionStatus::Paused => "⏯️",
     }
 }
 
@@ -91,7 +92,7 @@ pub fn buttons_for(status: MissionStatus) -> Vec<CardButton> {
             CardButton::OpenDashboard,
             CardButton::MuteMission,
         ],
-        MissionStatus::Active | MissionStatus::Pending => vec![
+        MissionStatus::Active | MissionStatus::Pending | MissionStatus::Paused => vec![
             CardButton::Reply,
             CardButton::OpenDashboard,
             CardButton::MuteMission,
@@ -192,6 +193,7 @@ fn status_line_for(
         MissionStatus::Interrupted => "Interrupted".to_string(),
         MissionStatus::NotFeasible => "Marked not feasible".to_string(),
         MissionStatus::Acknowledged => "Acknowledged".to_string(),
+        MissionStatus::Paused => "Paused".to_string(),
     }
 }
 
@@ -278,6 +280,7 @@ mod tests {
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         }
     }
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -778,6 +778,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             post(control::resume_mission),
         )
         .route(
+            "/api/control/missions/:id/clone",
+            post(control::clone_mission),
+        )
+        .route(
             "/api/control/missions/:id/parallel",
             post(control::start_mission_parallel),
         )

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1134,6 +1134,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .route("/api/backends", get(backends_api::list_backends))
         .route("/api/backends/:id", get(backends_api::get_backend))
         .route(
+            "/api/backends/:id/quota",
+            get(backends_api::get_backend_quota),
+        )
+        .route(
             "/api/backends/:id/agents",
             get(backends_api::list_backend_agents),
         )

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -770,6 +770,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             post(control::cancel_mission),
         )
         .route(
+            "/api/control/missions/:id/pause",
+            post(control::pause_mission),
+        )
+        .route(
             "/api/control/missions/:id/resume",
             post(control::resume_mission),
         )

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -129,8 +129,9 @@ fn claudecode_proxy_health_verdict(combined: &str, http_code: &str) -> Result<()
         return Err("Claude CLI proxy unreachable: DNS resolution failed".to_string());
     }
     if combined.contains("Connection refused") {
-        return Err("Claude CLI proxy unreachable: connection refused (proxy not listening?)"
-            .to_string());
+        return Err(
+            "Claude CLI proxy unreachable: connection refused (proxy not listening?)".to_string(),
+        );
     }
     if combined.contains("Network is unreachable") {
         return Err("Claude CLI proxy unreachable: network is unreachable".to_string());
@@ -838,9 +839,13 @@ pub fn run_claudecode_turn<'a>(
             // proxy instead so a down/hung/erroring proxy fails fast (≈8s) and
             // routes through ResetSessionFresh recovery, instead of silently
             // burning the full startup timeout (90s, ×2 with recovery).
-            if let Err(err_msg) =
-                check_claudecode_proxy_health(&workspace_exec, work_dir, &proxy.base_url, &proxy.api_key)
-                    .await
+            if let Err(err_msg) = check_claudecode_proxy_health(
+                &workspace_exec,
+                work_dir,
+                &proxy.base_url,
+                &proxy.api_key,
+            )
+            .await
             {
                 tracing::warn!(mission_id = %mission_id, "{}", err_msg);
                 return AgentResult::failure(err_msg, 0)

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -2862,6 +2862,7 @@ fn claudecode_oversized_resume_transcript(
     None
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_claudecode_turn_with_recovery(
     workspace: &Workspace,
     work_dir: &std::path::Path,

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -112,6 +112,96 @@ pub fn parse_background_task_start(content: &str) -> Option<(String, String)> {
     Some((id, path))
 }
 
+/// Classify a proxy health-probe result into pass/fast-fail.
+///
+/// The probe (`check_claudecode_proxy_health`) GETs `<base>/v1/models` through
+/// the same CLI proxy the Claude CLI will use. The verdict is deliberately
+/// conservative so it can only catch a genuinely-down/erroring proxy and never
+/// false-blocks a slow-but-working one:
+/// - any HTTP status in 2xx/3xx/4xx (incl. 401/404) proves the proxy is up and
+///   routing → pass (the `/v1/models` route does not even need to exist);
+/// - 5xx means the proxy's upstream is erroring (e.g. provider cooldown / 502),
+///   which is exactly the stall we want to fail fast on → fail;
+/// - a connection-level failure or no response (refused / DNS / unreachable /
+///   timeout / `000`) → fail.
+fn claudecode_proxy_health_verdict(combined: &str, http_code: &str) -> Result<(), String> {
+    if combined.contains("Could not resolve host") {
+        return Err("Claude CLI proxy unreachable: DNS resolution failed".to_string());
+    }
+    if combined.contains("Connection refused") {
+        return Err("Claude CLI proxy unreachable: connection refused (proxy not listening?)"
+            .to_string());
+    }
+    if combined.contains("Network is unreachable") {
+        return Err("Claude CLI proxy unreachable: network is unreachable".to_string());
+    }
+    if combined.contains("Connection timed out") || combined.contains("Operation timed out") {
+        return Err("Claude CLI proxy unreachable: connection timed out".to_string());
+    }
+
+    let code = http_code.trim();
+    if let Ok(n) = code.parse::<u16>() {
+        if n == 0 {
+            // curl's `000` sentinel: TCP/TLS connected attempt produced no HTTP
+            // response (proxy down or hung).
+            return Err(
+                "Claude CLI proxy did not return an HTTP response (proxy down or hung)".to_string(),
+            );
+        }
+        if (500..=599).contains(&n) {
+            return Err(format!(
+                "Claude CLI proxy upstream is erroring (HTTP {n}); failing fast instead of \
+                 waiting out the startup timeout"
+            ));
+        }
+        // Any other HTTP response (2xx/3xx/4xx, including 401/404) proves the
+        // proxy is up and routing requests.
+        return Ok(());
+    }
+
+    // Unparseable/empty code: treat as no response.
+    Err("Claude CLI proxy did not return an HTTP response (proxy down or hung)".to_string())
+}
+
+/// Fast health check for the CLI proxy auth path. Mirrors `check_api_reachability`'s
+/// in-sandbox curl, but probes the proxy (which proxy environments allow) rather
+/// than api.anthropic.com (which they block). The API key is passed via env so it
+/// never lands in the command string or logs.
+async fn check_claudecode_proxy_health(
+    workspace_exec: &WorkspaceExec,
+    cwd: &std::path::Path,
+    base_url: &str,
+    api_key: &str,
+) -> Result<(), String> {
+    let timeout_secs = std::env::var("SANDBOXED_SH_CLAUDECODE_PROXY_HEALTH_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(8);
+    let url = format!("{}/v1/models", base_url.trim_end_matches('/'));
+    let test_cmd = format!(
+        "curl -sS -o /dev/null -w '%{{http_code}}' --max-time {timeout_secs} \
+         -H \"Authorization: Bearer ${{CLAUDE_PROXY_HEALTH_KEY}}\" {url}"
+    );
+    let mut env = std::collections::HashMap::new();
+    env.insert("CLAUDE_PROXY_HEALTH_KEY".to_string(), api_key.to_string());
+
+    let output = match workspace_exec
+        .output(cwd, "/bin/sh", &["-c".to_string(), test_cmd], env)
+        .await
+    {
+        Ok(out) => out,
+        // An exec error here is about the sandbox, not the proxy; don't block.
+        Err(e) => {
+            tracing::debug!("Claude proxy health probe could not run ({e}); skipping fast-fail");
+            return Ok(());
+        }
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    claudecode_proxy_health_verdict(&combined, stdout.trim())
+}
+
 /// Execute a turn using Claude Code CLI backend.
 ///
 /// For Host workspaces: spawns the CLI directly on the host.
@@ -741,6 +831,26 @@ pub fn run_claudecode_turn<'a>(
                 tracing::error!(mission_id = %mission_id, "{}", err_msg);
                 return AgentResult::failure(err_msg, 0)
                     .with_terminal_reason(TerminalReason::LlmError);
+            }
+        } else if let Some(ref proxy) = proxy_auth {
+            // The CLI proxy is the auth path; the direct-Anthropic probe above is
+            // skipped because proxy environments block direct egress. Probe the
+            // proxy instead so a down/hung/erroring proxy fails fast (≈8s) and
+            // routes through ResetSessionFresh recovery, instead of silently
+            // burning the full startup timeout (90s, ×2 with recovery).
+            if let Err(err_msg) =
+                check_claudecode_proxy_health(&workspace_exec, work_dir, &proxy.base_url, &proxy.api_key)
+                    .await
+            {
+                tracing::warn!(mission_id = %mission_id, "{}", err_msg);
+                return AgentResult::failure(err_msg, 0)
+                    .with_terminal_reason(TerminalReason::LlmError)
+                    .with_data(claudecode_transport_failure_data(
+                        ClaudeTransportFailureStage::Startup,
+                        false,
+                        false,
+                        &[],
+                    ));
             }
         }
 
@@ -3233,5 +3343,89 @@ mod background_task_tests {
         let content = "Command running in background with ID: . \
              Output is being written to: /tmp/x.log";
         assert!(parse_background_task_start(content).is_none());
+    }
+}
+
+#[cfg(test)]
+mod resilience_tests {
+    use super::{claudecode_oversized_resume_transcript, claudecode_proxy_health_verdict};
+
+    // --- Proxy health verdict (fail-fast classification) ---
+
+    #[test]
+    fn proxy_verdict_passes_on_any_http_response() {
+        // 2xx/3xx/4xx all prove the proxy is up and routing — including 404
+        // (route may not exist) and 401 (auth) — so none should block.
+        for code in ["200", "204", "301", "400", "401", "403", "404", "429"] {
+            assert!(
+                claudecode_proxy_health_verdict("", code).is_ok(),
+                "HTTP {code} should pass"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_verdict_fails_on_upstream_5xx() {
+        // The observed production stall: provider cooldown / 502 surfaced by the proxy.
+        for code in ["500", "502", "503", "529"] {
+            assert!(
+                claudecode_proxy_health_verdict("", code).is_err(),
+                "HTTP {code} should fast-fail"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_verdict_fails_on_connection_errors_and_no_response() {
+        assert!(claudecode_proxy_health_verdict("curl: (7) Connection refused", "000").is_err());
+        assert!(claudecode_proxy_health_verdict("Could not resolve host: proxy", "000").is_err());
+        assert!(claudecode_proxy_health_verdict("Network is unreachable", "000").is_err());
+        assert!(claudecode_proxy_health_verdict("Operation timed out", "000").is_err());
+        // Empty / unparseable code with no recognizable error → treated as no response.
+        assert!(claudecode_proxy_health_verdict("", "000").is_err());
+        assert!(claudecode_proxy_health_verdict("", "").is_err());
+    }
+
+    // --- Oversized resume transcript detection ---
+
+    #[test]
+    fn oversized_transcript_detected_above_cap_only() {
+        use std::io::Write as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let work_dir = tmp.path();
+        let session_id = "11111111-2222-3333-4444-555555555555";
+        let proj = work_dir.join(".claude").join("projects").join("somehash");
+        std::fs::create_dir_all(&proj).unwrap();
+        let transcript = proj.join(format!("{session_id}.jsonl"));
+
+        // Small transcript: under the (default 25MB) cap → not flagged.
+        {
+            let mut f = std::fs::File::create(&transcript).unwrap();
+            f.write_all(b"{\"x\":1}\n").unwrap();
+        }
+        assert_eq!(
+            claudecode_oversized_resume_transcript(work_dir, session_id),
+            None
+        );
+
+        // Force a tiny cap via env so the test stays fast and deterministic.
+        std::env::set_var("SANDBOXED_SH_CLAUDECODE_MAX_RESUME_TRANSCRIPT_BYTES", "4");
+        let got = claudecode_oversized_resume_transcript(work_dir, session_id);
+        assert!(got.is_some(), "transcript above tiny cap should be flagged");
+
+        // Cap of 0 disables the check entirely.
+        std::env::set_var("SANDBOXED_SH_CLAUDECODE_MAX_RESUME_TRANSCRIPT_BYTES", "0");
+        assert_eq!(
+            claudecode_oversized_resume_transcript(work_dir, session_id),
+            None
+        );
+
+        // Unknown session id → nothing found.
+        std::env::set_var("SANDBOXED_SH_CLAUDECODE_MAX_RESUME_TRANSCRIPT_BYTES", "4");
+        assert_eq!(
+            claudecode_oversized_resume_transcript(work_dir, "no-such-session"),
+            None
+        );
+        std::env::remove_var("SANDBOXED_SH_CLAUDECODE_MAX_RESUME_TRANSCRIPT_BYTES");
     }
 }

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -2710,6 +2710,43 @@ fn claudecode_result_is_startup_transport_failure(result: &AgentResult) -> bool 
 /// previously carried near-duplicate copies of this loop, with the control
 /// copy missing the SIGKILL refresh and initial auth retry.
 #[allow(clippy::too_many_arguments)]
+/// Returns the byte size of the on-disk Claude session transcript for
+/// `session_id` when it exceeds the configured resume cap, otherwise `None`.
+///
+/// Resuming a very large transcript can make the CLI spend the entire startup
+/// window replaying it before emitting any stream-json event, tripping the
+/// startup timeout (see `run_claudecode_turn_with_recovery`). The cap is
+/// configurable via `SANDBOXED_SH_CLAUDECODE_MAX_RESUME_TRANSCRIPT_BYTES`
+/// (default 25 MB); set it to `0` to disable the check entirely.
+fn claudecode_oversized_resume_transcript(
+    work_dir: &std::path::Path,
+    session_id: &str,
+) -> Option<u64> {
+    let cap = std::env::var("SANDBOXED_SH_CLAUDECODE_MAX_RESUME_TRANSCRIPT_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(25_000_000);
+    if cap == 0 {
+        return None;
+    }
+    // Claude stores transcripts at
+    // <work_dir>/.claude/projects/<hash>/<session_id>.jsonl. The <hash> dir
+    // depends on the absolute cwd inside the container, so scan every project
+    // dir rather than guessing the hash.
+    let projects_dir = work_dir.join(".claude").join("projects");
+    let entries = std::fs::read_dir(&projects_dir).ok()?;
+    let file_name = format!("{session_id}.jsonl");
+    for entry in entries.flatten() {
+        let candidate = entry.path().join(&file_name);
+        if let Ok(meta) = std::fs::metadata(&candidate) {
+            if meta.is_file() && meta.len() > cap {
+                return Some(meta.len());
+            }
+        }
+    }
+    None
+}
+
 pub(crate) async fn run_claudecode_turn_with_recovery(
     workspace: &Workspace,
     work_dir: &std::path::Path,
@@ -2737,6 +2774,60 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
     let mut attempted_same_session_resume = false;
     let mut attempted_session_reset = false;
 
+    // Proactive guard: resuming a very large session transcript can make the
+    // Claude CLI spend the entire startup window replaying it before emitting
+    // any stream-json event, tripping the startup timeout. When the would-be
+    // resumed transcript exceeds the configured cap, rotate to a fresh session
+    // up front (same mechanism as the ResetSessionFresh recovery arm below) so
+    // the first attempt starts clean with rebuilt history instead of hanging.
+    let mut first_turn_is_continuation = is_continuation;
+    if is_continuation && !cancel.is_cancelled() && !crate::api::routes::is_shutdown_initiated() {
+        if let Some(sid) = effective_sid.clone() {
+            if let Some(size) = claudecode_oversized_resume_transcript(work_dir, &sid) {
+                let new_session_id = Uuid::new_v4().to_string();
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    old_session_id = %sid,
+                    new_session_id = %new_session_id,
+                    transcript_bytes = size,
+                    "Resume transcript exceeds cap; rotating to a fresh session before first attempt"
+                );
+                let _ = events_tx.send(AgentEvent::SessionIdUpdate {
+                    mission_id,
+                    session_id: new_session_id.clone(),
+                });
+                let session_marker = work_dir.join(".claude-session-initiated");
+                if session_marker.exists() {
+                    let _ = std::fs::remove_file(&session_marker);
+                }
+                let history_for_retry = match history.last() {
+                    Some((role, content)) if role == "user" && content == message => {
+                        &history[..history.len() - 1]
+                    }
+                    _ => history,
+                };
+                effective_msg = if history_for_retry.is_empty() {
+                    message.to_string()
+                } else {
+                    let history_ctx =
+                        build_history_context(history_for_retry, max_history_total_chars);
+                    format!(
+                        "## Prior conversation (session was reset: prior transcript too large to resume)\n\n\
+                         {history_ctx}\
+                         ## Current message\n\n\
+                         {message}"
+                    )
+                };
+                effective_sid = Some(new_session_id);
+                first_turn_is_continuation = false;
+                // A fresh session has no transcript to replay; if it still
+                // times out at startup the cause is environmental, so don't let
+                // recovery burn another reset on it.
+                attempted_session_reset = true;
+            }
+        }
+    }
+
     let mut result = run_claudecode_turn(
         workspace,
         work_dir,
@@ -2750,7 +2841,7 @@ pub(crate) async fn run_claudecode_turn_with_recovery(
         secrets.clone(),
         app_working_dir,
         effective_sid.as_deref(),
-        is_continuation,
+        first_turn_is_continuation,
         tool_hub.clone(),
         status.clone(),
         None, // override_auth: use default credential resolution

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -4,7 +4,8 @@
 //! Account/credential plumbing (cooldowns, leasing, CLI bootstrap) still
 //! lives in `mission_runner` and is consumed via `pub(crate)` items.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -14,8 +15,126 @@ use crate::agents::{AgentResult, CompletionConfidence, CompletionSignal, Termina
 use crate::api::control::AgentEvent;
 use crate::api::mission_runner::*;
 use crate::cost::resolve_cost_cents_and_source;
-use crate::workspace::Workspace;
+use crate::workspace::{Workspace, WorkspaceType};
 use crate::workspace_exec::WorkspaceExec;
+
+fn codex_workspace_home_dir(workspace: &Workspace) -> PathBuf {
+    match workspace.workspace_type {
+        WorkspaceType::Container => workspace.path.join("root"),
+        WorkspaceType::Host => PathBuf::from(crate::util::home_dir()),
+    }
+}
+
+fn copy_file_if_exists(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::copy(src, dst)?;
+    Ok(())
+}
+
+fn copy_dir_recursive_if_exists(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if !src.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_recursive_if_exists(&src_path, &dst_path)?;
+        } else if ty.is_file() {
+            copy_file_if_exists(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn prepare_codex_per_mission_home(
+    workspace: &Workspace,
+    workspace_exec: &WorkspaceExec,
+    mission_work_dir: &Path,
+    mission_id: Uuid,
+) -> HashMap<String, String> {
+    let source_codex_dir = codex_workspace_home_dir(workspace).join(".codex");
+    let mission_codex_dir = mission_work_dir.join(".codex");
+    let xdg_config_home = mission_work_dir.join(".config");
+    let xdg_data_home = mission_work_dir.join(".local").join("share");
+    let xdg_state_home = mission_work_dir.join(".local").join("state");
+    let xdg_cache_home = mission_work_dir.join(".cache");
+
+    for dir in [
+        &mission_codex_dir,
+        &xdg_config_home,
+        &xdg_data_home,
+        &xdg_state_home,
+        &xdg_cache_home,
+    ] {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            tracing::warn!(
+                mission_id = %mission_id,
+                path = %dir.display(),
+                error = %e,
+                "Failed to create per-mission Codex directory"
+            );
+        }
+    }
+
+    for file_name in ["auth.json", "config.toml"] {
+        if let Err(e) = copy_file_if_exists(
+            &source_codex_dir.join(file_name),
+            &mission_codex_dir.join(file_name),
+        ) {
+            tracing::warn!(
+                mission_id = %mission_id,
+                source = %source_codex_dir.join(file_name).display(),
+                dest = %mission_codex_dir.join(file_name).display(),
+                error = %e,
+                "Failed to copy Codex config file into per-mission home"
+            );
+        }
+    }
+    if let Err(e) = copy_dir_recursive_if_exists(
+        &source_codex_dir.join("skills"),
+        &mission_codex_dir.join("skills"),
+    ) {
+        tracing::warn!(
+            mission_id = %mission_id,
+            source = %source_codex_dir.join("skills").display(),
+            dest = %mission_codex_dir.join("skills").display(),
+            error = %e,
+            "Failed to copy Codex skills into per-mission home"
+        );
+    }
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        workspace_exec.translate_path_for_container(mission_work_dir),
+    );
+    env.insert(
+        "XDG_CONFIG_HOME".to_string(),
+        workspace_exec.translate_path_for_container(&xdg_config_home),
+    );
+    env.insert(
+        "XDG_DATA_HOME".to_string(),
+        workspace_exec.translate_path_for_container(&xdg_data_home),
+    );
+    env.insert(
+        "XDG_STATE_HOME".to_string(),
+        workspace_exec.translate_path_for_container(&xdg_state_home),
+    );
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        workspace_exec.translate_path_for_container(&xdg_cache_home),
+    );
+    env
+}
 
 pub(crate) fn codex_turn_requires_tool_activity(
     user_message: &str,
@@ -841,10 +960,19 @@ pub async fn run_codex_turn(
         "Starting Codex execution via WorkspaceExec"
     );
 
+    // Run Codex app-server with per-mission HOME/XDG state. Codex 0.137 keeps
+    // SQLite state under `$HOME/.codex`; sharing `/root/.codex` across
+    // concurrent container missions can make initialize fail with
+    // `database is locked` before the mission starts.
+    let mut extra_env =
+        prepare_codex_per_mission_home(workspace, &workspace_exec, mission_work_dir, mission_id);
+
     // DGX Spark build offload (opt-in per workspace) — see
     // Workspace::spark_offload_env. Exported to the codex app-server process so
     // the in-workspace `spark-build` wrapper can reach the host offload endpoint.
-    let extra_env = workspace.spark_offload_env(mission_id).unwrap_or_default();
+    if let Some(spark_env) = workspace.spark_offload_env(mission_id) {
+        extra_env.extend(spark_env);
+    }
 
     let codex_config = crate::backend::codex::client::CodexConfig {
         cli_path,

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -85,7 +85,11 @@ fn prepare_codex_per_mission_home(
         }
     }
 
-    for file_name in ["auth.json", "config.toml"] {
+    // Only copy user/auth material from the shared Codex home. The generated
+    // `config.toml` contains mission-scoped MCP env and is written separately
+    // into the mission workspace; copying a stale shared config can point
+    // automation-manager/orchestrator at another mission.
+    for file_name in ["auth.json"] {
         if let Err(e) = copy_file_if_exists(
             &source_codex_dir.join(file_name),
             &mission_codex_dir.join(file_name),
@@ -95,7 +99,7 @@ fn prepare_codex_per_mission_home(
                 source = %source_codex_dir.join(file_name).display(),
                 dest = %mission_codex_dir.join(file_name).display(),
                 error = %e,
-                "Failed to copy Codex config file into per-mission home"
+                "Failed to copy Codex auth file into per-mission home"
             );
         }
     }

--- a/src/api/runners/midturn.rs
+++ b/src/api/runners/midturn.rs
@@ -66,6 +66,7 @@ async fn drain_and_inject_from_store<F, Fut>(
             content: block,
             queued: false,
             mission_id: Some(mission_id),
+            source: None,
         });
         return;
     }

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -400,6 +400,7 @@ pub(crate) async fn background_task_autoresume_loop(
                     agent: None,
                     target_mission_id: Some(mission_id),
                     strict: true,
+                    source: None,
                     respond: ack_tx,
                 })
                 .await;

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -788,6 +788,7 @@ async fn send_user_message_to_mission(
             agent: None,
             target_mission_id: Some(mission.id),
             strict: false,
+            source: Some("telegram".to_string()),
             respond: queued_tx,
         })
         .await
@@ -4221,6 +4222,7 @@ pub async fn process_webhook_message(
                     content: content.clone(),
                     queued: false,
                     mission_id: Some(target_mission_id),
+                    source: Some("telegram".to_string()),
                 },
             )
             .await;
@@ -4249,6 +4251,7 @@ pub async fn process_webhook_message(
             agent: None,
             target_mission_id: Some(target_mission_id),
             strict: false,
+            source: Some("telegram".to_string()),
             respond: queued_tx,
         })
         .await;
@@ -5554,6 +5557,7 @@ async fn relay_workflow_reply_to_origin(
             agent: None,
             target_mission_id: Some(origin_mission_id),
             strict: false,
+            source: Some("telegram".to_string()),
             respond: queued_tx,
         })
         .await;

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -6642,6 +6642,7 @@ mod tests {
             created_at: "2026-05-20T00:00:00Z".to_string(),
             updated_at: "2026-05-20T00:00:00Z".to_string(),
             interrupted_at: None,
+            paused_at: None,
             resumable: false,
             desktop_sessions: vec![],
             session_id: None,

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -407,6 +407,7 @@ fn mission_rank(mission: &Mission, interest: TelegramMissionInterestLevel) -> i3
         MissionStatus::Active => 40,
         MissionStatus::Pending => 25,
         MissionStatus::Interrupted => 20,
+        MissionStatus::Paused => 10,
         MissionStatus::Acknowledged | MissionStatus::Completed | MissionStatus::NotFeasible => 0,
     };
     if mission.parent_mission_id.is_none() {
@@ -3477,6 +3478,7 @@ async fn resolve_or_create_mission(
             config_profile: ctx.channel.default_config_profile.clone(),
             parent_mission_id: None,
             working_directory: None,
+            scheduling: Default::default(),
             respond: tx,
         })
         .await;
@@ -6650,6 +6652,7 @@ mod tests {
             goal_mode: false,
             goal_objective: None,
             first_viewed_at: None,
+            scheduling: Default::default(),
         }
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2141,21 +2141,34 @@ pub async fn prepare_mission_workspace_with_skills_backend(
         None
     };
 
-    // Inject MISSION_ID and API_URL into stdio MCP server env vars,
-    // and JWT_SECRET only into the orchestrator MCP (not third-party MCPs).
+    // Inject mission runtime env into stdio MCP server env vars. Mission-owned
+    // fields are authoritative per generated workspace: profile/workspace env
+    // must not be allowed to preserve a stale MISSION_ID from another mission.
     let mcp_configs: Vec<McpServerConfig> = mcp_configs
         .into_iter()
         .map(|mut cfg| {
             if let McpTransport::Stdio { ref mut env, .. } = cfg.transport {
-                env.entry("MISSION_ID".to_string())
-                    .or_insert_with(|| mission_id.to_string());
+                let previous_mission_id =
+                    env.insert("MISSION_ID".to_string(), mission_id.to_string());
+                if let Some(previous) = previous_mission_id.as_deref() {
+                    if previous != mission_id.to_string() {
+                        tracing::warn!(
+                            mission = %mission_id,
+                            mcp = %cfg.name,
+                            stale_mission_id = %previous,
+                            "Overriding stale MCP MISSION_ID in generated workspace config"
+                        );
+                    }
+                }
                 // Use the server's own address so MCPs can reach the API.
                 // Private-network containers (Tailscale veth) cannot reach
                 // the host on 127.0.0.1 — use the veth gateway address there.
                 if let Ok(port) = std::env::var("PORT") {
                     let host_ip = workspace.host_ip_from_workspace();
-                    env.entry("API_URL".to_string())
-                        .or_insert_with(|| format!("http://{}:{}", host_ip, port));
+                    env.insert(
+                        "API_URL".to_string(),
+                        format!("http://{}:{}", host_ip, port),
+                    );
                 }
                 // Forward JWT_SECRET to trusted internal MCPs so they can
                 // mint service tokens.  Other MCPs (including third-party ones)
@@ -2172,8 +2185,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
                 // breaking the dashboard's worker chips and the WorkerPanel.
                 if cfg.name == "orchestrator" {
                     if let Some(user_id) = boss_user_id {
-                        env.entry("BOSS_USER_ID".to_string())
-                            .or_insert_with(|| user_id.to_string());
+                        env.insert("BOSS_USER_ID".to_string(), user_id.to_string());
                     }
                 }
             }
@@ -3493,6 +3505,38 @@ mod tests {
         assert!(result.contains("[otel]"));
         assert!(result.contains("\"new\""));
         assert!(!result.contains("\"old\""));
+    }
+
+    #[test]
+    fn test_codex_profile_replaces_stale_mcp_env() {
+        let profile = r#"[mcp_servers.automation_manager]
+command = "/usr/local/bin/automation-manager-mcp"
+
+[mcp_servers.automation_manager.env]
+MISSION_ID = "old-mission"
+WORKING_DIR = "/workspaces/mission-old"
+"#;
+        let mut env = HashMap::new();
+        env.insert("MISSION_ID".to_string(), "new-mission".to_string());
+        env.insert(
+            "WORKING_DIR".to_string(),
+            "/workspaces/mission-new".to_string(),
+        );
+        let entries = vec![CodexMcpEntry {
+            name: "automation_manager".to_string(),
+            command: Some("/usr/local/bin/automation-manager-mcp".to_string()),
+            args: vec![],
+            env,
+            url: None,
+            headers: HashMap::new(),
+        }];
+
+        let result = update_codex_mcp_config(profile, &entries);
+
+        assert!(result.contains("MISSION_ID = \"new-mission\""));
+        assert!(result.contains("WORKING_DIR = \"/workspaces/mission-new\""));
+        assert!(!result.contains("old-mission"));
+        assert!(!result.contains("mission-old"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Drop unattributed mission-scoped control stream events when the page is filtered to one mission.
- Tag live thinking/stream rows with mission ids so transient UI state cannot leak between missions.
- Run Codex app-server with a per-mission HOME/XDG state directory, copying workspace Codex auth/skills but not stale generated `config.toml`, to avoid shared ~/.codex SQLite locks and stale MCP mission env.
- Make generated MCP runtime env mission-authoritative: overwrite stale `MISSION_ID`, `API_URL`, and orchestrator `BOSS_USER_ID` instead of preserving profile/workspace values.
- Return a clear 404 when automation creation targets a missing mission, and log automation creation/stale mission env overrides for monitoring.

## Validation
- `cargo fmt --all --check`
- `cargo check`
- `cargo test workspace::tests::test_codex_profile_replaces_stale_mcp_env`
- `bunx vitest run src/app/control/control-client.item-views.test.ts`
- `bunx eslint src/lib/api.ts src/app/control/events-reducer.ts src/app/control/control-client.tsx src/app/control/control-client.item-views.test.ts` (existing warnings only)
- `bunx tsc --noEmit --pretty false` still fails on pre-existing TS7006 errors in `src/lib/client-message-id.test.ts`

## Deployment note
- Deployed the backend patch to prod and verified `/api/health` after restart.
- Recent prod logs show the automation scheduler started cleanly and no immediate `FOREIGN KEY`/automation errors after deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes mission message routing, SSE filtering, and parallel runner lifecycle (pause/schedule/deferral); regressions could drop live events, mis-route messages, or leave runners in inconsistent states.
> 
> **Overview**
> **Mission-scoped control UI** stops cross-mission leaks: mission-scoped SSE events without a `mission_id` are dropped (client and stream filter), and live **thinking** / **stream** rows carry and match on `missionId` when merging deltas and when `appendUnpersistedLiveTail` rebuilds history for the viewed mission.
> 
> **Mission switcher** gains inline rename (pencil / F2) with optimistic title updates, compact status icons instead of long labels, and virtual list rows keyed by stable id so pin/reorder doesn’t stack heights wrong.
> 
> **Control backend (FLEET)** adds operator **pause** (stops runners, `Paused` status, blocks delete/auto-start until resume), **clone** and **scheduling** (`priority`, `not_before`, `deadline`, deferred goals + periodic dispatch), normalized **backend quota** API, and **`source`** on user messages through the queue and events. Routing fixes honor an message’s explicit target instead of a drifted session pointer; paused missions reject stray sends/starts; automation create returns **404** for missing missions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfcfcc8621a24e0035c3ab2a33af1d69f6eaab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->