### PR TITLE
fix(control): don't show "Agent is working…" when history fetch fails

### DIFF
--- a/dashboard/src/app/control/control-client.tsx
+++ b/dashboard/src/app/control/control-client.tsx
@@ -3332,6 +3332,16 @@ export default function ControlClient() {
   // Mission state lives in `controlViewingMissionStore`; these local states
   // cover lower-churn loading/list UI around it.
   const [missionLoading, setMissionLoading] = useState(false);
+  // Mission id whose conversation-history fetch *failed* (network/5xx), as
+  // opposed to a mission that genuinely has no history yet. Both used to
+  // collapse to "no events" because the load swallowed errors with
+  // `.catch(() => null)`, so an active mission with a failed history fetch
+  // rendered the misleading "Agent is working…" placeholder forever (until a
+  // live SSE event happened to arrive). We track the failure separately so the
+  // empty-state can offer a Retry instead of pretending the agent is busy.
+  const [historyLoadFailedMissionId, setHistoryLoadFailedMissionId] = useState<
+    string | null
+  >(null);
   const [recentMissions, setRecentMissions] = useState<Mission[]>([]);
   const [dismissedResumeUI, setDismissedResumeUI] = useState(false);
 
@@ -5199,9 +5209,15 @@ export default function ControlClient() {
       try {
         // Load mission, events, and queue in parallel for faster load
         const queueGenAtFetch = queueMutationGenRef.current;
+        // Distinguish a *failed* history fetch from a genuinely empty one: the
+        // former should surface a Retry, the latter is a normal empty mission.
+        let historyFetchFailed = false;
         const [mission, events, queuedMessages] = await Promise.all([
           loadMission(id),
-          loadHistoryEvents(id).catch(() => null), // Don't fail if events unavailable
+          loadHistoryEvents(id).catch(() => {
+            historyFetchFailed = true;
+            return null;
+          }), // Don't fail the whole load if events are unavailable
           getQueue().catch(() => []), // Don't fail if queue unavailable
         ]);
         if (cancelled || fetchingMissionIdRef.current !== id) return;
@@ -5292,6 +5308,11 @@ export default function ControlClient() {
           queueGenAtFetch === queueMutationGenRef.current,
         );
         setItems(historyItems);
+        // Only flag a load failure when the fetch threw *and* we ended up with
+        // nothing to show — a partial/cached fallback is still a usable view.
+        setHistoryLoadFailedMissionId(
+          historyFetchFailed && historyItems.length === 0 ? id : null,
+        );
         adjustVisibleItemsLimit(historyItems);
         seedPaginationStateAfterInitialLoad(id, historicEventsLen);
         applyDesktopSessionState(mission);
@@ -5850,9 +5871,13 @@ export default function ControlClient() {
       try {
         // Load mission, events, and queue in parallel for faster load
         const queueGenAtFetch = queueMutationGenRef.current;
+        let historyFetchFailed = false;
         const [mission, events, queuedMessages] = await Promise.all([
           getMission(missionId),
-          loadHistoryEvents(missionId).catch(() => null), // Don't fail if events unavailable
+          loadHistoryEvents(missionId).catch(() => {
+            historyFetchFailed = true;
+            return null;
+          }), // Don't fail the whole load if events are unavailable
           getQueue().catch(() => []), // Don't fail if queue unavailable
         ]);
 
@@ -5881,6 +5906,9 @@ export default function ControlClient() {
         );
 
         setItems(historyItems);
+        setHistoryLoadFailedMissionId(
+          historyFetchFailed && historyItems.length === 0 ? missionId : null,
+        );
         adjustVisibleItemsLimit(historyItems);
         seedPaginationStateAfterInitialLoad(missionId, historicEventsLen);
         // Check if mission has an active desktop session (stored metadata or fallback to history)
@@ -9972,9 +10000,18 @@ export default function ControlClient() {
               ) : items.length === 0 ? (
                 <div className="flex h-full items-center justify-center">
                   <div className="text-center">
-                    <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-500/10">
-                      {viewingMissionIsRunning &&
-                      activeMission?.status === "active" ? (
+                    <div
+                      className={cn(
+                        "mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl",
+                        historyLoadFailedMissionId === viewingMissionId
+                          ? "bg-amber-500/10"
+                          : "bg-indigo-500/10",
+                      )}
+                    >
+                      {historyLoadFailedMissionId === viewingMissionId ? (
+                        <AlertTriangle className="h-8 w-8 text-amber-400" />
+                      ) : viewingMissionIsRunning &&
+                        activeMission?.status === "active" ? (
                         <Loader className="h-8 w-8 text-indigo-400 animate-spin" />
                       ) : (
                         <Bot className="h-8 w-8 text-indigo-400" />
@@ -9982,6 +10019,28 @@ export default function ControlClient() {
                     </div>
                     {missionLoading ? (
                       <Shimmer className="max-w-xs mx-auto" />
+                    ) : historyLoadFailedMissionId === viewingMissionId ? (
+                      <>
+                        <h2 className="text-lg font-medium text-white">
+                          Couldn’t load conversation
+                        </h2>
+                        <p className="mt-2 text-sm text-white/40 max-w-sm">
+                          The mission history failed to load (network or server
+                          error). The agent may still be running — retry to
+                          reconnect.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (viewingMissionId)
+                              void handleViewMission(viewingMissionId);
+                          }}
+                          className="mt-4 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-4 py-1.5 text-xs text-white/70 transition-colors hover:bg-white/[0.06] hover:text-white"
+                        >
+                          <RefreshCw className="h-3.5 w-3.5" />
+                          Retry
+                        </button>
+                      </>
                     ) : viewingMissionIsRunning &&
                       activeMission?.status === "active" ? (
                       <>

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -919,6 +919,14 @@ impl SqliteMissionStore {
             let conn = Connection::open(&db_path)
                 .map_err(|e| format!("Failed to open SQLite database: {}", e))?;
 
+            // A global store and the per-user store can open the same DB file
+            // and run schema/migrations concurrently at startup. Without a busy
+            // timeout, the second writer's DDL fails with SQLITE_BUSY and aborts
+            // store init (→ silent in-memory fallback). Make concurrent writers
+            // wait for the lock instead.
+            conn.busy_timeout(std::time::Duration::from_secs(10))
+                .map_err(|e| format!("Failed to set busy_timeout: {}", e))?;
+
             // Run schema
             conn.execute_batch(SCHEMA)
                 .map_err(|e| format!("Failed to run schema: {}", e))?;
@@ -2117,7 +2125,16 @@ impl SqliteMissionStore {
             // `github_pr` shipped briefly as INTEGER; it now holds a free-form
             // PR reference string (e.g. "owner/repo#123"). The column is freshly
             // added and always NULL in practice, so converting affinity via a
-            // lossless DROP + re-add as TEXT is safe and idempotent.
+            // lossless DROP + re-add as TEXT is safe.
+            //
+            // CRITICAL: this runs concurrently — a global store and the per-user
+            // store both initialize on the same DB file at startup. The DDL here
+            // MUST be non-fatal: a previous (#572) version returned Err when the
+            // racing init had already dropped the column ("no such column"),
+            // which failed the whole sqlite store init and silently fell the
+            // service back to an in-memory store (losing visibility of all
+            // persisted missions). So tolerate "already done" / concurrent races
+            // on every ALTER below instead of propagating them.
             if column == "github_pr" {
                 let is_integer: bool = conn
                     .prepare(
@@ -2130,8 +2147,12 @@ impl SqliteMissionStore {
                     tracing::info!(
                         "Running migration: converting 'github_pr' column from INTEGER to TEXT"
                     );
-                    conn.execute("ALTER TABLE missions DROP COLUMN github_pr", [])
-                        .map_err(|e| format!("Failed to drop github_pr column: {}", e))?;
+                    if let Err(e) = conn.execute("ALTER TABLE missions DROP COLUMN github_pr", []) {
+                        tracing::warn!(
+                            "github_pr INTEGER→TEXT drop skipped (already converted or concurrent migration): {}",
+                            e
+                        );
+                    }
                 }
             }
             let exists: bool = conn
@@ -2144,11 +2165,18 @@ impl SqliteMissionStore {
                     "Running migration: adding '{}' column to missions table",
                     column
                 );
-                conn.execute(
+                // Non-fatal: a concurrent init may have added the column between
+                // our `exists` check and here ("duplicate column name").
+                if let Err(e) = conn.execute(
                     &format!("ALTER TABLE missions ADD COLUMN {} {}", column, sql_type),
                     [],
-                )
-                .map_err(|e| format!("Failed to add {} column: {}", column, e))?;
+                ) {
+                    tracing::warn!(
+                        "Adding '{}' column skipped (already present or concurrent migration): {}",
+                        column,
+                        e
+                    );
+                }
             }
         }
 
@@ -11522,6 +11550,80 @@ mod tests {
         assert_eq!(mission.short_description, None);
         assert_eq!(mission.metadata_source, None);
         assert_eq!(mission.metadata_version, None);
+    }
+
+    /// Regression for the #572 incident: a global store and the per-user store
+    /// open the same DB file and run migrations concurrently at startup. The
+    /// `github_pr` INTEGER→TEXT conversion's DROP must NOT fail the store init
+    /// when a racing init already dropped/re-added the column — otherwise the
+    /// service silently falls back to an in-memory store and loses visibility of
+    /// every persisted mission.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_init_on_integer_github_pr_does_not_fall_back() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let base = temp_dir.path().to_path_buf();
+
+        // Seed a DB, then force it into the pre-#572 shape: github_pr is INTEGER
+        // and the newer columns are absent.
+        {
+            let store = SqliteMissionStore::new(base.clone(), "race")
+                .await
+                .expect("seed store");
+            drop(store);
+            let db = base.join("missions-race.db");
+            let conn = rusqlite::Connection::open(&db).expect("open seed");
+            conn.execute("ALTER TABLE missions DROP COLUMN github_pr", [])
+                .expect("drop text github_pr");
+            conn.execute("ALTER TABLE missions ADD COLUMN github_pr INTEGER", [])
+                .expect("re-add integer github_pr");
+            conn.execute("ALTER TABLE missions DROP COLUMN desired_state", [])
+                .ok();
+            conn.execute("ALTER TABLE missions DROP COLUMN next_check_at", [])
+                .ok();
+        }
+
+        // Two concurrent initializations on the SAME db file — both must succeed.
+        let h1 = {
+            let p = base.clone();
+            tokio::spawn(async move { SqliteMissionStore::new(p, "race").await.map(|_| ()) })
+        };
+        let h2 = {
+            let p = base.clone();
+            tokio::spawn(async move { SqliteMissionStore::new(p, "race").await.map(|_| ()) })
+        };
+        let (r1, r2) = tokio::join!(h1, h2);
+        assert!(
+            r1.expect("join1").is_ok(),
+            "concurrent init 1 must not fail (would fall back to in-memory)"
+        );
+        assert!(
+            r2.expect("join2").is_ok(),
+            "concurrent init 2 must not fail (would fall back to in-memory)"
+        );
+
+        // github_pr is TEXT and the new columns exist after the race.
+        let db = base.join("missions-race.db");
+        let conn = rusqlite::Connection::open(&db).expect("open verify");
+        let ty: String = conn
+            .query_row(
+                "SELECT type FROM pragma_table_info('missions') WHERE name = 'github_pr'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("github_pr column present");
+        assert_eq!(ty.to_uppercase(), "TEXT");
+        for col in ["desired_state", "next_check_at"] {
+            let exists: bool = conn
+                .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = ?1")
+                .unwrap()
+                .exists([col])
+                .unwrap();
+            assert!(
+                exists,
+                "{} column must exist after concurrent migration",
+                col
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Opening `/control?mission=<id>` for an **active** mission sometimes showed
the placeholder **"Agent is working… Processing your request."** forever
(or rendered a partial/garbled stream once a live SSE event happened to
arrive).

Root cause for the stuck placeholder: the history load swallowed fetch
errors with `loadHistoryEvents(id).catch(() => null)`, collapsing two very
different situations into the same empty state:

- **fetch failed** (network / 5xx) → should retry
- **no events yet** (genuinely empty active mission) → "Agent is working…" is fine

The render only checks `items.length === 0 && mission.status === "active"`,
so a *failed* history fetch on a running mission rendered the misleading
"Agent is working…" indefinitely, until a live event arrived.

## Fix

Track the failure separately (`historyLoadFailedMissionId`) in **both**
load paths (the `?mission=` URL effect and `handleViewMission`). The flag is
set only when the fetch actually threw **and** we ended up with zero items
(a partial/cached fallback stays usable, no false error).

The empty-state now branches on the failure first: it shows
**"Couldn't load conversation"** with a **Retry** button
(`handleViewMission(viewingMissionId)`) instead of pretending the agent is
busy. Genuinely-empty active missions still show "Agent is working…".

## Not addressed here

The occasional *garbled* live stream (heuristic stitching in
`mergeStreamFragment` / `text_op`, or `sinceSeq` set to the global
`latest_sequence` vs the conversation-anchored window) is a separate issue —
left untouched pending a runtime repro.

## Testing

- `npx tsc --noEmit`: no new errors (only pre-existing unrelated `.test.ts` errors).
- `eslint src/app/control/control-client.tsx`: 0 errors (pre-existing warnings only).
- `vitest run` reducer + item-views: 31/31 pass.

## Note

This branch also carries the earlier commit `d22abfc1`
*fix(migrations): make github_pr conversion concurrency-safe* — it had no PR
of its own, so it rides along here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SQLite migration and busy-timeout changes affect mission persistence at startup; the control UI change is localized but user-visible on load failures.
> 
> **Overview**
> Fixes the control dashboard **empty chat** state when **conversation history fails to load** on an active mission: instead of indefinitely showing **"Agent is working…"**, it tracks `historyLoadFailedMissionId` in both mission load paths and shows **"Couldn't load conversation"** with a **Retry** (only when the fetch threw and there are zero items to show).
> 
> Also hardens **SQLite mission store startup** when global and per-user stores open the same DB concurrently: sets a **10s busy timeout**, and makes **`github_pr` INTEGER→TEXT** and **ADD COLUMN** migrations **non-fatal** (warn/skip on race) so init no longer fails and silently falls back to in-memory storage. Adds a **multi-thread regression test** for concurrent init on a legacy INTEGER `github_pr` schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb6513697ee3064047d6d32e63b37673ed62313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->