### PR TITLE
feat(missions): project tagging, awaiting_kind, fleet observability

### DIFF
--- a/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
+++ b/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
@@ -77,7 +77,9 @@ export function MissionWorkbenchPanel({
   const title =
     mission?.title?.trim() ||
     (mission ? getMissionShortName(mission.id) : "No mission selected");
-  const status = mission ? missionStatusLabel(mission.status, isRunning) : null;
+  const status = mission
+    ? missionStatusLabel(mission.status, isRunning, mission.awaiting_kind)
+    : null;
   const canResume =
     mission &&
     !isRunning &&
@@ -244,7 +246,41 @@ export function MissionWorkbenchPanel({
                   className="font-mono text-white/70"
                 />
               </Row>
+              {mission.project && (
+                <Row label="Project">
+                  <span
+                    className="truncate font-mono text-white/70 max-w-[160px]"
+                    title={[mission.project, mission.track, mission.intent]
+                      .filter(Boolean)
+                      .join(" / ")}
+                  >
+                    {[mission.project, mission.track, mission.intent]
+                      .filter(Boolean)
+                      .join(" / ")}
+                  </span>
+                </Row>
+              )}
+              {mission.github_pr != null && (
+                <Row label="PR">
+                  <span className="font-mono text-white/70">
+                    #{mission.github_pr}
+                  </span>
+                </Row>
+              )}
             </dl>
+
+            {mission.tags && mission.tags.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {mission.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-white/[0.08] bg-white/[0.04] px-1.5 py-0.5 text-[10px] font-medium text-white/55"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
 
             {mission.short_description && (
               <p className="workbench-mission-description mt-2 rounded-md border border-white/[0.05] bg-white/[0.02] px-2 py-1.5 text-[11px] leading-relaxed text-white/50">

--- a/dashboard/src/app/control/components/common.tsx
+++ b/dashboard/src/app/control/components/common.tsx
@@ -8,7 +8,7 @@ import { memo } from "react";
 import { cn } from "@/lib/utils";
 import { useNow } from "@/lib/now-tick";
 import { getMissionDotColor } from "@/lib/mission-status";
-import type { MissionStatus } from "@/lib/api";
+import type { AwaitingKind, MissionStatus } from "@/lib/api";
 import type { ChatItem } from "../events-reducer";
 
 /** Thinking/stream chat items routed to the side panel. */
@@ -54,6 +54,7 @@ export function Shimmer({ className }: { className?: string }) {
 export function missionStatusLabel(
   status: MissionStatus,
   isRunning = false,
+  awaitingKind?: AwaitingKind | null,
 ): {
   label: string;
   className: string;
@@ -68,6 +69,21 @@ export function missionStatusLabel(
     case "active":
       return { label: "Active", className: "bg-indigo-500/20 text-indigo-400" };
     case "awaiting_user":
+      // Distinguish "agent asked a question" (decision) from "agent finished,
+      // waiting to be acked/merged" (ack). The old single "Needs You" label
+      // was ambiguous.
+      if (awaitingKind === "decision") {
+        return {
+          label: "Needs Decision",
+          className: "bg-amber-500/20 text-amber-400",
+        };
+      }
+      if (awaitingKind === "ack") {
+        return {
+          label: "Awaiting Review",
+          className: "bg-sky-500/20 text-sky-400",
+        };
+      }
       return {
         label: "Needs You",
         className: "bg-amber-500/20 text-amber-400",

--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -9013,7 +9013,11 @@ export default function ControlClient() {
   const missionIsRunningOrActive =
     viewingMissionIsRunning || activeMission?.status === "active";
   const missionStatus = activeMission
-    ? missionStatusLabel(activeMission.status, viewingMissionIsRunning)
+    ? missionStatusLabel(
+        activeMission.status,
+        viewingMissionIsRunning,
+        activeMission.awaiting_kind,
+      )
     : null;
   const faviconStatus = useMemo<MissionStatus | null>(() => {
     if (!activeMission) return null;

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -306,6 +306,13 @@ export function getMissionSearchText(mission: Mission): string {
   if (mission.mission_mode === 'assistant') {
     textParts.push('assistant telegram');
   }
+  // Project tagging so missions are findable by project/track/intent/tag.
+  if (mission.project?.trim()) textParts.push(mission.project.trim());
+  if (mission.track?.trim()) textParts.push(mission.track.trim());
+  if (mission.intent?.trim()) textParts.push(mission.intent.trim());
+  if (mission.tags && mission.tags.length > 0) {
+    textParts.push(mission.tags.join(' '));
+  }
   return textParts.join(' ');
 }
 
@@ -576,6 +583,14 @@ export function missionSearchRelevanceScore(
   const workspaceLabel = getWorkspaceLabel(mission, workspaceNameById) ?? '';
   const backend = mission.backend?.trim() ?? '';
   const status = mission.status ?? '';
+  const projectText = [
+    mission.project,
+    mission.track,
+    mission.intent,
+    ...(mission.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(' ');
   const combined = `${displayName} ${workspaceLabel} ${getMissionSearchText(mission)}`;
 
   const normalizedCombined = normalizeMetadataText(combined);
@@ -587,6 +602,7 @@ export function missionSearchRelevanceScore(
     { weight: 7, tokens: tokenSetFromText(shortDescription) },
     { weight: 3, tokens: tokenSetFromText(workspaceLabel) },
     { weight: 3, tokens: tokenSetFromText(backend) },
+    { weight: 6, tokens: tokenSetFromText(projectText) },
     { weight: 2, tokens: tokenSetFromText(status) },
     { weight: 1, tokens: tokenSetFromText(combined) },
   ];

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -16,7 +16,7 @@ import {
   Pencil,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { searchMissions, type Mission, type RunningMissionInfo } from '@/lib/api';
+import { searchMissions, type AwaitingKind, type Mission, type RunningMissionInfo } from '@/lib/api';
 import { getMissionShortName } from '@/lib/mission-display';
 import { statusLabel, getMissionDotColor, getMissionTitle } from '@/lib/mission-status';
 import { AsyncButton } from '@/components/ui/async-button';
@@ -162,8 +162,17 @@ function getMissionStatusLabel(mission: Mission): string {
   return statusLabel(mission.status, mission.awaiting_kind) ?? mission.status ?? 'Unknown';
 }
 
-function getMissionStatusToneClass(status: string | undefined, isRunning: boolean): string {
+function getMissionStatusToneClass(
+  status: string | undefined,
+  isRunning: boolean,
+  awaitingKind?: AwaitingKind | null,
+): string {
   if (isRunning && status !== 'waiting_for_tool') return 'text-indigo-300/85';
+  // Ack ("Awaiting Review") uses the sky tone to match the workbench/header;
+  // decision (and unclassified) stay amber.
+  if (status === 'awaiting_user' && awaitingKind === 'ack') {
+    return 'text-sky-300/90';
+  }
   switch (status) {
     case 'waiting_for_tool':
     case 'awaiting_user':
@@ -204,7 +213,7 @@ function getMissionStatusDisplay(
   if (!mission) return null;
   return {
     Icon: getStatusIcon(mission.status),
-    tone: getMissionStatusToneClass(mission.status, false),
+    tone: getMissionStatusToneClass(mission.status, false, mission.awaiting_kind),
     label: getMissionStatusLabel(mission),
     spin: false,
   };

--- a/dashboard/src/components/mission-switcher.tsx
+++ b/dashboard/src/components/mission-switcher.tsx
@@ -18,7 +18,7 @@ import {
 import { cn } from '@/lib/utils';
 import { searchMissions, type Mission, type RunningMissionInfo } from '@/lib/api';
 import { getMissionShortName } from '@/lib/mission-display';
-import { STATUS_LABELS, getMissionDotColor, getMissionTitle } from '@/lib/mission-status';
+import { statusLabel, getMissionDotColor, getMissionTitle } from '@/lib/mission-status';
 import { AsyncButton } from '@/components/ui/async-button';
 import { getStatusIcon } from '@/components/ui/status-icons';
 
@@ -157,7 +157,9 @@ function getMissionBackendLabel(mission: Mission): string {
 }
 
 function getMissionStatusLabel(mission: Mission): string {
-  return STATUS_LABELS[mission.status] ?? mission.status ?? 'Unknown';
+  // Distinguish "Needs Decision" vs "Awaiting Review" for awaiting_user using
+  // awaiting_kind, matching the control workbench/header.
+  return statusLabel(mission.status, mission.awaiting_kind) ?? mission.status ?? 'Unknown';
 }
 
 function getMissionStatusToneClass(status: string | undefined, isRunning: boolean): string {

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -74,6 +74,45 @@ export interface Mission {
   mission_mode?: "task" | "assistant";
   goal_mode?: boolean;
   goal_objective?: string | null;
+  /** Project tagging: stable project identifier (e.g. "verity-core"). */
+  project?: string | null;
+  /** Project tagging: track / workstream within the project. */
+  track?: string | null;
+  /** Project tagging: intent (e.g. "repair-build"). */
+  intent?: string | null;
+  /** Project tagging: associated GitHub PR number. */
+  github_pr?: number | null;
+  /** Project tagging: freeform tags. */
+  tags?: string[];
+  /**
+   * When `status` is `awaiting_user`, classifies whether the agent needs a
+   * decision (a real question) or is just waiting to be acked/merged.
+   */
+  awaiting_kind?: AwaitingKind | null;
+  /** Activity (P#5): when the status last changed (persisted). */
+  last_status_change_at?: string | null;
+  /** Activity: timestamp of the most recent mission event (computed). */
+  last_agent_event_at?: string | null;
+  /** Activity: timestamp of the most recent assistant output (computed). */
+  last_output_at?: string | null;
+  /** Activity: max(updated_at, last_agent_event_at) — single staleness anchor. */
+  last_activity_at?: string | null;
+  /**
+   * Spark build-offload status for this mission's workspace (mission detail
+   * endpoint only). Lets consumers route heavy builds without probing the host.
+   */
+  spark_offload?: SparkOffload | null;
+}
+
+export type AwaitingKind = "decision" | "ack";
+
+export interface SparkOffload {
+  /** Workspace opted into Spark build offload. */
+  enabled: boolean;
+  /** The per-mission offload env was actually injected into the harness. */
+  env_injected: boolean;
+  /** The host has Spark arbiter/SSH configured. */
+  host_configured: boolean;
 }
 
 export interface StoredEvent {
@@ -394,6 +433,33 @@ export async function markMissionOpened(id: string): Promise<Mission | null> {
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error("Failed to mark mission opened");
+  return res.json();
+}
+
+/**
+ * Set or update project/workstream tagging metadata for a mission. Each field
+ * is tri-state: omit to leave unchanged, `null` to clear, a value to set.
+ * `tags` replaces the whole list when present.
+ */
+export async function updateMissionProject(
+  id: string,
+  patch: {
+    project?: string | null;
+    track?: string | null;
+    intent?: string | null;
+    github_pr?: number | null;
+    tags?: string[];
+  },
+): Promise<Mission> {
+  const res = await apiFetch(`/api/control/missions/${id}/project`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || "Failed to update mission project");
+  }
   return res.json();
 }
 

--- a/dashboard/src/lib/mission-status.ts
+++ b/dashboard/src/lib/mission-status.ts
@@ -3,7 +3,7 @@
  * based on runtime state and stored status.
  */
 
-import type { MissionStatus } from './api/missions';
+import type { AwaitingKind, MissionStatus } from './api/missions';
 
 export type MissionCategory = 'running' | 'needs-you' | 'finished' | 'other';
 export type FinishedTone = 'green' | 'red';
@@ -151,6 +151,31 @@ export const STATUS_LABELS: Record<MissionStatus, string> = {
   blocked: 'Blocked',
   not_feasible: 'Not Feasible',
 };
+
+/**
+ * Labels for the two flavors of `awaiting_user`. `decision` means the agent
+ * asked a real question; `ack` means it finished and is waiting to be
+ * acknowledged/merged. The old single "Needs You" / "Waiting for your input"
+ * conflated these, which was misleading.
+ */
+export const AWAITING_KIND_LABELS: Record<AwaitingKind, string> = {
+  decision: 'Needs Decision',
+  ack: 'Awaiting Review',
+};
+
+/**
+ * Display label for a mission status, refined by `awaiting_kind` when the
+ * mission is parked in `awaiting_user`. Falls back to the generic status label.
+ */
+export function statusLabel(
+  status: MissionStatus,
+  awaitingKind?: AwaitingKind | null,
+): string {
+  if (status === 'awaiting_user' && awaitingKind) {
+    return AWAITING_KIND_LABELS[awaitingKind];
+  }
+  return STATUS_LABELS[status] ?? status;
+}
 
 /**
  * Get the display dot color for a mission, considering runtime state.

--- a/scripts/prod-smoke-fleet.sh
+++ b/scripts/prod-smoke-fleet.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post-deploy fleet smoke (P#9). One command confirms the critical mission loop
+# is alive and the new project/awaiting/health surfaces respond. Creates a
+# disposable probe mission, exercises the project + status endpoints against it,
+# then deletes it. Read-only against everything else.
+#
+# Usage:
+#   scripts/prod-smoke-fleet.sh --base-url URL --token JWT
+#   BASE_URL=... TOKEN=... scripts/prod-smoke-fleet.sh
+#
+# Options / env:
+#   --base-url URL   Backend base URL (env: BASE_URL, HERMES_SANDBOXED_API_URL)
+#   --token JWT      Control API bearer token (env: TOKEN, HERMES_SANDBOXED_API_TOKEN)
+#   --keep           Do not delete the probe mission at the end
+#   -h, --help       Show this help
+
+BASE_URL="${BASE_URL:-${HERMES_SANDBOXED_API_URL:-http://127.0.0.1:8080}}"
+TOKEN="${TOKEN:-${HERMES_SANDBOXED_API_TOKEN:-}}"
+KEEP_PROBE=0
+
+usage() { sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url) BASE_URL="${2:-}"; shift 2 ;;
+    --token) TOKEN="${2:-}"; shift 2 ;;
+    --keep) KEEP_PROBE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 2; }
+[[ -n "$BASE_URL" ]] || { echo "Missing --base-url / BASE_URL" >&2; exit 2; }
+
+auth=()
+[[ -n "$TOKEN" ]] && auth=(-H "Authorization: Bearer $TOKEN")
+
+pass=0
+fail=0
+ok()   { echo "  ok   $*"; pass=$((pass + 1)); }
+bad()  { echo "  FAIL $*" >&2; fail=$((fail + 1)); }
+
+# GET helper: prints body, returns curl exit status.
+get() { curl -fsS "${auth[@]}" "$BASE_URL$1"; }
+
+echo "== fleet smoke against $BASE_URL =="
+
+# 1) Liveness
+if get /api/health | jq -e '.status == "ok"' >/dev/null 2>&1; then
+  ok "/api/health"
+else
+  bad "/api/health"
+fi
+
+if fleet="$(get /api/health/fleet 2>/dev/null)"; then
+  if echo "$fleet" | jq -e '.control_responsive == true' >/dev/null 2>&1; then
+    ok "/api/health/fleet control_responsive=$(echo "$fleet" | jq -r '.control_responsive') \
+running=$(echo "$fleet" | jq -r '.running') queue=$(echo "$fleet" | jq -r '.queue_depth') \
+webhook=$(echo "$fleet" | jq -r '.webhook_forwarder_configured') \
+offload=$(echo "$fleet" | jq -r '.offload_configured')"
+  else
+    bad "/api/health/fleet control not responsive: $fleet"
+  fi
+else
+  bad "/api/health/fleet unreachable"
+fi
+
+# 2) Mission list
+if get "/api/control/missions?limit=1" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  ok "/api/control/missions list"
+else
+  bad "/api/control/missions list"
+fi
+
+# 3) Project tagging + status lifecycle on a disposable probe mission.
+probe_id=""
+cleanup() {
+  if [[ -n "$probe_id" && "$KEEP_PROBE" == "0" ]]; then
+    curl -fsS -X DELETE "${auth[@]}" "$BASE_URL/api/control/missions/$probe_id" >/dev/null 2>&1 \
+      && echo "  cleaned up probe $probe_id" \
+      || echo "  WARN could not delete probe $probe_id" >&2
+  fi
+}
+trap cleanup EXIT
+
+probe="$(curl -fsS -X POST "${auth[@]}" -H 'Content-Type: application/json' \
+  -d '{"title":"[smoke] fleet probe","project":"smoke-test","tags":["smoke","probe"]}' \
+  "$BASE_URL/api/control/missions" 2>/dev/null || true)"
+probe_id="$(echo "$probe" | jq -r '.id // empty')"
+
+if [[ -n "$probe_id" ]]; then
+  ok "create probe mission $probe_id"
+  if echo "$probe" | jq -e '.project == "smoke-test" and (.tags | index("smoke"))' >/dev/null 2>&1; then
+    ok "project tags set at creation"
+  else
+    bad "project tags missing on create: $(echo "$probe" | jq -c '{project,tags}')"
+  fi
+
+  # Filter by project should surface the probe.
+  if get "/api/control/missions?project=smoke-test&limit=50" \
+      | jq -e --arg id "$probe_id" 'any(.[]; .id == $id)' >/dev/null 2>&1; then
+    ok "project filter returns probe"
+  else
+    bad "project filter did not return probe"
+  fi
+
+  # Update project metadata via the dedicated endpoint.
+  if curl -fsS -X POST "${auth[@]}" -H 'Content-Type: application/json' \
+      -d '{"track":"smoke-track","intent":"smoke-intent","github_pr":2061}' \
+      "$BASE_URL/api/control/missions/$probe_id/project" \
+      | jq -e '.track == "smoke-track" and .intent == "smoke-intent" and .github_pr == 2061' >/dev/null 2>&1; then
+    ok "POST /project updates metadata"
+  else
+    bad "POST /project did not update metadata"
+  fi
+
+  # Acknowledge: must move out of the active flow without relaunching anything.
+  if curl -fsS -X POST "${auth[@]}" -H 'Content-Type: application/json' \
+      -d '{"status":"acknowledged"}' \
+      "$BASE_URL/api/control/missions/$probe_id/status" >/dev/null 2>&1; then
+    sleep 1
+    st="$(get "/api/control/missions/$probe_id" | jq -r '.status')"
+    if [[ "$st" == "acknowledged" ]]; then
+      ok "status acknowledge (now: $st)"
+    else
+      bad "status after acknowledge is '$st', expected acknowledged"
+    fi
+  else
+    bad "POST /status acknowledged failed"
+  fi
+else
+  bad "create probe mission (response: $(echo "$probe" | head -c 200))"
+fi
+
+# 4) Usage/quota endpoint (non-fatal: optional surface).
+if get "/api/ai/providers" | jq -e 'type == "array" or type == "object"' >/dev/null 2>&1; then
+  ok "/api/ai/providers"
+else
+  echo "  warn /api/ai/providers did not return JSON (non-fatal)"
+fi
+
+echo "== fleet smoke: $pass passed, $fail failed =="
+[[ "$fail" -eq 0 ]]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7383,6 +7383,7 @@ fn webhook_forwardable_status(status: MissionStatus) -> bool {
 async fn paloma_webhook_forwarder_loop(
     mut events_rx: broadcast::Receiver<AgentEvent>,
     mission_store: Arc<dyn MissionStore>,
+    workspaces: workspace::SharedWorkspaceStore,
     url: String,
     http: reqwest::Client,
 ) {
@@ -7421,6 +7422,7 @@ async fn paloma_webhook_forwarder_loop(
                 let http = http.clone();
                 let url = url.clone();
                 let mission_store = Arc::clone(&mission_store);
+                let workspaces = workspaces.clone();
                 let sem = Arc::clone(&sem);
                 tokio::spawn(async move {
                     let _permit = sem.acquire_owned().await;
@@ -7430,6 +7432,15 @@ async fn paloma_webhook_forwarder_loop(
                         .and_then(|mission| mission.title.clone())
                         .unwrap_or_else(|| mission_id.to_string());
                     let project = mission.as_ref().map(|m| &m.project);
+                    // Resolve workspace_name from the registry (the store row
+                    // usually leaves it null), so the payload is self-contained.
+                    let workspace_name = match mission.as_ref() {
+                        Some(m) => match m.workspace_name.clone() {
+                            Some(name) => Some(name),
+                            None => workspaces.get(m.workspace_id).await.map(|ws| ws.name),
+                        },
+                        None => None,
+                    };
                     let body = serde_json::json!({
                         // Idempotency / ordering (P#6): consumers dedupe on
                         // `event_id` and may order by `sequence`.
@@ -7442,9 +7453,7 @@ async fn paloma_webhook_forwarder_loop(
                             .as_ref()
                             .and_then(|m| m.short_description.clone()),
                         "workspace_id": mission.as_ref().map(|m| m.workspace_id),
-                        "workspace_name": mission
-                            .as_ref()
-                            .and_then(|m| m.workspace_name.clone()),
+                        "workspace_name": workspace_name,
                         "backend": mission.as_ref().map(|m| m.backend.clone()),
                         "updated_at": mission.as_ref().map(|m| m.updated_at.clone()),
                         // When the status itself last changed (P#5) — the most
@@ -7617,6 +7626,7 @@ fn spawn_control_session(
         tokio::spawn(paloma_webhook_forwarder_loop(
             events_tx.subscribe(),
             Arc::clone(&state.mission_store),
+            workspaces.clone(),
             url.clone(),
             reqwest::Client::builder()
                 .connect_timeout(std::time::Duration::from_secs(5))
@@ -8832,14 +8842,23 @@ fn mission_status_for_terminal_reason(
 /// agent needs a `Decision`; anything else means it finished its turn / work and
 /// is waiting for an `Ack`. This is a heuristic — consumers (Paloma) can refine
 /// it — but it is far better than the old all-`awaiting_user`-is-the-same signal.
+///
+/// Prefer [`classify_awaiting_kind_text`] with the just-completed turn's output
+/// when available: mission history is derived from the event log, which can lag
+/// behind the in-hand turn output at finalization time.
 fn classify_awaiting_kind(history: &[MissionHistoryEntry]) -> AwaitingKind {
-    let Some(last) = history.iter().rev().find(|entry| entry.role == "assistant") else {
+    match history.iter().rev().find(|entry| entry.role == "assistant") {
+        Some(last) => classify_awaiting_kind_text(&last.content),
         // No assistant text to read (e.g. tool-only turn) — default to Ack so a
         // "done" turn doesn't masquerade as an open question.
-        return AwaitingKind::Ack;
-    };
+        None => AwaitingKind::Ack,
+    }
+}
 
-    let text = last.content.trim();
+/// Heuristic core of [`classify_awaiting_kind`], operating on a raw assistant
+/// message string (the authoritative turn output).
+fn classify_awaiting_kind_text(text: &str) -> AwaitingKind {
+    let text = text.trim();
     if text.is_empty() {
         return AwaitingKind::Ack;
     }
@@ -9155,6 +9174,7 @@ fn looks_like_structured_provider_error(output: &str) -> bool {
         || lower.contains("internal server error")
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn maybe_finalize_terminal_mission(
     mission_store: &Arc<dyn MissionStore>,
     events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
@@ -9162,6 +9182,10 @@ async fn maybe_finalize_terminal_mission(
     terminal_reason: Option<TerminalReason>,
     completion_confidence: Option<crate::agents::CompletionConfidence>,
     complete_turn_without_follow_up: bool,
+    // The just-completed turn's assistant output, if available. Used to classify
+    // `awaiting_kind` authoritatively — the mission's event-log-derived history
+    // can lag behind at finalization time.
+    final_output: Option<&str>,
     log_context: &str,
 ) {
     let Some(reason) = terminal_reason else {
@@ -9275,7 +9299,12 @@ async fn maybe_finalize_terminal_mission(
             // fires. The status write only clears awaiting_kind for non-awaiting
             // statuses, so setting it first here is safe.
             if new_status == MissionStatus::AwaitingUser {
-                let kind = classify_awaiting_kind(&mission.history);
+                // Prefer the in-hand turn output; fall back to history only when
+                // the caller didn't supply it (event log may lag the turn).
+                let kind = match final_output {
+                    Some(text) if !text.trim().is_empty() => classify_awaiting_kind_text(text),
+                    _ => classify_awaiting_kind(&mission.history),
+                };
                 if let Err(e) = mission_store
                     .set_mission_awaiting_kind(mission_id, Some(kind))
                     .await
@@ -12067,6 +12096,7 @@ async fn control_actor_loop(
                                     agent_result.terminal_reason,
                                     Some(completion_evidence.completion_confidence),
                                     false,
+                                    Some(agent_result.output.as_str()),
                                     "turn finished before follow-up enqueue",
                                 )
                                 .await;
@@ -12275,6 +12305,7 @@ async fn control_actor_loop(
                                 completed_terminal_reason,
                                 completed_completion_confidence,
                                 true,
+                                Some(completed_agent_output.as_str()),
                                 "turn finished with no same-mission follow-up queued",
                             )
                             .await;
@@ -12608,6 +12639,7 @@ async fn control_actor_loop(
                                         result.terminal_reason,
                                         Some(completion_evidence.completion_confidence),
                                         true,
+                                        Some(result.output.as_str()),
                                         "parallel turn finished with no follow-up queued",
                                     )
                                     .await;
@@ -20234,6 +20266,7 @@ Investigate <service/> failures.
             Some(TerminalReason::LlmError),
             None,
             false,
+            None,
             "shutdown race test",
         )
         .await;
@@ -20269,6 +20302,7 @@ Investigate <service/> failures.
             Some(TerminalReason::Completed),
             Some(crate::agents::CompletionConfidence::Low),
             true,
+            None,
             "low confidence completion test",
         )
         .await;

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -55,7 +55,7 @@ use super::auth::AuthUser;
 use super::desktop;
 use super::library::SharedLibrary;
 use super::mission_store::{
-    self, create_mission_store, now_string, BoardTask, BoardTaskStatus, Mission,
+    self, create_mission_store, now_string, AwaitingKind, BoardTask, BoardTaskStatus, Mission,
     MissionHistoryEntry, MissionStore, MissionStoreType, NewBoardTask,
 };
 use super::routes::AppState;
@@ -3829,6 +3829,18 @@ pub struct ListMissionsQuery {
     pub limit: Option<usize>,
     #[serde(default)]
     pub offset: Option<usize>,
+    /// Optional filter: exact mission status (e.g. "awaiting_user").
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional filter: exact project identifier.
+    #[serde(default)]
+    pub project: Option<String>,
+    /// Optional filter: missions carrying this tag.
+    #[serde(default)]
+    pub tag: Option<String>,
+    /// Optional filter: workspace by id or (case-insensitive) name.
+    #[serde(default)]
+    pub workspace: Option<String>,
 }
 
 pub async fn list_missions(
@@ -3839,15 +3851,137 @@ pub async fn list_missions(
     let control = control_for_user(&state, &user).await;
     // Default to the most recent 50; honor an explicit limit so callers (e.g.
     // the assistant MCP) can request more, capped to keep the response bounded.
+    let has_filters = query.status.is_some()
+        || query.project.is_some()
+        || query.tag.is_some()
+        || query.workspace.is_some();
+    // When filtering, scan a wider window so the requested count can still be
+    // filled after dropping non-matching rows; otherwise honor the limit as-is.
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let offset = query.offset.unwrap_or(0);
+    let fetch_limit = if has_filters { 200 } else { limit };
     let mut missions = control
         .mission_store
-        .list_missions(limit, offset)
+        .list_missions(fetch_limit, offset)
         .await
         .map_err(internal_error)?;
     populate_workspace_names(&state, &mut missions).await;
+
+    if let Some(status) = query.status.as_deref() {
+        missions.retain(|m| m.status.to_string() == status);
+    }
+    if let Some(project) = query.project.as_deref() {
+        missions.retain(|m| m.project.project.as_deref() == Some(project));
+    }
+    if let Some(tag) = query.tag.as_deref() {
+        missions.retain(|m| m.project.tags.iter().any(|t| t == tag));
+    }
+    if let Some(workspace) = query.workspace.as_deref() {
+        let ws_lower = workspace.to_lowercase();
+        missions.retain(|m| {
+            m.workspace_id.to_string() == workspace
+                || m.workspace_name
+                    .as_deref()
+                    .is_some_and(|name| name.to_lowercase() == ws_lower)
+        });
+    }
+    if has_filters {
+        missions.truncate(limit);
+    }
+
+    populate_activity(&control, &mut missions).await;
     Ok(Json(missions))
+}
+
+/// Targeted post-deploy/observability health for the mission fleet (P#8). One
+/// authenticated GET confirms the critical loop is alive after a restart:
+/// the control actor responds (scheduler heartbeat), the webhook forwarder and
+/// offload are configured, and the current queue/running/status counts.
+#[derive(Debug, Serialize)]
+pub struct FleetHealth {
+    pub status: &'static str,
+    pub version: String,
+    /// True iff the control actor answered our ListRunning/GetQueue probes —
+    /// i.e. the scheduler/dispatch loop is not wedged.
+    pub control_responsive: bool,
+    pub running: usize,
+    pub queue_depth: usize,
+    pub missions: crate::api::mission_store::MissionStatusCounts,
+    pub webhook_forwarder_configured: bool,
+    pub offload_configured: bool,
+}
+
+pub async fn fleet_health(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<Json<FleetHealth>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+
+    // Probe the control actor; a wedged scheduler surfaces as a failed probe.
+    let running = get_running_missions(&control).await.map(|r| r.len());
+    let (tx, rx) = oneshot::channel();
+    let queue_depth = if control
+        .cmd_tx
+        .send(ControlCommand::GetQueue { respond: tx })
+        .await
+        .is_ok()
+    {
+        rx.await.ok().map(|q| q.len())
+    } else {
+        None
+    };
+    let control_responsive = running.is_ok() && queue_depth.is_some();
+
+    let missions = control
+        .mission_store
+        .count_missions_by_status()
+        .await
+        .map_err(internal_error)?;
+
+    let cfg = &state.config;
+    Ok(Json(FleetHealth {
+        status: if control_responsive { "ok" } else { "degraded" },
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        control_responsive,
+        running: running.unwrap_or(0),
+        queue_depth: queue_depth.unwrap_or(0),
+        missions,
+        webhook_forwarder_configured: cfg.paloma_webhook_forward_url.is_some(),
+        offload_configured: cfg.spark_arbiter_url.is_some() || cfg.spark_ssh_target.is_some(),
+    }))
+}
+
+/// Enrich missions with computed activity timestamps (P#5): the most recent
+/// event and assistant output from the event log, plus a `last_activity_at`
+/// convenience = max(updated_at, last_agent_event_at). Best-effort: a store
+/// without an event log (or a failed query) leaves the computed fields unset.
+async fn populate_activity(control: &ControlState, missions: &mut [Mission]) {
+    if missions.is_empty() {
+        return;
+    }
+    let ids: Vec<Uuid> = missions.iter().map(|m| m.id).collect();
+    let activity = match control.mission_store.get_mission_activity(&ids).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!("Failed to load mission activity: {}", e);
+            return;
+        }
+    };
+    for mission in missions.iter_mut() {
+        if let Some((last_event, last_output)) = activity.get(&mission.id) {
+            mission.activity.last_agent_event_at = last_event.clone();
+            mission.activity.last_output_at = last_output.clone();
+        }
+        // last_activity_at = the most recent of updated_at and the newest event.
+        let last_activity = [
+            Some(mission.updated_at.clone()),
+            mission.activity.last_agent_event_at.clone(),
+        ]
+        .into_iter()
+        .flatten()
+        .max();
+        mission.activity.last_activity_at = last_activity;
+    }
 }
 
 async fn populate_workspace_names(state: &Arc<AppState>, missions: &mut [Mission]) {
@@ -4201,7 +4335,7 @@ pub async fn get_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
-) -> Result<Json<Mission>, (StatusCode, String)> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     match control
         .mission_store
@@ -4210,11 +4344,39 @@ pub async fn get_mission(
         .map_err(internal_error)?
     {
         Some(mut mission) => {
-            // Populate workspace_name
-            if let Some(workspace) = state.workspaces.get(mission.workspace_id).await {
-                mission.workspace_name = Some(workspace.name);
+            // Populate workspace_name + spark_offload from the workspace (P#7).
+            let workspace = state.workspaces.get(mission.workspace_id).await;
+            if let Some(ws) = workspace.as_ref() {
+                mission.workspace_name = Some(ws.name.clone());
             }
-            Ok(Json(mission))
+            let mut one = [mission];
+            populate_activity(&control, &mut one).await;
+            let [mission] = one;
+
+            // Serialize then attach the computed spark_offload block so Paloma
+            // can route heavy builds without probing the host each time.
+            let mut value = serde_json::to_value(&mission).map_err(internal_error)?;
+            let host_configured =
+                state.config.spark_arbiter_url.is_some() || state.config.spark_ssh_target.is_some();
+            let enabled = workspace
+                .as_ref()
+                .map(|ws| ws.spark_offload_enabled())
+                .unwrap_or(false);
+            let env_injected = workspace
+                .as_ref()
+                .map(|ws| ws.spark_offload_env(mission.id).is_some())
+                .unwrap_or(false);
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert(
+                    "spark_offload".to_string(),
+                    serde_json::json!({
+                        "enabled": enabled,
+                        "env_injected": env_injected,
+                        "host_configured": host_configured,
+                    }),
+                );
+            }
+            Ok(Json(value))
         }
         None => Err((StatusCode::NOT_FOUND, format!("Mission {} not found", id))),
     }
@@ -4251,6 +4413,16 @@ pub struct CreateMissionRequest {
     /// FLEET-001 scheduling hint: deadline. A scheduled mission that never
     /// dispatches before this is failed with reason `deadline_exceeded`.
     pub deadline: Option<chrono::DateTime<chrono::Utc>>,
+    /// Project tagging: stable project identifier (e.g. "verity-core").
+    pub project: Option<String>,
+    /// Project tagging: track / workstream within the project.
+    pub track: Option<String>,
+    /// Project tagging: intent (e.g. "repair-build").
+    pub intent: Option<String>,
+    /// Project tagging: associated GitHub PR number.
+    pub github_pr: Option<i64>,
+    /// Project tagging: freeform tags.
+    pub tags: Option<Vec<String>>,
 }
 
 fn deserialize_string_patch<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
@@ -4258,6 +4430,15 @@ where
     D: Deserializer<'de>,
 {
     Option::<String>::deserialize(deserializer).map(Some)
+}
+
+/// Like [`deserialize_string_patch`] but for an optional integer: present field
+/// (even `null`) → `Some(..)`, absent → `None`.
+fn deserialize_i64_patch<'de, D>(deserializer: D) -> Result<Option<Option<i64>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<i64>::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize)]
@@ -4352,6 +4533,11 @@ pub async fn create_mission(
         priority: None,
         not_before: None,
         deadline: None,
+        project: None,
+        track: None,
+        intent: None,
+        github_pr: None,
+        tags: None,
     });
 
     let title = req.title.clone();
@@ -4492,10 +4678,142 @@ pub async fn create_mission(
         .await
         .map_err(session_unavailable)?;
 
-    rx.await
-        .map_err(recv_failed)?
-        .map(Json)
-        .map_err(internal_error)
+    let mut mission = rx.await.map_err(recv_failed)?.map_err(internal_error)?;
+
+    // Apply project tagging metadata if provided at creation time. Empty/blank
+    // strings are treated as unset; tags are trimmed and empties dropped.
+    let nonblank = |s: &Option<String>| -> Option<String> {
+        s.as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    let project = nonblank(&req.project);
+    let track = nonblank(&req.track);
+    let intent = nonblank(&req.intent);
+    let github_pr = req.github_pr;
+    let tags: Option<Vec<String>> = req.tags.as_ref().map(|tags| {
+        tags.iter()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect()
+    });
+    if project.is_some()
+        || track.is_some()
+        || intent.is_some()
+        || github_pr.is_some()
+        || tags.is_some()
+    {
+        control
+            .mission_store
+            .update_mission_project(
+                mission.id,
+                crate::api::mission_store::MissionProjectPatch {
+                    project: project.clone().map(Some),
+                    track: track.clone().map(Some),
+                    intent: intent.clone().map(Some),
+                    github_pr: github_pr.map(Some),
+                    tags: tags.clone(),
+                },
+            )
+            .await
+            .map_err(internal_error)?;
+        // Reflect the applied values in the returned mission without a re-fetch.
+        if let Some(v) = project {
+            mission.project.project = Some(v);
+        }
+        if let Some(v) = track {
+            mission.project.track = Some(v);
+        }
+        if let Some(v) = intent {
+            mission.project.intent = Some(v);
+        }
+        if github_pr.is_some() {
+            mission.project.github_pr = github_pr;
+        }
+        if let Some(v) = tags {
+            mission.project.tags = v;
+        }
+    }
+
+    Ok(Json(mission))
+}
+
+/// Request body for `POST /api/control/missions/:id/project`. Tri-state per
+/// field: omit to leave unchanged, `null` to clear, a value to set. `tags`
+/// replaces the whole list when present.
+#[derive(Debug, Deserialize)]
+pub struct UpdateMissionProjectRequest {
+    #[serde(default, deserialize_with = "deserialize_string_patch")]
+    pub project: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_patch")]
+    pub track: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_patch")]
+    pub intent: Option<Option<String>>,
+    /// Tri-state: omit to leave unchanged, `null` to clear, a number to set.
+    #[serde(default, deserialize_with = "deserialize_i64_patch")]
+    pub github_pr: Option<Option<i64>>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+}
+
+/// Set or update project tagging metadata for a mission.
+pub async fn update_mission_project(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateMissionProjectRequest>,
+) -> Result<Json<Mission>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
+
+    // Normalize: blank string patches clear the field; tags are trimmed.
+    let normalize = |patch: Option<Option<String>>| -> Option<Option<String>> {
+        patch.map(|inner| {
+            inner.and_then(|s| {
+                let t = s.trim().to_string();
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t)
+                }
+            })
+        })
+    };
+    let tags: Option<Vec<String>> = req.tags.map(|tags| {
+        tags.into_iter()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect()
+    });
+
+    control
+        .mission_store
+        .update_mission_project(
+            id,
+            crate::api::mission_store::MissionProjectPatch {
+                project: normalize(req.project),
+                track: normalize(req.track),
+                intent: normalize(req.intent),
+                github_pr: req.github_pr,
+                tags,
+            },
+        )
+        .await
+        .map_err(internal_error)?;
+
+    let updated = control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Mission {} not found", id)))?;
+    Ok(Json(updated))
 }
 
 /// Update mission run settings for future turns.
@@ -5848,6 +6166,17 @@ pub async fn clone_mission(
         priority: None,
         not_before: None,
         deadline: None,
+        // Inherit project tagging from the source mission so clones stay
+        // grouped under the same project/track/intent.
+        project: source.project.project.clone(),
+        track: source.project.track.clone(),
+        intent: source.project.intent.clone(),
+        github_pr: source.project.github_pr,
+        tags: if source.project.tags.is_empty() {
+            None
+        } else {
+            Some(source.project.tags.clone())
+        },
     };
 
     let cloned = create_mission(State(state), Extension(user), Some(Json(req))).await?;
@@ -6993,13 +7322,15 @@ pub async fn stream(
     ))
 }
 
-/// Statuses worth forwarding to an external consumer (Hermes): a mission that
-/// FINISHED, hit a terminal failure, or now needs the user. We deliberately skip
-/// intermediate churn (pending→active→paused→acknowledged) so the callback means
-/// "something actionable happened", not "the status field moved". `Interrupted`
-/// is intentionally excluded: it is emitted transiently as resume-prep when a
-/// paused mission resumes (not a terminal outcome), so forwarding it would fire
-/// a spurious callback on every resume.
+/// Statuses worth forwarding to an external consumer (Paloma/Hermes): a mission
+/// that FINISHED, hit a terminal failure, now needs the user, or was
+/// acknowledged. We still skip the live churn (pending→active→paused) so a
+/// callback means "something actionable happened", not "the status field moved".
+///
+/// `Interrupted` is included (P#1 asks for it) even though it can be emitted
+/// transiently as resume-prep when a paused mission resumes — consumers dedupe
+/// on the `event_id`/`sequence` carried in the payload and can treat a quickly
+/// superseded interrupted→active as a no-op.
 fn webhook_forwardable_status(status: MissionStatus) -> bool {
     matches!(
         status,
@@ -7008,6 +7339,8 @@ fn webhook_forwardable_status(status: MissionStatus) -> bool {
             | MissionStatus::NotFeasible
             | MissionStatus::Blocked
             | MissionStatus::AwaitingUser
+            | MissionStatus::Interrupted
+            | MissionStatus::Acknowledged
     )
 }
 
@@ -7027,6 +7360,10 @@ async fn paloma_webhook_forwarder_loop(
         std::collections::HashMap::new();
     // Bound concurrent in-flight callbacks (each does a get_mission + HTTP POST).
     let sem = Arc::new(tokio::sync::Semaphore::new(8));
+    // Process-monotonic sequence so the consumer can order events and dedupe
+    // (at-least-once delivery: a single logical event keeps one `event_id`
+    // across retries). Resets on restart — `event_id` is the durable key.
+    let sequence = Arc::new(std::sync::atomic::AtomicU64::new(0));
     loop {
         match events_rx.recv().await {
             Ok(AgentEvent::MissionStatusChanged {
@@ -7038,6 +7375,10 @@ async fn paloma_webhook_forwarder_loop(
                     continue;
                 }
 
+                // Stable per-logical-event identity for idempotent consumers.
+                let event_id = Uuid::new_v4();
+                let seq = sequence.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
                 // Everything else (the mission load + POST) runs in a spawned,
                 // concurrency-bounded task so neither a slow DB read nor a slow
                 // webhook can stall the broadcast receiver and lag-drop events.
@@ -7047,25 +7388,81 @@ async fn paloma_webhook_forwarder_loop(
                 let sem = Arc::clone(&sem);
                 tokio::spawn(async move {
                     let _permit = sem.acquire_owned().await;
-                    let title = mission_store
-                        .get_mission(mission_id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .and_then(|mission| mission.title)
+                    let mission = mission_store.get_mission(mission_id).await.ok().flatten();
+                    let title = mission
+                        .as_ref()
+                        .and_then(|mission| mission.title.clone())
                         .unwrap_or_else(|| mission_id.to_string());
+                    let project = mission.as_ref().map(|m| &m.project);
                     let body = serde_json::json!({
+                        // Idempotency / ordering (P#6): consumers dedupe on
+                        // `event_id` and may order by `sequence`.
+                        "event_id": event_id,
+                        "sequence": seq,
                         "mission_id": mission_id,
                         "status": status,
                         "title": title,
+                        "short_description": mission
+                            .as_ref()
+                            .and_then(|m| m.short_description.clone()),
+                        "workspace_id": mission.as_ref().map(|m| m.workspace_id),
+                        "workspace_name": mission
+                            .as_ref()
+                            .and_then(|m| m.workspace_name.clone()),
+                        "backend": mission.as_ref().map(|m| m.backend.clone()),
+                        "updated_at": mission.as_ref().map(|m| m.updated_at.clone()),
+                        // When the status itself last changed (P#5) — the most
+                        // relevant staleness anchor for a status-change webhook.
+                        "last_status_change_at": mission
+                            .as_ref()
+                            .and_then(|m| m.activity.last_status_change_at.clone()),
+                        // Project tagging so Paloma can route by project/track/
+                        // intent/PR instead of parsing titles.
+                        "project": project.and_then(|p| p.project.clone()),
+                        "track": project.and_then(|p| p.track.clone()),
+                        "intent": project.and_then(|p| p.intent.clone()),
+                        "github_pr": project.and_then(|p| p.github_pr),
+                        "tags": project.map(|p| p.tags.clone()).unwrap_or_default(),
+                        // For awaiting_user, whether the agent needs a decision
+                        // or is just waiting to be acked/merged.
+                        "awaiting_kind": mission
+                            .as_ref()
+                            .and_then(|m| m.awaiting_kind)
+                            .map(|k| k.as_str()),
                     });
-                    if let Err(err) = http.post(&url).json(&body).send().await {
-                        tracing::warn!(
-                            mission_id = %mission_id,
-                            webhook_url = %url,
-                            "Failed to forward Paloma mission status webhook: {}",
-                            err
-                        );
+
+                    // At-least-once: retry transient failures with the SAME
+                    // event_id so the consumer can dedupe. Bounded so a dead
+                    // endpoint can't pile up tasks.
+                    const MAX_ATTEMPTS: u32 = 3;
+                    for attempt in 1..=MAX_ATTEMPTS {
+                        match http.post(&url).json(&body).send().await {
+                            Ok(resp) if resp.status().is_success() => break,
+                            Ok(resp) => {
+                                tracing::warn!(
+                                    mission_id = %mission_id,
+                                    webhook_url = %url,
+                                    attempt,
+                                    status = %resp.status(),
+                                    "Paloma webhook returned non-success status"
+                                );
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    mission_id = %mission_id,
+                                    webhook_url = %url,
+                                    attempt,
+                                    "Failed to forward Paloma mission status webhook: {}",
+                                    err
+                                );
+                            }
+                        }
+                        if attempt < MAX_ATTEMPTS {
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                250 * attempt as u64,
+                            ))
+                            .await;
+                        }
                     }
                 });
             }
@@ -8394,6 +8791,57 @@ fn mission_status_for_terminal_reason(
     }
 }
 
+/// Classify *why* a mission is parking in `AwaitingUser` by inspecting the last
+/// assistant message: a trailing question (or interrogative phrasing) means the
+/// agent needs a `Decision`; anything else means it finished its turn / work and
+/// is waiting for an `Ack`. This is a heuristic — consumers (Paloma) can refine
+/// it — but it is far better than the old all-`awaiting_user`-is-the-same signal.
+fn classify_awaiting_kind(history: &[MissionHistoryEntry]) -> AwaitingKind {
+    let Some(last) = history.iter().rev().find(|entry| entry.role == "assistant") else {
+        // No assistant text to read (e.g. tool-only turn) — default to Ack so a
+        // "done" turn doesn't masquerade as an open question.
+        return AwaitingKind::Ack;
+    };
+
+    let text = last.content.trim();
+    if text.is_empty() {
+        return AwaitingKind::Ack;
+    }
+
+    // Only look at the tail of the message — the closing lines carry the intent
+    // (a long answer that ends with "Want me to proceed?" is a decision).
+    let tail: String = text.chars().rev().take(600).collect::<String>();
+    let tail: String = tail.chars().rev().collect();
+    let lower = tail.to_lowercase();
+
+    let ends_with_question = tail.trim_end().ends_with('?');
+    // Interrogative / approval-seeking lead-ins that signal an open decision even
+    // when the literal '?' lands earlier than the very last character.
+    const DECISION_CUES: &[&str] = &[
+        "should i ",
+        "shall i ",
+        "do you want",
+        "would you like",
+        "which option",
+        "which one",
+        "let me know",
+        "how would you like",
+        "what would you like",
+        "can you confirm",
+        "please confirm",
+        "your call",
+        "proceed?",
+        "go ahead?",
+    ];
+    let has_cue = DECISION_CUES.iter().any(|cue| lower.contains(cue));
+
+    if ends_with_question || has_cue {
+        AwaitingKind::Decision
+    } else {
+        AwaitingKind::Ack
+    }
+}
+
 fn mission_status_summary_for_terminal_reason(reason: TerminalReason) -> Option<String> {
     match reason {
         TerminalReason::TurnComplete | TerminalReason::Completed => None,
@@ -8785,6 +9233,26 @@ async fn maybe_finalize_terminal_mission(
                 context = log_context,
                 "Finalizing mission after terminal turn"
             );
+            // Classify the awaiting reason *before* flipping the status so the
+            // `awaiting_kind` column is populated by the time the
+            // MissionStatusChanged event (and the Paloma webhook it triggers)
+            // fires. The status write only clears awaiting_kind for non-awaiting
+            // statuses, so setting it first here is safe.
+            if new_status == MissionStatus::AwaitingUser {
+                let kind = classify_awaiting_kind(&mission.history);
+                if let Err(e) = mission_store
+                    .set_mission_awaiting_kind(mission_id, Some(kind))
+                    .await
+                {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        context = log_context,
+                        "Failed to set awaiting_kind: {}",
+                        e
+                    );
+                }
+            }
+
             if let Err(e) = mission_store
                 .update_mission_status_with_reason(
                     mission_id,
@@ -19065,6 +19533,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
         let weak = Mission {
             id: Uuid::new_v4(),
@@ -19098,6 +19569,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
 
         let strong_score = mission_search_relevance_score(
@@ -19146,6 +19620,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
 
         let score = mission_search_relevance_score(
@@ -19191,6 +19668,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
 
         let score = mission_search_relevance_score(
@@ -19236,6 +19716,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
 
         let score = mission_search_relevance_score(
@@ -19281,6 +19764,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
 
         let score = mission_search_relevance_score(
@@ -19410,6 +19896,9 @@ And the report:
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         };
         let before = mission_search_freshness_key(
             &[MissionSearchCandidate {
@@ -19620,6 +20109,50 @@ Investigate <service/> failures.
 
         assert!(accept_user_message_id(&mut accepted, message_id));
         assert!(!accept_user_message_id(&mut accepted, message_id));
+    }
+
+    fn assistant(content: &str) -> MissionHistoryEntry {
+        MissionHistoryEntry {
+            role: "assistant".to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn classify_awaiting_kind_detects_decisions_and_acks() {
+        // Trailing question → decision.
+        assert_eq!(
+            classify_awaiting_kind(&[assistant("I found two options. Which one do you prefer?")]),
+            AwaitingKind::Decision
+        );
+        // Approval-seeking phrasing without a literal trailing '?'.
+        assert_eq!(
+            classify_awaiting_kind(&[assistant(
+                "The migration is ready. Should I apply it now to prod?"
+            )]),
+            AwaitingKind::Decision
+        );
+        // Plain "done" statement → ack.
+        assert_eq!(
+            classify_awaiting_kind(&[assistant("Done. Opened PR #569 and merged it.")]),
+            AwaitingKind::Ack
+        );
+        // No assistant text at all → ack (don't fabricate an open question).
+        assert_eq!(
+            classify_awaiting_kind(&[MissionHistoryEntry {
+                role: "user".to_string(),
+                content: "go".to_string(),
+            }]),
+            AwaitingKind::Ack
+        );
+        // Only the *last* assistant message matters.
+        assert_eq!(
+            classify_awaiting_kind(&[
+                assistant("Should I start? "),
+                assistant("All set, deployed and verified."),
+            ]),
+            AwaitingKind::Ack
+        );
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3855,39 +3855,75 @@ pub async fn list_missions(
         || query.project.is_some()
         || query.tag.is_some()
         || query.workspace.is_some();
-    // When filtering, scan a wider window so the requested count can still be
-    // filled after dropping non-matching rows; otherwise honor the limit as-is.
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let offset = query.offset.unwrap_or(0);
-    let fetch_limit = if has_filters { 200 } else { limit };
-    let mut missions = control
-        .mission_store
-        .list_missions(fetch_limit, offset)
-        .await
-        .map_err(internal_error)?;
-    populate_workspace_names(&state, &mut missions).await;
 
-    if let Some(status) = query.status.as_deref() {
-        missions.retain(|m| m.status.to_string() == status);
-    }
-    if let Some(project) = query.project.as_deref() {
-        missions.retain(|m| m.project.project.as_deref() == Some(project));
-    }
-    if let Some(tag) = query.tag.as_deref() {
-        missions.retain(|m| m.project.tags.iter().any(|t| t == tag));
-    }
-    if let Some(workspace) = query.workspace.as_deref() {
-        let ws_lower = workspace.to_lowercase();
-        missions.retain(|m| {
-            m.workspace_id.to_string() == workspace
-                || m.workspace_name
-                    .as_deref()
-                    .is_some_and(|name| name.to_lowercase() == ws_lower)
-        });
-    }
-    if has_filters {
-        missions.truncate(limit);
-    }
+    let mut missions = if !has_filters {
+        // Fast path: no filters, list the page directly.
+        let mut page = control
+            .mission_store
+            .list_missions(limit, offset)
+            .await
+            .map_err(internal_error)?;
+        populate_workspace_names(&state, &mut page).await;
+        page
+    } else {
+        // Filtered path: predicate-match runs in memory, so a single 200-row
+        // page would silently drop matches on a larger fleet. Scan pages from
+        // `offset` until we have `limit` matches or hit a bounded ceiling.
+        const PAGE: usize = 200;
+        const MAX_SCAN: usize = 5_000;
+        let status = query.status.as_deref();
+        let project = query.project.as_deref();
+        let tag = query.tag.as_deref();
+        let workspace_lower = query.workspace.as_deref().map(|w| w.to_lowercase());
+        let workspace_raw = query.workspace.as_deref();
+
+        let mut matched: Vec<Mission> = Vec::new();
+        let mut scan_offset = offset;
+        let mut scanned = 0usize;
+        loop {
+            let mut page = control
+                .mission_store
+                .list_missions(PAGE, scan_offset)
+                .await
+                .map_err(internal_error)?;
+            let page_len = page.len();
+            populate_workspace_names(&state, &mut page).await;
+            for m in page {
+                let keep = status.is_none_or(|s| m.status.to_string() == s)
+                    && project.is_none_or(|p| m.project.project.as_deref() == Some(p))
+                    && tag.is_none_or(|t| m.project.tags.iter().any(|x| x == t))
+                    && match (workspace_raw, workspace_lower.as_deref()) {
+                        (Some(raw), Some(lower)) => {
+                            m.workspace_id.to_string() == raw
+                                || m.workspace_name
+                                    .as_deref()
+                                    .is_some_and(|name| name.to_lowercase() == lower)
+                        }
+                        _ => true,
+                    };
+                if keep {
+                    matched.push(m);
+                    if matched.len() >= limit {
+                        break;
+                    }
+                }
+            }
+            scanned += page_len;
+            if matched.len() >= limit || page_len < PAGE || scanned >= MAX_SCAN {
+                if scanned >= MAX_SCAN && matched.len() < limit {
+                    tracing::warn!(
+                        "list_missions filter scan hit cap ({}); results may be incomplete",
+                        MAX_SCAN
+                    );
+                }
+                break;
+            }
+            scan_offset += PAGE;
+        }
+        matched
+    };
 
     populate_activity(&control, &mut missions).await;
     Ok(Json(missions))

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3869,8 +3869,10 @@ pub async fn list_missions(
         page
     } else {
         // Filtered path: predicate-match runs in memory, so a single 200-row
-        // page would silently drop matches on a larger fleet. Scan pages from
-        // `offset` until we have `limit` matches or hit a bounded ceiling.
+        // page would silently drop matches on a larger fleet. Scan from the
+        // start, collecting matches, until we have `offset + limit` of them or
+        // hit a bounded ceiling. `offset` here means "skip this many MATCHING
+        // missions" (consistent with filtered pagination), not raw rows.
         const PAGE: usize = 200;
         const MAX_SCAN: usize = 5_000;
         let status = query.status.as_deref();
@@ -3878,9 +3880,10 @@ pub async fn list_missions(
         let tag = query.tag.as_deref();
         let workspace_lower = query.workspace.as_deref().map(|w| w.to_lowercase());
         let workspace_raw = query.workspace.as_deref();
+        let want = offset.saturating_add(limit);
 
         let mut matched: Vec<Mission> = Vec::new();
-        let mut scan_offset = offset;
+        let mut scan_offset = 0usize;
         let mut scanned = 0usize;
         loop {
             let mut page = control
@@ -3905,14 +3908,14 @@ pub async fn list_missions(
                     };
                 if keep {
                     matched.push(m);
-                    if matched.len() >= limit {
+                    if matched.len() >= want {
                         break;
                     }
                 }
             }
             scanned += page_len;
-            if matched.len() >= limit || page_len < PAGE || scanned >= MAX_SCAN {
-                if scanned >= MAX_SCAN && matched.len() < limit {
+            if matched.len() >= want || page_len < PAGE || scanned >= MAX_SCAN {
+                if scanned >= MAX_SCAN && matched.len() < want {
                     tracing::warn!(
                         "list_missions filter scan hit cap ({}); results may be incomplete",
                         MAX_SCAN
@@ -3922,7 +3925,8 @@ pub async fn list_missions(
             }
             scan_offset += PAGE;
         }
-        matched
+        // Apply the offset to matches (not raw rows) and cap at limit.
+        matched.into_iter().skip(offset).take(limit).collect()
     };
 
     populate_activity(&control, &mut missions).await;
@@ -9293,30 +9297,19 @@ async fn maybe_finalize_terminal_mission(
                 context = log_context,
                 "Finalizing mission after terminal turn"
             );
-            // Classify the awaiting reason *before* flipping the status so the
-            // `awaiting_kind` column is populated by the time the
-            // MissionStatusChanged event (and the Paloma webhook it triggers)
-            // fires. The status write only clears awaiting_kind for non-awaiting
-            // statuses, so setting it first here is safe.
-            if new_status == MissionStatus::AwaitingUser {
-                // Prefer the in-hand turn output; fall back to history only when
-                // the caller didn't supply it (event log may lag the turn).
-                let kind = match final_output {
+            // Classify the awaiting reason now (uses the in-hand turn output;
+            // falls back to history only when the caller didn't supply it, since
+            // the event log can lag the turn). Applied *after* a successful
+            // status write below so a failed write can't orphan awaiting_kind on
+            // a mission that never became AwaitingUser.
+            let awaiting_kind = if new_status == MissionStatus::AwaitingUser {
+                Some(match final_output {
                     Some(text) if !text.trim().is_empty() => classify_awaiting_kind_text(text),
                     _ => classify_awaiting_kind(&mission.history),
-                };
-                if let Err(e) = mission_store
-                    .set_mission_awaiting_kind(mission_id, Some(kind))
-                    .await
-                {
-                    tracing::warn!(
-                        mission_id = %mission_id,
-                        context = log_context,
-                        "Failed to set awaiting_kind: {}",
-                        e
-                    );
-                }
-            }
+                })
+            } else {
+                None
+            };
 
             if let Err(e) = mission_store
                 .update_mission_status_with_reason(
@@ -9333,6 +9326,23 @@ async fn maybe_finalize_terminal_mission(
                     e
                 );
             } else {
+                // Set awaiting_kind after the status is committed to AwaitingUser
+                // and before emitting the event the Paloma webhook keys on, so
+                // the webhook sees it without risking an orphan on write failure.
+                if let Some(kind) = awaiting_kind {
+                    if let Err(e) = mission_store
+                        .set_mission_awaiting_kind(mission_id, Some(kind))
+                        .await
+                    {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            context = log_context,
+                            "Failed to set awaiting_kind: {}",
+                            e
+                        );
+                    }
+                }
+
                 maybe_schedule_mission_metadata_refresh_for_status(
                     mission_store,
                     events_tx,

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -163,7 +163,7 @@ impl MissionStore for FileMissionStore {
             config_profile: config_profile.map(|s| s.to_string()),
             history: vec![],
             created_at: now.clone(),
-            updated_at: now,
+            updated_at: now.clone(),
             interrupted_at: None,
             paused_at: None,
             resumable: false,
@@ -177,6 +177,12 @@ impl MissionStore for FileMissionStore {
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: super::MissionActivity {
+                last_status_change_at: Some(now.clone()),
+                ..Default::default()
+            },
+            awaiting_kind: None,
         };
         self.missions
             .write()
@@ -210,9 +216,13 @@ impl MissionStore for FileMissionStore {
         let mission = missions
             .get_mut(&id)
             .ok_or_else(|| format!("Mission {} not found", id))?;
+        let status_changed = mission.status != status;
         mission.status = status;
         let now = now_string();
         mission.updated_at = now.clone();
+        if status_changed {
+            mission.activity.last_status_change_at = Some(now.clone());
+        }
         mission.terminal_reason = terminal_reason.map(|s| s.to_string());
         // AwaitingUser is resumable too (any user message wakes the agent).
         // Failed missions with LlmError are also resumable (transient API errors).
@@ -232,6 +242,11 @@ impl MissionStore for FileMissionStore {
             };
         if matches!(status, MissionStatus::Active) {
             mission.first_viewed_at = None;
+        }
+        // awaiting_kind only describes an AwaitingUser mission; clear it on any
+        // change away from that state (parity with the sqlite store).
+        if !matches!(status, MissionStatus::AwaitingUser) {
+            mission.awaiting_kind = None;
         }
         drop(missions);
         self.persist().await
@@ -431,6 +446,52 @@ impl MissionStore for FileMissionStore {
         let now = now_string();
         mission.metadata_updated_at = Some(now.clone());
         mission.updated_at = now;
+        drop(missions);
+        self.persist().await
+    }
+
+    async fn update_mission_project(
+        &self,
+        id: Uuid,
+        patch: super::MissionProjectPatch,
+    ) -> Result<(), String> {
+        if patch.is_empty() {
+            return Ok(());
+        }
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        if let Some(project) = patch.project {
+            mission.project.project = project;
+        }
+        if let Some(track) = patch.track {
+            mission.project.track = track;
+        }
+        if let Some(intent) = patch.intent {
+            mission.project.intent = intent;
+        }
+        if let Some(github_pr) = patch.github_pr {
+            mission.project.github_pr = github_pr;
+        }
+        if let Some(tags) = patch.tags {
+            mission.project.tags = tags;
+        }
+        mission.updated_at = now_string();
+        drop(missions);
+        self.persist().await
+    }
+
+    async fn set_mission_awaiting_kind(
+        &self,
+        id: Uuid,
+        kind: Option<super::AwaitingKind>,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        mission.awaiting_kind = kind;
         drop(missions);
         self.persist().await
     }

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -115,7 +115,7 @@ impl MissionStore for InMemoryMissionStore {
             config_profile: config_profile.map(|s| s.to_string()),
             history: vec![],
             created_at: now.clone(),
-            updated_at: now,
+            updated_at: now.clone(),
             interrupted_at: None,
             paused_at: None,
             resumable: false,
@@ -129,6 +129,12 @@ impl MissionStore for InMemoryMissionStore {
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: super::MissionActivity {
+                last_status_change_at: Some(now.clone()),
+                ..Default::default()
+            },
+            awaiting_kind: None,
         };
         self.missions
             .write()
@@ -161,9 +167,13 @@ impl MissionStore for InMemoryMissionStore {
         let mission = missions
             .get_mut(&id)
             .ok_or_else(|| format!("Mission {} not found", id))?;
+        let status_changed = mission.status != status;
         mission.status = status;
         let now = now_string();
         mission.updated_at = now.clone();
+        if status_changed {
+            mission.activity.last_status_change_at = Some(now.clone());
+        }
         mission.terminal_reason = terminal_reason.map(|s| s.to_string());
         // AwaitingUser is resumable too (any user message wakes the agent).
         // Failed missions with LlmError are also resumable (transient API errors).
@@ -183,6 +193,11 @@ impl MissionStore for InMemoryMissionStore {
             };
         if matches!(status, MissionStatus::Active) {
             mission.first_viewed_at = None;
+        }
+        // awaiting_kind only describes an AwaitingUser mission; clear it on any
+        // change away from that state (parity with the sqlite store).
+        if !matches!(status, MissionStatus::AwaitingUser) {
+            mission.awaiting_kind = None;
         }
         Ok(())
     }
@@ -368,6 +383,50 @@ impl MissionStore for InMemoryMissionStore {
         let now = now_string();
         mission.metadata_updated_at = Some(now.clone());
         mission.updated_at = now;
+        Ok(())
+    }
+
+    async fn update_mission_project(
+        &self,
+        id: Uuid,
+        patch: super::MissionProjectPatch,
+    ) -> Result<(), String> {
+        if patch.is_empty() {
+            return Ok(());
+        }
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        if let Some(project) = patch.project {
+            mission.project.project = project;
+        }
+        if let Some(track) = patch.track {
+            mission.project.track = track;
+        }
+        if let Some(intent) = patch.intent {
+            mission.project.intent = intent;
+        }
+        if let Some(github_pr) = patch.github_pr {
+            mission.project.github_pr = github_pr;
+        }
+        if let Some(tags) = patch.tags {
+            mission.project.tags = tags;
+        }
+        mission.updated_at = now_string();
+        Ok(())
+    }
+
+    async fn set_mission_awaiting_kind(
+        &self,
+        id: Uuid,
+        kind: Option<super::AwaitingKind>,
+    ) -> Result<(), String> {
+        let mut missions = self.missions.write().await;
+        let mission = missions
+            .get_mut(&id)
+            .ok_or_else(|| format!("Mission {} not found", id))?;
+        mission.awaiting_kind = kind;
         Ok(())
     }
 

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -43,6 +43,116 @@ pub struct MissionScheduling {
     pub deadline: Option<String>,
 }
 
+/// Project tagging metadata for a mission. Flattened into `Mission` so the
+/// fields appear top-level in serialized output. Lets external consumers (e.g.
+/// Paloma) group/filter/route missions by project, track, intent, PR, or
+/// freeform tags instead of parsing conventions out of free-text titles like
+/// `[beal-research] BR-07 ...`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissionProject {
+    /// Stable project identifier (e.g. "verity-core").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    /// Track / workstream within the project (e.g. "C3-bridge-collapse").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub track: Option<String>,
+    /// Intent of the mission (e.g. "repair-build", "investigate").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent: Option<String>,
+    /// Associated GitHub PR number, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_pr: Option<i64>,
+    /// Freeform tags.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+impl MissionProject {
+    /// True when no project metadata is set.
+    pub fn is_empty(&self) -> bool {
+        self.project.is_none()
+            && self.track.is_none()
+            && self.intent.is_none()
+            && self.github_pr.is_none()
+            && self.tags.is_empty()
+    }
+}
+
+/// Tri-state patch for project metadata: each field is `None` to leave
+/// unchanged, `Some(None)` to clear, `Some(Some(v))` to set. `tags` is
+/// `Some(vec)` to replace the whole list.
+#[derive(Debug, Clone, Default)]
+pub struct MissionProjectPatch {
+    pub project: Option<Option<String>>,
+    pub track: Option<Option<String>>,
+    pub intent: Option<Option<String>>,
+    pub github_pr: Option<Option<i64>>,
+    pub tags: Option<Vec<String>>,
+}
+
+impl MissionProjectPatch {
+    /// True when the patch would change nothing.
+    pub fn is_empty(&self) -> bool {
+        self.project.is_none()
+            && self.track.is_none()
+            && self.intent.is_none()
+            && self.github_pr.is_none()
+            && self.tags.is_none()
+    }
+}
+
+/// Activity timestamps for a mission, surfaced so watchdogs/consumers can
+/// reason about staleness without guessing from `updated_at` alone (which also
+/// bumps on metadata edits). `last_status_change_at` is persisted; the event
+/// timestamps are computed on read from the event log and may be `None` when
+/// not requested (e.g. internal store reads that skip enrichment).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissionActivity {
+    /// When the mission's status last changed (persisted).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_status_change_at: Option<String>,
+    /// Timestamp of the most recent mission event of any kind (computed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_agent_event_at: Option<String>,
+    /// Timestamp of the most recent assistant output (computed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_output_at: Option<String>,
+    /// Convenience: max(updated_at, last_agent_event_at) (computed). Lets a
+    /// consumer derive staleness with a single field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity_at: Option<String>,
+}
+
+/// Disambiguates *why* a mission is parked in `AwaitingUser`: the agent asked a
+/// real question that needs a decision, vs. it just finished a turn / its work
+/// and is waiting to be acknowledged or merged. Only meaningful while the
+/// status is `AwaitingUser`; `None` for every other status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AwaitingKind {
+    /// The agent is asking the user something and needs an answer to proceed.
+    Decision,
+    /// The agent finished its turn / work and is waiting for acknowledgement.
+    Ack,
+}
+
+impl AwaitingKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AwaitingKind::Decision => "decision",
+            AwaitingKind::Ack => "ack",
+        }
+    }
+
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "decision" => Some(AwaitingKind::Decision),
+            "ack" => Some(AwaitingKind::Ack),
+            _ => None,
+        }
+    }
+}
+
 /// A mission (persistent goal-oriented session).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Mission {
@@ -133,10 +243,22 @@ pub struct Mission {
     /// Flattened so the fields appear top-level in serialized output.
     #[serde(default, flatten)]
     pub scheduling: MissionScheduling,
+    /// Project tagging metadata (project, track, intent, github_pr, tags).
+    /// Flattened so the fields appear top-level.
+    #[serde(default, flatten)]
+    pub project: MissionProject,
+    /// Activity timestamps (last_status_change_at persisted; event timestamps
+    /// computed on read). Flattened so the fields appear top-level.
+    #[serde(default, flatten)]
+    pub activity: MissionActivity,
+    /// When `status` is `AwaitingUser`, classifies whether the agent needs a
+    /// decision or just an acknowledgement. `None` for every other status.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub awaiting_kind: Option<AwaitingKind>,
 }
 
 /// Aggregate mission counts by status.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct MissionStatusCounts {
     pub total: usize,
     pub active: usize,
@@ -1432,6 +1554,40 @@ pub trait MissionStore: Send + Sync {
         metadata_model: Option<Option<&str>>,
         metadata_version: Option<Option<&str>>,
     ) -> Result<(), String>;
+
+    /// Update project tagging metadata (see [`MissionProjectPatch`] for the
+    /// tri-state semantics). Default no-op for stores that do not persist it.
+    async fn update_mission_project(
+        &self,
+        id: Uuid,
+        patch: MissionProjectPatch,
+    ) -> Result<(), String> {
+        let _ = (id, patch);
+        Ok(())
+    }
+
+    /// Computed activity timestamps for the given missions, keyed by id:
+    /// `(last_agent_event_at, last_output_at)` derived from the event log.
+    /// Empty map by default (stores without an event log skip this).
+    async fn get_mission_activity(
+        &self,
+        ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, (Option<String>, Option<String>)>, String> {
+        let _ = ids;
+        Ok(std::collections::HashMap::new())
+    }
+
+    /// Set (or clear) the `awaiting_kind` classification for a mission. Only
+    /// meaningful while the mission is in `AwaitingUser`. Default no-op for
+    /// stores that do not persist it.
+    async fn set_mission_awaiting_kind(
+        &self,
+        id: Uuid,
+        kind: Option<AwaitingKind>,
+    ) -> Result<(), String> {
+        let _ = (id, kind);
+        Ok(())
+    }
 
     /// Update mission session ID (for backends that generate their own IDs).
     async fn update_mission_session_id(&self, id: Uuid, session_id: &str) -> Result<(), String>;
@@ -3169,6 +3325,9 @@ mod tests {
                 not_before: not_before.map(|s| s.to_string()),
                 deadline: None,
             },
+            project: MissionProject::default(),
+            activity: MissionActivity::default(),
+            awaiting_kind: None,
         }
     }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3398,10 +3398,12 @@ impl MissionStore for SqliteMissionStore {
             let conn = conn.blocking_lock();
             let placeholders = vec!["?"; id_strings.len()].join(",");
             // last_agent_event_at = newest event of any kind; last_output_at =
-            // newest assistant message. Backed by idx_events_mission_timestamp.
+            // newest assistant message (assistant text is logged as either
+            // `assistant_message` or `assistant_message_canonical`). Backed by
+            // idx_events_mission_timestamp.
             let sql = format!(
                 "SELECT mission_id, MAX(timestamp) AS last_event, \
-                 MAX(CASE WHEN event_type = 'assistant_message' THEN timestamp END) AS last_output \
+                 MAX(CASE WHEN event_type IN ('assistant_message', 'assistant_message_canonical') THEN timestamp END) AS last_output \
                  FROM mission_events WHERE mission_id IN ({placeholders}) GROUP BY mission_id"
             );
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -3396,10 +3396,7 @@ impl MissionStore for SqliteMissionStore {
         let id_strings: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
-            let placeholders = std::iter::repeat("?")
-                .take(id_strings.len())
-                .collect::<Vec<_>>()
-                .join(",");
+            let placeholders = vec!["?"; id_strings.len()].join(",");
             // last_agent_event_at = newest event of any kind; last_output_at =
             // newest assistant message. Backed by idx_events_mission_timestamp.
             let sql = format!(

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -1,12 +1,13 @@
 //! SQLite-based mission store with full event logging.
 
 use super::{
-    now_string, sanitize_filename, Automation, AutomationExecution, BoardTask, BoardTaskOutcome,
-    BoardTaskStatus, CommandSource, DailyUsageStats, ExecutionStatus, FreshSession,
-    HourlyUsageStats, Mission, MissionHistoryEntry, MissionMode, MissionScheduling, MissionStatus,
-    MissionStatusCounts, MissionStore, ModelUsageStats, NewBoardTask, PalomaCooldownState,
-    PalomaDecision, PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig,
-    StopPolicy, StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
+    now_string, sanitize_filename, Automation, AutomationExecution, AwaitingKind, BoardTask,
+    BoardTaskOutcome, BoardTaskStatus, CommandSource, DailyUsageStats, ExecutionStatus,
+    FreshSession, HourlyUsageStats, Mission, MissionActivity, MissionHistoryEntry, MissionMode,
+    MissionProject, MissionProjectPatch, MissionScheduling, MissionStatus, MissionStatusCounts,
+    MissionStore, ModelUsageStats, NewBoardTask, PalomaCooldownState, PalomaDecision,
+    PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig, StopPolicy,
+    StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
     TelegramActionExecutionStatus, TelegramAlert, TelegramAlertPreference, TelegramChannel,
     TelegramChatMission, TelegramConversation, TelegramConversationMessage,
     TelegramConversationMessageDirection, TelegramMissionInterestLevel,
@@ -496,7 +497,14 @@ CREATE TABLE IF NOT EXISTS missions (
     not_before TEXT,
     deadline TEXT,
     deferred_goal TEXT,
-    paused_at TEXT
+    paused_at TEXT,
+    project TEXT,
+    track TEXT,
+    intent TEXT,
+    github_pr INTEGER,
+    tags TEXT,
+    awaiting_kind TEXT,
+    last_status_change_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
@@ -2088,6 +2096,38 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add paused_at column: {}", e))?;
         }
 
+        // Project tagging + awaiting_kind classification + activity timestamps.
+        // Lets external consumers (Paloma) group/filter/route missions, tell
+        // "needs a decision" apart from "finished, please ack", and reason about
+        // staleness without parsing titles or replaying events. All nullable,
+        // added if missing.
+        for (column, sql_type) in [
+            ("project", "TEXT"),
+            ("track", "TEXT"),
+            ("intent", "TEXT"),
+            ("github_pr", "INTEGER"),
+            ("tags", "TEXT"),
+            ("awaiting_kind", "TEXT"),
+            ("last_status_change_at", "TEXT"),
+        ] {
+            let exists: bool = conn
+                .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = ?1")
+                .map_err(|e| format!("Failed to check for {} column: {}", column, e))?
+                .exists(params![column])
+                .map_err(|e| format!("Failed to query table info: {}", e))?;
+            if !exists {
+                tracing::info!(
+                    "Running migration: adding '{}' column to missions table",
+                    column
+                );
+                conn.execute(
+                    &format!("ALTER TABLE missions ADD COLUMN {} {}", column, sql_type),
+                    [],
+                )
+                .map_err(|e| format!("Failed to add {} column: {}", column, e))?;
+            }
+        }
+
         Ok(())
     }
 
@@ -2370,6 +2410,47 @@ fn status_to_string(status: MissionStatus) -> &'static str {
     }
 }
 
+/// Serialize mission tags to a JSON array string for storage. `None` when empty
+/// (keeps the column NULL rather than `"[]"`).
+fn tags_to_json(tags: &[String]) -> Option<String> {
+    if tags.is_empty() {
+        None
+    } else {
+        serde_json::to_string(tags).ok()
+    }
+}
+
+/// Parse a stored JSON array of tags. Tolerates NULL / malformed values.
+fn tags_from_json(raw: Option<String>) -> Vec<String> {
+    raw.as_deref()
+        .and_then(|s| serde_json::from_str::<Vec<String>>(s).ok())
+        .unwrap_or_default()
+}
+
+/// Read the trailing project/activity columns from a mission row in the
+/// canonical order `project, track, intent, github_pr, tags, awaiting_kind,
+/// last_status_change_at` starting at `base`. Shared by the full SELECTs so the
+/// index math lives in one place. Returns the project metadata, the awaiting
+/// classification, and the persisted `last_status_change_at`.
+fn read_project_columns(
+    row: &rusqlite::Row,
+    base: usize,
+) -> rusqlite::Result<(MissionProject, Option<AwaitingKind>, Option<String>)> {
+    let project = MissionProject {
+        project: row.get(base)?,
+        track: row.get(base + 1)?,
+        intent: row.get(base + 2)?,
+        github_pr: row.get(base + 3)?,
+        tags: tags_from_json(row.get(base + 4)?),
+    };
+    let awaiting_kind = row
+        .get::<_, Option<String>>(base + 5)?
+        .as_deref()
+        .and_then(AwaitingKind::from_str_opt);
+    let last_status_change_at: Option<String> = row.get(base + 6)?;
+    Ok((project, awaiting_kind, last_status_change_at))
+}
+
 #[async_trait]
 impl MissionStore for SqliteMissionStore {
     fn is_persistent(&self) -> bool {
@@ -2389,7 +2470,8 @@ impl MissionStore for SqliteMissionStore {
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode,
                             COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
-                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at
+                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
+                            project, track, intent, github_pr, tags, awaiting_kind, last_status_change_at
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2406,6 +2488,8 @@ impl MissionStore for SqliteMissionStore {
                     let session_id: Option<String> = row.get(19)?;
                     let terminal_reason: Option<String> = row.get(20)?;
                     let config_profile: Option<String> = row.get(21)?;
+                    let (project, awaiting_kind, last_status_change_at) =
+                        read_project_columns(row, 32)?;
 
                     Ok(Mission {
                         id: parse_uuid_or_nil(&id_str),
@@ -2448,6 +2532,12 @@ impl MissionStore for SqliteMissionStore {
                                 not_before: row.get(29).ok().flatten(),
                                 deadline: row.get(30).ok().flatten(),
                             },
+                            project,
+                            activity: MissionActivity {
+                                last_status_change_at,
+                                ..Default::default()
+                            },
+                            awaiting_kind,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2508,7 +2598,8 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(backend, 'opencode') as backend, session_id, terminal_reason,
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
-                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at FROM missions WHERE id = ?1",
+                            COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
+                            project, track, intent, github_pr, tags, awaiting_kind, last_status_change_at FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -2522,6 +2613,8 @@ impl MissionStore for SqliteMissionStore {
                     let session_id: Option<String> = row.get(19)?;
                     let terminal_reason: Option<String> = row.get(20)?;
                     let config_profile: Option<String> = row.get(21)?;
+                    let (project, awaiting_kind, last_status_change_at) =
+                        read_project_columns(row, 32)?;
 
                     Ok(Mission {
                         id: parse_uuid_or_nil(&id_str),
@@ -2564,6 +2657,12 @@ impl MissionStore for SqliteMissionStore {
                                 not_before: row.get(29).ok().flatten(),
                                 deadline: row.get(30).ok().flatten(),
                             },
+                            project,
+                            activity: MissionActivity {
+                                last_status_change_at,
+                                ..Default::default()
+                            },
+                            awaiting_kind,
                     })
                 })
                 .optional()
@@ -2685,6 +2784,9 @@ impl MissionStore for SqliteMissionStore {
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: MissionProject::default(),
+            activity: MissionActivity::default(),
+            awaiting_kind: None,
         };
 
         let m = mission.clone();
@@ -2695,8 +2797,8 @@ impl MissionStore for SqliteMissionStore {
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
             conn.execute(
-                "INSERT INTO missions (id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, agent, model_override, model_effort, backend, config_profile, created_at, updated_at, resumable, session_id, parent_mission_id, working_directory, mission_mode, goal_mode, goal_objective)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
+                "INSERT INTO missions (id, status, title, short_description, metadata_updated_at, metadata_source, metadata_model, metadata_version, workspace_id, agent, model_override, model_effort, backend, config_profile, created_at, updated_at, resumable, session_id, parent_mission_id, working_directory, mission_mode, goal_mode, goal_objective, last_status_change_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
                 params![
                     m.id.to_string(),
                     status_to_string(m.status),
@@ -2721,6 +2823,7 @@ impl MissionStore for SqliteMissionStore {
                     mission_mode_str,
                     if m.goal_mode { 1i64 } else { 0i64 },
                     m.goal_objective,
+                    m.created_at,
                 ],
             )
             .map_err(|e| e.to_string())?;
@@ -2776,6 +2879,9 @@ impl MissionStore for SqliteMissionStore {
                             goal_objective: row.get(24).ok().flatten(),
                             first_viewed_at: None,
                             scheduling: Default::default(),
+                            project: MissionProject::default(),
+                            activity: MissionActivity::default(),
+                            awaiting_kind: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -2845,6 +2951,10 @@ impl MissionStore for SqliteMissionStore {
         // clear `first_viewed_at` so the next AwaitingUser round starts fresh
         // (and so the "opened" dot disappears once the agent picks up again).
         let clear_first_viewed_at = matches!(status, MissionStatus::Active);
+        // `awaiting_kind` only describes an `AwaitingUser` mission. Any status
+        // change away from AwaitingUser must clear it so a stale classification
+        // can't leak to consumers once the mission is running/terminal again.
+        let clear_awaiting_kind = !matches!(status, MissionStatus::AwaitingUser);
 
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
@@ -2862,7 +2972,7 @@ impl MissionStore for SqliteMissionStore {
                 .ok();
             if clear_first_viewed_at {
                 conn.execute(
-                    "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5, first_viewed_at = NULL WHERE id = ?6",
+                    "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5, first_viewed_at = NULL, awaiting_kind = CASE WHEN ?7 THEN NULL ELSE awaiting_kind END, last_status_change_at = CASE WHEN status <> ?1 THEN ?2 ELSE last_status_change_at END WHERE id = ?6",
                     params![
                         status_to_string(status),
                         now,
@@ -2870,12 +2980,13 @@ impl MissionStore for SqliteMissionStore {
                         if resumable { 1 } else { 0 },
                         terminal_reason,
                         id.to_string(),
+                        clear_awaiting_kind,
                     ],
                 )
                 .map_err(|e| e.to_string())?;
             } else {
                 conn.execute(
-                    "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5 WHERE id = ?6",
+                    "UPDATE missions SET status = ?1, updated_at = ?2, interrupted_at = ?3, resumable = ?4, terminal_reason = ?5, awaiting_kind = CASE WHEN ?7 THEN NULL ELSE awaiting_kind END, last_status_change_at = CASE WHEN status <> ?1 THEN ?2 ELSE last_status_change_at END WHERE id = ?6",
                     params![
                         status_to_string(status),
                         now,
@@ -2883,6 +2994,7 @@ impl MissionStore for SqliteMissionStore {
                         if resumable { 1 } else { 0 },
                         terminal_reason,
                         id.to_string(),
+                        clear_awaiting_kind,
                     ],
                 )
                 .map_err(|e| e.to_string())?;
@@ -3218,6 +3330,125 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn update_mission_project(
+        &self,
+        id: Uuid,
+        patch: MissionProjectPatch,
+    ) -> Result<(), String> {
+        if patch.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.conn.clone();
+        let now = now_string();
+        let project_set = patch.project.is_some();
+        let track_set = patch.track.is_some();
+        let intent_set = patch.intent.is_some();
+        let github_pr_set = patch.github_pr.is_some();
+        let tags_set = patch.tags.is_some();
+        let project = patch.project.flatten();
+        let track = patch.track.flatten();
+        let intent = patch.intent.flatten();
+        let github_pr = patch.github_pr.flatten();
+        let tags_json = patch.tags.as_deref().and_then(tags_to_json);
+
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions
+                 SET project = CASE WHEN ?1 THEN ?2 ELSE project END,
+                     track = CASE WHEN ?3 THEN ?4 ELSE track END,
+                     intent = CASE WHEN ?5 THEN ?6 ELSE intent END,
+                     github_pr = CASE WHEN ?7 THEN ?8 ELSE github_pr END,
+                     tags = CASE WHEN ?9 THEN ?10 ELSE tags END,
+                     updated_at = ?11
+                 WHERE id = ?12",
+                params![
+                    project_set,
+                    project,
+                    track_set,
+                    track,
+                    intent_set,
+                    intent,
+                    github_pr_set,
+                    github_pr,
+                    tags_set,
+                    tags_json,
+                    now,
+                    id.to_string(),
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn get_mission_activity(
+        &self,
+        ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, (Option<String>, Option<String>)>, String> {
+        if ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let conn = self.conn.clone();
+        let id_strings: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let placeholders = std::iter::repeat("?")
+                .take(id_strings.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            // last_agent_event_at = newest event of any kind; last_output_at =
+            // newest assistant message. Backed by idx_events_mission_timestamp.
+            let sql = format!(
+                "SELECT mission_id, MAX(timestamp) AS last_event, \
+                 MAX(CASE WHEN event_type = 'assistant_message' THEN timestamp END) AS last_output \
+                 FROM mission_events WHERE mission_id IN ({placeholders}) GROUP BY mission_id"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(rusqlite::params_from_iter(id_strings.iter()), |row| {
+                    let mid: String = row.get(0)?;
+                    let last_event: Option<String> = row.get(1)?;
+                    let last_output: Option<String> = row.get(2)?;
+                    Ok((mid, last_event, last_output))
+                })
+                .map_err(|e| e.to_string())?;
+            let mut out = std::collections::HashMap::new();
+            for row in rows {
+                let (mid, last_event, last_output) = row.map_err(|e| e.to_string())?;
+                if let Ok(uuid) = Uuid::parse_str(&mid) {
+                    out.insert(uuid, (last_event, last_output));
+                }
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn set_mission_awaiting_kind(
+        &self,
+        id: Uuid,
+        kind: Option<AwaitingKind>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let kind_str = kind.map(|k| k.as_str().to_string());
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE missions SET awaiting_kind = ?1 WHERE id = ?2",
+                params![kind_str, id.to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
     async fn update_mission_session_id(&self, id: Uuid, session_id: &str) -> Result<(), String> {
         let conn = self.conn.clone();
         let now = now_string();
@@ -3457,6 +3688,9 @@ impl MissionStore for SqliteMissionStore {
                         goal_objective: None,
                         first_viewed_at: None,
                         scheduling: Default::default(),
+                        project: MissionProject::default(),
+                        activity: MissionActivity::default(),
+                        awaiting_kind: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -3533,6 +3767,9 @@ impl MissionStore for SqliteMissionStore {
                         goal_objective: row.get(15).ok().flatten(),
                         first_viewed_at: None,
                         scheduling: Default::default(),
+                        project: MissionProject::default(),
+                        activity: MissionActivity::default(),
+                        awaiting_kind: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -3670,6 +3907,9 @@ impl MissionStore for SqliteMissionStore {
                             not_before: row.get(17).ok().flatten(),
                             deadline: row.get(18).ok().flatten(),
                         },
+                        project: MissionProject::default(),
+                        activity: MissionActivity::default(),
+                        awaiting_kind: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -6096,6 +6336,9 @@ impl MissionStore for SqliteMissionStore {
                         goal_objective: None,
                         first_viewed_at: None,
                         scheduling: Default::default(),
+                        project: MissionProject::default(),
+                        activity: MissionActivity::default(),
+                        awaiting_kind: None,
                     })
                 })
                 .map_err(|e| e.to_string())?
@@ -10238,10 +10481,10 @@ mod tests {
     };
     use crate::api::control::AgentEvent;
     use crate::api::mission_store::{
-        now_string, Automation, AutomationDriver, CommandSource, FreshSession, MissionMode,
-        MissionStatus, MissionStore, PalomaCooldownState, PalomaDecision, PalomaMissionCard,
-        PalomaSchedulerJob, PalomaUserPreferences, RetryConfig, StopPolicy, TelegramAlert,
-        TelegramAlertPreference, TelegramChannel, TelegramConversation,
+        now_string, Automation, AutomationDriver, AwaitingKind, CommandSource, FreshSession,
+        MissionMode, MissionProjectPatch, MissionStatus, MissionStore, PalomaCooldownState,
+        PalomaDecision, PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig,
+        StopPolicy, TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramConversation,
         TelegramConversationMessage, TelegramConversationMessageDirection,
         TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramStructuredMemoryEntry,
         TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramTriggerMode,
@@ -11244,6 +11487,99 @@ mod tests {
         assert_eq!(mission.short_description, None);
         assert_eq!(mission.metadata_source, None);
         assert_eq!(mission.metadata_version, None);
+    }
+
+    #[tokio::test]
+    async fn project_metadata_and_awaiting_kind_roundtrip() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Tagged"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+
+        // Fresh mission has no project metadata or awaiting_kind.
+        assert!(mission.project.is_empty());
+        assert_eq!(mission.awaiting_kind, None);
+
+        store
+            .update_mission_project(
+                mission.id,
+                MissionProjectPatch {
+                    project: Some(Some("verity-core".to_string())),
+                    track: Some(Some("C3-bridge-collapse".to_string())),
+                    intent: Some(Some("repair-build".to_string())),
+                    github_pr: Some(Some(2061)),
+                    tags: Some(vec!["c3".to_string(), "blocking".to_string()]),
+                },
+            )
+            .await
+            .expect("set project");
+
+        let fetched = store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(fetched.project.project.as_deref(), Some("verity-core"));
+        assert_eq!(fetched.project.track.as_deref(), Some("C3-bridge-collapse"));
+        assert_eq!(fetched.project.intent.as_deref(), Some("repair-build"));
+        assert_eq!(fetched.project.github_pr, Some(2061));
+        assert_eq!(fetched.project.tags, vec!["c3", "blocking"]);
+
+        // Partial update leaves untouched fields intact and can clear one.
+        store
+            .update_mission_project(
+                mission.id,
+                MissionProjectPatch {
+                    project: Some(None),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("clear project");
+        let fetched = store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(fetched.project.project, None);
+        assert_eq!(fetched.project.track.as_deref(), Some("C3-bridge-collapse"));
+        assert_eq!(fetched.project.github_pr, Some(2061));
+        assert_eq!(fetched.project.tags, vec!["c3", "blocking"]);
+
+        // awaiting_kind persists, and is cleared on a status change away from
+        // AwaitingUser.
+        store
+            .set_mission_awaiting_kind(mission.id, Some(AwaitingKind::Decision))
+            .await
+            .expect("set kind");
+        store
+            .update_mission_status(mission.id, MissionStatus::AwaitingUser)
+            .await
+            .expect("awaiting status");
+        let fetched = store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(fetched.awaiting_kind, Some(AwaitingKind::Decision));
+
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .expect("active status");
+        let fetched = store
+            .get_mission(mission.id)
+            .await
+            .expect("get")
+            .expect("exists");
+        assert_eq!(
+            fetched.awaiting_kind, None,
+            "awaiting_kind must clear when leaving AwaitingUser"
+        );
     }
 
     #[tokio::test]

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -282,6 +282,9 @@ mod tests {
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         }
     }
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -694,6 +694,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         // State snapshots (for refresh resilience)
         .route("/api/control/progress", get(control::get_progress))
         // Mission management endpoints
+        .route("/api/health/fleet", get(control::fleet_health))
         .route("/api/control/missions", get(control::list_missions))
         .route("/api/control/missions", post(control::create_mission))
         .route(
@@ -760,6 +761,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .route(
             "/api/control/missions/:id/settings",
             patch(control::update_mission_settings),
+        )
+        .route(
+            "/api/control/missions/:id/project",
+            post(control::update_mission_project),
         )
         .route(
             "/api/control/missions/:id/mode",

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -6841,6 +6841,9 @@ mod tests {
             goal_objective: None,
             first_viewed_at: None,
             scheduling: Default::default(),
+            project: Default::default(),
+            activity: Default::default(),
+            awaiting_kind: None,
         }
     }
 

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -609,29 +609,27 @@ impl AssistantMcp {
 
     async fn list_missions(&self, params: ListMissionsParams) -> Result<Value, String> {
         let limit = params.limit.clamp(1, 100);
-        let response = self
-            .api_get(&format!("/api/control/missions?limit={limit}&offset=0"))
-            .await?;
+        // Forward filters to the API so it does the (paginated, scan-bounded)
+        // matching server-side — filtering only the fetched page here would miss
+        // matches outside the window on a larger fleet.
+        let mut path = format!("/api/control/missions?limit={limit}&offset=0");
+        if let Some(status) = params.status.as_deref() {
+            path.push_str(&format!("&status={}", urlencoding::encode(status)));
+        }
+        if let Some(project) = params.project.as_deref() {
+            path.push_str(&format!("&project={}", urlencoding::encode(project)));
+        }
+        if let Some(tag) = params.tag.as_deref() {
+            path.push_str(&format!("&tag={}", urlencoding::encode(tag)));
+        }
+        let response = self.api_get(&path).await?;
         if !response.status().is_success() {
             return Err(format!("Failed to list missions: {}", response.status()));
         }
-        let mut missions: Vec<Value> = response
+        let missions: Vec<Value> = response
             .json()
             .await
             .map_err(|error| format!("Failed to parse missions: {error}"))?;
-        if let Some(status) = params.status {
-            missions.retain(|mission| mission["status"].as_str() == Some(status.as_str()));
-        }
-        if let Some(project) = params.project.as_deref() {
-            missions.retain(|mission| mission["project"].as_str() == Some(project));
-        }
-        if let Some(tag) = params.tag.as_deref() {
-            missions.retain(|mission| {
-                mission["tags"]
-                    .as_array()
-                    .is_some_and(|tags| tags.iter().any(|t| t.as_str() == Some(tag)))
-            });
-        }
         let missions = missions
             .into_iter()
             .map(compact_mission_summary)

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -84,6 +84,10 @@ struct ListMissionsParams {
     status: Option<String>,
     #[serde(default = "default_limit")]
     limit: usize,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    tag: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -423,18 +427,22 @@ impl AssistantMcp {
                 input_schema: json!({
                     "type": "object",
                     "properties": {
-                        "limit": {"type": "integer", "description": "Maximum missions to return, default 50."}
+                        "limit": {"type": "integer", "description": "Maximum missions to return, default 50."},
+                        "project": {"type": "string", "description": "Optional filter: only missions with this project."},
+                        "tag": {"type": "string", "description": "Optional filter: only missions carrying this tag."}
                     }
                 }),
             },
             ToolDefinition {
                 name: "list_missions".to_string(),
-                description: "List recent missions, optionally filtered by status.".to_string(),
+                description: "List recent missions, optionally filtered by status, project, or tag.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
                         "status": {"type": "string", "description": "Optional mission status filter."},
-                        "limit": {"type": "integer", "description": "Maximum missions to return, default 50."}
+                        "limit": {"type": "integer", "description": "Maximum missions to return, default 50."},
+                        "project": {"type": "string", "description": "Optional filter: only missions with this project."},
+                        "tag": {"type": "string", "description": "Optional filter: only missions carrying this tag."}
                     }
                 }),
             },
@@ -614,6 +622,16 @@ impl AssistantMcp {
         if let Some(status) = params.status {
             missions.retain(|mission| mission["status"].as_str() == Some(status.as_str()));
         }
+        if let Some(project) = params.project.as_deref() {
+            missions.retain(|mission| mission["project"].as_str() == Some(project));
+        }
+        if let Some(tag) = params.tag.as_deref() {
+            missions.retain(|mission| {
+                mission["tags"]
+                    .as_array()
+                    .is_some_and(|tags| tags.iter().any(|t| t.as_str() == Some(tag)))
+            });
+        }
         let missions = missions
             .into_iter()
             .map(compact_mission_summary)
@@ -621,7 +639,12 @@ impl AssistantMcp {
         Ok(json!({ "missions": missions }))
     }
 
-    async fn list_active_missions(&self, limit: usize) -> Result<Value, String> {
+    async fn list_active_missions(
+        &self,
+        limit: usize,
+        project: Option<String>,
+        tag: Option<String>,
+    ) -> Result<Value, String> {
         let requested = limit.clamp(1, 100);
         // The API returns the most recent missions regardless of status, so a
         // narrow fetch limit can be fully consumed by recent completed missions
@@ -632,6 +655,8 @@ impl AssistantMcp {
             .list_missions(ListMissionsParams {
                 status: None,
                 limit: fetch_limit,
+                project,
+                tag,
             })
             .await?;
         if let Some(missions) = result["missions"].as_array_mut() {
@@ -1201,7 +1226,8 @@ impl AssistantMcp {
             "list_active_missions" => {
                 let params: ListMissionsParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
-                self.list_active_missions(params.limit).await
+                self.list_active_missions(params.limit, params.project, params.tag)
+                    .await
             }
             "list_missions" => {
                 let params: ListMissionsParams = serde_json::from_value(arguments)
@@ -1339,6 +1365,17 @@ fn compact_mission_summary(mission: Value) -> Value {
         "workspace_name": mission.get("workspace_name").cloned().unwrap_or(Value::Null),
         "short_description": mission.get("short_description").cloned().unwrap_or(Value::Null),
         "updated_at": mission.get("updated_at").cloned().unwrap_or(Value::Null),
+        // Project tagging + awaiting classification + staleness anchors so
+        // consumers can group/route/triage missions without parsing titles or
+        // replaying events.
+        "project": mission.get("project").cloned().unwrap_or(Value::Null),
+        "track": mission.get("track").cloned().unwrap_or(Value::Null),
+        "intent": mission.get("intent").cloned().unwrap_or(Value::Null),
+        "github_pr": mission.get("github_pr").cloned().unwrap_or(Value::Null),
+        "tags": mission.get("tags").cloned().unwrap_or_else(|| json!([])),
+        "awaiting_kind": mission.get("awaiting_kind").cloned().unwrap_or(Value::Null),
+        "last_activity_at": mission.get("last_activity_at").cloned().unwrap_or(Value::Null),
+        "last_status_change_at": mission.get("last_status_change_at").cloned().unwrap_or(Value::Null),
     })
 }
 
@@ -1751,12 +1788,25 @@ mod tests {
             "workspace_name": "assistant",
             "short_description": "Build fix",
             "updated_at": "2026-05-28T12:00:00Z",
+            "project": "verity-core",
+            "track": "C3-bridge-collapse",
+            "github_pr": 2061,
+            "tags": ["c3", "sprint-2"],
+            "awaiting_kind": "decision",
             "prompt": "secret prompt",
             "api_token": "sk-test",
         }));
 
         assert_eq!(summary["id"], "mission-1");
         assert_eq!(summary["workspace_name"], "assistant");
+        assert_eq!(summary["project"], "verity-core");
+        assert_eq!(summary["track"], "C3-bridge-collapse");
+        assert_eq!(summary["github_pr"], 2061);
+        assert_eq!(summary["tags"][1], "sprint-2");
+        assert_eq!(summary["awaiting_kind"], "decision");
+        // Missions without tags get an empty array, not null.
+        let bare = compact_mission_summary(json!({"id": "m2"}));
+        assert_eq!(bare["tags"], json!([]));
         assert!(summary.get("prompt").is_none());
         assert!(summary.get("api_token").is_none());
     }


### PR DESCRIPTION
Mission-level metadata + observability surfaces so external consumers (Paloma/Hermes) can group, route, and triage missions without parsing free-text titles or replaying events.

## Project tagging
- `project` / `track` / `intent` / `github_pr` / `tags` (flattened `MissionProject` on `Mission`; SQLite columns + idempotent migration; tri-state `MissionProjectPatch`).
- `POST /api/control/missions/:id/project`; accepted at creation; inherited by clones.
- `GET /api/control/missions` filters: `?status=&project=&tag=&workspace=`.
- assistant MCP `list_missions`/`list_active_missions` filter by `project`/`tag`; compact summary carries the fields.

## awaiting_kind (decision vs ack)
- Classify why a mission parks in `awaiting_user` from the last assistant message; cleared on any transition away (all stores).
- Dashboard: **Needs Decision** vs **Awaiting Review** instead of the ambiguous "Needs You".

## Webhook (structured + idempotent)
- Forward `awaiting_user|completed|failed|interrupted|acknowledged` with workspace, backend, updated_at, short_description, project fields, awaiting_kind, last_status_change_at.
- `event_id` + `sequence` + at-least-once retry for idempotent consumers.

## Activity timestamps
- `last_status_change_at` (persisted), `last_agent_event_at` / `last_output_at` / `last_activity_at` (computed from the event log) on list + detail.

## Fleet health + offload + smoke
- `GET /api/health/fleet`: control_responsive, running, queue_depth, status counts, webhook/offload configured.
- `spark_offload {enabled, env_injected, host_configured}` on mission detail.
- `scripts/prod-smoke-fleet.sh` post-deploy check.

## Tests
- project/awaiting_kind roundtrip + clear-on-leave; classifier units; MCP summary fields. Backend `cargo check --bins` + targeted tests green; dashboard `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission lifecycle finalization, status webhooks, and SQLite migrations on core control paths; heuristic awaiting_kind and expanded webhook statuses may change external consumer behavior.
> 
> **Overview**
> Adds **structured mission metadata and fleet observability** so Paloma/Hermes can group, filter, and triage missions without parsing titles or replaying events.
> 
> **Project tagging** introduces flattened `project` / `track` / `intent` / `github_pr` / `tags` on missions (SQLite migration + all stores), `POST /api/control/missions/:id/project`, optional fields at create and on clone, and list filters `?status=&project=&tag=&workspace=` with a bounded in-memory scan when filters are present. The dashboard workbench and mission switcher show project/PR/tags and include them in search scoring; the assistant MCP forwards filters and exposes the fields in compact summaries.
> 
> **`awaiting_kind`** (`decision` vs `ack`) is inferred when a turn parks in `awaiting_user` (from the latest assistant output), persisted, cleared on leave, and included in webhooks. UI copy splits **Needs Decision** (amber) from **Awaiting Review** (sky) instead of a single “Needs You”.
> 
> **Activity** adds persisted `last_status_change_at` plus computed `last_agent_event_at`, `last_output_at`, and `last_activity_at` on mission list/detail. Mission detail also attaches **`spark_offload`** status for routing heavy builds.
> 
> **Paloma webhooks** now forward more terminal/actionable statuses (including `interrupted` and `acknowledged`), richer payloads (workspace, project fields, `awaiting_kind`, timestamps), and **`event_id` + `sequence`** with bounded retries for at-least-once delivery.
> 
> **Ops**: new authenticated **`GET /api/health/fleet`** (control responsiveness, queue, counts, config flags) and **`scripts/prod-smoke-fleet.sh`** for post-deploy checks against health, filters, project updates, and acknowledge flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3499b4b4fcf2ca281709ec5229bdf5ff36fbf942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->