### PR TITLE
fix(dashboard): default Anthropic to claudecode + opencode

### DIFF
--- a/dashboard/src/components/ui/add-provider-modal.tsx
+++ b/dashboard/src/components/ui/add-provider-modal.tsx
@@ -209,8 +209,11 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
     const methods = getProviderAuthMethods(providerType);
 
     // Default backend targeting by provider (may be adjusted after method selection).
+    // Mirror the server's `default_backends_for_provider` (src/api/ai_providers.rs):
+    // Anthropic targets BOTH opencode and claudecode by default — Claude Code is the
+    // primary Anthropic backend, so it must be preselected, not just opencode.
     if (providerType === 'anthropic') {
-      setSelectedBackends(['opencode']);
+      setSelectedBackends(['opencode', 'claudecode']);
     } else if (providerType === 'openai') {
       setSelectedBackends(['opencode', 'codex']);
     } else if (providerType === 'google') {
@@ -240,6 +243,9 @@ export function AddProviderModal({ open, onClose, onSuccess, providerTypes }: Ad
     // Providers that support multiple backends should select targeting first.
     if (selectedProvider === 'anthropic' || selectedProvider === 'openai' || selectedProvider === 'google' || selectedProvider === 'xai') {
       // For OpenAI, default backends depend on auth method.
+      if (selectedProvider === 'anthropic') {
+        setSelectedBackends(['opencode', 'claudecode']);
+      }
       if (selectedProvider === 'openai') {
         setSelectedBackends(['opencode', 'codex']);
       }


### PR DESCRIPTION
The add-provider modal preselected only `opencode` for Anthropic, but the server's `default_backends_for_provider` (src/api/ai_providers.rs) returns `["opencode", "claudecode"]`. Claude Code is the primary Anthropic backend, so connecting an Anthropic account left **claudecode unselected by default** — the user had to manually tick it.

Aligns the frontend default to the server in both spots (provider-select preselect + post-method re-set). Frontend-only, type-safe one-line-per-spot change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only default checkbox state; no API or auth logic changes.
> 
> **Overview**
> **Aligns Anthropic backend preselection with the server** so new connections default to both OpenCode and Claude Code, not OpenCode alone.
> 
> In `add-provider-modal.tsx`, choosing Anthropic now sets `selectedBackends` to `['opencode', 'claudecode']` when the provider is picked and again after an auth method is chosen (OAuth/API path into backend selection). Comments reference `default_backends_for_provider` in `src/api/ai_providers.rs`, which already returns both backends for Anthropic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2cf3355da7a36cc5c2fce36297914b6a2170a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->