### PR TITLE
Implement remote node runner MVP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,10 @@ path = "src/bin/fido_agent_proxy.rs"
 name = "palomactl"
 path = "src/bin/palomactl.rs"
 
+[[bin]]
+name = "sandboxed-node"
+path = "src/bin/sandboxed_node.rs"
+
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -15,6 +15,8 @@ Supported now:
 - the command runs under `SANDBOXED_NODE_WORK_DIR/<mission-id>`
 - dispatch failures fail closed: the mission is marked failed and the API
   returns an error
+- future `not_before` scheduling with `remote_node_id` is rejected for now so
+  remote commands are never started before their requested dispatch window
 
 Not supported yet:
 
@@ -22,6 +24,7 @@ Not supported yet:
 - live token/tool streaming from remote back to core
 - workspace/container sync between core and node
 - node-side access to dashboard auth, mission DB, or broad core APIs
+- scheduled remote dispatch after a future `not_before`
 
 ## Build
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -1,36 +1,160 @@
-# Remote Mission Nodes
+# Remote Runner Nodes MVP
 
-Sandboxed.sh still runs missions locally by default. The remote-node work in
-this branch is a protocol skeleton for moving heavy missions to another machine
-without changing the normal local/container execution path.
+Remote nodes are an MVP execution path for selected missions. Core remains the
+source of truth for dashboard auth, mission records, events, and UI state. A
+node receives only a per-mission lease token signed from its own node secret.
+It never receives a dashboard JWT or broad API token.
 
-## Target Shape
+## Current Scope
 
-- **Core** stays responsible for auth, mission records, workspace metadata,
-  Library sync, event persistence, and the UI.
-- **Remote node** is a small Rust service installed on a compute host. It exposes
-  a narrow API to accept leases from core, start/stop mission processes, stream
-  harness events back, and report capacity.
-- **Leases** are short-lived capability tokens scoped to one mission. A node
-  never receives broad dashboard credentials.
-- **Heartbeats** report online/degraded/offline status, labels, CPU/RAM/disk/GPU
-  capacity, and current mission counts.
+Supported now:
 
-## Rollout Phases
+- core lists configured nodes and reports live heartbeat/capacity status
+- `sandboxed-node` exposes authenticated `/heartbeat` and `/execute`
+- selected missions can run one `remote_command` on a selected node
+- the command runs under `SANDBOXED_NODE_WORK_DIR/<mission-id>`
+- dispatch failures fail closed: the mission is marked failed and the API
+  returns an error
 
-1. Report configured remote-node state in Hermes mission control. Scheduling is
-   intentionally local-only.
-2. Add a `sandboxed-node` daemon with `/heartbeat`, `/leases`, `/events`, and
-   `/artifacts` endpoints.
-3. Let core choose a node for eligible missions using workspace requirements,
-   labels, and capacity.
-4. Add UI controls for node health, drain mode, resource usage, and per-mission
-   placement.
+Not supported yet:
 
-## Current Environment Flags
+- full AI backend execution on remote nodes
+- live token/tool streaming from remote back to core
+- workspace/container sync between core and node
+- node-side access to dashboard auth, mission DB, or broad core APIs
 
-- `SANDBOXED_REMOTE_NODES_ENABLED=1` enables the reporting path.
-- `SANDBOXED_REMOTE_NODES=http://node-a:9100,http://node-b:9100` records the
-  configured endpoint count.
+## Build
 
