### PR TITLE
feat(missions): forward project metadata on MCP create + track state + /tracks

### DIFF
--- a/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
+++ b/dashboard/src/app/control/components/MissionWorkbenchPanel.tsx
@@ -260,10 +260,20 @@ export function MissionWorkbenchPanel({
                   </span>
                 </Row>
               )}
-              {mission.github_pr != null && (
+              {mission.github_pr && (
                 <Row label="PR">
-                  <span className="font-mono text-white/70">
-                    #{mission.github_pr}
+                  <span
+                    className="truncate font-mono text-white/70 max-w-[160px]"
+                    title={mission.github_pr}
+                  >
+                    {mission.github_pr}
+                  </span>
+                </Row>
+              )}
+              {mission.desired_state && (
+                <Row label="State">
+                  <span className="font-mono text-sky-300/80">
+                    {mission.desired_state}
                   </span>
                 </Row>
               )}

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -78,12 +78,16 @@ export interface Mission {
   project?: string | null;
   /** Project tagging: track / workstream within the project. */
   track?: string | null;
-  /** Project tagging: intent (e.g. "repair-build"). */
+  /** Project tagging: intent (e.g. "review_merge_pr"). */
   intent?: string | null;
-  /** Project tagging: associated GitHub PR number. */
-  github_pr?: number | null;
+  /** Project tagging: associated GitHub PR ref (e.g. "owner/repo#123"). */
+  github_pr?: string | null;
   /** Project tagging: freeform tags. */
   tags?: string[];
+  /** Track state, e.g. "waiting_ci" / "waiting_review" / "blocked_external". */
+  desired_state?: string | null;
+  /** When the track should next be checked (RFC3339). */
+  next_check_at?: string | null;
   /**
    * When `status` is `awaiting_user`, classifies whether the agent needs a
    * decision (a real question) or is just waiting to be acked/merged.
@@ -447,8 +451,10 @@ export async function updateMissionProject(
     project?: string | null;
     track?: string | null;
     intent?: string | null;
-    github_pr?: number | null;
+    github_pr?: string | null;
     tags?: string[];
+    desired_state?: string | null;
+    next_check_at?: string | null;
   },
 ): Promise<Mission> {
   const res = await apiFetch(`/api/control/missions/${id}/project`, {
@@ -465,6 +471,27 @@ export async function updateMissionProject(
 
 export async function getRunningMissions(): Promise<RunningMissionInfo[]> {
   return apiGet("/api/control/running", "Failed to fetch running missions");
+}
+
+/** Per project/track rollup (`GET /api/control/tracks`). */
+export interface TrackSummary {
+  project?: string | null;
+  track?: string | null;
+  total: number;
+  active: number;
+  pending: number;
+  awaiting_user: number;
+  last_activity_at?: string | null;
+  latest_terminal_at?: string | null;
+  desired_state?: string | null;
+  github_pr?: string | null;
+  next_check_at?: string | null;
+}
+
+/** List project/track rollups, optionally restricted to one project. */
+export async function listTracks(project?: string): Promise<TrackSummary[]> {
+  const qs = project ? `?project=${encodeURIComponent(project)}` : "";
+  return apiGet(`/api/control/tracks${qs}`, "Failed to fetch tracks");
 }
 
 export async function startMissionParallel(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3991,6 +3991,129 @@ pub async fn fleet_health(
     }))
 }
 
+/// Per project/track rollup so Paloma can reason about a track in one call
+/// instead of scanning the fleet and parsing titles. Keyed by (project, track).
+#[derive(Debug, Clone, Serialize)]
+pub struct TrackSummary {
+    pub project: Option<String>,
+    pub track: Option<String>,
+    pub total: usize,
+    pub active: usize,
+    pub pending: usize,
+    pub awaiting_user: usize,
+    /// `updated_at` of the most recently updated mission in the track.
+    pub last_activity_at: Option<String>,
+    /// `updated_at` of the most recent terminal (completed/failed/…) mission.
+    pub latest_terminal_at: Option<String>,
+    /// Operator-declared state / PR / next-check, taken from the most recently
+    /// updated mission in the track that has each set.
+    pub desired_state: Option<String>,
+    pub github_pr: Option<String>,
+    pub next_check_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TracksQuery {
+    /// Optional: restrict to one project.
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// GET /api/control/tracks — roll missions up by (project, track). Untagged
+/// missions (no project and no track) are omitted. Scans newest-first up to a
+/// bounded ceiling.
+pub async fn list_tracks(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Query(query): Query<TracksQuery>,
+) -> Result<Json<Vec<TrackSummary>>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    const PAGE: usize = 200;
+    const MAX_SCAN: usize = 5_000;
+
+    // Preserve newest-first arrival order of groups, and let the first (most
+    // recent) mission seed each track's desired_state/github_pr/next_check_at.
+    let mut order: Vec<(String, String)> = Vec::new();
+    let mut groups: std::collections::HashMap<(String, String), TrackSummary> =
+        std::collections::HashMap::new();
+
+    let mut offset = 0usize;
+    while offset < MAX_SCAN {
+        let page = control
+            .mission_store
+            .list_missions(PAGE, offset)
+            .await
+            .map_err(internal_error)?;
+        let page_len = page.len();
+        for m in page {
+            let proj = m.project.project.clone();
+            let track = m.project.track.clone();
+            if proj.is_none() && track.is_none() {
+                continue; // untagged — not part of any track
+            }
+            if let Some(want) = query.project.as_deref() {
+                if proj.as_deref() != Some(want) {
+                    continue;
+                }
+            }
+            let key = (
+                proj.clone().unwrap_or_default(),
+                track.clone().unwrap_or_default(),
+            );
+            let entry = groups.entry(key.clone()).or_insert_with(|| {
+                order.push(key.clone());
+                TrackSummary {
+                    project: proj.clone(),
+                    track: track.clone(),
+                    total: 0,
+                    active: 0,
+                    pending: 0,
+                    awaiting_user: 0,
+                    last_activity_at: None,
+                    latest_terminal_at: None,
+                    desired_state: None,
+                    github_pr: None,
+                    next_check_at: None,
+                }
+            });
+            entry.total += 1;
+            match m.status {
+                MissionStatus::Active => entry.active += 1,
+                MissionStatus::Pending => entry.pending += 1,
+                MissionStatus::AwaitingUser => entry.awaiting_user += 1,
+                _ => {}
+            }
+            // Missions arrive newest-first, so the first non-None value wins
+            // (most recent). last_activity_at is the first (max) updated_at.
+            if entry.last_activity_at.is_none() {
+                entry.last_activity_at = Some(m.updated_at.clone());
+            }
+            if entry.latest_terminal_at.is_none() && m.status.is_terminal() {
+                entry.latest_terminal_at = Some(m.updated_at.clone());
+            }
+            if entry.desired_state.is_none() {
+                entry.desired_state = m.project.desired_state.clone();
+            }
+            if entry.github_pr.is_none() {
+                entry.github_pr = m.project.github_pr.clone();
+            }
+            if entry.next_check_at.is_none() {
+                entry.next_check_at = m.project.next_check_at.clone();
+            }
+        }
+        if page_len < PAGE {
+            break;
+        }
+        offset += PAGE;
+    }
+
+    let tracks = order
+        .into_iter()
+        .filter_map(|k| groups.remove(&k))
+        .collect::<Vec<_>>();
+    Ok(Json(tracks))
+}
+
 /// Enrich missions with computed activity timestamps (P#5): the most recent
 /// event and assistant output from the event log, plus a `last_activity_at`
 /// convenience = max(updated_at, last_agent_event_at). Best-effort: a store
@@ -4457,12 +4580,16 @@ pub struct CreateMissionRequest {
     pub project: Option<String>,
     /// Project tagging: track / workstream within the project.
     pub track: Option<String>,
-    /// Project tagging: intent (e.g. "repair-build").
+    /// Project tagging: intent (e.g. "review_merge_pr").
     pub intent: Option<String>,
-    /// Project tagging: associated GitHub PR number.
-    pub github_pr: Option<i64>,
+    /// Project tagging: associated GitHub PR ref (e.g. "owner/repo#123").
+    pub github_pr: Option<String>,
     /// Project tagging: freeform tags.
     pub tags: Option<Vec<String>>,
+    /// Track state, e.g. "waiting_ci" / "waiting_review" / "blocked_external".
+    pub desired_state: Option<String>,
+    /// When the track should next be checked (RFC3339).
+    pub next_check_at: Option<String>,
 }
 
 fn deserialize_string_patch<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
@@ -4470,15 +4597,6 @@ where
     D: Deserializer<'de>,
 {
     Option::<String>::deserialize(deserializer).map(Some)
-}
-
-/// Like [`deserialize_string_patch`] but for an optional integer: present field
-/// (even `null`) → `Some(..)`, absent → `None`.
-fn deserialize_i64_patch<'de, D>(deserializer: D) -> Result<Option<Option<i64>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Option::<i64>::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize)]
@@ -4578,6 +4696,8 @@ pub async fn create_mission(
         intent: None,
         github_pr: None,
         tags: None,
+        desired_state: None,
+        next_check_at: None,
     });
 
     let title = req.title.clone();
@@ -4731,7 +4851,9 @@ pub async fn create_mission(
     let project = nonblank(&req.project);
     let track = nonblank(&req.track);
     let intent = nonblank(&req.intent);
-    let github_pr = req.github_pr;
+    let github_pr = nonblank(&req.github_pr);
+    let desired_state = nonblank(&req.desired_state);
+    let next_check_at = nonblank(&req.next_check_at);
     let tags: Option<Vec<String>> = req.tags.as_ref().map(|tags| {
         tags.iter()
             .map(|t| t.trim().to_string())
@@ -4743,6 +4865,8 @@ pub async fn create_mission(
         || intent.is_some()
         || github_pr.is_some()
         || tags.is_some()
+        || desired_state.is_some()
+        || next_check_at.is_some()
     {
         control
             .mission_store
@@ -4752,25 +4876,21 @@ pub async fn create_mission(
                     project: project.clone().map(Some),
                     track: track.clone().map(Some),
                     intent: intent.clone().map(Some),
-                    github_pr: github_pr.map(Some),
+                    github_pr: github_pr.clone().map(Some),
                     tags: tags.clone(),
+                    desired_state: desired_state.clone().map(Some),
+                    next_check_at: next_check_at.clone().map(Some),
                 },
             )
             .await
             .map_err(internal_error)?;
         // Reflect the applied values in the returned mission without a re-fetch.
-        if let Some(v) = project {
-            mission.project.project = Some(v);
-        }
-        if let Some(v) = track {
-            mission.project.track = Some(v);
-        }
-        if let Some(v) = intent {
-            mission.project.intent = Some(v);
-        }
-        if github_pr.is_some() {
-            mission.project.github_pr = github_pr;
-        }
+        mission.project.project = project.or(mission.project.project);
+        mission.project.track = track.or(mission.project.track);
+        mission.project.intent = intent.or(mission.project.intent);
+        mission.project.github_pr = github_pr.or(mission.project.github_pr);
+        mission.project.desired_state = desired_state.or(mission.project.desired_state);
+        mission.project.next_check_at = next_check_at.or(mission.project.next_check_at);
         if let Some(v) = tags {
             mission.project.tags = v;
         }
@@ -4790,11 +4910,14 @@ pub struct UpdateMissionProjectRequest {
     pub track: Option<Option<String>>,
     #[serde(default, deserialize_with = "deserialize_string_patch")]
     pub intent: Option<Option<String>>,
-    /// Tri-state: omit to leave unchanged, `null` to clear, a number to set.
-    #[serde(default, deserialize_with = "deserialize_i64_patch")]
-    pub github_pr: Option<Option<i64>>,
+    #[serde(default, deserialize_with = "deserialize_string_patch")]
+    pub github_pr: Option<Option<String>>,
     #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_patch")]
+    pub desired_state: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_patch")]
+    pub next_check_at: Option<Option<String>>,
 }
 
 /// Set or update project tagging metadata for a mission.
@@ -4840,8 +4963,10 @@ pub async fn update_mission_project(
                 project: normalize(req.project),
                 track: normalize(req.track),
                 intent: normalize(req.intent),
-                github_pr: req.github_pr,
+                github_pr: normalize(req.github_pr),
                 tags,
+                desired_state: normalize(req.desired_state),
+                next_check_at: normalize(req.next_check_at),
             },
         )
         .await
@@ -6211,12 +6336,14 @@ pub async fn clone_mission(
         project: source.project.project.clone(),
         track: source.project.track.clone(),
         intent: source.project.intent.clone(),
-        github_pr: source.project.github_pr,
+        github_pr: source.project.github_pr.clone(),
         tags: if source.project.tags.is_empty() {
             None
         } else {
             Some(source.project.tags.clone())
         },
+        desired_state: source.project.desired_state.clone(),
+        next_check_at: source.project.next_check_at.clone(),
     };
 
     let cloned = create_mission(State(state), Extension(user), Some(Json(req))).await?;
@@ -7470,8 +7597,12 @@ async fn paloma_webhook_forwarder_loop(
                         "project": project.and_then(|p| p.project.clone()),
                         "track": project.and_then(|p| p.track.clone()),
                         "intent": project.and_then(|p| p.intent.clone()),
-                        "github_pr": project.and_then(|p| p.github_pr),
+                        "github_pr": project.and_then(|p| p.github_pr.clone()),
                         "tags": project.map(|p| p.tags.clone()).unwrap_or_default(),
+                        // Track state so a watchdog can tell "intentionally
+                        // waiting (CI/review/external)" from "no worker = stuck".
+                        "desired_state": project.and_then(|p| p.desired_state.clone()),
+                        "next_check_at": project.and_then(|p| p.next_check_at.clone()),
                         // For awaiting_user, whether the agent needs a decision
                         // or is just waiting to be acked/merged.
                         "awaiting_kind": mission

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -477,6 +477,12 @@ impl MissionStore for FileMissionStore {
         if let Some(tags) = patch.tags {
             mission.project.tags = tags;
         }
+        if let Some(desired_state) = patch.desired_state {
+            mission.project.desired_state = desired_state;
+        }
+        if let Some(next_check_at) = patch.next_check_at {
+            mission.project.next_check_at = next_check_at;
+        }
         mission.updated_at = now_string();
         drop(missions);
         self.persist().await

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -413,6 +413,12 @@ impl MissionStore for InMemoryMissionStore {
         if let Some(tags) = patch.tags {
             mission.project.tags = tags;
         }
+        if let Some(desired_state) = patch.desired_state {
+            mission.project.desired_state = desired_state;
+        }
+        if let Some(next_check_at) = patch.next_check_at {
+            mission.project.next_check_at = next_check_at;
+        }
         mission.updated_at = now_string();
         Ok(())
     }

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -56,15 +56,26 @@ pub struct MissionProject {
     /// Track / workstream within the project (e.g. "C3-bridge-collapse").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub track: Option<String>,
-    /// Intent of the mission (e.g. "repair-build", "investigate").
+    /// Intent of the mission (e.g. "repair-build", "review_merge_pr").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intent: Option<String>,
-    /// Associated GitHub PR number, if any.
+    /// Associated GitHub PR, as a free-form reference (e.g.
+    /// "lfglabs-dev/verity#2070" or just "2070").
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub github_pr: Option<i64>,
+    pub github_pr: Option<String>,
     /// Freeform tags.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Operator-declared desired/track state, e.g. "waiting_ci",
+    /// "waiting_review", "blocked_external". Free-form so consumers can evolve
+    /// the vocabulary without a server enum. Lets a watchdog tell "no worker =
+    /// problem" apart from "no worker = intentionally waiting on CI".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub desired_state: Option<String>,
+    /// When the track should next be checked (RFC3339). Paired with
+    /// `desired_state` so a watchdog knows when a `waiting_*` mission is overdue.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_check_at: Option<String>,
 }
 
 impl MissionProject {
@@ -75,6 +86,8 @@ impl MissionProject {
             && self.intent.is_none()
             && self.github_pr.is_none()
             && self.tags.is_empty()
+            && self.desired_state.is_none()
+            && self.next_check_at.is_none()
     }
 }
 
@@ -86,8 +99,10 @@ pub struct MissionProjectPatch {
     pub project: Option<Option<String>>,
     pub track: Option<Option<String>>,
     pub intent: Option<Option<String>>,
-    pub github_pr: Option<Option<i64>>,
+    pub github_pr: Option<Option<String>>,
     pub tags: Option<Vec<String>>,
+    pub desired_state: Option<Option<String>>,
+    pub next_check_at: Option<Option<String>>,
 }
 
 impl MissionProjectPatch {
@@ -98,6 +113,8 @@ impl MissionProjectPatch {
             && self.intent.is_none()
             && self.github_pr.is_none()
             && self.tags.is_none()
+            && self.desired_state.is_none()
+            && self.next_check_at.is_none()
     }
 }
 

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -501,8 +501,10 @@ CREATE TABLE IF NOT EXISTS missions (
     project TEXT,
     track TEXT,
     intent TEXT,
-    github_pr INTEGER,
+    github_pr TEXT,
     tags TEXT,
+    desired_state TEXT,
+    next_check_at TEXT,
     awaiting_kind TEXT,
     last_status_change_at TEXT
 );
@@ -2096,20 +2098,42 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to add paused_at column: {}", e))?;
         }
 
-        // Project tagging + awaiting_kind classification + activity timestamps.
-        // Lets external consumers (Paloma) group/filter/route missions, tell
-        // "needs a decision" apart from "finished, please ack", and reason about
-        // staleness without parsing titles or replaying events. All nullable,
-        // added if missing.
+        // Project tagging + awaiting_kind classification + activity timestamps +
+        // track state. Lets external consumers (Paloma) group/filter/route
+        // missions, tell "needs a decision" apart from "finished, please ack",
+        // tell "no worker = problem" apart from "intentionally waiting on CI",
+        // and reason about staleness without parsing titles. All nullable.
         for (column, sql_type) in [
             ("project", "TEXT"),
             ("track", "TEXT"),
             ("intent", "TEXT"),
-            ("github_pr", "INTEGER"),
+            ("github_pr", "TEXT"),
             ("tags", "TEXT"),
+            ("desired_state", "TEXT"),
+            ("next_check_at", "TEXT"),
             ("awaiting_kind", "TEXT"),
             ("last_status_change_at", "TEXT"),
         ] {
+            // `github_pr` shipped briefly as INTEGER; it now holds a free-form
+            // PR reference string (e.g. "owner/repo#123"). The column is freshly
+            // added and always NULL in practice, so converting affinity via a
+            // lossless DROP + re-add as TEXT is safe and idempotent.
+            if column == "github_pr" {
+                let is_integer: bool = conn
+                    .prepare(
+                        "SELECT 1 FROM pragma_table_info('missions') WHERE name = 'github_pr' AND UPPER(type) = 'INTEGER'",
+                    )
+                    .map_err(|e| format!("Failed to check github_pr type: {}", e))?
+                    .exists([])
+                    .map_err(|e| format!("Failed to query table info: {}", e))?;
+                if is_integer {
+                    tracing::info!(
+                        "Running migration: converting 'github_pr' column from INTEGER to TEXT"
+                    );
+                    conn.execute("ALTER TABLE missions DROP COLUMN github_pr", [])
+                        .map_err(|e| format!("Failed to drop github_pr column: {}", e))?;
+                }
+            }
             let exists: bool = conn
                 .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = ?1")
                 .map_err(|e| format!("Failed to check for {} column: {}", column, e))?
@@ -2428,10 +2452,10 @@ fn tags_from_json(raw: Option<String>) -> Vec<String> {
 }
 
 /// Read the trailing project/activity columns from a mission row in the
-/// canonical order `project, track, intent, github_pr, tags, awaiting_kind,
-/// last_status_change_at` starting at `base`. Shared by the full SELECTs so the
-/// index math lives in one place. Returns the project metadata, the awaiting
-/// classification, and the persisted `last_status_change_at`.
+/// canonical order `project, track, intent, github_pr, tags, desired_state,
+/// next_check_at, awaiting_kind, last_status_change_at` starting at `base`.
+/// Shared by the full SELECTs so the index math lives in one place. Returns the
+/// project metadata, the awaiting classification, and `last_status_change_at`.
 fn read_project_columns(
     row: &rusqlite::Row,
     base: usize,
@@ -2442,12 +2466,14 @@ fn read_project_columns(
         intent: row.get(base + 2)?,
         github_pr: row.get(base + 3)?,
         tags: tags_from_json(row.get(base + 4)?),
+        desired_state: row.get(base + 5)?,
+        next_check_at: row.get(base + 6)?,
     };
     let awaiting_kind = row
-        .get::<_, Option<String>>(base + 5)?
+        .get::<_, Option<String>>(base + 7)?
         .as_deref()
         .and_then(AwaitingKind::from_str_opt);
-    let last_status_change_at: Option<String> = row.get(base + 6)?;
+    let last_status_change_at: Option<String> = row.get(base + 8)?;
     Ok((project, awaiting_kind, last_status_change_at))
 }
 
@@ -2471,7 +2497,7 @@ impl MissionStore for SqliteMissionStore {
                             COALESCE(mission_mode, 'task') as mission_mode,
                             COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
                             COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
-                            project, track, intent, github_pr, tags, awaiting_kind, last_status_change_at
+                            project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at
                      FROM missions
                      ORDER BY updated_at DESC
                      LIMIT ?1 OFFSET ?2",
@@ -2599,7 +2625,7 @@ impl MissionStore for SqliteMissionStore {
                             config_profile, parent_mission_id, working_directory,
                             COALESCE(mission_mode, 'task') as mission_mode, COALESCE(goal_mode, 0) as goal_mode, goal_objective, first_viewed_at,
                             COALESCE(priority, 0) as priority, not_before, deadline, paused_at,
-                            project, track, intent, github_pr, tags, awaiting_kind, last_status_change_at FROM missions WHERE id = ?1",
+                            project, track, intent, github_pr, tags, desired_state, next_check_at, awaiting_kind, last_status_change_at FROM missions WHERE id = ?1",
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -3346,11 +3372,15 @@ impl MissionStore for SqliteMissionStore {
         let intent_set = patch.intent.is_some();
         let github_pr_set = patch.github_pr.is_some();
         let tags_set = patch.tags.is_some();
+        let desired_state_set = patch.desired_state.is_some();
+        let next_check_at_set = patch.next_check_at.is_some();
         let project = patch.project.flatten();
         let track = patch.track.flatten();
         let intent = patch.intent.flatten();
         let github_pr = patch.github_pr.flatten();
         let tags_json = patch.tags.as_deref().and_then(tags_to_json);
+        let desired_state = patch.desired_state.flatten();
+        let next_check_at = patch.next_check_at.flatten();
 
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
@@ -3361,8 +3391,10 @@ impl MissionStore for SqliteMissionStore {
                      intent = CASE WHEN ?5 THEN ?6 ELSE intent END,
                      github_pr = CASE WHEN ?7 THEN ?8 ELSE github_pr END,
                      tags = CASE WHEN ?9 THEN ?10 ELSE tags END,
-                     updated_at = ?11
-                 WHERE id = ?12",
+                     desired_state = CASE WHEN ?11 THEN ?12 ELSE desired_state END,
+                     next_check_at = CASE WHEN ?13 THEN ?14 ELSE next_check_at END,
+                     updated_at = ?15
+                 WHERE id = ?16",
                 params![
                     project_set,
                     project,
@@ -3374,6 +3406,10 @@ impl MissionStore for SqliteMissionStore {
                     github_pr,
                     tags_set,
                     tags_json,
+                    desired_state_set,
+                    desired_state,
+                    next_check_at_set,
+                    next_check_at,
                     now,
                     id.to_string(),
                 ],
@@ -11509,9 +11545,11 @@ mod tests {
                 MissionProjectPatch {
                     project: Some(Some("verity-core".to_string())),
                     track: Some(Some("C3-bridge-collapse".to_string())),
-                    intent: Some(Some("repair-build".to_string())),
-                    github_pr: Some(Some(2061)),
+                    intent: Some(Some("review_merge_pr".to_string())),
+                    github_pr: Some(Some("lfglabs-dev/verity#2070".to_string())),
                     tags: Some(vec!["c3".to_string(), "blocking".to_string()]),
+                    desired_state: Some(Some("waiting_ci".to_string())),
+                    next_check_at: Some(Some("2026-07-01T00:00:00Z".to_string())),
                 },
             )
             .await
@@ -11524,9 +11562,17 @@ mod tests {
             .expect("exists");
         assert_eq!(fetched.project.project.as_deref(), Some("verity-core"));
         assert_eq!(fetched.project.track.as_deref(), Some("C3-bridge-collapse"));
-        assert_eq!(fetched.project.intent.as_deref(), Some("repair-build"));
-        assert_eq!(fetched.project.github_pr, Some(2061));
+        assert_eq!(fetched.project.intent.as_deref(), Some("review_merge_pr"));
+        assert_eq!(
+            fetched.project.github_pr.as_deref(),
+            Some("lfglabs-dev/verity#2070")
+        );
         assert_eq!(fetched.project.tags, vec!["c3", "blocking"]);
+        assert_eq!(fetched.project.desired_state.as_deref(), Some("waiting_ci"));
+        assert_eq!(
+            fetched.project.next_check_at.as_deref(),
+            Some("2026-07-01T00:00:00Z")
+        );
 
         // Partial update leaves untouched fields intact and can clear one.
         store
@@ -11546,7 +11592,11 @@ mod tests {
             .expect("exists");
         assert_eq!(fetched.project.project, None);
         assert_eq!(fetched.project.track.as_deref(), Some("C3-bridge-collapse"));
-        assert_eq!(fetched.project.github_pr, Some(2061));
+        assert_eq!(
+            fetched.project.github_pr.as_deref(),
+            Some("lfglabs-dev/verity#2070")
+        );
+        assert_eq!(fetched.project.desired_state.as_deref(), Some("waiting_ci"));
         assert_eq!(fetched.project.tags, vec!["c3", "blocking"]);
 
         // awaiting_kind persists, and is cleared on a status change away from

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -695,6 +695,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .route("/api/control/progress", get(control::get_progress))
         // Mission management endpoints
         .route("/api/health/fleet", get(control::fleet_health))
+        .route("/api/control/tracks", get(control::list_tracks))
         .route("/api/control/missions", get(control::list_missions))
         .route("/api/control/missions", post(control::create_mission))
         .route(

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -138,6 +138,22 @@ struct StartMissionParams {
     config_profile: Option<String>,
     #[serde(default)]
     agent: Option<String>,
+    // Project tagging — forwarded so missions are created WITH structured
+    // metadata instead of null (watchdogs then don't have to parse titles).
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    track: Option<String>,
+    #[serde(default)]
+    intent: Option<String>,
+    #[serde(default)]
+    github_pr: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    desired_state: Option<String>,
+    #[serde(default)]
+    next_check_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -511,7 +527,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "start_mission".to_string(),
-                description: "Create a new sandboxed.sh mission and send its initial prompt.".to_string(),
+                description: "Create a new sandboxed.sh mission and send its initial prompt. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["title", "prompt"],
@@ -523,7 +539,14 @@ impl AssistantMcp {
                         "model_override": {"type": "string"},
                         "model_effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"]},
                         "config_profile": {"type": "string"},
-                        "agent": {"type": "string"}
+                        "agent": {"type": "string"},
+                        "project": {"type": "string", "description": "Stable project id (e.g. \"verity\")."},
+                        "track": {"type": "string", "description": "Track/workstream (e.g. \"core-c3\")."},
+                        "intent": {"type": "string", "description": "Intent (e.g. \"review_merge_pr\")."},
+                        "github_pr": {"type": "string", "description": "Associated PR ref (e.g. \"owner/repo#123\")."},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
+                        "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."}
                     }
                 }),
             },
@@ -827,6 +850,15 @@ impl AssistantMcp {
             "model_effort": params.model_effort,
             "config_profile": params.config_profile,
             "agent": params.agent,
+            // Project tagging at creation so the mission isn't born with null
+            // metadata (Paloma watchdogs then route by these, not titles).
+            "project": params.project,
+            "track": params.track,
+            "intent": params.intent,
+            "github_pr": params.github_pr,
+            "tags": params.tags,
+            "desired_state": params.desired_state,
+            "next_check_at": params.next_check_at,
         });
         let response = self.api_post("/api/control/missions", body).await?;
         if !response.status().is_success() {
@@ -1433,6 +1465,8 @@ fn compact_mission_summary(mission: Value) -> Value {
         "intent": mission.get("intent").cloned().unwrap_or(Value::Null),
         "github_pr": mission.get("github_pr").cloned().unwrap_or(Value::Null),
         "tags": mission.get("tags").cloned().unwrap_or_else(|| json!([])),
+        "desired_state": mission.get("desired_state").cloned().unwrap_or(Value::Null),
+        "next_check_at": mission.get("next_check_at").cloned().unwrap_or(Value::Null),
         "awaiting_kind": mission.get("awaiting_kind").cloned().unwrap_or(Value::Null),
         "last_activity_at": mission.get("last_activity_at").cloned().unwrap_or(Value::Null),
         "last_status_change_at": mission.get("last_status_change_at").cloned().unwrap_or(Value::Null),
@@ -1850,8 +1884,9 @@ mod tests {
             "updated_at": "2026-05-28T12:00:00Z",
             "project": "verity-core",
             "track": "C3-bridge-collapse",
-            "github_pr": 2061,
+            "github_pr": "lfglabs-dev/verity#2070",
             "tags": ["c3", "sprint-2"],
+            "desired_state": "waiting_ci",
             "awaiting_kind": "decision",
             "prompt": "secret prompt",
             "api_token": "sk-test",
@@ -1861,7 +1896,8 @@ mod tests {
         assert_eq!(summary["workspace_name"], "assistant");
         assert_eq!(summary["project"], "verity-core");
         assert_eq!(summary["track"], "C3-bridge-collapse");
-        assert_eq!(summary["github_pr"], 2061);
+        assert_eq!(summary["github_pr"], "lfglabs-dev/verity#2070");
+        assert_eq!(summary["desired_state"], "waiting_ci");
         assert_eq!(summary["tags"][1], "sprint-2");
         assert_eq!(summary["awaiting_kind"], "decision");
         // Missions without tags get an empty array, not null.


### PR DESCRIPTION
Closes the gap Paloma flagged: structured mission fields exist but are **null on recent missions** because the create path used by Paloma — the MCP `start_mission` tool — never forwarded them (the HTTP endpoint accepted them, the tool dropped them). So watchdogs fell back to title-parsing → false-positive "missing worker".

## Changes
### P0 — structured metadata actually gets set
- MCP `start_mission` now forwards `project / track / intent / github_pr / tags` (+ `desired_state` / `next_check_at`) into the create body, with matching schema. **This is the root-cause fix.**
- `github_pr` is now a **free-form ref string** (`"lfglabs-dev/verity#2070"`), not an int. Migration converts the freshly-added, all-NULL `INTEGER` column to `TEXT` (lossless).
- All fields exposed in `list missions`, `get mission`, webhook payloads, and the MCP compact summary.

### P1 — track state
- New `desired_state` (`waiting_ci` / `waiting_review` / `blocked_external`, free-form — no server enum) + `next_check_at` mission metadata. Settable at create and via `POST /api/control/missions/:id/project`; in list/get/webhook/MCP. Lets a watchdog tell "intentionally waiting on CI" from "no worker = stuck".

### P1 — track rollup
- New `GET /api/control/tracks` → array of `{project, track, total, active, pending, awaiting_user, last_activity_at, latest_terminal_at, desired_state, github_pr, next_check_at}`. Optional `?project=` filter. Moves the fragile grouping logic out of Telegram scripts.

### Dashboard
- Mission type (`github_pr` string + `desired_state`/`next_check_at`), `updateMissionProject` client, `listTracks` + `TrackSummary`, panel PR/State rows.

## Not included (deliberate, per Paloma)
- **P2 zombie-pending sweep** (TTL-fail/pause old title-less `pending` rows) — deferred; it's a mutating mass operation on prod data that deserves its own dry-run PR. Happy to do it next.
- `/api/health/fleet` `missions` shape is an object `{total,active,completed,failed}` — that's a consumer/doc concern, no change.

## Tests
- sqlite roundtrip updated (github_pr string, desired_state, next_check_at, clear-one). Backend `cargo test` + `clippy --all-targets` clean; dashboard `tsc` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission persistence (SQLite migration for github_pr), create/update APIs, webhooks, and MCP—the main risk is schema/API compatibility for consumers expecting numeric github_pr.
> 
> **Overview**
> Fixes Paloma’s root cause: MCP **`start_mission`** now forwards **project / track / intent / github_pr / tags** plus **`desired_state`** and **`next_check_at`** into mission create, so new missions aren’t born with null metadata.
> 
> **`github_pr`** changes from a number to a **free-form string** (e.g. `owner/repo#123`) across API, stores, webhooks, MCP summaries, and the dashboard workbench (full ref display + new **State** row). SQLite adds **`desired_state`** / **`next_check_at`** columns and migrates **`github_pr`** INTEGER → TEXT when needed.
> 
> New **`GET /api/control/tracks`** rolls tagged missions into per-(project, track) summaries (counts, activity, PR/state hints from the newest mission in each group), with optional **`?project=`** filter and a matching **`listTracks`** client.
> 
> Create, **`POST …/project`**, clone, and webhook payloads all carry the new fields; dashboard types and **`updateMissionProject`** are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafe610b5692aad7ee2fa5358da4e3307cf6d2bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->