### PR TITLE
Scrub inherited-but-broken TLS CA env vars for container missions

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5986,6 +5986,26 @@ fn format_exit_status(status: &std::process::ExitStatus) -> String {
     "code <unknown>".to_string()
 }
 
+/// Detect a TLS/CA failure in curl output.
+///
+/// A broken CA bundle (e.g. an inherited host `SSL_CERT_FILE` pointing at a
+/// path that does not exist inside the container) makes curl fail *before* any
+/// HTTP response, with messages like "error setting certificate", "SSL
+/// certificate problem", or "unable to get local issuer certificate". Without
+/// this, the basic-connectivity check reports such failures as a generic
+/// "network check failed", which misleads operators toward a DNS/routing hunt.
+fn tls_error_hint(output: &str) -> bool {
+    let lower = output.to_lowercase();
+    lower.contains("ssl certificate problem")
+        || lower.contains("error setting certificate")
+        || lower.contains("unable to get local issuer certificate")
+        || lower.contains("self-signed certificate")
+        || lower.contains("self signed certificate")
+        || lower.contains("certificate verify failed")
+        || lower.contains("ca file")
+        || lower.contains("cafile")
+}
+
 fn curl_dependency_error(output: &str) -> Option<&'static str> {
     let lower = output.to_lowercase();
     if lower.contains("curl: not found")
