### PR TITLE
feat(api): atomic mission prompt, unknown-field warnings, mission digest, integrity report

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2648,12 +2648,21 @@ pub struct ControlMessageRequest {
     /// message to the session's current mission.
     #[serde(default, alias = "target_mission_id")]
     pub mission_id: Option<Uuid>,
+    /// Catch-all for unrecognized request fields — surfaced as `warnings` in
+    /// the response instead of being silently dropped (a mistyped targeting
+    /// field once silently rerouted a message to the wrong mission).
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ControlMessageResponse {
     pub id: Uuid,
     pub queued: bool,
+    /// Non-fatal request problems (e.g. unrecognized fields that were
+    /// ignored). Empty on clean requests; omitted from the JSON then.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
 }
 
 /// A message waiting in the queue
@@ -3385,6 +3394,18 @@ pub async fn post_message(
     let id = req.client_message_id.unwrap_or_else(Uuid::new_v4);
     let agent = req.agent;
     let target_mission_id = req.mission_id;
+    // Fail loud on unrecognized fields (see ControlMessageRequest::extra).
+    let mut warnings: Vec<String> = Vec::new();
+    if !req.extra.is_empty() {
+        let ignored: Vec<&str> = req.extra.keys().map(String::as_str).collect();
+        let joined = ignored.join(",");
+        tracing::warn!(
+            user_id = %user.id,
+            ignored_fields = %joined,
+            "control message request carried unrecognized fields (ignored)"
+        );
+        warnings.push(format!("unrecognized fields ignored: {joined}"));
+    }
     // A real user message means the operator is steering this mission — reset
     // its stall-guard budget so future genuine stalls get the full allowance.
     if let Some(mid) = target_mission_id {
@@ -3424,7 +3445,11 @@ pub async fn post_message(
             status.state != ControlRunState::Idle
         }
     };
-    Ok(Json(ControlMessageResponse { id, queued }))
+    Ok(Json(ControlMessageResponse {
+        id,
+        queued,
+        warnings,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -4572,6 +4597,181 @@ pub async fn get_mission(
     }
 }
 
+/// Compact, orchestrator-friendly view of a mission: status, last exchange,
+/// and PR links — without the full transcript. Recap/orchestration sessions
+/// previously pulled entire mission histories (multi-KB each) just to answer
+/// "where is this mission at?"; this answers the same question in ~2 KB.
+pub async fn get_mission_digest(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let Some(mut mission) = control
+        .mission_store
+        .get_mission(id)
+        .await
+        .map_err(internal_error)?
+    else {
+        return Err((StatusCode::NOT_FOUND, format!("Mission {} not found", id)));
+    };
+    if mission.workspace_name.is_none() {
+        mission.workspace_name = state
+            .workspaces
+            .get(mission.workspace_id)
+            .await
+            .map(|ws| ws.name);
+    }
+
+    fn truncate_chars(s: &str, max: usize) -> String {
+        let total = s.chars().count();
+        if total <= max {
+            s.to_string()
+        } else {
+            let cut: String = s.chars().take(max).collect();
+            format!("{cut}… [+{} chars truncated]", total - max)
+        }
+    }
+
+    let last_assistant = mission
+        .history
+        .iter()
+        .rev()
+        .find(|e| e.role == "assistant" && !e.content.trim().is_empty())
+        .map(|e| truncate_chars(&e.content, 2000));
+    let last_user = mission
+        .history
+        .iter()
+        .rev()
+        .find(|e| e.role == "user")
+        .map(|e| truncate_chars(&e.content, 500));
+
+    // GitHub PR links mentioned near the end of the transcript (most recent
+    // first, deduped) — the fact orchestrators most often dig transcripts for.
+    let mut github_prs: Vec<String> = Vec::new();
+    for entry in mission.history.iter().rev().take(10) {
+        for word in entry.content.split_whitespace() {
+            let word = word.trim_matches(|c: char| {
+                !c.is_ascii_alphanumeric() && c != '/' && c != ':' && c != '.'
+            });
+            if word.starts_with("https://github.com/") && word.contains("/pull/") {
+                let url = word.trim_end_matches(|c: char| !c.is_ascii_digit());
+                if !url.is_empty() && !github_prs.iter().any(|u| u == url) {
+                    github_prs.push(url.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(Json(serde_json::json!({
+        "id": mission.id,
+        "title": mission.title,
+        "status": mission.status,
+        "awaiting_kind": mission.awaiting_kind.map(|k| k.as_str()),
+        "terminal_reason": mission.terminal_reason,
+        "short_description": mission.short_description,
+        "backend": mission.backend,
+        "model_override": mission.model_override,
+        "model_effort": mission.model_effort,
+        "workspace_id": mission.workspace_id,
+        "workspace_name": mission.workspace_name,
+        "project": mission.project,
+        "created_at": mission.created_at,
+        "updated_at": mission.updated_at,
+        "history_len": mission.history.len(),
+        "last_user_message": last_user,
+        "last_assistant_message": last_assistant,
+        "github_prs": github_prs,
+    })))
+}
+
+/// Fleet integrity report: mission-store anomalies that otherwise fail
+/// silently — pending missions nothing will ever dispatch, active missions
+/// with no recent progress, and long-idle awaiting_user rows. Read-only;
+/// intended for a daily sweep or an on-demand health check (178 orphaned
+/// pending missions once accumulated unnoticed before this existed).
+pub async fn missions_integrity(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let control = control_for_user(&state, &user).await;
+    let missions = control
+        .mission_store
+        .list_missions(5000, 0)
+        .await
+        .map_err(internal_error)?;
+    let now = chrono::Utc::now();
+    let age_minutes = |ts: &str| -> i64 {
+        chrono::DateTime::parse_from_rfc3339(ts)
+            .map(|t| (now - t.with_timezone(&chrono::Utc)).num_minutes())
+            .unwrap_or(0)
+    };
+    let brief = |m: &Mission| {
+        serde_json::json!({
+            "id": m.id,
+            "title": m.title,
+            "status": m.status,
+            "updated_age_minutes": age_minutes(&m.updated_at),
+        })
+    };
+
+    // Pending missions: split into scheduler-visible (deferred goal set,
+    // waiting on capacity/not_before) vs orphaned (nothing will dispatch them).
+    let mut orphaned_pending: Vec<serde_json::Value> = Vec::new();
+    let mut scheduled_waiting: Vec<serde_json::Value> = Vec::new();
+    for m in missions
+        .iter()
+        .filter(|m| m.status == MissionStatus::Pending)
+    {
+        if age_minutes(&m.created_at) < 15 {
+            continue; // freshly created; give the caller time to deliver a goal
+        }
+        let has_goal = control
+            .mission_store
+            .get_deferred_goal(m.id)
+            .await
+            .ok()
+            .flatten()
+            .is_some();
+        if has_goal {
+            scheduled_waiting.push(brief(m));
+        } else {
+            orphaned_pending.push(brief(m));
+        }
+    }
+
+    let stale_active: Vec<serde_json::Value> = missions
+        .iter()
+        .filter(|m| m.status == MissionStatus::Active && age_minutes(&m.updated_at) > 24 * 60)
+        .map(brief)
+        .collect();
+    let stale_awaiting: Vec<serde_json::Value> = missions
+        .iter()
+        .filter(|m| m.status == MissionStatus::AwaitingUser && age_minutes(&m.updated_at) > 72 * 60)
+        .map(brief)
+        .collect();
+
+    let truncate = |mut v: Vec<serde_json::Value>| -> (usize, Vec<serde_json::Value>) {
+        let count = v.len();
+        v.truncate(20);
+        (count, v)
+    };
+    let (orphaned_count, orphaned_pending) = truncate(orphaned_pending);
+    let (scheduled_count, scheduled_waiting) = truncate(scheduled_waiting);
+    let (stale_active_count, stale_active) = truncate(stale_active);
+    let (stale_awaiting_count, stale_awaiting) = truncate(stale_awaiting);
+
+    Ok(Json(serde_json::json!({
+        "generated_at": now.to_rfc3339(),
+        "scanned": missions.len(),
+        "healthy": orphaned_count == 0 && stale_active_count == 0,
+        "orphaned_pending": { "count": orphaned_count, "missions": orphaned_pending },
+        "scheduled_waiting": { "count": scheduled_count, "missions": scheduled_waiting },
+        "stale_active": { "count": stale_active_count, "missions": stale_active },
+        "stale_awaiting_user": { "count": stale_awaiting_count, "missions": stale_awaiting },
+    })))
+}
+
 /// Create a new mission and switch to it.
 /// Request body for creating a mission
 #[derive(Debug, Deserialize)]
@@ -4617,6 +4817,20 @@ pub struct CreateMissionRequest {
     pub desired_state: Option<String>,
     /// When the track should next be checked (RFC3339).
     pub next_check_at: Option<String>,
+    /// Initial prompt for the mission. Stored as the mission's deferred goal:
+    /// the FLEET-001 scheduler dispatches it as the first user message as soon
+    /// as parallel capacity allows (immediately when a slot is free, honoring
+    /// `not_before` when set). This makes create+start atomic — callers no
+    /// longer need a follow-up `POST /api/control/message`, whose delivery
+    /// used to be droppable at capacity, orphaning the mission.
+    pub prompt: Option<String>,
+    /// Catch-all for unrecognized request fields. Serde ignores unknown fields
+    /// by default, which has repeatedly hidden client bugs (a `prompt` sent
+    /// before the field existed, a mistyped `target_mission_id`). Captured
+    /// here so the handler can surface them via the `X-Ignored-Fields`
+    /// response header and a warning log instead of dropping them silently.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 fn deserialize_string_patch<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
@@ -4704,7 +4918,7 @@ pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
     body: Option<Json<CreateMissionRequest>>,
-) -> Result<Json<Mission>, (StatusCode, String)> {
+) -> Result<(axum::http::HeaderMap, Json<Mission>), (StatusCode, String)> {
     let (tx, rx) = oneshot::channel();
 
     let req = body.map(|b| b.0).unwrap_or(CreateMissionRequest {
@@ -4727,7 +4941,26 @@ pub async fn create_mission(
         tags: None,
         desired_state: None,
         next_check_at: None,
+        prompt: None,
+        extra: Default::default(),
     });
+
+    // Fail loud on unrecognized fields: log + surface in a response header so
+    // a client bug (typo, field sent to the wrong endpoint) is observable
+    // instead of silently changing behavior.
+    let mut headers = axum::http::HeaderMap::new();
+    if !req.extra.is_empty() {
+        let ignored: Vec<&str> = req.extra.keys().map(String::as_str).collect();
+        let joined = ignored.join(",");
+        tracing::warn!(
+            user_id = %user.id,
+            ignored_fields = %joined,
+            "create_mission request carried unrecognized fields (ignored)"
+        );
+        if let Ok(value) = axum::http::HeaderValue::from_str(&joined) {
+            headers.insert("x-ignored-fields", value);
+        }
+    }
 
     let title = req.title.clone();
     let workspace_id = req.workspace_id;
@@ -4925,7 +5158,28 @@ pub async fn create_mission(
         }
     }
 
-    Ok(Json(mission))
+    // Atomic create+start: stash the initial prompt as the deferred goal. The
+    // FLEET-001 scheduler pass (every ~5s) dispatches pending missions with a
+    // deferred goal as soon as parallel capacity allows, honoring `not_before`
+    // when set. Unlike the old create-then-message pattern, this cannot be
+    // dropped at capacity.
+    if let Some(prompt) = nonblank(&req.prompt) {
+        control
+            .mission_store
+            .set_deferred_goal(mission.id, Some(prompt.clone()))
+            .await
+            .map_err(internal_error)?;
+        // Surface the queued goal so UIs show it as pending until dispatch.
+        let _ = control.events_tx.send(AgentEvent::UserMessage {
+            id: Uuid::new_v4(),
+            content: prompt,
+            queued: true,
+            mission_id: Some(mission.id),
+            source: Some(format!("api:{}", user.id)),
+        });
+    }
+
+    Ok((headers, Json(mission)))
 }
 
 /// Request body for `POST /api/control/missions/:id/project`. Tri-state per
@@ -6373,9 +6627,11 @@ pub async fn clone_mission(
         },
         desired_state: source.project.desired_state.clone(),
         next_check_at: source.project.next_check_at.clone(),
+        prompt: None,
+        extra: Default::default(),
     };
 
-    let cloned = create_mission(State(state), Extension(user), Some(Json(req))).await?;
+    let (_headers, cloned) = create_mission(State(state), Extension(user), Some(Json(req))).await?;
     let clone_id = cloned.0.id;
 
     // Optionally seed the clone with the source's conversation history

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -699,6 +699,14 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .route("/api/control/missions", get(control::list_missions))
         .route("/api/control/missions", post(control::create_mission))
         .route(
+            "/api/control/missions/integrity",
+            get(control::missions_integrity),
+        )
+        .route(
+            "/api/control/missions/:id/digest",
+            get(control::get_mission_digest),
+        )
+        .route(
             "/api/control/missions/search",
             get(control::search_missions),
         )

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -477,7 +477,16 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "get_mission".to_string(),
-                description: "Get one mission by UUID.".to_string(),
+                description: "Get one mission by UUID (full record incl. history — heavy; prefer get_mission_digest for status checks).".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {"mission_id": {"type": "string"}}
+                }),
+            },
+            ToolDefinition {
+                name: "get_mission_digest".to_string(),
+                description: "Compact ~2KB mission status: state, awaiting_kind, last user/assistant messages (truncated), GitHub PR links, project metadata. Use this instead of get_mission/get_mission_events for recaps and 'where is it?' checks — it avoids pulling whole transcripts into context.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -731,6 +740,20 @@ impl AssistantMcp {
             .map_err(|error| format!("Failed to parse mission: {error}"))
     }
 
+    async fn get_mission_digest(&self, params: MissionIdParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.mission_id)?;
+        let response = self
+            .api_get(&format!("/api/control/missions/{id}/digest"))
+            .await?;
+        if !response.status().is_success() {
+            return Err(format!("Mission not found: {}", response.status()));
+        }
+        response
+            .json()
+            .await
+            .map_err(|error| format!("Failed to parse mission digest: {error}"))
+    }
+
     async fn get_mission_events(&self, params: MissionEventsParams) -> Result<Value, String> {
         let id = parse_uuid(&params.mission_id)?;
         let limit = params.limit.clamp(1, 200);
@@ -850,6 +873,11 @@ impl AssistantMcp {
             "model_effort": params.model_effort,
             "config_profile": params.config_profile,
             "agent": params.agent,
+            // Atomic create+start: the API stores the prompt as the mission's
+            // deferred goal and the scheduler dispatches it as soon as
+            // capacity allows. The old create-then-send_message pattern could
+            // be dropped at capacity, leaving zombie Pending missions.
+            "prompt": params.prompt,
             // Project tagging at creation so the mission isn't born with null
             // metadata (Paloma watchdogs then route by these, not titles).
             "project": params.project,
@@ -869,14 +897,9 @@ impl AssistantMcp {
             .json()
             .await
             .map_err(|error| format!("Failed to parse created mission: {error}"))?;
-        let Some(mission_id) = mission["id"].as_str() else {
+        if mission["id"].as_str().is_none() {
             return Err("Created mission response did not include an id".to_string());
-        };
-        self.send_message(SendMessageParams {
-            mission_id: mission_id.to_string(),
-            content: params.prompt,
-        })
-        .await?;
+        }
         Ok(json!({ "mission": mission }))
     }
 
@@ -1325,6 +1348,11 @@ impl AssistantMcp {
                 let params: MissionIdParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
                 self.get_mission(params).await
+            }
+            "get_mission_digest" => {
+                let params: MissionIdParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.get_mission_digest(params).await
             }
             "get_mission_events" => {
                 let params: MissionEventsParams = serde_json::from_value(arguments)

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1148,6 +1148,12 @@ impl OrchestratorMcp {
             "parent_mission_id": self.mission_id.to_string(),
             "working_directory": params.working_directory,
             "workspace_id": workspace_id,
+            // Atomic create+start: the API stores the prompt as the mission's
+            // deferred goal and the scheduler dispatches it once capacity
+            // allows. The old create-then-message pattern could be dropped at
+            // capacity, leaving a zombie Pending worker the boss believed was
+            // running.
+            "prompt": params.prompt,
         });
 
         let response = self.api_post("/api/control/missions", body).await?;
@@ -1160,21 +1166,6 @@ impl OrchestratorMcp {
             .json()
             .await
             .map_err(|e| format!("Failed to parse response: {}", e))?;
-
-        let worker_id = mission["id"].as_str().unwrap_or("");
-
-        // If a prompt was provided, send it as the first message
-        if let Some(prompt) = params.prompt {
-            if !prompt.trim().is_empty() && !worker_id.is_empty() {
-                let msg_body = json!({
-                    "content": prompt,
-                    "mission_id": worker_id,
-                });
-                if let Err(e) = self.api_post("/api/control/message", msg_body).await {
-                    eprintln!("[orchestrator-mcp] Warning: created mission but failed to send initial prompt: {}", e);
-                }
-            }
-        }
 
         Ok(mission)
     }


### PR DESCRIPTION
Four reliability/efficiency changes from the fleet-architecture review:

1. CreateMissionRequest.prompt — stored as the mission's deferred goal;
   the FLEET-001 scheduler dispatches it as the first message as soon as
   capacity allows. Create+start becomes atomic: the create-then-message
   pattern used by every orchestrator could be dropped at capacity (or
   silently ignored, as the Beal dispatcher's 'prompt' field was for
   months), leaving zombie Pending missions. assistant_mcp start_mission
   and orchestrator_mcp spawn_worker now use it.

2. Unknown-field warnings — CreateMissionRequest and
   ControlMessageRequest capture unrecognized fields via serde(flatten)
   and surface them (X-Ignored-Fields header on create, warnings[] in
   the message response) instead of silently ignoring them. Three
   production incidents traced back to silently-dropped fields.

3. GET /api/control/missions/:id/digest + assistant_mcp
   get_mission_digest — ~2KB status view (state, awaiting_kind, last
   exchange truncated, GitHub PR links, project metadata). Recap
   sessions previously pulled full transcripts (54M input tokens over
   two weeks of TUI sessions, mostly status checks).

4. GET /api/control/missions/integrity — read-only anomaly report:
   orphaned pending (nothing will dispatch), scheduled-waiting,
   stale-active, stale-awaiting. 178 orphaned missions once accumulated
   unnoticed; this makes the failure mode observable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core mission creation and message ingestion paths (deferred goals, response shape/headers); behavior is intentional but affects all orchestrators and clients that relied on silent unknown-field drops or create-then-message.
> 
> **Overview**
> **Mission create + start is now one step.** `CreateMissionRequest` accepts an optional **`prompt`**, stored as a **deferred goal** and dispatched by the existing scheduler when capacity allows—replacing the fragile create-then-`POST /api/control/message` flow that could drop at capacity and leave **Pending** missions with no work. **`assistant_mcp`** and **`orchestrator_mcp`** send `prompt` on create and no longer post a separate initial message.
> 
> **Unknown request fields are visible instead of silently ignored.** **`ControlMessageRequest`** and **`CreateMissionRequest`** use **`serde(flatten)`** on an **`extra`** map: create missions return **`X-Ignored-Fields`**; control messages return **`warnings[]`** and log the ignored keys.
> 
> **New read-only fleet tooling:** **`GET /api/control/missions/:id/digest`** returns a small status snapshot (truncated last exchange, PR links, metadata) for orchestration/recaps; **`GET /api/control/missions/integrity`** reports orphaned pending, scheduled-waiting, stale active, and long-idle **awaiting_user** missions. Routes are wired in **`routes.rs`**; **`assistant_mcp`** adds **`get_mission_digest`** and steers callers away from full **`get_mission`** for status checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2f5ade5f5f444114e82a7d9cc97bca19e34789b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->