### PR TITLE
fix(library): path validation on fresh install + harden traversal guard

### DIFF
--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -584,9 +584,6 @@ impl LibraryStore {
 
     /// Validate that a path doesn't escape the base directory via traversal.
     fn validate_path_within(&self, base: &std::path::Path, target: &std::path::Path) -> Result<()> {
-        // Canonicalize what we can, but for non-existent paths we need to check components
-        let base_canonical = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
-
         // Check for path traversal in the target path components
         for component in target.components() {
             if let std::path::Component::ParentDir = component {
@@ -594,15 +591,39 @@ impl LibraryStore {
             }
         }
 
-        // If the file exists, verify it's within the base directory
+        // Canonicalize base fully if it exists; otherwise resolve as far as possible
+        // through its already-existing ancestors (preserving symlink safety for the
+        // existing portion while accepting paths whose final component(s) will be
+        // created during this operation).
+        let base_canonical = if base.exists() {
+            base.canonicalize()?
+        } else {
+            let mut candidate = base.to_path_buf();
+            while !candidate.exists()
+                && candidate != candidate.parent().map(|p| p.to_path_buf()).unwrap_or(candidate.clone())
+            {
+                if let Some(parent) = candidate.parent() {
+                    candidate = parent.to_path_buf();
+                } else {
+                    break;
+                }
+            }
+            // Try to canonicalize base itself (may succeed if just created), fall back to resolved ancestor
+            base.canonicalize().ok().unwrap_or_else(|| candidate)
+        };
+
+        // If the file exists, verify it's within the base directory via full canonicalization
         if target.exists() {
             let target_canonical = target.canonicalize()?;
             if !target_canonical.starts_with(&base_canonical) {
                 anyhow::bail!("Path escapes allowed directory");
             }
         } else {
-            // For new files, verify the parent directory exists and is within base
-            // This prevents symlink bypass attacks where a symlinked parent could escape
+            // For new files, we need two guarantees:
+            // 1) Every *existing* ancestor of target must still be under base_canonical
+            //    (catches mid-tree symlink attacks).
+            // 2) target must actually descend from base (not just any sibling dir at the
+            //    same level as the truncated non-existent path).
             let mut current = target.to_path_buf();
             while let Some(parent) = current.parent() {
                 if parent.exists() {
@@ -613,6 +634,17 @@ impl LibraryStore {
                     break;
                 }
                 current = parent.to_path_buf();
+            }
+            // Confirm the target genuinely starts with base path using string-level prefix.
+            // This works even when base doesn't exist on disk yet (no symlinks can interfere).
+            let base_str = base_canonical.to_string_lossy();
+            let target_str = target.to_string_lossy();
+            if !target_str.starts_with(base_str.as_ref()) {
+                anyhow::bail!("Path escapes allowed directory");
+            }
+            // Ensure target is strictly deeper than base (target != base).
+            if target_str == base_str {
+                anyhow::bail!("Target equals base directory");
             }
         }
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -598,18 +598,21 @@ impl LibraryStore {
         let base_canonical = if base.exists() {
             base.canonicalize()?
         } else {
+            // Walk up to the nearest existing ancestor and canonicalize THAT, so the
+            // prefix checks below compare fully-resolved paths — exactly how the
+            // target's ancestors are canonicalized. Leaving the ancestor unresolved
+            // makes a base that crosses a symlink (e.g. macOS /var → /private/var,
+            // or a Docker volume mount) spuriously reject legitimate fresh-install
+            // writes, because the target side resolves the symlink and the base side
+            // does not.
             let mut candidate = base.to_path_buf();
-            while !candidate.exists()
-                && candidate != candidate.parent().map(|p| p.to_path_buf()).unwrap_or(candidate.clone())
-            {
-                if let Some(parent) = candidate.parent() {
-                    candidate = parent.to_path_buf();
-                } else {
-                    break;
+            while !candidate.exists() {
+                match candidate.parent() {
+                    Some(parent) if parent != candidate => candidate = parent.to_path_buf(),
+                    _ => break,
                 }
             }
-            // Try to canonicalize base itself (may succeed if just created), fall back to resolved ancestor
-            base.canonicalize().ok().unwrap_or_else(|| candidate)
+            candidate.canonicalize().unwrap_or(candidate)
         };
 
         // If the file exists, verify it's within the base directory via full canonicalization
@@ -635,15 +638,18 @@ impl LibraryStore {
                 }
                 current = parent.to_path_buf();
             }
-            // Confirm the target genuinely starts with base path using string-level prefix.
-            // This works even when base doesn't exist on disk yet (no symlinks can interfere).
-            let base_str = base_canonical.to_string_lossy();
-            let target_str = target.to_string_lossy();
-            if !target_str.starts_with(base_str.as_ref()) {
+            // Confirm the target genuinely descends from base. Use component-aware
+            // `Path::starts_with` (NOT string-level `str::starts_with`): a raw string
+            // prefix would let a sibling that merely shares a name prefix slip through
+            // — e.g. base `…/lib` vs target `…/library/evil`. Compared against the
+            // literal `base` the target was built from; symlink safety for the
+            // already-existing portion is enforced by the ancestor canonicalization
+            // check above (base itself may not exist yet on a fresh install).
+            if !target.starts_with(base) {
                 anyhow::bail!("Path escapes allowed directory");
             }
             // Ensure target is strictly deeper than base (target != base).
-            if target_str == base_str {
+            if target == base {
                 anyhow::bail!("Target equals base directory");
             }
         }
@@ -2414,6 +2420,62 @@ This is the body."#;
     fn test_validate_relative_file_path_allows_profile_paths() {
         assert!(LibraryStore::validate_relative_file_path(".opencode/settings.json").is_ok());
         assert!(LibraryStore::validate_relative_file_path(".sandboxed-sh/config.json").is_ok());
+    }
+
+    // `validate_path_within` doesn't read any `self` fields, so a bare store
+    // with a dummy path is enough to exercise it.
+    fn test_store() -> LibraryStore {
+        LibraryStore {
+            path: std::path::PathBuf::from("/unused"),
+            remote: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_validate_path_within_allows_descendant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("lib");
+        std::fs::create_dir_all(&base).unwrap();
+        let target = base.join("sub/file.json");
+        assert!(test_store().validate_path_within(&base, &target).is_ok());
+    }
+
+    #[test]
+    fn test_validate_path_within_allows_fresh_install_missing_base() {
+        // The fresh-install case (#563): base directory doesn't exist yet but
+        // the file underneath it must still be creatable.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("configs/default"); // does not exist
+        let target = base.join(".opencode/settings.json");
+        assert!(test_store().validate_path_within(&base, &target).is_ok());
+    }
+
+    #[test]
+    fn test_validate_path_within_rejects_parent_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("lib");
+        std::fs::create_dir_all(&base).unwrap();
+        let target = base.join("../escape.json");
+        assert!(test_store().validate_path_within(&base, &target).is_err());
+    }
+
+    #[test]
+    fn test_validate_path_within_rejects_sibling_name_prefix() {
+        // Regression guard: a sibling sharing a name *prefix* with base
+        // (`…/lib` vs `…/library/…`) must NOT pass via raw string-prefix match.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("lib");
+        let sibling = tmp.path().join("library/evil.json");
+        assert!(test_store().validate_path_within(&base, &sibling).is_err());
+    }
+
+    #[test]
+    fn test_validate_path_within_rejects_target_equal_base() {
+        // base not yet created (fresh-install path): target == base must not be
+        // treated as a writable file under base.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("lib");
+        assert!(test_store().validate_path_within(&base, &base).is_err());
     }
 }
 


### PR DESCRIPTION
Supersedes #563 (cherry-picks @karypid's commit, preserving authorship) and adds hardening + tests.

## Problem (from #563)
On a fresh `docker compose up`, saving a config-profile file (e.g. `.opencode/settings.json`) 500s because `validate_path_within` can't canonicalize a base directory that doesn't exist yet.

## Changes
- **@karypid:** resolve the base through its existing ancestors so a not-yet-created base is accepted (the fresh-install fix).
- **Hardening 1 — prefix boundary:** replace the final `str::starts_with` containment check with component-aware `Path::starts_with`. A raw string prefix would let a sibling sharing a name prefix through (base `…/lib` vs `…/library/evil`).
- **Hardening 2 — symlink consistency:** canonicalize the nearest existing ancestor when base is missing, so both sides of the prefix check are fully resolved. Otherwise a base crossing a symlink (macOS `/var`→`/private/var`, Docker volume mounts) spuriously rejects legitimate writes.

## Tests
5 new unit tests for `validate_path_within`: descendant allowed, fresh-install (missing base) allowed, parent-traversal rejected, sibling-name-prefix rejected, target==base rejected.

Closes #563.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive path containment used before config/skill writes; changes are defensive but alter acceptance rules for edge cases (missing base, symlinks, siblings).
> 
> **Overview**
> Fixes **config-profile and library file writes failing on fresh install** when the profile/base directory does not exist yet (e.g. first save of `.opencode/settings.json` under `configs/default`).
> 
> **`validate_path_within`** is reworked for missing bases: canonicalize the nearest existing ancestor of `base` (not only `base` itself) so prefix checks stay symlink-consistent with resolved target ancestors (Docker mounts, macOS `/var` symlinks). For **non-existent targets**, it still walks existing ancestors under `base_canonical`, then adds **component-aware** `Path::starts_with(base)` so a sibling like `library/…` cannot pass a string-prefix check against `lib`, and rejects **target == base** as a writable path.
> 
> Adds **five unit tests** covering allowed descendants, fresh-install missing base, `..` traversal, sibling name-prefix escape, and target-equals-base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ebe02b527866ad88f596c3da106e0f80c29f2da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->