### PR TITLE
fix(paloma): sign webhook forwards with HMAC (X-Hub-Signature-256)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,10 @@ JWT_TTL_DAYS=30
 # notable statuses (completed, failed, not_feasible, blocked, awaiting_user).
 # Leave unset to disable the forwarder entirely.
 # PALOMA_WEBHOOK_FORWARD_URL=http://127.0.0.1:8644/webhooks/mission-complete
+# Optional: shared secret for the forwarder. When set, each POST carries a
+# GitHub-style `X-Hub-Signature-256: sha256=<hex>` header (HMAC-SHA256 of the
+# raw body) so signed-webhook consumers (e.g. Hermes) accept the delivery.
+# PALOMA_WEBHOOK_SECRET=change-me
 
 # =============================================================================
 # Optional: Web Search (Tavily)

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -570,6 +570,7 @@ mod tests {
             default_backend: None,
             automations_enabled: true,
             paloma_webhook_forward_url: None,
+            paloma_webhook_secret: None,
             max_concurrent_tasks: 5,
             spark_arbiter_url: None,
             spark_arbiter_token: None,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7540,6 +7540,7 @@ async fn paloma_webhook_forwarder_loop(
     mission_store: Arc<dyn MissionStore>,
     workspaces: workspace::SharedWorkspaceStore,
     url: String,
+    secret: Option<String>,
     http: reqwest::Client,
 ) {
     tracing::info!(webhook_url = %url, "Paloma mission-status webhook forwarder started");
@@ -7576,6 +7577,7 @@ async fn paloma_webhook_forwarder_loop(
                 // webhook can stall the broadcast receiver and lag-drop events.
                 let http = http.clone();
                 let url = url.clone();
+                let secret = secret.clone();
                 let mission_store = Arc::clone(&mission_store);
                 let workspaces = workspaces.clone();
                 let sem = Arc::clone(&sem);
@@ -7635,12 +7637,45 @@ async fn paloma_webhook_forwarder_loop(
                             .map(|k| k.as_str()),
                     });
 
+                    // Serialize once so the signature is computed over the
+                    // exact bytes sent (consumers verify HMAC over the raw
+                    // body, e.g. the Hermes webhook platform's GitHub-style
+                    // `X-Hub-Signature-256` check).
+                    let payload = match serde_json::to_vec(&body) {
+                        Ok(bytes) => bytes,
+                        Err(err) => {
+                            tracing::warn!(
+                                mission_id = %mission_id,
+                                "Failed to serialize Paloma webhook payload: {}",
+                                err
+                            );
+                            return;
+                        }
+                    };
+                    let signature = secret.as_ref().and_then(|secret| {
+                        use hmac::{Hmac, Mac};
+                        let mut mac =
+                            Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+                        mac.update(&payload);
+                        Some(format!(
+                            "sha256={}",
+                            hex::encode(mac.finalize().into_bytes())
+                        ))
+                    });
+
                     // At-least-once: retry transient failures with the SAME
                     // event_id so the consumer can dedupe. Bounded so a dead
                     // endpoint can't pile up tasks.
                     const MAX_ATTEMPTS: u32 = 3;
                     for attempt in 1..=MAX_ATTEMPTS {
-                        match http.post(&url).json(&body).send().await {
+                        let mut request = http
+                            .post(&url)
+                            .header(reqwest::header::CONTENT_TYPE, "application/json")
+                            .body(payload.clone());
+                        if let Some(signature) = signature.as_deref() {
+                            request = request.header("X-Hub-Signature-256", signature);
+                        }
+                        match request.send().await {
                             Ok(resp) if resp.status().is_success() => break,
                             Ok(resp) => {
                                 tracing::warn!(
@@ -7787,6 +7822,7 @@ fn spawn_control_session(
             Arc::clone(&state.mission_store),
             workspaces.clone(),
             url.clone(),
+            config.paloma_webhook_secret.clone(),
             reqwest::Client::builder()
                 .connect_timeout(std::time::Duration::from_secs(5))
                 .timeout(std::time::Duration::from_secs(10))

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@
 //! - `DEFAULT_BACKEND` - Optional. Default backend to use.
 //!   If not set, defaults to the first available backend with priority: claudecode → opencode → grok → gemini → codex.
 //! - `PALOMA_WEBHOOK_FORWARD_URL` - Optional. External webhook to receive mission status changes.
+//! - `PALOMA_WEBHOOK_SECRET` - Optional. HMAC-SHA256 secret; adds `X-Hub-Signature-256` to forwarded webhooks.
 //!
 //! Note: The agent has **full system access**. It can read/write any file, execute any command,
 //! and search anywhere on the machine. The `WORKING_DIR` is just the default for relative paths.
@@ -240,6 +241,12 @@ pub struct Config {
 
     /// Optional external webhook that receives Paloma mission status-change events.
     pub paloma_webhook_forward_url: Option<String>,
+
+    /// Optional shared secret for the Paloma webhook. When set, each forwarded
+    /// request carries a GitHub-style `X-Hub-Signature-256: sha256=<hex>`
+    /// header (HMAC-SHA256 of the raw body) so consumers that require signed
+    /// webhooks (e.g. the Hermes gateway webhook platform) accept it.
+    pub paloma_webhook_secret: Option<String>,
 
     /// DGX Spark build-offload config (all optional; offload is disabled unless
     /// all three are set). The host holds these credentials so workspaces never
@@ -624,6 +631,11 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        let paloma_webhook_secret = std::env::var("PALOMA_WEBHOOK_SECRET")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let env_opt = |k: &str| {
             std::env::var(k)
                 .ok()
@@ -653,6 +665,7 @@ impl Config {
             default_backend,
             automations_enabled,
             paloma_webhook_forward_url,
+            paloma_webhook_secret,
             spark_arbiter_url,
             spark_arbiter_token,
             spark_ssh_target,
@@ -681,6 +694,7 @@ impl Config {
             default_backend: None,
             automations_enabled: true,
             paloma_webhook_forward_url: None,
+            paloma_webhook_secret: None,
             spark_arbiter_url: None,
             spark_arbiter_token: None,
             spark_ssh_target: None,


### PR DESCRIPTION
## Problem
The Paloma mission-status webhook forwarder (`PALOMA_WEBHOOK_FORWARD_URL`) POSTs bare JSON with no signature. The Hermes gateway webhook platform rejects unsigned deliveries when the subscription has a secret — on prod, **every forward since 2026-06-27 was rejected with 401 Invalid signature (837 rejections)**, so no mission-status wakeup (completed / failed / blocked / awaiting_user) ever reached Hermes or Telegram.

## Fix
New optional `PALOMA_WEBHOOK_SECRET` env. When set, the forwarder serializes the payload once and signs the exact bytes sent with a GitHub-style `X-Hub-Signature-256: sha256=<hex>` header (HMAC-SHA256 over the raw body), which Hermes verifies natively (validated against the live prod endpoint: signed test POST → 202 accepted). Unset = previous unsigned behavior, no breaking change.

## Deploy note
Requires adding `PALOMA_WEBHOOK_SECRET=<hermes subscription secret>` to `/etc/open_agent/open_agent.env` on prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0764565e15e48fb82eaafedd2476621ff5392614. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->