### PR TITLE
Fix OpenCode Z.AI provider adapter config

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4980,6 +4980,8 @@ pub(crate) fn ensure_opencode_provider_for_model(
             let base_url = std::env::var("ZAI_BASE_URL")
                 .unwrap_or_else(|_| "https://api.z.ai/api/coding/paas/v4".to_string());
             Some(serde_json::json!({
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "Z.AI",
                 "models": {
                     model_id: model_entry.clone()
                 },
@@ -9350,6 +9352,61 @@ mod tests {
             opencode_json["provider"]["spark"]["options"]["baseURL"],
             "https://spark-de79.gazella-vector.ts.net/v1"
         );
+    }
+
+    #[test]
+    fn ensure_provider_for_model_injects_zai_openai_compatible_adapter() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_dir = temp_dir.path().join("app");
+        let config_dir = temp_dir.path().join("opencode");
+        fs::create_dir_all(&app_dir).expect("app dir");
+        fs::create_dir_all(&config_dir).expect("config dir");
+
+        ensure_opencode_provider_for_model(&config_dir, &app_dir, "zai/glm-5.2", "127.0.0.1", None);
+
+        let opencode_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
+        )
+        .expect("parse opencode.json");
+        let provider = &opencode_json["provider"]["zai"];
+        assert_eq!(provider["npm"], "@ai-sdk/openai-compatible");
+        assert_eq!(provider["name"], "Z.AI");
+        assert_eq!(
+            provider["options"]["baseURL"],
+            "https://api.z.ai/api/coding/paas/v4"
+        );
+        assert_eq!(provider["models"]["glm-5.2"]["name"], "glm-5.2");
+        assert_eq!(
+            provider["models"]["glm-5.2"]["capabilities"]["interleaved"]["field"],
+            "reasoning_content"
+        );
+    }
+
+    #[test]
+    fn ensure_provider_for_model_injects_minimax_openai_compatible_adapter() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_dir = temp_dir.path().join("app");
+        let config_dir = temp_dir.path().join("opencode");
+        fs::create_dir_all(&app_dir).expect("app dir");
+        fs::create_dir_all(&config_dir).expect("config dir");
+
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "minimax/MiniMax-M3",
+            "127.0.0.1",
+            None,
+        );
+
+        let opencode_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
+        )
+        .expect("parse opencode.json");
+        let provider = &opencode_json["provider"]["minimax"];
+        assert_eq!(provider["npm"], "@ai-sdk/openai-compatible");
+        assert_eq!(provider["name"], "Minimax");
+        assert_eq!(provider["options"]["baseURL"], "https://api.minimax.io/v1");
+        assert_eq!(provider["models"]["MiniMax-M3"]["name"], "MiniMax-M3");
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5081,6 +5081,20 @@ pub(crate) fn ensure_opencode_provider_for_model(
             Some(o) => o,
             None => return,
         };
+        // Backfill adapter fields missing from blocks persisted by older
+        // builds — without `npm` the AI-SDK loads a broken transport
+        // ("fn3 is not a function").
+        let mut repaired = false;
+        if let Some(def) = provider_def.as_object() {
+            for key in ["npm", "name", "options"] {
+                if !obj.contains_key(key) {
+                    if let Some(value) = def.get(key) {
+                        obj.insert(key.to_string(), value.clone());
+                        repaired = true;
+                    }
+                }
+            }
+        }
         let models = obj
             .entry("models".to_string())
             .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
@@ -5098,7 +5112,7 @@ pub(crate) fn ensure_opencode_provider_for_model(
                         }
                     }
                 }
