### PR TITLE
Improve Hermes mission control

### DIFF
--- a/dashboard/src/components/hermes/hermes-page.tsx
+++ b/dashboard/src/components/hermes/hermes-page.tsx
@@ -1,97 +1,377 @@
 "use client";
 
 import Link from "next/link";
+import type { ReactNode } from "react";
 import useSWR from "swr";
-import { ArrowUpRight, CircleOff } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  ArrowUpRight,
+  Bot,
+  CheckCircle2,
+  CircleOff,
+  Clock3,
+  Loader,
+  MessageSquare,
+  RadioTower,
+} from "lucide-react";
 
-import { getHermesAssistantStatus } from "@/lib/api/assistant";
+import {
+  getHermesAssistantStatus,
+  getHermesMissionControl,
+  type HermesMissionCard,
+} from "@/lib/api";
 import { HermesThread } from "@/components/hermes/hermes-thread";
 import { AlertsFeed } from "@/components/hermes/alerts-feed";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { cn } from "@/lib/utils";
 
-/**
- * Landing page: chat with the Hermes assistant, with the cross-mission
- * alerts feed on a right rail. Management of the Hermes runtime itself
- * (gateways, memory, skills) stays on /assistant.
- */
 export default function HermesPage() {
   const { data: status, isLoading } = useSWR(
     "hermes-assistant-status",
     getHermesAssistantStatus,
     { refreshInterval: 30000, revalidateOnFocus: false },
   );
+  const { data: control, isLoading: controlLoading } = useSWR(
+    "hermes-mission-control",
+    getHermesMissionControl,
+    { refreshInterval: 15000, revalidateOnFocus: false },
+  );
 
   const runtimeReady = Boolean(status?.service_active);
+  const runtimeChecking = isLoading && !status;
+  const runtime = control?.runtime;
+  const sessionSources = Object.entries(control?.sessions.by_source ?? {})
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
 
   return (
-    <div className="flex flex-col lg:h-screen lg:flex-row lg:overflow-hidden">
-      {/* Chat column */}
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-4">
-          <div>
-            <h1 className="text-xl font-semibold text-white">Hermes</h1>
-            <p className="text-sm text-white/50">
-              Your assistant, wired into every mission.
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            {status?.model && (
-              <span
-                className="hidden rounded-md border border-white/[0.06] bg-white/[0.03] px-1.5 py-0.5 font-mono text-[10px] text-white/45 sm:inline"
-                title="Model the Hermes runtime is configured to use"
-              >
-                {status.model}
-              </span>
-            )}
-            <span className="flex items-center gap-1.5 text-xs text-white/45">
-              <span
-                className={
-                  runtimeReady
-                    ? "h-1.5 w-1.5 rounded-full bg-emerald-400"
-                    : "h-1.5 w-1.5 rounded-full bg-white/25"
-                }
-              />
-              {isLoading ? "checking…" : runtimeReady ? "online" : "offline"}
-            </span>
-            <Link
-              href="/assistant"
-              className="inline-flex items-center gap-1 text-xs text-white/45 transition-colors hover:text-white/75"
-            >
-              Manage <ArrowUpRight className="h-3 w-3" />
-            </Link>
-          </div>
+    <div className="flex flex-col lg:h-screen lg:overflow-hidden">
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-4">
+        <div>
+          <h1 className="text-xl font-semibold text-white">Hermes</h1>
+          <p className="text-sm text-white/50">
+            Mission control, assistant runtime, and operator chat.
+          </p>
         </div>
-
-        {runtimeReady || isLoading ? (
-          <HermesThread className="flex-1" />
-        ) : (
-          <div className="flex flex-1 items-center justify-center p-8">
-            <div className="max-w-md text-center">
-              <CircleOff className="mx-auto h-8 w-8 text-white/25" />
-              <p className="mt-3 text-sm text-white/70">
-                The Hermes runtime is not running.
-              </p>
-              <p className="mt-1 text-xs text-white/40">
-                Install or start it from the Assistant page, then come back —
-                this page talks to the same Hermes that answers you on
-                Telegram.
-              </p>
-              <Link
-                href="/assistant"
-                className="mt-4 inline-flex items-center gap-1 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-600"
-              >
-                Open Assistant setup <ArrowUpRight className="h-3 w-3" />
-              </Link>
-            </div>
-          </div>
-        )}
+        <div className="flex items-center gap-3">
+          {runtime?.model && (
+            <span
+              className="hidden rounded-md border border-white/[0.06] bg-white/[0.03] px-1.5 py-0.5 font-mono text-[10px] text-white/45 sm:inline"
+              title="Model the Hermes runtime is configured to use"
+            >
+              {runtime.model}
+            </span>
+          )}
+          <span className="flex items-center gap-1.5 text-xs text-white/45">
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full",
+                runtimeReady ? "bg-emerald-400" : "bg-white/25",
+              )}
+            />
+            {isLoading ? "checking..." : runtimeReady ? "online" : "offline"}
+          </span>
+          <Link
+            href="/assistant"
+            className="inline-flex items-center gap-1 text-xs text-white/45 transition-colors hover:text-white/75"
+          >
+            Manage <ArrowUpRight className="h-3 w-3" />
+          </Link>
+        </div>
       </div>
 
