### PR TITLE
feat(missions): accept model_effort=xhigh for codex backend

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4656,7 +4656,9 @@ fn normalize_model_effort_for_backend(backend: Option<&str>, raw: &str) -> Optio
     let normalized = normalize_model_effort(raw)?;
     match (backend, normalized.as_str()) {
         (Some("claudecode"), "low" | "medium" | "high" | "xhigh" | "max") => Some(normalized),
-        (Some("codex"), "low" | "medium" | "high") => Some(normalized),
+        // Codex CLI accepts `model_reasoning_effort=xhigh` (verified on
+        // codex-cli 0.137); the config value is passed through verbatim.
+        (Some("codex"), "low" | "medium" | "high" | "xhigh") => Some(normalized),
         _ => None,
     }
 }
@@ -4664,7 +4666,7 @@ fn normalize_model_effort_for_backend(backend: Option<&str>, raw: &str) -> Optio
 fn supported_model_efforts_for_backend(backend: Option<&str>) -> &'static str {
     match backend {
         Some("claudecode") => "low, medium, high, xhigh, max",
-        Some("codex") => "low, medium, high",
+        Some("codex") => "low, medium, high, xhigh",
         _ => "none",
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -627,7 +627,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "update_mission_settings".to_string(),
-                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok), model, reasoning effort, or agent. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. Note: model_effort only applies to claudecode (low/medium/high/xhigh/max) and codex (low/medium/high).".to_string(),
+                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok), model, reasoning effort, or agent. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. Note: model_effort only applies to claudecode (low/medium/high/xhigh/max) and codex (low/medium/high/xhigh).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -617,7 +617,7 @@ impl OrchestratorMcp {
                                     "prompt": { "type": "string", "description": "Full worker prompt: exact scope, absolute paths, success condition, verification command" },
                                     "backend": { "type": "string", "description": "codex | opencode | grok (never claudecode)" },
                                     "model_override": { "type": "string" },
-                                    "model_effort": { "type": "string", "description": "low | medium | high (codex)" },
+                                    "model_effort": { "type": "string", "description": "low | medium | high | xhigh (codex)" },
                                     "working_directory": { "type": "string", "description": "Worker cwd; superseded by worktree.path if a worktree is given" },
                                     "depends_on": { "type": "array", "items": { "type": "string" }, "description": "task_keys that must settle successfully or be accepted first" },
                                     "worktree": {


### PR DESCRIPTION
The API capped codex missions at model_effort=high, but the Codex CLI
accepts model_reasoning_effort=xhigh (verified on codex-cli 0.137, the
version deployed on prod) and passes it through to gpt-5.5. The cap
forced orchestrators asking for extra-high reasoning to silently fall
back to high.

Allow xhigh in normalize_model_effort_for_backend and update the MCP
tool schemas/descriptions to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation and documentation change; no auth or data-path changes, and behavior only expands an accepted effort level for codex.
> 
> **Overview**
> **Codex missions can now use `model_effort=xhigh`.** The control API previously rejected `xhigh` for the codex backend and only allowed low/medium/high, so requests for extra-high reasoning were dropped or normalized away even though Codex CLI accepts `model_reasoning_effort=xhigh`.
> 
> **Backend validation** in `normalize_model_effort_for_backend` and the codex branch of `supported_model_efforts_for_backend` now include `xhigh`, with a short comment that the value is passed through to the CLI.
> 
> **MCP docs** on `update_mission_settings` (assistant) and orchestrator task `model_effort` now state codex supports `low | medium | high | xhigh` instead of stopping at `high`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c76c8354195e02673afebd751259d5f222205c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->