-            } else {
+            } else if !repaired {
                 return; // already present, nothing to do
             }
         } else {
@@ -9380,6 +9394,44 @@ mod tests {
             provider["models"]["glm-5.2"]["capabilities"]["interleaved"]["field"],
             "reasoning_content"
         );
+    }
+
+    #[test]
+    fn ensure_provider_for_model_repairs_existing_partial_zai_block() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_dir = temp_dir.path().join("app");
+        let config_dir = temp_dir.path().join("opencode");
+        fs::create_dir_all(&app_dir).expect("app dir");
+        fs::create_dir_all(&config_dir).expect("config dir");
+
+        // Simulate a config persisted by an older build that omitted the
+        // adapter fields (`npm`/`name`), which crashed OpenCode's transport.
+        fs::write(
+            config_dir.join("opencode.json"),
+            serde_json::json!({
+                "provider": {
+                    "zai": {
+                        "models": { "glm-5.2": { "name": "glm-5.2" } },
+                        "options": { "baseURL": "https://custom.example/v4" }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write opencode.json");
+
+        ensure_opencode_provider_for_model(&config_dir, &app_dir, "zai/glm-5.2", "127.0.0.1", None);
+
+        let opencode_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
+        )
+        .expect("parse opencode.json");
+        let provider = &opencode_json["provider"]["zai"];
+        assert_eq!(provider["npm"], "@ai-sdk/openai-compatible");
+        assert_eq!(provider["name"], "Z.AI");
+        // Existing options must not be clobbered.
+        assert_eq!(provider["options"]["baseURL"], "https://custom.example/v4");
+        assert_eq!(provider["models"]["glm-5.2"]["name"], "glm-5.2");
     }
 
     #[test]

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1366,10 +1366,14 @@ pub fn get_api_key_for_provider(
                     return Some(key.clone());
                 }
             }
-            // OAuth access tokens can also be used as bearer tokens for some APIs
-            if let Some(ref oauth) = provider.oauth {
-                if !oauth.access_token.is_empty() {
-                    return Some(oauth.access_token.clone());
+            // OAuth access tokens can also be used as bearer tokens for some APIs.
+            // Grok Build OAuth is CLI-only here; it is not a replacement for
+            // XAI_API_KEY on xAI's OpenAI-compatible API.
+            if provider_type != ProviderType::Xai {
+                if let Some(ref oauth) = provider.oauth {
+                    if !oauth.access_token.is_empty() {
+                        return Some(oauth.access_token.clone());
+                    }
                 }
             }
         }

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -230,6 +230,76 @@ pub struct CatalogModelOption {
     pub configured: bool,
 }
 
+pub(crate) async fn catalog_model_options_for_state(
+    state: &AppState,
+    include_unverified: bool,
+    configured_only: bool,
+) -> Vec<CatalogModelOption> {
+    let working_dir = state.config.working_dir.to_string_lossy().to_string();
+    let mut config = load_providers_config(&working_dir);
+
+    let cached = state.model_catalog.read().await;
+    merge_cached_provider_models(&mut config, &cached, include_unverified);
+
+    let mut configured = get_configured_provider_ids(state.config.working_dir.as_path());
+    let store_providers = state.ai_providers.list().await;
+    for provider in &store_providers {
+        if !provider.enabled || !provider.has_credentials() {
+            continue;
+        }
+        let id = if provider.provider_type == ProviderType::Custom {
+            sanitize_custom_provider_id(&provider.name)
+        } else {
+            provider.provider_type.id().to_string()
+        };
+        configured.insert(id);
+    }
+
+    let mut providers = if configured_only {
+        config
+            .providers
+            .into_iter()
+            .filter(|provider| configured.contains(&provider.id))
+            .collect()
+    } else {
+        config.providers
+    };
+    merge_store_provider_models(&mut providers, &store_providers, !configured_only);
+    apply_live_custom_provider_models(
+        &mut providers,
+        &store_providers,
+        &cached,
+        include_unverified,
+    );
+    drop(cached);
+
+    let mut models = Vec::new();
+    for provider in &providers {
+        let is_configured = configured.contains(&provider.id);
+        if configured_only && !is_configured {
+            continue;
+        }
+        for model in &provider.models {
+            models.push(CatalogModelOption {
+                provider_id: provider.id.clone(),
+                provider_name: provider.name.clone(),
+                id: model.id.clone(),
+                value: format!("{}/{}", provider.id, model.id),
+                name: model.name.clone(),
+                description: model.description.clone(),
+                configured: is_configured,
+            });
+        }
+    }
+
+    models.sort_by(|a, b| {
+        a.provider_id
+            .cmp(&b.provider_id)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    models
+}
+
 /// Response for the full model catalog endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FullCatalogResponse {
@@ -719,11 +789,38 @@ fn default_providers_config() -> ProvidersConfig {
                     // using Codex with a ChatGPT account"), and everything older
                     // than it is dead too. Newest first.
                     ProviderModel {
+                        id: "gpt-5.6-sol".to_string(),
+                        name: "GPT-5.6 Sol".to_string(),
+                        description: Some(
+                            "Preview flagship GPT-5.6 model for approved OpenAI API/Codex access"
+                                .to_string(),
+                        ),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.6-terra".to_string(),
+                        name: "GPT-5.6 Terra".to_string(),
+                        description: Some(
+                            "Preview GPT-5.6 model with lower cost than Sol".to_string(),
+                        ),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.6-luna".to_string(),
+                        name: "GPT-5.6 Luna".to_string(),
+                        description: Some(
+                            "Preview GPT-5.6 model optimized for speed and cost".to_string(),
+                        ),
+                    },
+                    ProviderModel {
                         id: "gpt-5.5".to_string(),
                         name: "GPT-5.5".to_string(),
                         description: Some(
                             "Latest frontier coding model in Codex (Spud, 2026-04)".to_string(),
                         ),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.5-pro".to_string(),
+                        name: "GPT-5.5 Pro".to_string(),
+                        description: Some("Highest-capability GPT-5.5 model".to_string()),
                     },
                     ProviderModel {
                         id: "gpt-5.5-codex".to_string(),
@@ -734,6 +831,26 @@ fn default_providers_config() -> ProvidersConfig {
                         id: "gpt-5.4".to_string(),
                         name: "GPT-5.4".to_string(),
                         description: Some("Previous frontier coding model in Codex".to_string()),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.4-pro".to_string(),
+                        name: "GPT-5.4 Pro".to_string(),
+                        description: Some("Highest-capability GPT-5.4 model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.4-mini".to_string(),
+                        name: "GPT-5.4 Mini".to_string(),
+                        description: Some("Smaller, lower-latency GPT-5.4 model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.4-nano".to_string(),
+                        name: "GPT-5.4 Nano".to_string(),
+                        description: Some("Smallest, lowest-cost GPT-5.4 model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "gpt-5.3-codex".to_string(),
+                        name: "GPT-5.3 Codex".to_string(),
+                        description: Some("Codex-specialized model".to_string()),
                     },
                 ],
             },
@@ -1869,43 +1986,9 @@ pub async fn list_providers(
 pub async fn list_full_model_catalog(
     State(state): State<Arc<AppState>>,
 ) -> Json<FullCatalogResponse> {
-    let working_dir = state.config.working_dir.to_string_lossy().to_string();
-    let mut config = load_providers_config(&working_dir);
-
     // "Everything supported" => always include public-catalog (unverified)
     // models and providers that aren't configured yet.
-    let cached = state.model_catalog.read().await;
-    merge_cached_provider_models(&mut config, &cached, true);
-
-    let configured = get_configured_provider_ids(state.config.working_dir.as_path());
-
-    let mut providers = config.providers;
-    let store_providers = state.ai_providers.list().await;
-    merge_store_provider_models(&mut providers, &store_providers, true);
-    apply_live_custom_provider_models(&mut providers, &store_providers, &cached, true);
-    drop(cached);
-
-    let mut models = Vec::new();
-    for provider in &providers {
-        let is_configured = configured.contains(&provider.id);
-        for model in &provider.models {
-            models.push(CatalogModelOption {
-                provider_id: provider.id.clone(),
-                provider_name: provider.name.clone(),
-                id: model.id.clone(),
-                value: format!("{}/{}", provider.id, model.id),
-                name: model.name.clone(),
-                description: model.description.clone(),
-                configured: is_configured,
-            });
-        }
-    }
-    // Stable order: provider, then model name.
-    models.sort_by(|a, b| {
-        a.provider_id
-            .cmp(&b.provider_id)
-            .then_with(|| a.name.cmp(&b.name))
-    });
+    let models = catalog_model_options_for_state(&state, true, false).await;
 
     Json(FullCatalogResponse {
         count: models.len(),
@@ -1987,14 +2070,27 @@ pub async fn list_backend_model_options(
         };
 
     push_options("claudecode", Some(&["anthropic"]), false, None);
-    // Codex model catalog includes codex-* IDs plus the latest plain
-    // `gpt-5.X` flagship models (currently 5.5 and 5.4). The Codex CLI
+    // Codex model catalog includes codex-* IDs plus current GPT-5 family
+    // API slugs. The Codex CLI
     // passes `--model <slug>` straight through to OpenAI's backend, so
     // a new slug starts working as soon as the backend recognizes it
     // — there is no hard dependency on the CLI's embedded catalog
     // being up-to-date.
-    let codex_filter: &dyn Fn(&str) -> bool =
-        &|id: &str| id.contains("codex") || id == "gpt-5.5" || id == "gpt-5.4";
+    let codex_filter: &dyn Fn(&str) -> bool = &|id: &str| {
+        id.contains("codex")
+            || matches!(
+                id,
+                "gpt-5.5"
+                    | "gpt-5.6-sol"
+                    | "gpt-5.6-terra"
+                    | "gpt-5.6-luna"
+                    | "gpt-5.5-pro"
+                    | "gpt-5.4"
+                    | "gpt-5.4-pro"
+                    | "gpt-5.4-mini"
+                    | "gpt-5.4-nano"
+            )
+    };
     push_options("codex", Some(&["openai"]), false, Some(codex_filter));
     push_options("gemini", Some(&["google"]), false, None);
     push_options("opencode", None, true, None);
@@ -2295,6 +2391,42 @@ mod tests {
             .models
             .iter()
             .any(|model| model.id == "claude-opus-4-7"));
+    }
+
+    #[test]
+    fn default_openai_catalog_includes_current_gpt_family() {
+        let defaults = default_providers_config();
+        let openai = defaults
+            .providers
+            .iter()
+            .find(|provider| provider.id == "openai")
+            .expect("openai provider");
+        let ids = openai
+            .models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>();
+
+        for id in [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5.5-pro",
+            "gpt-5.4",
+            "gpt-5.4-pro",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano",
+        ] {
+            assert!(ids.contains(&id), "missing OpenAI model {id}");
+        }
+
+        for invalid_id in ["gpt-5.6", "sol", "terra", "luna"] {
+            assert!(
+                !ids.contains(&invalid_id),
+                "bare/non-API slug should not be exposed: {invalid_id}"
+            );
+        }
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -5,7 +5,7 @@
 //! the chain until one succeeds. Pre-stream 429/529 errors trigger instant
 //! failover to the next entry in the chain.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -313,20 +313,53 @@ async fn list_models(
         return resp;
     }
     let chains = state.chain_store.list().await;
-    let data = chains
-        .into_iter()
-        .map(|c| ModelObject {
+    let mut seen = HashSet::new();
+    let mut data = Vec::new();
+    for c in chains {
+        if !seen.insert(c.id.clone()) {
+            continue;
+        }
+        data.push(ModelObject {
             id: c.id,
             object: "model",
             created: c.created_at.timestamp(),
             owned_by: "sandboxed",
-        })
-        .collect();
+        });
+    }
+
+    let direct_models =
+        crate::api::providers::catalog_model_options_for_state(&state, true, true).await;
+    append_direct_models_to_proxy_models(
+        &mut data,
+        &mut seen,
+        direct_models,
+        chrono::Utc::now().timestamp(),
+    );
+    data.sort_by(|a, b| a.id.cmp(&b.id));
     Json(ModelsResponse {
         object: "list",
         data,
     })
     .into_response()
+}
+
+fn append_direct_models_to_proxy_models(
+    data: &mut Vec<ModelObject>,
+    seen: &mut HashSet<String>,
+    models: Vec<crate::api::providers::CatalogModelOption>,
+    created: i64,
+) {
+    for model in models {
+        if !model.configured || !seen.insert(model.value.clone()) {
+            continue;
+        }
+        data.push(ModelObject {
+            id: model.value,
+            object: "model",
+            created,
+            owned_by: "sandboxed",
+        });
+    }
 }
 
 async fn get_deferred_request(
@@ -5053,6 +5086,60 @@ mod tests {
         // Empty halves.
         assert!(parse_direct_model_entry("xai/").is_none());
         assert!(parse_direct_model_entry("/grok-4.5").is_none());
+    }
+
+    #[test]
+    fn proxy_model_list_appends_configured_direct_provider_models() {
+        let mut seen = HashSet::new();
+        seen.insert("xai/grok-4.5".to_string());
+        let mut data = vec![ModelObject {
+            id: "xai/grok-4.5".to_string(),
+            object: "model",
+            created: 1,
+            owned_by: "sandboxed",
+        }];
+
+        append_direct_models_to_proxy_models(
+            &mut data,
+            &mut seen,
+            vec![
+                crate::api::providers::CatalogModelOption {
+                    provider_id: "xai".to_string(),
+                    provider_name: "xAI".to_string(),
+                    id: "grok-4.5".to_string(),
+                    value: "xai/grok-4.5".to_string(),
+                    name: "Grok 4.5".to_string(),
+                    description: None,
+                    configured: true,
+                },
+                crate::api::providers::CatalogModelOption {
+                    provider_id: "openai".to_string(),
+                    provider_name: "OpenAI".to_string(),
+                    id: "gpt-5.6-sol".to_string(),
+                    value: "openai/gpt-5.6-sol".to_string(),
+                    name: "GPT-5.6 Sol".to_string(),
+                    description: None,
+                    configured: true,
+                },
+                crate::api::providers::CatalogModelOption {
+                    provider_id: "anthropic".to_string(),
+                    provider_name: "Anthropic".to_string(),
+                    id: "claude-sonnet-4-5".to_string(),
+                    value: "anthropic/claude-sonnet-4-5".to_string(),
+                    name: "Claude Sonnet 4.5".to_string(),
+                    description: None,
+                    configured: false,
+                },
+            ],
+            2,
+        );
+
+        let ids = data
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["xai/grok-4.5", "openai/gpt-5.6-sol"]);
+        assert_eq!(data[1].created, 2);
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -329,6 +329,7 @@ async fn list_models(
 
     let direct_models =
         crate::api::providers::catalog_model_options_for_state(&state, true, true).await;
+    let direct_models = routable_direct_catalog_models(&state, direct_models).await;
     append_direct_models_to_proxy_models(
         &mut data,
         &mut seen,
@@ -341,6 +342,41 @@ async fn list_models(
         data,
     })
     .into_response()
+}
+
+async fn routable_direct_catalog_models(
+    state: &Arc<super::routes::AppState>,
+    models: Vec<crate::api::providers::CatalogModelOption>,
+) -> Vec<crate::api::providers::CatalogModelOption> {
+    let standard_accounts =
+        crate::api::ai_providers::read_standard_accounts(&state.config.working_dir);
+    let mut routable = Vec::new();
+    for model in models {
+        if !model.configured {
+            continue;
+        }
+        let entry = crate::provider_health::ChainEntry {
+            provider_id: model.provider_id.clone(),
+            model_id: model.id.clone(),
+        };
+        let entries = state
+            .chain_store
+            .resolve_entries(
+                &[entry],
+                &state.ai_providers,
+                &standard_accounts,
+                &state.health_tracker,
+            )
+            .await;
+        if entries.iter().any(|entry| {
+            let provider_type =
+                ProviderType::from_id(&entry.provider_id).unwrap_or(ProviderType::Custom);
+            has_routable_proxy_credentials(provider_type, entry.api_key.is_some(), entry.has_oauth)
+        }) {
+            routable.push(model);
+        }
+    }
+    routable
 }
 
 fn append_direct_models_to_proxy_models(

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -40,7 +40,7 @@ const fn pricing(
 // Prices are nanodollars per token. Provider rates are published per 1M tokens,
 // so "$1.25 / 1M tokens" becomes 1_250 nanodollars per token.
 //
-// Sources checked May 26, 2026:
+// Sources checked July 9, 2026:
 // - OpenAI API pricing and model pages: https://developers.openai.com/api/docs/pricing
 // - xAI model pricing: https://docs.x.ai/developers/pricing
 // - Z.AI pricing: https://docs.z.ai/guides/overview/pricing
@@ -157,9 +157,34 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(250, 2_000, None, Some(25)),
     },
     PricingEntry {
+        canonical: "gpt-5.6-sol",
+        aliases: &["gpt-5.6-sol", "gpt-5-6-sol"],
+        pricing: pricing(5_000, 30_000, Some(6_250), Some(500)),
+    },
+    PricingEntry {
+        canonical: "gpt-5.6-terra",
+        aliases: &["gpt-5.6-terra", "gpt-5-6-terra"],
+        pricing: pricing(2_500, 15_000, Some(3_125), Some(250)),
+    },
+    PricingEntry {
+        canonical: "gpt-5.6-luna",
+        aliases: &["gpt-5.6-luna", "gpt-5-6-luna"],
+        pricing: pricing(1_000, 6_000, Some(1_250), Some(100)),
+    },
+    PricingEntry {
+        canonical: "gpt-5.5-pro",
+        aliases: &["gpt-5.5-pro", "gpt-5-5-pro"],
+        pricing: pricing(30_000, 180_000, None, None),
+    },
+    PricingEntry {
         canonical: "gpt-5.5",
         aliases: &["gpt-5.5", "gpt-5-5"],
         pricing: pricing(5_000, 30_000, None, Some(500)),
+    },
+    PricingEntry {
+        canonical: "gpt-5.4-pro",
+        aliases: &["gpt-5.4-pro", "gpt-5-4-pro"],
+        pricing: pricing(30_000, 180_000, None, None),
     },
     PricingEntry {
         canonical: "gpt-5.4",
@@ -530,6 +555,11 @@ mod tests {
         );
         assert_eq!(normalize_model("gpt-4o-2024-08-06"), "gpt-4o");
         assert_eq!(normalize_model("gpt-5.3-codex"), "gpt-5.3");
+        assert_eq!(normalize_model("openai/gpt-5.6-sol"), "gpt-5.6-sol");
+        assert_eq!(normalize_model("openai/gpt-5.6-terra"), "gpt-5.6-terra");
+        assert_eq!(normalize_model("openai/gpt-5.6-luna"), "gpt-5.6-luna");
+        assert_eq!(normalize_model("gpt-5.5-pro"), "gpt-5.5-pro");
+        assert_eq!(normalize_model("gpt-5.4-pro"), "gpt-5.4-pro");
         assert_eq!(normalize_model("OpenAI/GPT-5"), "gpt-5");
         assert_eq!(normalize_model("openai/gpt-5.1-codex"), "gpt-5");
         assert_eq!(normalize_model("gpt-5-mini"), "gpt-5-mini");
@@ -563,6 +593,11 @@ mod tests {
         assert!(pricing_for_model("claude-haiku-4-5").is_some());
         assert!(pricing_for_model("gpt-4o").is_some());
         assert!(pricing_for_model("gpt-5.3-codex").is_some());
+        assert!(pricing_for_model("openai/gpt-5.6-sol").is_some());
+        assert!(pricing_for_model("openai/gpt-5.6-terra").is_some());
+        assert!(pricing_for_model("openai/gpt-5.6-luna").is_some());
+        assert!(pricing_for_model("gpt-5.5-pro").is_some());
+        assert!(pricing_for_model("gpt-5.4-pro").is_some());
         assert!(pricing_for_model("OpenAI/GPT-5").is_some());
         assert!(pricing_for_model("openai/gpt-5.1-codex").is_some());
         assert!(pricing_for_model("gpt-5-mini").is_some());

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -1300,14 +1300,15 @@ impl ModelChainStore {
                     .map(|oauth| oauth.expires_at > now_ms + 60_000)
                     .unwrap_or(false);
                 // Hoist the OAuth access token to `api_key` so the proxy can
-                // forward it as a Bearer credential. This works for providers
-                // whose chat endpoint accepts the OAuth access token directly:
+                // forward it as a Bearer credential. This only works for
+                // providers whose chat endpoint accepts the OAuth access token
+                // directly:
                 //   - Anthropic: `api.anthropic.com/v1/messages` (with the
                 //     `oauth-2025-04-20` beta header), and
-                //   - xAI/Grok: `api.x.ai/v1/chat/completions` accepts the
-                //     Grok-Build OAuth token as a Bearer (scope `api:access`).
                 //   - Kimi: `api.kimi.com/coding/v1/chat/completions` accepts the
                 //     Kimi Code subscription OAuth access token as a Bearer.
+                // xAI/Grok Build OAuth is for the Grok CLI, not a substitute
+                // for `XAI_API_KEY` at `api.x.ai/v1/chat/completions`.
                 // OpenAI (Codex) JWTs do NOT work at
                 // `api.openai.com/v1/chat/completions`; those accounts keep
                 // `api_key = None, has_oauth = true` and route through the
@@ -1316,7 +1317,6 @@ impl ModelChainStore {
                     if !matches!(
                         provider_type,
                         crate::ai_providers::ProviderType::Anthropic
-                            | crate::ai_providers::ProviderType::Xai
                             | crate::ai_providers::ProviderType::Kimi
                     ) {
                         return None;
@@ -1384,7 +1384,13 @@ impl ModelChainStore {
                 // attaching OAuth-only headers (Bearer + oauth beta) to an
                 // x-api-key request. Google still needs `has_oauth=true` to
                 // trigger its adapter regardless of store-token freshness.
-                let credential_is_oauth_token = account.api_key.is_none() && oauth_is_fresh;
+                let provider_oauth_is_proxy_routable = matches!(
+                    provider_type,
+                    crate::ai_providers::ProviderType::Anthropic
+                        | crate::ai_providers::ProviderType::Kimi
+                );
+                let credential_is_oauth_token =
+                    account.api_key.is_none() && oauth_is_fresh && provider_oauth_is_proxy_routable;
                 let entry_has_oauth = credential_is_oauth_token || google_oauth_routable;
                 let entry_has_api_key = routed_api_key.is_some();
                 resolved.push(ResolvedEntry {
@@ -1664,6 +1670,45 @@ mod tests {
             resolved
         );
         assert_eq!(resolved[0].account_id, standard[0].account_id);
+    }
+
+    #[tokio::test]
+    async fn resolve_chain_does_not_treat_xai_oauth_as_proxy_api_key() {
+        let mut xai = AIProvider::new(ProviderType::Xai, "xAI Grok OAuth".to_string());
+        xai.oauth = Some(OAuthCredentials {
+            access_token: "grok-oauth-token".to_string(),
+            refresh_token: "grok-refresh-token".to_string(),
+            expires_at: future_ms(6),
+        });
+        xai.status = ProviderStatus::Connected;
+
+        let store = store_with(vec![xai]).await;
+        let chains = store_with_chain(
+            "grok",
+            vec![ChainEntry {
+                provider_id: "xai".to_string(),
+                model_id: "grok-4.5".to_string(),
+            }],
+        )
+        .await;
+        let tracker = ProviderHealthTracker::new();
+
+        let resolved = chains.resolve_chain("grok", &store, &[], &tracker).await;
+
+        assert_eq!(resolved.len(), 1);
+        assert!(
+            resolved[0].api_key.is_none(),
+            "Grok Build OAuth must not be forwarded as XAI_API_KEY"
+        );
+        assert!(
+            !resolved[0].has_oauth,
+            "xAI OAuth is CLI-only for this router path"
+        );
+        assert!(!crate::api::proxy::has_routable_proxy_credentials(
+            ProviderType::Xai,
+            resolved[0].api_key.is_some(),
+            resolved[0].has_oauth
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- force direct `zai/*` OpenCode model overrides through the explicit `@ai-sdk/openai-compatible` adapter block, matching the MiniMax custom adapter path
- preserve GLM reasoning-content capability metadata and the Z.AI coding endpoint base URL
- add regression coverage for generated Z.AI GLM and MiniMax provider block shapes

## Root cause
Sandboxed's OpenCode runner already injects provider definitions for direct non-core providers before invoking `opencode run`. MiniMax was injected as an explicit OpenAI-compatible adapter, but Z.AI only injected `models` and `options`, leaving OpenCode to merge that partial object with its built-in provider/catalog implementation. That partial provider shape can trip OpenCode/AI SDK provider initialization before work starts, surfacing as `fn3 is not a function` instead of a provider response.

The fix makes Z.AI use the same explicit adapter shape as MiniMax:

```json
{
  "npm": "@ai-sdk/openai-compatible",
  "name": "Z.AI",
  "models": { "glm-5.2": { "name": "glm-5.2", "capabilities": { "interleaved": { "field": "reasoning_content" } } } },
  "options": { "baseURL": "https://api.z.ai/api/coding/paas/v4" }
}
```

## Verification
- `cargo fmt`
- `PATH="$HOME/.cargo/bin:$PATH" timeout 900 cargo check --lib` passed after installing Rust 1.91 locally, required by `rust-version = "1.91"` and lockfile v4
- OpenCode smoke, disposable HOME/XDG and fake `ZHIPU_API_KEY`: selected `llm.runtime=ai-sdk`, `providerID=zai`, `modelID=glm-5.2`, reached expected provider 401 at `https://api.z.ai/api/coding/paas/v4/chat/completions`; no `fn3`
- OpenCode smoke, disposable HOME/XDG and fake `MINIMAX_API_KEY`: selected `llm.runtime=ai-sdk`, `providerID=minimax`, `modelID=MiniMax-M3`, reached expected provider 401 at `https://api.minimax.io/v1/chat/completions`; no `fn3`

## Notes
- The exact reported `2026-07-09T072910.log` was not present in this workspace or host log search, so reproduction used the smallest local OpenCode invocations with fake credentials and redacted output.
- `cargo test ensure_provider_for_model_injects_ -- --nocapture` was attempted, but the test binary compile timed out in this environment after 7 minutes with no diagnostics. The regression tests are included and `cargo check --lib` validates the code compiles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission OpenCode config, proxy model discovery, and chain credential resolution for xAI; mis-routing could hide models or break Grok OAuth-only setups that previously appeared routable.
> 
> **Overview**
> **OpenCode Z.AI/MiniMax** provider injection now uses the full `@ai-sdk/openai-compatible` adapter shape (`npm`, `name`, `models`, `options`), and existing partial `zai` blocks in `opencode.json` are backfilled so OpenCode no longer hits the broken transport (`fn3 is not a function`). Regression tests cover fresh injection and repair without clobbering custom `baseURL`.
> 
> **Provider catalog and harness pickers** gain current OpenAI GPT-5.x slugs (5.6 Sol/Terra/Luna, 5.5-pro, 5.4-pro/mini/nano, 5.3-codex) with an expanded Codex backend filter; catalog building is centralized in `catalog_model_options_for_state` (used by `/api/providers/catalog` and the proxy).
> 
> **Proxy `/v1/models`** still lists chain IDs, then appends **configured** `provider/model` entries that actually resolve to routable credentials (deduped, sorted). **xAI Grok Build OAuth** is no longer treated as a proxy API key or OAuth-routable credential—only `XAI_API_KEY` (and similar paths) count for xAI chat routing; credential lookup skips OAuth for xAI. **Cost** tables add pricing/normalization for the new GPT models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15c3c5dbdf6781e2f3c9fce717228209225c912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->