### PR TITLE
Fix palomactl merged PR gate fallback

### DIFF
--- a/dashboard/src/app/control/components/common.tsx
+++ b/dashboard/src/app/control/components/common.tsx
@@ -68,6 +68,11 @@ export function missionStatusLabel(
       return { label: "Pending", className: "bg-zinc-500/20 text-zinc-400" };
     case "active":
       return { label: "Active", className: "bg-indigo-500/20 text-indigo-400" };
+    case "waiting_background":
+      return {
+        label: "Working (Background)",
+        className: "bg-indigo-500/20 text-indigo-400",
+      };
     case "awaiting_user":
       // Distinguish "agent asked a question" (decision) from "agent finished,
       // waiting to be acked/merged" (ack). The old single "Needs You" label

--- a/dashboard/src/app/history/page.tsx
+++ b/dashboard/src/app/history/page.tsx
@@ -29,6 +29,7 @@ const statusConfig: Record<string, { color: string; bg: string }> = {
   failed: { color: "text-red-400", bg: "bg-red-500/10" },
   cancelled: { color: "text-white/40", bg: "bg-white/[0.04]" },
   active: { color: "text-indigo-400", bg: "bg-indigo-500/10" },
+  waiting_background: { color: "text-indigo-400", bg: "bg-indigo-500/10" },
   interrupted: { color: "text-amber-400", bg: "bg-amber-500/10" },
   blocked: { color: "text-orange-400", bg: "bg-orange-500/10" },
   not_feasible: { color: "text-rose-400", bg: "bg-rose-500/10" },

--- a/dashboard/src/components/active-automations.tsx
+++ b/dashboard/src/components/active-automations.tsx
@@ -30,6 +30,7 @@ const LIVE_STATUSES: ReadonlySet<MissionStatus> = new Set<MissionStatus>([
   'active',
   'awaiting_user',
   'blocked',
+  'waiting_background',
 ]);
 
 /**

--- a/dashboard/src/components/ui/status-icons.tsx
+++ b/dashboard/src/components/ui/status-icons.tsx
@@ -24,6 +24,7 @@ export const STATUS_ICONS: Record<string, StatusIcon> = {
   pending: Clock,
   active: CircleNotch,
   running: CircleNotch,
+  waiting_background: CircleNotch,
   awaiting_user: Bell,
   acknowledged: CheckCircle,
   completed: CheckCircle,

--- a/dashboard/src/components/workers-strip.tsx
+++ b/dashboard/src/components/workers-strip.tsx
@@ -140,6 +140,7 @@ function chipStatusFor(mission: Mission, info?: RunningMissionInfo): ChipStatus 
         fill: '',
       };
     case 'active':
+    case 'waiting_background':
       return {
         ...base,
         indicator: <Dot color="bg-indigo-400" pulse />,

--- a/dashboard/src/hooks/use-favicon-status.ts
+++ b/dashboard/src/hooks/use-favicon-status.ts
@@ -19,6 +19,7 @@ const STATUS_COLORS: Record<MissionStatus, string> = {
   interrupted: "#f87171", // red-400
   blocked: "#f87171", // red-400
   not_feasible: "#f87171", // red-400
+  waiting_background: "#818cf8", // indigo-400, work still running in background
 };
 
 /** Status dot radius & position (bottom-right, on a 64×64 canvas). */

--- a/dashboard/src/lib/api/missions.ts
+++ b/dashboard/src/lib/api/missions.ts
@@ -17,7 +17,8 @@ export type MissionStatus =
   | "failed"
   | "interrupted"
   | "blocked"
-  | "not_feasible";
+  | "not_feasible"
+  | "waiting_background";
 
 export type ModelEffort = "low" | "medium" | "high" | "xhigh" | "max";
 

--- a/dashboard/src/lib/client-message-id.test.ts
+++ b/dashboard/src/lib/client-message-id.test.ts
@@ -11,14 +11,14 @@ describe("createClientMessageId", () => {
     expect(
       createClientMessageId({
         randomUUID: () => "11111111-2222-4333-8444-555555555555",
-        getRandomValues: (array) => array,
+        getRandomValues: (array: Uint8Array) => array,
       }),
     ).toBe("11111111-2222-4333-8444-555555555555");
   });
 
   it("falls back to a v4 UUID when randomUUID is unavailable", () => {
     const id = createClientMessageId({
-      getRandomValues: (array) => {
+      getRandomValues: (array: Uint8Array) => {
         array.set([
           0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
           0xbb, 0xcc, 0xdd, 0xee, 0xff,

--- a/dashboard/src/lib/mission-status.ts
+++ b/dashboard/src/lib/mission-status.ts
@@ -72,6 +72,13 @@ export function categorizeMission(
     return 'running';
   }
 
+  // The agent's turn ended but background shell jobs it spawned are still
+  // live. Work is genuinely in progress, so surface it in Running rather than
+  // letting it fall through to Other (where it would look idle/dropped).
+  if (status === 'waiting_background') {
+    return 'running';
+  }
+
   if (needsAttentionStatus(status)) {
     return 'needs-you';
   }
@@ -126,6 +133,7 @@ export const STATUS_DOT_COLORS: Record<MissionStatus, string> = {
   interrupted: 'bg-red-400',
   blocked: 'bg-red-400',
   not_feasible: 'bg-red-400',
+  waiting_background: 'bg-indigo-400',
 };
 
 export const STATUS_TEXT_COLORS: Record<MissionStatus, string> = {
@@ -138,6 +146,7 @@ export const STATUS_TEXT_COLORS: Record<MissionStatus, string> = {
   interrupted: 'text-red-400',
   blocked: 'text-red-400',
   not_feasible: 'text-red-400',
+  waiting_background: 'text-indigo-400',
 };
 
 export const STATUS_LABELS: Record<MissionStatus, string> = {
@@ -150,6 +159,7 @@ export const STATUS_LABELS: Record<MissionStatus, string> = {
   interrupted: 'Interrupted',
   blocked: 'Blocked',
   not_feasible: 'Not Feasible',
+  waiting_background: 'Working (Background)',
 };
 
 /**

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -397,6 +397,10 @@ pub async fn scheduler_pass(
                     // Runner may exist in another control session or be mid-start;
                     // leave it alone.
                 }
+                MissionStatus::WaitingBackground => {
+                    // Worker parked on live background jobs; the auto-resume
+                    // watcher will wake it when they finish. Not settled — leave it.
+                }
                 MissionStatus::Paused => {
                     // Operator-paused worker: leave it alone, the dispatcher will
                     // resume it when unpaused.

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -518,6 +518,13 @@ pub enum MissionStatus {
     /// User opened the mission while it was AwaitingUser and the ack grace
     /// period elapsed without a new message — mission is auto-archived.
     Acknowledged,
+    /// The agent's turn finished but it left one or more background shell jobs
+    /// (`Bash run_in_background`) running in the workspace. The mission is NOT
+    /// done: it is parked waiting for that background work to complete, and the
+    /// auto-resume watcher will wake it with the output. Non-terminal, and NOT
+    /// eligible for ack-promotion while jobs are live — otherwise a mission
+    /// could silently look "done" while work is still running.
+    WaitingBackground,
     Completed,
     Failed,
     /// Mission was interrupted (server shutdown, cancellation, etc.)
@@ -539,6 +546,7 @@ impl std::fmt::Display for MissionStatus {
             Self::Active => write!(f, "active"),
             Self::AwaitingUser => write!(f, "awaiting_user"),
             Self::Acknowledged => write!(f, "acknowledged"),
+            Self::WaitingBackground => write!(f, "waiting_background"),
             Self::Completed => write!(f, "completed"),
             Self::Failed => write!(f, "failed"),
             Self::Blocked => write!(f, "blocked"),
@@ -569,4 +577,37 @@ impl MissionStatus {
 /// that read more clearly as `mission_status_is_terminal(status)`.
 pub fn mission_status_is_terminal(status: MissionStatus) -> bool {
     status.is_terminal()
+}
+
+#[cfg(test)]
+mod mission_status_tests {
+    use super::MissionStatus;
+
+    #[test]
+    fn waiting_background_serde_roundtrip_is_snake_case() {
+        // The wire form must be `waiting_background` (snake_case) so dashboard
+        // and Paloma clients that key off the string agree with the backend.
+        let json = serde_json::to_string(&MissionStatus::WaitingBackground).unwrap();
+        assert_eq!(json, "\"waiting_background\"");
+        let back: MissionStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, MissionStatus::WaitingBackground);
+    }
+
+    #[test]
+    fn waiting_background_display_matches_serde() {
+        // Display and serde must not drift — several call sites persist via
+        // Display and read back via serde.
+        assert_eq!(
+            MissionStatus::WaitingBackground.to_string(),
+            "waiting_background"
+        );
+    }
+
+    #[test]
+    fn waiting_background_is_not_terminal() {
+        // Background work is still running, so the mission is NOT done. Marking
+        // it terminal would let it be archived/acked while work is in flight —
+        // exactly the bug this status exists to prevent.
+        assert!(!MissionStatus::WaitingBackground.is_terminal());
+    }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -42,7 +42,8 @@ use uuid::Uuid;
 #[allow(unused_imports)]
 use super::supervision::{
     ack_promotion_loop, background_task_autoresume_loop, cleanup_stale_active_missions_once,
-    recover_server_shutdown_missions, stale_mission_cleanup_loop, stuck_mission_watchdog_loop,
+    recover_server_shutdown_missions, reset_waiting_background_on_boot, stale_mission_cleanup_loop,
+    stuck_mission_watchdog_loop,
 };
 use crate::agents::{AgentContext, AgentRef, TerminalReason};
 use crate::config::Config;
@@ -7855,6 +7856,18 @@ fn spawn_control_session(
     // completion inside the workspace, and resumes the agent with the output.
     // Uses an in-memory registry (no persistent store required). Gated by
     // `BACKGROUND_TASK_AUTORESUME` (default enabled).
+    // Settle any mission left in `WaitingBackground` by a previous process:
+    // the in-memory background-task registry is empty at boot, so those jobs are
+    // no longer tracked and the mission would be stranded outside every terminal
+    // path. Runs regardless of whether the watcher below is enabled.
+    if state.mission_store.is_persistent() {
+        let store = Arc::clone(&state.mission_store);
+        let tx = events_tx.clone();
+        tokio::spawn(async move {
+            reset_waiting_background_on_boot(store, tx).await;
+        });
+    }
+
     if super::mission_runner::background_task_autoresume_enabled() {
         tokio::spawn(background_task_autoresume_loop(
             Arc::clone(&state.mission_store),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -85,6 +85,29 @@ pub(crate) const ACK_GRACE_SECONDS: u64 = 3600;
 pub(crate) const ACK_PROMOTION_TICK_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(60);
 
+/// Whether an incoming user message (a real one, or the background-task
+/// auto-resume synthetic message) should re-activate `status` to `Active`.
+///
+/// Kept as one predicate so every message-dequeue site agrees. It deliberately
+/// includes `WaitingBackground`: a resume delivered while background jobs were
+/// still live must flip the mission to `Active` — which clears `first_viewed_at`
+/// (see `MissionStore::update_mission_status`) — otherwise the stale timestamp
+/// survives the later demotion back to `AwaitingUser` and the ack-promotion
+/// sweep can archive a mission whose next turn just started.
+pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
+    matches!(
+        status,
+        MissionStatus::Pending
+            | MissionStatus::Interrupted
+            | MissionStatus::Blocked
+            | MissionStatus::Completed
+            | MissionStatus::Failed
+            | MissionStatus::AwaitingUser
+            | MissionStatus::WaitingBackground
+            | MissionStatus::Acknowledged
+    )
+}
+
 /// Returns a safe index to truncate a string at, ensuring we don't cut UTF-8 characters.
 pub(crate) fn safe_truncate_index(s: &str, max: usize) -> usize {
     if s.len() <= max {
@@ -10416,16 +10439,7 @@ async fn control_actor_loop(
                                                 continue;
                                             }
                                             // Activate mission: if pending, interrupted, blocked, completed, or failed, update status to active
-                                            if matches!(
-                                                mission.status,
-                                                MissionStatus::Pending
-                                                    | MissionStatus::Interrupted
-                                                    | MissionStatus::Blocked
-                                                    | MissionStatus::Completed
-                                                    | MissionStatus::Failed
-                                                    | MissionStatus::AwaitingUser
-                                                    | MissionStatus::Acknowledged
-                                            ) {
+                                            if message_activates_mission(mission.status) {
                                                 tracing::info!(
                                                     "Activating parallel mission {} (was {})",
                                                     tid, mission.status
@@ -10551,16 +10565,7 @@ async fn control_actor_loop(
                                             );
                                         }
                                         // Activate mission if it was pending/interrupted/blocked/completed
-                                        if matches!(
-                                            mission.status,
-                                            MissionStatus::Pending
-                                                | MissionStatus::Interrupted
-                                                | MissionStatus::Blocked
-                                                | MissionStatus::Completed
-                                                | MissionStatus::Failed
-                                                | MissionStatus::AwaitingUser
-                                                | MissionStatus::Acknowledged
-                                        ) {
+                                        if message_activates_mission(mission.status) {
                                             tracing::info!(
                                                 "Activating main mission {} (was {})",
                                                 tid, mission.status
@@ -10599,16 +10604,7 @@ async fn control_actor_loop(
                                                 history.push((entry.role.clone(), entry.content.clone()));
                                             }
                                             // Activate mission if it was pending/interrupted/blocked/completed
-                                            if matches!(
-                                                mission.status,
-                                                MissionStatus::Pending
-                                                    | MissionStatus::Interrupted
-                                                    | MissionStatus::Blocked
-                                                    | MissionStatus::Completed
-                                                    | MissionStatus::Failed
-                                                    | MissionStatus::AwaitingUser
-                                                    | MissionStatus::Acknowledged
-                                            ) {
+                                            if message_activates_mission(mission.status) {
                                                 tracing::info!(
                                                     "Activating switched mission {} (was {})",
                                                     tid, mission.status
@@ -10642,16 +10638,7 @@ async fn control_actor_loop(
                                                 );
                                             }
                                             // Activate mission if it was pending/interrupted/blocked/completed (same mission, reloading)
-                                            if matches!(
-                                                mission.status,
-                                                MissionStatus::Pending
-                                                    | MissionStatus::Interrupted
-                                                    | MissionStatus::Blocked
-                                                    | MissionStatus::Completed
-                                                    | MissionStatus::Failed
-                                                    | MissionStatus::AwaitingUser
-                                                    | MissionStatus::Acknowledged
-                                            ) {
+                                            if message_activates_mission(mission.status) {
                                                 tracing::info!(
                                                     "Activating reloaded mission {} (was {})",
                                                     tid, mission.status
@@ -10768,16 +10755,7 @@ async fn control_actor_loop(
                                     match mission_store.get_mission(mid).await {
                                         Ok(Some(mission)) => {
                                             // Activate mission: if pending, interrupted, blocked, completed, or failed, update status to active
-                                            if matches!(
-                                                mission.status,
-                                                MissionStatus::Pending
-                                                    | MissionStatus::Interrupted
-                                                    | MissionStatus::Blocked
-                                                    | MissionStatus::Completed
-                                                    | MissionStatus::Failed
-                                                    | MissionStatus::AwaitingUser
-                                                    | MissionStatus::Acknowledged
-                                            ) {
+                                            if message_activates_mission(mission.status) {
                                                 tracing::info!(
                                                     "Activating mission {} (was {})",
                                                     mid, mission.status
@@ -20397,6 +20375,84 @@ Investigate <service/> failures.
         assert_eq!(
             mission_status_for_terminal_reason(TerminalReason::Completed, true),
             Some((MissionStatus::Completed, "completed"))
+        );
+    }
+
+    #[test]
+    fn message_activates_mission_includes_waiting_background() {
+        // A resume delivered while background jobs are still live lands on a
+        // WaitingBackground mission; it must be activation-eligible so the flip
+        // to Active clears first_viewed_at and closes the ack race.
+        assert!(message_activates_mission(MissionStatus::WaitingBackground));
+        for status in [
+            MissionStatus::Pending,
+            MissionStatus::Interrupted,
+            MissionStatus::Blocked,
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::AwaitingUser,
+            MissionStatus::Acknowledged,
+        ] {
+            assert!(
+                message_activates_mission(status),
+                "{status} should activate"
+            );
+        }
+        // Already-running and explicitly-paused missions are handled elsewhere
+        // (a running mission needs no activation; a paused one must stay parked
+        // until the user resumes it), so they are not activation-eligible here.
+        assert!(!message_activates_mission(MissionStatus::Active));
+        assert!(!message_activates_mission(MissionStatus::Paused));
+    }
+
+    #[tokio::test]
+    async fn activating_waiting_background_clears_first_viewed_at_and_blocks_ack() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(Some("bg resume race"), None, None, None, None, None, None)
+            .await
+            .expect("mission should be created");
+        // The mission parked awaiting the user, was opened (first_viewed_at set),
+        // then a background job promoted it to WaitingBackground.
+        let long_ago = (chrono::Utc::now() - chrono::Duration::hours(24)).to_rfc3339();
+        store
+            .set_mission_first_viewed_at_if_unset(mission.id, &long_ago)
+            .await
+            .expect("set first_viewed_at");
+        store
+            .update_mission_status(mission.id, MissionStatus::WaitingBackground)
+            .await
+            .expect("set waiting_background");
+
+        // The auto-resume dequeue path activates the mission to Active.
+        assert!(message_activates_mission(MissionStatus::WaitingBackground));
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .expect("activate to Active");
+
+        // Activation cleared the stale first_viewed_at, so once the resumed turn
+        // re-parks in AwaitingUser the ack-promotion sweep must not archive it.
+        store
+            .update_mission_status(mission.id, MissionStatus::AwaitingUser)
+            .await
+            .expect("re-park in awaiting_user");
+        let after = store
+            .get_mission(mission.id)
+            .await
+            .expect("get mission")
+            .expect("mission exists");
+        assert_eq!(
+            after.first_viewed_at, None,
+            "activation must clear first_viewed_at"
+        );
+        let promoted = store
+            .acknowledge_stale_awaiting_user_missions(0)
+            .await
+            .expect("run ack sweep");
+        assert!(
+            !promoted.contains(&mission.id),
+            "a freshly-resumed mission must not be ack-promoted after demotion"
         );
     }
 

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -233,6 +233,7 @@ impl MissionStore for FileMissionStore {
                 | MissionStatus::Failed
                 | MissionStatus::AwaitingUser
                 | MissionStatus::Acknowledged
+                | MissionStatus::WaitingBackground
         );
         mission.interrupted_at =
             if matches!(status, MissionStatus::Interrupted | MissionStatus::Blocked) {

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -184,6 +184,7 @@ impl MissionStore for InMemoryMissionStore {
                 | MissionStatus::Failed
                 | MissionStatus::AwaitingUser
                 | MissionStatus::Acknowledged
+                | MissionStatus::WaitingBackground
         );
         mission.interrupted_at =
             if matches!(status, MissionStatus::Interrupted | MissionStatus::Blocked) {
@@ -701,6 +702,51 @@ impl MissionStore for InMemoryMissionStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn waiting_background_is_never_ack_promoted() {
+        // A mission parked in WaitingBackground has live background work; the
+        // stale-ack sweep must skip it even after its view-grace elapses,
+        // otherwise it would be archived while work is still running.
+        let store = InMemoryMissionStore::new();
+        let mission = store
+            .create_mission(Some("bg mission"), None, None, None, None, None, None)
+            .await
+            .expect("create mission");
+        store
+            .update_mission_status(mission.id, MissionStatus::WaitingBackground)
+            .await
+            .expect("set waiting_background");
+        // Mark it viewed well in the past so the grace window is definitely
+        // exceeded — the only thing that should save it is the status guard.
+        let long_ago = (chrono::Utc::now() - chrono::Duration::hours(24)).to_rfc3339();
+        store
+            .set_mission_first_viewed_at_if_unset(mission.id, &long_ago)
+            .await
+            .expect("set first viewed");
+
+        let promoted = store
+            .acknowledge_stale_awaiting_user_missions(0)
+            .await
+            .expect("run ack sweep");
+        assert!(
+            !promoted.contains(&mission.id),
+            "waiting_background must not be ack-promoted"
+        );
+
+        let after = store
+            .get_mission(mission.id)
+            .await
+            .expect("get mission")
+            .expect("mission exists");
+        assert_eq!(after.status, MissionStatus::WaitingBackground);
+
+        let waiting = store
+            .get_waiting_background_mission_ids()
+            .await
+            .expect("list waiting_background");
+        assert!(waiting.contains(&mission.id));
+    }
 
     #[tokio::test]
     async fn update_mission_metadata_is_noop_when_fields_missing() {

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1685,6 +1685,24 @@ pub trait MissionStore: Send + Sync {
         grace_seconds: u64,
     ) -> Result<Vec<Uuid>, String>;
 
+    /// IDs of missions currently parked in `WaitingBackground` — the agent's
+    /// turn ended but tracked background shell jobs are (or were) still live.
+    ///
+    /// Used by the background-task auto-resume watcher to reconcile the
+    /// persisted status against the in-memory registry: a `WaitingBackground`
+    /// mission with no live jobs left must be flipped back to `AwaitingUser` so
+    /// the normal ack flow can settle it, instead of being stranded forever
+    /// (e.g. after a restart drops the in-memory registry). Default impl scans
+    /// via `list_missions`; the sqlite store overrides it with a targeted query.
+    async fn get_waiting_background_mission_ids(&self) -> Result<Vec<Uuid>, String> {
+        let missions = self.list_missions(1000, 0).await?;
+        Ok(missions
+            .into_iter()
+            .filter(|m| m.status == MissionStatus::WaitingBackground)
+            .map(|m| m.id)
+            .collect())
+    }
+
     /// Get recently interrupted missions that were stopped by server shutdown.
     async fn get_recent_server_shutdown_mission_ids(
         &self,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2437,6 +2437,7 @@ fn parse_status(s: &str) -> MissionStatus {
         "active" => MissionStatus::Active,
         "awaiting_user" => MissionStatus::AwaitingUser,
         "acknowledged" => MissionStatus::Acknowledged,
+        "waiting_background" => MissionStatus::WaitingBackground,
         "completed" => MissionStatus::Completed,
         "failed" => MissionStatus::Failed,
         "interrupted" => MissionStatus::Interrupted,
@@ -2453,6 +2454,7 @@ fn status_to_string(status: MissionStatus) -> &'static str {
         MissionStatus::Active => "active",
         MissionStatus::AwaitingUser => "awaiting_user",
         MissionStatus::Acknowledged => "acknowledged",
+        MissionStatus::WaitingBackground => "waiting_background",
         MissionStatus::Completed => "completed",
         MissionStatus::Failed => "failed",
         MissionStatus::Interrupted => "interrupted",
@@ -2999,6 +3001,7 @@ impl MissionStore for SqliteMissionStore {
                 | MissionStatus::Failed
                 | MissionStatus::AwaitingUser
                 | MissionStatus::Acknowledged
+                | MissionStatus::WaitingBackground
         );
         let terminal_reason = terminal_reason.map(|s| s.to_string());
         // Transitioning back to Active means the user just sent a new message —
@@ -3158,6 +3161,27 @@ impl MissionStore for SqliteMissionStore {
                 .map_err(|e| e.to_string())?;
             }
             tx.commit().map_err(|e| e.to_string())?;
+            Ok(ids)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn get_waiting_background_mission_ids(&self) -> Result<Vec<Uuid>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare("SELECT id FROM missions WHERE status = 'waiting_background'")
+                .map_err(|e| e.to_string())?;
+            let ids = stmt
+                .query_map([], |row| {
+                    let id_str: String = row.get(0)?;
+                    Ok(parse_uuid_or_nil(&id_str))
+                })
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
             Ok(ids)
         })
         .await

--- a/src/api/paloma/mission_card.rs
+++ b/src/api/paloma/mission_card.rs
@@ -80,6 +80,7 @@ pub fn status_emoji(status: MissionStatus) -> &'static str {
         MissionStatus::NotFeasible => "🚫",
         MissionStatus::Acknowledged => "☑️",
         MissionStatus::Paused => "⏯️",
+        MissionStatus::WaitingBackground => "🔄",
     }
 }
 
@@ -92,7 +93,10 @@ pub fn buttons_for(status: MissionStatus) -> Vec<CardButton> {
             CardButton::OpenDashboard,
             CardButton::MuteMission,
         ],
-        MissionStatus::Active | MissionStatus::Pending | MissionStatus::Paused => vec![
+        MissionStatus::Active
+        | MissionStatus::Pending
+        | MissionStatus::Paused
+        | MissionStatus::WaitingBackground => vec![
             CardButton::Reply,
             CardButton::OpenDashboard,
             CardButton::MuteMission,
@@ -194,6 +198,15 @@ fn status_line_for(
         MissionStatus::NotFeasible => "Marked not feasible".to_string(),
         MissionStatus::Acknowledged => "Acknowledged".to_string(),
         MissionStatus::Paused => "Paused".to_string(),
+        MissionStatus::WaitingBackground => match elapsed {
+            Some(elapsed) if elapsed >= Duration::minutes(1) => {
+                format!(
+                    "Waiting on background jobs — running for {}",
+                    format_elapsed(elapsed)
+                )
+            }
+            _ => "Waiting on background jobs".to_string(),
+        },
     }
 }
 

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -32,7 +32,7 @@ use super::mission_store::MissionStore;
 
 mod bg_autoresume;
 
-pub(crate) use bg_autoresume::background_task_autoresume_loop;
+pub(crate) use bg_autoresume::{background_task_autoresume_loop, reset_waiting_background_on_boot};
 
 pub(crate) async fn recover_server_shutdown_missions(
     mission_store: Arc<dyn MissionStore>,

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -128,6 +128,109 @@ fn bg_decide_finished(
     )
 }
 
+/// Pure reconciliation between a mission's persisted status and whether it has
+/// live background jobs. Returns `Some(new_status)` when a transition is needed.
+///
+/// Only the two "parked" statuses participate: a mission actively running a turn
+/// (`Active`), pending, or terminal is left untouched even if the registry still
+/// lists a job for it (that job is drained by the terminal/timeout paths).
+fn reconcile_parked_status(current: MissionStatus, has_live_jobs: bool) -> Option<MissionStatus> {
+    match (current, has_live_jobs) {
+        (MissionStatus::AwaitingUser, true) => Some(MissionStatus::WaitingBackground),
+        (MissionStatus::WaitingBackground, false) => Some(MissionStatus::AwaitingUser),
+        _ => None,
+    }
+}
+
+/// Apply [`reconcile_parked_status`] across the missions that currently have
+/// live jobs (promote `AwaitingUser` -> `WaitingBackground`) and the missions
+/// persisted as `WaitingBackground` (demote back to `AwaitingUser` once their
+/// jobs are gone). Broadcasts `MissionStatusChanged` for every transition so
+/// dashboard/Paloma clients update without a refresh.
+async fn reconcile_waiting_background(
+    mission_store: &Arc<dyn MissionStore>,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    missions_with_live_jobs: &HashSet<Uuid>,
+) {
+    // Promote missions that just gained (or still have) live jobs.
+    for &mission_id in missions_with_live_jobs {
+        let current = match mission_store.get_mission(mission_id).await {
+            Ok(Some(m)) => m.status,
+            _ => continue,
+        };
+        if let Some(next) = reconcile_parked_status(current, true) {
+            apply_reconciled_status(mission_store, events_tx, mission_id, next).await;
+        }
+    }
+
+    // Demote missions still marked WaitingBackground whose jobs are gone.
+    let waiting = match mission_store.get_waiting_background_mission_ids().await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::debug!("bg-autoresume: list waiting_background failed: {}", e);
+            return;
+        }
+    };
+    for mission_id in waiting {
+        if missions_with_live_jobs.contains(&mission_id) {
+            continue;
+        }
+        if let Some(next) = reconcile_parked_status(MissionStatus::WaitingBackground, false) {
+            apply_reconciled_status(mission_store, events_tx, mission_id, next).await;
+        }
+    }
+}
+
+async fn apply_reconciled_status(
+    mission_store: &Arc<dyn MissionStore>,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    mission_id: Uuid,
+    next: MissionStatus,
+) {
+    let reason = match next {
+        MissionStatus::WaitingBackground => Some("background_jobs_running"),
+        _ => None,
+    };
+    if let Err(e) = mission_store
+        .update_mission_status_with_reason(mission_id, next, reason)
+        .await
+    {
+        tracing::warn!(
+            mission_id = %mission_id,
+            ?next,
+            "bg-autoresume: failed to reconcile background status: {}",
+            e
+        );
+        return;
+    }
+    tracing::info!(
+        mission_id = %mission_id,
+        status = %next,
+        "bg-autoresume: reconciled mission background status"
+    );
+    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id,
+        status: next,
+        summary: None,
+    });
+}
+
+/// Boot-time settle for stranded `WaitingBackground` missions.
+///
+/// The background-task registry is in-memory, so a restart loses the record of
+/// which jobs were live. Any mission persisted as `WaitingBackground` therefore
+/// has no known live jobs at boot and must be settled back to `AwaitingUser` so
+/// the normal ack flow can archive it — otherwise it is stranded outside every
+/// terminal path. Runs unconditionally (independent of whether the auto-resume
+/// watcher is enabled), since only the watcher would otherwise heal it.
+pub(crate) async fn reset_waiting_background_on_boot(
+    mission_store: Arc<dyn MissionStore>,
+    events_tx: broadcast::Sender<AgentEvent>,
+) {
+    let no_live_jobs = HashSet::new();
+    reconcile_waiting_background(&mission_store, &events_tx, &no_live_jobs).await;
+}
+
 /// Watcher that auto-resumes missions whose background shell tasks have finished.
 ///
 /// Uses an in-memory [`BackgroundTaskRegistry`] shared with the control actor.
@@ -162,6 +265,18 @@ pub(crate) async fn background_task_autoresume_loop(
                 .collect()
         };
 
+        // Keep the persisted mission status in sync with the live registry so a
+        // mission with running background work is never presented as "done":
+        //   - AwaitingUser + live jobs  -> WaitingBackground (visible as ongoing,
+        //     and NOT eligible for ack-promotion, which only touches AwaitingUser)
+        //   - WaitingBackground + no live jobs -> AwaitingUser (settle back so the
+        //     normal ack flow can archive it; also un-strands a mission whose
+        //     in-memory registry was lost across a restart).
+        // Runs every tick, including when the registry is empty, precisely so the
+        // "no live jobs" settle-back path can fire.
+        let missions_with_live_jobs: HashSet<Uuid> = snapshot.iter().map(|(m, _)| *m).collect();
+        reconcile_waiting_background(&mission_store, &events_tx, &missions_with_live_jobs).await;
+
         if snapshot.is_empty() {
             watches.clear();
             continue;
@@ -194,7 +309,10 @@ pub(crate) async fn background_task_autoresume_loop(
                     continue;
                 }
             };
-            if mission.status != MissionStatus::AwaitingUser {
+            if !matches!(
+                mission.status,
+                MissionStatus::AwaitingUser | MissionStatus::WaitingBackground
+            ) {
                 let terminal = matches!(
                     mission.status,
                     MissionStatus::Completed | MissionStatus::Failed | MissionStatus::NotFeasible
@@ -663,9 +781,9 @@ fn truncate_for_pgrep(command: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        bg_decide_finished, parse_probe_line, pgrep_pattern_for_task, shell_single_quote,
-        truncate_for_pgrep, BackgroundTask, BgProbe, BgWatch, BG_IDLE_STABLE_SECS,
-        BG_START_GRACE_SECS,
+        bg_decide_finished, parse_probe_line, pgrep_pattern_for_task, reconcile_parked_status,
+        shell_single_quote, truncate_for_pgrep, BackgroundTask, BgProbe, BgWatch, MissionStatus,
+        BG_IDLE_STABLE_SECS, BG_START_GRACE_SECS,
     };
     use std::time::{Duration, Instant};
 
@@ -849,5 +967,60 @@ mod tests {
         let t = truncate_for_pgrep(&long);
         assert!(t.len() <= 120);
         assert!(long.starts_with(&t));
+    }
+
+    #[test]
+    fn reconcile_promotes_awaiting_user_with_live_jobs() {
+        // A mission that ended its turn but left background jobs running must be
+        // moved off AwaitingUser so it is never presented as done / ack-promoted.
+        assert_eq!(
+            reconcile_parked_status(MissionStatus::AwaitingUser, true),
+            Some(MissionStatus::WaitingBackground)
+        );
+    }
+
+    #[test]
+    fn reconcile_demotes_waiting_background_when_jobs_gone() {
+        // Once the background work drains, settle back to AwaitingUser so the
+        // normal ack flow can archive the mission (and un-strand it after a
+        // restart lost the in-memory registry).
+        assert_eq!(
+            reconcile_parked_status(MissionStatus::WaitingBackground, false),
+            Some(MissionStatus::AwaitingUser)
+        );
+    }
+
+    #[test]
+    fn reconcile_is_noop_when_already_consistent() {
+        // No transition when the persisted status already matches reality.
+        assert_eq!(
+            reconcile_parked_status(MissionStatus::AwaitingUser, false),
+            None
+        );
+        assert_eq!(
+            reconcile_parked_status(MissionStatus::WaitingBackground, true),
+            None
+        );
+    }
+
+    #[test]
+    fn reconcile_never_touches_active_or_terminal_statuses() {
+        // A mission actively running a turn, or already terminal, must never be
+        // flipped by the reconciler even if the registry still lists a job for
+        // it (that job is drained by the terminal/timeout paths instead).
+        for status in [
+            MissionStatus::Active,
+            MissionStatus::Pending,
+            MissionStatus::Completed,
+            MissionStatus::Failed,
+            MissionStatus::NotFeasible,
+            MissionStatus::Acknowledged,
+            MissionStatus::Blocked,
+            MissionStatus::Interrupted,
+            MissionStatus::Paused,
+        ] {
+            assert_eq!(reconcile_parked_status(status, true), None);
+            assert_eq!(reconcile_parked_status(status, false), None);
+        }
     }
 }

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -175,9 +175,29 @@ async fn reconcile_waiting_background(
         if missions_with_live_jobs.contains(&mission_id) {
             continue;
         }
-        if let Some(next) = reconcile_parked_status(MissionStatus::WaitingBackground, false) {
-            apply_reconciled_status(mission_store, events_tx, mission_id, next).await;
-        }
+        demote_parked_if_jobs_gone(mission_store, events_tx, mission_id).await;
+    }
+}
+
+/// Demote a single mission from `WaitingBackground` back to `AwaitingUser` now
+/// that its jobs are gone — but only after re-reading its current status.
+///
+/// The id came from a `get_waiting_background_mission_ids` snapshot; between that
+/// snapshot and this call auto-resume may have flipped the mission to `Active`.
+/// Re-reading and routing through [`reconcile_parked_status`] (which returns
+/// `None` for `Active`) ensures a running turn is never clobbered back to
+/// `AwaitingUser`, matching how the promotion loop re-reads each mission.
+async fn demote_parked_if_jobs_gone(
+    mission_store: &Arc<dyn MissionStore>,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    mission_id: Uuid,
+) {
+    let current = match mission_store.get_mission(mission_id).await {
+        Ok(Some(m)) => m.status,
+        _ => return,
+    };
+    if let Some(next) = reconcile_parked_status(current, false) {
+        apply_reconciled_status(mission_store, events_tx, mission_id, next).await;
     }
 }
 
@@ -781,11 +801,14 @@ fn truncate_for_pgrep(command: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        bg_decide_finished, parse_probe_line, pgrep_pattern_for_task, reconcile_parked_status,
-        shell_single_quote, truncate_for_pgrep, BackgroundTask, BgProbe, BgWatch, MissionStatus,
-        BG_IDLE_STABLE_SECS, BG_START_GRACE_SECS,
+        bg_decide_finished, demote_parked_if_jobs_gone, parse_probe_line, pgrep_pattern_for_task,
+        reconcile_parked_status, shell_single_quote, truncate_for_pgrep, BackgroundTask, BgProbe,
+        BgWatch, MissionStatus, BG_IDLE_STABLE_SECS, BG_START_GRACE_SECS,
     };
+    use crate::api::mission_store::{InMemoryMissionStore, MissionStore};
+    use std::sync::Arc;
     use std::time::{Duration, Instant};
+    use tokio::sync::broadcast;
 
     fn sample_task(id: &str, output_path: &str, command: &str) -> BackgroundTask {
         BackgroundTask {
@@ -1022,5 +1045,61 @@ mod tests {
             assert_eq!(reconcile_parked_status(status, true), None);
             assert_eq!(reconcile_parked_status(status, false), None);
         }
+    }
+
+    #[tokio::test]
+    async fn demote_leaves_reactivated_mission_active() {
+        // Regression: the demotion loop must re-read status. A mission id can be
+        // listed as WaitingBackground, then flip to Active (auto-resume started a
+        // turn) before this runs. Demoting it unconditionally would clobber the
+        // running turn back to AwaitingUser and re-open the ack race.
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let mission = store
+            .create_mission(Some("bg resume race"), None, None, None, None, None, None)
+            .await
+            .expect("mission should be created");
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .expect("set active");
+
+        demote_parked_if_jobs_gone(&store, &events_tx, mission.id).await;
+
+        let after = store
+            .get_mission(mission.id)
+            .await
+            .expect("get mission")
+            .expect("mission exists");
+        assert_eq!(
+            after.status,
+            MissionStatus::Active,
+            "a reactivated mission must not be demoted to AwaitingUser"
+        );
+    }
+
+    #[tokio::test]
+    async fn demote_settles_waiting_background_mission() {
+        // The normal path: a still-WaitingBackground mission whose jobs drained
+        // settles back to AwaitingUser so the ack flow can archive it.
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let (events_tx, _events_rx) = broadcast::channel(8);
+        let mission = store
+            .create_mission(Some("bg drained"), None, None, None, None, None, None)
+            .await
+            .expect("mission should be created");
+        store
+            .update_mission_status(mission.id, MissionStatus::WaitingBackground)
+            .await
+            .expect("set waiting_background");
+
+        demote_parked_if_jobs_gone(&store, &events_tx, mission.id).await;
+
+        let after = store
+            .get_mission(mission.id)
+            .await
+            .expect("get mission")
+            .expect("mission exists");
+        assert_eq!(after.status, MissionStatus::AwaitingUser);
     }
 }

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -401,7 +401,7 @@ fn mission_rank(mission: &Mission, interest: TelegramMissionInterestLevel) -> i3
     score += match mission.status {
         MissionStatus::Blocked | MissionStatus::Failed => 60,
         MissionStatus::AwaitingUser => 50,
-        MissionStatus::Active => 40,
+        MissionStatus::Active | MissionStatus::WaitingBackground => 40,
         MissionStatus::Pending => 25,
         MissionStatus::Interrupted => 20,
         MissionStatus::Paused => 10,

--- a/src/bin/palomactl.rs
+++ b/src/bin/palomactl.rs
@@ -474,12 +474,7 @@ struct PrGates {
     recommendation: Option<String>,
 }
 
-fn pr_gates(root: &Path, owner_repo: &str, number: u64) -> Result<PrGates> {
-    let mut gates = load_pr_fixture(root, owner_repo, number)
-        .or_else(|| gh_pr_gates(owner_repo, number))
-        .ok_or_else(|| anyhow!("could not read PR gates from fixture or gh"))?;
-    gates.owner_repo = owner_repo.to_string();
-    gates.number = number;
+fn apply_pr_gate_recommendation(gates: &mut PrGates) {
     let merge_state_status = gates
         .merge_state_status
         .as_deref()
@@ -515,6 +510,15 @@ fn pr_gates(root: &Path, owner_repo: &str, number: u64) -> Result<PrGates> {
     } else {
         Some("needs_checks_or_review".to_string())
     };
+}
+
+fn pr_gates(root: &Path, owner_repo: &str, number: u64) -> Result<PrGates> {
+    let mut gates = load_pr_fixture(root, owner_repo, number)
+        .or_else(|| gh_pr_gates(owner_repo, number))
+        .ok_or_else(|| anyhow!("could not read PR gates from fixture or gh"))?;
+    gates.owner_repo = owner_repo.to_string();
+    gates.number = number;
+    apply_pr_gate_recommendation(&mut gates);
     Ok(gates)
 }
 
@@ -589,24 +593,8 @@ fn parse_status_check_rollup(value: &Value) -> Vec<CheckRun> {
         .unwrap_or_default()
 }
 
-fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            owner_repo,
-            "--json",
-            "state,isDraft,mergeable,mergeStateStatus,merged,statusCheckRollup,comments",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let value: Value = serde_json::from_slice(&output.stdout).ok()?;
-    let checks = parse_status_check_rollup(&value);
+fn parse_gh_pr_gates(owner_repo: &str, number: u64, value: &Value) -> PrGates {
+    let checks = parse_status_check_rollup(value);
     let bugbot_accessible = value
         .get("comments")
         .and_then(Value::as_array)
@@ -621,14 +609,21 @@ fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
             })
         })
         .unwrap_or(false);
-    Some(PrGates {
+    let state = value
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let merged_at = value
+        .get("mergedAt")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some();
+    PrGates {
         owner_repo: owner_repo.to_string(),
         number,
-        state: value
-            .get("state")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_ascii_lowercase(),
+        state: state.clone(),
         draft: value
             .get("isDraft")
             .and_then(Value::as_bool)
@@ -636,7 +631,9 @@ fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
         merged: value
             .get("merged")
             .and_then(Value::as_bool)
-            .unwrap_or(false),
+            .unwrap_or(false)
+            || merged_at
+            || state.eq_ignore_ascii_case("merged"),
         mergeable: value
             .get("mergeable")
             .and_then(Value::as_str)
@@ -653,7 +650,27 @@ fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
         checks,
         bugbot_accessible,
         recommendation: None,
-    })
+    }
+}
+
+fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            owner_repo,
+            "--json",
+            "state,isDraft,mergeable,mergeStateStatus,mergedAt,statusCheckRollup,comments",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: Value = serde_json::from_slice(&output.stdout).ok()?;
+    Some(parse_gh_pr_gates(owner_repo, number, &value))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1054,6 +1071,26 @@ mod tests {
             }"#,
         );
         let gates = pr_gates(tmp.path(), "lfglabs-dev/verity", 106).unwrap();
+        assert_eq!(gates.recommendation.as_deref(), Some("already_merged"));
+    }
+
+    #[test]
+    fn gh_merged_at_without_merged_field_recommends_already_merged() {
+        let value = json!({
+            "state": "MERGED",
+            "isDraft": false,
+            "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
+            "mergedAt": "2026-07-01T11:22:33Z",
+            "statusCheckRollup": [
+                {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
+            ],
+            "comments": []
+        });
+        let mut gates = parse_gh_pr_gates("Th0rgal/sandboxed.sh", 575, &value);
+        apply_pr_gate_recommendation(&mut gates);
+
+        assert!(gates.merged);
         assert_eq!(gates.recommendation.as_deref(), Some("already_merged"));
     }
 


### PR DESCRIPTION
## Summary
- switch live `gh pr view` field list from unsupported `merged` to `mergedAt`
- classify gh-style merged PR JSON via `mergedAt` or `state == MERGED` while keeping fixture `merged: true` compatibility
- add regression coverage for gh JSON with `mergedAt` and no `merged` field

## Validation
```
cargo fmt --all --check
# passed with no output
```

```
PATH=/workspaces/mission-7ca97e23/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH cargo test --bin palomactl
Finished `test` profile [unoptimized + debuginfo] target(s) in 21m 21s
running 24 tests
test tests::gh_merged_at_without_merged_field_recommends_already_merged ... ok
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.67s
```

```
PATH=/workspaces/mission-7ca97e23/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH cargo build --bin palomactl && ./target/debug/palomactl pr-gates Th0rgal/sandboxed.sh 575
Finished `dev` profile [unoptimized + debuginfo] target(s) in 15m 54s
{
  "owner_repo": "Th0rgal/sandboxed.sh",
  "number": 575,
  "state": "merged",
  "draft": false,
  "merged": true,
  "mergeable": null,
  "merge_state_status": "unknown",
  "conflicting": false,
  "recommendation": "already_merged"
}
recommendation=already_merged
```

```
gh pr view 575 -R Th0rgal/sandboxed.sh --json state,isDraft,mergeable,mergeStateStatus,mergedAt,statusCheckRollup,comments --jq {state, mergedAt, mergeStateStatus}
{"mergeStateStatus":"UNKNOWN","mergedAt":"2026-07-01T12:44:51Z","state":"MERGED"}
```

```
git diff --check
# passed with no output
```

```
secret scan: no secret patterns found in diff
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission status semantics, ack promotion, boot recovery, and multi-client wire format; mitigated by targeted tests but touches core control-plane behavior.
> 
> **Overview**
> Introduces a non-terminal **`waiting_background`** mission status so work that continues in background shell jobs after the agent’s turn is not shown or archived as idle/done. The background auto-resume loop now **reconciles** `AwaitingUser` ↔ `WaitingBackground` from the live job registry each tick, **demotes** safely when jobs drain (re-reads status so an auto-resumed `Active` turn is not clobbered), and **resets stranded** `WaitingBackground` missions on boot when the in-memory registry is empty. **`message_activates_mission`** centralizes activation rules and includes `WaitingBackground` so resume clears `first_viewed_at` and idempotently and avoids ack-promotion races.
> 
> **Dashboard** and **Paloma/Telegram** surfaces add labels, colors, icons, favicon, running categorization, live automation status, and board scheduler behavior for the new status; mission stores persist/parse it and exclude it from stale ack promotion.
> 
> Separately, **`palomactl pr-gates`** uses `gh`’s **`mergedAt`** (and `state == merged`) instead of unsupported `merged`, with shared **`apply_pr_gate_recommendation`** and a regression test. A small **`client-message-id.test.ts`** typing fix keeps dashboard typecheck green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bce8ffad2f363bba4f0a62504d270f033dd509e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Second fix: keep missions visible while background jobs run

Missions could move to `acknowledged`/terminal-looking states while background shell jobs they spawned were still running, hiding active work from active/running lists.

- New non-terminal `MissionStatus::WaitingBackground`; a mission with live background jobs is never shown as done and stays in active/running queries + mission detail.
- Background autoresume loop is authoritative: reconciles `AwaitingUser <-> WaitingBackground` each tick from the live background-task registry (pure `reconcile_parked_status`), settles to the correct parked state when jobs finish, and resets stranded `WaitingBackground` on boot so a lost registry cannot park a mission forever.
- Dashboard: `waiting_background` added to status types, color/label maps, icons, favicon, live/running categorization, control switches.
- Also cleared a pre-existing TS7006 implicit-any in `client-message-id.test.ts` so dashboard typecheck is green.
