### PR TITLE
Support GPT-5.6 models

### DIFF
--- a/dashboard/src/components/hermes/hermes-page.tsx
+++ b/dashboard/src/components/hermes/hermes-page.tsx
@@ -312,6 +312,7 @@ function isNativeCodexRuntime(model: string | null, baseUrl: string | null) {
 
   return (
     normalizedModel.includes("openai-codex") ||
+    normalizedModel.includes("gpt-5.6") ||
     normalizedModel.includes("gpt-5.5") ||
     normalizedBaseUrl.includes("chatgpt.com/backend-api/codex")
   );

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -877,8 +877,8 @@ export function NewMissionDialog({
               </select>
               <p className="text-xs text-white/30 mt-1.5">
                 {selectedBackend === 'opencode'
-                    ? 'Use provider/model format (e.g., openai/gpt-5-codex).'
-                    : 'Use the raw model ID (e.g., gpt-5-codex or claude-fable-5).'}
+                    ? 'Use provider/model format (e.g., openai/gpt-5.6).'
+                    : 'Use the raw model ID (e.g., gpt-5.6 or claude-fable-5).'}
               </p>
             </div>
 

--- a/src/api/codex_usage.rs
+++ b/src/api/codex_usage.rs
@@ -257,7 +257,7 @@ pub fn parse_cooldown_reset(body: &[u8], now_unix: i64) -> Option<i64> {
 /// Active probe: ask the Codex backend for this account's limits and parse the
 /// `x-codex-*` headers. `access_token` must be a fresh ChatGPT OAuth token.
 ///
-/// Sends a minimal `gpt-5.5` request — the only model class accepted on a
+/// Sends a minimal `gpt-5.6` request — the current model class accepted on a
 /// ChatGPT account (codex-specific ids 400). When budget remains this consumes
 /// one message; when exhausted the backend 429s (free) but still returns the
 /// headers, which is exactly what we want.
@@ -267,7 +267,7 @@ pub async fn probe(
     account_id: &str,
 ) -> Result<CodexUsageSnapshot, String> {
     let body = serde_json::json!({
-        "model": "gpt-5.5",
+        "model": "gpt-5.6",
         "instructions": "x",
         "input": [{
             "type": "message",

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -778,7 +778,7 @@ mod tests {
                         title: "first".into(),
                         prompt: "do x".into(),
                         backend: "codex".into(),
-                        model_override: Some("gpt-5.5".into()),
+                        model_override: Some("gpt-5.6".into()),
                         model_effort: None,
                         working_directory: None,
                         depends_on: vec![],

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2548,7 +2548,7 @@ pub(crate) async fn resolve_claudecode_default_model(
 pub(crate) fn resolve_codex_default_model() -> String {
     // Keep aligned with Codex upstream:
     // https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json
-    "gpt-5.5".to_string()
+    "gpt-5.6".to_string()
 }
 
 /// Return the default model for Gemini CLI when no override is specified.

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -63,6 +63,8 @@ const OPENROUTER_SEED_MODEL_IDS: &[&str] = &[
     "anthropic/claude-opus-4.8",
     "anthropic/claude-sonnet-4.6",
     "google/gemini-3.1-pro-preview",
+    "openai/gpt-5.6",
+    "openai/gpt-5.6-sol",
     "openai/gpt-5.5",
     "meta-llama/llama-3.3-70b-instruct:free",
 ];
@@ -802,11 +804,18 @@ fn default_providers_config() -> ProvidersConfig {
                     // using Codex with a ChatGPT account"), and everything older
                     // than it is dead too. Newest first.
                     ProviderModel {
+                        id: "gpt-5.6".to_string(),
+                        name: "GPT-5.6".to_string(),
+                        description: Some(
+                            "Alias for GPT-5.6 Sol, OpenAI's flagship reasoning and coding model"
+                                .to_string(),
+                        ),
+                    },
+                    ProviderModel {
                         id: "gpt-5.6-sol".to_string(),
                         name: "GPT-5.6 Sol".to_string(),
                         description: Some(
-                            "Preview flagship GPT-5.6 model for approved OpenAI API/Codex access"
-                                .to_string(),
+                            "Flagship GPT-5.6 model for complex reasoning and coding".to_string(),
                         ),
                     },
                     ProviderModel {
@@ -896,8 +905,8 @@ fn default_providers_config() -> ProvidersConfig {
                         description: Some("Google Gemini via OpenRouter".to_string()),
                     },
                     ProviderModel {
-                        id: "openai/gpt-5.5".to_string(),
-                        name: "GPT-5.5".to_string(),
+                        id: "openai/gpt-5.6".to_string(),
+                        name: "GPT-5.6".to_string(),
                         description: Some("OpenAI GPT via OpenRouter".to_string()),
                     },
                     ProviderModel {
@@ -2103,6 +2112,7 @@ pub async fn list_backend_model_options(
             || matches!(
                 id,
                 "gpt-5.5"
+                    | "gpt-5.6"
                     | "gpt-5.6-sol"
                     | "gpt-5.6-terra"
                     | "gpt-5.6-luna"
@@ -2422,6 +2432,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         for id in [
+            "gpt-5.6",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",
@@ -2435,7 +2446,7 @@ mod tests {
             assert!(ids.contains(&id), "missing OpenAI model {id}");
         }
 
-        for invalid_id in ["gpt-5.6", "sol", "terra", "luna"] {
+        for invalid_id in ["sol", "terra", "luna"] {
             assert!(
                 !ids.contains(&invalid_id),
                 "bare/non-API slug should not be exposed: {invalid_id}"
@@ -2481,6 +2492,7 @@ mod tests {
             .map(|i| make(&format!("vendor/model-{i:03}")))
             .collect();
         entries.push(make("anthropic/claude-opus-4.8"));
+        entries.push(make("openai/gpt-5.6"));
         entries.push(make("openai/gpt-5.5"));
 
         let capped = cap_catalog_entries(
@@ -2490,6 +2502,7 @@ mod tests {
         );
         assert_eq!(capped.len(), MAX_CATALOG_MODELS_PER_PROVIDER);
         assert_eq!(capped[0].id, "anthropic/claude-opus-4.8");
+        assert!(capped.iter().any(|entry| entry.id == "openai/gpt-5.6"));
         assert!(capped.iter().any(|entry| entry.id == "openai/gpt-5.5"));
     }
 

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -1396,7 +1396,7 @@ pub async fn run_codex_turn(
     if lower_final.contains("does not exist or you do not have access")
         || lower_final.contains("model_not_found")
     {
-        final_message.push_str("\n\nTry model `gpt-5.5` or `gpt-5-codex` for Codex missions.");
+        final_message.push_str("\n\nTry model `gpt-5.6` or `gpt-5-codex` for Codex missions.");
         if matches!(
             model,
             Some("gpt-5.3-codex" | "gpt-5.4-codex" | "gpt-5.5-codex")

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2203,7 +2203,7 @@ async fn get_hermes_assistant_status(
     // Hermes runtime resolves the persisted config.yaml model FIRST (its
     // runtime_provider treats the env as a stale override). Prefer the live
     // config for display so switching Hermes to a native provider (e.g.
-    // openai-codex/gpt-5.5) doesn't keep showing the routing fallback.
+    // openai-codex/gpt-5.6) doesn't keep showing the routing fallback.
     let env_model = env_contents
         .as_deref()
         .and_then(|contents| parse_env_value(contents, "HERMES_ASSISTANT_MODEL"))
@@ -4250,7 +4250,7 @@ fn is_env_name_char(ch: char) -> bool {
 fn hermes_uses_native_codex(model: Option<&str>, base_url: Option<&str>) -> bool {
     let model_is_codex = model.is_some_and(|m| {
         let value = m.to_ascii_lowercase();
-        value.contains("openai-codex") || value.contains("gpt-5.5")
+        value.contains("openai-codex") || value.contains("gpt-5.6") || value.contains("gpt-5.5")
     });
     let base_url_is_codex = base_url.is_some_and(|url| {
         url.to_ascii_lowercase()
@@ -4572,10 +4572,10 @@ mod tests {
 
     #[test]
     fn hermes_config_model_label_prefers_provider_and_default() {
-        let yaml = "model:\n  base_url: https://chatgpt.com/backend-api/codex\n  default: gpt-5.5\n  provider: openai-codex\nproviders: {}\n";
+        let yaml = "model:\n  base_url: https://chatgpt.com/backend-api/codex\n  default: gpt-5.6\n  provider: openai-codex\nproviders: {}\n";
         assert_eq!(
             hermes_config_model_label(yaml).as_deref(),
-            Some("openai-codex/gpt-5.5")
+            Some("openai-codex/gpt-5.6")
         );
         // `auto` provider is not a meaningful label component.
         let auto = "model:\n  provider: auto\n  default: builtin/assistant\n";
@@ -4589,6 +4589,7 @@ mod tests {
 
     #[test]
     fn hermes_native_codex_detection_accepts_model_and_backend_url() {
+        assert!(hermes_uses_native_codex(Some("openai-codex/gpt-5.6"), None));
         assert!(hermes_uses_native_codex(Some("openai-codex/gpt-5.5"), None));
         assert!(hermes_uses_native_codex(
             None,

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1905,7 +1905,7 @@ mod tests {
             "status": "active",
             "mission_mode": "default",
             "backend": "codex",
-            "model_override": "gpt-5.5",
+            "model_override": "gpt-5.6",
             "workspace_id": "workspace-1",
             "workspace_name": "assistant",
             "short_description": "Build fix",

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -344,7 +344,7 @@ struct MergeBranchParams {
     /// Backend for the auto-registered conflict-resolver task (default codex)
     #[serde(default)]
     resolver_backend: Option<String>,
-    /// Model for the resolver task (default gpt-5.5)
+    /// Model for the resolver task (default gpt-5.6)
     #[serde(default)]
     resolver_model: Option<String>,
 }
@@ -690,7 +690,7 @@ impl OrchestratorMcp {
                         "push": { "type": "boolean", "description": "Push target to origin after a clean merge" },
                         "delete_source": { "type": "boolean", "description": "Delete the source branch after a clean merge" },
                         "resolver_backend": { "type": "string", "description": "Backend for the auto conflict-resolver task (default codex)" },
-                        "resolver_model": { "type": "string", "description": "Model for the resolver task (default gpt-5.5)" }
+                        "resolver_model": { "type": "string", "description": "Model for the resolver task (default gpt-5.6)" }
                     }
                 }),
             },
@@ -712,7 +712,7 @@ impl OrchestratorMcp {
                         },
                         "model_override": {
                             "type": "string",
-                            "description": "Model to use. Must match the backend: Claude models (e.g. 'claude-opus-4-7') for claudecode, GPT models (e.g. 'gpt-5.5') for codex, Gemini models for gemini, Grok models for grok, 'provider/model' format for opencode."
+                            "description": "Model to use. Must match the backend: Claude models (e.g. 'claude-opus-4-7') for claudecode, GPT models (e.g. 'gpt-5.6') for codex, Gemini models for gemini, Grok models for grok, 'provider/model' format for opencode."
                         },
                         "model_effort": {
                             "type": "string",
@@ -1115,7 +1115,7 @@ impl OrchestratorMcp {
         }
         if claude_worker && !claude_allowed {
             return Err(
-                "Refused: Claude models/backends are not allowed for worker missions                  (operator policy). Use opencode+builtin/smart, opencode+genius,                  codex+gpt-5.5, or grok instead. If the operator explicitly approved a                  Claude worker, set SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1."
+                "Refused: Claude models/backends are not allowed for worker missions                  (operator policy). Use opencode+builtin/smart, opencode+genius,                  codex+gpt-5.6, or grok instead. If the operator explicitly approved a                  Claude worker, set SANDBOXED_SH_ALLOW_CLAUDE_WORKERS=1."
                     .to_string(),
             );
         }
@@ -2028,7 +2028,7 @@ impl OrchestratorMcp {
                     model_override: Some(
                         params
                             .resolver_model
-                            .unwrap_or_else(|| "gpt-5.5".to_string()),
+                            .unwrap_or_else(|| "gpt-5.6".to_string()),
                     ),
                     model_effort: Some("high".to_string()),
                     working_directory: Some(repo_dir.clone()),

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -158,7 +158,7 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
     },
     PricingEntry {
         canonical: "gpt-5.6-sol",
-        aliases: &["gpt-5.6-sol", "gpt-5-6-sol"],
+        aliases: &["gpt-5.6", "gpt-5-6", "gpt-5.6-sol", "gpt-5-6-sol"],
         pricing: pricing(5_000, 30_000, Some(6_250), Some(500)),
     },
     PricingEntry {
@@ -413,13 +413,39 @@ fn normalize_model(model: &str) -> &str {
         if entry
             .aliases
             .iter()
-            .any(|alias| normalized_for_match.contains(alias))
+            .any(|alias| model_alias_matches(&normalized_for_match, alias))
         {
             return entry.canonical;
         }
     }
 
     trimmed
+}
+
+fn model_alias_matches(model: &str, alias: &str) -> bool {
+    for (idx, _) in model.match_indices(alias) {
+        let after = &model[idx + alias.len()..];
+        if after.is_empty() {
+            return true;
+        }
+        if alias.as_bytes().last().is_some_and(|b| b.is_ascii_digit()) {
+            // Numeric family aliases may have date/version suffixes, but should
+            // not swallow named variants such as gpt-5.6-terra.
+            if let Some(suffix) = after.strip_prefix('-') {
+                if suffix
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|b| b.is_ascii_digit())
+                    || suffix.starts_with("codex")
+                {
+                    return true;
+                }
+            }
+            continue;
+        }
+        return true;
+    }
+    false
 }
 
 /// Normalize model names to the canonical pricing key.
@@ -555,6 +581,8 @@ mod tests {
         );
         assert_eq!(normalize_model("gpt-4o-2024-08-06"), "gpt-4o");
         assert_eq!(normalize_model("gpt-5.3-codex"), "gpt-5.3");
+        assert_eq!(normalize_model("openai/gpt-5.6"), "gpt-5.6-sol");
+        assert_eq!(normalize_model("gpt-5.6-2026-07-09"), "gpt-5.6-sol");
         assert_eq!(normalize_model("openai/gpt-5.6-sol"), "gpt-5.6-sol");
         assert_eq!(normalize_model("openai/gpt-5.6-terra"), "gpt-5.6-terra");
         assert_eq!(normalize_model("openai/gpt-5.6-luna"), "gpt-5.6-luna");
@@ -593,6 +621,7 @@ mod tests {
         assert!(pricing_for_model("claude-haiku-4-5").is_some());
         assert!(pricing_for_model("gpt-4o").is_some());
         assert!(pricing_for_model("gpt-5.3-codex").is_some());
+        assert!(pricing_for_model("openai/gpt-5.6").is_some());
         assert!(pricing_for_model("openai/gpt-5.6-sol").is_some());
         assert!(pricing_for_model("openai/gpt-5.6-terra").is_some());
         assert!(pricing_for_model("openai/gpt-5.6-luna").is_some());


### PR DESCRIPTION
## Summary

- Add the official `gpt-5.6` alias to the OpenAI provider catalog and Codex backend model picker, alongside `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- Make Codex missions default to `gpt-5.6`, update worker/resolver defaults and user-facing hints, and recognize GPT-5.6 native Codex/Hermes runtime configs.
- Align usage pricing/normalization so `gpt-5.6` maps to Sol pricing without incorrectly swallowing named variants like `gpt-5.6-terra`.

## Validation

- `cargo fmt --all --check`
- `cargo test --no-run`
- Focused Rust tests for provider catalog, cost normalization/pricing, Hermes detection, board tasks, and assistant mission summaries
- `cd dashboard && bun run test:unit`
- `cd dashboard && bunx eslint src/components/new-mission-dialog.tsx src/components/hermes/hermes-page.tsx`

Full `cd dashboard && bun run lint` still fails on existing vendored/context lint violations under `dashboard/context/...`, unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Broad but mechanical string/default updates across UI, providers, and cost lookup; no auth or persistence schema changes, with added tests for catalog and normalization edge cases.
> 
> **Overview**
> Promotes **GPT-5.6** as the primary Codex/OpenAI subscription model across defaults, catalogs, and operator-facing hints, while keeping **GPT-5.5** where backward compatibility still matters.
> 
> **Defaults and routing:** Codex missions without a model override now resolve to `gpt-5.6` (control layer, mission runner, orchestrator merge-resolver workers, and related MCP docs). The Codex usage **probe** uses `gpt-5.6` so ChatGPT-account limit checks hit the model class the backend currently accepts.
> 
> **Catalog and pickers:** The OpenAI provider list adds the official `gpt-5.6` alias (described as an alias for Sol), updates OpenRouter seed/prefixed IDs from `openai/gpt-5.5` to `openai/gpt-5.6`, and extends Codex backend filters so `gpt-5.6` is a first-class selectable slug. Hermes native-Codex detection treats `gpt-5.6` like other ChatGPT Codex models.
> 
> **Cost normalization:** `gpt-5.6` maps to **Sol** pricing via new aliases; matching logic is tightened so numeric family aliases do not incorrectly absorb named variants such as `gpt-5.6-terra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b164693636cb858d768e64c0a4cc31728796017c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->