-      {/* Alerts rail — mirrors the Overview right rail (width, border, padding) */}
-      <div className="flex w-full flex-col gap-4 border-t border-white/[0.06] p-4 lg:h-screen lg:w-72 lg:border-l lg:border-t-0">
-        <div className="min-h-0 flex-1">
+      <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden xl:grid-cols-[minmax(420px,1fr)_360px_300px]">
+        <main className="min-h-0 overflow-y-auto px-5 py-4">
+          {controlLoading && !control ? (
+            <div className="flex items-center gap-2 text-sm text-white/45">
+              <Loader className="h-4 w-4 animate-spin" /> Loading mission control...
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <section className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <Metric
+                  icon={Activity}
+                  label="Active"
+                  value={String(control?.active.length ?? 0)}
+                  detail={`${control?.mission_status_counts.active ?? 0} running / ${control?.mission_status_counts.waiting_background ?? 0} background`}
+                />
+                <Metric
+                  icon={AlertTriangle}
+                  label="Needs Attention"
+                  value={String(control?.needs_attention.length ?? 0)}
+                  detail={
+                    control?.failures[0]
+                      ? `${control.failures[0].class}: ${control.failures[0].count}`
+                      : "No grouped failures"
+                  }
+                  tone={(control?.needs_attention.length ?? 0) > 0 ? "warn" : "ok"}
+                />
+                <Metric
+                  icon={MessageSquare}
+                  label="Hermes Sessions"
+                  value={String(control?.sessions.total ?? 0)}
+                  detail={`${control?.sessions.messages ?? 0} messages / ${control?.sessions.tool_calls ?? 0} tools`}
+                />
+              </section>
+
+              <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                <RuntimePanel
+                  serviceActive={runtimeReady}
+                  model={runtime?.model ?? status?.model ?? null}
+                  baseUrl={runtime?.base_url ?? null}
+                  expectedBaseUrl={runtime?.expected_base_url ?? null}
+                  usesProxy={runtime?.uses_sandboxed_proxy ?? false}
+                  notes={runtime?.notes ?? status?.notes ?? []}
+                />
+                <Panel title="Watchers" icon={RadioTower}>
+                  <div className="space-y-2">
+                    {sessionSources.length === 0 ? (
+                      <p className="text-xs text-white/35">
+                        No recent Hermes session activity.
+                      </p>
+                    ) : (
+                      sessionSources.map(([source, count]) => (
+                        <div
+                          key={source}
+                          className="flex items-center justify-between text-xs"
+                        >
+                          <span className="capitalize text-white/65">{source}</span>
+                          <span className="font-mono text-white/40">{count}</span>
+                        </div>
+                      ))
+                    )}
+                    <div className="border-t border-white/[0.06] pt-2 text-xs text-white/40">
+                      Remote nodes:{" "}
+                      {control?.remote_nodes.enabled ? "enabled" : "disabled"}
+                      {control?.remote_nodes.configured_nodes
+                        ? ` / ${control.remote_nodes.configured_nodes} configured`
+                        : ""}
+                    </div>
+                  </div>
+                </Panel>
+              </section>
+
+              <MissionList
+                title="Now"
+                icon={Clock3}
+                missions={control?.active ?? []}
+                empty="No active supervised missions."
+              />
+              <MissionList
+                title="Needs Attention"
+                icon={AlertTriangle}
+                missions={control?.needs_attention ?? []}
+                empty="No stuck or failed missions in the current scan."
+              />
+              <MissionList
+                title="Handled Recently"
+                icon={CheckCircle2}
+                missions={control?.handled_recently ?? []}
+                empty="No recent acknowledged missions."
+              />
+            </div>
+          )}
+        </main>
+
+        <aside className="min-h-0 border-t border-white/[0.06] xl:border-l xl:border-t-0">
+          {runtimeReady || runtimeChecking ? (
+            <HermesThread className="h-full" />
+          ) : (
+            <HermesOfflinePanel />
+          )}
+        </aside>
+
+        <aside className="min-h-0 border-t border-white/[0.06] p-4 xl:border-l xl:border-t-0">
           <AlertsFeed />
-        </div>
+        </aside>
       </div>
     </div>
   );
