### PR TITLE
Fix path validation when base is missing (the case on fresh install)

### DIFF
--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -584,9 +584,6 @@ impl LibraryStore {
 
     /// Validate that a path doesn't escape the base directory via traversal.
     fn validate_path_within(&self, base: &std::path::Path, target: &std::path::Path) -> Result<()> {
-        // Canonicalize what we can, but for non-existent paths we need to check components
-        let base_canonical = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
-
         // Check for path traversal in the target path components
         for component in target.components() {
             if let std::path::Component::ParentDir = component {
@@ -594,15 +591,39 @@ impl LibraryStore {
             }
         }
 
-        // If the file exists, verify it's within the base directory
+        // Canonicalize base fully if it exists; otherwise resolve as far as possible
+        // through its already-existing ancestors (preserving symlink safety for the
+        // existing portion while accepting paths whose final component(s) will be
+        // created during this operation).
+        let base_canonical = if base.exists() {
+            base.canonicalize()?
+        } else {
+            let mut candidate = base.to_path_buf();
+            while !candidate.exists()
+                && candidate != candidate.parent().map(|p| p.to_path_buf()).unwrap_or(candidate.clone())
+            {
+                if let Some(parent) = candidate.parent() {
+                    candidate = parent.to_path_buf();
+                } else {
+                    break;
+                }
+            }
+            // Try to canonicalize base itself (may succeed if just created), fall back to resolved ancestor
+            base.canonicalize().ok().unwrap_or_else(|| candidate)
+        };
+
+        // If the file exists, verify it's within the base directory via full canonicalization
         if target.exists() {
             let target_canonical = target.canonicalize()?;
             if !target_canonical.starts_with(&base_canonical) {
                 anyhow::bail!("Path escapes allowed directory");
             }
         } else {
-            // For new files, verify the parent directory exists and is within base
-            // This prevents symlink bypass attacks where a symlinked parent could escape
+            // For new files, we need two guarantees:
+            // 1) Every *existing* ancestor of target must still be under base_canonical
+            //    (catches mid-tree symlink attacks).
+            // 2) target must actually descend from base (not just any sibling dir at the
+            //    same level as the truncated non-existent path).
             let mut current = target.to_path_buf();
             while let Some(parent) = current.parent() {
                 if parent.exists() {
@@ -613,6 +634,17 @@ impl LibraryStore {
                     break;
                 }
                 current = parent.to_path_buf();
+            }
+            // Confirm the target genuinely starts with base path using string-level prefix.
+            // This works even when base doesn't exist on disk yet (no symlinks can interfere).
+            let base_str = base_canonical.to_string_lossy();
+            let target_str = target.to_string_lossy();
+            if !target_str.starts_with(base_str.as_ref()) {
+                anyhow::bail!("Path escapes allowed directory");
+            }
+            // Ensure target is strictly deeper than base (target != base).
+            if target_str == base_str {
+                anyhow::bail!("Target equals base directory");
             }
         }
 


### PR DESCRIPTION
Hello,

On my first use after `docker compose up` I was having trouble with opencode missions. I figured out I can configure the default `opencode.json` from "Library -> Profiles" but I could not edit the config:

-  I was getting a warning that the host was not in sync
- Pulling from host would fail with a 500 error

```
sandboxed-sh-1  | 2026-06-23T22:19:37.303078Z DEBUG request{method=PUT uri=/api/library/config-profile/default/file/.opencode/settings.json version=HTTP/1.1}: tower_http::trace::on_request: started processing request
sandboxed-sh-1  | 2026-06-23T22:19:37.303382Z DEBUG request{method=PUT uri=/api/library/config-profile/default/file/.opencode/settings.json version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=0 ms status=500
sandboxed-sh-1  | 2026-06-23T22:19:37.303410Z ERROR request{method=PUT uri=/api/library/config-profile/default/file/.opencode/settings.json version=HTTP/1.1}: tower_http::trace::on_failure: response failed classification=Status code: 500 Internal Server Error latency=0 ms
``` 

The UI would show "Failed to save config profile file: Internal Server Error".

I managed to figure out how to get past this by using the console to create the file manually.

This patch fixes the issue by canonicalizing/validating the path up to the point where it exists, allowing creation if missing. This allowed me to push the file on a fresh install.

To reproduce:

1. Make sure sandboxed-sh volumes are deleted
2. Run the docker compose up
3. Go to Library --> Profiles and try to pull the config from host and/or edit it.
 