### PR TITLE
feat(providers): provider-faithful `optimize` block on usage API

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -107,12 +107,27 @@ function fmtResetEpoch(secs: number | undefined | null): string {
   return fmtReset(new Date(secs * 1000).toISOString());
 }
 
-/** Usage bar: shows used/limit with a mini progress bar */
-function UsageBar({ used, limit, label }: { used?: number | null; limit?: number | null; label: string }) {
-  if (limit == null && used == null) return null;
-  const remaining = used ?? 0;
+/**
+ * Usage bar: fills the *consumed* portion of a limit.
+ *
+ * `remaining` is how much is LEFT (e.g. `tokens_remaining`, or
+ * `(1 - utilization) * 100` for percentage windows). The bar shows
+ * `limit - remaining` consumed. (Previously this prop was named `used`, which
+ * was misleading — every call site has always passed a remaining value.)
+ */
+function UsageBar({
+  remaining,
+  limit,
+  label,
+}: {
+  remaining?: number | null;
+  limit?: number | null;
+  label: string;
+}) {
+  if (limit == null && remaining == null) return null;
+  const left = remaining ?? 0;
   const total = limit ?? 0;
-  const usedCount = total - remaining;
+  const usedCount = total - left;
   const pct = total > 0 ? Math.min(100, (usedCount / total) * 100) : 0;
   const color = pct > 90 ? 'bg-red-400' : pct > 70 ? 'bg-amber-400' : 'bg-emerald-400';
 
@@ -194,14 +209,14 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
           </div>
           {usage.unified_5h_utilization != null && (
             <UsageBar
-              used={Math.round((1 - usage.unified_5h_utilization) * 100)}
+              remaining={Math.round((1 - usage.unified_5h_utilization) * 100)}
               limit={100}
               label={`5h window (${usage.unified_5h_status || ''})`}
             />
           )}
           {usage.unified_7d_utilization != null && (
             <UsageBar
-              used={Math.round((1 - usage.unified_7d_utilization) * 100)}
+              remaining={Math.round((1 - usage.unified_7d_utilization) * 100)}
               limit={100}
               label={`7d window (${usage.unified_7d_status || ''})`}
             />
@@ -226,18 +241,18 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
       {/* Anthropic legacy rate limits */}
       {type === 'anthropic' && !usage.unified_status && usage.requests_limit != null && (
         <div className="space-y-2">
-          <UsageBar used={usage.requests_remaining} limit={usage.requests_limit} label="Requests" />
-          <UsageBar used={usage.tokens_remaining} limit={usage.tokens_limit} label="Tokens" />
-          <UsageBar used={usage.input_tokens_remaining} limit={usage.input_tokens_limit} label="Input tokens" />
-          <UsageBar used={usage.output_tokens_remaining} limit={usage.output_tokens_limit} label="Output tokens" />
+          <UsageBar remaining={usage.requests_remaining} limit={usage.requests_limit} label="Requests" />
+          <UsageBar remaining={usage.tokens_remaining} limit={usage.tokens_limit} label="Tokens" />
+          <UsageBar remaining={usage.input_tokens_remaining} limit={usage.input_tokens_limit} label="Input tokens" />
+          <UsageBar remaining={usage.output_tokens_remaining} limit={usage.output_tokens_limit} label="Output tokens" />
         </div>
       )}
 
       {/* OpenAI style rate limits */}
       {type === 'openai' && usage.requests_limit != null && (
         <div className="space-y-2">
-          <UsageBar used={usage.requests_remaining} limit={usage.requests_limit} label="Requests" />
-          <UsageBar used={usage.tokens_remaining} limit={usage.tokens_limit} label="Tokens" />
+          <UsageBar remaining={usage.requests_remaining} limit={usage.requests_limit} label="Requests" />
+          <UsageBar remaining={usage.tokens_remaining} limit={usage.tokens_limit} label="Tokens" />
           <div className="flex gap-4 text-[10px] text-white/30">
             {usage.requests_reset && (
               <span>Requests reset: {fmtReset(usage.requests_reset)}</span>
@@ -265,14 +280,14 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
           </div>
           {usage.codex_primary_used_percent != null && (
             <UsageBar
-              used={Math.round(100 - usage.codex_primary_used_percent)}
+              remaining={Math.round(100 - usage.codex_primary_used_percent)}
               limit={100}
               label="5h window"
             />
           )}
           {usage.codex_secondary_used_percent != null && (
             <UsageBar
-              used={Math.round(100 - usage.codex_secondary_used_percent)}
+              remaining={Math.round(100 - usage.codex_secondary_used_percent)}
               limit={100}
               label="Weekly window"
             />
@@ -303,8 +318,8 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
       {/* Cerebras style rate limits */}
       {type === 'cerebras' && (
         <div className="space-y-2">
-          <UsageBar used={usage.requests_remaining_day} limit={usage.requests_limit_day} label="Requests (daily)" />
-          <UsageBar used={usage.tokens_remaining_minute} limit={usage.tokens_limit_minute} label="Tokens (per minute)" />
+          <UsageBar remaining={usage.requests_remaining_day} limit={usage.requests_limit_day} label="Requests (daily)" />
+          <UsageBar remaining={usage.tokens_remaining_minute} limit={usage.tokens_limit_minute} label="Tokens (per minute)" />
           <div className="flex gap-4 text-[10px] text-white/30">
             {usage.requests_reset_day && (
               <span>Daily reset: {fmtReset(usage.requests_reset_day)}</span>
@@ -330,8 +345,8 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
           }>).map((m) => (
             <div key={m.model} className="space-y-1">
               <div className="text-[11px] text-white/50 font-medium">{m.model}</div>
-              <UsageBar used={m.interval_remaining} limit={m.interval_total} label="Interval" />
-              <UsageBar used={m.weekly_remaining} limit={m.weekly_total} label="Weekly" />
+              <UsageBar remaining={m.interval_remaining} limit={m.interval_total} label="Interval" />
+              <UsageBar remaining={m.weekly_remaining} limit={m.weekly_total} label="Weekly" />
               <div className="flex gap-4 text-[10px] text-white/30">
                 {m.interval_reset > 0 && (
                   <span>Interval reset: {fmtReset(new Date(m.interval_reset).toISOString())}</span>

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -352,8 +352,48 @@ export interface ProviderUsage {
   codex_credits_balance?: number;
   codex_credits_unlimited?: boolean;
   codex_source?: "probe" | "passive";
+  // Provider-faithful normalized view for token-spend optimization. Each window
+  // only carries the fields its provider actually reports (so shapes differ by
+  // vendor); `burn` is null unless a pace/rate could be derived. One call gives
+  // pct_remaining, reset_at, and burn rate together.
+  optimize?: UsageOptimize;
   // Any additional fields
   [key: string]: unknown;
+}
+
+export interface UsageOptimizeBurn {
+  /** %-window providers: projected utilization at reset (>=100 ⇒ will exhaust). */
+  projected_pct_at_reset?: number | null;
+  on_track_to_exhaust?: boolean | null;
+  /** Absolute-token windows: observed consumption rate from the snapshot delta. */
+  tokens_per_min?: number | null;
+  sample_seconds?: number | null;
+  projected_exhaustion_at?: string | null;
+  basis?: "window_pace" | "observed_delta" | "window_pace+observed_delta";
+}
+
+export interface UsageOptimizeWindow {
+  key: string;
+  label: string;
+  metric: "tokens" | "requests" | "mixed";
+  source: string;
+  pct_used: number | null;
+  pct_remaining: number | null;
+  limit: number | null;
+  remaining: number | null;
+  used: number | null;
+  window_seconds: number | null;
+  reset_at: string | null;
+  reset_in_seconds: number | null;
+  burn: UsageOptimizeBurn | null;
+  [key: string]: unknown;
+}
+
+export interface UsageOptimize {
+  as_of: string;
+  /** Key of the most binding window (lowest pct_remaining), or null. */
+  primary_window: string | null;
+  windows: UsageOptimizeWindow[];
 }
 
 export async function getProviderUsage(id: string): Promise<ProviderUsage> {

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -7322,8 +7322,22 @@ async fn live_fetch_and_cache(
     state: Arc<super::routes::AppState>,
     id: String,
 ) -> Result<serde_json::Value, (StatusCode, String)> {
+    // Grab the previous snapshot (value + age) BEFORE we overwrite it, so the
+    // optimize block can derive an observed burn rate from the delta between
+    // the two samples.
+    let prev = state.provider_usage_cache.get(&id).await;
     let result = get_provider_usage(State(Arc::clone(&state)), AxumPath(id.clone())).await?;
-    let value = result.0;
+    let mut value = result.0;
+
+    // Append the provider-faithful normalized `optimize` block (pct_remaining,
+    // reset_at, burn) so a client gets all three in one call. Computed here,
+    // once, so both the single and bulk cached endpoints serve it.
+    let prev_ref = prev.as_ref().map(|c| (&c.value, c.fetched_at.elapsed()));
+    let optimize = super::usage_optimize::build_optimize_block(&value, prev_ref);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("optimize".to_string(), optimize);
+    }
+
     state.provider_usage_cache.insert(id, value.clone()).await;
     Ok(value)
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -59,6 +59,7 @@ pub(crate) mod supervision;
 pub mod system;
 pub mod telegram;
 pub mod types;
+pub mod usage_optimize;
 pub mod workspaces;
 
 pub use routes::serve;

--- a/src/api/usage_optimize.rs
+++ b/src/api/usage_optimize.rs
@@ -1,0 +1,647 @@
+//! Provider-faithful "optimize" normalization for the usage API.
+//!
+//! The per-provider `/api/ai/providers/:id/usage` response is a flat bag of
+//! vendor-specific fields (Anthropic unified `unified_5h_utilization`, Codex
+//! `codex_primary_used_percent`, OpenAI-style `tokens_remaining`/`tokens_limit`,
+//! Cerebras `*_day`/`*_minute`, …). A client that wants to "optimize for token
+//! spending" otherwise has to special-case every vendor to answer three
+//! questions: how much is left (so `pct_remaining` is computable), exactly when
+//! does it reset, and how fast am I burning it.
+//!
+//! This module derives a single normalized `optimize` block from whatever the
+//! provider already reported. The guiding rule is **provider truth**: a field
+//! is only emitted when the underlying provider actually exposes it, every
+//! window is tagged with its `source`, and nothing is fabricated — windows
+//! differ per provider and carry different data on purpose.
+//!
+//! Two burn/pace signals are produced, each only where it is genuinely
+//! supported:
+//!   * **window pace** (`projected_pct_at_reset`) for percentage-window
+//!     providers whose window length + reset time are known — pure provider
+//!     truth, no second sample needed. Answers "am I on track to exhaust this
+//!     window before it resets?".
+//!   * **observed burn** (`tokens_per_min`) for absolute-token windows, derived
+//!     from the delta between the previous cached snapshot and this one. Only
+//!     possible when two snapshots exist and the window didn't reset between
+//!     them.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde_json::{json, Map, Value};
+
+/// Anthropic unified subscription window lengths. These are not in the response
+/// (only the reset time is), so we pin the documented window spans to derive a
+/// pace. 5-hour and 7-day rolling windows.
+const ANTHROPIC_5H_SECONDS: i64 = 5 * 3600;
+const ANTHROPIC_7D_SECONDS: i64 = 7 * 24 * 3600;
+
+/// A single normalized usage window plus the derived pace/burn for it.
+struct Window {
+    key: &'static str,
+    label: String,
+    /// "tokens" | "requests" | "mixed" — what the window meters.
+    metric: &'static str,
+    pct_used: Option<f64>,
+    pct_remaining: Option<f64>,
+    limit: Option<u64>,
+    remaining: Option<u64>,
+    used: Option<u64>,
+    reset_at: Option<DateTime<Utc>>,
+    window_seconds: Option<i64>,
+    source: &'static str,
+    /// Extra provider-truth fields that don't fit the normalized shape but are
+    /// worth surfacing transparently (e.g. the raw Anthropic utilization and
+    /// the assumption we made about its direction).
+    extra: Map<String, Value>,
+}
+
+impl Window {
+    fn new(
+        key: &'static str,
+        label: impl Into<String>,
+        metric: &'static str,
+        source: &'static str,
+    ) -> Self {
+        Window {
+            key,
+            label: label.into(),
+            metric,
+            pct_used: None,
+            pct_remaining: None,
+            limit: None,
+            remaining: None,
+            used: None,
+            reset_at: None,
+            window_seconds: None,
+            source,
+            extra: Map::new(),
+        }
+    }
+
+    /// Fill pct_used/pct_remaining from an absolute limit+remaining pair.
+    fn with_absolute(mut self, limit: u64, remaining: u64) -> Self {
+        let remaining = remaining.min(limit);
+        self.limit = Some(limit);
+        self.remaining = Some(remaining);
+        self.used = Some(limit - remaining);
+        if limit > 0 {
+            self.pct_remaining = Some(remaining as f64 / limit as f64 * 100.0);
+            self.pct_used = Some((limit - remaining) as f64 / limit as f64 * 100.0);
+        }
+        self
+    }
+
+    /// Fill pct_used/pct_remaining from a 0..=100 used-percent value.
+    fn with_used_percent(mut self, used_pct: f64) -> Self {
+        let used_pct = used_pct.max(0.0);
+        self.pct_used = Some(used_pct);
+        self.pct_remaining = Some((100.0 - used_pct).max(0.0));
+        self
+    }
+
+    /// Window pace: project the used-percent forward across the full window
+    /// using the elapsed fraction so far. Only valid when we know both the
+    /// reset time and the window length, and at least one second has elapsed in
+    /// the current window. Pure provider truth — no second sample needed.
+    fn window_pace(&self, now: DateTime<Utc>) -> Option<(f64, bool)> {
+        let pct_used = self.pct_used?;
+        let reset_at = self.reset_at?;
+        let window_seconds = self.window_seconds?;
+        if window_seconds <= 0 {
+            return None;
+        }
+        let window_start = reset_at - chrono::Duration::seconds(window_seconds);
+        let elapsed = (now - window_start).num_seconds();
+        // Outside the window (clock skew / stale reset) → can't project.
+        if elapsed <= 0 || elapsed > window_seconds {
+            return None;
+        }
+        let projected = pct_used * (window_seconds as f64 / elapsed as f64);
+        Some((projected, projected >= 100.0))
+    }
+
+    fn into_json(self, now: DateTime<Utc>, observed: Option<ObservedBurn>) -> Value {
+        let mut obj = Map::new();
+        obj.insert("key".into(), json!(self.key));
+        obj.insert("label".into(), json!(self.label));
+        obj.insert("metric".into(), json!(self.metric));
+        obj.insert("source".into(), json!(self.source));
+        obj.insert("pct_used".into(), round2(self.pct_used));
+        obj.insert("pct_remaining".into(), round2(self.pct_remaining));
+        obj.insert("limit".into(), opt_u64(self.limit));
+        obj.insert("remaining".into(), opt_u64(self.remaining));
+        obj.insert("used".into(), opt_u64(self.used));
+        obj.insert("window_seconds".into(), opt_i64(self.window_seconds));
+
+        match self.reset_at {
+            Some(reset_at) => {
+                obj.insert("reset_at".into(), json!(reset_at.to_rfc3339()));
+                obj.insert(
+                    "reset_in_seconds".into(),
+                    json!((reset_at - now).num_seconds()),
+                );
+            }
+            None => {
+                obj.insert("reset_at".into(), Value::Null);
+                obj.insert("reset_in_seconds".into(), Value::Null);
+            }
+        }
+
+        // Burn / pace block — only present when something was computable.
+        let mut burn = Map::new();
+        if let Some((projected, exhaust)) = self.window_pace(now) {
+            burn.insert("projected_pct_at_reset".into(), round2(Some(projected)));
+            burn.insert("on_track_to_exhaust".into(), json!(exhaust));
+            burn.insert("basis".into(), json!("window_pace"));
+        }
+        if let Some(ob) = observed {
+            burn.insert("tokens_per_min".into(), round2(Some(ob.per_min)));
+            burn.insert("sample_seconds".into(), json!(ob.sample_seconds));
+            match ob.projected_exhaustion_at {
+                Some(at) => burn.insert("projected_exhaustion_at".into(), json!(at.to_rfc3339())),
+                None => burn.insert("projected_exhaustion_at".into(), Value::Null),
+            };
+            // If both bases contributed, label it as such.
+            let basis = if burn.contains_key("projected_pct_at_reset") {
+                "window_pace+observed_delta"
+            } else {
+                "observed_delta"
+            };
+            burn.insert("basis".into(), json!(basis));
+        }
+        obj.insert(
+            "burn".into(),
+            if burn.is_empty() {
+                Value::Null
+            } else {
+                Value::Object(burn)
+            },
+        );
+
+        for (k, v) in self.extra {
+            obj.insert(k, v);
+        }
+        Value::Object(obj)
+    }
+}
+
+/// Observed burn derived from the delta between two snapshots of an
+/// absolute-token window.
+struct ObservedBurn {
+    per_min: f64,
+    sample_seconds: i64,
+    projected_exhaustion_at: Option<DateTime<Utc>>,
+}
+
+/// Build the normalized `optimize` block from a usage value, optionally using
+/// the previous cached snapshot (and its age) to derive observed burn rates.
+pub fn build_optimize_block(value: &Value, prev: Option<(&Value, Duration)>) -> Value {
+    build_optimize_block_at(value, prev, Utc::now())
+}
+
+/// Testable core: `now` is injected so unit tests are deterministic.
+fn build_optimize_block_at(
+    value: &Value,
+    prev: Option<(&Value, Duration)>,
+    now: DateTime<Utc>,
+) -> Value {
+    let windows = collect_windows(value);
+
+    let mut window_values: Vec<Value> = Vec::with_capacity(windows.len());
+    let mut primary: Option<(&'static str, f64)> = None;
+
+    for w in windows {
+        // Pick the most binding window = lowest pct_remaining.
+        if let Some(pr) = w.pct_remaining {
+            match primary {
+                Some((_, best)) if best <= pr => {}
+                _ => primary = Some((w.key, pr)),
+            }
+        }
+        let observed = w
+            .remaining
+            .and_then(|rem| observed_burn(prev, w.key, rem, now));
+        window_values.push(w.into_json(now, observed));
+    }
+
+    json!({
+        "as_of": now.to_rfc3339(),
+        "primary_window": primary.map(|(k, _)| k),
+        "windows": window_values,
+    })
+}
+
+/// Detect every window the provider reported. Order matters only for display.
+fn collect_windows(v: &Value) -> Vec<Window> {
+    let mut out = Vec::new();
+
+    // ── Anthropic unified subscription windows (Claude Code OAuth) ──
+    // `unified_5h_utilization` is a 0..1 fraction. Its direction (used vs
+    // remaining) is undocumented; the Anthropic API convention is "fraction
+    // used", so we assume that and ALSO surface the raw value + the assumption
+    // so a consumer is never locked into our interpretation.
+    for (util_key, reset_key, key, label, window_seconds) in [
+        (
+            "unified_5h_utilization",
+            "unified_5h_reset",
+            "anthropic_5h",
+            "5-hour",
+            ANTHROPIC_5H_SECONDS,
+        ),
+        (
+            "unified_7d_utilization",
+            "unified_7d_reset",
+            "anthropic_7d",
+            "7-day",
+            ANTHROPIC_7D_SECONDS,
+        ),
+    ] {
+        if let Some(util) = get_f64(v, util_key) {
+            let used_pct = (util * 100.0).max(0.0);
+            let mut w =
+                Window::new(key, label, "mixed", "anthropic_unified").with_used_percent(used_pct);
+            w.window_seconds = Some(window_seconds);
+            w.reset_at = get_rfc3339(v, reset_key);
+            w.extra.insert("raw_utilization".into(), json!(util));
+            w.extra
+                .insert("assumes".into(), json!("utilization=fraction_used"));
+            out.push(w);
+        }
+    }
+
+    // ── Codex (OpenAI ChatGPT subscription) windows — used-percent is explicit ──
+    for (pct_key, win_min_key, reset_key, key, label) in [
+        (
+            "codex_primary_used_percent",
+            "codex_primary_window_minutes",
+            "codex_primary_reset_at",
+            "codex_primary",
+            "5-hour",
+        ),
+        (
+            "codex_secondary_used_percent",
+            "codex_secondary_window_minutes",
+            "codex_secondary_reset_at",
+            "codex_secondary",
+            "weekly",
+        ),
+    ] {
+        if let Some(used_pct) = get_f64(v, pct_key) {
+            let mut w = Window::new(key, label, "mixed", "codex").with_used_percent(used_pct);
+            w.window_seconds = get_i64(v, win_min_key).map(|m| m * 60);
+            w.reset_at = get_epoch_secs(v, reset_key);
+            out.push(w);
+        }
+    }
+
+    // ── Absolute token/request windows (Anthropic legacy, OpenAI, xAI, Groq) ──
+    if let (Some(limit), Some(remaining)) =
+        (get_u64(v, "tokens_limit"), get_u64(v, "tokens_remaining"))
+    {
+        let mut w = Window::new("tokens", "tokens", "tokens", "provider_tokens")
+            .with_absolute(limit, remaining);
+        w.reset_at = normalize_reset(v.get("tokens_reset"));
+        out.push(w);
+    }
+    if let (Some(limit), Some(remaining)) = (
+        get_u64(v, "requests_limit"),
+        get_u64(v, "requests_remaining"),
+    ) {
+        let mut w = Window::new("requests", "requests", "requests", "provider_requests")
+            .with_absolute(limit, remaining);
+        w.reset_at = normalize_reset(v.get("requests_reset"));
+        out.push(w);
+    }
+    if let (Some(limit), Some(remaining)) = (
+        get_u64(v, "input_tokens_limit"),
+        get_u64(v, "input_tokens_remaining"),
+    ) {
+        let mut w = Window::new("input_tokens", "input tokens", "tokens", "provider_tokens")
+            .with_absolute(limit, remaining);
+        w.reset_at = normalize_reset(v.get("input_tokens_reset"));
+        out.push(w);
+    }
+    if let (Some(limit), Some(remaining)) = (
+        get_u64(v, "output_tokens_limit"),
+        get_u64(v, "output_tokens_remaining"),
+    ) {
+        let mut w = Window::new(
+            "output_tokens",
+            "output tokens",
+            "tokens",
+            "provider_tokens",
+        )
+        .with_absolute(limit, remaining);
+        w.reset_at = normalize_reset(v.get("output_tokens_reset"));
+        out.push(w);
+    }
+
+    // ── Cerebras (per-day requests, per-minute tokens) ──
+    if let (Some(limit), Some(remaining)) = (
+        get_u64(v, "tokens_limit_minute"),
+        get_u64(v, "tokens_remaining_minute"),
+    ) {
+        let mut w = Window::new("tokens_minute", "tokens / minute", "tokens", "cerebras")
+            .with_absolute(limit, remaining);
+        w.reset_at = normalize_reset(v.get("tokens_reset_minute"));
+        out.push(w);
+    }
+    if let (Some(limit), Some(remaining)) = (
+        get_u64(v, "requests_limit_day"),
+        get_u64(v, "requests_remaining_day"),
+    ) {
+        let mut w = Window::new("requests_day", "requests / day", "requests", "cerebras")
+            .with_absolute(limit, remaining);
+        w.reset_at = normalize_reset(v.get("requests_reset_day"));
+        out.push(w);
+    }
+
+    out
+}
+
+/// Observed burn for an absolute window keyed by its `remaining` field name.
+/// Compares the previous snapshot's remaining to the current one over the
+/// snapshot age. Returns None when there's no prior sample, the window reset
+/// between samples (remaining went up), or nothing was consumed.
+fn observed_burn(
+    prev: Option<(&Value, Duration)>,
+    window_key: &str,
+    cur_remaining: u64,
+    now: DateTime<Utc>,
+) -> Option<ObservedBurn> {
+    let remaining_field = match window_key {
+        "tokens" => "tokens_remaining",
+        "requests" => "requests_remaining",
+        "input_tokens" => "input_tokens_remaining",
+        "output_tokens" => "output_tokens_remaining",
+        "tokens_minute" => "tokens_remaining_minute",
+        "requests_day" => "requests_remaining_day",
+        _ => return None,
+    };
+    let (prev_value, age) = prev?;
+    let prev_remaining = get_u64(prev_value, remaining_field)?;
+    let sample_seconds = age.as_secs() as i64;
+    if sample_seconds <= 0 || prev_remaining < cur_remaining {
+        // No elapsed time, or remaining grew → the window replenished/reset;
+        // a delta-based rate would be meaningless.
+        return None;
+    }
+    let consumed = prev_remaining - cur_remaining;
+    if consumed == 0 {
+        return None;
+    }
+    let per_min = consumed as f64 / (sample_seconds as f64 / 60.0);
+    let projected_exhaustion_at = if per_min > 0.0 {
+        let secs_left = cur_remaining as f64 / per_min * 60.0;
+        Some(now + chrono::Duration::seconds(secs_left as i64))
+    } else {
+        None
+    };
+    Some(ObservedBurn {
+        per_min,
+        sample_seconds,
+        projected_exhaustion_at,
+    })
+}
+
+// ── small JSON helpers ────────────────────────────────────────────────────
+
+fn get_f64(v: &Value, key: &str) -> Option<f64> {
+    v.get(key).and_then(|x| x.as_f64())
+}
+
+fn get_i64(v: &Value, key: &str) -> Option<i64> {
+    v.get(key).and_then(|x| x.as_i64())
+}
+
+fn get_u64(v: &Value, key: &str) -> Option<u64> {
+    v.get(key).and_then(|x| {
+        x.as_u64()
+            .or_else(|| x.as_i64().filter(|n| *n >= 0).map(|n| n as u64))
+            .or_else(|| x.as_f64().filter(|f| *f >= 0.0).map(|f| f as u64))
+    })
+}
+
+fn get_rfc3339(v: &Value, key: &str) -> Option<DateTime<Utc>> {
+    let s = v.get(key)?.as_str()?;
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|d| d.with_timezone(&Utc))
+}
+
+fn get_epoch_secs(v: &Value, key: &str) -> Option<DateTime<Utc>> {
+    let n = get_i64(v, key)?;
+    DateTime::<Utc>::from_timestamp(n, 0)
+}
+
+/// Normalize a provider "reset" field that may be an RFC 3339 string, a unix
+/// epoch (seconds), or a relative duration string like "2s" / "1m30s".
+fn normalize_reset(v: Option<&Value>) -> Option<DateTime<Utc>> {
+    normalize_reset_at(v, Utc::now())
+}
+
+fn normalize_reset_at(v: Option<&Value>, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let v = v?;
+    if let Some(n) = v.as_i64() {
+        // Heuristic: a plausible epoch (after 2001) is absolute; a small number
+        // is a relative seconds offset.
+        if n > 1_000_000_000 {
+            return DateTime::<Utc>::from_timestamp(n, 0);
+        }
+        if n >= 0 {
+            return Some(now + chrono::Duration::seconds(n));
+        }
+    }
+    let s = v.as_str()?;
+    if let Ok(d) = DateTime::parse_from_rfc3339(s) {
+        return Some(d.with_timezone(&Utc));
+    }
+    if let Ok(n) = s.parse::<i64>() {
+        if n > 1_000_000_000 {
+            return DateTime::<Utc>::from_timestamp(n, 0);
+        }
+        return Some(now + chrono::Duration::seconds(n));
+    }
+    parse_duration_string(s).map(|secs| now + chrono::Duration::seconds(secs))
+}
+
+/// Parse "1m30s", "2s", "500ms", "1h" → whole seconds. ms rounds up to ≥1s when
+/// non-zero so a sub-second reset still reads as imminent rather than "now".
+fn parse_duration_string(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let mut total_ms: i64 = 0;
+    let mut num = String::new();
+    let mut unit = String::new();
+    let mut saw_unit = false;
+    for ch in s.chars() {
+        if ch.is_ascii_digit() || ch == '.' {
+            if saw_unit {
+                total_ms += flush_unit(&num, &unit)?;
+                num.clear();
+                unit.clear();
+                saw_unit = false;
+            }
+            num.push(ch);
+        } else if ch.is_ascii_alphabetic() {
+            saw_unit = true;
+            unit.push(ch);
+        } else {
+            return None;
+        }
+    }
+    if num.is_empty() && unit.is_empty() {
+        return None;
+    }
+    total_ms += flush_unit(&num, &unit)?;
+    Some(if total_ms > 0 && total_ms < 1000 {
+        1
+    } else {
+        total_ms / 1000
+    })
+}
+
+fn flush_unit(num: &str, unit: &str) -> Option<i64> {
+    if num.is_empty() {
+        return None;
+    }
+    let val: f64 = num.parse().ok()?;
+    let ms = match unit {
+        "ms" => val,
+        "s" | "" => val * 1000.0,
+        "m" => val * 60_000.0,
+        "h" => val * 3_600_000.0,
+        "d" => val * 86_400_000.0,
+        _ => return None,
+    };
+    Some(ms as i64)
+}
+
+fn round2(v: Option<f64>) -> Value {
+    match v {
+        Some(f) if f.is_finite() => json!((f * 100.0).round() / 100.0),
+        _ => Value::Null,
+    }
+}
+
+fn opt_u64(v: Option<u64>) -> Value {
+    v.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+fn opt_i64(v: Option<i64>) -> Value {
+    v.map(|n| json!(n)).unwrap_or(Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-25T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn window<'a>(opt: &'a Value, key: &str) -> &'a Value {
+        opt["windows"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|w| w["key"] == key)
+            .unwrap_or_else(|| panic!("window {key} missing in {opt}"))
+    }
+
+    #[test]
+    fn anthropic_unified_used_and_remaining() {
+        // 1h into a 5h window, 40% used → pace projects 200% (will exhaust).
+        let reset = (now() + chrono::Duration::hours(4)).to_rfc3339();
+        let v = json!({ "unified_5h_utilization": 0.4, "unified_5h_reset": reset });
+        let opt = build_optimize_block_at(&v, None, now());
+        let w = window(&opt, "anthropic_5h");
+        assert_eq!(w["pct_used"], json!(40.0));
+        assert_eq!(w["pct_remaining"], json!(60.0));
+        assert_eq!(w["raw_utilization"], json!(0.4));
+        assert_eq!(w["source"], json!("anthropic_unified"));
+        assert_eq!(w["burn"]["on_track_to_exhaust"], json!(true));
+        assert_eq!(w["burn"]["projected_pct_at_reset"], json!(200.0));
+        assert_eq!(opt["primary_window"], json!("anthropic_5h"));
+    }
+
+    #[test]
+    fn codex_used_percent_window_and_reset() {
+        let reset_epoch = (now() + chrono::Duration::hours(2)).timestamp();
+        let v = json!({
+            "codex_primary_used_percent": 25.0,
+            "codex_primary_window_minutes": 300,
+            "codex_primary_reset_at": reset_epoch,
+        });
+        let opt = build_optimize_block_at(&v, None, now());
+        let w = window(&opt, "codex_primary");
+        assert_eq!(w["pct_used"], json!(25.0));
+        assert_eq!(w["pct_remaining"], json!(75.0));
+        assert_eq!(w["window_seconds"], json!(18000));
+        assert_eq!(w["reset_in_seconds"], json!(7200));
+        assert_eq!(w["source"], json!("codex"));
+    }
+
+    #[test]
+    fn absolute_tokens_pct_and_observed_burn() {
+        let cur = json!({ "tokens_limit": 1000u64, "tokens_remaining": 400u64 });
+        let prev = json!({ "tokens_limit": 1000u64, "tokens_remaining": 700u64 });
+        // 300 tokens consumed over 60s → 300/min; 400 left → exhaust in 80s.
+        let opt = build_optimize_block_at(&cur, Some((&prev, Duration::from_secs(60))), now());
+        let w = window(&opt, "tokens");
+        assert_eq!(w["limit"], json!(1000));
+        assert_eq!(w["remaining"], json!(400));
+        assert_eq!(w["used"], json!(600));
+        assert_eq!(w["pct_remaining"], json!(40.0));
+        assert_eq!(w["burn"]["tokens_per_min"], json!(300.0));
+        assert_eq!(w["burn"]["basis"], json!("observed_delta"));
+        let eta = w["burn"]["projected_exhaustion_at"].as_str().unwrap();
+        assert_eq!(eta, (now() + chrono::Duration::seconds(80)).to_rfc3339());
+    }
+
+    #[test]
+    fn observed_burn_skipped_on_reset() {
+        // remaining grew (window replenished) → no burn.
+        let cur = json!({ "tokens_limit": 1000u64, "tokens_remaining": 900u64 });
+        let prev = json!({ "tokens_limit": 1000u64, "tokens_remaining": 100u64 });
+        let opt = build_optimize_block_at(&cur, Some((&prev, Duration::from_secs(60))), now());
+        let w = window(&opt, "tokens");
+        assert_eq!(w["burn"], Value::Null);
+    }
+
+    #[test]
+    fn primary_window_is_most_binding() {
+        let v = json!({
+            "tokens_limit": 1000u64, "tokens_remaining": 800u64,      // 80% remaining
+            "requests_limit": 100u64, "requests_remaining": 5u64,     // 5% remaining ← binding
+        });
+        let opt = build_optimize_block_at(&v, None, now());
+        assert_eq!(opt["primary_window"], json!("requests"));
+    }
+
+    #[test]
+    fn reset_duration_string_and_epoch() {
+        assert_eq!(parse_duration_string("1m30s"), Some(90));
+        assert_eq!(parse_duration_string("2s"), Some(2));
+        assert_eq!(parse_duration_string("500ms"), Some(1));
+        assert_eq!(parse_duration_string("1h"), Some(3600));
+        let n = now();
+        let from_dur = normalize_reset_at(Some(&json!("90s")), n).unwrap();
+        assert_eq!((from_dur - n).num_seconds(), 90);
+        let from_epoch = normalize_reset_at(Some(&json!(n.timestamp() + 100)), n).unwrap();
+        assert_eq!((from_epoch - n).num_seconds(), 100);
+    }
+
+    #[test]
+    fn empty_when_no_usage_fields() {
+        let v = json!({ "provider_type": "anthropic", "status": "connected" });
+        let opt = build_optimize_block_at(&v, None, now());
+        assert_eq!(opt["windows"].as_array().unwrap().len(), 0);
+        assert_eq!(opt["primary_window"], Value::Null);
+    }
+}


### PR DESCRIPTION
## What

Adds a normalized, vendor-neutral **`optimize`** block to the provider usage
response (`/api/ai/providers/:id/usage` + bulk `/usage`) so a client can
optimize token spend in **one call** instead of special-casing each vendor.

Per provider window — emitted **only when the provider actually reports it**,
each tagged with `source`, nothing fabricated (windows differ per provider on
purpose):

- `pct_used` / `pct_remaining` + absolute `limit`/`remaining`/`used` where known
- `reset_at` (RFC3339) + `reset_in_seconds`, normalized from RFC3339 / unix
  epoch / relative duration strings (`"1m30s"`)
- `burn`:
  - **window pace** (`projected_pct_at_reset`, `on_track_to_exhaust`) for
    percentage-window subscriptions (Anthropic, Codex) — pure provider truth, no
    second sample
  - **observed** `tokens_per_min` + `projected_exhaustion_at` for absolute-token
    windows, from the previous-snapshot delta
- `primary_window` = most binding window (lowest `pct_remaining`)

Covers Anthropic unified 5h/7d (raw utilization + assumption surfaced since the
direction is undocumented), Codex primary/secondary, OpenAI-style absolute
token/request windows, and Cerebras day/minute. Injected once in
`live_fetch_and_cache` (the single point every served path flows through), using
the previous cached snapshot for delta-based burn.

Also renames the misleading `UsageBar` `used` prop → `remaining` (it always
carried a remaining value): confirms the dashboard already agrees with the
backend that Anthropic `utilization = fraction used` — there was no inversion
bug, just a bad prop name.

## Testing

- 7 unit tests in `usage_optimize.rs` (Anthropic unified, Codex, absolute tokens
  + observed burn, reset-on-replenish, primary-window, reset parsing, empty case)
- `cargo fmt` + clippy clean; dashboard `tsc` clean
- Deployed to dev + smoke-verified: block present/well-formed; reads empty for
  accounts with no live usage data (all dev/prod Anthropic accounts are
  currently token-revoked, so the populated path is covered by unit tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New derived fields on a hot usage path and burn math depend on cache timing and assumptions (e.g. Anthropic utilization direction); behavior is additive but clients may rely on the new shape.
> 
> **Overview**
> Adds a normalized **`optimize`** object to provider usage responses (single and bulk cached paths) so clients can reason about limits, resets, and burn without per-vendor parsing.
> 
> **Backend:** New `usage_optimize` module derives `windows` (Anthropic unified, Codex, absolute token/request, Cerebras, etc.) with `pct_used`/`pct_remaining`, normalized `reset_at`, **`primary_window`** (tightest limit), and optional **`burn`** — window-pace projection for %-based subscriptions and **observed** `tokens_per_min` from the prior cached snapshot delta. Injection happens once in **`live_fetch_and_cache`** after a live fetch and before the cache write.
> 
> **Dashboard/API types:** `ProviderUsage` gains `UsageOptimize*` TypeScript types. **`UsageBar`** renames the misleading **`used`** prop to **`remaining`** (semantics unchanged; bars still show consumed = limit − remaining).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fc137804dae49aeffc5c9eefc37c4dccb38279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->