@@ -6052,6 +6072,11 @@ async fn check_basic_internet_connectivity(
 
         let err = if let Some(message) = curl_dependency_error(&combined) {
             format!("Workspace dependency check failed: {}", message)
+        } else if tls_error_hint(&combined) {
+            "TLS/certificate error reaching the internet. \
+             A CA bundle env var (e.g. SSL_CERT_FILE) may point at a path that \
+             does not exist in the workspace, or a proxy is intercepting HTTPS."
+                .to_string()
         } else if combined.contains("Network is unreachable") {
             "No internet connectivity: Network is unreachable. \
              The workspace has no network access."
@@ -8155,7 +8180,7 @@ mod tests {
         replace_filepath_artifact_with_tool_output, running_health, sanitized_opencode_stdout,
         set_codex_account_cooldown, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
         strip_think_tags, summarize_codex_usage_caps, summarize_recent_opencode_stderr,
-        text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer,
+        text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
         truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
         ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
@@ -8196,6 +8221,30 @@ mod tests {
     fn curl_dependency_error_ignores_network_failures() {
         assert!(curl_dependency_error("curl: (7) Failed to connect to 1.1.1.1").is_none());
         assert!(curl_dependency_error("Network is unreachable").is_none());
+    }
+
+    #[test]
+    fn tls_error_hint_detects_broken_ca_bundle() {
+        // curl (77): what a bogus SSL_CERT_FILE produces.
+        assert!(tls_error_hint(
+            "curl: (77) error setting certificate file: /venv/certifi/cacert.pem"
+        ));
+        assert!(tls_error_hint(
+            "curl: (60) SSL certificate problem: unable to get local issuer certificate"
+        ));
+        assert!(tls_error_hint(
+            "SSL certificate problem: self-signed certificate"
+        ));
+    }
+
+    #[test]
+    fn tls_error_hint_ignores_dns_and_routing_failures() {
+        assert!(!tls_error_hint(
+            "curl: (6) Could not resolve host: api.anthropic.com"
+        ));
+        assert!(!tls_error_hint("Network is unreachable"));
+        assert!(!tls_error_hint("Connection timed out"));
+        assert!(!tls_error_hint("200"));
     }
 
     #[test]

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -25,6 +25,22 @@ const CONTAINER_KEEPALIVE_ENV_VALUE: &str = "1";
 const ALLOW_TRANSIENT_CONTAINER_NSENTER_ENV: &str =
     "SANDBOXED_SH_ALLOW_TRANSIENT_CONTAINER_NSENTER";
 
+/// TLS CA-bundle env vars that point at a filesystem path. When the host
+/// process that launches a container mission (e.g. the sandboxed.sh daemon
+/// started from a Python venv) has one of these set, the value leaks into the
+/// container via process inheritance on the `nsenter` path — but the path
+/// (e.g. a Hermes venv `certifi/cacert.pem`) does not exist inside the
+/// container rootfs. OpenSSL/curl/Node then fail to load *any* CA store and
+/// every HTTPS request dies, which the provider preflight reports as a
+/// misleading DNS/connectivity failure. See `ca_env_scrub_prelude`.
+const CA_BUNDLE_ENV_VARS: &[&str] = &[
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS",
+];
+
 const CONTAINER_DEFAULT_PATH_DIRS: &[&str] = &[
     "/root/.bun/bin",
     "/root/.cache/.bun/bin",
@@ -57,6 +73,28 @@ fn normalize_container_path(existing: Option<&str>) -> String {
     }
 
     dirs.join(":")
+}
+
+/// POSIX-sh snippet that scrubs inherited-but-broken TLS CA-bundle env vars.
+///
+/// This is prepended to the `/bin/sh -lc` command that `nsenter` runs *inside*
+/// the container namespace, so the `[ -e ]` checks see the container rootfs
+/// (not the host). For each var in [`CA_BUNDLE_ENV_VARS`], it unsets the var
+/// when it is set to a path that does not exist inside the container. Vars that
+/// point at a path present in the container (e.g. a shared
+/// `/etc/ssl/certs/...`) are left untouched, and any workspace-configured value
+/// is re-`export`ed *after* this prelude, so intentional overrides survive.
+///
+/// The variable names are compile-time constants (never user input), so the
+/// generated `eval`/`unset` is not an injection vector.
+fn ca_env_scrub_prelude() -> String {
+    let names = CA_BUNDLE_ENV_VARS.join(" ");
+    format!(
+        "for __oa_ca in {names}; do \
+         eval \"__oa_ca_val=\\${{$__oa_ca:-}}\"; \
+         if [ -n \"$__oa_ca_val\" ] && [ ! -e \"$__oa_ca_val\" ]; then unset \"$__oa_ca\"; fi; \
+         done; unset __oa_ca __oa_ca_val; "
+    )
 }
 
 fn environ_has_keepalive_marker(environ: &[u8]) -> bool {
@@ -321,9 +359,11 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        environ_has_keepalive_marker, normalize_container_path, resolv_conf_bind_args,
-        synthesized_container_resolv_conf,
+        ca_env_scrub_prelude, environ_has_keepalive_marker, normalize_container_path,
+        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
+        CA_BUNDLE_ENV_VARS,
     };
+    use std::collections::HashMap;
     use std::path::Path;
 
     #[test]
@@ -368,6 +408,57 @@ mod tests {
         assert_eq!(dirs[0], "/tmp/wrapper");
         assert_eq!(dirs.iter().filter(|dir| **dir == "/usr/bin").count(), 1);
         assert_eq!(dirs.iter().filter(|dir| **dir == "/tmp/wrapper").count(), 1);
+    }
+
+    #[test]
+    fn ca_scrub_prelude_covers_all_ca_bundle_vars() {
+        let prelude = ca_env_scrub_prelude();
+        for name in CA_BUNDLE_ENV_VARS {
+            assert!(
+                prelude.contains(name),
+                "prelude should reference {name}: {prelude}"
+            );
+        }
+        // Only unsets when the referenced path is absent inside the container.
+        assert!(prelude.contains("[ ! -e "));
+        assert!(prelude.contains("unset "));
+    }
+
+    #[test]
+    fn shell_command_scrubs_ca_env_before_exporting_workspace_vars() {
+        let mut env = HashMap::new();
+        env.insert(
+            "SSL_CERT_FILE".to_string(),
+            "/root/workspace-ca.pem".to_string(),
+        );
+        let cmd = WorkspaceExec::build_shell_command_with_env(
+            "/w",
+            "/usr/local/bin/claude",
+            &[],
+            Some(&env),
+        );
+
+        let scrub_at = cmd.find("__oa_ca").expect("scrub prelude present");
+        let export_at = cmd
+            .find("export SSL_CERT_FILE=")
+            .expect("workspace SSL_CERT_FILE re-exported after scrub");
+        // Prelude runs first; the intentional workspace override is applied
+        // afterwards so it survives the scrub.
+        assert!(
+            scrub_at < export_at,
+            "scrub must precede workspace exports: {cmd}"
+        );
+        assert!(cmd.contains("exec '/usr/local/bin/claude'"));
+    }
+
+    #[test]
+    fn shell_command_without_env_still_scrubs_ca_vars() {
+        // Even with no workspace env (preflight uses an empty map), the nsenter
+        // shell must still drop inherited-but-broken CA vars.
+        let cmd = WorkspaceExec::build_shell_command_with_env("/w", "curl", &[], None);
+        assert!(cmd.contains("SSL_CERT_FILE"));
+        assert!(cmd.contains("NODE_EXTRA_CA_CERTS"));
+        assert!(cmd.trim_start().starts_with("for __oa_ca in"));
     }
 
     #[test]
@@ -655,6 +746,12 @@ impl WorkspaceExec {
     ) -> String {
         let mut cmd = String::new();
 
+        // Drop inherited-but-broken TLS CA env vars (e.g. a host venv
+        // SSL_CERT_FILE) before exporting workspace vars, so they can't break
+        // HTTPS inside the container. Runs first so workspace-configured CA
+        // vars re-exported below still win.
+        cmd.push_str(&ca_env_scrub_prelude());
+
         // Export env vars inside the shell command so they're available in the container.
         // Keys are validated to POSIX env var names (alphanumeric + underscore) to prevent
         // shell injection via crafted env var keys. Values are single-quote escaped.
@@ -708,6 +805,14 @@ impl WorkspaceExec {
         tailnet_only: bool,
     ) -> String {
         let mut cmd = String::new();
+
+        // Scrub inherited-but-broken TLS CA env vars before anything else so
+        // the Tailscale bootstrap's own HTTPS calls (and the exec'd program)
+        // fall back to the container's default CA store. Only meaningful on the
+        // nsenter path where env is inherited; harmless under nspawn.
+        if export_all_env {
+            cmd.push_str(&ca_env_scrub_prelude());
+        }
 
         // Export env vars so the bootstrap script and program can use them.
         for (k, v) in env {

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -85,6 +85,10 @@ fn normalize_container_path(existing: Option<&str>) -> String {
 /// `/etc/ssl/certs/...`) are left untouched, and any workspace-configured value
 /// is re-`export`ed *after* this prelude, so intentional overrides survive.
 ///
+/// `SSL_CERT_DIR` may be a colon-separated directory list (OpenSSL 3+), so it
+/// is only unset when *none* of its components exist in the container; the
+/// other vars are single file paths.
+///
 /// The variable names are compile-time constants (never user input), so the
 /// generated `eval`/`unset` is not an injection vector.
 fn ca_env_scrub_prelude() -> String {
@@ -92,8 +96,17 @@ fn ca_env_scrub_prelude() -> String {
     format!(
         "for __oa_ca in {names}; do \
          eval \"__oa_ca_val=\\${{$__oa_ca:-}}\"; \
-         if [ -n \"$__oa_ca_val\" ] && [ ! -e \"$__oa_ca_val\" ]; then unset \"$__oa_ca\"; fi; \
-         done; unset __oa_ca __oa_ca_val; "
+         [ -n \"$__oa_ca_val\" ] || continue; \
+         if [ \"$__oa_ca\" = SSL_CERT_DIR ]; then \
+         __oa_ca_keep=; __oa_ca_rest=$__oa_ca_val; \
+         while [ -n \"$__oa_ca_rest\" ]; do \
+         __oa_ca_dir=${{__oa_ca_rest%%:*}}; \
+         case $__oa_ca_rest in *:*) __oa_ca_rest=${{__oa_ca_rest#*:}};; *) __oa_ca_rest=;; esac; \
+         if [ -n \"$__oa_ca_dir\" ] && [ -e \"$__oa_ca_dir\" ]; then __oa_ca_keep=1; fi; \
+         done; \
+         if [ -z \"$__oa_ca_keep\" ]; then unset SSL_CERT_DIR; fi; \
+         elif [ ! -e \"$__oa_ca_val\" ]; then unset \"$__oa_ca\"; fi; \
+         done; unset __oa_ca __oa_ca_val __oa_ca_keep __oa_ca_rest __oa_ca_dir; "
     )
 }
 
@@ -422,6 +435,49 @@ mod tests {
         // Only unsets when the referenced path is absent inside the container.
         assert!(prelude.contains("[ ! -e "));
         assert!(prelude.contains("unset "));
+    }
+
+    /// Runs the generated prelude in a real POSIX shell to verify scrub
+    /// semantics, including colon-separated `SSL_CERT_DIR` lists (OpenSSL 3+):
+    /// the var must survive if any component exists in the container.
+    #[test]
+    fn ca_scrub_prelude_shell_semantics() {
+        let run = |env: &[(&str, &str)]| -> String {
+            let script = format!(
+                "{} echo \"${{SSL_CERT_FILE:-UNSET}}|${{SSL_CERT_DIR:-UNSET}}\"",
+                ca_env_scrub_prelude()
+            );
+            let mut cmd = std::process::Command::new("/bin/sh");
+            // The test runner's own environment may carry CA vars (the very
+            // leak this prelude fixes), so start from a clean slate.
+            cmd.env_clear();
+            cmd.arg("-c").arg(&script);
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+            let out = cmd.output().expect("run /bin/sh");
+            assert!(out.status.success(), "prelude script failed: {out:?}");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+
+        // Broken single-path var is scrubbed; existing one is kept.
+        assert_eq!(
+            run(&[
+                ("SSL_CERT_FILE", "/nonexistent/cacert.pem"),
+                ("SSL_CERT_DIR", "/etc"),
+            ]),
+            "UNSET|/etc"
+        );
+        // Colon-separated SSL_CERT_DIR survives when any component exists.
+        assert_eq!(
+            run(&[("SSL_CERT_DIR", "/nonexistent-dir:/etc")]),
+            "UNSET|/nonexistent-dir:/etc"
+        );
+        // ...and is scrubbed only when no component exists.
+        assert_eq!(
+            run(&[("SSL_CERT_DIR", "/nonexistent-a:/nonexistent-b")]),
+            "UNSET|UNSET"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Residual dgx-spark provider-preflight failure after #587. #587 fixed the container resolv.conf ordering, but a fresh claudecode mission on the `dgx-spark` workspace still died before the prompt with:

> DNS resolution failed for 'api.anthropic.com'. The workspace DNS is not properly configured.

**Root cause (verified from code, not the error text):** DNS is *not* the actual problem. A container mission is attached via `nsenter … /bin/sh -lc …`, and that shell **inherits the sandboxed.sh daemon's environment**. `build_env()` only layers workspace vars on top via `export`; it never removes daemon-inherited vars. On dgx-spark the daemon is started from a Hermes Python venv that exports `SSL_CERT_FILE` (a `…/venv/…/certifi/cacert.pem` path). That path does not exist inside the container rootfs, so OpenSSL/curl/Node fail to load *any* CA store and every HTTPS request fails. The preflight's `curl` to the provider then fails and gets bucketed into a misleading DNS/connectivity error class. Manually `unset`-ing the five CA vars inside the keepalive makes `curl -4 -I https://api.anthropic.com` succeed — matching the reported observation.

The leak is specific to the **nsenter** path (persistent keepalive + attach, which is what dgx-spark uses). The `systemd-nspawn` path already gets a clean env via explicit `--setenv`, so it is unaffected.

## Changes

- **`src/workspace_exec.rs`** — new `ca_env_scrub_prelude()` prepended to the nsenter `/bin/sh -lc` command in both shell builders (`build_shell_command_with_env`, `build_tailscale_bootstrap_command`). Running *inside the container namespace*, it unsets any of `SSL_CERT_FILE`, `SSL_CERT_DIR`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS` whose referenced path is absent in the container. This satisfies the spec exactly:
  - path exists in container → kept (e.g. a shared `/etc/ssl/certs/…`);
  - workspace-configured value → re-`export`ed *after* the prelude, so it always wins;
  - inherited host-only path that is missing → scrubbed, so tools fall back to the container's own default CA store.
  - Var names are compile-time constants, so the generated `eval`/`unset` is not an injection vector.
- **`src/api/mission_runner.rs`** — `tls_error_hint()` classifier so the basic-connectivity preflight reports a broken CA bundle as a TLS/certificate error instead of a generic "network check failed".

## Does this fix dgx-spark without manual env unsets?

Yes. The nsenter shell (used by both the preflight `curl` and the claude CLI itself) now drops the bad inherited `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS` before running anything, so HTTPS to the providers works with the container's default CA store — no manual `unset` needed. Verified the generated POSIX snippet at runtime: a missing-path CA var is unset while an existing-path one is preserved.

## Tests

`cargo fmt`, `cargo clippy --lib` (clean), and targeted `cargo test --lib`:
- `ca_scrub_prelude_covers_all_ca_bundle_vars`
- `shell_command_scrubs_ca_env_before_exporting_workspace_vars` (prelude precedes workspace exports)
- `shell_command_without_env_still_scrubs_ca_vars` (empty-env preflight path still scrubs)
- `tls_error_hint_detects_broken_ca_bundle` / `tls_error_hint_ignores_dns_and_routing_failures`

All existing `workspace_exec` tests (incl. the #587 resolver tests) still pass.

## Follow-up (NOT in this PR): veth /24 route collision

The host mitigation `ip route replace 10.88.0.142/32 dev ve-<iface>` points at a separate, durable networking bug. The documented provisioning (`docs/install-native.md`) configures a single `[Match] Name=ve-*` networkd unit with `Address=10.88.0.1/24` + `DHCPServer=yes`. When more than one container is up, every `ve-*` interface claims the same `10.88.0.0/24` on the host, so the kernel has multiple ambiguous routes for that subnet and return traffic to a given container can egress the wrong veth — which is exactly what the `/32` pin works around. This is a host networking/provisioning change (per-container point-to-point subnet, or per-veth `/32` host routes added at container boot), not related to the CA env fix, and riskier — so it should be its own PR. Filing separately; not bundled here to keep this change surgical. No IPs/interface names are hardcoded anywhere in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every nsenter container mission builds its shell environment and HTTPS tooling behavior; scoped to the nsenter path with tests, but affects mission startup and provider preflight diagnostics.
> 
> **Overview**
> Fixes container missions failing HTTPS (and misleading “DNS” preflight errors) when the host daemon inherits CA-bundle env vars whose paths do not exist inside the container rootfs.
> 
> **`workspace_exec`:** Prepends a POSIX `ca_env_scrub_prelude()` to nsenter `/bin/sh -lc` commands in `build_shell_command_with_env` and (when `export_all_env`) `build_tailscale_bootstrap_command`. Inside the container namespace it unsets `SSL_CERT_FILE`, `SSL_CERT_DIR`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, and `NODE_EXTRA_CA_CERTS` when their referenced paths are missing; `SSL_CERT_DIR` colon-lists are kept if any component exists. Workspace `export` values still run after the prelude so intentional CA overrides win.
> 
> **`mission_runner`:** Adds `tls_error_hint()` so basic connectivity `curl` failures classify broken CA/TLS output as a certificate error (with guidance about inherited `SSL_CERT_FILE` / proxy) instead of a generic network failure.
> 
> New unit/shell tests cover prelude coverage, ordering vs workspace exports, empty-env preflight, and TLS vs DNS/routing curl output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939441a914f6ba5a046ac1385f66987351b6c99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->