### PR TITLE
fix(oauth): Anthropic store↔tier reconcile + feat: MiniMax/Z.AI quota windows

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -331,28 +331,20 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
         </div>
       )}
 
-      {/* Minimax model usage */}
-      {type === 'minimax' && Array.isArray(usage.model_usage) && (
+      {/* Minimax coding plan — per-category 5h + weekly windows (remaining %) */}
+      {type === 'minimax' && Array.isArray(usage.model_usage) && usage.model_usage.length > 0 && (
         <div className="space-y-3">
-          {(usage.model_usage as Array<{
-            model: string;
-            interval_total: number;
-            interval_remaining: number;
-            weekly_total: number;
-            weekly_remaining: number;
-            interval_reset: number;
-            weekly_reset: number;
-          }>).map((m) => (
+          {usage.model_usage.map((m) => (
             <div key={m.model} className="space-y-1">
               <div className="text-[11px] text-white/50 font-medium">{m.model}</div>
-              <UsageBar remaining={m.interval_remaining} limit={m.interval_total} label="Interval" />
-              <UsageBar remaining={m.weekly_remaining} limit={m.weekly_total} label="Weekly" />
+              <UsageBar remaining={m.interval_remaining_percent} limit={100} label="5h window" />
+              <UsageBar remaining={m.weekly_remaining_percent} limit={100} label="Weekly" />
               <div className="flex gap-4 text-[10px] text-white/30">
                 {m.interval_reset > 0 && (
-                  <span>Interval reset: {fmtReset(new Date(m.interval_reset).toISOString())}</span>
+                  <span>5h reset: {fmtResetEpoch(m.interval_reset)}</span>
                 )}
                 {m.weekly_reset > 0 && (
-                  <span>Weekly reset: {fmtReset(new Date(m.weekly_reset).toISOString())}</span>
+                  <span>Weekly reset: {fmtResetEpoch(m.weekly_reset)}</span>
                 )}
               </div>
             </div>
@@ -361,13 +353,37 @@ function UsageDetails({ usage, loading }: { usage: ProviderUsage | null; loading
       )}
 
       {/* Minimax connected without model data */}
-      {type === 'minimax' && usage.status === 'connected' && !Array.isArray(usage.model_usage) && (
+      {type === 'minimax' && usage.status === 'connected' &&
+        !(Array.isArray(usage.model_usage) && usage.model_usage.length > 0) && (
         <div className="text-[11px] text-emerald-400/70">Connected</div>
       )}
 
-      {/* Z.AI - minimal info */}
-      {type === 'zai' && usage.status === 'connected' && (
-        <div className="text-[11px] text-emerald-400/70">Connected - Z.AI does not expose rate limit headers</div>
+      {/* Z.AI GLM coding plan — 5h + weekly token windows (percent used) */}
+      {type === 'zai' && usage.zai_weekly_used_percent != null && (
+        <div className="space-y-2">
+          {usage.zai_plan && (
+            <div className="text-[11px] text-white/50">
+              <span className="text-white/30">Plan:</span> {usage.zai_plan}
+            </div>
+          )}
+          {usage.zai_5h_used_percent != null && (
+            <UsageBar remaining={100 - usage.zai_5h_used_percent} limit={100} label="5h window" />
+          )}
+          <UsageBar remaining={100 - usage.zai_weekly_used_percent} limit={100} label="Weekly" />
+          <div className="flex gap-4 text-[10px] text-white/30">
+            {usage.zai_5h_reset != null && usage.zai_5h_reset > 0 && (
+              <span>5h reset: {fmtResetEpoch(usage.zai_5h_reset)}</span>
+            )}
+            {usage.zai_weekly_reset != null && usage.zai_weekly_reset > 0 && (
+              <span>Weekly reset: {fmtResetEpoch(usage.zai_weekly_reset)}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Z.AI connected without quota data (non-coding-plan key) */}
+      {type === 'zai' && usage.status === 'connected' && usage.zai_weekly_used_percent == null && (
+        <div className="text-[11px] text-emerald-400/70">Connected</div>
       )}
 
       {/* Google - account info only */}

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -337,8 +337,26 @@ export interface ProviderUsage {
   tokens_reset_minute?: string;
   // Minimax coding plan
   coding_plan?: Record<string, unknown>;
-  // Z.AI last call usage
-  last_call_usage?: Record<string, unknown>;
+  // MiniMax coding plan — per-category remaining percentages (0..100) and reset
+  // times (unix epoch seconds). Representative-window fields feed `optimize`.
+  model_usage?: Array<{
+    model: string;
+    interval_remaining_percent: number;
+    weekly_remaining_percent: number;
+    interval_reset: number;
+    weekly_reset: number;
+  }>;
+  minimax_interval_remaining_percent?: number;
+  minimax_weekly_remaining_percent?: number;
+  minimax_interval_reset?: number;
+  minimax_weekly_reset?: number;
+  // Z.AI GLM coding plan — `percentage` is percent USED; reset is unix epoch
+  // seconds (absent for an untouched window). `zai_plan` is the tier (max/pro/…).
+  zai_plan?: string;
+  zai_5h_used_percent?: number;
+  zai_5h_reset?: number;
+  zai_weekly_used_percent?: number;
+  zai_weekly_reset?: number;
   // Codex (OpenAI ChatGPT subscription) limits — primary = 5h window,
   // secondary = weekly (7d) window. Reset fields are unix epoch seconds.
   codex_plan_type?: string;

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -7071,31 +7071,81 @@ async fn get_provider_usage(
                     if let Ok(data) = r.json::<serde_json::Value>().await {
                         let map = info.as_object_mut().unwrap();
                         map.insert("status".to_string(), serde_json::json!("connected"));
-                        // Extract model_remains into a structured array.
-                        // Only include coding models (MiniMax-M*) since all models
-                        // share the same quota pool and showing 20+ entries is noisy.
+                        // MiniMax meters the coding plan per category ("general"
+                        // for the text/LLM pool, "video", …) on a 5-hour rolling
+                        // window plus a weekly window. The binding signal is
+                        // `current_*_remaining_percent` (0..100); the raw token
+                        // counts are routinely 0/0 for the text pool, so we don't
+                        // rely on them. Reset times arrive as epoch milliseconds.
                         if let Some(models) = data.get("model_remains").and_then(|v| v.as_array()) {
+                            let ms_to_secs = |m: &serde_json::Value, key: &str| -> i64 {
+                                m.get(key).and_then(|v| v.as_i64()).unwrap_or(0) / 1000
+                            };
                             let model_usage: Vec<serde_json::Value> = models
                                 .iter()
-                                .filter(|m| {
-                                    m.get("model_name")
-                                        .and_then(|v| v.as_str())
-                                        .map(|n| n.starts_with("MiniMax-M"))
-                                        .unwrap_or(false)
-                                })
                                 .map(|m| {
                                     serde_json::json!({
                                         "model": m.get("model_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                                        "interval_total": m.get("current_interval_total_count").and_then(|v| v.as_u64()).unwrap_or(0),
-                                        "interval_remaining": m.get("current_interval_usage_count").and_then(|v| v.as_u64()).unwrap_or(0),
-                                        "weekly_total": m.get("current_weekly_total_count").and_then(|v| v.as_u64()).unwrap_or(0),
-                                        "weekly_remaining": m.get("current_weekly_usage_count").and_then(|v| v.as_u64()).unwrap_or(0),
-                                        "interval_reset": m.get("end_time").and_then(|v| v.as_i64()).unwrap_or(0),
-                                        "weekly_reset": m.get("weekly_end_time").and_then(|v| v.as_i64()).unwrap_or(0),
+                                        "interval_remaining_percent": m.get("current_interval_remaining_percent").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                                        "weekly_remaining_percent": m.get("current_weekly_remaining_percent").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                                        "interval_reset": ms_to_secs(m, "end_time"),
+                                        "weekly_reset": ms_to_secs(m, "weekly_end_time"),
                                     })
                                 })
                                 .collect();
                             map.insert("model_usage".to_string(), serde_json::json!(model_usage));
+
+                            // Flat representative-window fields for the optimize
+                            // block. The "general" category is the text/coding
+                            // pool the subscription is really about; fall back to
+                            // the most-consumed (lowest remaining) category, else
+                            // the first one.
+                            let representative = models
+                                .iter()
+                                .find(|m| {
+                                    m.get("model_name").and_then(|v| v.as_str()) == Some("general")
+                                })
+                                .or_else(|| {
+                                    models.iter().min_by(|a, b| {
+                                        let ra = a
+                                            .get("current_interval_remaining_percent")
+                                            .and_then(|v| v.as_f64())
+                                            .unwrap_or(100.0);
+                                        let rb = b
+                                            .get("current_interval_remaining_percent")
+                                            .and_then(|v| v.as_f64())
+                                            .unwrap_or(100.0);
+                                        ra.partial_cmp(&rb).unwrap_or(std::cmp::Ordering::Equal)
+                                    })
+                                });
+                            if let Some(rep) = representative {
+                                if let Some(p) = rep
+                                    .get("current_interval_remaining_percent")
+                                    .and_then(|v| v.as_f64())
+                                {
+                                    map.insert(
+                                        "minimax_interval_remaining_percent".into(),
+                                        serde_json::json!(p),
+                                    );
+                                    map.insert(
+                                        "minimax_interval_reset".into(),
+                                        serde_json::json!(ms_to_secs(rep, "end_time")),
+                                    );
+                                }
+                                if let Some(p) = rep
+                                    .get("current_weekly_remaining_percent")
+                                    .and_then(|v| v.as_f64())
+                                {
+                                    map.insert(
+                                        "minimax_weekly_remaining_percent".into(),
+                                        serde_json::json!(p),
+                                    );
+                                    map.insert(
+                                        "minimax_weekly_reset".into(),
+                                        serde_json::json!(ms_to_secs(rep, "weekly_end_time")),
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -7156,29 +7206,88 @@ async fn get_provider_usage(
                 }
             };
 
-            // Z.AI doesn't expose rate-limit headers. Previously we sent a
-            // 1-token chat completion as a probe, but that burns quota every
-            // 60s and quickly hits 429 on free tiers. The `/models` endpoint
-            // is auth-checked without consuming inference budget, so use it
-            // instead — same connectedness signal, no rate-limit churn.
+            // Z.AI's coding plan exposes a monitor endpoint with the 5-hour and
+            // weekly token windows (`percentage` = percent USED, `nextResetTime`
+            // = epoch ms; an untouched window omits the reset). It does NOT
+            // consume inference budget. Two quirks vs. every other provider:
+            //   * the Authorization header carries the raw token, NO "Bearer".
+            //   * the payload is nested under `data.limits[]`, tagged by
+            //     (unit, number): unit=3,number=5 ⇒ 5-hour; unit=6,number=1 ⇒ weekly.
+            let mut info = serde_json::json!({
+                "provider_type": "zai",
+                "provider_name": provider_name,
+            });
             let resp = client
-                .get("https://open.bigmodel.cn/api/paas/v4/models")
-                .header("Authorization", format!("Bearer {}", key))
+                .get("https://api.z.ai/api/monitor/usage/quota/limit")
+                .header("Authorization", key) // intentionally no "Bearer" prefix
+                .header("Accept-Language", "en-US,en")
+                .header("Content-Type", "application/json")
                 .send()
                 .await;
 
             match resp {
+                Ok(r) if r.status().is_success() => {
+                    let map = info.as_object_mut().unwrap();
+                    map.insert("status".to_string(), serde_json::json!("connected"));
+                    if let Ok(data) = r.json::<serde_json::Value>().await {
+                        let body = data.get("data").unwrap_or(&data);
+                        if let Some(level) = body.get("level").and_then(|v| v.as_str()) {
+                            map.insert("zai_plan".to_string(), serde_json::json!(level));
+                        }
+                        if let Some(limits) = body.get("limits").and_then(|v| v.as_array()) {
+                            for limit in limits {
+                                // Only the token windows feed the optimize block.
+                                if limit.get("type").and_then(|v| v.as_str())
+                                    != Some("TOKENS_LIMIT")
+                                {
+                                    continue;
+                                }
+                                let unit = limit.get("unit").and_then(|v| v.as_i64());
+                                let number = limit.get("number").and_then(|v| v.as_i64());
+                                let pct = limit
+                                    .get("percentage")
+                                    .and_then(|v| v.as_f64())
+                                    .unwrap_or(0.0);
+                                // epoch ms → seconds; absent for an untouched window.
+                                let reset = limit
+                                    .get("nextResetTime")
+                                    .and_then(|v| v.as_i64())
+                                    .map(|ms| ms / 1000);
+                                let (pct_key, reset_key) = match (unit, number) {
+                                    (Some(3), Some(5)) => ("zai_5h_used_percent", "zai_5h_reset"),
+                                    (Some(6), Some(1)) => {
+                                        ("zai_weekly_used_percent", "zai_weekly_reset")
+                                    }
+                                    _ => continue,
+                                };
+                                map.insert(pct_key.to_string(), serde_json::json!(pct));
+                                if let Some(reset) = reset {
+                                    map.insert(reset_key.to_string(), serde_json::json!(reset));
+                                }
+                            }
+                        }
+                    }
+                    info
+                }
                 Ok(r) => {
+                    // Not a coding-plan token (or endpoint unavailable). Fall back
+                    // to a budget-free connectivity check so pay-as-you-go API
+                    // keys still report "connected" instead of erroring.
                     let status_code = r.status().as_u16();
-                    let mut info = serde_json::json!({
-                        "provider_type": "zai",
-                        "provider_name": provider_name,
-                        "status": if status_code < 400 { "connected" } else { "error" },
-                    });
-                    if status_code >= 400 {
-                        info.as_object_mut().unwrap().insert(
+                    let models = client
+                        .get("https://open.bigmodel.cn/api/paas/v4/models")
+                        .header("Authorization", format!("Bearer {}", key))
+                        .send()
+                        .await;
+                    let connected = matches!(models, Ok(ref m) if m.status().is_success());
+                    let map = info.as_object_mut().unwrap();
+                    if connected {
+                        map.insert("status".to_string(), serde_json::json!("connected"));
+                    } else {
+                        map.insert("status".to_string(), serde_json::json!("error"));
+                        map.insert(
                             "error".to_string(),
-                            serde_json::json!(format!("API returned {}", status_code)),
+                            serde_json::json!(format!("Quota endpoint returned {}", status_code)),
                         );
                     }
                     info

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -68,7 +68,7 @@ fn oauth_refresh_mark_token_dead(account_id: uuid::Uuid, token: &str) {
     }
 }
 
-fn oauth_refresh_clear_dead(account_id: uuid::Uuid) {
+pub(crate) fn oauth_refresh_clear_dead(account_id: uuid::Uuid) {
     if let Ok(mut m) = OAUTH_REFRESH_DEADLETTER.lock() {
         m.remove(&account_id);
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,6 +43,7 @@ pub mod mission_workspace_gc;
 mod model_routing;
 mod monitoring;
 mod native_loop_observer;
+pub mod oauth_reconcile;
 pub mod opencode;
 pub mod paloma;
 mod provider_usage_cache;

--- a/src/api/oauth_reconcile.rs
+++ b/src/api/oauth_reconcile.rs
@@ -1,0 +1,279 @@
+//! Reconcile rotated Anthropic OAuth tokens back into the `ai_providers.json`
+//! store records — the missing half of the split-brain fix.
+//!
+//! Background: Anthropic rotates AND revokes the refresh token on every refresh,
+//! so every persisted copy of a given account's token must move together. The
+//! per-mission Claude Code harness refreshes the token inside its isolated HOME
+//! and the runner syncs that back to the shared credential *tiers*
+//! (`sync_oauth_to_all_tiers`) — but it never updates the multi-account
+//! AIProviderStore *record*. The record then keeps a stale (already-rotated)
+//! refresh token, and the proactive store-refresh pass tries to refresh it →
+//! `invalid_grant` → Anthropic revokes the whole family → the freshly-rotated
+//! tier token dies too. That's the recurring "account revoked" loop.
+//!
+//! The store is in-memory cached behind a single owner (the AppState
+//! `AIProviderStore`), so a second instance can't safely write the file. This
+//! module therefore splits the work:
+//!   * the runner (which has no store handle) drops a small **pending-rotation
+//!     sidecar** recording `old_refresh_token → new_*` (file-only);
+//!   * the proactive loop (which owns the store) drains the sidecar and, in the
+//!     same cycle, also propagates its own file-tier rotations — matching the
+//!     account by its *old* refresh token (unambiguous at rotation time) and
+//!     writing the rotated token into that record.
+//!
+//! Result: the store record always follows the tier, so the proactive pass
+//! never refreshes a dead token, and the family is never revoked from under a
+//! live mission.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::ai_providers::{AIProviderStore, OAuthCredentials, ProviderType};
+
+/// One rotation waiting to be reconciled into the store.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PendingRotation {
+    /// Provider key, currently only `"anthropic"`.
+    pub provider: String,
+    /// The refresh token the store record is expected to still hold (the value
+    /// before this rotation) — used to locate the owning account.
+    pub old_refresh_token: String,
+    pub new_refresh_token: String,
+    pub new_access_token: String,
+    pub expires_at: i64,
+}
+
+/// Sidecar path, co-located with `ai_providers.json` under the app working dir
+/// (`<working_dir>/.sandboxed-sh/`). It MUST track the store, not `$HOME`:
+/// separate dev/prod services on one host share a `$HOME` (e.g.
+/// `/var/lib/opencode`) but have distinct working dirs, so a `$HOME`-based
+/// sidecar would let the two environments drain and reconcile each other's
+/// rotations. Both the runner (`app_working_dir`) and the proactive loop
+/// (`config.working_dir`) pass the same working dir, so they resolve the same
+/// per-environment file.
+pub fn sidecar_path(working_dir: &Path) -> PathBuf {
+    working_dir
+        .join(".sandboxed-sh")
+        .join("anthropic_rotation_pending.json")
+}
+
+/// Read the pending queue (empty on missing/corrupt file).
+pub fn read_pending(path: &Path) -> Vec<PendingRotation> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Queue a rotation for the loop to reconcile. Idempotent on `new_refresh_token`
+/// (re-recording the same rotation replaces the prior entry rather than piling
+/// up). Atomic temp+rename write so a crash can't leave a half-written file.
+pub fn record_pending_rotation(path: &Path, rot: PendingRotation) -> std::io::Result<()> {
+    // A no-op rotation (token unchanged) carries no information.
+    if rot.old_refresh_token == rot.new_refresh_token || rot.new_refresh_token.trim().is_empty() {
+        return Ok(());
+    }
+    let mut list = read_pending(path);
+    list.retain(|r| r.new_refresh_token != rot.new_refresh_token);
+    list.push(rot);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_vec_pretty(&list)?)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Remove the sidecar (after a successful drain).
+pub fn clear_pending(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Pure matcher: find the account whose current refresh token equals `old` so a
+/// rotation can be attributed unambiguously. Kept separate from store I/O so it
+/// is trivially unit-testable.
+pub fn match_account_by_old_token(accounts: &[(Uuid, Option<String>)], old: &str) -> Option<Uuid> {
+    if old.trim().is_empty() {
+        return None;
+    }
+    accounts
+        .iter()
+        .find(|(_, tok)| tok.as_deref() == Some(old))
+        .map(|(id, _)| *id)
+}
+
+/// Write a rotated token into the store record of the account that currently
+/// holds `old_refresh_token`. Returns the matched account id, or None when no
+/// record still holds the old token (already reconciled, or a foreign tier).
+pub async fn apply_rotation(
+    store: &AIProviderStore,
+    provider_type: ProviderType,
+    rot: &PendingRotation,
+) -> Option<Uuid> {
+    let accounts: Vec<(Uuid, Option<String>)> = store
+        .get_all_by_type(provider_type)
+        .await
+        .into_iter()
+        .map(|a| (a.id, a.oauth.map(|o| o.refresh_token)))
+        .collect();
+
+    let id = match_account_by_old_token(&accounts, &rot.old_refresh_token)?;
+    store
+        .set_oauth_credentials(
+            id,
+            OAuthCredentials {
+                access_token: rot.new_access_token.clone(),
+                refresh_token: rot.new_refresh_token.clone(),
+                expires_at: rot.expires_at,
+            },
+        )
+        .await;
+    // The record now carries a live token again — lift any cached invalid_grant.
+    crate::api::ai_providers::oauth_refresh_clear_dead(id);
+    tracing::info!(
+        account_id = %id,
+        provider = ?provider_type,
+        new_expires_at = rot.expires_at,
+        "Reconciled store record from out-of-band tier rotation"
+    );
+    Some(id)
+}
+
+/// Drain every queued rotation into the store, then clear the sidecar. Called at
+/// the top of each proactive-refresh cycle, BEFORE the store/tier refresh passes
+/// (so a stale record is healed before anything tries to refresh it).
+pub async fn drain_pending(store: &AIProviderStore, path: &Path) -> u32 {
+    let list = read_pending(path);
+    if list.is_empty() {
+        return 0;
+    }
+    let mut applied = 0u32;
+    for rot in &list {
+        let provider_type = match rot.provider.as_str() {
+            "anthropic" => ProviderType::Anthropic,
+            _ => continue,
+        };
+        if apply_rotation(store, provider_type, rot).await.is_some() {
+            applied += 1;
+        }
+    }
+    clear_pending(path);
+    applied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn match_by_old_token_finds_owner() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let accounts = vec![
+            (a, Some("tok-A".to_string())),
+            (b, Some("tok-B".to_string())),
+        ];
+        assert_eq!(match_account_by_old_token(&accounts, "tok-B"), Some(b));
+        assert_eq!(match_account_by_old_token(&accounts, "tok-A"), Some(a));
+        assert_eq!(match_account_by_old_token(&accounts, "tok-X"), None);
+        assert_eq!(match_account_by_old_token(&accounts, ""), None);
+    }
+
+    #[test]
+    fn match_ignores_accounts_without_token() {
+        let a = Uuid::new_v4();
+        let accounts = vec![(a, None), (Uuid::new_v4(), Some("other".to_string()))];
+        assert_eq!(match_account_by_old_token(&accounts, "missing"), None);
+        let _ = a;
+    }
+
+    #[test]
+    fn sidecar_roundtrip_dedup_and_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("pending.json");
+        let mk = |old: &str, new: &str| PendingRotation {
+            provider: "anthropic".into(),
+            old_refresh_token: old.into(),
+            new_refresh_token: new.into(),
+            new_access_token: "acc".into(),
+            expires_at: 123,
+        };
+        // no-op (old==new) is dropped
+        record_pending_rotation(&path, mk("same", "same")).unwrap();
+        assert!(read_pending(&path).is_empty());
+
+        record_pending_rotation(&path, mk("old1", "new1")).unwrap();
+        record_pending_rotation(&path, mk("old2", "new2")).unwrap();
+        assert_eq!(read_pending(&path).len(), 2);
+
+        // re-recording the same new token replaces, not appends
+        record_pending_rotation(&path, mk("old1b", "new1")).unwrap();
+        let list = read_pending(&path);
+        assert_eq!(list.len(), 2);
+        assert_eq!(
+            list.iter()
+                .find(|r| r.new_refresh_token == "new1")
+                .unwrap()
+                .old_refresh_token,
+            "old1b"
+        );
+
+        clear_pending(&path);
+        assert!(read_pending(&path).is_empty());
+    }
+
+    #[tokio::test]
+    async fn drain_updates_matching_store_record_and_skips_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AIProviderStore::new(dir.path().join("ai_providers.json")).await;
+        let mut p = crate::ai_providers::AIProvider::new(ProviderType::Anthropic, "Acct".into());
+        p.oauth = Some(OAuthCredentials {
+            access_token: "old-acc".into(),
+            refresh_token: "OLD".into(),
+            expires_at: 1,
+        });
+        let id = store.add(p).await;
+
+        let path = dir.path().join("pending.json");
+        record_pending_rotation(
+            &path,
+            PendingRotation {
+                provider: "anthropic".into(),
+                old_refresh_token: "OLD".into(),
+                new_refresh_token: "NEW".into(),
+                new_access_token: "new-acc".into(),
+                expires_at: 999,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(drain_pending(&store, &path).await, 1);
+        let o = store.get(id).await.unwrap().oauth.unwrap();
+        assert_eq!(o.refresh_token, "NEW");
+        assert_eq!(o.access_token, "new-acc");
+        assert_eq!(o.expires_at, 999);
+        assert!(read_pending(&path).is_empty()); // sidecar cleared
+
+        // A rotation whose old token no longer matches any record is a no-op
+        // (e.g. it belonged to a different account / was already reconciled).
+        record_pending_rotation(
+            &path,
+            PendingRotation {
+                provider: "anthropic".into(),
+                old_refresh_token: "OLD".into(),
+                new_refresh_token: "NEWER".into(),
+                new_access_token: "x".into(),
+                expires_at: 1000,
+            },
+        )
+        .unwrap();
+        assert_eq!(drain_pending(&store, &path).await, 0);
+        assert_eq!(
+            store.get(id).await.unwrap().oauth.unwrap().refresh_token,
+            "NEW"
+        );
+    }
+}

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2765,6 +2765,23 @@ async fn oauth_token_refresher_loop(
     let store_oauth_types = [ProviderType::Anthropic, ProviderType::Xai];
 
     loop {
+        // Heal any out-of-band tier rotations FIRST: per-mission Claude Code
+        // harnesses rotate the Anthropic token inside their isolated HOME and the
+        // runner queues the rotation here. Reconciling the store record before
+        // the refresh passes below stops the store pass from refreshing a token
+        // the mission already rotated (which would revoke the live family).
+        let reconciled = crate::api::oauth_reconcile::drain_pending(
+            &ai_providers,
+            &crate::api::oauth_reconcile::sidecar_path(&working_dir),
+        )
+        .await;
+        if reconciled > 0 {
+            tracing::info!(
+                reconciled,
+                "Reconciled store records from queued tier rotations"
+            );
+        }
+
         // Refresh store-backed OAuth accounts FIRST. For any account that also
         // owns the shared credential tiers, this rotates the token AND writes it
         // to the tiers before the file-tier pass runs below — otherwise that
@@ -2836,7 +2853,7 @@ async fn oauth_token_refresher_loop(
             match ai_providers_api::refresh_oauth_token_with_lock(provider_type, entry.expires_at)
                 .await
             {
-                Ok((_new_access, _new_refresh, new_expires_at)) => {
+                Ok((new_access, new_refresh, new_expires_at)) => {
                     let new_time_until = new_expires_at - now_ms;
                     tracing::info!(
                         provider_type = ?provider_type,
@@ -2844,6 +2861,28 @@ async fn oauth_token_refresher_loop(
                         "Successfully refreshed OAuth token proactively"
                     );
                     refreshed_count += 1;
+                    // The file-tier pass just rotated the token without touching
+                    // the AIProviderStore record. Propagate it into the matching
+                    // record (by the pre-rotation token) so the next store pass
+                    // doesn't try to refresh a now-dead token and revoke the
+                    // family. Anthropic is the only provider with both a tier and
+                    // multi-account store records.
+                    if provider_type == ProviderType::Anthropic
+                        && new_refresh != entry.refresh_token
+                    {
+                        crate::api::oauth_reconcile::apply_rotation(
+                            &ai_providers,
+                            provider_type,
+                            &crate::api::oauth_reconcile::PendingRotation {
+                                provider: "anthropic".to_string(),
+                                old_refresh_token: entry.refresh_token.clone(),
+                                new_refresh_token: new_refresh,
+                                new_access_token: new_access,
+                                expires_at: new_expires_at,
+                            },
+                        )
+                        .await;
+                    }
                 }
                 Err(e) => match e {
                     ai_providers_api::OAuthRefreshError::InvalidGrant(reason) => {

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -407,23 +407,53 @@ pub fn run_claudecode_turn<'a>(
                         .map(|(e, _)| e)
                         .unwrap_or(i64::MIN);
                     if m_expires > host_expires {
+                        // Capture the host's pre-rotation refresh token so the
+                        // store-reconcile pass can find the owning account record.
+                        let host_old_refresh = read_claude_cli_credentials(&host_path)
+                            .map(|(_, _, r, _)| r)
+                            .unwrap_or_default();
                         tracing::info!(
                             mission_id = %mission_id,
                             mission_expires_at = m_expires,
                             host_expires_at = host_expires,
                             "Mission credentials are fresher than host; syncing back to all storage tiers"
                         );
-                        if let Err(e) = crate::api::ai_providers::sync_oauth_to_all_tiers(
+                        match crate::api::ai_providers::sync_oauth_to_all_tiers(
                             crate::ai_providers::ProviderType::Anthropic,
                             &m_refresh,
                             &m_access,
                             m_expires,
                         ) {
-                            tracing::warn!(
-                                mission_id = %mission_id,
-                                error = %e,
-                                "Failed to write mission-rotated Anthropic credentials back to host"
-                            );
+                            Ok(()) => {
+                                // The runner has no safe handle on the in-memory
+                                // AIProviderStore (a second instance would
+                                // split-brain ai_providers.json), so queue the
+                                // rotation for the proactive loop — which owns the
+                                // store — to apply against the matching record.
+                                if let Err(e) = crate::api::oauth_reconcile::record_pending_rotation(
+                                    &crate::api::oauth_reconcile::sidecar_path(app_working_dir),
+                                    crate::api::oauth_reconcile::PendingRotation {
+                                        provider: "anthropic".to_string(),
+                                        old_refresh_token: host_old_refresh,
+                                        new_refresh_token: m_refresh.clone(),
+                                        new_access_token: m_access.clone(),
+                                        expires_at: m_expires,
+                                    },
+                                ) {
+                                    tracing::warn!(
+                                        mission_id = %mission_id,
+                                        error = %e,
+                                        "Failed to queue Anthropic rotation for store reconcile"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    mission_id = %mission_id,
+                                    error = %e,
+                                    "Failed to write mission-rotated Anthropic credentials back to host"
+                                );
+                            }
                         }
                     }
                 }

--- a/src/api/usage_optimize.rs
+++ b/src/api/usage_optimize.rs
@@ -36,6 +36,12 @@ use serde_json::{json, Map, Value};
 const ANTHROPIC_5H_SECONDS: i64 = 5 * 3600;
 const ANTHROPIC_7D_SECONDS: i64 = 7 * 24 * 3600;
 
+/// MiniMax coding plan and Z.AI GLM coding plan both meter on a 5-hour rolling
+/// window plus a weekly window. Like Anthropic, the response carries only the
+/// reset time, so we pin the documented spans to derive a pace.
+const FIVE_HOURS_SECONDS: i64 = 5 * 3600;
+const WEEKLY_SECONDS: i64 = 7 * 24 * 3600;
+
 /// A single normalized usage window plus the derived pace/burn for it.
 struct Window {
     key: &'static str,
@@ -97,6 +103,16 @@ impl Window {
         let used_pct = used_pct.max(0.0);
         self.pct_used = Some(used_pct);
         self.pct_remaining = Some((100.0 - used_pct).max(0.0));
+        self
+    }
+
+    /// Fill pct_used/pct_remaining from a 0..=100 remaining-percent value.
+    /// MiniMax reports `*_remaining_percent` directly, so we take it as truth
+    /// rather than recomputing it from the (often zero / unreliable) raw counts.
+    fn with_remaining_percent(mut self, remaining_pct: f64) -> Self {
+        let remaining_pct = remaining_pct.clamp(0.0, 100.0);
+        self.pct_remaining = Some(remaining_pct);
+        self.pct_used = Some(100.0 - remaining_pct);
         self
     }
 
@@ -355,6 +371,64 @@ fn collect_windows(v: &Value) -> Vec<Window> {
             .with_absolute(limit, remaining);
         w.reset_at = normalize_reset(v.get("requests_reset_day"));
         out.push(w);
+    }
+
+    // ── MiniMax coding plan (5-hour interval + weekly) — remaining-percent ──
+    // MiniMax exposes `current_interval_remaining_percent` / weekly equivalent;
+    // the raw token counts are frequently 0/0 for the text pool, so the percent
+    // is the binding signal. Resets are normalized to epoch seconds by the
+    // handler before they reach here.
+    for (rem_key, reset_key, key, label, window_seconds) in [
+        (
+            "minimax_interval_remaining_percent",
+            "minimax_interval_reset",
+            "minimax_5h",
+            "5-hour",
+            FIVE_HOURS_SECONDS,
+        ),
+        (
+            "minimax_weekly_remaining_percent",
+            "minimax_weekly_reset",
+            "minimax_weekly",
+            "weekly",
+            WEEKLY_SECONDS,
+        ),
+    ] {
+        if let Some(rem_pct) = get_f64(v, rem_key) {
+            let mut w =
+                Window::new(key, label, "tokens", "minimax").with_remaining_percent(rem_pct);
+            w.window_seconds = Some(window_seconds);
+            w.reset_at = get_epoch_secs(v, reset_key);
+            out.push(w);
+        }
+    }
+
+    // ── Z.AI GLM coding plan (5-hour + weekly) — used-percent windows ──
+    // Z.AI's monitor endpoint reports `percentage` as percent USED; it omits a
+    // reset time for a window that hasn't been touched yet. Resets are
+    // normalized to epoch seconds by the handler before they reach here.
+    for (pct_key, reset_key, key, label, window_seconds) in [
+        (
+            "zai_5h_used_percent",
+            "zai_5h_reset",
+            "zai_5h",
+            "5-hour",
+            FIVE_HOURS_SECONDS,
+        ),
+        (
+            "zai_weekly_used_percent",
+            "zai_weekly_reset",
+            "zai_weekly",
+            "weekly",
+            WEEKLY_SECONDS,
+        ),
+    ] {
+        if let Some(used_pct) = get_f64(v, pct_key) {
+            let mut w = Window::new(key, label, "tokens", "zai").with_used_percent(used_pct);
+            w.window_seconds = Some(window_seconds);
+            w.reset_at = get_epoch_secs(v, reset_key);
+            out.push(w);
+        }
     }
 
     out
@@ -635,6 +709,49 @@ mod tests {
         assert_eq!((from_dur - n).num_seconds(), 90);
         let from_epoch = normalize_reset_at(Some(&json!(n.timestamp() + 100)), n).unwrap();
         assert_eq!((from_epoch - n).num_seconds(), 100);
+    }
+
+    #[test]
+    fn minimax_remaining_percent_windows() {
+        // 93% remaining on the 5h window, reset 3h out (epoch seconds).
+        let reset = (now() + chrono::Duration::hours(3)).timestamp();
+        let v = json!({
+            "minimax_interval_remaining_percent": 93,
+            "minimax_interval_reset": reset,
+            "minimax_weekly_remaining_percent": 100,
+            "minimax_weekly_reset": (now() + chrono::Duration::days(4)).timestamp(),
+        });
+        let opt = build_optimize_block_at(&v, None, now());
+        let w = window(&opt, "minimax_5h");
+        assert_eq!(w["pct_remaining"], json!(93.0));
+        assert_eq!(w["pct_used"], json!(7.0));
+        assert_eq!(w["window_seconds"], json!(18000));
+        assert_eq!(w["source"], json!("minimax"));
+        assert_eq!(w["reset_in_seconds"], json!(10800));
+        // Most binding window = the 5h (93% < 100%).
+        assert_eq!(opt["primary_window"], json!("minimax_5h"));
+    }
+
+    #[test]
+    fn zai_used_percent_windows() {
+        // Weekly window 12% used, reset 2 days out; 5h window untouched (no reset).
+        let weekly_reset = (now() + chrono::Duration::days(2)).timestamp();
+        let v = json!({
+            "zai_5h_used_percent": 0,
+            "zai_weekly_used_percent": 12,
+            "zai_weekly_reset": weekly_reset,
+        });
+        let opt = build_optimize_block_at(&v, None, now());
+        let w5 = window(&opt, "zai_5h");
+        assert_eq!(w5["pct_remaining"], json!(100.0));
+        assert_eq!(w5["reset_at"], Value::Null);
+        let ww = window(&opt, "zai_weekly");
+        assert_eq!(ww["pct_used"], json!(12.0));
+        assert_eq!(ww["pct_remaining"], json!(88.0));
+        assert_eq!(ww["source"], json!("zai"));
+        assert_eq!(ww["window_seconds"], json!(604800));
+        // 5h is least-remaining is 100, weekly is 88 → weekly binds.
+        assert_eq!(opt["primary_window"], json!("zai_weekly"));
     }
 
     #[test]


### PR DESCRIPTION
Two related provider changes, validated together.

## 1. fix(oauth): reconcile rotated Anthropic tokens into the store record
Fixes the recurring **"Anthropic account revoked"** loop. Anthropic rotates AND revokes the refresh token on every refresh, so all persisted copies must move together. Per-mission Claude Code harnesses rotate the token in their isolated HOME and the runner syncs it to the credential *tiers* — but never to the multi-account `ai_providers.json` *store record*. The record keeps the stale token; the proactive store-refresh pass refreshes that dead token → `invalid_grant` → Anthropic revokes the family → the live tier token dies too.

New `oauth_reconcile` module: the runner queues each rotation (`old→new`) in a **per-environment** sidecar co-located with the store (NOT `$HOME` — dev/prod share a `$HOME` but have distinct working dirs); the proactive loop drains it at cycle start AND propagates its own tier-pass rotations, matching the owning account by its pre-rotation token. Result: the store record always follows the tier, so the proactive pass never refreshes a dead token.

Tested: unit + integration (matcher, sidecar dedup/no-op, drain→store, stale no-match); **end-to-end on dev** (forged rotation sidecar → loop reconciled the matching record, sidecar cleared, log confirmed).

## 2. feat(providers): real MiniMax + Z.AI quota windows in the optimize block
Wires real subscription usage for MiniMax (coding plan) and Z.AI into the usage endpoint's normalized `optimize` block (5h + weekly windows like Anthropic/Codex). Handles MiniMax per-category metering (`current_*_remaining_percent`, ms resets) and Z.AI's Bearer-less `data.limits[]` shape.

Both build green, fmt + clippy clean, oauth_reconcile (4) + usage_optimize (9, incl. MiniMax) tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Anthropic OAuth refresh and multi-store token reconciliation—security-critical auth paths where mistakes can revoke live accounts; provider usage API changes are lower risk but touch external quota endpoints.
> 
> **Overview**
> Fixes the recurring **Anthropic account revoked** loop by keeping `ai_providers.json` store records in sync when refresh tokens rotate elsewhere. Mission Claude Code runs sync fresher OAuth to credential tiers but not the multi-account store; proactive store refresh then hits a dead refresh token and can revoke the whole token family. A new **`oauth_reconcile`** flow queues `old→new` rotations in a per-environment sidecar under the app working dir, drains them at the start of each proactive OAuth cycle, and applies the same reconciliation when the file-tier refresh pass rotates Anthropic tokens. The Claude Code runner records pending rotations after tier sync; reconciled accounts clear the OAuth refresh deadletter cache.
> 
> **MiniMax** and **Z.AI** usage now reflect real coding-plan windows instead of placeholders. MiniMax reads **remaining %** for 5h and weekly buckets (all categories, epoch-second resets) and exposes representative fields for routing **`optimize`**. Z.AI calls the quota monitor API (raw token auth, nested `limits[]`) with a **`/models`** fallback for non–coding-plan keys. **`usage_optimize`** adds 5h/weekly windows for both providers; the providers settings UI shows plan tier, usage bars, and reset times for MiniMax and Z.AI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4220be8e35c64b92f33c3753a9501b4bf589bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->