### PR TITLE
feat(paloma): mirror status as webhook event type for route-level filtering

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7605,6 +7605,12 @@ async fn paloma_webhook_forwarder_loop(
                         "sequence": seq,
                         "mission_id": mission_id,
                         "status": status,
+                        // Event-type mirror of `status` so consumers with
+                        // route-level event filters (e.g. the Hermes webhook
+                        // platform reads `payload.type`) can drop unwanted
+                        // transitions like `acknowledged` before spawning an
+                        // agent run.
+                        "type": status,
                         "title": title,
                         "short_description": mission
                             .as_ref()


### PR DESCRIPTION
## Problem
Each mission end fires **two** forwardable webhook transitions — `awaiting_user`, then `acknowledged` ~1s later when fleet-daemon auto-acks — so Hermes runs two summary agents and sends two Telegram pings per mission (observed live on prod after #577 restored the pipeline).

## Fix
Mirror `status` into a `type` field in the forwarded payload. The Hermes webhook platform's route-level event filter reads `payload.type`, so the subscription can drop unwanted transitions **before** any agent run.

## Deploy pairing
At deploy time, set on the Hermes `mission-complete` subscription (hot-reloaded, no restart):
```json
"events": ["completed", "failed", "blocked", "awaiting_user"]
```
Backward-compatible: with `events: []` (current state) all transitions still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive JSON field on forwarded webhooks; no auth or persistence changes, and empty event filters remain backward-compatible.
> 
> **Overview**
> Mission status webhooks now include **`type`**, set to the same value as **`status`**, so downstream consumers (Hermes) can filter on `payload.type` at the route without changing existing **`status`** semantics.
> 
> This is meant to stop duplicate agent runs and notifications when a mission emits both **`awaiting_user`** and a follow-up **`acknowledged`** transition; subscriptions can exclude **`acknowledged`** while leaving **`events: []`** behavior unchanged (all transitions still pass).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be8389434918bbf4f5e3fc996cd74b7ea31d58e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->