-These flags do not change scheduling yet.
+On core and each node:
+
+```bash
+cargo build --bin sandboxed-sh --bin sandboxed-node
+```
+
+Install the node binary on each runner:
+
+```bash
+sudo install -m 0755 target/debug/sandboxed-node /usr/local/bin/sandboxed-node
+```
+
+## Node Configuration
+
+Use one distinct secret per node. Do not paste the secret into logs or docs.
+
+Babylon:
+
+```bash
+export SANDBOXED_NODE_ID=babylon
+export SANDBOXED_NODE_BIND=0.0.0.0:3088
+export SANDBOXED_NODE_WORK_DIR=/var/lib/sandboxed-node/work
+export SANDBOXED_NODE_CAPACITY=1
+export SANDBOXED_NODE_TOKEN="$SANDBOXED_REMOTE_NODE_BABYLON_TOKEN"
+/usr/local/bin/sandboxed-node
+```
+
+Nippur:
+
+```bash
+export SANDBOXED_NODE_ID=nippur
+export SANDBOXED_NODE_BIND=0.0.0.0:3088
+export SANDBOXED_NODE_WORK_DIR=/var/lib/sandboxed-node/work
+export SANDBOXED_NODE_CAPACITY=1
+export SANDBOXED_NODE_TOKEN="$SANDBOXED_REMOTE_NODE_NIPPUR_TOKEN"
+/usr/local/bin/sandboxed-node
+```
+
+Ashur:
+
+```bash
+export SANDBOXED_NODE_ID=ashur
+export SANDBOXED_NODE_BIND=0.0.0.0:3088
+export SANDBOXED_NODE_WORK_DIR=/var/lib/sandboxed-node/work
+export SANDBOXED_NODE_CAPACITY=1
+export SANDBOXED_NODE_TOKEN="$SANDBOXED_REMOTE_NODE_ASHUR_TOKEN"
+/usr/local/bin/sandboxed-node
+```
+
+Minimal systemd unit:
+
+```ini
+[Unit]
+Description=sandboxed.sh remote runner node
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=/etc/sandboxed-node.env
+ExecStart=/usr/local/bin/sandboxed-node
+Restart=always
+RestartSec=5
+User=root
+WorkingDirectory=/var/lib/sandboxed-node
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`/etc/sandboxed-node.env` contains only env-var assignments such as
+`SANDBOXED_NODE_ID`, `SANDBOXED_NODE_BIND`, `SANDBOXED_NODE_WORK_DIR`,
+`SANDBOXED_NODE_CAPACITY`, and `SANDBOXED_NODE_TOKEN`.
+
+## Core Configuration
+
+Configure the three Thomas/Paloma servers on the core backend:
+
+```bash
+export SANDBOXED_REMOTE_NODES_ENABLED=true
+export SANDBOXED_REMOTE_NODES='babylon=http://54.36.175.109:3088,nippur=http://37.187.92.183:3088,ashur=http://188.40.69.160:3088'
+export SANDBOXED_REMOTE_NODE_BABYLON_TOKEN='<set in environment only>'
+export SANDBOXED_REMOTE_NODE_NIPPUR_TOKEN='<set in environment only>'
+export SANDBOXED_REMOTE_NODE_ASHUR_TOKEN='<set in environment only>'
+```
+
+The token env names are also the default names inferred from the node ids. To
+override a token env name, use `id=url|TOKEN_ENV_NAME` in
+`SANDBOXED_REMOTE_NODES`.
+
+## Smoke Tests
+
+Check live node status from core:
+
+```bash
+curl -H "Authorization: Bearer $DASHBOARD_JWT" \
+  "$SANDBOXED_CORE_URL/api/remote-nodes"
+```
+
+Run a selected remote MVP mission:
+
+```bash
+curl -sS -X POST "$SANDBOXED_CORE_URL/api/control/missions" \
+  -H "Authorization: Bearer $DASHBOARD_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "remote smoke on babylon",
+    "backend": "codex",
+    "remote_node_id": "babylon",
+    "remote_command": "hostname && docker --version && pwd && echo sandboxed-node-ok"
+  }'
+```
+
+Repeat with `"nippur"` and `"ashur"` for those nodes. The mission is stored in
+core. Its final assistant event contains the remote command stdout/stderr and
+the status becomes `completed` only when the remote command exits with code 0.
+
+## Failure Behavior
+
+- Unknown selected node: request fails with a clear error.
+- Remote nodes disabled: request fails with a clear error.
+- Missing node token env: mission is marked `failed`; the error names only the
+  missing env var.
+- Node offline or rejects lease: mission is marked `failed`; no local success is
+  reported.
+- Non-zero command exit: mission is stored and marked `failed` with the remote
+  stdout/stderr event preserved.
+
+## Production Readiness Gaps
+
+Before production deploy, this needs remote workspace synchronization, remote
+AI backend process supervision, streamed event forwarding, durable node lease
+tracking, capacity-aware queueing, TLS or private-network enforcement, and
+operator UI for selecting nodes.

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -575,6 +575,7 @@ mod tests {
             spark_arbiter_url: None,
             spark_arbiter_token: None,
             spark_ssh_target: None,
+            remote_nodes: crate::remote_node::RemoteNodeSettings::default(),
         }
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4824,6 +4824,11 @@ pub struct CreateMissionRequest {
     /// longer need a follow-up `POST /api/control/message`, whose delivery
     /// used to be droppable at capacity, orphaning the mission.
     pub prompt: Option<String>,
+    /// Remote runner node id. When set, core creates the mission locally and
+    /// dispatches `remote_command` to that node behind the remote-node flag.
+    pub remote_node_id: Option<String>,
+    /// MVP remote execution payload. Full AI mission streaming remains local.
+    pub remote_command: Option<String>,
     /// Catch-all for unrecognized request fields. Serde ignores unknown fields
     /// by default, which has repeatedly hidden client bugs (a `prompt` sent
     /// before the field existed, a mistyped `target_mission_id`). Captured
@@ -4942,6 +4947,8 @@ pub async fn create_mission(
         desired_state: None,
         next_check_at: None,
         prompt: None,
+        remote_node_id: None,
+        remote_command: None,
         extra: Default::default(),
     });
 
@@ -5179,7 +5186,147 @@ pub async fn create_mission(
         });
     }
 
+    if let Some(remote_node_id) = req
+        .remote_node_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        let remote_command = req
+            .remote_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "remote_command is required when remote_node_id is set".to_string(),
+                )
+            })?;
+        match dispatch_remote_mission_mvp(
+            &state,
+            &control,
+            &mission,
+            remote_node_id,
+            remote_command,
+        )
+        .await
+        {
+            Ok(updated) => return Ok((headers, Json(updated))),
+            Err(message) => {
+                let _ = control
+                    .mission_store
+                    .update_mission_status_with_reason(
+                        mission.id,
+                        MissionStatus::Failed,
+                        Some("remote_dispatch_failed"),
+                    )
+                    .await;
+                let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                    mission_id: mission.id,
+                    status: MissionStatus::Failed,
+                    summary: Some(message.clone()),
+                });
+                return Err((StatusCode::BAD_GATEWAY, message));
+            }
+        }
+    }
+
     Ok((headers, Json(mission)))
+}
+
+async fn dispatch_remote_mission_mvp(
+    state: &Arc<AppState>,
+    control: &ControlState,
+    mission: &Mission,
+    remote_node_id: &str,
+    remote_command: &str,
+) -> Result<Mission, String> {
+    let node = crate::remote_node::placement_for_selected_node(
+        &state.config.remote_nodes,
+        Some(remote_node_id),
+    )
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "remote node placement unexpectedly returned local".to_string())?;
+    let shared_token = std::env::var(&node.token_env)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            format!(
+                "remote node '{}' has no token in {}",
+                node.id, node.token_env
+            )
+        })?;
+    let claims = crate::remote_node::LeaseClaims {
+        mission_id: mission.id,
+        node_id: node.id.clone(),
+        scope: "mission:execute".to_string(),
+        expires_at: (chrono::Utc::now() + chrono::Duration::minutes(15)).timestamp(),
+    };
+    let lease_token = crate::remote_node::create_lease_token(&claims, &shared_token)
+        .map_err(|e| e.to_string())?;
+    let request = crate::remote_node::LeaseRequest {
+        mission_id: mission.id,
+        node_id: node.id.clone(),
+        lease_token,
+        command: remote_command.to_string(),
+    };
+
+    control
+        .mission_store
+        .update_mission_status(mission.id, MissionStatus::Active)
+        .await?;
+    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id: mission.id,
+        status: MissionStatus::Active,
+        summary: Some(format!("Dispatching to remote node '{}'", node.id)),
+    });
+
+    let client = crate::remote_node::RemoteNodeClient::default();
+    let response = client
+        .execute(node, &shared_token, &request)
+        .await
+        .map_err(|e| e.to_string())?;
+    let success = response.exit_code == Some(0);
+    let content = format!(
+        "Remote node '{}' exited with {:?}\n\nstdout:\n{}\n\nstderr:\n{}",
+        node.id, response.exit_code, response.stdout, response.stderr
+    );
+    let event = AgentEvent::AssistantMessage {
+        id: Uuid::new_v4(),
+        content,
+        success,
+        cost_cents: 0,
+        cost_source: crate::agents::CostSource::Unknown,
+        usage: None,
+        model: None,
+        model_normalized: None,
+        mission_id: Some(mission.id),
+        shared_files: None,
+        resumable: !success,
+        completion_evidence: None,
+    };
+    let _ = control.mission_store.log_event(mission.id, &event).await;
+    let _ = control.events_tx.send(event);
+    let status = if success {
+        MissionStatus::Completed
+    } else {
+        MissionStatus::Failed
+    };
+    control
+        .mission_store
+        .update_mission_status_with_reason(mission.id, status, Some("remote_node_mvp"))
+        .await?;
+    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id: mission.id,
+        status,
+        summary: Some(format!("Remote node '{}' finished", node.id)),
+    });
+    control
+        .mission_store
+        .get_mission(mission.id)
+        .await?
+        .ok_or_else(|| format!("Mission {} disappeared after remote dispatch", mission.id))
 }
 
 /// Request body for `POST /api/control/missions/:id/project`. Tri-state per
@@ -6761,6 +6908,8 @@ pub async fn clone_mission(
         desired_state: source.project.desired_state.clone(),
         next_check_at: source.project.next_check_at.clone(),
         prompt: None,
+        remote_node_id: None,
+        remote_command: None,
         extra: Default::default(),
     };
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5105,6 +5105,16 @@ pub async fn create_mission(
                 "remote_command is required when remote_node_id is set".to_string(),
             ));
         }
+        if remote_dispatch_is_scheduled_for_future(
+            Some(node_id),
+            req.not_before,
+            chrono::Utc::now(),
+        ) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "remote-node MVP does not support future not_before scheduling yet; create the remote mission after the dispatch window opens".to_string(),
+            ));
+        }
         crate::remote_node::placement_for_selected_node(&state.config.remote_nodes, Some(node_id))
             .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
     }
@@ -5244,6 +5254,17 @@ pub async fn create_mission(
     }
 
     Ok((headers, Json(mission)))
+}
+
+fn remote_dispatch_is_scheduled_for_future(
+    remote_node_id: Option<&str>,
+    not_before: Option<chrono::DateTime<chrono::Utc>>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    remote_node_id
+        .map(str::trim)
+        .is_some_and(|id| !id.is_empty())
+        && not_before.is_some_and(|t| t > now)
 }
 
 async fn dispatch_remote_mission_mvp(
@@ -21038,6 +21059,27 @@ Investigate <service/> failures.
         // until the user resumes it), so they are not activation-eligible here.
         assert!(!message_activates_mission(MissionStatus::Active));
         assert!(!message_activates_mission(MissionStatus::Paused));
+    }
+
+    #[test]
+    fn remote_dispatch_future_not_before_is_not_immediate() {
+        let now = chrono::Utc::now();
+
+        assert!(remote_dispatch_is_scheduled_for_future(
+            Some("babylon"),
+            Some(now + chrono::Duration::minutes(5)),
+            now
+        ));
+        assert!(!remote_dispatch_is_scheduled_for_future(
+            Some("babylon"),
+            Some(now - chrono::Duration::minutes(5)),
+            now
+        ));
+        assert!(!remote_dispatch_is_scheduled_for_future(
+            None,
+            Some(now + chrono::Duration::minutes(5)),
+            now
+        ));
     }
 
     #[tokio::test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5084,6 +5084,31 @@ pub async fn create_mission(
         }
     }
 
+    // Validate the remote-node payload before persisting the mission so a
+    // bad request cannot leave an orphaned pending mission behind.
+    let remote_node_id = req
+        .remote_node_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+    let remote_command = req
+        .remote_command
+        .as_deref()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(str::to_string);
+    if let Some(node_id) = remote_node_id.as_deref() {
+        if remote_command.is_none() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "remote_command is required when remote_node_id is set".to_string(),
+            ));
+        }
+        crate::remote_node::placement_for_selected_node(&state.config.remote_nodes, Some(node_id))
+            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    }
+
     let control = control_for_user(&state, &user).await;
     control
         .cmd_tx
@@ -5186,23 +5211,9 @@ pub async fn create_mission(
         });
     }
 
-    if let Some(remote_node_id) = req
-        .remote_node_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
+    if let (Some(remote_node_id), Some(remote_command)) =
+        (remote_node_id.as_deref(), remote_command.as_deref())
     {
-        let remote_command = req
-            .remote_command
-            .as_deref()
-            .map(str::trim)
-            .filter(|command| !command.is_empty())
-            .ok_or_else(|| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    "remote_command is required when remote_node_id is set".to_string(),
-                )
-            })?;
         match dispatch_remote_mission_mvp(
             &state,
             &control,

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -666,6 +666,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
 
     let protected_routes = Router::new()
         .route("/api/stats", get(get_stats))
+        .route("/api/remote-nodes", get(list_remote_nodes))
         .route("/api/ai/usage/summary", get(get_ai_usage_summary))
         .route("/api/task", post(create_task))
         .route("/api/task/:id", get(get_task))
@@ -1385,6 +1386,49 @@ async fn health(State(state): State<Arc<AppState>>) -> (HeaderMap, Json<HealthRe
             github_enabled: state.config.auth.github_enabled(),
         }),
     )
+}
+
+/// List configured remote runner nodes with live heartbeat status.
+async fn list_remote_nodes(
+    State(state): State<Arc<AppState>>,
+) -> Json<Vec<crate::remote_node::NodeStatus>> {
+    let client = crate::remote_node::RemoteNodeClient::default();
+    let mut statuses = Vec::new();
+    for node in &state.config.remote_nodes.nodes {
+        let mut status = crate::remote_node::NodeStatus {
+            id: node.id.clone(),
+            base_url: node.base_url.clone(),
+            token_env: node.token_env.clone(),
+            online: false,
+            capacity_total: None,
+            capacity_available: None,
+            active_leases: None,
+            version: None,
+            error: None,
+        };
+        match std::env::var(&node.token_env)
+            .ok()
+            .filter(|token| !token.trim().is_empty())
+        {
+            Some(token) => match client.heartbeat(node, &token).await {
+                Ok(heartbeat) => {
+                    status.online = heartbeat.online;
+                    status.capacity_total = Some(heartbeat.capacity_total);
+                    status.capacity_available = Some(heartbeat.capacity_available);
+                    status.active_leases = Some(heartbeat.active_leases);
+                    status.version = Some(heartbeat.version);
+                }
+                Err(err) => {
+                    status.error = Some(err.to_string());
+                }
+            },
+            None => {
+                status.error = Some(format!("missing token env {}", node.token_env));
+            }
+        }
+        statuses.push(status);
+    }
+    Json(statuses)
 }
 
 /// Optional query parameters for the stats endpoint.

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -1,0 +1,110 @@
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    routing::{get, post},
+    Json, Router,
+};
+use sandboxed_sh::remote_node::{
+    bearer_token, run_lease_command, ExecuteResponse, LeaseRequest, NodeHeartbeat,
+};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::{info, warn};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Clone)]
+struct NodeState {
+    node_id: String,
+    shared_token: String,
+    work_root: PathBuf,
+    capacity_total: u32,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "sandboxed_sh=info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let node_id = std::env::var("SANDBOXED_NODE_ID").unwrap_or_else(|_| "local-node".to_string());
+    let shared_token = std::env::var("SANDBOXED_NODE_TOKEN")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("SANDBOXED_NODE_TOKEN must be set"))?;
+    let bind = std::env::var("SANDBOXED_NODE_BIND")
+        .unwrap_or_else(|_| "0.0.0.0:3088".to_string())
+        .parse::<SocketAddr>()?;
+    let work_root = std::env::var("SANDBOXED_NODE_WORK_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/var/lib/sandboxed-node/work"));
+    let capacity_total = std::env::var("SANDBOXED_NODE_CAPACITY")
+        .ok()
+        .and_then(|raw| raw.parse::<u32>().ok())
+        .unwrap_or(1);
+    tokio::fs::create_dir_all(&work_root).await?;
+
+    let state = Arc::new(NodeState {
+        node_id,
+        shared_token,
+        work_root,
+        capacity_total,
+    });
+    let app = Router::new()
+        .route("/heartbeat", get(heartbeat))
+        .route("/execute", post(execute))
+        .with_state(state);
+
+    info!("starting sandboxed-node on {bind}");
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+fn check_auth(headers: &HeaderMap, state: &NodeState) -> Result<(), (StatusCode, String)> {
+    match bearer_token(headers) {
+        Some(token) if token == state.shared_token => Ok(()),
+        _ => Err((StatusCode::UNAUTHORIZED, "invalid node token".to_string())),
+    }
+}
+
+async fn heartbeat(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+) -> Result<Json<NodeHeartbeat>, (StatusCode, String)> {
+    check_auth(&headers, &state)?;
+    Ok(Json(NodeHeartbeat {
+        node_id: state.node_id.clone(),
+        online: true,
+        capacity_total: state.capacity_total,
+        capacity_available: state.capacity_total,
+        active_leases: 0,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    }))
+}
+
+async fn execute(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+    Json(request): Json<LeaseRequest>,
+) -> Result<Json<ExecuteResponse>, (StatusCode, String)> {
+    check_auth(&headers, &state)?;
+    match run_lease_command(
+        &state.node_id,
+        &state.shared_token,
+        state.work_root.clone(),
+        request,
+    )
+    .await
+    {
+        Ok(response) => Ok(Json(response)),
+        Err(err) => {
+            warn!("lease execution rejected: {err}");
+            Err((StatusCode::BAD_REQUEST, err.to_string()))
+        }
+    }
+}

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -9,16 +9,17 @@ use sandboxed_sh::remote_node::{
 };
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-#[derive(Clone)]
 struct NodeState {
     node_id: String,
     shared_token: String,
     work_root: PathBuf,
     capacity_total: u32,
+    active_leases: AtomicU32,
 }
 
 #[tokio::main]
@@ -53,6 +54,7 @@ async fn main() -> anyhow::Result<()> {
         shared_token,
         work_root,
         capacity_total,
+        active_leases: AtomicU32::new(0),
     });
     let app = Router::new()
         .route("/heartbeat", get(heartbeat))
@@ -77,12 +79,13 @@ async fn heartbeat(
     headers: HeaderMap,
 ) -> Result<Json<NodeHeartbeat>, (StatusCode, String)> {
     check_auth(&headers, &state)?;
+    let active_leases = state.active_leases.load(Ordering::Acquire);
     Ok(Json(NodeHeartbeat {
         node_id: state.node_id.clone(),
         online: true,
         capacity_total: state.capacity_total,
-        capacity_available: state.capacity_total,
-        active_leases: 0,
+        capacity_available: state.capacity_total.saturating_sub(active_leases),
+        active_leases,
         version: env!("CARGO_PKG_VERSION").to_string(),
     }))
 }
@@ -93,18 +96,96 @@ async fn execute(
     Json(request): Json<LeaseRequest>,
 ) -> Result<Json<ExecuteResponse>, (StatusCode, String)> {
     check_auth(&headers, &state)?;
-    match run_lease_command(
+    state.active_leases.fetch_add(1, Ordering::AcqRel);
+    let result = run_lease_command(
         &state.node_id,
         &state.shared_token,
         state.work_root.clone(),
         request,
     )
-    .await
-    {
+    .await;
+    state.active_leases.fetch_sub(1, Ordering::AcqRel);
+    match result {
         Ok(response) => Ok(Json(response)),
         Err(err) => {
             warn!("lease execution rejected: {err}");
             Err((StatusCode::BAD_REQUEST, err.to_string()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header::AUTHORIZATION;
+    use sandboxed_sh::remote_node::{create_lease_token, LeaseClaims};
+    use uuid::Uuid;
+
+    fn auth_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            format!("Bearer {token}")
+                .parse()
+                .expect("valid auth header"),
+        );
+        headers
+    }
+
+    #[tokio::test]
+    async fn heartbeat_reports_active_lease_capacity() {
+        let work_root = tempfile::tempdir().expect("tempdir");
+        let state = Arc::new(NodeState {
+            node_id: "test-node".to_string(),
+            shared_token: "node-secret".to_string(),
+            work_root: work_root.path().to_path_buf(),
+            capacity_total: 2,
+            active_leases: AtomicU32::new(0),
+        });
+        let mission_id = Uuid::new_v4();
+        let claims = LeaseClaims {
+            mission_id,
+            node_id: state.node_id.clone(),
+            scope: "mission:execute".to_string(),
+            expires_at: (chrono::Utc::now() + chrono::Duration::minutes(1)).timestamp(),
+        };
+        let request = LeaseRequest {
+            mission_id,
+            node_id: state.node_id.clone(),
+            lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
+            command: "sleep 0.2".to_string(),
+        };
+        let headers = auth_headers(&state.shared_token);
+
+        let running = tokio::spawn(execute(
+            State(state.clone()),
+            headers.clone(),
+            Json(request),
+        ));
+
+        let mut observed_busy = None;
+        for _ in 0..20 {
+            let snapshot = heartbeat(State(state.clone()), headers.clone())
+                .await
+                .expect("heartbeat")
+                .0;
+            if snapshot.active_leases == 1 {
+                observed_busy = Some(snapshot);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let busy = observed_busy.expect("heartbeat should observe active execute");
+        assert_eq!(busy.capacity_total, 2);
+        assert_eq!(busy.capacity_available, 1);
+        let _response = running
+            .await
+            .expect("execute task")
+            .expect("execute response");
+
+        let idle = heartbeat(State(state), headers).await.expect("heartbeat").0;
+        assert_eq!(idle.active_leases, 0);
+        assert_eq!(idle.capacity_available, 2);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,10 @@ pub struct Config {
     pub spark_arbiter_token: Option<String>,
     /// SSH target for rsync of the workspace, e.g. `th0rgal@100.77.4.93`.
     pub spark_ssh_target: Option<String>,
+
+    /// Remote runner node configuration. Disabled unless
+    /// `SANDBOXED_REMOTE_NODES_ENABLED=true`.
+    pub remote_nodes: crate::remote_node::RemoteNodeSettings,
 }
 
 /// API auth configuration.
@@ -645,6 +649,9 @@ impl Config {
         let spark_arbiter_url = env_opt("SPARK_ARBITER_URL");
         let spark_arbiter_token = env_opt("SPARK_ARBITER_TOKEN");
         let spark_ssh_target = env_opt("SPARK_SSH_TARGET");
+        let remote_nodes = crate::remote_node::RemoteNodeSettings::from_env().map_err(|e| {
+            ConfigError::InvalidValue("SANDBOXED_REMOTE_NODES".to_string(), e.to_string())
+        })?;
 
         Ok(Self {
             default_model,
@@ -669,6 +676,7 @@ impl Config {
             spark_arbiter_url,
             spark_arbiter_token,
             spark_ssh_target,
+            remote_nodes,
         })
     }
 
@@ -698,6 +706,7 @@ impl Config {
             spark_arbiter_url: None,
             spark_arbiter_token: None,
             spark_ssh_target: None,
+            remote_nodes: crate::remote_node::RemoteNodeSettings::default(),
         }
     }
 }

--- a/src/remote_node.rs
+++ b/src/remote_node.rs
@@ -1,11 +1,15 @@
-//! Remote mission-node protocol skeleton.
-//!
-//! This module intentionally does not schedule work yet. It defines the stable
-//! contract shape for a future `sandboxed-node` daemon while keeping core local
-//! mission execution unchanged.
-
+use axum::http::HeaderMap;
+use base64::Engine;
+use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use sha2::Sha256;
+use std::path::PathBuf;
+use std::time::Duration;
+use thiserror::Error;
+use tokio::process::Command;
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -15,35 +19,6 @@ pub enum RemoteNodeStatus {
     Online,
     Degraded,
     Offline,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct RemoteNodeCapacity {
-    pub cpu_cores: Option<u32>,
-    pub memory_bytes: Option<u64>,
-    pub disk_free_bytes: Option<u64>,
-    pub gpu_labels: Vec<String>,
-    pub running_missions: u32,
-    pub max_missions: Option<u32>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemoteNodeHeartbeat {
-    pub node_id: String,
-    pub status: RemoteNodeStatus,
-    pub labels: HashMap<String, String>,
-    pub capacity: RemoteNodeCapacity,
-    pub observed_at: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemoteMissionLease {
-    pub lease_id: String,
-    pub mission_id: String,
-    pub workspace_id: String,
-    pub expires_at: String,
-    pub callback_url: String,
-    pub capability_token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,43 +31,37 @@ pub struct RemoteNodeOverview {
 
 impl RemoteNodeOverview {
     pub fn from_env() -> Self {
-        Self::from_raw_env(
-            std::env::var("SANDBOXED_REMOTE_NODES_ENABLED").ok(),
-            std::env::var("SANDBOXED_REMOTE_NODES").ok(),
-        )
+        match RemoteNodeSettings::from_env() {
+            Ok(settings) => Self::from_settings(&settings),
+            Err(err) => Self {
+                enabled: false,
+                configured_nodes: 0,
+                status: RemoteNodeStatus::Degraded,
+                notes: vec![format!("Remote node configuration is invalid: {err}")],
+            },
+        }
     }
 
-    fn from_raw_env(enabled_raw: Option<String>, nodes_raw: Option<String>) -> Self {
-        let enabled = enabled_raw.is_some_and(|v| {
-            matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
-        });
-        let configured_nodes = nodes_raw
-            .map(|v| {
-                v.split(',')
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .count()
-            })
-            .unwrap_or(0);
-
+    pub fn from_settings(settings: &RemoteNodeSettings) -> Self {
         let mut notes = Vec::new();
-        if !enabled {
+        if !settings.enabled {
             notes.push(
                 "Remote mission nodes are disabled; local/container execution is unchanged."
                     .to_string(),
             );
-        } else if configured_nodes == 0 {
+        } else if settings.nodes.is_empty() {
             notes.push(
                 "Remote nodes are enabled, but no node endpoints are configured.".to_string(),
             );
         } else {
-            notes.push("Remote node scheduling is protocol-only in this build.".to_string());
+            notes.push(
+                "Remote node MVP is enabled for explicit selected-node missions.".to_string(),
+            );
         }
-
         Self {
-            enabled,
-            configured_nodes,
-            status: if enabled {
+            enabled: settings.enabled,
+            configured_nodes: settings.nodes.len(),
+            status: if settings.enabled {
                 RemoteNodeStatus::Unknown
             } else {
                 RemoteNodeStatus::Disabled
@@ -102,30 +71,447 @@ impl RemoteNodeOverview {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum RemoteNodeError {
+    #[error("remote nodes are disabled; set SANDBOXED_REMOTE_NODES_ENABLED=true")]
+    Disabled,
+    #[error("remote node '{0}' is not configured")]
+    UnknownNode(String),
+    #[error("remote node '{0}' has no token in {1}")]
+    MissingToken(String, String),
+    #[error("invalid remote node config: {0}")]
+    InvalidConfig(String),
+    #[error("remote node request failed: {0}")]
+    Request(String),
+    #[error("remote node rejected lease: {0}")]
+    Rejected(String),
+    #[error("invalid lease token: {0}")]
+    InvalidLease(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteNodeConfig {
+    pub id: String,
+    pub base_url: String,
+    pub token_env: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteNodeSettings {
+    pub enabled: bool,
+    pub nodes: Vec<RemoteNodeConfig>,
+}
+
+impl RemoteNodeSettings {
+    pub fn from_env() -> Result<Self, RemoteNodeError> {
+        let enabled = parse_bool_env("SANDBOXED_REMOTE_NODES_ENABLED").unwrap_or(false);
+        let raw = match std::env::var("SANDBOXED_REMOTE_NODES") {
+            Ok(raw) if !raw.trim().is_empty() => raw,
+            _ => {
+                return Ok(Self {
+                    enabled,
+                    nodes: vec![],
+                })
+            }
+        };
+        parse_node_list(&raw).map(|nodes| Self { enabled, nodes })
+    }
+
+    pub fn node(&self, id: &str) -> Option<&RemoteNodeConfig> {
+        self.nodes.iter().find(|node| node.id == id)
+    }
+}
+
+fn parse_bool_env(key: &str) -> Option<bool> {
+    let raw = std::env::var(key).ok()?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+pub fn default_token_env(node_id: &str) -> String {
+    let suffix = node_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("SANDBOXED_REMOTE_NODE_{}_TOKEN", suffix)
+}
+
+pub fn parse_node_list(raw: &str) -> Result<Vec<RemoteNodeConfig>, RemoteNodeError> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| {
+            let (id, rest) = entry.split_once('=').ok_or_else(|| {
+                RemoteNodeError::InvalidConfig(format!(
+                    "entry '{entry}' must be id=url or id=url|TOKEN_ENV"
+                ))
+            })?;
+            let id = id.trim();
+            if id.is_empty() {
+                return Err(RemoteNodeError::InvalidConfig(
+                    "node id cannot be empty".to_string(),
+                ));
+            }
+            let mut parts = rest.split('|').map(str::trim);
+            let base_url = parts
+                .next()
+                .filter(|url| !url.is_empty())
+                .ok_or_else(|| RemoteNodeError::InvalidConfig(format!("{id} has empty url")))?;
+            let token_env = parts
+                .next()
+                .filter(|token_env| !token_env.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| default_token_env(id));
+            if parts.next().is_some() {
+                return Err(RemoteNodeError::InvalidConfig(format!(
+                    "{id} has too many pipe-separated fields"
+                )));
+            }
+            Ok(RemoteNodeConfig {
+                id: id.to_string(),
+                base_url: base_url.trim_end_matches('/').to_string(),
+                token_env,
+                labels: None,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeHeartbeat {
+    pub node_id: String,
+    pub online: bool,
+    pub capacity_total: u32,
+    pub capacity_available: u32,
+    pub active_leases: u32,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeStatus {
+    pub id: String,
+    pub base_url: String,
+    pub token_env: String,
+    pub online: bool,
+    pub capacity_total: Option<u32>,
+    pub capacity_available: Option<u32>,
+    pub active_leases: Option<u32>,
+    pub version: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaseClaims {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    pub scope: String,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaseRequest {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    pub lease_token: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecuteResponse {
+    pub accepted: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Clone)]
+pub struct RemoteNodeClient {
+    http: reqwest::Client,
+}
+
+impl Default for RemoteNodeClient {
+    fn default() -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .connect_timeout(Duration::from_secs(5))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl RemoteNodeClient {
+    pub async fn heartbeat(
+        &self,
+        node: &RemoteNodeConfig,
+        token: &str,
+    ) -> Result<NodeHeartbeat, RemoteNodeError> {
+        let url = format!("{}/heartbeat", node.base_url);
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(RemoteNodeError::Request(format!(
+                "heartbeat returned {}",
+                response.status()
+            )));
+        }
+        response
+            .json::<NodeHeartbeat>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+
+    pub async fn execute(
+        &self,
+        node: &RemoteNodeConfig,
+        shared_token: &str,
+        request: &LeaseRequest,
+    ) -> Result<ExecuteResponse, RemoteNodeError> {
+        let url = format!("{}/execute", node.base_url);
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(shared_token)
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RemoteNodeError::Rejected(format!("{status}: {body}")));
+        }
+        response
+            .json::<ExecuteResponse>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+}
+
+pub fn create_lease_token(claims: &LeaseClaims, secret: &str) -> Result<String, RemoteNodeError> {
+    if secret.trim().is_empty() {
+        return Err(RemoteNodeError::InvalidLease(
+            "empty signing secret".to_string(),
+        ));
+    }
+    let json =
+        serde_json::to_vec(claims).map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json);
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    mac.update(payload.as_bytes());
+    let signature = hex::encode(mac.finalize().into_bytes());
+    Ok(format!("{payload}.{signature}"))
+}
+
+pub fn validate_lease_token(
+    token: &str,
+    secret: &str,
+    expected_node_id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<LeaseClaims, RemoteNodeError> {
+    let (payload, signature) = token
+        .split_once('.')
+        .ok_or_else(|| RemoteNodeError::InvalidLease("missing signature".to_string()))?;
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    mac.update(payload.as_bytes());
+    let expected = hex::encode(mac.finalize().into_bytes());
+    if !constant_time_eq(signature.as_bytes(), expected.as_bytes()) {
+        return Err(RemoteNodeError::InvalidLease("bad signature".to_string()));
+    }
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    let claims: LeaseClaims =
+        serde_json::from_slice(&bytes).map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    if claims.node_id != expected_node_id {
+        return Err(RemoteNodeError::InvalidLease("wrong node".to_string()));
+    }
+    if claims.expires_at <= now.timestamp() {
+        return Err(RemoteNodeError::InvalidLease("expired".to_string()));
+    }
+    if claims.scope != "mission:execute" {
+        return Err(RemoteNodeError::InvalidLease("wrong scope".to_string()));
+    }
+    Ok(claims)
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+pub fn placement_for_selected_node<'a>(
+    settings: &'a RemoteNodeSettings,
+    selected_node_id: Option<&str>,
+) -> Result<Option<&'a RemoteNodeConfig>, RemoteNodeError> {
+    let Some(node_id) = selected_node_id.filter(|id| !id.trim().is_empty()) else {
+        return Ok(None);
+    };
+    if !settings.enabled {
+        return Err(RemoteNodeError::Disabled);
+    }
+    settings
+        .node(node_id)
+        .map(Some)
+        .ok_or_else(|| RemoteNodeError::UnknownNode(node_id.to_string()))
+}
+
+pub fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+}
+
+pub async fn run_lease_command(
+    node_id: &str,
+    token_secret: &str,
+    work_root: PathBuf,
+    request: LeaseRequest,
+) -> Result<ExecuteResponse, RemoteNodeError> {
+    validate_lease_token(
+        &request.lease_token,
+        token_secret,
+        node_id,
+        chrono::Utc::now(),
+    )?;
+    let mission_dir = work_root.join(request.mission_id.to_string());
+    tokio::fs::create_dir_all(&mission_dir)
+        .await
+        .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+    let output = Command::new("bash")
+        .arg("-lc")
+        .arg(&request.command)
+        .current_dir(&mission_dir)
+        .output()
+        .await
+        .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+    Ok(ExecuteResponse {
+        accepted: true,
+        exit_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{RemoteNodeOverview, RemoteNodeStatus};
+    use super::*;
+    use axum::{routing::get, Json, Router};
+    use tokio::net::TcpListener;
 
     #[test]
-    fn remote_nodes_default_to_disabled() {
-        let overview = RemoteNodeOverview::from_raw_env(None, None);
-
-        assert!(!overview.enabled);
-        assert_eq!(overview.configured_nodes, 0);
-        assert_eq!(overview.status, RemoteNodeStatus::Disabled);
-        assert!(overview.notes[0].contains("disabled"));
+    fn parses_env_node_list_with_default_token_env() {
+        let nodes = parse_node_list(
+            "babylon=http://54.36.175.109:3088,nippur=http://37.187.92.183:3088|NIPPUR_TOKEN",
+        )
+        .unwrap();
+        assert_eq!(nodes[0].id, "babylon");
+        assert_eq!(nodes[0].token_env, "SANDBOXED_REMOTE_NODE_BABYLON_TOKEN");
+        assert_eq!(nodes[1].token_env, "NIPPUR_TOKEN");
     }
 
     #[test]
-    fn remote_nodes_count_configured_endpoints_when_enabled() {
-        let overview = RemoteNodeOverview::from_raw_env(
-            Some("true".to_string()),
-            Some("http://n1:9100, , http://n2:9100".to_string()),
+    fn validates_scoped_lease_token() {
+        let mission_id = Uuid::new_v4();
+        let claims = LeaseClaims {
+            mission_id,
+            node_id: "babylon".to_string(),
+            scope: "mission:execute".to_string(),
+            expires_at: chrono::Utc::now().timestamp() + 60,
+        };
+        let token = create_lease_token(&claims, "node-secret").unwrap();
+        let parsed =
+            validate_lease_token(&token, "node-secret", "babylon", chrono::Utc::now()).unwrap();
+        assert_eq!(parsed.mission_id, mission_id);
+        assert!(
+            validate_lease_token(&token, "other-secret", "babylon", chrono::Utc::now()).is_err()
         );
+        assert!(validate_lease_token(&token, "node-secret", "nippur", chrono::Utc::now()).is_err());
+    }
 
-        assert!(overview.enabled);
-        assert_eq!(overview.configured_nodes, 2);
-        assert_eq!(overview.status, RemoteNodeStatus::Unknown);
-        assert!(overview.notes[0].contains("protocol-only"));
+    #[tokio::test]
+    async fn heartbeat_client_reads_node_status() {
+        async fn heartbeat() -> Json<NodeHeartbeat> {
+            Json(NodeHeartbeat {
+                node_id: "babylon".to_string(),
+                online: true,
+                capacity_total: 2,
+                capacity_available: 1,
+                active_leases: 1,
+                version: "test".to_string(),
+            })
+        }
+        let app = Router::new().route("/heartbeat", get(heartbeat));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = RemoteNodeClient::default();
+        let node = RemoteNodeConfig {
+            id: "babylon".to_string(),
+            base_url: format!("http://{addr}"),
+            token_env: "TOKEN".to_string(),
+            labels: None,
+        };
+        let heartbeat = client.heartbeat(&node, "unused").await.unwrap();
+        assert_eq!(heartbeat.capacity_available, 1);
+    }
+
+    #[test]
+    fn placement_requires_enabled_selected_configured_node() {
+        let node = RemoteNodeConfig {
+            id: "babylon".to_string(),
+            base_url: "http://127.0.0.1:3088".to_string(),
+            token_env: "TOKEN".to_string(),
+            labels: None,
+        };
+        let disabled = RemoteNodeSettings {
+            enabled: false,
+            nodes: vec![node.clone()],
+        };
+        assert!(matches!(
+            placement_for_selected_node(&disabled, Some("babylon")),
+            Err(RemoteNodeError::Disabled)
+        ));
+        let enabled = RemoteNodeSettings {
+            enabled: true,
+            nodes: vec![node],
+        };
+        assert_eq!(
+            placement_for_selected_node(&enabled, Some("babylon"))
+                .unwrap()
+                .unwrap()
+                .id,
+            "babylon"
+        );
+        assert!(matches!(
+            placement_for_selected_node(&enabled, Some("ashur")),
+            Err(RemoteNodeError::UnknownNode(_))
+        ));
     }
 }

--- a/src/remote_node.rs
+++ b/src/remote_node.rs
@@ -106,9 +106,15 @@ pub struct RemoteNodeSettings {
 
 impl RemoteNodeSettings {
     pub fn from_env() -> Result<Self, RemoteNodeError> {
-        let enabled = parse_bool_env("SANDBOXED_REMOTE_NODES_ENABLED").unwrap_or(false);
-        let raw = match std::env::var("SANDBOXED_REMOTE_NODES") {
-            Ok(raw) if !raw.trim().is_empty() => raw,
+        Self::from_raw(
+            parse_bool_env("SANDBOXED_REMOTE_NODES_ENABLED").unwrap_or(false),
+            std::env::var("SANDBOXED_REMOTE_NODES").ok(),
+        )
+    }
+
+    fn from_raw(enabled: bool, raw: Option<String>) -> Result<Self, RemoteNodeError> {
+        let raw = match raw {
+            Some(raw) if !raw.trim().is_empty() => raw,
             _ => {
                 return Ok(Self {
                     enabled,
@@ -116,7 +122,17 @@ impl RemoteNodeSettings {
                 })
             }
         };
-        parse_node_list(&raw).map(|nodes| Self { enabled, nodes })
+        match parse_node_list(&raw) {
+            Ok(nodes) => Ok(Self { enabled, nodes }),
+            // A stale or legacy SANDBOXED_REMOTE_NODES value (e.g. the old
+            // URL-only format) must not prevent core startup while the
+            // feature is disabled.
+            Err(_) if !enabled => Ok(Self {
+                enabled,
+                nodes: vec![],
+            }),
+            Err(err) => Err(err),
+        }
     }
 
     pub fn node(&self, id: &str) -> Option<&RemoteNodeConfig> {
@@ -235,6 +251,10 @@ pub struct ExecuteResponse {
     pub stderr: String,
 }
 
+/// Total request timeout for `/execute`, which blocks until the remote
+/// command completes.
+const EXECUTE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
 #[derive(Clone)]
 pub struct RemoteNodeClient {
     http: reqwest::Client,
@@ -288,6 +308,10 @@ impl RemoteNodeClient {
         let response = self
             .http
             .post(url)
+            // Override the client-wide 30s timeout: remote commands
+            // (builds, tests) routinely run for minutes and the response
+            // only arrives once the command finishes.
+            .timeout(EXECUTE_TIMEOUT)
             .bearer_auth(shared_token)
             .json(request)
             .send()
@@ -391,12 +415,17 @@ pub async fn run_lease_command(
     work_root: PathBuf,
     request: LeaseRequest,
 ) -> Result<ExecuteResponse, RemoteNodeError> {
-    validate_lease_token(
+    let claims = validate_lease_token(
         &request.lease_token,
         token_secret,
         node_id,
         chrono::Utc::now(),
     )?;
+    if claims.mission_id != request.mission_id {
+        return Err(RemoteNodeError::InvalidLease(
+            "lease is scoped to a different mission".to_string(),
+        ));
+    }
     let mission_dir = work_root.join(request.mission_id.to_string());
     tokio::fs::create_dir_all(&mission_dir)
         .await
@@ -431,6 +460,48 @@ mod tests {
         assert_eq!(nodes[0].id, "babylon");
         assert_eq!(nodes[0].token_env, "SANDBOXED_REMOTE_NODE_BABYLON_TOKEN");
         assert_eq!(nodes[1].token_env, "NIPPUR_TOKEN");
+    }
+
+    #[test]
+    fn disabled_settings_tolerate_legacy_node_list_format() {
+        let settings =
+            RemoteNodeSettings::from_raw(false, Some("http://n1:9100,http://n2:9100".to_string()))
+                .unwrap();
+        assert!(!settings.enabled);
+        assert!(settings.nodes.is_empty());
+
+        assert!(RemoteNodeSettings::from_raw(
+            true,
+            Some("http://n1:9100,http://n2:9100".to_string())
+        )
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn run_lease_command_rejects_mismatched_mission_id() {
+        let claims = LeaseClaims {
+            mission_id: Uuid::new_v4(),
+            node_id: "babylon".to_string(),
+            scope: "mission:execute".to_string(),
+            expires_at: chrono::Utc::now().timestamp() + 60,
+        };
+        let token = create_lease_token(&claims, "node-secret").unwrap();
+        let work_root = tempfile::tempdir().unwrap();
+        let request = LeaseRequest {
+            mission_id: Uuid::new_v4(),
+            node_id: "babylon".to_string(),
+            lease_token: token,
+            command: "true".to_string(),
+        };
+        let err = run_lease_command(
+            "babylon",
+            "node-secret",
+            work_root.path().to_path_buf(),
+            request,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, RemoteNodeError::InvalidLease(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the protocol-only remote node skeleton with an MVP `sandboxed-node` binary exposing authenticated `/heartbeat` and `/execute`
- add core remote node config parsing, live `/api/remote-nodes` heartbeat status, scoped HMAC mission lease tokens, and explicit selected-node create-mission dispatch via `remote_node_id` + `remote_command`
- update `docs/REMOTE_NODES.md` with babylon/nippur/ashur configuration and smoke-test commands using env var names only

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test remote_node --lib`
- `PATH="$HOME/.cargo/bin:$PATH" cargo check --bins`

