### PR TITLE
fix(control): defer capacity-dropped targeted messages instead of orphaning missions

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2643,7 +2643,10 @@ pub struct ControlMessageRequest {
     pub agent: Option<String>,
     /// Target mission ID. If provided and differs from the currently running mission,
     /// the backend will automatically start this mission in parallel (if capacity allows).
-    #[serde(default)]
+    /// `target_mission_id` is accepted as an alias — unknown fields are otherwise
+    /// silently ignored, and a mistyped targeting field would silently reroute the
+    /// message to the session's current mission.
+    #[serde(default, alias = "target_mission_id")]
     pub mission_id: Option<Uuid>,
 }
 
@@ -10448,20 +10451,59 @@ async fn control_actor_loop(
                                 let max_parallel = crate::settings::max_parallel_missions_cached_or(config.max_parallel_missions);
 
                                 if total_running >= max_parallel {
-                                    tracing::warn!(
-                                        "Cannot start parallel mission {}: max {} reached. \
-                                         Dropping targeted message to avoid sending to wrong mission.",
-                                        tid, max_parallel
-                                    );
-                                    let _ = events_tx.send(AgentEvent::Error {
-                                        message: format!(
-                                            "Cannot start mission {}: max parallel missions ({}) reached",
-                                            tid, max_parallel
-                                        ),
-                                        mission_id: Some(tid),
-                                        resumable: true,
-                                    });
-                                    let _ = respond.send(UserMessageAck::Dropped);
+                                    // At capacity, dropping the message would orphan the
+                                    // mission: it stays Pending with no deferred_goal, so
+                                    // the FLEET-001 scheduler never dispatches it and the
+                                    // HTTP response (`queued: false`) is indistinguishable
+                                    // from a successful delivery. Stash the content as the
+                                    // deferred goal instead — the scheduler pass re-injects
+                                    // it as a normal targeted message once a slot frees.
+                                    let combined = match mission_store
+                                        .get_deferred_goal(tid)
+                                        .await
+                                        .ok()
+                                        .flatten()
+                                    {
+                                        Some(prev) if !prev.is_empty() => {
+                                            format!("{prev}\n{content}")
+                                        }
+                                        _ => content.clone(),
+                                    };
+                                    match mission_store.set_deferred_goal(tid, Some(combined)).await
+                                    {
+                                        Ok(()) => {
+                                            tracing::info!(
+                                                mission_id = %tid,
+                                                max_parallel,
+                                                "At capacity: deferring targeted message as scheduled goal"
+                                            );
+                                            let _ = events_tx.send(AgentEvent::UserMessage {
+                                                id,
+                                                content: content.clone(),
+                                                queued: true,
+                                                mission_id: Some(tid),
+                                                source: source.clone(),
+                                            });
+                                            let _ = respond.send(UserMessageAck::Queued);
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                mission_id = %tid,
+                                                "Cannot start parallel mission (max {} reached) and \
+                                                 failed to stash deferred goal: {e}",
+                                                max_parallel
+                                            );
+                                            let _ = events_tx.send(AgentEvent::Error {
+                                                message: format!(
+                                                    "Cannot start mission {}: max parallel missions ({}) reached",
+                                                    tid, max_parallel
+                                                ),
+                                                mission_id: Some(tid),
+                                                resumable: true,
+                                            });
+                                            let _ = respond.send(UserMessageAck::Dropped);
+                                        }
+                                    }
                                     continue;
                                 } else {
                                     // Load mission and start in parallel


### PR DESCRIPTION
When a targeted message arrived while all parallel slots were busy,
Case 2 dropped it outright. The mission (freshly created by
start_mission) then sat Pending forever: no deferred_goal means the
FLEET-001 scheduler never picks it up, and the HTTP response
(queued: false) is indistinguishable from a successful delivery, so
orchestrators believe the mission started. 178 orphaned pending
missions accumulated on prod this way; today it deadlocked the Beal
research pipeline for 12 hours (BR-16 zombie counted as live backlog).

At capacity, stash the message content as the mission's deferred goal
(same mechanism as the FLEET-001 not_before deferral) and ack Queued —
the scheduler pass re-injects it as a targeted message once a slot
frees. Also accept 'target_mission_id' as a serde alias on
ControlMessageRequest: unknown fields are silently ignored, and a
mistyped targeting field silently rerouted the message to the session's
current mission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission message routing and HTTP/event ack semantics under load in the control plane; mitigated by reusing the existing deferred-goal scheduler path already used for `not_before`.
> 
> **Overview**
> When a **targeted parallel mission** cannot start because **max parallel slots** are full, the control loop no longer **drops** the user message and acks failure. It now **stashes the content in `deferred_goal`** (merging with any existing stash), emits a **queued** user-message event, and returns **`UserMessageAck::Queued`** so callers and the UI treat it as pending work. The existing **FLEET-001 scheduler** can then **re-inject** that goal once capacity frees, instead of leaving the mission **Pending with no goal** forever.
> 
> **`ControlMessageRequest`** also accepts **`target_mission_id`** as a **serde alias** for **`mission_id`**, so clients that send the alternate field name are not silently ignored and misrouted to the session’s current mission.
> 
> If **`set_deferred_goal`** fails, behavior falls back to the previous **Error + Dropped** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adad2c2d8e3bd4eb83b32c3a7e1f69209b11003f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->