+}
+
+function HermesOfflinePanel() {
+  return (
+    <div className="flex h-full min-h-[360px] items-center justify-center p-6">
+      <div className="max-w-xs text-center">
+        <CircleOff className="mx-auto h-8 w-8 text-white/25" />
+        <p className="mt-3 text-sm text-white/70">Hermes chat is offline.</p>
+        <p className="mt-1 text-xs text-white/40">
+          Mission control remains available so the runtime can be diagnosed.
+        </p>
+        <Link
+          href="/assistant"
+          className="mt-4 inline-flex items-center gap-1 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-600"
+        >
+          Open Assistant setup <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+  detail,
+  tone = "neutral",
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  detail: string;
+  tone?: "neutral" | "ok" | "warn";
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.025] p-3">
+      <div className="flex items-center gap-2 text-xs text-white/45">
+        <Icon className={cn("h-3.5 w-3.5", tone === "warn" ? "text-amber-300" : tone === "ok" ? "text-emerald-300" : "text-primary")} />
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
+      <div className="mt-1 truncate text-xs text-white/40">{detail}</div>
+    </div>
+  );
+}
+
+function Panel({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: LucideIcon;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-white/[0.06] bg-white/[0.025] p-3">
+      <div className="mb-3 flex items-center gap-2 text-xs font-medium text-white/70">
+        <Icon className="h-3.5 w-3.5 text-primary" />
+        {title}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function RuntimePanel({
+  serviceActive,
+  model,
+  baseUrl,
+  expectedBaseUrl,
+  usesProxy,
+  notes,
+}: {
+  serviceActive: boolean;
+  model: string | null;
+  baseUrl: string | null;
+  expectedBaseUrl: string | null;
+  usesProxy: boolean;
+  notes: string[];
+}) {
+  return (
+    <Panel title="Provider Health" icon={Bot}>
+      <div className="space-y-2 text-xs">
+        <StatusLine label="Runtime" ok={serviceActive} text={serviceActive ? "service active" : "service offline"} />
+        <StatusLine label="Routing" ok={usesProxy} text={usesProxy ? "through sandboxed.sh /v1" : "direct or unknown"} />
+        <div className="truncate text-white/45">Model: <span className="font-mono text-white/65">{model ?? "unknown"}</span></div>
+        <div className="truncate text-white/35" title={baseUrl ?? expectedBaseUrl ?? undefined}>
+          Base URL: {baseUrl ?? "unknown"}
+        </div>
+        {notes.slice(0, 3).map((note) => (
+          <div key={note} className="rounded-md bg-amber-500/10 px-2 py-1 text-amber-200/80">
+            {note}
+          </div>
+        ))}
+      </div>
+    </Panel>
+  );
+}
+
+function StatusLine({ label, ok, text }: { label: string; ok: boolean; text: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-white/45">{label}</span>
+      <span className={cn("flex items-center gap-1.5", ok ? "text-emerald-300/80" : "text-amber-300/80")}>
+        <span className={cn("h-1.5 w-1.5 rounded-full", ok ? "bg-emerald-400" : "bg-amber-300")} />
+        {text}
+      </span>
+    </div>
+  );
+}
+
+function MissionList({
+  title,
+  icon: Icon,
+  missions,
+  empty,
+}: {
+  title: string;
+  icon: LucideIcon;
+  missions: HermesMissionCard[];
+  empty: string;
+}) {
+  return (
+    <Panel title={title} icon={Icon}>
+      <div className="divide-y divide-white/[0.04]">
+        {missions.length === 0 ? (
+          <p className="py-2 text-xs text-white/35">{empty}</p>
+        ) : (
+          missions.map((mission) => <MissionRow key={mission.id} mission={mission} />)
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+function MissionRow({ mission }: { mission: HermesMissionCard }) {
+  const ts = new Date(mission.last_activity_at ?? mission.updated_at);
+  return (
+    <Link
+      href={`/control?mission=${mission.id}`}
+      className="block py-2 transition-colors hover:bg-white/[0.03]"
+    >
+      <div className="flex min-w-0 items-center gap-2 px-1">
+        <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dotForStatus(mission.status))} />
+        <span className="min-w-0 flex-1 truncate text-sm text-white/80">
+          {mission.title || shortMission(mission.id)}
+        </span>
+        {!Number.isNaN(ts.getTime()) && (
+          <RelativeTime date={ts} className="shrink-0 text-[10px] text-white/30" />
+        )}
+      </div>
+      <div className="mt-0.5 flex min-w-0 items-center gap-2 px-1 pl-3.5 text-[11px] text-white/40">
+        <span className="shrink-0">{mission.status}</span>
+        <span className="shrink-0">{mission.backend}{mission.model_effort ? `/${mission.model_effort}` : ""}</span>
+        {mission.workspace_name && <span className="truncate">{mission.workspace_name}</span>}
+        {mission.attention && <span className="truncate text-amber-300/70">{mission.attention}</span>}
+      </div>
+    </Link>
+  );
+}
+
+function shortMission(id: string) {
+  return id.slice(0, 8);
+}
+
+function dotForStatus(status: string) {
+  switch (status) {
+    case "active":
+      return "bg-sky-400";
+    case "pending":
+    case "waiting_background":
+      return "bg-amber-300";
+    case "acknowledged":
+    case "completed":
+      return "bg-emerald-400";
+    case "failed":
+    case "blocked":
+    case "interrupted":
+    case "not_feasible":
+      return "bg-red-400";
+    default:
+      return "bg-white/30";
+  }
 }

--- a/dashboard/src/lib/api/hermes.ts
+++ b/dashboard/src/lib/api/hermes.ts
@@ -257,3 +257,75 @@ export async function listAlerts(opts?: {
     "Failed to load alerts feed",
   );
 }
+
+// ---------------------------------------------------------------------------
+// Mission-control console
+// ---------------------------------------------------------------------------
+
+export interface HermesRuntimeSummary {
+  service_name: string;
+  service_active: boolean;
+  model: string | null;
+  base_url: string | null;
+  expected_base_url: string;
+  uses_sandboxed_proxy: boolean;
+  env_present: boolean;
+  config_present: boolean;
+  token_present: boolean;
+  notes: string[];
+}
+
+export interface HermesSessionRollup {
+  since: string;
+  total: number;
+  by_source: Record<string, number>;
+  messages: number;
+  tool_calls: number;
+  open: number;
+}
+
+export interface HermesMissionCard {
+  id: string;
+  title: string | null;
+  status: string;
+  workspace_name: string | null;
+  backend: string;
+  model_override: string | null;
+  model_effort: string | null;
+  terminal_reason: string | null;
+  updated_at: string;
+  last_agent_event_at: string | null;
+  last_activity_at: string | null;
+  attention: string | null;
+}
+
+export interface HermesFailureRollup {
+  class: string;
+  count: number;
+}
+
+export interface HermesRemoteNodeOverview {
+  enabled: boolean;
+  configured_nodes: number;
+  status: string;
+  notes: string[];
+}
+
+export interface HermesMissionControl {
+  generated_at: string;
+  runtime: HermesRuntimeSummary;
+  sessions: HermesSessionRollup;
+  active: HermesMissionCard[];
+  needs_attention: HermesMissionCard[];
+  handled_recently: HermesMissionCard[];
+  failures: HermesFailureRollup[];
+  mission_status_counts: Record<string, number>;
+  remote_nodes: HermesRemoteNodeOverview;
+}
+
+export async function getHermesMissionControl(): Promise<HermesMissionControl> {
+  return apiGet<HermesMissionControl>(
+    "/api/system/hermes-assistant/mission-control",
+    "Failed to load Hermes mission control",
+  );
+}

--- a/dashboard/src/lib/api/index.ts
+++ b/dashboard/src/lib/api/index.ts
@@ -248,6 +248,12 @@ export {
   type AlertMissionSummary,
   type AlertFeedEntry,
   type AlertsFeedResponse,
+  type HermesMissionControl,
+  type HermesMissionCard,
+  type HermesRuntimeSummary,
+  type HermesSessionRollup,
+  type HermesFailureRollup,
+  type HermesRemoteNodeOverview,
   listHermesSessions,
   createHermesSession,
   getHermesSessionMessages,
@@ -255,4 +261,5 @@ export {
   deleteHermesSession,
   hermesChatStream,
   listAlerts,
+  getHermesMissionControl,
 } from "./hermes";

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -1,0 +1,36 @@
+# Remote Mission Nodes
+
+Sandboxed.sh still runs missions locally by default. The remote-node work in
+this branch is a protocol skeleton for moving heavy missions to another machine
+without changing the normal local/container execution path.
+
+## Target Shape
+
+- **Core** stays responsible for auth, mission records, workspace metadata,
+  Library sync, event persistence, and the UI.
+- **Remote node** is a small Rust service installed on a compute host. It exposes
+  a narrow API to accept leases from core, start/stop mission processes, stream
+  harness events back, and report capacity.
+- **Leases** are short-lived capability tokens scoped to one mission. A node
+  never receives broad dashboard credentials.
+- **Heartbeats** report online/degraded/offline status, labels, CPU/RAM/disk/GPU
+  capacity, and current mission counts.
+
+## Rollout Phases
+
+1. Report configured remote-node state in Hermes mission control. Scheduling is
+   intentionally local-only.
+2. Add a `sandboxed-node` daemon with `/heartbeat`, `/leases`, `/events`, and
+   `/artifacts` endpoints.
+3. Let core choose a node for eligible missions using workspace requirements,
+   labels, and capacity.
+4. Add UI controls for node health, drain mode, resource usage, and per-mission
+   placement.
+
+## Current Environment Flags
+
+- `SANDBOXED_REMOTE_NODES_ENABLED=1` enables the reporting path.
+- `SANDBOXED_REMOTE_NODES=http://node-a:9100,http://node-b:9100` records the
+  configured endpoint count.
+
+These flags do not change scheduling yet.

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -176,7 +176,7 @@ pub async fn ask_send(
     if req.sandbox && sandbox_dir.is_none() {
         return Err((
             StatusCode::BAD_REQUEST,
-            "Sandbox mode requires a git workspace (no isolated worktree could be created)"
+            "sandbox_unavailable: could not create an isolated git worktree or temp-copy sandbox"
                 .to_string(),
         ));
     }
@@ -302,7 +302,7 @@ pub async fn ask_send_stream(
     if req.sandbox && sandbox_dir.is_none() {
         return Err((
             StatusCode::BAD_REQUEST,
-            "Sandbox mode requires a git workspace (no isolated worktree could be created)"
+            "sandbox_unavailable: could not create an isolated git worktree or temp-copy sandbox"
                 .to_string(),
         ));
     }

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1421,6 +1421,43 @@ pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Opti
     let sandbox = PathBuf::from(format!("/tmp/ask-sandbox-{}", Uuid::new_v4()));
     let base_str = base_work_dir.to_string_lossy().to_string();
     let sandbox_str = sandbox.to_string_lossy().to_string();
+    let is_git_cmd = format!(
+        "git -C {b} rev-parse --git-dir >/dev/null 2>&1",
+        b = single_quote(&base_str)
+    );
+    let args = vec!["-lc".to_string(), is_git_cmd];
+    let is_git = exec
+        .output(base_work_dir, "/bin/bash", &args, HashMap::new())
+        .await
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+
+    if !is_git {
+        let copy_cmd = format!(
+            "set -e; test -d {b}; rm -rf {s}; mkdir -p {s}; \
+             if command -v rsync >/dev/null 2>&1; then \
+               rsync -a --exclude .git --exclude node_modules --exclude target --exclude .next -- {b}/ {s}/; \
+             else \
+               (cd {b} && tar --exclude .git --exclude node_modules --exclude target --exclude .next -cf - .) | (cd {s} && tar -xf -); \
+             fi; echo SANDBOX_OK",
+            b = single_quote(&base_str),
+            s = single_quote(&sandbox_str)
+        );
+        let args = vec!["-lc".to_string(), copy_cmd];
+        return match exec
+            .output(base_work_dir, "/bin/bash", &args, HashMap::new())
+            .await
+        {
+            Ok(out)
+                if out.status.success()
+                    && String::from_utf8_lossy(&out.stdout).contains("SANDBOX_OK") =>
+            {
+                Some(sandbox)
+            }
+            _ => None,
+        };
+    }
+
     let cmd = format!(
         "git -C {b} rev-parse --git-dir >/dev/null 2>&1 && \
          git -C {b} worktree add --detach {s} HEAD >/dev/null 2>&1 && \

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3,6 +3,7 @@
 //! Provides endpoints to query and update system components like OpenCode
 //! and related CLI components.
 
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -23,6 +24,8 @@ use tokio::process::Command;
 use uuid::Uuid;
 
 use super::auth::AuthUser;
+use super::control::{self, MissionStatus};
+use super::mission_store::Mission;
 use super::routes::AppState;
 use crate::util::home_dir;
 use crate::workspace::{Workspace, WorkspaceStatus, WorkspaceType};
@@ -311,6 +314,10 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/components/by-workspace", get(get_components_by_workspace))
         .route("/hermes-assistant/adopt", post(adopt_hermes_assistant))
         .route("/hermes-assistant/status", get(get_hermes_assistant_status))
+        .route(
+            "/hermes-assistant/mission-control",
+            get(get_hermes_mission_control),
+        )
         .route(
             "/hermes-assistant/skills",
             get(list_hermes_assistant_skills),
@@ -861,6 +868,65 @@ pub struct HermesAssistantStatusResponse {
     pub telegram_pending_update_count: Option<i64>,
     pub telegram_last_error: Option<String>,
     pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HermesRuntimeSummary {
+    pub service_name: String,
+    pub service_active: bool,
+    pub model: Option<String>,
+    pub base_url: Option<String>,
+    pub expected_base_url: String,
+    pub uses_sandboxed_proxy: bool,
+    pub env_present: bool,
+    pub config_present: bool,
+    pub token_present: bool,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HermesSessionRollup {
+    pub since: String,
+    pub total: u64,
+    pub by_source: HashMap<String, u64>,
+    pub messages: u64,
+    pub tool_calls: u64,
+    pub open: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HermesMissionCard {
+    pub id: Uuid,
+    pub title: Option<String>,
+    pub status: String,
+    pub workspace_name: Option<String>,
+    pub backend: String,
+    pub model_override: Option<String>,
+    pub model_effort: Option<String>,
+    pub terminal_reason: Option<String>,
+    pub updated_at: String,
+    pub last_agent_event_at: Option<String>,
+    pub last_activity_at: Option<String>,
+    pub attention: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HermesFailureRollup {
+    pub class: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HermesMissionControlResponse {
+    pub generated_at: String,
+    pub runtime: HermesRuntimeSummary,
+    pub sessions: HermesSessionRollup,
+    pub active: Vec<HermesMissionCard>,
+    pub needs_attention: Vec<HermesMissionCard>,
+    pub handled_recently: Vec<HermesMissionCard>,
+    pub failures: Vec<HermesFailureRollup>,
+    pub mission_status_counts: HashMap<String, u64>,
+    pub remote_nodes: crate::remote_node::RemoteNodeOverview,
 }
 
 #[derive(Debug, Serialize)]
@@ -4097,6 +4163,393 @@ fn stream_package_uninstall(
     }
 }
 
+fn hermes_config_base_url(config_yaml: &str) -> Option<String> {
+    let value: serde_yaml::Value = serde_yaml::from_str(config_yaml).ok()?;
+    value
+        .get("model")?
+        .get("base_url")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
+fn expand_hermes_env_refs(raw: String, env_contents: Option<&str>) -> String {
+    let Some(env_contents) = env_contents else {
+        return raw;
+    };
+
+    let mut output = String::with_capacity(raw.len());
+    let mut iter = raw.char_indices().peekable();
+    while let Some((idx, ch)) = iter.next() {
+        if ch != '$' {
+            output.push(ch);
+            continue;
+        }
+
+        if matches!(iter.peek(), Some((_, '{'))) {
+            let _ = iter.next();
+            let name_start = idx + 2;
+            let mut name_end = name_start;
+            let mut closed = false;
+            while let Some((next_idx, next_ch)) = iter.next() {
+                if next_ch == '}' {
+                    closed = true;
+                    break;
+                }
+                name_end = next_idx + next_ch.len_utf8();
+            }
+            let name = &raw[name_start..name_end];
+            if closed && is_env_name(name) {
+                if let Some(value) = parse_env_value(env_contents, name) {
+                    output.push_str(&value);
+                } else {
+                    output.push_str(&raw[idx..name_end + 1]);
+                }
+            } else {
+                output.push_str(&raw[idx..name_end]);
+                if closed {
+                    output.push('}');
+                }
+            }
+            continue;
+        }
+
+        let name_start = idx + 1;
+        let mut name_end = name_start;
+        while let Some((next_idx, next_ch)) = iter.peek().copied() {
+            if !is_env_name_char(next_ch) {
+                break;
+            }
+            let _ = iter.next();
+            name_end = next_idx + next_ch.len_utf8();
+        }
+        let name = &raw[name_start..name_end];
+        if !name.is_empty() && is_env_name(name) {
+            if let Some(value) = parse_env_value(env_contents, name) {
+                output.push_str(&value);
+            } else {
+                output.push_str(&raw[idx..name_end]);
+            }
+        } else {
+            output.push('$');
+        }
+    }
+
+    output
+}
+
+fn is_env_name(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(is_env_name_char)
+}
+
+fn is_env_name_char(ch: char) -> bool {
+    ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_'
+}
+
+fn runtime_name_for_config(config: &crate::config::Config) -> &'static str {
+    assistant_runtime_name(config)
+}
+
+async fn build_hermes_runtime_summary(state: &AppState) -> HermesRuntimeSummary {
+    let runtime_name = runtime_name_for_config(&state.config);
+    let service_name = format!("{runtime_name}.service");
+    let env_path = format!("/etc/sandboxed-sh/{runtime_name}.env");
+    let config_path = format!("/var/lib/{runtime_name}/config.yaml");
+    let expected_base_url = format!("{}/v1", local_api_url(&state.config));
+    let service_active = Command::new("systemctl")
+        .args(["is-active", "--quiet", &service_name])
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false);
+
+    let env_contents = tokio::fs::read_to_string(&env_path).await.ok();
+    let config_contents = tokio::fs::read_to_string(&config_path).await.ok();
+    let env_model = env_contents
+        .as_deref()
+        .and_then(|contents| parse_env_value(contents, "HERMES_ASSISTANT_MODEL"))
+        .filter(|value| !value.trim().is_empty());
+    let env_base_url = env_contents
+        .as_deref()
+        .and_then(|contents| parse_env_value(contents, "OPENAI_BASE_URL"))
+        .filter(|value| !value.trim().is_empty());
+    let env_text = env_contents.as_deref();
+    let config_model = config_contents
+        .as_deref()
+        .and_then(hermes_config_model_label)
+        .map(|value| expand_hermes_env_refs(value, env_text));
+    let config_base_url = config_contents
+        .as_deref()
+        .and_then(hermes_config_base_url)
+        .map(|value| expand_hermes_env_refs(value, env_text));
+    let model = config_model.or(env_model);
+    let base_url = config_base_url.or(env_base_url);
+    let token_present = env_contents
+        .as_deref()
+        .and_then(|contents| parse_env_value(contents, "TELEGRAM_BOT_TOKEN"))
+        .is_some_and(|value| !value.trim().is_empty());
+    let uses_sandboxed_proxy = base_url
+        .as_deref()
+        .is_some_and(|url| url.trim_end_matches('/') == expected_base_url.trim_end_matches('/'));
+
+    let mut notes = Vec::new();
+    if !service_active {
+        notes.push("Hermes service is not active.".to_string());
+    }
+    if !uses_sandboxed_proxy {
+        notes.push(format!(
+            "Hermes model traffic is not routed through the sandboxed.sh proxy ({expected_base_url})."
+        ));
+    }
+    if model
+        .as_deref()
+        .is_some_and(|m| m.contains("openai-codex") || m.contains("gpt-5.5"))
+    {
+        notes.push(
+            "Hermes is configured for a direct Codex/OpenAI model; revoked OAuth will break assistant turns.".to_string(),
+        );
+    }
+    if !token_present {
+        notes.push("TELEGRAM_BOT_TOKEN is not present in the Hermes env file.".to_string());
+    }
+
+    HermesRuntimeSummary {
+        service_name,
+        service_active,
+        model,
+        base_url,
+        expected_base_url,
+        uses_sandboxed_proxy,
+        env_present: env_contents.is_some(),
+        config_present: config_contents.is_some(),
+        token_present,
+        notes,
+    }
+}
+
+fn parse_rfc3339_utc(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|t| t.with_timezone(&chrono::Utc))
+}
+
+fn mission_attention(now: chrono::DateTime<chrono::Utc>, mission: &Mission) -> Option<String> {
+    if mission.status == MissionStatus::Failed {
+        return Some(
+            mission
+                .terminal_reason
+                .clone()
+                .unwrap_or_else(|| "failed".to_string()),
+        );
+    }
+    if matches!(
+        mission.status,
+        MissionStatus::Interrupted | MissionStatus::Blocked | MissionStatus::NotFeasible
+    ) {
+        return Some(mission.status.to_string());
+    }
+    if matches!(
+        mission.status,
+        MissionStatus::Active | MissionStatus::WaitingBackground
+    ) {
+        let anchor = mission
+            .activity
+            .last_activity_at
+            .as_deref()
+            .or(Some(&mission.updated_at))
+            .and_then(parse_rfc3339_utc);
+        if let Some(anchor) = anchor {
+            let age = now.signed_duration_since(anchor).num_minutes();
+            if age >= 30 {
+                return Some(format!("no activity for {age}m"));
+            }
+        }
+    }
+    None
+}
+
+fn mission_card(now: chrono::DateTime<chrono::Utc>, mission: &Mission) -> HermesMissionCard {
+    HermesMissionCard {
+        id: mission.id,
+        title: mission.title.clone(),
+        status: mission.status.to_string(),
+        workspace_name: mission.workspace_name.clone(),
+        backend: mission.backend.clone(),
+        model_override: mission.model_override.clone(),
+        model_effort: mission.model_effort.clone(),
+        terminal_reason: mission.terminal_reason.clone(),
+        updated_at: mission.updated_at.clone(),
+        last_agent_event_at: mission.activity.last_agent_event_at.clone(),
+        last_activity_at: mission.activity.last_activity_at.clone(),
+        attention: mission_attention(now, mission),
+    }
+}
+
+fn enrich_mission_activity(
+    mut missions: Vec<Mission>,
+    activity: &HashMap<Uuid, (Option<String>, Option<String>)>,
+) -> Vec<Mission> {
+    for mission in &mut missions {
+        if let Some((last_event, last_output)) = activity.get(&mission.id) {
+            mission.activity.last_agent_event_at = last_event.clone();
+            mission.activity.last_output_at = last_output.clone();
+        }
+        mission.activity.last_activity_at = [
+            Some(mission.updated_at.clone()),
+            mission.activity.last_agent_event_at.clone(),
+        ]
+        .into_iter()
+        .flatten()
+        .max();
+    }
+    missions
+}
+
+fn failure_class(mission: &Mission) -> String {
+    mission
+        .terminal_reason
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| mission.status.to_string())
+}
+
+async fn read_hermes_session_rollup(runtime_name: &str) -> HermesSessionRollup {
+    let since = (chrono::Utc::now() - chrono::Duration::days(3)).to_rfc3339();
+    let db_path = std::path::PathBuf::from(format!("/var/lib/{runtime_name}/state.db"));
+    tokio::task::spawn_blocking(move || {
+        let since_epoch = (chrono::Utc::now() - chrono::Duration::days(3)).timestamp() as f64;
+        let mut rollup = HermesSessionRollup {
+            since,
+            total: 0,
+            by_source: HashMap::new(),
+            messages: 0,
+            tool_calls: 0,
+            open: 0,
+        };
+        if !db_path.exists() {
+            return rollup;
+        }
+        let Ok(conn) = rusqlite::Connection::open_with_flags(
+            &db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        ) else {
+            return rollup;
+        };
+        let Ok(mut stmt) = conn.prepare(
+            "SELECT COALESCE(source, 'unknown'), COUNT(*), COALESCE(SUM(message_count), 0), \
+                    COALESCE(SUM(tool_call_count), 0), \
+                    COALESCE(SUM(CASE WHEN ended_at IS NULL THEN 1 ELSE 0 END), 0) \
+             FROM sessions WHERE started_at >= ?1 GROUP BY COALESCE(source, 'unknown')",
+        ) else {
+            return rollup;
+        };
+        let rows = match stmt.query_map([since_epoch], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        }) {
+            Ok(rows) => rows,
+            Err(_) => return rollup,
+        };
+        for row in rows.flatten() {
+            let (source, count, messages, tools, open) = row;
+            let count = count.max(0) as u64;
+            rollup.total += count;
+            rollup.messages += messages.max(0) as u64;
+            rollup.tool_calls += tools.max(0) as u64;
+            rollup.open += open.max(0) as u64;
+            rollup.by_source.insert(source, count);
+        }
+        rollup
+    })
+    .await
+    .unwrap_or_else(|_| HermesSessionRollup {
+        since: (chrono::Utc::now() - chrono::Duration::days(3)).to_rfc3339(),
+        total: 0,
+        by_source: HashMap::new(),
+        messages: 0,
+        tool_calls: 0,
+        open: 0,
+    })
+}
+
+async fn get_hermes_mission_control(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Result<Json<HermesMissionControlResponse>, (StatusCode, String)> {
+    let now = chrono::Utc::now();
+    let control = control::control_for_user(&state, &user).await;
+    let mut missions = control
+        .mission_store
+        .list_missions(300, 0)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let ids: Vec<Uuid> = missions.iter().map(|m| m.id).collect();
+    let activity = control
+        .mission_store
+        .get_mission_activity(&ids)
+        .await
+        .unwrap_or_default();
+    missions = enrich_mission_activity(missions, &activity);
+
+    let mut status_counts: HashMap<String, u64> = HashMap::new();
+    let mut failure_counts: HashMap<String, u64> = HashMap::new();
+    let mut active = Vec::new();
+    let mut needs_attention = Vec::new();
+    let mut handled_recently = Vec::new();
+
+    for mission in &missions {
+        *status_counts.entry(mission.status.to_string()).or_default() += 1;
+        if mission.status == MissionStatus::Failed {
+            *failure_counts.entry(failure_class(mission)).or_default() += 1;
+        }
+        let card = mission_card(now, mission);
+        if matches!(
+            mission.status,
+            MissionStatus::Active | MissionStatus::Pending | MissionStatus::WaitingBackground
+        ) && active.len() < 12
+        {
+            active.push(card.clone());
+        }
+        if card.attention.is_some() && needs_attention.len() < 20 {
+            needs_attention.push(card.clone());
+        }
+        if matches!(
+            mission.status,
+            MissionStatus::Acknowledged | MissionStatus::Completed
+        ) && handled_recently.len() < 16
+        {
+            handled_recently.push(card);
+        }
+    }
+
+    let mut failures: Vec<_> = failure_counts
+        .into_iter()
+        .map(|(class, count)| HermesFailureRollup { class, count })
+        .collect();
+    failures.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.class.cmp(&b.class)));
+
+    let runtime = build_hermes_runtime_summary(&state).await;
+    let sessions = read_hermes_session_rollup(runtime_name_for_config(&state.config)).await;
+
+    Ok(Json(HermesMissionControlResponse {
+        generated_at: now.to_rfc3339(),
+        runtime,
+        sessions,
+        active,
+        needs_attention,
+        handled_recently,
+        failures,
+        mission_status_counts: status_counts,
+        remote_nodes: crate::remote_node::RemoteNodeOverview::from_env(),
+    }))
+}
+
 /// Stream the Claude Code uninstall process.
 fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::convert::Infallible>> {
     stream_package_uninstall("@anthropic-ai/claude-code", ".claude", "Claude Code")
@@ -4105,10 +4558,10 @@ fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::conve
 #[cfg(test)]
 mod tests {
     use super::{
-        evaluate_debounce, evaluate_deploy_request, extract_version_token,
-        hermes_config_model_label, is_safe_repo_path, normalize_repo_path, select_repo_path,
-        systemd_service_component_from_states, ComponentStatus, DebounceDecision, DeployRefusal,
-        DEPLOY_DEBOUNCE_SECS,
+        evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
+        hermes_config_base_url, hermes_config_model_label, is_safe_repo_path, normalize_repo_path,
+        select_repo_path, systemd_service_component_from_states, ComponentStatus, DebounceDecision,
+        DeployRefusal, DEPLOY_DEBOUNCE_SECS,
     };
 
     #[test]
@@ -4126,6 +4579,24 @@ mod tests {
         );
         assert_eq!(hermes_config_model_label("providers: {}\n"), None);
         assert_eq!(hermes_config_model_label("model: {}\n"), None);
+    }
+
+    #[test]
+    fn hermes_config_values_expand_env_placeholders() {
+        let env = "HERMES_ASSISTANT_MODEL=gpt-5.1\nOPENAI_BASE_URL=http://127.0.0.1:3002/v1\n";
+        let yaml = "model:\n  base_url: ${OPENAI_BASE_URL}\n  default: ${HERMES_ASSISTANT_MODEL}\n  provider: custom\n";
+
+        let model =
+            hermes_config_model_label(yaml).map(|value| expand_hermes_env_refs(value, Some(env)));
+        let base_url =
+            hermes_config_base_url(yaml).map(|value| expand_hermes_env_refs(value, Some(env)));
+
+        assert_eq!(model.as_deref(), Some("custom/gpt-5.1"));
+        assert_eq!(base_url.as_deref(), Some("http://127.0.0.1:3002/v1"));
+        assert_eq!(
+            expand_hermes_env_refs("custom/${HERMES_ASSISTANT_MODEL}".to_string(), Some(env)),
+            "custom/gpt-5.1"
+        );
     }
 
     // ─── Deploy safety rails ────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod opencode;
 pub mod opencode_config;
 pub mod pkg_manager;
 pub mod provider_health;
+pub mod remote_node;
 pub mod secrets;
 pub mod settings;
 pub mod skills_registry;

--- a/src/remote_node.rs
+++ b/src/remote_node.rs
@@ -1,0 +1,131 @@
+//! Remote mission-node protocol skeleton.
+//!
+//! This module intentionally does not schedule work yet. It defines the stable
+//! contract shape for a future `sandboxed-node` daemon while keeping core local
+//! mission execution unchanged.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteNodeStatus {
+    Disabled,
+    Unknown,
+    Online,
+    Degraded,
+    Offline,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RemoteNodeCapacity {
+    pub cpu_cores: Option<u32>,
+    pub memory_bytes: Option<u64>,
+    pub disk_free_bytes: Option<u64>,
+    pub gpu_labels: Vec<String>,
+    pub running_missions: u32,
+    pub max_missions: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteNodeHeartbeat {
+    pub node_id: String,
+    pub status: RemoteNodeStatus,
+    pub labels: HashMap<String, String>,
+    pub capacity: RemoteNodeCapacity,
+    pub observed_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteMissionLease {
+    pub lease_id: String,
+    pub mission_id: String,
+    pub workspace_id: String,
+    pub expires_at: String,
+    pub callback_url: String,
+    pub capability_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteNodeOverview {
+    pub enabled: bool,
+    pub configured_nodes: usize,
+    pub status: RemoteNodeStatus,
+    pub notes: Vec<String>,
+}
+
+impl RemoteNodeOverview {
+    pub fn from_env() -> Self {
+        Self::from_raw_env(
+            std::env::var("SANDBOXED_REMOTE_NODES_ENABLED").ok(),
+            std::env::var("SANDBOXED_REMOTE_NODES").ok(),
+        )
+    }
+
+    fn from_raw_env(enabled_raw: Option<String>, nodes_raw: Option<String>) -> Self {
+        let enabled = enabled_raw.is_some_and(|v| {
+            matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+        });
+        let configured_nodes = nodes_raw
+            .map(|v| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .count()
+            })
+            .unwrap_or(0);
+
+        let mut notes = Vec::new();
+        if !enabled {
+            notes.push(
+                "Remote mission nodes are disabled; local/container execution is unchanged."
+                    .to_string(),
+            );
+        } else if configured_nodes == 0 {
+            notes.push(
+                "Remote nodes are enabled, but no node endpoints are configured.".to_string(),
+            );
+        } else {
+            notes.push("Remote node scheduling is protocol-only in this build.".to_string());
+        }
+
+        Self {
+            enabled,
+            configured_nodes,
+            status: if enabled {
+                RemoteNodeStatus::Unknown
+            } else {
+                RemoteNodeStatus::Disabled
+            },
+            notes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RemoteNodeOverview, RemoteNodeStatus};
+
+    #[test]
+    fn remote_nodes_default_to_disabled() {
+        let overview = RemoteNodeOverview::from_raw_env(None, None);
+
+        assert!(!overview.enabled);
+        assert_eq!(overview.configured_nodes, 0);
+        assert_eq!(overview.status, RemoteNodeStatus::Disabled);
+        assert!(overview.notes[0].contains("disabled"));
+    }
+
+    #[test]
+    fn remote_nodes_count_configured_endpoints_when_enabled() {
+        let overview = RemoteNodeOverview::from_raw_env(
+            Some("true".to_string()),
+            Some("http://n1:9100, , http://n2:9100".to_string()),
+        );
+
+        assert!(overview.enabled);
+        assert_eq!(overview.configured_nodes, 2);
+        assert_eq!(overview.status, RemoteNodeStatus::Unknown);
+        assert!(overview.notes[0].contains("protocol-only"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Hermes mission-control backend endpoint that rolls up runtime health, recent mission activity, attention/failure buckets, Hermes session activity, and remote-node readiness.
- Rework the Hermes page into an operator console with mission-control panels, runtime routing status, watchers, remote-node state, chat, and alerts.
- Harden Ask sandbox preparation so non-git work directories fall back to an isolated temp copy instead of failing hard.
- Add a disabled-by-default remote mission-node protocol skeleton and design note for future external compute scheduling.

## Notes

- The runtime summary expands Hermes config values that reference env vars, so `${OPENAI_BASE_URL}` and embedded model placeholders are shown as the effective values.
- Remote-node flags are reporting-only in this PR; they do not change mission scheduling.

## Validation

- `cargo fmt --all`
- `cargo test`
- `bunx eslint src/components/hermes/hermes-page.tsx src/lib/api/hermes.ts src/lib/api/index.ts`
- `bunx tsc --noEmit`
- `bun run build`
- Deployed exact branch build to `sandboxed-sh-dev` and verified:
  - `GET https://agent-backend-dev.thomas.md/api/health`
  - `GET https://agent-backend-dev.thomas.md/api/system/hermes-assistant/mission-control`

Dev smoke confirmed Hermes routing resolves to `http://127.0.0.1:3002/v1` and `uses_sandboxed_proxy=true`; the dev Hermes service itself is currently inactive, which the endpoint reports explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New system endpoint aggregates missions and reads host Hermes config/SQLite; the non-git Ask sandbox can copy large trees when operators opt in. Remote-node changes are reporting-only.
> 
> **Overview**
> Turns the Hermes page into a **three-column operator console**: mission-control metrics and lists in the main column, chat in the middle, and the alerts feed on the right. Mission control keeps loading when chat is offline so runtime issues can still be diagnosed.
> 
> Adds **`GET /api/system/hermes-assistant/mission-control`**, which rolls up Hermes runtime health (service state, model/base URL with **env placeholder expansion**, proxy routing checks), recent Hermes session stats from `state.db`, mission buckets (**active**, **needs attention**, **handled recently**), failure groupings, status counts, and **remote-node env reporting** via `RemoteNodeOverview::from_env()`.
> 
> **Ask sandbox mode** no longer requires git: non-git workdirs get an isolated **rsync/tar temp copy** (with common heavy dirs excluded); failures return a clearer `sandbox_unavailable` error.
> 
> Introduces a **`remote_node` module** and **`docs/REMOTE_NODES.md`** as a disabled-by-default protocol skeleton—flags only affect what mission control reports, not scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a326b649096a60aa1048726388c9ed81d1eaf304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->