## Notes
- This is intentionally a small vertical slice: remote command execution under a per-mission work dir, not full remote AI backend streaming or workspace sync.
- Explicit remote dispatch fails closed: the mission is marked failed and the API returns an error if the node is disabled, unknown, missing token env, offline, or rejects the lease.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated remote execution path runs arbitrary shell on runner hosts and extends mission create with synchronous HTTP dispatch; mitigated by scoped lease tokens, pre-create validation, and fail-closed status handling, but still security-sensitive and operationally new.
> 
> **Overview**
> Replaces the protocol-only remote-node skeleton with a working **remote runner MVP**: a new `sandboxed-node` binary, env-driven node registry on core, and synchronous dispatch when creating missions with `remote_node_id` + `remote_command`.
> 
> **Runner service:** Adds `sandboxed-node` with bearer auth on `/heartbeat` (capacity/version) and `/execute` (validates per-mission HMAC lease, runs `bash -lc` under `SANDBOXED_NODE_WORK_DIR/<mission-id>`). Core loads `RemoteNodeSettings` from `SANDBOXED_REMOTE_NODES_ENABLED` and `SANDBOXED_REMOTE_NODES` (`id=url|TOKEN_ENV`), exposes **`GET /api/remote-nodes`** with live heartbeats, and signs short-lived `mission:execute` lease tokens from each node’s shared secret.
> 
> **Mission API:** `POST /api/control/missions` accepts optional `remote_node_id` and `remote_command`; validates placement and rejects future `not_before` for remote jobs before create. After the mission is persisted, core calls the node, logs stdout/stderr as an assistant event, and sets **completed** vs **failed** from exit code; dispatch errors return **502** and mark the mission failed (fail closed).
> 
> **Docs:** `docs/REMOTE_NODES.md` is rewritten for build/install, core/node env, smoke curls, and explicit non-goals (no remote AI streaming, workspace sync, or scheduled remote dispatch yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6522ffd96f2e9481de04eaa370d570c340ec560d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->