### PR TITLE
Disk hardening + scope lifecycle + remote-node fleet Phase 0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,10 @@ JWT_TTL_DAYS=30
 # SANDBOXED_REMOTE_NODE_NIPPUR_TOKEN=change-me
 # Fleet-monitor heartbeat poll interval in seconds (0 disables the loop).
 # REMOTE_NODE_MONITOR_SECS=15
+# Auto-placement floors: nodes below these available-resource thresholds are
+# excluded from `remote_node_id: "auto"` / POST /api/remote-build placement.
+# REMOTE_NODE_MIN_DISK_GB=20
+# REMOTE_NODE_MIN_MEM_GB=8
 
 # =============================================================================
 # Optional: Disk hygiene & self-maintenance

--- a/.env.example
+++ b/.env.example
@@ -213,3 +213,7 @@ JWT_TTL_DAYS=30
 # SCOPE_REAPER_ENABLED=1
 # SCOPE_REAPER_INTERVAL_MINUTES=15
 # SCOPE_ZOMBIE_MAX_AGE_HOURS=12
+# Grace (seconds) between a stopping mission status and exec-scope teardown;
+# must exceed the 10s background-watcher poll so AwaitingUser→WaitingBackground
+# promotions are observed by the pre-stop recheck.
+# SCOPE_TEARDOWN_GRACE_SECS=30

--- a/.env.example
+++ b/.env.example
@@ -175,3 +175,11 @@ JWT_TTL_DAYS=30
 # How many `.pre-deploy-<sha>` binary backups /api/system/deploy keeps per
 # deployed binary (older ones are pruned after a successful deploy).
 # DEPLOY_BACKUP_KEEP=2
+#
+# Disk health thresholds (percent of root filesystem used). At warn, alerts
+# fire; at critical, new mission creation is refused (DISK_ADMISSION_ENABLED=0
+# to bypass). Alerts repeat every DISK_ALERT_REPEAT_HOURS while elevated.
+# DISK_WARN_PCT=90
+# DISK_CRITICAL_PCT=95
+# DISK_ADMISSION_ENABLED=1
+# DISK_ALERT_REPEAT_HOURS=24

--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,22 @@ JWT_TTL_DAYS=30
 # SANDBOXED_PUBLIC_URL=https://dashboard.example.com
 
 # =============================================================================
+# Optional: Remote runner nodes
+# =============================================================================
+# Core-side configuration for dispatching selected missions to sandboxed-node
+# runners (see docs/REMOTE_NODES.md). Node-side vars (SANDBOXED_NODE_ID/BIND/
+# WORK_DIR/CAPACITY/TOKEN/TOKEN_PREVIOUS/LABELS/MAX_JOB_SECS) live in each
+# node's own env file (e.g. /etc/sandboxed-node.env), not here.
+# SANDBOXED_REMOTE_NODES_ENABLED=false
+# Comma-separated node list: id=url or id=url|TOKEN_ENV_NAME.
+# SANDBOXED_REMOTE_NODES='babylon=http://100.64.0.11:3088,nippur=http://100.64.0.12:3088'
+# One bearer secret per node; default env name is SANDBOXED_REMOTE_NODE_<ID>_TOKEN.
+# SANDBOXED_REMOTE_NODE_BABYLON_TOKEN=change-me
+# SANDBOXED_REMOTE_NODE_NIPPUR_TOKEN=change-me
+# Fleet-monitor heartbeat poll interval in seconds (0 disables the loop).
+# REMOTE_NODE_MONITOR_SECS=15
+
+# =============================================================================
 # Optional: Disk hygiene & self-maintenance
 # =============================================================================
 # How many `.pre-deploy-<sha>` binary backups /api/system/deploy keeps per

--- a/.env.example
+++ b/.env.example
@@ -174,7 +174,7 @@ JWT_TTL_DAYS=30
 # =============================================================================
 # Core-side configuration for dispatching selected missions to sandboxed-node
 # runners (see docs/REMOTE_NODES.md). Node-side vars (SANDBOXED_NODE_ID/BIND/
-# WORK_DIR/CAPACITY/TOKEN/TOKEN_PREVIOUS/LABELS/MAX_JOB_SECS) live in each
+# WORK_DIR/CAPACITY/TOKEN/TOKEN_PREVIOUS/LABELS/MAX_JOB_SECS/MAX_QUEUED) live in each
 # node's own env file (e.g. /etc/sandboxed-node.env), not here.
 # SANDBOXED_REMOTE_NODES_ENABLED=false
 # Comma-separated node list: id=url or id=url|TOKEN_ENV_NAME.
@@ -188,6 +188,8 @@ JWT_TTL_DAYS=30
 # excluded from `remote_node_id: "auto"` / POST /api/remote-build placement.
 # REMOTE_NODE_MIN_DISK_GB=20
 # REMOTE_NODE_MIN_MEM_GB=8
+# Per-mission remote-build capability lifetime (minimum 300s, default 6h).
+# REMOTE_BUILD_TOKEN_TTL_SECS=21600
 
 # =============================================================================
 # Optional: Disk hygiene & self-maintenance

--- a/.env.example
+++ b/.env.example
@@ -168,3 +168,10 @@ JWT_TTL_DAYS=30
 # GITHUB_OAUTH_ALLOWLIST=alice,bob
 # GITHUB_OAUTH_REDIRECT_ALLOWLIST=sandboxed://auth/callback
 # SANDBOXED_PUBLIC_URL=https://dashboard.example.com
+
+# =============================================================================
+# Optional: Disk hygiene & self-maintenance
+# =============================================================================
+# How many `.pre-deploy-<sha>` binary backups /api/system/deploy keeps per
+# deployed binary (older ones are pruned after a successful deploy).
+# DEPLOY_BACKUP_KEEP=2

--- a/.env.example
+++ b/.env.example
@@ -183,3 +183,13 @@ JWT_TTL_DAYS=30
 # DISK_CRITICAL_PCT=95
 # DISK_ADMISSION_ENABLED=1
 # DISK_ALERT_REPEAT_HOURS=24
+#
+# Exec-scope lifecycle. Mission-end teardown stops a mission's
+# sandboxed-exec-*.scope units (harness processes); the periodic reaper
+# sweeps zombies missed across restarts. AwaitingUser/Paused missions get
+# their scopes stopped too by default (resume re-spawns the harness).
+# SCOPE_STOP_ON_AWAITING_USER=1
+# SCOPE_STOP_ON_PAUSE=1
+# SCOPE_REAPER_ENABLED=1
+# SCOPE_REAPER_INTERVAL_MINUTES=15
+# SCOPE_ZOMBIE_MAX_AGE_HOURS=12

--- a/dashboard/src/app/settings/data/page.tsx
+++ b/dashboard/src/app/settings/data/page.tsx
@@ -501,6 +501,18 @@ export default function DataSettingsPage() {
                 )}
               </div>
             </div>
+
+            <p className="mt-3 text-xs text-white/40">
+              Stopped missions (awaiting user / paused) are kept{' '}
+              {serverSettings?.auto_cleanup_stopped_days ?? 30} days; orphan
+              directories with no matching mission are{' '}
+              {(serverSettings?.auto_cleanup_orphans_enabled ??
+                serverSettings?.auto_cleanup_enabled)
+                ? 'collected'
+                : 'kept'}
+              . Tune via <code>auto_cleanup_stopped_days</code> /{' '}
+              <code>auto_cleanup_orphans_enabled</code> in the settings API.
+            </p>
           </div>
 
           {/* Backup & Restore */}

--- a/dashboard/src/components/active-automations.tsx
+++ b/dashboard/src/components/active-automations.tsx
@@ -479,6 +479,10 @@ function triggerChip(a: Automation): string {
       return 'webhook';
     case 'cron':
       return 'cron';
+    case 'durable_job_terminal':
+      return 'on job finish';
+    case 'telegram':
+      return 'telegram';
     default:
       return trigger.type;
   }

--- a/dashboard/src/components/assistant/assistant-page.tsx
+++ b/dashboard/src/components/assistant/assistant-page.tsx
@@ -139,6 +139,12 @@ function triggerLabel(t: TriggerType): string {
       return `every ${humanizeDuration(t.seconds)}`;
     case 'agent_finished':
       return 'when agent finishes';
+    case 'durable_job_terminal':
+      return 'when durable job finishes';
+    case 'cron':
+      return `cron ${t.expression}`;
+    case 'telegram':
+      return 'telegram';
     case 'webhook':
       return 'webhook';
     default:

--- a/dashboard/src/components/mission-automations-dialog.tsx
+++ b/dashboard/src/components/mission-automations-dialog.tsx
@@ -525,6 +525,15 @@ export function MissionAutomationsDialog({
     if (automation.trigger?.type === 'agent_finished') {
       return 'After agent finishes';
     }
+    if (automation.trigger?.type === 'durable_job_terminal') {
+      return 'After durable job finishes';
+    }
+    if (automation.trigger?.type === 'cron') {
+      return `Cron ${automation.trigger.expression}`;
+    }
+    if (automation.trigger?.type === 'telegram') {
+      return 'Telegram';
+    }
     if (automation.trigger?.type === 'webhook') {
       return 'Webhook';
     }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3149,6 +3149,8 @@ export interface SettingsResponse {
   max_concurrent_tasks: number | null;
   auto_cleanup_enabled: boolean | null;
   auto_cleanup_days: number | null;
+  auto_cleanup_stopped_days: number | null;
+  auto_cleanup_orphans_enabled: boolean | null;
   ask_assistant_model: string | null;
   metadata_model: string | null;
 }

--- a/dashboard/src/lib/api/automations.ts
+++ b/dashboard/src/lib/api/automations.ts
@@ -28,7 +28,10 @@ export type AutomationDriver = "scheduler" | "harness_loop";
 
 export type TriggerType =
   | { type: "interval"; seconds: number }
+  | { type: "cron"; expression: string; timezone: string }
   | { type: "agent_finished" }
+  | { type: "durable_job_terminal"; job_id: string }
+  | { type: "telegram"; config: { channel_id: string } }
   | {
       type: "webhook";
       config: {

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -35,6 +35,12 @@ Supported now:
 - declarative `lean_build` jobs: the node fetches a pinned commit itself,
   runs a constrained `lake`/`lean`/`elan` argv with shared elan/lake caches,
   and reports artifact digests (see "Lean build jobs" below)
+- capacity-aware auto placement: `remote_node_id: "auto"` (plus optional
+  `remote_requirements` labels) picks the least-loaded eligible node from the
+  fleet cache and fails closed with a per-node exclusion report
+- `POST /api/remote-build`: an in-workspace, capability-token-authenticated
+  endpoint that dispatches a `lean_build` job (auto-placed by default) and
+  waits for the result — used by the `remote-lean-build` wrapper
 - dispatch failures fail closed: the mission is marked failed and the API
   returns an error
 - future `not_before` scheduling with `remote_node_id` is rejected for now so
@@ -250,6 +256,92 @@ Execution model:
   match is recorded with its sha256 and size.
 - The heartbeat's `cached_toolchains` lists the directory names under
   `<workdir>/caches/elan/toolchains/`.
+
+## Auto Placement
+
+`POST /api/control/missions` accepts `remote_node_id: "auto"` (optionally
+with `remote_requirements: ["lean", ...]`, default none for raw commands),
+and `POST /api/remote-build` defaults to it (requirements default
+`["lean"]`). Placement runs against the fleet monitor's cached heartbeats
+**before** the mission/job is persisted, so failures surface as a clean API
+error.
+
+A node is eligible when all of the following hold:
+
+- cached status is `online`
+- its labels (heartbeat, falling back to static config) cover every
+  requirement
+- `disk_available` ≥ `REMOTE_NODE_MIN_DISK_GB` (default 20)
+- `mem_available` ≥ `REMOTE_NODE_MIN_MEM_GB` (default 8)
+- `active_jobs + queued_jobs < 2 * capacity_total`
+
+Eligible nodes are ranked least-loaded first (ties broken by most available
+memory). When no node qualifies the request **fails closed** with every
+configured node listed alongside its exclusion reason (offline / missing
+label X / low disk / low memory / busy), e.g.
+`no eligible remote node (babylon: low disk (12 GiB available, 20 GiB
+required); nippur: missing label 'lean')`.
+
+## POST /api/remote-build
+
+Dispatches a `lean_build` job from inside a mission workspace. Auth is a
+per-mission HMAC capability token (same signing secret as the spark-offload
+token, domain-separated with a `remote-build:` prefix), injected into
+harness envs as `REMOTE_BUILD_URL` / `REMOTE_BUILD_TOKEN` /
+`REMOTE_BUILD_MISSION_ID` whenever remote nodes (or spark offload) are
+enabled. Node bearer tokens never enter the workspace.
+
+Request body:
+
+```json
+{
+  "mission_id": "<uuid>",
+  "token": "<REMOTE_BUILD_TOKEN>",
+  "repo": "https://github.com/org/repo.git",
+  "commit": "<40-hex sha>",
+  "cwd_rel": "verity",
+  "command": ["lake", "build"],
+  "timeout_secs": 3600,
+  "requirements": ["lean"],
+  "node_id": "auto",
+  "wait": true,
+  "artifacts": [".lake/build/lib/*"]
+}
+```
+
+`requirements` defaults to `["lean"]`, `node_id` to `"auto"`, `wait` to
+`true`. With `wait: true` the call polls the node every 3s (client-side cap
+2h) and returns `{exit_code, state, duration_secs, log_tail, node_id,
+job_id, artifacts}`. With `wait: false` it returns `202 {job_id, node_id}`;
+poll `GET /api/remote-build/:job_id?mission_id=...&token=...&node_id=...`
+for the job status. Placement failures and unconfigured/unavailable fleets
+answer `503` with the reason, so callers can fall back to a local build.
+
+## remote-lean-build wrapper
+
+`scripts/remote-lean-build` is the in-workspace client for the endpoint. Run
+it from anywhere inside a git checkout:
+
+```bash
+remote-lean-build                # lake build at your current repo position
+remote-lean-build lake build Verity
+```
+
+It derives `repo` (`git remote get-url origin`), `commit`
+(`git rev-parse HEAD`) and `cwd_rel` (`git rev-parse --show-prefix`),
+refuses a dirty tree (exit 2 — the node builds a pinned commit, so
+uncommitted changes would be silently ignored), POSTs to
+`$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
+prints the remote log tail, and exits with the remote build's exit code. On
+HTTP 503 (placement failure, fleet down, feature off) it prints the reason
+and exits 75 (`EX_TEMPFAIL`) so scripts can fall back to a local build:
+
+```bash
+remote-lean-build || { [ $? -eq 75 ] && lake build; }
+```
+
+Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
+node's `SANDBOXED_NODE_MAX_JOB_SECS`).
 
 ## Core Configuration
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -9,8 +9,15 @@ It never receives a dashboard JWT or broad API token.
 
 Supported now:
 
-- core lists configured nodes and reports live heartbeat/capacity status
+- core lists configured nodes and reports cached fleet status (heartbeat v2:
+  capacity, labels, CPU/memory/disk figures, job counts)
+- a background fleet monitor polls every node's `/heartbeat` on an interval
+  (`REMOTE_NODE_MONITOR_SECS`, default 15s, `0` disables) and derives per-node
+  statuses: `online` (fresh heartbeat), `degraded` (1-2 consecutive misses),
+  `offline` (3+ consecutive misses)
 - `sandboxed-node` exposes authenticated `/heartbeat` and `/execute`
+- node bearer-token rotation: the node accepts the current token and, during a
+  rotation window, the previous one (`SANDBOXED_NODE_TOKEN_PREVIOUS`)
 - selected missions can run one `remote_command` on a selected node
 - the command runs under `SANDBOXED_NODE_WORK_DIR/<mission-id>`
 - dispatch failures fail closed: the mission is marked failed and the API
@@ -44,38 +51,56 @@ sudo install -m 0755 target/debug/sandboxed-node /usr/local/bin/sandboxed-node
 
 Use one distinct secret per node. Do not paste the secret into logs or docs.
 
-Babylon:
+The node binds to `127.0.0.1:3088` by default so it is never reachable over a
+network by accident. To let core reach it, set `SANDBOXED_NODE_BIND` to a
+private interface — preferably the node's tailscale IP (e.g.
+`SANDBOXED_NODE_BIND=100.77.4.93:3088`), or `0.0.0.0:3088` only when the host
+firewall restricts the port to core.
+
+Example (Babylon):
 
 ```bash
 export SANDBOXED_NODE_ID=babylon
-export SANDBOXED_NODE_BIND=0.0.0.0:3088
+# Bind a private/tailscale interface; default is 127.0.0.1:3088.
+export SANDBOXED_NODE_BIND=<tailscale-ip>:3088
 export SANDBOXED_NODE_WORK_DIR=/var/lib/sandboxed-node/work
 export SANDBOXED_NODE_CAPACITY=1
 export SANDBOXED_NODE_TOKEN="$SANDBOXED_REMOTE_NODE_BABYLON_TOKEN"
+# Optional: comma-separated capability labels reported in heartbeats.
+export SANDBOXED_NODE_LABELS=lean,docker
 /usr/local/bin/sandboxed-node
 ```
 
-Nippur:
+Nippur and Ashur are configured identically with their own
+`SANDBOXED_NODE_ID` and token.
 
-```bash
-export SANDBOXED_NODE_ID=nippur
-export SANDBOXED_NODE_BIND=0.0.0.0:3088
-export SANDBOXED_NODE_WORK_DIR=/var/lib/sandboxed-node/work
-export SANDBOXED_NODE_CAPACITY=1
-export SANDBOXED_NODE_TOKEN="$SANDBOXED_REMOTE_NODE_NIPPUR_TOKEN"
-/usr/local/bin/sandboxed-node
-```
+### Token rotation
 
-Ashur:
+To rotate a node token with zero downtime:
 
-```bash
-export SANDBOXED_NODE_ID=ashur
-export SANDBOXED_NODE_BIND=0.0.0.0:3088
-export SANDBOXED_NODE_WORK_DIR=/var/lib/sandboxed-node/work
-export SANDBOXED_NODE_CAPACITY=1
-export SANDBOXED_NODE_TOKEN="$SANDBOXED_REMOTE_NODE_ASHUR_TOKEN"
-/usr/local/bin/sandboxed-node
-```
+1. On the node, set `SANDBOXED_NODE_TOKEN` to the new secret and
+   `SANDBOXED_NODE_TOKEN_PREVIOUS` to the old one, then restart the node. It
+   now accepts both (constant-time comparison for each).
+2. Update the core env (`SANDBOXED_REMOTE_NODE_<ID>_TOKEN`) to the new secret
+   and restart/redeploy core.
+3. Remove `SANDBOXED_NODE_TOKEN_PREVIOUS` on the node and restart it.
+
+### Heartbeat v2
+
+`GET /heartbeat` returns the v1 fields (`node_id`, `online`, `capacity_total`,
+`capacity_available`, `active_leases`, `version`) plus:
+
+- `protocol_version` (currently `2`; core treats a missing field as `1`)
+- `labels` (from `SANDBOXED_NODE_LABELS`)
+- `cpu_total` (logical cores)
+- `mem_total_bytes` / `mem_available_bytes`
+- `disk_total_bytes` / `disk_available_bytes` (filesystem backing the work
+  dir, falling back to root)
+- `active_jobs` / `queued_jobs` (async job API)
+- `cached_toolchains` (empty until toolchain prewarming ships)
+
+All new fields are serde-default-tolerant in both directions, so mixed-version
+core/node fleets keep working during upgrades.
 
 Minimal systemd unit:
 
@@ -99,7 +124,9 @@ WantedBy=multi-user.target
 
 `/etc/sandboxed-node.env` contains only env-var assignments such as
 `SANDBOXED_NODE_ID`, `SANDBOXED_NODE_BIND`, `SANDBOXED_NODE_WORK_DIR`,
-`SANDBOXED_NODE_CAPACITY`, and `SANDBOXED_NODE_TOKEN`.
+`SANDBOXED_NODE_CAPACITY`, `SANDBOXED_NODE_TOKEN`,
+`SANDBOXED_NODE_TOKEN_PREVIOUS` (rotation only), and
+`SANDBOXED_NODE_LABELS`.
 
 ## Core Configuration
 
@@ -117,14 +144,24 @@ The token env names are also the default names inferred from the node ids. To
 override a token env name, use `id=url|TOKEN_ENV_NAME` in
 `SANDBOXED_REMOTE_NODES`.
 
+Optional: `REMOTE_NODE_MONITOR_SECS` sets the fleet-monitor poll interval
+(default 15; `0` disables the loop, in which case `/api/remote-nodes` probes
+uncached nodes on demand).
+
 ## Smoke Tests
 
-Check live node status from core:
+Check fleet status from core:
 
 ```bash
 curl -H "Authorization: Bearer $DASHBOARD_JWT" \
   "$SANDBOXED_CORE_URL/api/remote-nodes"
 ```
+
+The response is `{ "enabled": bool, "nodes": [...], "recent_jobs": [...] }`.
+Each node entry carries the cached `status`
+(`online`/`degraded`/`offline`/`unknown`), labels, capacity, job counts,
+memory/disk availability, `cached_toolchains`, and `last_seen`; `recent_jobs`
+lists the last dispatch outcomes across the fleet.
 
 Run a selected remote MVP mission:
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -20,6 +20,18 @@ Supported now:
   rotation window, the previous one (`SANDBOXED_NODE_TOKEN_PREVIOUS`)
 - selected missions can run one `remote_command` on a selected node
 - the command runs under `SANDBOXED_NODE_WORK_DIR/<mission-id>`
+- async job API on the node (`POST /jobs`, `GET /jobs/:id`,
+  `POST /jobs/:id/cancel`, `GET /jobs`): jobs are persisted to
+  `<workdir>/jobs.db`, run under a capacity semaphore
+  (`SANDBOXED_NODE_CAPACITY`), capture combined stdout+stderr to
+  `<workdir>/logs/<job-id>.log`, and are killed by process group on
+  cancel/timeout (`SANDBOXED_NODE_MAX_JOB_SECS`, default 14400s). Jobs left
+  in flight across a node restart are marked `lost`
+- non-blocking core dispatch: pass `"remote_async": true` alongside
+  `remote_node_id`/`remote_command` in `POST /api/control/missions` — the
+  mission goes Active immediately and a background poll loop (3s) finalizes
+  it when the job completes; 5 consecutive unreachable polls fail the mission
+  with reason `remote_node_lost`
 - dispatch failures fail closed: the mission is marked failed and the API
   returns an error
 - future `not_before` scheduling with `remote_node_id` is rejected for now so
@@ -125,8 +137,49 @@ WantedBy=multi-user.target
 `/etc/sandboxed-node.env` contains only env-var assignments such as
 `SANDBOXED_NODE_ID`, `SANDBOXED_NODE_BIND`, `SANDBOXED_NODE_WORK_DIR`,
 `SANDBOXED_NODE_CAPACITY`, `SANDBOXED_NODE_TOKEN`,
-`SANDBOXED_NODE_TOKEN_PREVIOUS` (rotation only), and
-`SANDBOXED_NODE_LABELS`.
+`SANDBOXED_NODE_TOKEN_PREVIOUS` (rotation only), `SANDBOXED_NODE_LABELS`,
+and `SANDBOXED_NODE_MAX_JOB_SECS`.
+
+## Async Job API
+
+The node exposes a durable job API next to the blocking `/execute` path. All
+endpoints require the shared bearer token; `POST /jobs` additionally requires
+a per-job HMAC lease scoped to `job:submit` (minted by core; `mission:execute`
+leases are rejected, and vice versa).
+
+- `POST /jobs` with `{job_id, mission_id, lease_token, payload}` where
+  `payload` is `{"kind": "raw_command", "command": "...", "timeout_secs"?:
+  N, "env"?: {..}}`. Returns `202 {job_id, state: "queued"}`; duplicate
+  `job_id` returns `409`.
+- `GET /jobs/:id` — full status (`queued|running|succeeded|failed|cancelled|
+  lost`, exit code, timestamps, error) plus up to the last 64 KiB of the
+  combined log as `log_tail`.
+- `POST /jobs/:id/cancel` — SIGTERMs the job's process group (SIGKILL after
+  10s); returns the current state and whether a live job got the request.
+- `GET /jobs?limit=N` — recent jobs, newest first (default 20, no log tails).
+
+Async mission dispatch from core:
+
+```bash
+curl -sS -X POST "$SANDBOXED_CORE_URL/api/control/missions" \
+  -H "Authorization: Bearer $DASHBOARD_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "async remote smoke on babylon",
+    "remote_node_id": "babylon",
+    "remote_command": "hostname && sleep 30 && echo done",
+    "remote_async": true
+  }'
+```
+
+The API returns immediately with the mission Active; core polls the job every
+3s, logs a progress note on job state changes, and finalizes the mission with
+reason `remote_node_job` (or `remote_node_lost` when the node stays
+unreachable for 5 consecutive polls). Cancelling from the dashboard works
+indirectly: when the mission leaves the Active state for any reason, the poll
+loop cancels the node job on its next tick. There is no dedicated
+mission-cancel -> job-cancel plumbing yet; wiring an explicit cancel hook is a
+follow-up.
 
 ## Core Configuration
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -137,18 +137,36 @@ EnvironmentFile=/etc/sandboxed-node.env
 ExecStart=/usr/local/bin/sandboxed-node
 Restart=always
 RestartSec=5
-User=root
+User=sandboxed-node
+Group=sandboxed-node
 WorkingDirectory=/var/lib/sandboxed-node
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/sandboxed-node
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
 
 [Install]
 WantedBy=multi-user.target
 ```
 
+Create the service account and writable state directory before starting the
+unit (`useradd --system --home /var/lib/sandboxed-node sandboxed-node` and
+`install -d -o sandboxed-node -g sandboxed-node /var/lib/sandboxed-node`).
+Lean/Lake builds execute repository-controlled code, so running this service as
+root is unsupported; the argv allowlist is defense in depth, not a sandbox.
+The binary refuses UID 0 by default; `SANDBOXED_NODE_ALLOW_ROOT=1` is available
+only as an explicit emergency migration override.
+
 `/etc/sandboxed-node.env` contains only env-var assignments such as
 `SANDBOXED_NODE_ID`, `SANDBOXED_NODE_BIND`, `SANDBOXED_NODE_WORK_DIR`,
 `SANDBOXED_NODE_CAPACITY`, `SANDBOXED_NODE_TOKEN`,
 `SANDBOXED_NODE_TOKEN_PREVIOUS` (rotation only), `SANDBOXED_NODE_LABELS`,
-and `SANDBOXED_NODE_MAX_JOB_SECS`.
+`SANDBOXED_NODE_MAX_JOB_SECS`, and `SANDBOXED_NODE_MAX_QUEUED` (jobs waiting
+behind capacity; defaults to four times `SANDBOXED_NODE_CAPACITY`).
 
 Node env vars for lean-build jobs:
 
@@ -228,8 +246,9 @@ Validation (node-side, before anything runs):
 - `source.commit` must be a full 40-char lowercase hex SHA (no branches).
 - `cwd_rel` uses the same strict path allowlist as the Spark offload
   (`[A-Za-z0-9._-]` components, no `..`, no `-`-leading component).
-- `command` is executed directly (never via a shell) and its argv[0]
-  basename must be `lake`, `lean`, or `elan`.
+- `command` is executed directly (never via a shell); accepted entry points are
+  `lake build ...` and `lean ...`. The service environment is cleared before
+  execution so node bearer/signing secrets are not inherited by build code.
 - `env` keys must be within `SANDBOXED_NODE_ENV_ALLOWLIST`.
 - `timeout_secs` is clamped to `SANDBOXED_NODE_MAX_JOB_SECS`.
 
@@ -313,8 +332,11 @@ Request body:
 `true`. With `wait: true` the call polls the node every 3s (client-side cap
 2h) and returns `{exit_code, state, duration_secs, log_tail, node_id,
 job_id, artifacts}`. With `wait: false` it returns `202 {job_id, node_id}`;
-poll `GET /api/remote-build/:job_id?mission_id=...&token=...&node_id=...`
-for the job status. Placement failures and unconfigured/unavailable fleets
+poll `GET /api/remote-build/:job_id?mission_id=...&node_id=...` with the
+capability in `Authorization: Bearer $REMOTE_BUILD_TOKEN` for the job status.
+Capabilities expire after six hours by default (`REMOTE_BUILD_TOKEN_TTL_SECS`)
+and new submissions require a live mission. Placement failures and
+unconfigured/unavailable fleets
 answer `503` with the reason, so callers can fall back to a local build.
 
 ## remote-lean-build wrapper

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -32,6 +32,9 @@ Supported now:
   mission goes Active immediately and a background poll loop (3s) finalizes
   it when the job completes; 5 consecutive unreachable polls fail the mission
   with reason `remote_node_lost`
+- declarative `lean_build` jobs: the node fetches a pinned commit itself,
+  runs a constrained `lake`/`lean`/`elan` argv with shared elan/lake caches,
+  and reports artifact digests (see "Lean build jobs" below)
 - dispatch failures fail closed: the mission is marked failed and the API
   returns an error
 - future `not_before` scheduling with `remote_node_id` is rejected for now so
@@ -109,7 +112,8 @@ To rotate a node token with zero downtime:
 - `disk_total_bytes` / `disk_available_bytes` (filesystem backing the work
   dir, falling back to root)
 - `active_jobs` / `queued_jobs` (async job API)
-- `cached_toolchains` (empty until toolchain prewarming ships)
+- `cached_toolchains` (Lean toolchain dirs under the node's shared elan
+  cache; empty until the first `lean_build` job warms it)
 
 All new fields are serde-default-tolerant in both directions, so mixed-version
 core/node fleets keep working during upgrades.
@@ -140,6 +144,19 @@ WantedBy=multi-user.target
 `SANDBOXED_NODE_TOKEN_PREVIOUS` (rotation only), `SANDBOXED_NODE_LABELS`,
 and `SANDBOXED_NODE_MAX_JOB_SECS`.
 
+Node env vars for lean-build jobs:
+
+- `SANDBOXED_NODE_ENV_ALLOWLIST` — comma-separated env keys a `lean_build`
+  payload may set (default `LEAN_NUM_THREADS,LAKE_JOBS`); anything else is
+  rejected before the build starts.
+- `SANDBOXED_NODE_MIN_FREE_GB` — free-space floor (default 10 GiB) for the
+  node's cache GC: every 30 minutes, when the work-dir filesystem drops below
+  it, checkout dirs then lake cache slots are LRU-deleted (by dir mtime)
+  until the threshold is met.
+- `SANDBOXED_NODE_GIT_SSH_KEY` — path to an SSH key used for git fetches
+  (`GIT_SSH_COMMAND="ssh -i <key> -o IdentitiesOnly=yes -o
+  StrictHostKeyChecking=accept-new"`); unset = default git auth.
+
 ## Async Job API
 
 The node exposes a durable job API next to the blocking `/execute` path. All
@@ -149,11 +166,12 @@ leases are rejected, and vice versa).
 
 - `POST /jobs` with `{job_id, mission_id, lease_token, payload}` where
   `payload` is `{"kind": "raw_command", "command": "...", "timeout_secs"?:
-  N, "env"?: {..}}`. Returns `202 {job_id, state: "queued"}`; duplicate
-  `job_id` returns `409`.
+  N, "env"?: {..}}` or a `lean_build` payload (below). Returns `202 {job_id,
+  state: "queued"}`; duplicate `job_id` returns `409`.
 - `GET /jobs/:id` — full status (`queued|running|succeeded|failed|cancelled|
   lost`, exit code, timestamps, error) plus up to the last 64 KiB of the
-  combined log as `log_tail`.
+  combined log as `log_tail` and, for successful builds, `artifacts`
+  (`[{path, sha256, size_bytes}]`).
 - `POST /jobs/:id/cancel` — SIGTERMs the job's process group (SIGKILL after
   10s); returns the current state and whether a live job got the request.
 - `GET /jobs?limit=N` — recent jobs, newest first (default 20, no log tails).
@@ -180,6 +198,58 @@ indirectly: when the mission leaves the Active state for any reason, the poll
 loop cancels the node job on its next tick. There is no dedicated
 mission-cancel -> job-cancel plumbing yet; wiring an explicit cancel hook is a
 follow-up.
+
+## Lean Build Jobs
+
+`lean_build` is a declarative job payload: no workspace sync, no shell. The
+node checks out the pinned commit itself and runs a constrained argv:
+
+```json
+{
+  "kind": "lean_build",
+  "source": {"repo": "https://github.com/org/repo.git", "commit": "<40-hex sha>"},
+  "cwd_rel": "morpho-verity",
+  "command": ["lake", "build"],
+  "timeout_secs": 3600,
+  "cache_key": null,
+  "artifacts": [".lake/build/lib/*"],
+  "env": {"LEAN_NUM_THREADS": "8"}
+}
+```
+
+Validation (node-side, before anything runs):
+
+- `source.commit` must be a full 40-char lowercase hex SHA (no branches).
+- `cwd_rel` uses the same strict path allowlist as the Spark offload
+  (`[A-Za-z0-9._-]` components, no `..`, no `-`-leading component).
+- `command` is executed directly (never via a shell) and its argv[0]
+  basename must be `lake`, `lean`, or `elan`.
+- `env` keys must be within `SANDBOXED_NODE_ENV_ALLOWLIST`.
+- `timeout_secs` is clamped to `SANDBOXED_NODE_MAX_JOB_SECS`.
+
+Execution model:
+
+- Checkouts are content-addressed at
+  `<workdir>/checkouts/<sha256(repo)[..16]>/<commit>/` and reused across
+  jobs; materialization is `git init` + `git fetch --depth 1 <repo>
+  <commit>` + detached checkout (+ best-effort shallow submodules) into a
+  temp dir, then an atomic rename. Builds of the same commit are serialized
+  by a file lock.
+- Builds run with shared caches: `ELAN_HOME=<workdir>/caches/elan`,
+  `XDG_CACHE_HOME=<workdir>/caches/xdg`, `HOME=<workdir>/caches/home`, and
+  `<workdir>/caches/elan/bin` prepended to `PATH`.
+- Lake cache: `cache_key` defaults to a digest of the build cwd's
+  `lean-toolchain` + `lake-manifest.json`. Before a cold build the slot
+  `<workdir>/caches/lake/<key>/` is hardlink-copied (`cp -al`) into
+  `<cwd>/.lake`; after a successful build the slot is refreshed the same way
+  (tmp dir + atomic rename, under a per-key flock). Accepted caveat: mtime
+  drift may cause partial rebuilds, never wrong artifacts.
+- `artifacts` patterns are resolved relative to the checkout root after a
+  successful build: exact relative paths, or `*` within a single path
+  segment (never across `/`); `..` and absolute paths are rejected. Each
+  match is recorded with its sha256 and size.
+- The heartbeat's `cached_toolchains` lists the directory names under
+  `<workdir>/caches/elan/toolchains/`.
 
 ## Core Configuration
 

--- a/docs/examples/hermes-config.yaml.example
+++ b/docs/examples/hermes-config.yaml.example
@@ -22,7 +22,8 @@ mcp_servers:
       HERMES_SANDBOXED_API_URL: ${HERMES_SANDBOXED_API_URL}
       HERMES_SANDBOXED_API_TOKEN: ${HERMES_SANDBOXED_API_TOKEN}
       HERMES_DEFAULT_WORKSPACE_ID: ${HERMES_DEFAULT_WORKSPACE_ID}
-    timeout: 120
+    # Ask turns can make multiple sequential LLM/tool calls.
+    timeout: 600
     connect_timeout: 15
     tools:
       include:
@@ -34,6 +35,7 @@ mcp_servers:
         - get_mission_diagnostics
         - start_mission
         - send_message_to_mission
+        - ask_mission
         - update_mission_settings
         - resume_mission
         - cancel_mission

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# remote-lean-build — dispatch the current repo's Lean build to a remote
+# runner node via the host's POST /api/remote-build endpoint.
+#
+# Usage: remote-lean-build [build argv...]        (default: lake build)
+#
+# Run it from anywhere inside a git checkout; the build cwd on the node is
+# derived from your position in the repo (git rev-parse --show-prefix).
+#
+# Requires (injected into mission workspaces by sandboxed.sh):
+#   REMOTE_BUILD_URL         host endpoint, e.g. http://10.88.0.1:3000/api/remote-build
+#   REMOTE_BUILD_TOKEN       per-mission capability token
+#   REMOTE_BUILD_MISSION_ID  mission UUID
+#
+# Exit codes:
+#   remote build's exit code on success/failure of the build itself
+#   2   dirty working tree (commit or stash first — the node builds a pinned commit)
+#   75  remote build unavailable (EX_TEMPFAIL: placement failed / nodes down /
+#       not configured) — fall back to a local build
+set -u
+
+die() { echo "remote-lean-build: $1" >&2; exit "${2:-1}"; }
+
+[ -n "${REMOTE_BUILD_URL:-}" ] || die "REMOTE_BUILD_URL is not set (remote builds unavailable)" 75
+[ -n "${REMOTE_BUILD_TOKEN:-}" ] || die "REMOTE_BUILD_TOKEN is not set" 75
+[ -n "${REMOTE_BUILD_MISSION_ID:-}" ] || die "REMOTE_BUILD_MISSION_ID is not set" 75
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
+command -v curl >/dev/null 2>&1 || die "curl is required"
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git checkout"
+
+# The node fetches a pinned commit; uncommitted changes would silently not
+# be part of the remote build.
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    die "working tree is dirty; commit (and push) your changes first" 2
+fi
+
+repo="$(git remote get-url origin 2>/dev/null)" || die "no 'origin' remote"
+commit="$(git rev-parse HEAD)" || die "cannot resolve HEAD"
+cwd_rel="$(git rev-parse --show-prefix)"; cwd_rel="${cwd_rel%/}"
+
+# Build argv: everything passed on the command line, default `lake build`.
+if [ "$#" -eq 0 ]; then set -- lake build; fi
+
+body="$(python3 - "$REMOTE_BUILD_MISSION_ID" "$REMOTE_BUILD_TOKEN" "$repo" "$commit" "$cwd_rel" "$@" <<'PY'
+import json, sys, os
+mission_id, token, repo, commit, cwd_rel = sys.argv[1:6]
+command = sys.argv[6:]
+req = {
+    "mission_id": mission_id,
+    "token": token,
+    "repo": repo,
+    "commit": commit,
+    "command": command,
+    "wait": True,
+}
+if cwd_rel:
+    req["cwd_rel"] = cwd_rel
+timeout = os.environ.get("REMOTE_BUILD_TIMEOUT_SECS")
+if timeout:
+    req["timeout_secs"] = int(timeout)
+print(json.dumps(req))
+PY
+)" || die "failed to encode request"
+
+echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    --max-time 7500 \
+    -d "$body" "$REMOTE_BUILD_URL")" || die "cannot reach $REMOTE_BUILD_URL" 75
+
+if [ "$http_code" = "503" ]; then
+    echo "remote-lean-build: remote build unavailable:" >&2
+    cat "$response_file" >&2; echo >&2
+    exit 75  # EX_TEMPFAIL: caller should fall back to a local build
+fi
+if [ "$http_code" != "200" ]; then
+    echo "remote-lean-build: HTTP $http_code from $REMOTE_BUILD_URL:" >&2
+    cat "$response_file" >&2; echo >&2
+    exit 1
+fi
+
+python3 - "$response_file" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    resp = json.load(f)
+sys.stderr.write(
+    "remote-lean-build: job %s on node '%s' finished: %s (exit %s, %ss)\n"
+    % (resp.get("job_id"), resp.get("node_id"), resp.get("state"),
+       resp.get("exit_code"), resp.get("duration_secs"))
+)
+log_tail = resp.get("log_tail") or ""
+if log_tail:
+    sys.stdout.write(log_tail)
+    if not log_tail.endswith("\n"):
+        sys.stdout.write("\n")
+for artifact in resp.get("artifacts") or []:
+    sys.stderr.write(
+        "artifact: %(path)s sha256=%(sha256)s (%(size_bytes)d bytes)\n" % artifact
+    )
+exit_code = resp.get("exit_code")
+sys.exit(exit_code if isinstance(exit_code, int) and 0 <= exit_code <= 255 else 1)
+PY

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -71,7 +71,7 @@ http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
     --max-time 7500 \
     -d "$body" "$REMOTE_BUILD_URL")" || die "cannot reach $REMOTE_BUILD_URL" 75
 
-if [ "$http_code" = "503" ]; then
+if [ "$http_code" = "401" ] || [ "$http_code" = "403" ] || [ "$http_code" = "503" ]; then
     echo "remote-lean-build: remote build unavailable:" >&2
     cat "$response_file" >&2; echo >&2
     exit 75  # EX_TEMPFAIL: caller should fall back to a local build

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 use crate::api::mission_store::MissionStore;
 use crate::api::proxy_keys::SharedProxyApiKeyStore;
 use crate::api::runners::{effective_mid_turn_kind, MidTurnKind};
-use crate::workspace::SharedWorkspaceStore;
+use crate::workspace::{use_nspawn_for_workspace, SharedWorkspaceStore, WorkspaceType};
 use crate::workspace_exec::WorkspaceExec;
 
 pub use client::AskClient;
@@ -562,7 +562,9 @@ async fn build_system_prompt(turn: &AskTurn, user_content: &str) -> String {
         ""
     };
 
-    let cwd = turn.work_dir.display();
+    let cwd = turn
+        .workspace_exec
+        .translate_path_for_container(&turn.work_dir);
     format!(
         "You are the Ask co-pilot for an autonomous coding mission. A separate \
          \"working agent\" is doing the real work in this same workspace; you are a \
@@ -1418,9 +1420,13 @@ pub async fn prepend_pending_operator_notes(
 /// `None` for an explicit sandbox request as an error rather than silently
 /// running against the live tree.
 pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Option<PathBuf> {
-    let sandbox = PathBuf::from(format!("/tmp/ask-sandbox-{}", Uuid::new_v4()));
-    let base_str = base_work_dir.to_string_lossy().to_string();
-    let sandbox_str = sandbox.to_string_lossy().to_string();
+    let sandbox_guest = PathBuf::from(format!("/tmp/ask-sandbox-{}", Uuid::new_v4()));
+    let sandbox_host = sandbox_host_path(exec, &sandbox_guest);
+    // Shell snippets execute in the workspace context. For nspawn workspaces,
+    // interpolating host paths here makes both `git -C` and `test -d` point at
+    // paths that do not exist in the guest, so every sandbox request fails.
+    let base_str = exec.translate_path_for_container(base_work_dir);
+    let sandbox_str = sandbox_guest.to_string_lossy().to_string();
     let is_git_cmd = format!(
         "git -C {b} rev-parse --git-dir >/dev/null 2>&1",
         b = single_quote(&base_str)
@@ -1452,15 +1458,22 @@ pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Opti
                 if out.status.success()
                     && String::from_utf8_lossy(&out.stdout).contains("SANDBOX_OK") =>
             {
-                Some(sandbox)
+                Some(sandbox_host)
             }
-            _ => None,
+            Ok(out) => {
+                log_sandbox_command_failure("copy", &out);
+                None
+            }
+            Err(error) => {
+                tracing::warn!(stage = "copy", %error, "Ask sandbox command failed to start");
+                None
+            }
         };
     }
 
     let cmd = format!(
         "git -C {b} rev-parse --git-dir >/dev/null 2>&1 && \
-         git -C {b} worktree add --detach {s} HEAD >/dev/null 2>&1 && \
+         git -C {b} worktree add --detach {s} HEAD >/dev/null && \
          echo SANDBOX_OK",
         b = single_quote(&base_str),
         s = single_quote(&sandbox_str)
@@ -1474,17 +1487,57 @@ pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Opti
             if out.status.success()
                 && String::from_utf8_lossy(&out.stdout).contains("SANDBOX_OK") =>
         {
-            Some(sandbox)
+            Some(sandbox_host)
         }
-        _ => None,
+        Ok(out) => {
+            log_sandbox_command_failure("git-worktree", &out);
+            None
+        }
+        Err(error) => {
+            tracing::warn!(stage = "git-worktree", %error, "Ask sandbox command failed to start");
+            None
+        }
     }
+}
+
+fn sandbox_host_path(exec: &WorkspaceExec, guest_path: &Path) -> PathBuf {
+    sandbox_host_path_for_context(
+        &exec.workspace.path,
+        exec.workspace.workspace_type == WorkspaceType::Container
+            && use_nspawn_for_workspace(&exec.workspace),
+        guest_path,
+    )
+}
+
+fn sandbox_host_path_for_context(
+    workspace_root: &Path,
+    nspawn_container: bool,
+    guest_path: &Path,
+) -> PathBuf {
+    if nspawn_container {
+        workspace_root.join(guest_path.strip_prefix("/").unwrap_or(guest_path))
+    } else {
+        guest_path.to_path_buf()
+    }
+}
+
+fn log_sandbox_command_failure(stage: &str, output: &std::process::Output) {
+    // Keep diagnostics bounded: command stderr can contain large git output,
+    // while paths and exit status are enough to diagnose sandbox preparation.
+    let stderr = truncate(String::from_utf8_lossy(&output.stderr).trim(), 2_000);
+    tracing::warn!(
+        stage,
+        status = ?output.status,
+        stderr,
+        "Ask sandbox preparation failed"
+    );
 }
 
 /// Tear down a sandbox created by [`prepare_sandbox`]. Best-effort: removes the
 /// git worktree if it is one, otherwise `rm -rf`s the copy.
 pub async fn cleanup_sandbox(exec: &WorkspaceExec, base_work_dir: &Path, sandbox: &Path) {
-    let base_str = base_work_dir.to_string_lossy().to_string();
-    let sandbox_str = sandbox.to_string_lossy().to_string();
+    let base_str = exec.translate_path_for_container(base_work_dir);
+    let sandbox_str = exec.translate_path_for_container(sandbox);
     let cmd = format!(
         "git -C {b} worktree remove --force {s} 2>/dev/null || rm -rf {s}",
         b = single_quote(&base_str),
@@ -1558,6 +1611,39 @@ fn message_mentions_secret(text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nspawn_sandbox_keeps_distinct_host_and_guest_paths() {
+        let root = Path::new("/srv/containers/demo");
+        let guest = Path::new("/tmp/ask-sandbox-test");
+
+        // The old implementation returned the guest path as the host cwd.
+        // WorkspaceExec cannot relativize it to the container root and would
+        // therefore translate it to `/`.
+        let old_relative = guest.strip_prefix(root).unwrap_or_else(|_| Path::new(""));
+        let old_translation = if old_relative.as_os_str().is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", old_relative.display())
+        };
+        assert_eq!(old_translation, "/");
+
+        let host = sandbox_host_path_for_context(root, true, guest);
+        assert_eq!(host, root.join("tmp/ask-sandbox-test"));
+        assert_eq!(
+            format!("/{}", host.strip_prefix(root).unwrap().display()),
+            guest.display().to_string()
+        );
+    }
+
+    #[test]
+    fn host_sandbox_uses_the_execution_path_directly() {
+        let guest = Path::new("/tmp/ask-sandbox-test");
+        assert_eq!(
+            sandbox_host_path_for_context(Path::new("/ignored"), false, guest),
+            guest
+        );
+    }
 
     async fn temp_store() -> Arc<AskStore> {
         let path = std::env::temp_dir().join(format!("ask-bridge-{}.db", Uuid::new_v4()));

--- a/src/api/console.rs
+++ b/src/api/console.rs
@@ -751,10 +751,21 @@ async fn handle_new_workspace_shell(
                 .build_interactive_shell_invocation(&workspace.path, shell, &shell_args, extra_env)
                 .await
             {
-                Ok(Some((program, args))) => {
+                Ok(Some((program, args, env))) => {
                     let mut cmd = CommandBuilder::new(&program);
                     for arg in &args {
                         cmd.arg(arg);
+                    }
+                    // The nsenter invocation itself runs on the API host.
+                    // Start from the explicit workspace environment so API
+                    // credentials cannot leak and the container receives the
+                    // WORKSPACE_*, DISPLAY, HOME, PATH, and configured values
+                    // prepared by WorkspaceExec.
+                    cmd.env_clear();
+                    for (key, value) in env {
+                        if !key.trim().is_empty() {
+                            cmd.env(key, value);
+                        }
                     }
                     cmd
                 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4868,6 +4868,11 @@ pub struct CreateMissionRequest {
     pub remote_node_id: Option<String>,
     /// MVP remote execution payload. Full AI mission streaming remains local.
     pub remote_command: Option<String>,
+    /// When true (with `remote_node_id` + `remote_command`), dispatch through
+    /// the node's async job API: the mission goes Active immediately and a
+    /// background poll loop finalizes it when the job completes. Default
+    /// false keeps the synchronous blocking `/execute` path unchanged.
+    pub remote_async: Option<bool>,
     /// Catch-all for unrecognized request fields. Serde ignores unknown fields
     /// by default, which has repeatedly hidden client bugs (a `prompt` sent
     /// before the field existed, a mistyped `target_mission_id`). Captured
@@ -4994,6 +4999,7 @@ pub async fn create_mission(
         prompt: None,
         remote_node_id: None,
         remote_command: None,
+        remote_async: None,
         extra: Default::default(),
     });
 
@@ -5269,15 +5275,13 @@ pub async fn create_mission(
     if let (Some(remote_node_id), Some(remote_command)) =
         (remote_node_id.as_deref(), remote_command.as_deref())
     {
-        match dispatch_remote_mission_mvp(
-            &state,
-            &control,
-            &mission,
-            remote_node_id,
-            remote_command,
-        )
-        .await
-        {
+        let dispatch = if req.remote_async.unwrap_or(false) {
+            dispatch_remote_job(&state, &control, &mission, remote_node_id, remote_command).await
+        } else {
+            dispatch_remote_mission_mvp(&state, &control, &mission, remote_node_id, remote_command)
+                .await
+        };
+        match dispatch {
             Ok(updated) => return Ok((headers, Json(updated))),
             Err(message) => {
                 let _ = control
@@ -5337,8 +5341,9 @@ async fn dispatch_remote_mission_mvp(
     let claims = crate::remote_node::LeaseClaims {
         mission_id: mission.id,
         node_id: node.id.clone(),
-        scope: "mission:execute".to_string(),
+        scope: crate::remote_node::SCOPE_MISSION_EXECUTE.to_string(),
         expires_at: (chrono::Utc::now() + chrono::Duration::minutes(15)).timestamp(),
+        job_id: None,
     };
     let lease_token = crate::remote_node::create_lease_token(&claims, &shared_token)
         .map_err(|e| e.to_string())?;
@@ -5359,6 +5364,7 @@ async fn dispatch_remote_mission_mvp(
         summary: Some(format!("Dispatching to remote node '{}'", node.id)),
     });
 
+    let started_at = chrono::Utc::now();
     let client = crate::remote_node::RemoteNodeClient::default();
     let response = client
         .execute(node, &shared_token, &request)
@@ -5369,6 +5375,45 @@ async fn dispatch_remote_mission_mvp(
         "Remote node '{}' exited with {:?}\n\nstdout:\n{}\n\nstderr:\n{}",
         node.id, response.exit_code, response.stdout, response.stderr
     );
+    finalize_remote_mission(
+        control,
+        mission.id,
+        &node.id,
+        success,
+        content,
+        "remote_node_mvp",
+    )
+    .await?;
+    state
+        .fleet
+        .record_outcome(crate::remote_node::DispatchOutcome {
+            mission_id: mission.id,
+            node_id: node.id.clone(),
+            job_id: None,
+            state: if success { "succeeded" } else { "failed" }.to_string(),
+            exit_code: response.exit_code,
+            error: None,
+            started_at,
+            finished_at: Some(chrono::Utc::now()),
+        });
+    control
+        .mission_store
+        .get_mission(mission.id)
+        .await?
+        .ok_or_else(|| format!("Mission {} disappeared after remote dispatch", mission.id))
+}
+
+/// Terminal bookkeeping shared by the sync (`/execute`) and async (job) remote
+/// paths: log the final assistant message, flip the mission to
+/// completed/failed with `status_reason`, and broadcast the status change.
+async fn finalize_remote_mission(
+    control: &ControlState,
+    mission_id: Uuid,
+    node_id: &str,
+    success: bool,
+    content: String,
+    status_reason: &str,
+) -> Result<(), String> {
     let event = AgentEvent::AssistantMessage {
         id: Uuid::new_v4(),
         content,
@@ -5378,12 +5423,12 @@ async fn dispatch_remote_mission_mvp(
         usage: None,
         model: None,
         model_normalized: None,
-        mission_id: Some(mission.id),
+        mission_id: Some(mission_id),
         shared_files: None,
         resumable: !success,
         completion_evidence: None,
     };
-    let _ = control.mission_store.log_event(mission.id, &event).await;
+    let _ = control.mission_store.log_event(mission_id, &event).await;
     let _ = control.events_tx.send(event);
     let status = if success {
         MissionStatus::Completed
@@ -5392,18 +5437,265 @@ async fn dispatch_remote_mission_mvp(
     };
     control
         .mission_store
-        .update_mission_status_with_reason(mission.id, status, Some("remote_node_mvp"))
+        .update_mission_status_with_reason(mission_id, status, Some(status_reason))
+        .await?;
+    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id,
+        status,
+        summary: Some(format!("Remote node '{node_id}' finished")),
+    });
+    Ok(())
+}
+
+/// Async remote dispatch: mint a `job:submit` lease, queue the command on the
+/// node's job API, mark the mission Active immediately, and finalize it from
+/// a background poll loop. Unlike [`dispatch_remote_mission_mvp`], the create
+/// request does not block for the command's duration.
+async fn dispatch_remote_job(
+    state: &Arc<AppState>,
+    control: &ControlState,
+    mission: &Mission,
+    remote_node_id: &str,
+    remote_command: &str,
+) -> Result<Mission, String> {
+    let node = crate::remote_node::placement_for_selected_node(
+        &state.config.remote_nodes,
+        Some(remote_node_id),
+    )
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "remote node placement unexpectedly returned local".to_string())?
+    .clone();
+    let shared_token = std::env::var(&node.token_env)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            format!(
+                "remote node '{}' has no token in {}",
+                node.id, node.token_env
+            )
+        })?;
+    let job_id = Uuid::new_v4();
+    let claims = crate::remote_node::LeaseClaims {
+        mission_id: mission.id,
+        node_id: node.id.clone(),
+        scope: crate::remote_node::SCOPE_JOB_SUBMIT.to_string(),
+        expires_at: (chrono::Utc::now() + chrono::Duration::minutes(15)).timestamp(),
+        job_id: Some(job_id),
+    };
+    let lease_token = crate::remote_node::create_lease_token(&claims, &shared_token)
+        .map_err(|e| e.to_string())?;
+    let request = crate::remote_node::SubmitJobRequest {
+        job_id,
+        mission_id: mission.id,
+        lease_token,
+        payload: crate::remote_node::JobPayload::RawCommand {
+            command: remote_command.to_string(),
+            timeout_secs: None,
+            env: None,
+        },
+    };
+
+    let client = crate::remote_node::RemoteNodeClient::default();
+    let accepted = client
+        .submit_job(&node, &shared_token, &request)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    control
+        .mission_store
+        .update_mission_status(mission.id, MissionStatus::Active)
         .await?;
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
         mission_id: mission.id,
-        status,
-        summary: Some(format!("Remote node '{}' finished", node.id)),
+        status: MissionStatus::Active,
+        summary: Some(format!(
+            "Dispatched job {} to remote node '{}'",
+            job_id, node.id
+        )),
     });
-    control
+
+    let started_at = chrono::Utc::now();
+    state
+        .fleet
+        .record_outcome(crate::remote_node::DispatchOutcome {
+            mission_id: mission.id,
+            node_id: node.id.clone(),
+            job_id: Some(job_id),
+            state: accepted.state.clone(),
+            exit_code: None,
+            error: None,
+            started_at,
+            finished_at: None,
+        });
+
+    let updated = control
         .mission_store
         .get_mission(mission.id)
         .await?
-        .ok_or_else(|| format!("Mission {} disappeared after remote dispatch", mission.id))
+        .ok_or_else(|| format!("Mission {} disappeared after remote dispatch", mission.id))?;
+
+    let poll_control = control.clone();
+    let fleet = Arc::clone(&state.fleet);
+    let mission_id = mission.id;
+    tokio::spawn(async move {
+        poll_remote_job(
+            poll_control,
+            fleet,
+            client,
+            node,
+            shared_token,
+            mission_id,
+            job_id,
+            started_at,
+        )
+        .await;
+    });
+
+    Ok(updated)
+}
+
+/// Background poll loop for one async remote job. Emits sparse progress
+/// events (job state changes only), fails the mission after 5 consecutive
+/// unreachable polls (`remote_node_lost`), honors external mission
+/// cancellation by cancelling the node job, and finalizes the mission through
+/// the same path as the synchronous dispatch.
+#[allow(clippy::too_many_arguments)]
+async fn poll_remote_job(
+    control: ControlState,
+    fleet: Arc<crate::remote_node::FleetMonitor>,
+    client: crate::remote_node::RemoteNodeClient,
+    node: crate::remote_node::RemoteNodeConfig,
+    shared_token: String,
+    mission_id: Uuid,
+    job_id: Uuid,
+    started_at: chrono::DateTime<chrono::Utc>,
+) {
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+    const MAX_CONSECUTIVE_FAILURES: u32 = 5;
+    let outcome = |state: &str, exit_code: Option<i32>, error: Option<String>, terminal: bool| {
+        crate::remote_node::DispatchOutcome {
+            mission_id,
+            node_id: node.id.clone(),
+            job_id: Some(job_id),
+            state: state.to_string(),
+            exit_code,
+            error,
+            started_at,
+            finished_at: terminal.then(chrono::Utc::now),
+        }
+    };
+    let mut last_state = "queued".to_string();
+    let mut failures = 0u32;
+    loop {
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        // Honor external mission cancellation when trivially observable: if
+        // an operator moved the mission out of Active (cancel/interrupt/
+        // pause), stop polling and cancel the job on the node.
+        if let Ok(Some(current)) = control.mission_store.get_mission(mission_id).await {
+            if current.status != MissionStatus::Active {
+                let _ = client.cancel_job(&node, &shared_token, job_id).await;
+                fleet.record_outcome(outcome(
+                    "cancelled",
+                    None,
+                    Some(format!(
+                        "mission left active state ({}); job cancelled on node",
+                        current.status
+                    )),
+                    true,
+                ));
+                return;
+            }
+        }
+
+        match client.get_job(&node, &shared_token, job_id).await {
+            Err(err) => {
+                failures += 1;
+                if failures >= MAX_CONSECUTIVE_FAILURES {
+                    let content = format!(
+                        "Remote node '{}' became unreachable while running job {} \
+                         ({failures} consecutive poll failures; last error: {err}). \
+                         Marking the mission failed.",
+                        node.id, job_id
+                    );
+                    let _ = finalize_remote_mission(
+                        &control,
+                        mission_id,
+                        &node.id,
+                        false,
+                        content,
+                        "remote_node_lost",
+                    )
+                    .await;
+                    fleet.record_outcome(outcome("lost", None, Some(err.to_string()), true));
+                    return;
+                }
+            }
+            Ok(status) => {
+                failures = 0;
+                let terminal = matches!(
+                    status.state.as_str(),
+                    "succeeded" | "failed" | "cancelled" | "lost"
+                );
+                if terminal {
+                    let success = status.state == "succeeded";
+                    let content = format!(
+                        "Remote node '{}' job {} finished with state '{}' (exit {:?}){}\n\nlog tail:\n{}",
+                        node.id,
+                        job_id,
+                        status.state,
+                        status.exit_code,
+                        status
+                            .error
+                            .as_deref()
+                            .map(|e| format!("\nerror: {e}"))
+                            .unwrap_or_default(),
+                        status.log_tail.as_deref().unwrap_or("(empty)"),
+                    );
+                    let _ = finalize_remote_mission(
+                        &control,
+                        mission_id,
+                        &node.id,
+                        success,
+                        content,
+                        "remote_node_job",
+                    )
+                    .await;
+                    fleet.record_outcome(outcome(
+                        &status.state,
+                        status.exit_code,
+                        status.error.clone(),
+                        true,
+                    ));
+                    return;
+                }
+                if status.state != last_state {
+                    // Sparse progress note: only on job state changes.
+                    let event = AgentEvent::AssistantMessage {
+                        id: Uuid::new_v4(),
+                        content: format!(
+                            "Remote job {} on node '{}' is now {}",
+                            job_id, node.id, status.state
+                        ),
+                        success: true,
+                        cost_cents: 0,
+                        cost_source: crate::agents::CostSource::Unknown,
+                        usage: None,
+                        model: None,
+                        model_normalized: None,
+                        mission_id: Some(mission_id),
+                        shared_files: None,
+                        resumable: false,
+                        completion_evidence: None,
+                    };
+                    let _ = control.mission_store.log_event(mission_id, &event).await;
+                    let _ = control.events_tx.send(event);
+                    fleet.record_outcome(outcome(&status.state, None, None, false));
+                    last_state = status.state.clone();
+                }
+            }
+        }
+    }
 }
 
 /// Request body for `POST /api/control/missions/:id/project`. Tri-state per
@@ -6987,6 +7279,7 @@ pub async fn clone_mission(
         prompt: None,
         remote_node_id: None,
         remote_command: None,
+        remote_async: None,
         extra: Default::default(),
     };
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -157,9 +157,12 @@ pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
 }
 
 fn remote_node_needs_on_demand_probe(
-    status: Option<&crate::remote_node::RemoteNodeStatus>,
+    _status: Option<&crate::remote_node::RemoteNodeStatus>,
 ) -> bool {
-    status.is_none_or(|status| *status != crate::remote_node::RemoteNodeStatus::Online)
+    // Auto-placement has already rejected the cached fleet. Even an Online
+    // heartbeat may carry stale load or resource figures, so refresh every
+    // configured node once before returning 503.
+    true
 }
 
 fn should_finalize_remote_job(inactive_status: Option<MissionStatus>) -> bool {
@@ -5260,7 +5263,8 @@ pub async fn create_mission(
                     Err(initial_err) => {
                         // The periodic monitor may be disabled, or this request
                         // may race its first heartbeat. Match `/api/remote-build`:
-                        // re-probe missing and non-online nodes, then retry
+                        // re-probe every configured node (including Online
+                        // entries with potentially stale load), then retry
                         // placement once.
                         let retry_nodes: Vec<_> = state
                             .config
@@ -22072,7 +22076,7 @@ Investigate <service/> failures.
     }
 
     #[test]
-    fn raw_remote_auto_placement_reprobes_every_non_online_node() {
+    fn raw_remote_auto_placement_reprobes_every_node() {
         use crate::remote_node::RemoteNodeStatus;
 
         assert!(remote_node_needs_on_demand_probe(None));
@@ -22086,7 +22090,7 @@ Investigate <service/> failures.
         ] {
             assert!(remote_node_needs_on_demand_probe(Some(&status)));
         }
-        assert!(!remote_node_needs_on_demand_probe(Some(
+        assert!(remote_node_needs_on_demand_probe(Some(
             &RemoteNodeStatus::Online
         )));
     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5533,8 +5533,9 @@ async fn dispatch_remote_mission_mvp(
         "Remote node '{}' exited with {:?}\n\nstdout:\n{}\n\nstderr:\n{}",
         node.id, response.exit_code, response.stdout, response.stderr
     );
+    let owner = RemoteMissionOwner::live(control);
     finalize_remote_mission(
-        control,
+        &owner,
         mission.id,
         &node.id,
         success,
@@ -5564,8 +5565,36 @@ async fn dispatch_remote_mission_mvp(
 /// Terminal bookkeeping shared by the sync (`/execute`) and async (job) remote
 /// paths: log the final assistant message, flip the mission to
 /// completed/failed with `status_reason`, and broadcast the status change.
+#[derive(Clone)]
+struct RemoteMissionOwner {
+    mission_store: Arc<dyn MissionStore>,
+    events_tx: Option<broadcast::Sender<AgentEvent>>,
+}
+
+impl RemoteMissionOwner {
+    fn live(control: &ControlState) -> Self {
+        Self {
+            mission_store: Arc::clone(&control.mission_store),
+            events_tx: Some(control.events_tx.clone()),
+        }
+    }
+
+    fn offline(mission_store: Arc<dyn MissionStore>) -> Self {
+        Self {
+            mission_store,
+            events_tx: None,
+        }
+    }
+
+    fn send(&self, event: AgentEvent) {
+        if let Some(events_tx) = &self.events_tx {
+            let _ = events_tx.send(event);
+        }
+    }
+}
+
 async fn finalize_remote_mission(
-    control: &ControlState,
+    owner: &RemoteMissionOwner,
     mission_id: Uuid,
     node_id: &str,
     success: bool,
@@ -5586,18 +5615,18 @@ async fn finalize_remote_mission(
         resumable: !success,
         completion_evidence: None,
     };
-    let _ = control.mission_store.log_event(mission_id, &event).await;
-    let _ = control.events_tx.send(event);
+    let _ = owner.mission_store.log_event(mission_id, &event).await;
+    owner.send(event);
     let status = if success {
         MissionStatus::Completed
     } else {
         MissionStatus::Failed
     };
-    control
+    owner
         .mission_store
         .update_mission_status_with_reason(mission_id, status, Some(status_reason))
         .await?;
-    let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+    owner.send(AgentEvent::MissionStatusChanged {
         mission_id,
         status,
         summary: Some(format!("Remote node '{node_id}' finished")),
@@ -5708,14 +5737,14 @@ async fn dispatch_remote_job(
                 "remote job cancellation after activation failure will be retried by poller"
             );
         }
-        let poll_control = control.clone();
+        let poll_owner = RemoteMissionOwner::live(control);
         let fleet = Arc::clone(&state.fleet);
         let ledger_dir = state.config.working_dir.clone();
         let mission_id = mission.id;
         let started_at = chrono::Utc::now();
         tokio::spawn(async move {
             poll_remote_job(
-                poll_control,
+                poll_owner,
                 fleet,
                 client,
                 node,
@@ -5752,7 +5781,7 @@ async fn dispatch_remote_job(
             finished_at: None,
         });
 
-    let poll_control = control.clone();
+    let poll_owner = RemoteMissionOwner::live(control);
     let fleet = Arc::clone(&state.fleet);
     let mission_id = mission.id;
     let ledger_dir = state.config.working_dir.clone();
@@ -5762,7 +5791,7 @@ async fn dispatch_remote_job(
         move || {
             tokio::spawn(async move {
                 poll_remote_job(
-                    poll_control,
+                    poll_owner,
                     fleet,
                     client,
                     node,
@@ -5953,24 +5982,49 @@ async fn reconcile_pending_handles(
                 }
                 continue;
             }
-            // A user whose session has not booted yet must not lose the only
-            // recovery handle. Once found, reattach even when the mission is
-            // inactive: the poll loop will request cancellation and retain
-            // the handle until the node confirms a terminal state.
-            let mut owning: Option<(ControlState, MissionStatus)> = None;
+            // Reattach even when the owner has not booted a control session:
+            // durable node work must still be observed/cancelled while an
+            // OAuth user remains offline after restart.
+            let mut owning: Option<(RemoteMissionOwner, MissionStatus)> = None;
             for session in state.control.all_sessions().await {
                 if let Ok(Some(mission)) =
                     session.mission_store.get_mission(handle.mission_id).await
                 {
-                    owning = Some((session, mission.status));
+                    owning = Some((RemoteMissionOwner::live(&session), mission.status));
                     break;
                 }
             }
-            let Some((session, mission_status)) = owning else {
+            if owning.is_none() {
+                match super::mission_workspace_gc::persisted_mission_store(
+                    state.as_ref(),
+                    handle.mission_id,
+                )
+                .await
+                {
+                    Ok(Some((store, status))) => {
+                        tracing::info!(
+                            mission_id = %handle.mission_id,
+                            job_id = %handle.job_id,
+                            "re-attaching remote job for offline persisted owner"
+                        );
+                        owning = Some((RemoteMissionOwner::offline(store), status));
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(
+                            mission_id = %handle.mission_id,
+                            job_id = %handle.job_id,
+                            ?err,
+                            "remote job persisted owner lookup failed; will retry"
+                        );
+                    }
+                }
+            }
+            let Some((owner, mission_status)) = owning else {
                 tracing::info!(
                     mission_id = %handle.mission_id,
                     job_id = %handle.job_id,
-                    "remote job handle kept: owning session not booted yet; will retry"
+                    "remote job handle kept: owning persisted mission not found; will retry"
                 );
                 continue;
             };
@@ -5992,7 +6046,7 @@ async fn reconcile_pending_handles(
                     let ledger_dir = working_dir.to_path_buf();
                     tokio::spawn(async move {
                         poll_remote_job(
-                            session,
+                            owner,
                             fleet,
                             crate::remote_node::RemoteNodeClient::default(),
                             node,
@@ -6021,11 +6075,11 @@ async fn reconcile_pending_handles(
                         node = %handle.node_id,
                         "remote job's node no longer configured; failing mission"
                     );
-                    let _ = session
+                    let _ = owner
                         .mission_store
                         .update_mission_status(handle.mission_id, MissionStatus::Failed)
                         .await;
-                    let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+                    owner.send(AgentEvent::MissionStatusChanged {
                         mission_id: handle.mission_id,
                         status: MissionStatus::Failed,
                         summary: Some(
@@ -6085,7 +6139,7 @@ async fn poll_recovered_remote_build(
 /// the same path as the synchronous dispatch.
 #[allow(clippy::too_many_arguments)]
 async fn poll_remote_job(
-    control: ControlState,
+    owner: RemoteMissionOwner,
     fleet: Arc<crate::remote_node::FleetMonitor>,
     client: crate::remote_node::RemoteNodeClient,
     node: crate::remote_node::RemoteNodeConfig,
@@ -6118,7 +6172,7 @@ async fn poll_remote_job(
         // request cancellation but retain the durable handle and keep polling
         // until the node confirms a terminal state. A transient cancel outage
         // must not orphan a still-running remote job.
-        let inactive_status = match control.mission_store.get_mission(mission_id).await {
+        let inactive_status = match owner.mission_store.get_mission(mission_id).await {
             Ok(Some(current)) if current.status != MissionStatus::Active => Some(current.status),
             _ => None,
         };
@@ -6164,7 +6218,7 @@ async fn poll_remote_job(
                         node.id, job_id
                     );
                     let _ = finalize_remote_mission(
-                        &control,
+                        &owner,
                         mission_id,
                         &node.id,
                         false,
@@ -6204,7 +6258,7 @@ async fn poll_remote_job(
                     );
                     if should_finalize_remote_job(inactive_status) {
                         let _ = finalize_remote_mission(
-                            &control,
+                            &owner,
                             mission_id,
                             &node.id,
                             success,
@@ -6248,8 +6302,8 @@ async fn poll_remote_job(
                         resumable: false,
                         completion_evidence: None,
                     };
-                    let _ = control.mission_store.log_event(mission_id, &event).await;
-                    let _ = control.events_tx.send(event);
+                    let _ = owner.mission_store.log_event(mission_id, &event).await;
+                    owner.send(event);
                     fleet.record_outcome(outcome(&status.state, None, None, false));
                     last_state = status.state.clone();
                 }
@@ -22214,6 +22268,39 @@ Investigate <service/> failures.
 
         assert!(observer_started.load(std::sync::atomic::Ordering::SeqCst));
         assert!(error.contains(&missing_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn offline_remote_owner_finalizes_persisted_mission_without_a_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn MissionStore> = Arc::new(
+            mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "github:42")
+                .await
+                .unwrap(),
+        );
+        let mission = store
+            .create_mission(Some("offline remote"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await
+            .unwrap();
+        let owner = RemoteMissionOwner::offline(Arc::clone(&store));
+
+        finalize_remote_mission(
+            &owner,
+            mission.id,
+            "node-a",
+            true,
+            "remote result".to_string(),
+            "remote_node_job",
+        )
+        .await
+        .unwrap();
+
+        let finalized = store.get_mission(mission.id).await.unwrap().unwrap();
+        assert_eq!(finalized.status, MissionStatus::Completed);
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5683,10 +5683,50 @@ async fn dispatch_remote_job(
     };
 
     let client = crate::remote_node::RemoteNodeClient::default();
-    let accepted = client
-        .submit_job(&node, &shared_token, &request)
-        .await
-        .map_err(|e| e.to_string())?;
+    let submit_started_at = chrono::Utc::now();
+    let ledger_dir = state.config.working_dir.clone();
+    // Record the generated id before the POST. If the process dies after the
+    // node accepts but before the HTTP result is observed, restart recovery
+    // still has enough information to cancel the maybe-accepted job.
+    crate::remote_node::job_ledger::record(
+        &ledger_dir,
+        crate::remote_node::job_ledger::JobHandle {
+            mission_id: mission.id,
+            node_id: node.id.clone(),
+            job_id,
+            started_at: submit_started_at,
+            kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
+        },
+    )
+    .await
+    .map_err(|error| format!("remote job recovery handle could not be prepared: {error}"))?;
+    let accepted = match client.submit_job(&node, &shared_token, &request).await {
+        Ok(accepted) => accepted,
+        Err(crate::remote_node::RemoteNodeError::Request(message)) => {
+            // A transport/response failure is ambiguous: the node may have
+            // durably queued this exact job id before the response was lost.
+            // Keep the cancellation-only handle while returning failure so
+            // restart recovery cannot orphan the possible remote process.
+            spawn_untracked_remote_job_cancellation(
+                Arc::clone(&state.fleet),
+                node,
+                shared_token,
+                mission.id,
+                job_id,
+                submit_started_at,
+                ledger_dir,
+            );
+            return Err(format!(
+                "remote job submit outcome is ambiguous; cancellation is being reconciled: {message}"
+            ));
+        }
+        Err(error) => {
+            // A node HTTP rejection is definitive: the handler did not queue
+            // the job, so this pre-submit handle can be discarded.
+            crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
+            return Err(error.to_string());
+        }
+    };
 
     // Persist the job handle BEFORE marking the mission Active: if the API
     // restarts from here on, the startup reconciler can re-attach a poll
@@ -5697,24 +5737,23 @@ async fn dispatch_remote_job(
             mission_id: mission.id,
             node_id: node.id.clone(),
             job_id,
-            started_at: chrono::Utc::now(),
+            started_at: submit_started_at,
             kind: crate::remote_node::job_ledger::JobHandleKind::Mission,
         },
     )
     .await
     {
-        // Never expose an Active mission without a durable recovery handle.
-        // Retain the only copy of the accepted handle in an in-process
-        // cancellation observer. Ledger failures often coincide with broader
-        // outages, so one ignored cancel attempt is not sufficient.
+        // Never expose an Active mission without a durable accepted handle.
+        // The pre-submit tentative entry remains the restart fallback; also
+        // start cancellation immediately rather than letting the job run.
         spawn_untracked_remote_job_cancellation(
             Arc::clone(&state.fleet),
-            client,
             node,
             shared_token,
             mission.id,
             job_id,
-            chrono::Utc::now(),
+            submit_started_at,
+            state.config.working_dir.clone(),
         );
         return Err(format!(
             "remote job accepted but recovery handle could not be persisted: {err}"
@@ -5828,22 +5867,27 @@ async fn read_dispatched_mission_after_observer_start(
         .ok_or_else(|| format!("Mission {mission_id} disappeared after remote dispatch"))
 }
 
-/// Retry cancellation for an accepted remote job whose durable ledger entry
-/// could not be written. The observer intentionally owns the only remaining
-/// `(node, job)` handle until a terminal response arrives; without it a
-/// transient cancel failure leaks remote capacity until the node timeout.
+/// Retry cancellation for a remote job that must not outlive its failed
+/// dispatch. The tentative ledger entry survives a process restart; this
+/// in-process observer removes it only after terminal state or authoritative
+/// 404, so a transient cancel failure cannot leak node capacity.
 fn spawn_untracked_remote_job_cancellation(
     fleet: Arc<crate::remote_node::FleetMonitor>,
-    client: crate::remote_node::RemoteNodeClient,
     node: crate::remote_node::RemoteNodeConfig,
     shared_token: String,
     mission_id: Uuid,
     job_id: Uuid,
     started_at: chrono::DateTime<chrono::Utc>,
+    ledger_dir: std::path::PathBuf,
 ) {
     tokio::spawn(async move {
+        let client = crate::remote_node::RemoteNodeClient::default();
         loop {
             if let Err(error) = client.cancel_job(&node, &shared_token, job_id).await {
+                if error.is_not_found() {
+                    crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
+                    return;
+                }
                 tracing::warn!(
                     mission_id = %mission_id,
                     node_id = %node.id,
@@ -5852,11 +5896,13 @@ fn spawn_untracked_remote_job_cancellation(
                     "untracked remote job cancellation failed; retrying"
                 );
             }
-            if let Ok(status) = client.get_job(&node, &shared_token, job_id).await {
-                if matches!(
-                    status.state.as_str(),
-                    "succeeded" | "failed" | "cancelled" | "lost"
-                ) {
+            match client.get_job(&node, &shared_token, job_id).await {
+                Ok(status)
+                    if matches!(
+                        status.state.as_str(),
+                        "succeeded" | "failed" | "cancelled" | "lost"
+                    ) =>
+                {
                     fleet.record_outcome(crate::remote_node::DispatchOutcome {
                         mission_id,
                         node_id: node.id.clone(),
@@ -5867,8 +5913,14 @@ fn spawn_untracked_remote_job_cancellation(
                         started_at,
                         finished_at: Some(chrono::Utc::now()),
                     });
+                    crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
                     return;
                 }
+                Err(error) if error.is_not_found() => {
+                    crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
+                    return;
+                }
+                Ok(_) | Err(_) => {}
             }
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
         }
@@ -5945,6 +5997,36 @@ async fn reconcile_pending_handles(
 ) {
     {
         for handle in handles {
+            if handle.kind == crate::remote_node::job_ledger::JobHandleKind::Tentative {
+                let node = state.config.remote_nodes.node(&handle.node_id).cloned();
+                let shared_token = node
+                    .as_ref()
+                    .and_then(|node| std::env::var(&node.token_env).ok())
+                    .filter(|value| !value.trim().is_empty());
+                match (node, shared_token) {
+                    (Some(node), Some(shared_token)) => {
+                        settled.insert(handle.job_id);
+                        spawn_untracked_remote_job_cancellation(
+                            Arc::clone(&state.fleet),
+                            node,
+                            shared_token,
+                            handle.mission_id,
+                            handle.job_id,
+                            handle.started_at,
+                            working_dir.to_path_buf(),
+                        );
+                    }
+                    _ => {
+                        tracing::warn!(
+                            mission_id = %handle.mission_id,
+                            job_id = %handle.job_id,
+                            node = %handle.node_id,
+                            "tentative remote job retained: node config/token unavailable"
+                        );
+                    }
+                }
+                continue;
+            }
             if handle.kind == crate::remote_node::job_ledger::JobHandleKind::RemoteBuild {
                 let node = state.config.remote_nodes.node(&handle.node_id).cloned();
                 let shared_token = node

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5539,6 +5539,20 @@ async fn dispatch_remote_job(
         .await
         .map_err(|e| e.to_string())?;
 
+    // Persist the job handle BEFORE marking the mission Active: if the API
+    // restarts from here on, the startup reconciler can re-attach a poll
+    // loop instead of leaving an Active mission orphaned.
+    crate::remote_node::job_ledger::record(
+        &state.config.working_dir,
+        crate::remote_node::job_ledger::JobHandle {
+            mission_id: mission.id,
+            node_id: node.id.clone(),
+            job_id,
+            started_at: chrono::Utc::now(),
+        },
+    )
+    .await;
+
     control
         .mission_store
         .update_mission_status(mission.id, MissionStatus::Active)
@@ -5575,6 +5589,7 @@ async fn dispatch_remote_job(
     let poll_control = control.clone();
     let fleet = Arc::clone(&state.fleet);
     let mission_id = mission.id;
+    let ledger_dir = state.config.working_dir.clone();
     tokio::spawn(async move {
         poll_remote_job(
             poll_control,
@@ -5587,9 +5602,102 @@ async fn dispatch_remote_job(
             started_at,
         )
         .await;
+        // The poll loop only returns once the mission is finalized (or the
+        // job was cancelled/lost); the handle is no longer needed.
+        crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
     });
 
     Ok(updated)
+}
+
+/// Startup reconciliation for async remote jobs that were in flight when the
+/// previous process exited. For each persisted handle: if its mission is
+/// still Active in some live session's store, re-attach a poll loop (the
+/// node job is durable — jobs.db — so its result is recoverable); otherwise
+/// drop the stale handle. Handles whose node is no longer configured fail
+/// their mission explicitly rather than leaving it Active forever.
+pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        // Let control sessions boot before touching their stores.
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        let working_dir = state.config.working_dir.clone();
+        let handles = crate::remote_node::job_ledger::load(&working_dir).await;
+        if handles.is_empty() {
+            return;
+        }
+        tracing::info!(
+            count = handles.len(),
+            "reconciling async remote jobs from previous process"
+        );
+        for handle in handles {
+            let mut owning: Option<ControlState> = None;
+            for session in state.control.all_sessions().await {
+                if let Ok(Some(mission)) =
+                    session.mission_store.get_mission(handle.mission_id).await
+                {
+                    if mission.status == MissionStatus::Active {
+                        owning = Some(session);
+                    }
+                    break;
+                }
+            }
+            let Some(session) = owning else {
+                // Mission gone or no longer Active: nothing to resume.
+                crate::remote_node::job_ledger::remove(&working_dir, handle.job_id).await;
+                continue;
+            };
+            let node = state.config.remote_nodes.node(&handle.node_id).cloned();
+            let shared_token = node
+                .as_ref()
+                .and_then(|n| std::env::var(&n.token_env).ok())
+                .filter(|v| !v.trim().is_empty());
+            match (node, shared_token) {
+                (Some(node), Some(shared_token)) => {
+                    tracing::info!(
+                        mission_id = %handle.mission_id,
+                        job_id = %handle.job_id,
+                        node = %node.id,
+                        "re-attaching poll loop to in-flight remote job"
+                    );
+                    let fleet = Arc::clone(&state.fleet);
+                    let ledger_dir = working_dir.clone();
+                    tokio::spawn(async move {
+                        poll_remote_job(
+                            session,
+                            fleet,
+                            crate::remote_node::RemoteNodeClient::default(),
+                            node,
+                            shared_token,
+                            handle.mission_id,
+                            handle.job_id,
+                            handle.started_at,
+                        )
+                        .await;
+                        crate::remote_node::job_ledger::remove(&ledger_dir, handle.job_id).await;
+                    });
+                }
+                _ => {
+                    tracing::warn!(
+                        mission_id = %handle.mission_id,
+                        node = %handle.node_id,
+                        "remote job's node no longer configured; failing mission"
+                    );
+                    let _ = session
+                        .mission_store
+                        .update_mission_status(handle.mission_id, MissionStatus::Failed)
+                        .await;
+                    let _ = session.events_tx.send(AgentEvent::MissionStatusChanged {
+                        mission_id: handle.mission_id,
+                        status: MissionStatus::Failed,
+                        summary: Some(
+                            "remote_node_lost: node unconfigured after restart".to_string(),
+                        ),
+                    });
+                    crate::remote_node::job_ledger::remove(&working_dir, handle.job_id).await;
+                }
+            }
+        }
+    });
 }
 
 /// Background poll loop for one async remote job. Emits sparse progress

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -108,6 +108,16 @@ pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
     )
 }
 
+fn remote_node_needs_on_demand_probe(
+    status: Option<&crate::remote_node::RemoteNodeStatus>,
+) -> bool {
+    status.is_none_or(|status| *status == crate::remote_node::RemoteNodeStatus::Unknown)
+}
+
+fn should_finalize_remote_job(inactive_status: Option<MissionStatus>) -> bool {
+    inactive_status.is_none()
+}
+
 /// Returns a safe index to truncate a string at, ensuring we don't cut UTF-8 characters.
 pub(crate) fn safe_truncate_index(s: &str, max: usize) -> usize {
     if s.len() <= max {
@@ -5193,10 +5203,42 @@ pub async fn create_mission(
             // Raw remote commands default to no label requirements; the
             // lean_build path (`POST /api/remote-build`) defaults to ["lean"].
             let requirements = req.remote_requirements.clone().unwrap_or_default();
-            let resolved = state
-                .fleet
-                .place_auto(&state.config.remote_nodes, &requirements)
-                .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+            let resolved =
+                match state
+                    .fleet
+                    .place_auto(&state.config.remote_nodes, &requirements)
+                {
+                    Ok(resolved) => resolved,
+                    Err(initial_err) => {
+                        // The periodic monitor may be disabled, or this request
+                        // may race its first heartbeat. Match `/api/remote-build`:
+                        // probe only cold nodes, then retry placement once.
+                        let cold: Vec<_> = state
+                            .config
+                            .remote_nodes
+                            .nodes
+                            .iter()
+                            .filter(|node| {
+                                let cached = state.fleet.get(&node.id);
+                                remote_node_needs_on_demand_probe(
+                                    cached.as_ref().map(|cached| &cached.status),
+                                )
+                            })
+                            .collect();
+                        if cold.is_empty() {
+                            return Err((StatusCode::SERVICE_UNAVAILABLE, initial_err.to_string()));
+                        }
+                        let client = crate::remote_node::RemoteNodeClient::default();
+                        futures::future::join_all(cold.into_iter().map(|node| {
+                            crate::remote_node::probe_node(&state.fleet, &client, node)
+                        }))
+                        .await;
+                        state
+                            .fleet
+                            .place_auto(&state.config.remote_nodes, &requirements)
+                            .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?
+                    }
+                };
             tracing::info!(node_id = %resolved, "auto placement selected remote node");
             remote_node_id = Some(resolved);
         } else {
@@ -5896,15 +5938,25 @@ async fn poll_remote_job(
                             .unwrap_or_default(),
                         status.log_tail.as_deref().unwrap_or("(empty)"),
                     );
-                    let _ = finalize_remote_mission(
-                        &control,
-                        mission_id,
-                        &node.id,
-                        success,
-                        content,
-                        "remote_node_job",
-                    )
-                    .await;
+                    if should_finalize_remote_job(inactive_status) {
+                        let _ = finalize_remote_mission(
+                            &control,
+                            mission_id,
+                            &node.id,
+                            success,
+                            content,
+                            "remote_node_job",
+                        )
+                        .await;
+                    } else {
+                        tracing::info!(
+                            mission_id = %mission_id,
+                            job_id = %job_id,
+                            node = %node.id,
+                            state = %status.state,
+                            "remote job reached a terminal state after operator interruption; preserving mission status"
+                        );
+                    }
                     fleet.record_outcome(outcome(
                         &status.state,
                         status.exit_code,
@@ -21675,6 +21727,40 @@ Investigate <service/> failures.
         // until the user resumes it), so they are not activation-eligible here.
         assert!(!message_activates_mission(MissionStatus::Active));
         assert!(!message_activates_mission(MissionStatus::Paused));
+    }
+
+    #[test]
+    fn raw_remote_auto_placement_probes_only_cold_nodes() {
+        use crate::remote_node::RemoteNodeStatus;
+
+        assert!(remote_node_needs_on_demand_probe(None));
+        assert!(remote_node_needs_on_demand_probe(Some(
+            &RemoteNodeStatus::Unknown
+        )));
+        for status in [
+            RemoteNodeStatus::Online,
+            RemoteNodeStatus::Degraded,
+            RemoteNodeStatus::Offline,
+            RemoteNodeStatus::Disabled,
+        ] {
+            assert!(!remote_node_needs_on_demand_probe(Some(&status)));
+        }
+    }
+
+    #[test]
+    fn remote_terminal_result_preserves_operator_selected_status() {
+        assert!(should_finalize_remote_job(None));
+        for status in [
+            MissionStatus::Interrupted,
+            MissionStatus::Paused,
+            MissionStatus::Blocked,
+            MissionStatus::Failed,
+        ] {
+            assert!(
+                !should_finalize_remote_job(Some(status)),
+                "terminal node result must not overwrite {status}"
+            );
+        }
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -51,6 +51,7 @@ use crate::mcp::McpRegistry;
 use crate::secrets::SecretsStore;
 use crate::util::{build_history_context, internal_error};
 use crate::workspace;
+use crate::workspace_exec::WorkspaceExec;
 
 use super::auth::AuthUser;
 use super::desktop;
@@ -63,6 +64,52 @@ use super::routes::AppState;
 
 pub(crate) const SERVER_SHUTDOWN_AUTO_RESUME_MAX_AGE_HOURS: u64 = 48;
 const INTERRUPTED_RESUME_PROMPT: &str = "You were interrupted, resume your work.";
+
+fn parse_durable_job_result(result: &serde_json::Value) -> Option<serde_json::Value> {
+    fn visit(value: &serde_json::Value, depth: u8) -> Option<serde_json::Value> {
+        if depth > 4 {
+            return None;
+        }
+        if value.get("id").and_then(|id| id.as_str()).is_some()
+            && value
+                .get("stdout_log")
+                .and_then(|path| path.as_str())
+                .is_some()
+        {
+            return Some(value.clone());
+        }
+        if let Some(inner) = value.get("result") {
+            if let Some(job) = visit(inner, depth + 1) {
+                return Some(job);
+            }
+        }
+        if let Some(content) = value.get("content") {
+            if let Some(job) = visit(content, depth + 1) {
+                return Some(job);
+            }
+        }
+        if let Some(items) = value.as_array() {
+            for item in items {
+                if let Some(job) = visit(item, depth + 1) {
+                    return Some(job);
+                }
+                if let Some(text) = item.get("text") {
+                    if let Some(job) = visit(text, depth + 1) {
+                        return Some(job);
+                    }
+                }
+            }
+        }
+        if let Some(raw) = value.as_str() {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(raw) {
+                return visit(&parsed, depth + 1);
+            }
+        }
+        None
+    }
+
+    visit(result, 0)
+}
 
 /// One entry in the main control queue: (message id, content, optional per-message
 /// agent override, target mission id, source). Aliased to keep signatures under
@@ -111,7 +158,7 @@ pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
 fn remote_node_needs_on_demand_probe(
     status: Option<&crate::remote_node::RemoteNodeStatus>,
 ) -> bool {
-    status.is_none_or(|status| *status == crate::remote_node::RemoteNodeStatus::Unknown)
+    status.is_none_or(|status| *status != crate::remote_node::RemoteNodeStatus::Online)
 }
 
 fn should_finalize_remote_job(inactive_status: Option<MissionStatus>) -> bool {
@@ -5212,8 +5259,9 @@ pub async fn create_mission(
                     Err(initial_err) => {
                         // The periodic monitor may be disabled, or this request
                         // may race its first heartbeat. Match `/api/remote-build`:
-                        // probe only cold nodes, then retry placement once.
-                        let cold: Vec<_> = state
+                        // re-probe missing and non-online nodes, then retry
+                        // placement once.
+                        let retry_nodes: Vec<_> = state
                             .config
                             .remote_nodes
                             .nodes
@@ -5225,11 +5273,11 @@ pub async fn create_mission(
                                 )
                             })
                             .collect();
-                        if cold.is_empty() {
+                        if retry_nodes.is_empty() {
                             return Err((StatusCode::SERVICE_UNAVAILABLE, initial_err.to_string()));
                         }
                         let client = crate::remote_node::RemoteNodeClient::default();
-                        futures::future::join_all(cold.into_iter().map(|node| {
+                        futures::future::join_all(retry_nodes.into_iter().map(|node| {
                             crate::remote_node::probe_node(&state.fleet, &client, node)
                         }))
                         .await;
@@ -14661,6 +14709,58 @@ async fn control_actor_loop(
                                             .insert(task_id, task);
                                     }
                                 }
+                            } else if name.ends_with("durable_job_start") {
+                                if let (Some(mid), Some(job)) =
+                                    (mission_id, parse_durable_job_result(result))
+                                {
+                                    let Some(job_id) =
+                                        job.get("id").and_then(|value| value.as_str())
+                                    else {
+                                        continue;
+                                    };
+                                    let command = job
+                                        .get("command")
+                                        .and_then(|value| value.as_str())
+                                        .unwrap_or_default()
+                                        .to_string();
+                                    let mut output_path = job
+                                        .get("stdout_log")
+                                        .and_then(|value| value.as_str())
+                                        .unwrap_or_default()
+                                        .to_string();
+                                    if let Ok(Some(mission)) = mission_store.get_mission(*mid).await {
+                                        if let Some(workspace) =
+                                            workspaces.get(mission.workspace_id).await
+                                        {
+                                            output_path = WorkspaceExec::new(workspace)
+                                                .translate_path_for_container(
+                                                    std::path::Path::new(&output_path),
+                                                );
+                                        }
+                                    }
+                                    let task = super::mission_runner::BackgroundTask {
+                                        id: format!("durable:{job_id}"),
+                                        output_path,
+                                        command,
+                                        started_at: std::time::Instant::now(),
+                                    };
+                                    tracing::info!(
+                                        mission_id = %mid,
+                                        durable_job_id = %job_id,
+                                        "Captured durable background job; scheduling auto-resume on completion"
+                                    );
+                                    if let Some(runner) = parallel_runners.get_mut(mid) {
+                                        runner
+                                            .background_tasks
+                                            .insert(task.id.clone(), task.clone());
+                                    }
+                                    background_tasks
+                                        .write()
+                                        .await
+                                        .entry(*mid)
+                                        .or_default()
+                                        .insert(task.id.clone(), task);
+                                }
                             }
                         }
                     }
@@ -18146,6 +18246,28 @@ mod tests {
             content: content.to_string(),
             metadata: serde_json::json!({}),
         }
+    }
+
+    #[test]
+    fn durable_job_result_parser_accepts_direct_and_mcp_content_shapes() {
+        let job = serde_json::json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "stdout_log": "/workspace/.sandboxed-sh/durable-jobs/job/stdout.log",
+            "command": "lake build"
+        });
+        assert_eq!(parse_durable_job_result(&job), Some(job.clone()));
+
+        let wrapped = serde_json::json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string(&job).unwrap()
+            }]
+        });
+        assert_eq!(parse_durable_job_result(&wrapped), Some(job));
+        assert!(parse_durable_job_result(&serde_json::json!({
+            "content": "not a job"
+        }))
+        .is_none());
     }
 
     #[test]
@@ -21730,7 +21852,7 @@ Investigate <service/> failures.
     }
 
     #[test]
-    fn raw_remote_auto_placement_probes_only_cold_nodes() {
+    fn raw_remote_auto_placement_reprobes_every_non_online_node() {
         use crate::remote_node::RemoteNodeStatus;
 
         assert!(remote_node_needs_on_demand_probe(None));
@@ -21738,13 +21860,15 @@ Investigate <service/> failures.
             &RemoteNodeStatus::Unknown
         )));
         for status in [
-            RemoteNodeStatus::Online,
             RemoteNodeStatus::Degraded,
             RemoteNodeStatus::Offline,
             RemoteNodeStatus::Disabled,
         ] {
-            assert!(!remote_node_needs_on_demand_probe(Some(&status)));
+            assert!(remote_node_needs_on_demand_probe(Some(&status)));
         }
+        assert!(!remote_node_needs_on_demand_probe(Some(
+            &RemoteNodeStatus::Online
+        )));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5648,9 +5648,18 @@ async fn dispatch_remote_job(
     .await
     {
         // Never expose an Active mission without a durable recovery handle.
-        // Best-effort cancellation prevents an accepted node job from running
-        // after the caller receives the persistence failure.
-        let _ = client.cancel_job(&node, &shared_token, job_id).await;
+        // Retain the only copy of the accepted handle in an in-process
+        // cancellation observer. Ledger failures often coincide with broader
+        // outages, so one ignored cancel attempt is not sufficient.
+        spawn_untracked_remote_job_cancellation(
+            Arc::clone(&state.fleet),
+            client,
+            node,
+            shared_token,
+            mission.id,
+            job_id,
+            chrono::Utc::now(),
+        );
         return Err(format!(
             "remote job accepted but recovery handle could not be persisted: {err}"
         ));
@@ -5744,6 +5753,53 @@ async fn dispatch_remote_job(
     });
 
     Ok(updated)
+}
+
+/// Retry cancellation for an accepted remote job whose durable ledger entry
+/// could not be written. The observer intentionally owns the only remaining
+/// `(node, job)` handle until a terminal response arrives; without it a
+/// transient cancel failure leaks remote capacity until the node timeout.
+fn spawn_untracked_remote_job_cancellation(
+    fleet: Arc<crate::remote_node::FleetMonitor>,
+    client: crate::remote_node::RemoteNodeClient,
+    node: crate::remote_node::RemoteNodeConfig,
+    shared_token: String,
+    mission_id: Uuid,
+    job_id: Uuid,
+    started_at: chrono::DateTime<chrono::Utc>,
+) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(error) = client.cancel_job(&node, &shared_token, job_id).await {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    node_id = %node.id,
+                    job_id = %job_id,
+                    ?error,
+                    "untracked remote job cancellation failed; retrying"
+                );
+            }
+            if let Ok(status) = client.get_job(&node, &shared_token, job_id).await {
+                if matches!(
+                    status.state.as_str(),
+                    "succeeded" | "failed" | "cancelled" | "lost"
+                ) {
+                    fleet.record_outcome(crate::remote_node::DispatchOutcome {
+                        mission_id,
+                        node_id: node.id.clone(),
+                        job_id: Some(job_id),
+                        state: status.state,
+                        exit_code: status.exit_code,
+                        error: status.error,
+                        started_at,
+                        finished_at: Some(chrono::Utc::now()),
+                    });
+                    return;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        }
+    });
 }
 
 /// Startup reconciliation for async remote jobs that were in flight when the

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -8457,6 +8457,11 @@ fn spawn_control_session(
         ));
     }
 
+    // Event-driven scope teardown: stop a mission's exec scopes as soon as
+    // its status stops needing a live harness. The periodic scope reaper
+    // (scope_reaper::spawn) backstops events missed across restarts.
+    super::scope_reaper::spawn_status_listener(events_tx.subscribe());
+
     // Shared registry of in-flight Claude Code background shell tasks. Written
     // by the control actor's ToolResult arm; read by the auto-resume watcher.
     let background_tasks: super::mission_runner::BackgroundTaskRegistry =

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5630,20 +5630,35 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
             "reconciling async remote jobs from previous process"
         );
         for handle in handles {
+            // Positive-evidence rule: only drop a handle when a live session
+            // PROVES the mission no longer needs it (found and not Active).
+            // A user whose session hasn't booted yet must not lose the only
+            // copy of their job handle — keep it for a later pass instead.
             let mut owning: Option<ControlState> = None;
+            let mut proven_inactive = false;
             for session in state.control.all_sessions().await {
                 if let Ok(Some(mission)) =
                     session.mission_store.get_mission(handle.mission_id).await
                 {
                     if mission.status == MissionStatus::Active {
                         owning = Some(session);
+                    } else {
+                        proven_inactive = true;
                     }
                     break;
                 }
             }
             let Some(session) = owning else {
-                // Mission gone or no longer Active: nothing to resume.
-                crate::remote_node::job_ledger::remove(&working_dir, handle.job_id).await;
+                if proven_inactive {
+                    // Finalized elsewhere: the handle is no longer needed.
+                    crate::remote_node::job_ledger::remove(&working_dir, handle.job_id).await;
+                } else {
+                    tracing::info!(
+                        mission_id = %handle.mission_id,
+                        job_id = %handle.job_id,
+                        "remote job handle kept: owning session not booted yet"
+                    );
+                }
                 continue;
             };
             let node = state.config.remote_nodes.node(&handle.node_id).cloned();

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5752,34 +5752,51 @@ async fn dispatch_remote_job(
             finished_at: None,
         });
 
-    let updated = control
-        .mission_store
-        .get_mission(mission.id)
-        .await?
-        .ok_or_else(|| format!("Mission {} disappeared after remote dispatch", mission.id))?;
-
     let poll_control = control.clone();
     let fleet = Arc::clone(&state.fleet);
     let mission_id = mission.id;
     let ledger_dir = state.config.working_dir.clone();
-    tokio::spawn(async move {
-        poll_remote_job(
-            poll_control,
-            fleet,
-            client,
-            node,
-            shared_token,
-            mission_id,
-            job_id,
-            started_at,
-        )
-        .await;
-        // The poll loop only returns once the mission is finalized (or the
-        // job was cancelled/lost); the handle is no longer needed.
-        crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
-    });
+    let updated = read_dispatched_mission_after_observer_start(
+        &control.mission_store,
+        mission.id,
+        move || {
+            tokio::spawn(async move {
+                poll_remote_job(
+                    poll_control,
+                    fleet,
+                    client,
+                    node,
+                    shared_token,
+                    mission_id,
+                    job_id,
+                    started_at,
+                )
+                .await;
+                // The poll loop only returns once the mission is finalized (or the
+                // job was cancelled/lost); the handle is no longer needed.
+                crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
+            });
+        },
+    )
+    .await?;
 
     Ok(updated)
+}
+
+/// Start ownership of an accepted remote job before any fallible final read.
+/// The observer must survive both a store error and a row that disappeared
+/// after dispatch, otherwise the durable node job remains unpolled until the
+/// API process restarts.
+async fn read_dispatched_mission_after_observer_start(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Uuid,
+    start_observer: impl FnOnce(),
+) -> Result<Mission, String> {
+    start_observer();
+    mission_store
+        .get_mission(mission_id)
+        .await?
+        .ok_or_else(|| format!("Mission {mission_id} disappeared after remote dispatch"))
 }
 
 /// Retry cancellation for an accepted remote job whose durable ledger entry
@@ -22180,6 +22197,23 @@ Investigate <service/> failures.
                 "terminal node result must not overwrite {status}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn remote_dispatch_starts_observer_before_missing_mission_read() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let observer_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let started_for_observer = Arc::clone(&observer_started);
+        let missing_id = Uuid::new_v4();
+
+        let error = read_dispatched_mission_after_observer_start(&store, missing_id, move || {
+            started_for_observer.store(true, std::sync::atomic::Ordering::SeqCst);
+        })
+        .await
+        .expect_err("missing post-dispatch mission must fail the response read");
+
+        assert!(observer_started.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(error.contains(&missing_id.to_string()));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5639,6 +5639,7 @@ async fn dispatch_remote_job(
             node_id: node.id.clone(),
             job_id,
             started_at: chrono::Utc::now(),
+            kind: crate::remote_node::job_ledger::JobHandleKind::Mission,
         },
     )
     .await
@@ -5779,6 +5780,43 @@ async fn reconcile_pending_handles(
 ) {
     {
         for handle in handles {
+            if handle.kind == crate::remote_node::job_ledger::JobHandleKind::RemoteBuild {
+                let node = state.config.remote_nodes.node(&handle.node_id).cloned();
+                let shared_token = node
+                    .as_ref()
+                    .and_then(|node| std::env::var(&node.token_env).ok())
+                    .filter(|value| !value.trim().is_empty());
+                match (node, shared_token) {
+                    (Some(node), Some(shared_token)) => {
+                        settled.insert(handle.job_id);
+                        let ledger_dir = working_dir.to_path_buf();
+                        let fleet = Arc::clone(&state.fleet);
+                        tokio::spawn(async move {
+                            poll_recovered_remote_build(
+                                fleet,
+                                crate::remote_node::RemoteNodeClient::default(),
+                                node,
+                                shared_token,
+                                handle.mission_id,
+                                handle.job_id,
+                                handle.started_at,
+                            )
+                            .await;
+                            crate::remote_node::job_ledger::remove(&ledger_dir, handle.job_id)
+                                .await;
+                        });
+                    }
+                    _ => {
+                        tracing::warn!(
+                            mission_id = %handle.mission_id,
+                            job_id = %handle.job_id,
+                            node = %handle.node_id,
+                            "waited remote build retained: node config/token unavailable"
+                        );
+                    }
+                }
+                continue;
+            }
             // Positive-evidence rule: only drop a handle when a live session
             // PROVES the mission no longer needs it (found and not Active).
             // A user whose session hasn't booted yet must not lose the only
@@ -5863,6 +5901,44 @@ async fn reconcile_pending_handles(
                     settled.insert(handle.job_id);
                 }
             }
+        }
+    }
+}
+
+/// Observe a waited remote-build job after API restart. This deliberately has
+/// no mission-status side effects: the build was a tool call within a mission,
+/// not the mission's own remote execution backend.
+async fn poll_recovered_remote_build(
+    fleet: Arc<crate::remote_node::FleetMonitor>,
+    client: crate::remote_node::RemoteNodeClient,
+    node: crate::remote_node::RemoteNodeConfig,
+    shared_token: String,
+    mission_id: Uuid,
+    job_id: Uuid,
+    started_at: chrono::DateTime<chrono::Utc>,
+) {
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        match client.get_job(&node, &shared_token, job_id).await {
+            Ok(status)
+                if matches!(
+                    status.state.as_str(),
+                    "succeeded" | "failed" | "cancelled" | "lost"
+                ) =>
+            {
+                fleet.record_outcome(crate::remote_node::DispatchOutcome {
+                    mission_id,
+                    node_id: node.id.clone(),
+                    job_id: Some(job_id),
+                    state: status.state,
+                    exit_code: status.exit_code,
+                    error: status.error,
+                    started_at,
+                    finished_at: Some(chrono::Utc::now()),
+                });
+                return;
+            }
+            Ok(_) | Err(_) => {}
         }
     }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -165,6 +165,26 @@ fn remote_node_needs_on_demand_probe(
     true
 }
 
+fn wakeup_supersession_key(
+    source: Option<&str>,
+    trigger: &mission_store::TriggerType,
+) -> Option<String> {
+    match source? {
+        // Wall-clock wakeups all represent the mission's next timer and may
+        // supersede one another regardless of which helper created them.
+        "claude-builtin" | "automation-manager" => Some("wall-clock".to_string()),
+        // Durable completions are independent. Only a replacement watcher for
+        // the same job may supersede an older one.
+        "durable-job-terminal" => match trigger {
+            mission_store::TriggerType::DurableJobTerminal { job_id } => {
+                Some(format!("durable-job:{job_id}"))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn should_finalize_remote_job(inactive_status: Option<MissionStatus>) -> bool {
     inactive_status.is_none()
 }
@@ -15749,6 +15769,13 @@ pub async fn create_automation(
     };
 
     let is_one_shot_wakeup = automation.variables.contains_key("__wakeup_source");
+    let wakeup_key = wakeup_supersession_key(
+        automation
+            .variables
+            .get("__wakeup_source")
+            .map(String::as_str),
+        &automation.trigger,
+    );
 
     tracing::info!(
         mission_id = %mission_id,
@@ -15780,7 +15807,7 @@ pub async fn create_automation(
     // overlapping creates converge on exactly the newest wakeup instead of
     // deactivating each other.
     let mut wakeup_iteration: u32 = 1;
-    if is_one_shot_wakeup {
+    if let Some(wakeup_key) = wakeup_key {
         if let Ok(existing) = control
             .mission_store
             .get_mission_automations(mission_id)
@@ -15789,7 +15816,13 @@ pub async fn create_automation(
             let new_key = (automation.created_at.clone(), automation.id.to_string());
             let priors: Vec<_> = existing
                 .into_iter()
-                .filter(|a| a.id != automation.id && a.variables.contains_key("__wakeup_source"))
+                .filter(|a| {
+                    a.id != automation.id
+                        && wakeup_supersession_key(
+                            a.variables.get("__wakeup_source").map(String::as_str),
+                            &a.trigger,
+                        ) == Some(wakeup_key.clone())
+                })
                 .collect();
             wakeup_iteration = (priors.len() as u32).saturating_add(1);
             for prior in priors
@@ -22093,6 +22126,37 @@ Investigate <service/> failures.
         assert!(remote_node_needs_on_demand_probe(Some(
             &RemoteNodeStatus::Online
         )));
+    }
+
+    #[test]
+    fn durable_wakeup_supersession_is_scoped_to_job_id() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let first_key = wakeup_supersession_key(
+            Some("durable-job-terminal"),
+            &mission_store::TriggerType::DurableJobTerminal { job_id: first },
+        );
+        let replacement_key = wakeup_supersession_key(
+            Some("durable-job-terminal"),
+            &mission_store::TriggerType::DurableJobTerminal { job_id: first },
+        );
+        let independent_key = wakeup_supersession_key(
+            Some("durable-job-terminal"),
+            &mission_store::TriggerType::DurableJobTerminal { job_id: second },
+        );
+
+        assert_eq!(first_key, replacement_key);
+        assert_ne!(first_key, independent_key);
+        assert_eq!(
+            wakeup_supersession_key(
+                Some("automation-manager"),
+                &mission_store::TriggerType::Interval { seconds: 60 }
+            ),
+            wakeup_supersession_key(
+                Some("claude-builtin"),
+                &mission_store::TriggerType::Interval { seconds: 120 }
+            )
+        );
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5640,8 +5640,15 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
         let mut pass = 0u32;
         loop {
             pass += 1;
-            let pending: Vec<_> = crate::remote_node::job_ledger::load(&working_dir)
-                .await
+            let handles = match crate::remote_node::job_ledger::load(&working_dir).await {
+                Ok(handles) => handles,
+                Err(err) => {
+                    tracing::warn!(?err, "remote job ledger unreadable; reconciler will retry");
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    continue;
+                }
+            };
+            let pending: Vec<_> = handles
                 .into_iter()
                 .filter(|h| !settled.contains(&h.job_id))
                 .collect();
@@ -5655,10 +5662,16 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
                 );
             }
             reconcile_pending_handles(&state, &working_dir, pending, &mut settled).await;
-            let unresolved = crate::remote_node::job_ledger::load(&working_dir)
-                .await
-                .into_iter()
-                .any(|h| !settled.contains(&h.job_id));
+            let unresolved = match crate::remote_node::job_ledger::load(&working_dir).await {
+                Ok(handles) => handles.into_iter().any(|h| !settled.contains(&h.job_id)),
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "remote job ledger unreadable after reconciliation; will retry"
+                    );
+                    true
+                }
+            };
             if !unresolved {
                 return;
             }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10,6 +10,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::Infallible;
 use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -9439,6 +9440,7 @@ fn spawn_control_session(
             workspaces.clone(),
             state.events_tx.clone(),
             telegram_bridge.clone(),
+            config.working_dir.clone(),
         ));
     } else if state.mission_store.is_persistent() {
         tracing::info!("Automation scheduler disabled by config");
@@ -9508,6 +9510,7 @@ async fn automation_scheduler_loop(
     workspaces: workspace::SharedWorkspaceStore,
     events_tx: broadcast::Sender<AgentEvent>,
     telegram_bridge: Option<super::telegram::SharedTelegramBridge>,
+    working_dir: PathBuf,
 ) {
     use super::automation_variables::{substitute_variables, SubstitutionContext};
     use super::mission_store::{AutomationExecution, CommandSource, ExecutionStatus, TriggerType};
@@ -9593,6 +9596,7 @@ async fn automation_scheduler_loop(
                     expression: String,
                     timezone: String,
                 },
+                DurableJobTerminal(Uuid),
             }
             let schedule = match &automation.trigger {
                 TriggerType::Interval { seconds } => ScheduleKind::Interval(*seconds),
@@ -9606,6 +9610,9 @@ async fn automation_scheduler_loop(
                 TriggerType::Webhook { .. } => continue,
                 TriggerType::AgentFinished => continue,
                 TriggerType::Telegram { .. } => continue,
+                TriggerType::DurableJobTerminal { job_id } => {
+                    ScheduleKind::DurableJobTerminal(*job_id)
+                }
             };
 
             let mission = match mission_store.get_mission(automation.mission_id).await {
@@ -9742,6 +9749,27 @@ async fn automation_scheduler_loop(
                         }
                     }
                 }
+                ScheduleKind::DurableJobTerminal(job_id) => {
+                    match super::durable_jobs::terminal_for_mission(
+                        &working_dir,
+                        *job_id,
+                        mission.id,
+                    )
+                    .await
+                    {
+                        Ok(terminal) => terminal,
+                        Err(error) => {
+                            tracing::debug!(
+                                automation_id = %automation.id,
+                                mission_id = %mission.id,
+                                durable_job_id = %job_id,
+                                %error,
+                                "Durable-job automation is not ready"
+                            );
+                            false
+                        }
+                    }
+                }
             };
 
             if !should_trigger {
@@ -9861,7 +9889,12 @@ async fn automation_scheduler_loop(
                 automation_id: automation.id,
                 mission_id: mission.id,
                 triggered_at: mission_store::now_string(),
-                trigger_source: "interval".to_string(),
+                trigger_source: match &schedule {
+                    ScheduleKind::Interval(_) => "interval",
+                    ScheduleKind::Cron { .. } => "cron",
+                    ScheduleKind::DurableJobTerminal(_) => "durable_job_terminal",
+                }
+                .to_string(),
                 status: ExecutionStatus::Pending,
                 webhook_payload: None,
                 variables_used: automation.variables.clone(),
@@ -15598,6 +15631,12 @@ pub async fn create_automation(
         }
     }
 
+    if let mission_store::TriggerType::DurableJobTerminal { job_id } = &trigger {
+        super::durable_jobs::terminal_for_mission(&state.config.working_dir, *job_id, mission_id)
+            .await
+            .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
+    }
+
     let start_immediately = req.start_immediately;
 
     // For interval/cron triggers, if start_immediately is false, set last_triggered_at
@@ -15649,11 +15688,7 @@ pub async fn create_automation(
         driver: mission_store::AutomationDriver::Scheduler,
     };
 
-    let is_builtin_wakeup = automation
-        .variables
-        .get("__wakeup_source")
-        .map(String::as_str)
-        == Some("claude-builtin");
+    let is_one_shot_wakeup = automation.variables.contains_key("__wakeup_source");
 
     tracing::info!(
         mission_id = %mission_id,
@@ -15661,7 +15696,7 @@ pub async fn create_automation(
         command_source = ?automation.command_source,
         trigger = ?automation.trigger,
         fresh_session = ?automation.fresh_session,
-        is_builtin_wakeup,
+        is_one_shot_wakeup,
         "Creating mission automation"
     );
 
@@ -15671,7 +15706,7 @@ pub async fn create_automation(
         .await
         .map_err(internal_error)?;
 
-    // One pending built-in wakeup per mission: a new ScheduleWakeup
+    // One pending wakeup per mission: a new ScheduleWakeup
     // supersedes any earlier un-fired one. Without this, a turn that starts
     // before the previous wakeup fires (user message, other automation)
     // schedules a second wakeup, and the leftovers pile up into overlapping
@@ -15685,7 +15720,7 @@ pub async fn create_automation(
     // overlapping creates converge on exactly the newest wakeup instead of
     // deactivating each other.
     let mut wakeup_iteration: u32 = 1;
-    if is_builtin_wakeup {
+    if is_one_shot_wakeup {
         if let Ok(existing) = control
             .mission_store
             .get_mission_automations(mission_id)
@@ -15694,11 +15729,7 @@ pub async fn create_automation(
             let new_key = (automation.created_at.clone(), automation.id.to_string());
             let priors: Vec<_> = existing
                 .into_iter()
-                .filter(|a| {
-                    a.id != automation.id
-                        && a.variables.get("__wakeup_source").map(String::as_str)
-                            == Some("claude-builtin")
-                })
+                .filter(|a| a.id != automation.id && a.variables.contains_key("__wakeup_source"))
                 .collect();
             wakeup_iteration = (priors.len() as u32).saturating_add(1);
             for prior in priors
@@ -15723,7 +15754,7 @@ pub async fn create_automation(
     // Persist a goal-iteration marker for self-paced loops so the dashboard
     // and assistant can see loop progress after a reload — previously this
     // state lived only in the (transient) wakeup automations.
-    if is_builtin_wakeup {
+    if is_one_shot_wakeup {
         let _ = control.events_tx.send(AgentEvent::GoalIteration {
             iteration: wakeup_iteration,
             objective: automation
@@ -15892,6 +15923,24 @@ pub async fn update_automation(
 
     if let Some(active) = req.active {
         automation.active = active;
+    }
+
+    if let mission_store::TriggerType::Cron { expression, .. } = &automation.trigger {
+        if croner::Cron::new(expression).parse().is_err() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("Invalid cron expression: {expression}"),
+            ));
+        }
+    }
+    if let mission_store::TriggerType::DurableJobTerminal { job_id } = &automation.trigger {
+        super::durable_jobs::terminal_for_mission(
+            &state.config.working_dir,
+            *job_id,
+            automation.mission_id,
+        )
+        .await
+        .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
     }
 
     if automation.fresh_session == mission_store::FreshSession::Switch {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5542,7 +5542,7 @@ async fn dispatch_remote_job(
     // Persist the job handle BEFORE marking the mission Active: if the API
     // restarts from here on, the startup reconciler can re-attach a poll
     // loop instead of leaving an Active mission orphaned.
-    crate::remote_node::job_ledger::record(
+    if let Err(err) = crate::remote_node::job_ledger::record(
         &state.config.working_dir,
         crate::remote_node::job_ledger::JobHandle {
             mission_id: mission.id,
@@ -5551,7 +5551,16 @@ async fn dispatch_remote_job(
             started_at: chrono::Utc::now(),
         },
     )
-    .await;
+    .await
+    {
+        // Never expose an Active mission without a durable recovery handle.
+        // Best-effort cancellation prevents an accepted node job from running
+        // after the caller receives the persistence failure.
+        let _ = client.cancel_job(&node, &shared_token, job_id).await;
+        return Err(format!(
+            "remote job accepted but recovery handle could not be persisted: {err}"
+        ));
+    }
 
     control
         .mission_store

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4001,6 +4001,40 @@ pub struct FleetHealth {
     pub missions: crate::api::mission_store::MissionStatusCounts,
     pub webhook_forwarder_configured: bool,
     pub offload_configured: bool,
+    /// Root-filesystem usage so fleet controllers can preflight capacity
+    /// instead of discovering a full disk through worker failures.
+    pub disk_used: u64,
+    pub disk_total: u64,
+    pub disk_percent: f32,
+    pub disk_level: crate::api::monitoring::DiskHealthLevel,
+}
+
+/// Admission preflight: `Some(reason)` when new missions must be refused
+/// because the root filesystem is critically full. `DISK_ADMISSION_ENABLED=0`
+/// is the escape hatch. Warn level admits but logs.
+fn disk_admission_refusal() -> Option<String> {
+    let enabled = std::env::var("DISK_ADMISSION_ENABLED")
+        .map(|v| v.trim() != "0" && !v.trim().eq_ignore_ascii_case("false"))
+        .unwrap_or(true);
+    if !enabled {
+        return None;
+    }
+    let (used, total, percent) = crate::api::monitoring::current_disk_usage();
+    match crate::api::monitoring::DiskHealthLevel::from_percent(percent) {
+        crate::api::monitoring::DiskHealthLevel::Critical => Some(format!(
+            "mission creation refused: disk critically full ({percent:.1}% used, {} GB free). \
+             Free space or raise DISK_CRITICAL_PCT, then retry.",
+            total.saturating_sub(used) / (1024 * 1024 * 1024)
+        )),
+        crate::api::monitoring::DiskHealthLevel::Warn => {
+            tracing::warn!(
+                disk_percent = percent,
+                "disk usage above warn threshold; admitting mission anyway"
+            );
+            None
+        }
+        crate::api::monitoring::DiskHealthLevel::Ok => None,
+    }
 }
 
 pub async fn fleet_health(
@@ -4031,6 +4065,7 @@ pub async fn fleet_health(
         .map_err(internal_error)?;
 
     let cfg = &state.config;
+    let (disk_used, disk_total, disk_percent) = crate::api::monitoring::current_disk_usage();
     Ok(Json(FleetHealth {
         status: if control_responsive { "ok" } else { "degraded" },
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -4040,6 +4075,10 @@ pub async fn fleet_health(
         missions,
         webhook_forwarder_configured: cfg.paloma_webhook_forward_url.is_some(),
         offload_configured: cfg.spark_arbiter_url.is_some() || cfg.spark_ssh_target.is_some(),
+        disk_used,
+        disk_total,
+        disk_percent,
+        disk_level: crate::api::monitoring::DiskHealthLevel::from_percent(disk_percent),
     }))
 }
 
@@ -11579,6 +11618,15 @@ async fn control_actor_loop(
                         }
                     }
                     ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, backend, config_profile, parent_mission_id, working_directory, scheduling, respond } => {
+                        // Disk preflight: refuse new missions when the root
+                        // filesystem is critically full instead of letting
+                        // workers die mid-flight on ENOSPC. Actor-level so
+                        // the HTTP, Ask and Telegram entrypoints are all
+                        // covered by this single gate.
+                        if let Some(refusal) = disk_admission_refusal() {
+                            let _ = respond.send(Err(refusal));
+                            continue;
+                        }
                         // First persist current mission history
                         persist_mission_history(
                             &mission_store,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5621,14 +5621,51 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
         // Let control sessions boot before touching their stores.
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         let working_dir = state.config.working_dir.clone();
-        let handles = crate::remote_node::job_ledger::load(&working_dir).await;
-        if handles.is_empty() {
-            return;
+        // Job ids a poll loop was already re-attached for (or that were
+        // finalized), so retry passes never double-attach.
+        let mut settled: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+        // Retry until every persisted handle is settled: a handle whose
+        // owning session has not booted yet is picked up on a later pass
+        // (sessions boot lazily on the user's first request). Early passes
+        // are frequent, later ones back off.
+        let mut pass = 0u32;
+        loop {
+            pass += 1;
+            let pending: Vec<_> = crate::remote_node::job_ledger::load(&working_dir)
+                .await
+                .into_iter()
+                .filter(|h| !settled.contains(&h.job_id))
+                .collect();
+            if pending.is_empty() {
+                return;
+            }
+            if pass == 1 {
+                tracing::info!(
+                    count = pending.len(),
+                    "reconciling async remote jobs from previous process"
+                );
+            }
+            reconcile_pending_handles(&state, &working_dir, pending, &mut settled).await;
+            let unresolved = crate::remote_node::job_ledger::load(&working_dir)
+                .await
+                .into_iter()
+                .any(|h| !settled.contains(&h.job_id));
+            if !unresolved {
+                return;
+            }
+            let backoff = if pass < 10 { 60 } else { 600 };
+            tokio::time::sleep(std::time::Duration::from_secs(backoff)).await;
         }
-        tracing::info!(
-            count = handles.len(),
-            "reconciling async remote jobs from previous process"
-        );
+    });
+}
+
+async fn reconcile_pending_handles(
+    state: &Arc<AppState>,
+    working_dir: &std::path::Path,
+    handles: Vec<crate::remote_node::job_ledger::JobHandle>,
+    settled: &mut std::collections::HashSet<Uuid>,
+) {
+    {
         for handle in handles {
             // Positive-evidence rule: only drop a handle when a live session
             // PROVES the mission no longer needs it (found and not Active).
@@ -5651,12 +5688,13 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
             let Some(session) = owning else {
                 if proven_inactive {
                     // Finalized elsewhere: the handle is no longer needed.
-                    crate::remote_node::job_ledger::remove(&working_dir, handle.job_id).await;
+                    crate::remote_node::job_ledger::remove(working_dir, handle.job_id).await;
+                    settled.insert(handle.job_id);
                 } else {
                     tracing::info!(
                         mission_id = %handle.mission_id,
                         job_id = %handle.job_id,
-                        "remote job handle kept: owning session not booted yet"
+                        "remote job handle kept: owning session not booted yet; will retry"
                     );
                 }
                 continue;
@@ -5674,8 +5712,9 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
                         node = %node.id,
                         "re-attaching poll loop to in-flight remote job"
                     );
+                    settled.insert(handle.job_id);
                     let fleet = Arc::clone(&state.fleet);
-                    let ledger_dir = working_dir.clone();
+                    let ledger_dir = working_dir.to_path_buf();
                     tokio::spawn(async move {
                         poll_remote_job(
                             session,
@@ -5708,11 +5747,12 @@ pub fn spawn_remote_job_reconciler(state: Arc<AppState>) {
                             "remote_node_lost: node unconfigured after restart".to_string(),
                         ),
                     });
-                    crate::remote_node::job_ledger::remove(&working_dir, handle.job_id).await;
+                    crate::remote_node::job_ledger::remove(working_dir, handle.job_id).await;
+                    settled.insert(handle.job_id);
                 }
             }
         }
-    });
+    }
 }
 
 /// Background poll loop for one async remote job. Emits sparse progress

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5817,36 +5817,25 @@ async fn reconcile_pending_handles(
                 }
                 continue;
             }
-            // Positive-evidence rule: only drop a handle when a live session
-            // PROVES the mission no longer needs it (found and not Active).
-            // A user whose session hasn't booted yet must not lose the only
-            // copy of their job handle — keep it for a later pass instead.
-            let mut owning: Option<ControlState> = None;
-            let mut proven_inactive = false;
+            // A user whose session has not booted yet must not lose the only
+            // recovery handle. Once found, reattach even when the mission is
+            // inactive: the poll loop will request cancellation and retain
+            // the handle until the node confirms a terminal state.
+            let mut owning: Option<(ControlState, MissionStatus)> = None;
             for session in state.control.all_sessions().await {
                 if let Ok(Some(mission)) =
                     session.mission_store.get_mission(handle.mission_id).await
                 {
-                    if mission.status == MissionStatus::Active {
-                        owning = Some(session);
-                    } else {
-                        proven_inactive = true;
-                    }
+                    owning = Some((session, mission.status));
                     break;
                 }
             }
-            let Some(session) = owning else {
-                if proven_inactive {
-                    // Finalized elsewhere: the handle is no longer needed.
-                    crate::remote_node::job_ledger::remove(working_dir, handle.job_id).await;
-                    settled.insert(handle.job_id);
-                } else {
-                    tracing::info!(
-                        mission_id = %handle.mission_id,
-                        job_id = %handle.job_id,
-                        "remote job handle kept: owning session not booted yet; will retry"
-                    );
-                }
+            let Some((session, mission_status)) = owning else {
+                tracing::info!(
+                    mission_id = %handle.mission_id,
+                    job_id = %handle.job_id,
+                    "remote job handle kept: owning session not booted yet; will retry"
+                );
                 continue;
             };
             let node = state.config.remote_nodes.node(&handle.node_id).cloned();
@@ -5881,6 +5870,16 @@ async fn reconcile_pending_handles(
                     });
                 }
                 _ => {
+                    if mission_status != MissionStatus::Active {
+                        tracing::warn!(
+                            mission_id = %handle.mission_id,
+                            job_id = %handle.job_id,
+                            node = %handle.node_id,
+                            %mission_status,
+                            "inactive remote job handle retained: cancellation node unavailable"
+                        );
+                        continue;
+                    }
                     tracing::warn!(
                         mission_id = %handle.mission_id,
                         node = %handle.node_id,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3301,6 +3301,13 @@ impl ControlHub {
         self.sessions.read().await.values().cloned().collect()
     }
 
+    /// User ids of all live control sessions. Used by GC/reaper to decide
+    /// whether the cross-store mission index is complete (a persisted store
+    /// with no live session means missions exist that the index can't see).
+    pub async fn session_user_ids(&self) -> Vec<String> {
+        self.sessions.read().await.keys().cloned().collect()
+    }
+
     /// Get a mission store for desktop management.
     /// Uses the default user's store if available, or creates a temporary one.
     pub async fn get_mission_store(&self) -> Arc<dyn MissionStore> {
@@ -8753,7 +8760,10 @@ fn spawn_control_session(
     // Event-driven scope teardown: stop a mission's exec scopes as soon as
     // its status stops needing a live harness. The periodic scope reaper
     // (scope_reaper::spawn) backstops events missed across restarts.
-    super::scope_reaper::spawn_status_listener(events_tx.subscribe());
+    super::scope_reaper::spawn_status_listener(
+        events_tx.subscribe(),
+        Arc::clone(&state.mission_store),
+    );
 
     // Shared registry of in-flight Claude Code background shell tasks. Written
     // by the control actor's ToolResult arm; read by the auto-resume watcher.

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5813,21 +5813,30 @@ async fn poll_remote_job(
         tokio::time::sleep(POLL_INTERVAL).await;
 
         // Honor external mission cancellation when trivially observable: if
-        // an operator moved the mission out of Active (cancel/interrupt/
-        // pause), stop polling and cancel the job on the node.
-        if let Ok(Some(current)) = control.mission_store.get_mission(mission_id).await {
-            if current.status != MissionStatus::Active {
-                let _ = client.cancel_job(&node, &shared_token, job_id).await;
-                fleet.record_outcome(outcome(
-                    "cancelled",
-                    None,
-                    Some(format!(
-                        "mission left active state ({}); job cancelled on node",
-                        current.status
-                    )),
-                    true,
-                ));
-                return;
+        // an operator moved the mission out of Active (cancel/interrupt/pause),
+        // request cancellation but retain the durable handle and keep polling
+        // until the node confirms a terminal state. A transient cancel outage
+        // must not orphan a still-running remote job.
+        let inactive_status = match control.mission_store.get_mission(mission_id).await {
+            Ok(Some(current)) if current.status != MissionStatus::Active => Some(current.status),
+            _ => None,
+        };
+        if let Some(status) = inactive_status {
+            if let Err(err) = client.cancel_job(&node, &shared_token, job_id).await {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    job_id = %job_id,
+                    node = %node.id,
+                    ?err,
+                    "remote job cancellation failed; retaining handle and retrying"
+                );
+            } else {
+                tracing::debug!(
+                    mission_id = %mission_id,
+                    job_id = %job_id,
+                    %status,
+                    "remote job cancellation requested; awaiting terminal state"
+                );
             }
         }
 
@@ -5835,6 +5844,18 @@ async fn poll_remote_job(
             Err(err) => {
                 failures += 1;
                 if failures >= MAX_CONSECUTIVE_FAILURES {
+                    if inactive_status.is_some() {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            job_id = %job_id,
+                            node = %node.id,
+                            failures,
+                            ?err,
+                            "remote job still unreachable during cancellation; retaining handle"
+                        );
+                        failures = 0;
+                        continue;
+                    }
                     let content = format!(
                         "Remote node '{}' became unreachable while running job {} \
                          ({failures} consecutive poll failures; last error: {err}). \

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -185,8 +185,11 @@ fn wakeup_supersession_key(
     }
 }
 
-fn should_finalize_remote_job(inactive_status: Option<MissionStatus>) -> bool {
-    inactive_status.is_none()
+fn should_finalize_remote_job(current_status: Option<MissionStatus>) -> bool {
+    matches!(
+        current_status,
+        None | Some(MissionStatus::Active | MissionStatus::Pending)
+    )
 }
 
 /// Returns a safe index to truncate a string at, ensuring we don't cut UTF-8 characters.
@@ -5986,7 +5989,7 @@ async fn reconcile_pending_handles(
                     });
                 }
                 _ => {
-                    if mission_status != MissionStatus::Active {
+                    if !should_finalize_remote_job(Some(mission_status)) {
                         tracing::warn!(
                             mission_id = %handle.mission_id,
                             job_id = %handle.job_id,
@@ -22162,6 +22165,10 @@ Investigate <service/> failures.
     #[test]
     fn remote_terminal_result_preserves_operator_selected_status() {
         assert!(should_finalize_remote_job(None));
+        assert!(should_finalize_remote_job(Some(MissionStatus::Active)));
+        // A durable handle proves this is the narrow crash window after the
+        // node accepted the job but before Pending was promoted to Active.
+        assert!(should_finalize_remote_job(Some(MissionStatus::Pending)));
         for status in [
             MissionStatus::Interrupted,
             MissionStatus::Paused,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5653,10 +5653,43 @@ async fn dispatch_remote_job(
         ));
     }
 
-    control
+    if let Err(err) = control
         .mission_store
         .update_mission_status(mission.id, MissionStatus::Active)
-        .await?;
+        .await
+    {
+        // The node already accepted the job and its handle is durable. Ask
+        // for cancellation immediately, then keep polling until terminal so
+        // a failed mission activation cannot leak node capacity.
+        if let Err(cancel_err) = client.cancel_job(&node, &shared_token, job_id).await {
+            tracing::warn!(
+                mission_id = %mission.id,
+                job_id = %job_id,
+                ?cancel_err,
+                "remote job cancellation after activation failure will be retried by poller"
+            );
+        }
+        let poll_control = control.clone();
+        let fleet = Arc::clone(&state.fleet);
+        let ledger_dir = state.config.working_dir.clone();
+        let mission_id = mission.id;
+        let started_at = chrono::Utc::now();
+        tokio::spawn(async move {
+            poll_remote_job(
+                poll_control,
+                fleet,
+                client,
+                node,
+                shared_token,
+                mission_id,
+                job_id,
+                started_at,
+            )
+            .await;
+            crate::remote_node::job_ledger::remove(&ledger_dir, job_id).await;
+        });
+        return Err(err);
+    }
     let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
         mission_id: mission.id,
         status: MissionStatus::Active,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5403,12 +5403,13 @@ pub async fn create_mission(
     if let (Some(remote_node_id), Some(remote_command)) =
         (remote_node_id.as_deref(), remote_command.as_deref())
     {
-        let dispatch = if req.remote_async.unwrap_or(false) {
-            dispatch_remote_job(&state, &control, &mission, remote_node_id, remote_command).await
-        } else {
-            dispatch_remote_mission_mvp(&state, &control, &mission, remote_node_id, remote_command)
-                .await
-        };
+        // All remote commands use the durable node job API. The legacy
+        // synchronous `/execute` path has no cancellation handle if its HTTP
+        // wait expires, so routing `remote_async=false` through it could orphan
+        // a process on the node. The response contract here is unchanged: the
+        // mission is returned Active while its durable poller owns completion.
+        let dispatch =
+            dispatch_remote_job(&state, &control, &mission, remote_node_id, remote_command).await;
         match dispatch {
             Ok(updated) => return Ok((headers, Json(updated))),
             Err(message) => {
@@ -5444,6 +5445,7 @@ fn remote_dispatch_is_scheduled_for_future(
         && not_before.is_some_and(|t| t > now)
 }
 
+#[allow(dead_code)]
 async fn dispatch_remote_mission_mvp(
     state: &Arc<AppState>,
     control: &ControlState,
@@ -6070,7 +6072,12 @@ async fn poll_remote_job(
                     )
                     .await;
                     fleet.record_outcome(outcome("lost", None, Some(err.to_string()), true));
-                    return;
+                    // Finalization moves the mission out of Active. Keep the
+                    // durable handle and continue: the next iteration enters
+                    // the cancellation-aware path, and wrappers only remove
+                    // the ledger entry after a terminal node response.
+                    failures = 0;
+                    continue;
                 }
             }
             Ok(status) => {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4872,7 +4872,13 @@ pub struct CreateMissionRequest {
     pub prompt: Option<String>,
     /// Remote runner node id. When set, core creates the mission locally and
     /// dispatches `remote_command` to that node behind the remote-node flag.
+    /// The special value `"auto"` picks a node via capacity-aware placement
+    /// (`FleetMonitor::place_auto`) before the mission is persisted.
     pub remote_node_id: Option<String>,
+    /// Label requirements for `remote_node_id: "auto"` placement. Defaults to
+    /// no requirements for raw remote commands (`lean_build` dispatch via
+    /// `POST /api/remote-build` defaults to `["lean"]`).
+    pub remote_requirements: Option<Vec<String>>,
     /// MVP remote execution payload. Full AI mission streaming remains local.
     pub remote_command: Option<String>,
     /// When true (with `remote_node_id` + `remote_command`), dispatch through
@@ -5005,6 +5011,7 @@ pub async fn create_mission(
         next_check_at: None,
         prompt: None,
         remote_node_id: None,
+        remote_requirements: None,
         remote_command: None,
         remote_async: None,
         extra: Default::default(),
@@ -5144,7 +5151,7 @@ pub async fn create_mission(
 
     // Validate the remote-node payload before persisting the mission so a
     // bad request cannot leave an orphaned pending mission behind.
-    let remote_node_id = req
+    let mut remote_node_id = req
         .remote_node_id
         .as_deref()
         .map(str::trim)
@@ -5173,8 +5180,32 @@ pub async fn create_mission(
                 "remote-node MVP does not support future not_before scheduling yet; create the remote mission after the dispatch window opens".to_string(),
             ));
         }
-        crate::remote_node::placement_for_selected_node(&state.config.remote_nodes, Some(node_id))
+        if node_id.eq_ignore_ascii_case("auto") {
+            // Capacity-aware auto placement, resolved BEFORE the mission is
+            // persisted so placement failures surface as a clean API error
+            // instead of an orphaned failed mission.
+            if !state.config.remote_nodes.enabled {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    crate::remote_node::RemoteNodeError::Disabled.to_string(),
+                ));
+            }
+            // Raw remote commands default to no label requirements; the
+            // lean_build path (`POST /api/remote-build`) defaults to ["lean"].
+            let requirements = req.remote_requirements.clone().unwrap_or_default();
+            let resolved = state
+                .fleet
+                .place_auto(&state.config.remote_nodes, &requirements)
+                .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+            tracing::info!(node_id = %resolved, "auto placement selected remote node");
+            remote_node_id = Some(resolved);
+        } else {
+            crate::remote_node::placement_for_selected_node(
+                &state.config.remote_nodes,
+                Some(node_id),
+            )
             .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+        }
     }
 
     let control = control_for_user(&state, &user).await;
@@ -7285,6 +7316,7 @@ pub async fn clone_mission(
         next_check_at: source.project.next_check_at.clone(),
         prompt: None,
         remote_node_id: None,
+        remote_requirements: None,
         remote_command: None,
         remote_async: None,
         extra: Default::default(),

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -1,0 +1,160 @@
+//! Background disk-usage watcher.
+//!
+//! The 2026-07-12 incident: the root filesystem filled up silently until
+//! mission workers, then the supervisor itself, started dying on ENOSPC.
+//! This task samples root-disk usage every few minutes and pushes an alert
+//! through the Paloma webhook (HMAC-signed, same channel as mission status
+//! forwarding) when usage crosses the Warn/Critical thresholds, re-alerts
+//! periodically while elevated, and sends a recovery notice once usage
+//! drops back under the hysteresis band.
+//!
+//! Delivery is best-effort: `tracing::error!`/`warn!` is the baseline that
+//! always fires; the webhook only when `PALOMA_WEBHOOK_FORWARD_URL` is set.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::monitoring::{self, DiskHealthLevel};
+use super::routes::AppState;
+
+/// How often usage is sampled.
+const TICK_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Hysteresis: recovery is announced only once usage falls this many
+/// percentage points below the warn threshold, so a value oscillating
+/// around the threshold doesn't flap alert/recovery pairs.
+const RECOVERY_MARGIN_PCT: f32 = 3.0;
+
+fn repeat_interval() -> Duration {
+    let hours = std::env::var("DISK_ALERT_REPEAT_HOURS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|h| *h >= 1)
+        .unwrap_or(24);
+    Duration::from_secs(hours * 3600)
+}
+
+fn rank(level: DiskHealthLevel) -> u8 {
+    match level {
+        DiskHealthLevel::Ok => 0,
+        DiskHealthLevel::Warn => 1,
+        DiskHealthLevel::Critical => 2,
+    }
+}
+
+/// Spawn the watcher loop. Safe to call once at server start.
+pub fn spawn(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        run_loop(state).await;
+    });
+}
+
+async fn run_loop(state: Arc<AppState>) {
+    let mut interval = tokio::time::interval(TICK_INTERVAL);
+    // Skip the boot tick; the server is busy starting subsystems.
+    interval.tick().await;
+    // The level we last notified about (Ok = nothing outstanding).
+    let mut alerted_level = DiskHealthLevel::Ok;
+    let mut last_alert_at: Option<tokio::time::Instant> = None;
+    loop {
+        interval.tick().await;
+        let (used, total, percent) = monitoring::current_disk_usage();
+        let level = DiskHealthLevel::from_percent(percent);
+
+        let escalated = rank(level) > rank(alerted_level);
+        let repeat_due = last_alert_at
+            .map(|t| t.elapsed() >= repeat_interval())
+            .unwrap_or(true);
+        let recovered = alerted_level != DiskHealthLevel::Ok
+            && percent < monitoring::disk_warn_pct() - RECOVERY_MARGIN_PCT;
+
+        if level != DiskHealthLevel::Ok && (escalated || repeat_due) {
+            let free_gb = total.saturating_sub(used) / (1024 * 1024 * 1024);
+            let message = format!(
+                "Disk {level:?}: root filesystem at {percent:.1}% ({free_gb} GB free). \
+                 Mission admission is refused at critical level."
+            );
+            match level {
+                DiskHealthLevel::Critical => tracing::error!(percent, free_gb, "{message}"),
+                _ => tracing::warn!(percent, free_gb, "{message}"),
+            }
+            deliver_webhook(&state, level, used, total, percent, &message).await;
+            alerted_level = level;
+            last_alert_at = Some(tokio::time::Instant::now());
+        } else if recovered {
+            let message = format!(
+                "Disk recovered: root filesystem back to {percent:.1}% used; \
+                 mission admission restored."
+            );
+            tracing::info!(percent, "{message}");
+            deliver_webhook(&state, DiskHealthLevel::Ok, used, total, percent, &message).await;
+            alerted_level = DiskHealthLevel::Ok;
+            last_alert_at = None;
+        }
+    }
+}
+
+/// POST the alert to the Paloma webhook, HMAC-signed over the raw body with
+/// `PALOMA_WEBHOOK_SECRET` (GitHub-style `X-Hub-Signature-256`), matching the
+/// mission-status forwarder so the receiving end verifies both identically.
+async fn deliver_webhook(
+    state: &Arc<AppState>,
+    level: DiskHealthLevel,
+    used: u64,
+    total: u64,
+    percent: f32,
+    message: &str,
+) {
+    let Some(url) = state.config.paloma_webhook_forward_url.clone() else {
+        return;
+    };
+    let body = serde_json::json!({
+        "type": "disk_alert",
+        "event_id": uuid::Uuid::new_v4(),
+        "level": level,
+        "disk_used": used,
+        "disk_total": total,
+        "disk_percent": percent,
+        "message": message,
+        "occurred_at": chrono::Utc::now().to_rfc3339(),
+    });
+    let payload = match serde_json::to_vec(&body) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::warn!(?err, "failed to serialize disk alert payload");
+            return;
+        }
+    };
+    let signature = state.config.paloma_webhook_secret.as_ref().and_then(|s| {
+        use hmac::{Hmac, Mac};
+        let mut mac = Hmac::<sha2::Sha256>::new_from_slice(s.as_bytes()).ok()?;
+        mac.update(&payload);
+        Some(format!(
+            "sha256={}",
+            hex::encode(mac.finalize().into_bytes())
+        ))
+    });
+    let http = reqwest::Client::new();
+    const MAX_ATTEMPTS: u32 = 3;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let mut request = http
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(payload.clone());
+        if let Some(signature) = signature.as_deref() {
+            request = request.header("X-Hub-Signature-256", signature);
+        }
+        match request.send().await {
+            Ok(resp) if resp.status().is_success() => return,
+            Ok(resp) => {
+                tracing::warn!(attempt, status = %resp.status(), "disk alert webhook non-success");
+            }
+            Err(err) => {
+                tracing::warn!(attempt, ?err, "disk alert webhook send failed");
+            }
+        }
+        if attempt < MAX_ATTEMPTS {
+            tokio::time::sleep(Duration::from_millis(250 * attempt as u64)).await;
+        }
+    }
+}

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -126,6 +126,55 @@ fn jobs_root(state: &AppState) -> PathBuf {
     state.config.working_dir.join(".sandboxed-sh/durable-jobs")
 }
 
+/// Observe whether a durable job owned by `mission_id` is terminal without
+/// requiring an agent turn to call the durable-job API. The automation
+/// scheduler uses this to provide event-like completion wakeups while keeping
+/// the file-backed registry authoritative across API restarts.
+pub(crate) async fn terminal_for_mission(
+    working_dir: &Path,
+    id: Uuid,
+    mission_id: Uuid,
+) -> Result<bool, String> {
+    let path = working_dir
+        .join(".sandboxed-sh/durable-jobs")
+        .join(id.to_string())
+        .join("job.json");
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|_| format!("durable job not found: {id}"))?;
+    let job: DurableJob =
+        serde_json::from_slice(&bytes).map_err(|e| format!("invalid durable job entry: {e}"))?;
+
+    if job.started_by_mission_id != Some(mission_id) {
+        return Err(format!(
+            "durable job {id} is not owned by mission {mission_id}"
+        ));
+    }
+
+    if matches!(
+        job.status,
+        DurableJobStatus::Completed
+            | DurableJobStatus::Failed
+            | DurableJobStatus::Cancelled
+            | DurableJobStatus::Unknown
+    ) {
+        return Ok(true);
+    }
+
+    // The child watcher is process-local, so an API restart can leave job.json
+    // at `running`. The wrapper's atomic exit record is the restart-safe source
+    // of truth and should wake the owner even before a GET refreshes job.json.
+    if let Ok(bytes) = tokio::fs::read(&job.status_file).await {
+        if serde_json::from_slice::<ExitRecord>(&bytes).is_ok() {
+            return Ok(true);
+        }
+    }
+
+    // If neither watcher nor wrapper could persist a terminal record, a dead
+    // supervisor still requires owner attention rather than infinite polling.
+    Ok(job.pid.is_some_and(|pid| !process_alive(pid)))
+}
+
 fn job_dir(state: &AppState, id: Uuid) -> PathBuf {
     jobs_root(state).join(id.to_string())
 }
@@ -768,6 +817,67 @@ mod tests {
         let merged = merge_job_for_write(Some(current), next);
 
         assert_eq!(merged.status, DurableJobStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn terminal_observer_uses_restart_safe_exit_record_and_enforces_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let mut job = test_job(DurableJobStatus::Running);
+        job.started_by_mission_id = Some(mission_id);
+        job.pid = None;
+        job.status_file = dir.path().join("exit.json").to_string_lossy().to_string();
+        let registry_dir = dir
+            .path()
+            .join(".sandboxed-sh/durable-jobs")
+            .join(job.id.to_string());
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        std::fs::write(
+            registry_dir.join("job.json"),
+            serde_json::to_vec(&job).unwrap(),
+        )
+        .unwrap();
+
+        assert!(!terminal_for_mission(dir.path(), job.id, mission_id)
+            .await
+            .unwrap());
+        assert!(terminal_for_mission(dir.path(), job.id, Uuid::new_v4())
+            .await
+            .unwrap_err()
+            .contains("not owned"));
+
+        let exit = ExitRecord {
+            exit_code: Some(0),
+            signal: None,
+            finished_at: Utc::now(),
+        };
+        std::fs::write(&job.status_file, serde_json::to_vec(&exit).unwrap()).unwrap();
+        assert!(terminal_for_mission(dir.path(), job.id, mission_id)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn terminal_observer_accepts_persisted_terminal_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let mut job = test_job(DurableJobStatus::Failed);
+        job.started_by_mission_id = Some(mission_id);
+        job.pid = None;
+        let registry_dir = dir
+            .path()
+            .join(".sandboxed-sh/durable-jobs")
+            .join(job.id.to_string());
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        std::fs::write(
+            registry_dir.join("job.json"),
+            serde_json::to_vec(&job).unwrap(),
+        )
+        .unwrap();
+
+        assert!(terminal_for_mission(dir.path(), job.id, mission_id)
+            .await
+            .unwrap());
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -160,6 +160,15 @@ fn explicit_owner_authorized(job: &DurableJob, user_id: &str) -> Option<bool> {
     job.owner_user_id.as_deref().map(|owner| owner == user_id)
 }
 
+fn durable_shell_wrapper(command: &str) -> String {
+    // Isolate the caller's shell options and `exit` calls. In particular,
+    // `set -e; false` must terminate only this subshell so the parent can
+    // always persist the restart-safe terminal record.
+    format!(
+        "(\n{command}\n)\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n"
+    )
+}
+
 async fn authorize_job(
     state: &Arc<AppState>,
     user: &AuthUser,
@@ -574,10 +583,7 @@ pub async fn start_job(
         .open(&stderr_log)
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let wrapper = format!(
-        "{{ {}; }}\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n",
-        command
-    );
+    let wrapper = durable_shell_wrapper(command);
 
     let now = Utc::now();
     let mut job = DurableJob {
@@ -869,6 +875,22 @@ mod tests {
         job.owner_user_id = Some("alice".to_string());
         assert_eq!(explicit_owner_authorized(&job, "alice"), Some(true));
         assert_eq!(explicit_owner_authorized(&job, "bob"), Some(false));
+    }
+
+    #[test]
+    fn wrapper_records_failure_even_when_command_enables_errexit() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_file = dir.path().join("exit.json");
+        let output = std::process::Command::new("/bin/sh")
+            .args(["-lc", &durable_shell_wrapper("set -eu; false")])
+            .env("SANDBOXED_SH_DURABLE_STATUS", &status_file)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        let record: ExitRecord =
+            serde_json::from_slice(&std::fs::read(status_file).unwrap()).unwrap();
+        assert_eq!(record.exit_code, Some(1));
+        assert_eq!(record.signal, None);
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -88,6 +88,12 @@ fn default_tail_bytes() -> usize {
     16 * 1024
 }
 
+fn require_workspace_scope(workspace_id: Option<Uuid>) -> Result<Uuid, String> {
+    workspace_id.ok_or_else(|| {
+        "workspace_id is required; unscoped durable jobs cannot run on the API host".to_string()
+    })
+}
+
 #[derive(Debug, Serialize)]
 pub struct JobLogsResponse {
     pub job_id: Uuid,
@@ -384,22 +390,15 @@ pub async fn start_job(
     if command.is_empty() {
         return Err(err(StatusCode::BAD_REQUEST, "command is required"));
     }
-    if req.started_by_mission_id.is_some() && req.workspace_id.is_none() {
-        return Err(err(
-            StatusCode::BAD_REQUEST,
-            "mission-owned durable jobs require workspace_id",
-        ));
-    }
+    let workspace_id = require_workspace_scope(req.workspace_id)
+        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
 
-    let workspace =
-        match req.workspace_id {
-            Some(id) => {
-                Some(state.workspaces.get(id).await.ok_or_else(|| {
-                    err(StatusCode::NOT_FOUND, format!("workspace not found: {id}"))
-                })?)
-            }
-            None => None,
-        };
+    let workspace = Some(state.workspaces.get(workspace_id).await.ok_or_else(|| {
+        err(
+            StatusCode::NOT_FOUND,
+            format!("workspace not found: {workspace_id}"),
+        )
+    })?);
     let cwd = match workspace.as_ref() {
         Some(workspace) => resolve_workspace_cwd(
             &workspace.path,
@@ -706,6 +705,15 @@ mod tests {
     fn resolve_cwd_defaults_to_base() {
         let base = std::env::current_dir().unwrap();
         assert_eq!(resolve_cwd(&base, None).unwrap(), base);
+    }
+
+    #[test]
+    fn durable_jobs_require_a_workspace_scope() {
+        let id = Uuid::new_v4();
+        assert_eq!(require_workspace_scope(Some(id)).unwrap(), id);
+        assert!(require_workspace_scope(None)
+            .unwrap_err()
+            .contains("cannot run on the API host"));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -26,6 +26,8 @@ use super::{auth::AuthUser, control::control_for_user, routes::AppState};
 use crate::workspace::WorkspaceType;
 use crate::workspace_exec::WorkspaceExec;
 
+const PIDLESS_START_GRACE_SECS: i64 = 30;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DurableJobStatus {
@@ -264,7 +266,13 @@ pub(crate) async fn terminal_for_mission(
 
     // If neither watcher nor wrapper could persist a terminal record, a dead
     // supervisor still requires owner attention rather than infinite polling.
-    Ok(job.pid.is_some_and(|pid| !process_alive(pid)))
+    // Keep a short grace for the normal start_job window between the initial
+    // record and the post-spawn PID update. After a restart that update can no
+    // longer arrive, so an older pidless record must wake its owner too.
+    Ok(match job.pid {
+        Some(pid) => !process_alive(pid),
+        None => (Utc::now() - job.updated_at).num_seconds() >= PIDLESS_START_GRACE_SECS,
+    })
 }
 
 fn job_dir(state: &AppState, id: Uuid) -> PathBuf {
@@ -973,6 +981,16 @@ mod tests {
             .await
             .unwrap_err()
             .contains("not owned"));
+
+        job.updated_at = Utc::now() - chrono::Duration::seconds(PIDLESS_START_GRACE_SECS + 1);
+        std::fs::write(
+            registry_dir.join("job.json"),
+            serde_json::to_vec(&job).unwrap(),
+        )
+        .unwrap();
+        assert!(terminal_for_mission(dir.path(), job.id, mission_id)
+            .await
+            .unwrap());
 
         let exit = ExitRecord {
             exit_code: Some(0),

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -10,7 +10,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path as AxumPath, State},
+    extract::{Extension, Path as AxumPath, State},
     http::StatusCode,
     routing::{get, post},
     Json, Router,
@@ -22,7 +22,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::process::{Child, Command};
 use uuid::Uuid;
 
-use super::routes::AppState;
+use super::{auth::AuthUser, control::control_for_user, routes::AppState};
 use crate::workspace::WorkspaceType;
 use crate::workspace_exec::WorkspaceExec;
 
@@ -50,6 +50,10 @@ pub struct DurableJob {
     pub started_by_mission_id: Option<Uuid>,
     #[serde(default)]
     pub workspace_id: Option<Uuid>,
+    /// Authenticated API user that launched the job. Legacy entries fall back
+    /// to their owning mission for authorization.
+    #[serde(default)]
+    pub owner_user_id: Option<String>,
     pub stdout_log: String,
     pub stderr_log: String,
     pub status_file: String,
@@ -120,6 +124,85 @@ fn err(status: StatusCode, message: impl Into<String>) -> (StatusCode, Json<Erro
             error: message.into(),
         }),
     )
+}
+
+async fn authorize_start(
+    state: &Arc<AppState>,
+    user: &AuthUser,
+    workspace_id: Option<Uuid>,
+    mission_id: Option<Uuid>,
+) -> Result<(Uuid, Uuid), (StatusCode, Json<ErrorResponse>)> {
+    let workspace_id = require_workspace_scope(workspace_id)
+        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
+    let mission_id = mission_id.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "started_by_mission_id is required for durable jobs",
+        )
+    })?;
+    let control = control_for_user(state, user).await;
+    let mission = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error))?
+        .ok_or_else(|| err(StatusCode::FORBIDDEN, "mission is not owned by the caller"))?;
+    if mission.workspace_id != workspace_id {
+        return Err(err(
+            StatusCode::FORBIDDEN,
+            "workspace does not belong to the caller mission",
+        ));
+    }
+    Ok((workspace_id, mission_id))
+}
+
+fn explicit_owner_authorized(job: &DurableJob, user_id: &str) -> Option<bool> {
+    job.owner_user_id.as_deref().map(|owner| owner == user_id)
+}
+
+async fn authorize_job(
+    state: &Arc<AppState>,
+    user: &AuthUser,
+    job: &DurableJob,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if let Some(allowed) = explicit_owner_authorized(job, &user.id) {
+        return if allowed {
+            Ok(())
+        } else {
+            Err(err(
+                StatusCode::FORBIDDEN,
+                "durable job belongs to another user",
+            ))
+        };
+    }
+
+    // Backward compatibility for jobs created before owner_user_id existed.
+    let mission_id = job.started_by_mission_id.ok_or_else(|| {
+        err(
+            StatusCode::FORBIDDEN,
+            "legacy durable job has no caller ownership metadata",
+        )
+    })?;
+    let workspace_id = job.workspace_id.ok_or_else(|| {
+        err(
+            StatusCode::FORBIDDEN,
+            "legacy durable job has no workspace ownership metadata",
+        )
+    })?;
+    let control = control_for_user(state, user).await;
+    let mission = control
+        .mission_store
+        .get_mission(mission_id)
+        .await
+        .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error))?
+        .ok_or_else(|| err(StatusCode::FORBIDDEN, "durable job belongs to another user"))?;
+    if mission.workspace_id != workspace_id {
+        return Err(err(
+            StatusCode::FORBIDDEN,
+            "durable job belongs to another user",
+        ));
+    }
+    Ok(())
 }
 
 fn jobs_root(state: &AppState) -> PathBuf {
@@ -433,14 +516,15 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
 
 pub async fn start_job(
     State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
     Json(req): Json<StartDurableJobRequest>,
 ) -> Result<Json<DurableJob>, (StatusCode, Json<ErrorResponse>)> {
     let command = req.command.trim();
     if command.is_empty() {
         return Err(err(StatusCode::BAD_REQUEST, "command is required"));
     }
-    let workspace_id = require_workspace_scope(req.workspace_id)
-        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
+    let (workspace_id, started_by_mission_id) =
+        authorize_start(&state, &user, req.workspace_id, req.started_by_mission_id).await?;
 
     let workspace = Some(state.workspaces.get(workspace_id).await.ok_or_else(|| {
         err(
@@ -506,8 +590,9 @@ pub async fn start_job(
         signal: None,
         created_at: now,
         updated_at: now,
-        started_by_mission_id: req.started_by_mission_id,
+        started_by_mission_id: Some(started_by_mission_id),
         workspace_id: req.workspace_id,
+        owner_user_id: Some(user.id.clone()),
         stdout_log: stdout_log.to_string_lossy().to_string(),
         stderr_log: stderr_log.to_string_lossy().to_string(),
         status_file: status_file.to_string_lossy().to_string(),
@@ -616,7 +701,10 @@ pub async fn start_job(
     Ok(Json(job))
 }
 
-pub async fn list_jobs(State(state): State<Arc<AppState>>) -> Json<Vec<DurableJob>> {
+pub async fn list_jobs(
+    State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
+) -> Json<Vec<DurableJob>> {
     let mut jobs = Vec::new();
     let root = jobs_root(&state);
     if let Ok(mut entries) = tokio::fs::read_dir(root).await {
@@ -624,7 +712,9 @@ pub async fn list_jobs(State(state): State<Arc<AppState>>) -> Json<Vec<DurableJo
             let path = entry.path().join("job.json");
             if let Ok(bytes) = tokio::fs::read(path).await {
                 if let Ok(job) = serde_json::from_slice::<DurableJob>(&bytes) {
-                    jobs.push(refresh_job(&state, job).await);
+                    if authorize_job(&state, &user, &job).await.is_ok() {
+                        jobs.push(refresh_job(&state, job).await);
+                    }
                 }
             }
         }
@@ -635,11 +725,13 @@ pub async fn list_jobs(State(state): State<Arc<AppState>>) -> Json<Vec<DurableJo
 
 pub async fn get_job(
     State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
     AxumPath(id): AxumPath<Uuid>,
 ) -> Result<Json<DurableJob>, (StatusCode, Json<ErrorResponse>)> {
     let job = read_job(&state, id)
         .await
         .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+    authorize_job(&state, &user, &job).await?;
     Ok(Json(refresh_job(&state, job).await))
 }
 
@@ -665,12 +757,14 @@ async fn tail_file(path: &str, max_bytes: usize) -> String {
 
 pub async fn job_logs(
     State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
     AxumPath(id): AxumPath<Uuid>,
     axum::extract::Query(query): axum::extract::Query<JobLogsQuery>,
 ) -> Result<Json<JobLogsResponse>, (StatusCode, Json<ErrorResponse>)> {
     let job = read_job(&state, id)
         .await
         .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+    authorize_job(&state, &user, &job).await?;
 
     let stdout = if query.stream.as_deref() == Some("stderr") {
         String::new()
@@ -692,11 +786,13 @@ pub async fn job_logs(
 
 pub async fn cancel_job(
     State(state): State<Arc<AppState>>,
+    Extension(user): Extension<AuthUser>,
     AxumPath(id): AxumPath<Uuid>,
 ) -> Result<Json<DurableJob>, (StatusCode, Json<ErrorResponse>)> {
     let mut job = read_job(&state, id)
         .await
         .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
+    authorize_job(&state, &user, &job).await?;
     job = refresh_job(&state, job).await;
     if job.status == DurableJobStatus::Running {
         job.status = DurableJobStatus::Cancelled;
@@ -743,6 +839,7 @@ mod tests {
             updated_at: now,
             started_by_mission_id: None,
             workspace_id: None,
+            owner_user_id: None,
             stdout_log: "/tmp/stdout.log".to_string(),
             stderr_log: "/tmp/stderr.log".to_string(),
             status_file: "/tmp/exit.json".to_string(),
@@ -763,6 +860,15 @@ mod tests {
         assert!(require_workspace_scope(None)
             .unwrap_err()
             .contains("cannot run on the API host"));
+    }
+
+    #[test]
+    fn explicit_job_owner_is_isolated_between_users() {
+        let mut job = test_job(DurableJobStatus::Running);
+        assert_eq!(explicit_owner_authorized(&job, "alice"), None);
+        job.owner_user_id = Some("alice".to_string());
+        assert_eq!(explicit_owner_authorized(&job, "alice"), Some(true));
+        assert_eq!(explicit_owner_authorized(&job, "bob"), Some(false));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -23,6 +23,8 @@ use tokio::process::{Child, Command};
 use uuid::Uuid;
 
 use super::routes::AppState;
+use crate::workspace::WorkspaceType;
+use crate::workspace_exec::WorkspaceExec;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -46,6 +48,8 @@ pub struct DurableJob {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub started_by_mission_id: Option<Uuid>,
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
     pub stdout_log: String,
     pub stderr_log: String,
     pub status_file: String,
@@ -58,6 +62,11 @@ pub struct StartDurableJobRequest {
     pub cwd: Option<String>,
     #[serde(default)]
     pub started_by_mission_id: Option<Uuid>,
+    /// Run through this workspace's execution layer. Container workspaces
+    /// therefore use their persistent nspawn namespace and mission cgroup
+    /// caps instead of leaking heavy work into the API service cgroup.
+    #[serde(default)]
+    pub workspace_id: Option<Uuid>,
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
 }
@@ -139,6 +148,48 @@ fn resolve_cwd(base: &Path, raw: Option<&str>) -> Result<PathBuf, String> {
     }
 
     Ok(cwd)
+}
+
+fn resolve_workspace_cwd(
+    workspace_root: &Path,
+    workspace_type: WorkspaceType,
+    raw: Option<&str>,
+) -> Result<PathBuf, String> {
+    let cwd = match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => workspace_root.to_path_buf(),
+        Some(value) => {
+            let path = PathBuf::from(value);
+            if path.is_absolute() && path.starts_with(workspace_root) {
+                path
+            } else if path.is_absolute() && workspace_type == WorkspaceType::Container {
+                workspace_root.join(path.strip_prefix("/").unwrap_or(&path))
+            } else if path.is_absolute() {
+                return Err(format!(
+                    "cwd must stay within workspace root {}",
+                    workspace_root.display()
+                ));
+            } else {
+                workspace_root.join(path)
+            }
+        }
+    };
+
+    if !cwd.is_dir() {
+        return Err(format!("cwd does not exist: {}", cwd.display()));
+    }
+    let canonical_root = workspace_root
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve workspace root: {e}"))?;
+    let canonical_cwd = cwd
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve cwd: {e}"))?;
+    if !canonical_cwd.starts_with(&canonical_root) {
+        return Err(format!(
+            "cwd escapes workspace root {}",
+            workspace_root.display()
+        ));
+    }
+    Ok(canonical_cwd)
 }
 
 fn merge_job_for_write(current: Option<DurableJob>, mut next: DurableJob) -> DurableJob {
@@ -314,18 +365,52 @@ pub async fn start_job(
     if command.is_empty() {
         return Err(err(StatusCode::BAD_REQUEST, "command is required"));
     }
+    if req.started_by_mission_id.is_some() && req.workspace_id.is_none() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "mission-owned durable jobs require workspace_id",
+        ));
+    }
 
-    let cwd = resolve_cwd(&state.config.working_dir, req.cwd.as_deref())
-        .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
+    let workspace =
+        match req.workspace_id {
+            Some(id) => {
+                Some(state.workspaces.get(id).await.ok_or_else(|| {
+                    err(StatusCode::NOT_FOUND, format!("workspace not found: {id}"))
+                })?)
+            }
+            None => None,
+        };
+    let cwd = match workspace.as_ref() {
+        Some(workspace) => resolve_workspace_cwd(
+            &workspace.path,
+            workspace.workspace_type,
+            req.cwd.as_deref(),
+        ),
+        None => resolve_cwd(&state.config.working_dir, req.cwd.as_deref()),
+    }
+    .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
 
     let id = Uuid::new_v4();
     let dir = job_dir(&state, id);
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let stdout_log = dir.join("stdout.log");
-    let stderr_log = dir.join("stderr.log");
-    let status_file = dir.join("exit.json");
+    let runtime_dir = workspace
+        .as_ref()
+        .map(|workspace| {
+            workspace
+                .path
+                .join(".sandboxed-sh/durable-jobs")
+                .join(id.to_string())
+        })
+        .unwrap_or_else(|| dir.clone());
+    tokio::fs::create_dir_all(&runtime_dir)
+        .await
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let stdout_log = runtime_dir.join("stdout.log");
+    let stderr_log = runtime_dir.join("stderr.log");
+    let status_file = runtime_dir.join("exit.json");
 
     let stdout = std::fs::OpenOptions::new()
         .create(true)
@@ -339,30 +424,9 @@ pub async fn start_job(
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let wrapper = format!(
-        "cd \"$SANDBOXED_SH_DURABLE_CWD\" && {{ {}; }}\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n",
+        "{{ {}; }}\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n",
         command
     );
-
-    let mut child = Command::new("/bin/sh");
-    child
-        .arg("-lc")
-        .arg(wrapper)
-        .current_dir(&cwd)
-        .envs(req.env)
-        .env("SANDBOXED_SH_DURABLE_CWD", &cwd)
-        .env("SANDBOXED_SH_DURABLE_STATUS", &status_file)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr));
-    #[cfg(unix)]
-    unsafe {
-        child.pre_exec(|| {
-            if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
 
     let now = Utc::now();
     let mut job = DurableJob {
@@ -376,6 +440,7 @@ pub async fn start_job(
         created_at: now,
         updated_at: now,
         started_by_mission_id: req.started_by_mission_id,
+        workspace_id: req.workspace_id,
         stdout_log: stdout_log.to_string_lossy().to_string(),
         stderr_log: stderr_log.to_string_lossy().to_string(),
         status_file: status_file.to_string_lossy().to_string(),
@@ -384,7 +449,54 @@ pub async fn start_job(
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    let child = match child.spawn() {
+    let mut job_env = req.env;
+    let status_path_for_child = workspace
+        .as_ref()
+        .map(|workspace| {
+            WorkspaceExec::new(workspace.clone()).translate_path_for_container(&status_file)
+        })
+        .unwrap_or_else(|| status_file.to_string_lossy().to_string());
+    job_env.insert(
+        "SANDBOXED_SH_DURABLE_STATUS".to_string(),
+        status_path_for_child,
+    );
+    let shell_args = vec!["-lc".to_string(), wrapper];
+    let child_result = match workspace {
+        Some(workspace) => {
+            WorkspaceExec::new(workspace)
+                .spawn_with_stdio(
+                    &cwd,
+                    "/bin/sh",
+                    &shell_args,
+                    job_env,
+                    Stdio::null(),
+                    Stdio::from(stdout),
+                    Stdio::from(stderr),
+                )
+                .await
+        }
+        None => {
+            let mut child = Command::new("/bin/sh");
+            child
+                .args(&shell_args)
+                .current_dir(&cwd)
+                .envs(job_env)
+                .stdin(Stdio::null())
+                .stdout(Stdio::from(stdout))
+                .stderr(Stdio::from(stderr));
+            #[cfg(unix)]
+            unsafe {
+                child.pre_exec(|| {
+                    if libc::setsid() == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+            child.spawn().map_err(anyhow::Error::from)
+        }
+    };
+    let child = match child_result {
         Ok(child) => child,
         Err(e) => {
             job.status = DurableJobStatus::Failed;
@@ -539,6 +651,7 @@ mod tests {
             created_at: now,
             updated_at: now,
             started_by_mission_id: None,
+            workspace_id: None,
             stdout_log: "/tmp/stdout.log".to_string(),
             stderr_log: "/tmp/stderr.log".to_string(),
             status_file: "/tmp/exit.json".to_string(),
@@ -556,6 +669,29 @@ mod tests {
         let base = std::env::current_dir().unwrap();
         let result = resolve_cwd(&base, Some("__definitely_missing_durable_job_cwd__"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn workspace_cwd_maps_container_absolute_path_inside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let mission = dir.path().join("workspaces/mission-deadbeef");
+        std::fs::create_dir_all(&mission).unwrap();
+
+        let resolved = resolve_workspace_cwd(
+            dir.path(),
+            WorkspaceType::Container,
+            Some("/workspaces/mission-deadbeef"),
+        )
+        .unwrap();
+
+        assert_eq!(resolved, mission.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn workspace_cwd_rejects_host_absolute_path_and_relative_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve_workspace_cwd(dir.path(), WorkspaceType::Host, Some("/tmp")).is_err());
+        assert!(resolve_workspace_cwd(dir.path(), WorkspaceType::Container, Some("../")).is_err());
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -53,6 +53,11 @@ pub struct DurableJob {
     pub stdout_log: String,
     pub stderr_log: String,
     pub status_file: String,
+    /// Transient systemd scope owned by this durable job. It intentionally
+    /// does not carry the launching mission's tag, so mission teardown cannot
+    /// terminate it.
+    #[serde(default)]
+    pub scope_unit: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -319,6 +324,20 @@ fn terminate_process_group(pid: u32) {
     }
 }
 
+async fn stop_scope(unit: &str) -> bool {
+    let unit = if unit.ends_with(".scope") {
+        unit.to_string()
+    } else {
+        format!("{unit}.scope")
+    };
+    Command::new("systemctl")
+        .args(["stop", unit.as_str()])
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 #[cfg(not(unix))]
 fn terminate_process_group(_pid: u32) {}
 
@@ -444,6 +463,11 @@ pub async fn start_job(
         stdout_log: stdout_log.to_string_lossy().to_string(),
         stderr_log: stderr_log.to_string_lossy().to_string(),
         status_file: status_file.to_string_lossy().to_string(),
+        scope_unit: workspace.as_ref().and_then(|workspace| {
+            WorkspaceExec::new(workspace.clone())
+                .machine_name()
+                .map(|machine| crate::workspace_exec::durable_scope_unit(&machine, id))
+        }),
     };
     job = write_job(&state, &job)
         .await
@@ -472,6 +496,7 @@ pub async fn start_job(
                     Stdio::null(),
                     Stdio::from(stdout),
                     Stdio::from(stderr),
+                    id,
                 )
                 .await
         }
@@ -510,8 +535,14 @@ pub async fn start_job(
     job = match write_job(&state, &job).await {
         Ok(job) => job,
         Err(e) => {
-            if let Some(pid) = job.pid {
-                terminate_process_group(pid);
+            let stopped_scope = match job.scope_unit.as_deref() {
+                Some(unit) => stop_scope(unit).await,
+                None => false,
+            };
+            if !stopped_scope {
+                if let Some(pid) = job.pid {
+                    terminate_process_group(pid);
+                }
             }
             job.status = DurableJobStatus::Failed;
             job.updated_at = Utc::now();
@@ -521,8 +552,14 @@ pub async fn start_job(
         }
     };
     if job.status == DurableJobStatus::Cancelled {
-        if let Some(pid) = job.pid {
-            terminate_process_group(pid);
+        let stopped_scope = match job.scope_unit.as_deref() {
+            Some(unit) => stop_scope(unit).await,
+            None => false,
+        };
+        if !stopped_scope {
+            if let Some(pid) = job.pid {
+                terminate_process_group(pid);
+            }
         }
     }
 
@@ -619,8 +656,14 @@ pub async fn cancel_job(
         job = write_job(&state, &job)
             .await
             .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
-        if let Some(pid) = job.pid {
-            terminate_process_group(pid);
+        let stopped_scope = match job.scope_unit.as_deref() {
+            Some(unit) => stop_scope(unit).await,
+            None => false,
+        };
+        if !stopped_scope {
+            if let Some(pid) = job.pid {
+                terminate_process_group(pid);
+            }
         }
     }
     Ok(Json(job))
@@ -655,6 +698,7 @@ mod tests {
             stdout_log: "/tmp/stdout.log".to_string(),
             stderr_log: "/tmp/stderr.log".to_string(),
             status_file: "/tmp/exit.json".to_string(),
+            scope_unit: None,
         }
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7127,8 +7127,8 @@ fn copy_host_executable_into_container(
 
 fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
     output.split_whitespace().find_map(|word| {
-        let candidate = word.trim_start_matches(|c: char| c == 'v' || c == 'V');
-        let mut parts = candidate.split(|c: char| c == '.' || c == '-' || c == '+');
+        let candidate = word.trim_start_matches(['v', 'V']);
+        let mut parts = candidate.split(['.', '-', '+']);
         let major = parts.next()?.parse().ok()?;
         let minor = parts.next()?.parse().ok()?;
         let patch = parts.next()?.parse().ok()?;

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3891,33 +3891,49 @@ fn opencode_session_token_from_line(line: &str) -> Option<&str> {
     None
 }
 
+fn preferred_opencode_bin_dir(nspawn_container: bool, host_home: &str) -> String {
+    if nspawn_container {
+        // Container bootstrap and host synchronization both install the
+        // managed CLI here. Preferring /root/.opencode/bin used to shadow a
+        // newer /usr/local/bin/opencode with a years-old container-local copy.
+        "/usr/local/bin".to_string()
+    } else {
+        format!("{host_home}/.opencode/bin")
+    }
+}
+
+fn prepend_unique_path_entry(current: &str, entry: &str) -> String {
+    std::iter::once(entry)
+        .chain(
+            current
+                .split(':')
+                .filter(|part| !part.is_empty() && *part != entry),
+        )
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+fn should_sync_container_opencode(is_container: bool, uses_nspawn: bool) -> bool {
+    is_container && uses_nspawn
+}
+
 pub(crate) fn prepend_opencode_bin_to_path(
     env: &mut HashMap<String, String>,
     workspace: &Workspace,
 ) {
-    let home = if workspace.workspace_type == WorkspaceType::Container
-        && workspace::use_nspawn_for_workspace(workspace)
-    {
-        "/root".to_string()
-    } else {
-        home_dir()
-    };
-    let bin_dir = format!("{}/.opencode/bin", home);
+    let nspawn_container = workspace.workspace_type == WorkspaceType::Container
+        && workspace::use_nspawn_for_workspace(workspace);
+    let bin_dir = preferred_opencode_bin_dir(nspawn_container, &home_dir());
 
     let current = env
         .get("PATH")
         .cloned()
         .or_else(|| std::env::var("PATH").ok())
         .unwrap_or_default();
-    let already = current.split(':').any(|p| p == bin_dir);
-    if !already {
-        let next = if current.is_empty() {
-            bin_dir.clone()
-        } else {
-            format!("{}:{}", bin_dir, current)
-        };
-        env.insert("PATH".to_string(), next);
-    }
+    env.insert(
+        "PATH".to_string(),
+        prepend_unique_path_entry(&current, &bin_dir),
+    );
 }
 
 pub(crate) fn extract_opencode_session_id(output: &str) -> Option<String> {
@@ -7082,7 +7098,11 @@ fn copy_host_executable_into_container(
         .map_err(|e| format!("Failed to create container /usr/local/bin: {}", e))?;
 
     let dest = dest_dir.join(name);
-    let tmp = dest_dir.join(format!("{}.tmp", name));
+    // Multiple missions can prepare the same container concurrently. A fixed
+    // temporary filename lets one copy truncate or rename another copy while
+    // it is still in progress, so every atomic install needs its own staging
+    // path.
+    let tmp = dest_dir.join(format!("{}.tmp-{}", name, uuid::Uuid::new_v4().simple()));
     std::fs::copy(host_executable, &tmp).map_err(|e| {
         format!(
             "Failed to copy host executable {} into container: {}",
@@ -7097,10 +7117,120 @@ fn copy_host_executable_into_container(
         let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755));
     }
 
-    std::fs::rename(&tmp, &dest)
-        .map_err(|e| format!("Failed to finalize container executable: {}", e))?;
+    if let Err(e) = std::fs::rename(&tmp, &dest) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("Failed to finalize container executable: {}", e));
+    }
 
     Ok(format!("/usr/local/bin/{}", name))
+}
+
+fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
+    output.split_whitespace().find_map(|word| {
+        let candidate = word.trim_start_matches(|c: char| c == 'v' || c == 'V');
+        let mut parts = candidate.split(|c: char| c == '.' || c == '-' || c == '+');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        Some((major, minor, patch))
+    })
+}
+
+async fn host_cli_version(program: &std::path::Path) -> Option<(u64, u64, u64)> {
+    let output = tokio::process::Command::new(program)
+        .arg("--version")
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let combined = format!(
+        "{} {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_cli_semver(&combined)
+}
+
+async fn workspace_cli_version(
+    workspace_exec: &WorkspaceExec,
+    cwd: &std::path::Path,
+    program: &str,
+) -> Option<(u64, u64, u64)> {
+    let output = workspace_exec
+        .output(cwd, program, &["--version".to_string()], HashMap::new())
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let combined = format!(
+        "{} {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_cli_semver(&combined)
+}
+
+/// Keep a container's managed OpenCode CLI identical to the backend host CLI.
+///
+/// Per-workspace execution deliberately resolves binaries inside the target
+/// container. Long-lived containers can therefore retain an old OpenCode even
+/// after the host was upgraded; current plugins then fail during bootstrap
+/// before a model request is made. Exact version equality gives every
+/// workspace the version operators validated on the host and avoids a 100+ MB
+/// copy on every mission.
+async fn sync_container_opencode_from_host(
+    workspace_exec: &WorkspaceExec,
+    cwd: &std::path::Path,
+) -> Result<Option<String>, String> {
+    if !should_sync_container_opencode(
+        workspace_exec.workspace.workspace_type == WorkspaceType::Container,
+        workspace::use_nspawn_for_workspace(&workspace_exec.workspace),
+    ) {
+        return Ok(None);
+    }
+
+    let Some(host_opencode) = resolve_host_executable("opencode") else {
+        return Ok(None);
+    };
+    let Some(host_version) = host_cli_version(&host_opencode).await else {
+        tracing::warn!(
+            host_path = %host_opencode.display(),
+            "Could not determine host OpenCode version; leaving container CLI unchanged"
+        );
+        return Ok(None);
+    };
+
+    let container_program = "/usr/local/bin/opencode";
+    let container_version = if command_available(workspace_exec, cwd, container_program).await {
+        workspace_cli_version(workspace_exec, cwd, container_program).await
+    } else {
+        None
+    };
+
+    if container_version == Some(host_version) {
+        return Ok(None);
+    }
+
+    let installed = copy_host_executable_into_container(&workspace_exec.workspace, &host_opencode)?;
+    let installed_version = workspace_cli_version(workspace_exec, cwd, &installed).await;
+    if installed_version != Some(host_version) {
+        return Err(format!(
+            "Copied host OpenCode {:?} into container, but version probe returned {:?}",
+            host_version, installed_version
+        ));
+    }
+
+    tracing::info!(
+        host_path = %host_opencode.display(),
+        container_path = %installed,
+        old_version = ?container_version,
+        new_version = ?host_version,
+        "Synchronized host OpenCode CLI into container"
+    );
+    Ok(Some(installed))
 }
 
 async fn resolve_opencode_installer_fetcher(
@@ -7172,6 +7302,12 @@ pub(crate) async fn ensure_opencode_cli_available(
     workspace_exec: &WorkspaceExec,
     cwd: &std::path::Path,
 ) -> Result<(), String> {
+    // Availability alone is insufficient: the per-workspace migration exposed
+    // stale container CLIs that could not load plugins installed from `latest`.
+    // Synchronize from the managed host installation before accepting the
+    // container binary.
+    sync_container_opencode_from_host(workspace_exec, cwd).await?;
+
     if opencode_binary_available(workspace_exec, cwd).await {
         return Ok(());
     }
@@ -8174,12 +8310,14 @@ mod tests {
         is_success_path_provider_payload_error, is_success_path_rate_limited_error,
         is_tool_call_only_output, opencode_goal_terminal_status,
         opencode_idle_timeout_result_message, opencode_output_needs_fallback,
-        opencode_session_exists_in_data_home, opencode_session_token_from_line,
+        opencode_session_exists_in_data_home, opencode_session_token_from_line, parse_cli_semver,
         parse_opencode_goal_objective, parse_opencode_session_token, parse_opencode_sse_event,
-        parse_opencode_stderr_text_part, preferred_model_for_cost, record_codex_error_message,
+        parse_opencode_stderr_text_part, preferred_model_for_cost, preferred_opencode_bin_dir,
+        prepend_unique_path_entry, record_codex_error_message,
         replace_filepath_artifact_with_tool_output, running_health, sanitized_opencode_stdout,
-        set_codex_account_cooldown, stall_severity, strip_ansi_codes, strip_opencode_banner_lines,
-        strip_think_tags, summarize_codex_usage_caps, summarize_recent_opencode_stderr,
+        set_codex_account_cooldown, should_sync_container_opencode, stall_severity,
+        strip_ansi_codes, strip_opencode_banner_lines, strip_think_tags,
+        summarize_codex_usage_caps, summarize_recent_opencode_stderr,
         text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
         truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
@@ -11074,6 +11212,55 @@ mod tests {
     fn is_codex_node_wrapper_rejects_nonexistent_file() {
         let wrapper_path = std::path::Path::new("/nonexistent/path/codex");
         assert!(!is_codex_node_wrapper(wrapper_path));
+    }
+
+    #[test]
+    fn parse_cli_semver_accepts_opencode_version_formats() {
+        assert_eq!(parse_cli_semver("1.17.18\n"), Some((1, 17, 18)));
+        assert_eq!(
+            parse_cli_semver("opencode version v1.17.18-beta.2"),
+            Some((1, 17, 18))
+        );
+    }
+
+    #[test]
+    fn parse_cli_semver_rejects_incomplete_or_unrelated_output() {
+        assert_eq!(parse_cli_semver("opencode 1.17"), None);
+        assert_eq!(parse_cli_semver("version unknown"), None);
+    }
+
+    #[test]
+    fn nspawn_opencode_path_prefers_managed_system_binary() {
+        assert_eq!(
+            preferred_opencode_bin_dir(true, "/ignored"),
+            "/usr/local/bin"
+        );
+        assert_eq!(
+            preferred_opencode_bin_dir(false, "/home/agent"),
+            "/home/agent/.opencode/bin"
+        );
+    }
+
+    #[test]
+    fn opencode_path_entry_is_moved_to_front_without_duplicates() {
+        assert_eq!(
+            prepend_unique_path_entry(
+                "/root/.opencode/bin:/usr/local/bin:/usr/bin:/usr/local/bin",
+                "/usr/local/bin"
+            ),
+            "/usr/local/bin:/root/.opencode/bin:/usr/bin"
+        );
+        assert_eq!(
+            prepend_unique_path_entry("", "/usr/local/bin"),
+            "/usr/local/bin"
+        );
+    }
+
+    #[test]
+    fn opencode_sync_is_limited_to_nspawn_containers() {
+        assert!(should_sync_container_opencode(true, true));
+        assert!(!should_sync_container_opencode(true, false));
+        assert!(!should_sync_container_opencode(false, true));
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -5373,11 +5373,53 @@ fn write_json_file(path: &std::path::Path, value: &serde_json::Value) -> std::io
     std::fs::write(path, contents)
 }
 
+fn selected_opencode_auth_path(
+    work_dir: &std::path::Path,
+    shared_path: Option<std::path::PathBuf>,
+    shared_xdg: bool,
+) -> Option<std::path::PathBuf> {
+    if shared_xdg {
+        shared_path
+    } else {
+        Some(
+            work_dir
+                .join(".local")
+                .join("share")
+                .join("opencode")
+                .join("auth.json"),
+        )
+    }
+}
+
+fn selected_opencode_provider_auth_dir(
+    work_dir: &std::path::Path,
+    shared_path: Option<std::path::PathBuf>,
+    shared_xdg: bool,
+) -> Option<std::path::PathBuf> {
+    if shared_xdg {
+        shared_path
+    } else {
+        Some(work_dir.join(".opencode").join("auth"))
+    }
+}
+
 pub(crate) fn sync_opencode_auth_to_workspace(
     workspace: &Workspace,
     app_working_dir: &std::path::Path,
+    work_dir: &std::path::Path,
+    shared_xdg: bool,
 ) -> Option<serde_json::Value> {
     let mut auth_json: Option<serde_json::Value> = None;
+    let auth_path = selected_opencode_auth_path(
+        work_dir,
+        workspace_opencode_auth_path(workspace),
+        shared_xdg,
+    );
+    let provider_auth_dir = selected_opencode_provider_auth_dir(
+        work_dir,
+        workspace_opencode_provider_auth_dir(workspace),
+        shared_xdg,
+    );
 
     if let Some(source_path) = host_opencode_auth_path() {
         if let Ok(contents) = std::fs::read_to_string(&source_path) {
@@ -5386,8 +5428,8 @@ pub(crate) fn sync_opencode_auth_to_workspace(
             }
         }
 
-        if let Some(dest_path) = workspace_opencode_auth_path(workspace) {
-            if dest_path != source_path && source_path.exists() {
+        if let Some(dest_path) = auth_path.as_ref() {
+            if dest_path.as_path() != source_path.as_path() && source_path.exists() {
                 if let Some(parent) = dest_path.parent() {
                     if let Err(e) = std::fs::create_dir_all(parent) {
                         tracing::warn!(
@@ -5397,7 +5439,7 @@ pub(crate) fn sync_opencode_auth_to_workspace(
                         );
                     }
                 }
-                if let Err(e) = std::fs::copy(&source_path, &dest_path) {
+                if let Err(e) = std::fs::copy(&source_path, dest_path) {
                     tracing::warn!(
                         "Failed to copy OpenCode auth.json to workspace {}: {}",
                         dest_path.display(),
@@ -5411,8 +5453,8 @@ pub(crate) fn sync_opencode_auth_to_workspace(
     if auth_json.is_none() {
         auth_json = build_opencode_auth_from_ai_providers(app_working_dir);
         if let Some(ref value) = auth_json {
-            if let Some(dest_path) = workspace_opencode_auth_path(workspace) {
-                if let Err(e) = write_json_file(&dest_path, value) {
+            if let Some(dest_path) = auth_path.as_ref() {
+                if let Err(e) = write_json_file(dest_path, value) {
                     tracing::warn!(
                         "Failed to write OpenCode auth.json to workspace {}: {}",
                         dest_path.display(),
@@ -5432,10 +5474,9 @@ pub(crate) fn sync_opencode_auth_to_workspace(
         "cerebras",
         "minimax",
     ];
-    if let (Some(src_dir), Some(dest_dir)) = (
-        host_opencode_provider_auth_dir(),
-        workspace_opencode_provider_auth_dir(workspace),
-    ) {
+    if let (Some(src_dir), Some(dest_dir)) =
+        (host_opencode_provider_auth_dir(), provider_auth_dir.clone())
+    {
         for provider in providers {
             let src = src_dir.join(format!("{}.json", provider));
             if !src.exists() {
@@ -5464,8 +5505,8 @@ pub(crate) fn sync_opencode_auth_to_workspace(
     }
 
     // Merge provider auth files into auth.json for env export (e.g., XAI_API_KEY)
-    if let Some(provider_dir) = workspace_opencode_provider_auth_dir(workspace) {
-        let provider_entries = load_provider_auth_entries(&provider_dir);
+    if let Some(provider_dir) = provider_auth_dir.as_ref() {
+        let provider_entries = load_provider_auth_entries(provider_dir);
         if !provider_entries.is_empty() {
             let mut merged = match auth_json.take() {
                 Some(serde_json::Value::Object(map)) => map,
@@ -5477,9 +5518,9 @@ pub(crate) fn sync_opencode_auth_to_workspace(
             }
             auth_json = Some(serde_json::Value::Object(merged));
 
-            if let Some(dest_path) = workspace_opencode_auth_path(workspace) {
+            if let Some(dest_path) = auth_path.as_ref() {
                 if let Some(ref value) = auth_json {
-                    if let Err(e) = write_json_file(&dest_path, value) {
+                    if let Err(e) = write_json_file(dest_path, value) {
                         tracing::warn!(
                             "Failed to write merged OpenCode auth.json to workspace {}: {}",
                             dest_path.display(),
@@ -5491,10 +5532,7 @@ pub(crate) fn sync_opencode_auth_to_workspace(
         }
     }
 
-    if let (Some(value), Some(dest_dir)) = (
-        auth_json.as_ref(),
-        workspace_opencode_provider_auth_dir(workspace),
-    ) {
+    if let (Some(value), Some(dest_dir)) = (auth_json.as_ref(), provider_auth_dir) {
         let provider_entries = [
             ("openai", "OpenAI"),
             ("anthropic", "Anthropic"),
@@ -8315,6 +8353,7 @@ mod tests {
         parse_opencode_stderr_text_part, preferred_model_for_cost, preferred_opencode_bin_dir,
         prepend_unique_path_entry, record_codex_error_message,
         replace_filepath_artifact_with_tool_output, running_health, sanitized_opencode_stdout,
+        selected_opencode_auth_path, selected_opencode_provider_auth_dir,
         set_codex_account_cooldown, should_sync_container_opencode, stall_severity,
         strip_ansi_codes, strip_opencode_banner_lines, strip_think_tags,
         summarize_codex_usage_caps, summarize_recent_opencode_stderr,
@@ -8338,6 +8377,30 @@ mod tests {
     use std::fs;
     use std::time::Duration;
     use uuid::Uuid;
+
+    #[test]
+    fn isolated_opencode_auth_follows_the_mission_xdg_paths() {
+        let work_dir = std::path::Path::new("/containers/demo/workspaces/mission-abcd");
+        let shared_auth = std::path::PathBuf::from("/containers/demo/root/auth.json");
+        let shared_providers = std::path::PathBuf::from("/containers/demo/root/.opencode/auth");
+
+        assert_eq!(
+            selected_opencode_auth_path(work_dir, Some(shared_auth.clone()), false),
+            Some(work_dir.join(".local/share/opencode/auth.json"))
+        );
+        assert_eq!(
+            selected_opencode_provider_auth_dir(work_dir, Some(shared_providers.clone()), false),
+            Some(work_dir.join(".opencode/auth"))
+        );
+        assert_eq!(
+            selected_opencode_auth_path(work_dir, Some(shared_auth.clone()), true),
+            Some(shared_auth)
+        );
+        assert_eq!(
+            selected_opencode_provider_auth_dir(work_dir, Some(shared_providers.clone()), true),
+            Some(shared_providers)
+        );
+    }
 
     #[test]
     fn curl_dependency_error_detects_missing_curl() {

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -481,6 +481,9 @@ pub enum TriggerType {
     Webhook { config: WebhookConfig },
     /// Trigger immediately after an agent turn finishes for the mission
     AgentFinished,
+    /// Trigger once the durable job started by this mission is no longer
+    /// running. This avoids spending repeated agent turns polling a build.
+    DurableJobTerminal { job_id: Uuid },
     /// Telegram bot trigger (messages are routed via the Telegram bridge)
     Telegram { config: TelegramTriggerConfig },
 }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -780,6 +780,19 @@ impl SqliteMissionStore {
                 TriggerType::Webhook { config }
             }
             "agent_finished" => TriggerType::AgentFinished,
+            "durable_job_terminal" => {
+                let data: serde_json::Value = serde_json::from_str(&trigger_data)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+                let job_id = data["job_id"]
+                    .as_str()
+                    .and_then(|value| Uuid::parse_str(value).ok())
+                    .ok_or_else(|| {
+                        rusqlite::Error::ToSqlConversionFailure(
+                            "Invalid durable_job_terminal job_id".into(),
+                        )
+                    })?;
+                TriggerType::DurableJobTerminal { job_id }
+            }
             "telegram" => {
                 let config: super::TelegramTriggerConfig = serde_json::from_str(&trigger_data)
                     .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
@@ -5949,6 +5962,10 @@ impl MissionStore for SqliteMissionStore {
                 serde_json::to_string(config).map_err(|e| e.to_string())?,
             ),
             TriggerType::AgentFinished => ("agent_finished", "{}".to_string()),
+            TriggerType::DurableJobTerminal { job_id } => (
+                "durable_job_terminal",
+                serde_json::json!({ "job_id": job_id }).to_string(),
+            ),
             TriggerType::Telegram { config } => (
                 "telegram",
                 serde_json::to_string(config).map_err(|e| e.to_string())?,
@@ -6189,6 +6206,10 @@ impl MissionStore for SqliteMissionStore {
                 serde_json::to_string(config).map_err(|e| e.to_string())?,
             ),
             TriggerType::AgentFinished => ("agent_finished", "{}".to_string()),
+            TriggerType::DurableJobTerminal { job_id } => (
+                "durable_job_terminal",
+                serde_json::json!({ "job_id": job_id }).to_string(),
+            ),
             TriggerType::Telegram { config } => (
                 "telegram",
                 serde_json::to_string(config).map_err(|e| e.to_string())?,
@@ -9827,6 +9848,10 @@ impl MissionStore for SqliteMissionStore {
                         serde_json::to_string(config).unwrap_or_else(|_| "{}".to_string()),
                     ),
                     TriggerType::AgentFinished => ("agent_finished", "{}".to_string()),
+                    TriggerType::DurableJobTerminal { job_id } => (
+                        "durable_job_terminal",
+                        serde_json::json!({ "job_id": job_id }).to_string(),
+                    ),
                     TriggerType::Telegram { config } => (
                         "telegram",
                         serde_json::to_string(config).unwrap_or_else(|_| "{}".to_string()),
@@ -14462,6 +14487,57 @@ mod tests {
             ids.contains(&preserved_active_id),
             "active harness_loop row represents an in-progress loop and must survive"
         );
+    }
+
+    #[tokio::test]
+    async fn durable_job_terminal_automation_roundtrips() {
+        use std::collections::HashMap;
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(
+                Some("durable owner"),
+                None,
+                None,
+                None,
+                None,
+                Some("codex"),
+                None,
+            )
+            .await
+            .expect("mission");
+        let job_id = Uuid::new_v4();
+        let automation = Automation {
+            id: Uuid::new_v4(),
+            mission_id: mission.id,
+            command_source: CommandSource::Inline {
+                content: "inspect terminal job".into(),
+            },
+            trigger: TriggerType::DurableJobTerminal { job_id },
+            variables: HashMap::new(),
+            active: true,
+            created_at: now_string(),
+            last_triggered_at: None,
+            retry_config: RetryConfig::default(),
+            stop_policy: StopPolicy::AfterFirstFire,
+            fresh_session: FreshSession::Keep,
+            consecutive_failures: 0,
+            driver: AutomationDriver::Scheduler,
+        };
+
+        store
+            .create_automation(automation.clone())
+            .await
+            .expect("create automation");
+        let loaded = store
+            .get_automation(automation.id)
+            .await
+            .expect("load automation")
+            .expect("automation exists");
+        assert_eq!(loaded.trigger, TriggerType::DurableJobTerminal { job_id });
     }
 
     #[tokio::test]

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -80,6 +80,83 @@ async fn read_settings(state: &Arc<AppState>) -> (bool, u32) {
     (enabled, days)
 }
 
+/// One mission's GC/reaper-relevant metadata, keyed by 8-hex short id.
+#[derive(Debug, Clone)]
+pub struct MissionIndexEntry {
+    pub status: MissionStatus,
+    pub updated_at: DateTime<Utc>,
+    pub workspace_id: uuid::Uuid,
+}
+
+/// How protected a status is, for short-id collision resolution: running >
+/// parked > terminal. The more protective entry wins so a collision can
+/// never cause a live mission's dir/scope to be collected.
+fn protection_rank(status: &MissionStatus) -> u8 {
+    match status {
+        MissionStatus::Active | MissionStatus::Pending | MissionStatus::WaitingBackground => 2,
+        MissionStatus::AwaitingUser | MissionStatus::Paused => 1,
+        _ => 0,
+    }
+}
+
+/// Index every mission across all live sessions' stores by the first 8 hex
+/// chars of its id — the same prefix embedded in workspace dir names
+/// (`mission-<8hex>`) and exec scope units (`-m<8hex>-`). Shared by the
+/// orphan-dir sweep and the scope reaper.
+pub(crate) async fn build_mission_index(
+    state: &Arc<AppState>,
+) -> std::collections::HashMap<String, MissionIndexEntry> {
+    let mut index: std::collections::HashMap<String, MissionIndexEntry> =
+        std::collections::HashMap::new();
+    let sessions = state.control.all_sessions().await;
+    for session in sessions {
+        let store = session.mission_store.clone();
+        let mut offset = 0usize;
+        loop {
+            let page = match store.list_missions(LIST_PAGE_SIZE, offset).await {
+                Ok(page) => page,
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "mission index: list_missions failed; skipping session"
+                    );
+                    break;
+                }
+            };
+            if page.is_empty() {
+                break;
+            }
+            let page_len = page.len();
+            for mission in page {
+                let short = mission.id.to_string()[..8].to_string();
+                let updated_at = DateTime::parse_from_rfc3339(&mission.updated_at)
+                    .map(|ts| ts.with_timezone(&Utc))
+                    // Unparseable timestamp → treat as "just now" so the
+                    // entry is maximally protective rather than collectable.
+                    .unwrap_or_else(|_| Utc::now());
+                let entry = MissionIndexEntry {
+                    status: mission.status,
+                    updated_at,
+                    workspace_id: mission.workspace_id,
+                };
+                match index.get(&short) {
+                    Some(existing)
+                        if (protection_rank(&existing.status), existing.updated_at)
+                            >= (protection_rank(&entry.status), entry.updated_at) => {}
+                    _ => {
+                        index.insert(short, entry);
+                    }
+                }
+            }
+            if page_len < LIST_PAGE_SIZE {
+                break;
+            }
+            offset += page_len;
+        }
+    }
+    index
+}
+
 #[derive(Default)]
 pub struct SweepReport {
     pub scanned: usize,

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -200,10 +200,14 @@ pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
             let page = match store.list_missions(LIST_PAGE_SIZE, offset).await {
                 Ok(page) => page,
                 Err(err) => {
+                    // Fail closed: a store we couldn't fully page may hold
+                    // missions whose dirs/scopes must not be treated as
+                    // unknown by the deletion branches.
                     tracing::warn!(
                         ?err,
-                        "mission index: list_missions failed; skipping session"
+                        "mission index: list_missions failed; index marked incomplete"
                     );
+                    complete = false;
                     break;
                 }
             };

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -258,8 +258,21 @@ pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
         .working_dir
         .join(".sandboxed-sh")
         .join("missions");
-    if let Ok(mut rd) = tokio::fs::read_dir(&missions_dir).await {
-        while let Ok(Some(entry)) = rd.next_entry().await {
+    match tokio::fs::read_dir(&missions_dir).await {
+        Ok(mut rd) => loop {
+            let entry = match rd.next_entry().await {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break,
+                Err(err) => {
+                    tracing::warn!(
+                        dir = %missions_dir.display(),
+                        ?err,
+                        "mission index: directory iteration failed; index marked incomplete"
+                    );
+                    complete = false;
+                    break;
+                }
+            };
             let name = entry.file_name().to_string_lossy().into_owned();
             let Some(stem) = name.strip_prefix("missions-") else {
                 continue;
@@ -307,6 +320,15 @@ pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
                     complete = false;
                 }
             }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            tracing::warn!(
+                dir = %missions_dir.display(),
+                ?err,
+                "mission index: persisted-store directory unreadable; index marked incomplete"
+            );
+            complete = false;
         }
     }
 

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -32,6 +32,9 @@ const TICK_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour
 /// Default retention when no value is configured in settings.
 pub const DEFAULT_RETENTION_DAYS: u32 = 7;
 
+/// Default long-stop retention for AwaitingUser/Paused mission dirs.
+pub const DEFAULT_STOPPED_RETENTION_DAYS: u32 = 30;
+
 /// Page size for `list_missions` pagination — keeps the scan bounded in
 /// memory even when a session has thousands of missions.
 const LIST_PAGE_SIZE: usize = 200;
@@ -51,33 +54,58 @@ async fn run_loop(state: Arc<AppState>) {
     loop {
         interval.tick().await;
         let started = std::time::Instant::now();
-        let (enabled, days) = read_settings(&state).await;
-        if !enabled {
+        let settings = read_settings(&state).await;
+        if !settings.enabled {
             tracing::trace!("mission workspace GC disabled");
             continue;
         }
-        let cutoff = Utc::now() - chrono::Duration::days(days as i64);
-        let report = run_once(&state, cutoff).await;
+        let now = Utc::now();
+        let params = SweepParams {
+            cutoff: now - chrono::Duration::days(settings.days as i64),
+            stopped_cutoff: now - chrono::Duration::days(settings.stopped_days as i64),
+            orphans_enabled: settings.orphans_enabled,
+        };
+        let report = run_once(&state, &params).await;
         tracing::info!(
             removed = report.removed,
+            orphans_removed = report.orphans_removed,
+            stopped_removed = report.stopped_removed,
             errors = report.errors,
             scanned = report.scanned,
             bytes_freed = report.bytes_freed,
             duration_ms = started.elapsed().as_millis() as u64,
-            retention_days = days,
+            retention_days = settings.days,
+            stopped_retention_days = settings.stopped_days,
             "mission workspace GC sweep finished",
         );
     }
 }
 
-async fn read_settings(state: &Arc<AppState>) -> (bool, u32) {
+struct GcSettings {
+    enabled: bool,
+    days: u32,
+    stopped_days: u32,
+    orphans_enabled: bool,
+}
+
+async fn read_settings(state: &Arc<AppState>) -> GcSettings {
     let snapshot = state.settings.get().await;
     let enabled = snapshot.auto_cleanup_enabled.unwrap_or(false);
     let days = snapshot
         .auto_cleanup_days
         .filter(|d| *d >= 1)
         .unwrap_or(DEFAULT_RETENTION_DAYS);
-    (enabled, days)
+    let stopped_days = snapshot
+        .auto_cleanup_stopped_days
+        .filter(|d| *d >= 1)
+        .unwrap_or(DEFAULT_STOPPED_RETENTION_DAYS);
+    let orphans_enabled = snapshot.auto_cleanup_orphans_enabled.unwrap_or(enabled);
+    GcSettings {
+        enabled,
+        days,
+        stopped_days,
+        orphans_enabled,
+    }
 }
 
 /// One mission's GC/reaper-relevant metadata, keyed by 8-hex short id.
@@ -161,12 +189,32 @@ pub(crate) async fn build_mission_index(
 pub struct SweepReport {
     pub scanned: usize,
     pub removed: usize,
+    /// Dirs matching no mission in any store (hard-deleted / legacy DBs).
+    pub orphans_removed: usize,
+    /// AwaitingUser/Paused dirs past the long-stop retention.
+    pub stopped_removed: usize,
     pub errors: usize,
     pub bytes_freed: u64,
 }
 
-/// One full pass: enumerate sessions → missions → eligible → delete.
-pub async fn run_once(state: &Arc<AppState>, cutoff: DateTime<Utc>) -> SweepReport {
+/// Cutoffs and toggles for one sweep.
+pub struct SweepParams {
+    /// Terminal missions older than this are collected.
+    pub cutoff: DateTime<Utc>,
+    /// AwaitingUser/Paused missions older than this are collected.
+    pub stopped_cutoff: DateTime<Utc>,
+    /// Whether unmatched `mission-*` dirs are collected.
+    pub orphans_enabled: bool,
+}
+
+/// One full pass. Phase 1 is DB-driven (mission → its recorded workspace →
+/// dir). Phase 2 is disk-driven (every `mission-*` dir under every known
+/// workspace root, reconciled against the mission index) — it catches what
+/// phase 1 structurally cannot: dirs of hard-deleted missions, dirs under a
+/// different-but-existing workspace than the mission's recorded one, and
+/// long-stopped AwaitingUser/Paused missions.
+pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepReport {
+    let cutoff = params.cutoff;
     let mut report = SweepReport::default();
     let sessions = state.control.all_sessions().await;
     for session in sessions {
@@ -199,7 +247,16 @@ pub async fn run_once(state: &Arc<AppState>, cutoff: DateTime<Utc>) -> SweepRepo
                 let workspace_id = mission.workspace_id;
                 let ws = match state.workspaces.get(workspace_id).await {
                     Some(ws) => ws,
-                    None => continue,
+                    None => {
+                        // The orphan sweep (phase 2) is what actually
+                        // reclaims these; the log is forensics.
+                        tracing::debug!(
+                            mission_id = %mission.id,
+                            workspace_id = %workspace_id,
+                            "mission GC: workspace no longer exists; dir left to orphan sweep",
+                        );
+                        continue;
+                    }
                 };
                 let dir = workspace::mission_workspace_dir_for_root(&ws.path, mission.id);
                 if !dir.exists() {
@@ -235,7 +292,131 @@ pub async fn run_once(state: &Arc<AppState>, cutoff: DateTime<Utc>) -> SweepRepo
             offset += page_len;
         }
     }
+
+    orphan_sweep(state, params, &mut report).await;
+
     report
+}
+
+/// Disk-driven reconciliation pass (phase 2). Every decision is logged with
+/// its reason; deletion requires positive evidence of collectability, and a
+/// live exec scope always wins.
+async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut SweepReport) {
+    let index = build_mission_index(state).await;
+    // Any dir whose short id is referenced by a live exec scope is kept
+    // unconditionally: a process may hold cwd/fds there.
+    let scope_protected: std::collections::HashSet<String> =
+        super::scope_reaper::list_exec_scope_units()
+            .await
+            .iter()
+            .filter_map(|u| crate::workspace_exec::mission_short_id_from_exec_unit(u))
+            .collect();
+
+    for ws in state.workspaces.list().await {
+        let root = workspace::workspaces_root_for(&ws.path);
+        let Ok(mut rd) = tokio::fs::read_dir(&root).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(short) = name.strip_prefix("mission-") else {
+                continue;
+            };
+            if short.len() != 8 || !short.chars().all(|c| c.is_ascii_hexdigit()) {
+                continue;
+            }
+            let dir = entry.path();
+            if !entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            if scope_protected.contains(short) {
+                tracing::debug!(path = %dir.display(), "mission GC: kept (live exec scope)");
+                continue;
+            }
+            enum Verdict {
+                Keep(&'static str),
+                Delete(&'static str, bool /*orphan*/, bool /*stopped*/),
+            }
+            let verdict = match index.get(short) {
+                Some(e) => match e.status {
+                    MissionStatus::Active
+                    | MissionStatus::Pending
+                    | MissionStatus::WaitingBackground => Verdict::Keep("mission running"),
+                    MissionStatus::AwaitingUser | MissionStatus::Paused => {
+                        if e.updated_at < params.stopped_cutoff {
+                            Verdict::Delete("stopped mission past long-stop retention", false, true)
+                        } else {
+                            Verdict::Keep("awaiting user / paused within retention")
+                        }
+                    }
+                    _ => {
+                        if e.updated_at < params.cutoff {
+                            Verdict::Delete("terminal mission past retention", false, false)
+                        } else {
+                            Verdict::Keep("terminal mission within retention")
+                        }
+                    }
+                },
+                None => {
+                    if !params.orphans_enabled {
+                        Verdict::Keep("orphan collection disabled")
+                    } else {
+                        // No mission anywhere claims this dir. Use the dir
+                        // mtime as the age signal, with the normal retention
+                        // as a grace period for freshly-created dirs whose
+                        // mission row hasn't landed yet.
+                        let old_enough = match tokio::fs::metadata(&dir).await {
+                            Ok(meta) => match meta.modified() {
+                                Ok(mtime) => chrono::DateTime::<Utc>::from(mtime) < params.cutoff,
+                                Err(_) => false,
+                            },
+                            Err(_) => false,
+                        };
+                        if old_enough {
+                            Verdict::Delete("no mission in any store", true, false)
+                        } else {
+                            Verdict::Keep("unmatched but too recent")
+                        }
+                    }
+                }
+            };
+            match verdict {
+                Verdict::Keep(reason) => {
+                    tracing::debug!(path = %dir.display(), reason, "mission GC: kept");
+                }
+                Verdict::Delete(reason, orphan, stopped) => {
+                    let size = directory_size_bytes(&dir).await;
+                    match tokio::fs::remove_dir_all(&dir).await {
+                        Ok(()) => {
+                            report.removed += 1;
+                            if orphan {
+                                report.orphans_removed += 1;
+                            }
+                            if stopped {
+                                report.stopped_removed += 1;
+                            }
+                            report.bytes_freed = report.bytes_freed.saturating_add(size);
+                            tracing::info!(
+                                path = %dir.display(),
+                                workspace = %ws.name,
+                                bytes = size,
+                                reason,
+                                "mission GC: removed workspace directory (orphan sweep)",
+                            );
+                        }
+                        Err(err) => {
+                            report.errors += 1;
+                            tracing::warn!(
+                                path = %dir.display(),
+                                ?err,
+                                "mission GC: failed to remove directory (orphan sweep)",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Strict terminal-status filter — narrower than

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -184,6 +184,72 @@ fn index_store_file_blocking(
     Ok(out)
 }
 
+/// Resolve one exact mission from persisted stores without requiring its user
+/// session to have booted in this process. Remote-build admission uses this
+/// after restart so a still-running OAuth user's workspace is not rejected.
+pub(crate) async fn persisted_mission_status(
+    state: &AppState,
+    mission_id: uuid::Uuid,
+) -> Result<Option<MissionStatus>, String> {
+    let missions_dir = state
+        .config
+        .working_dir
+        .join(".sandboxed-sh")
+        .join("missions");
+    tokio::task::spawn_blocking(move || {
+        let entries = match std::fs::read_dir(&missions_dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(format!("read {}: {err}", missions_dir.display())),
+        };
+        let id = mission_id.to_string();
+        for entry in entries {
+            let entry = entry.map_err(|err| err.to_string())?;
+            let path = entry.path();
+            match path.extension().and_then(|ext| ext.to_str()) {
+                Some("db") => {
+                    let conn = rusqlite::Connection::open_with_flags(
+                        &path,
+                        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+                    )
+                    .map_err(|err| format!("open {}: {err}", path.display()))?;
+                    let mut stmt = conn
+                        .prepare("SELECT status FROM missions WHERE id = ?1 LIMIT 1")
+                        .map_err(|err| format!("query {}: {err}", path.display()))?;
+                    let mut rows = stmt
+                        .query([id.as_str()])
+                        .map_err(|err| format!("query {}: {err}", path.display()))?;
+                    if let Some(row) = rows.next().map_err(|err| err.to_string())? {
+                        let raw: String = row.get(0).map_err(|err| err.to_string())?;
+                        let status = serde_json::from_value(serde_json::Value::String(raw))
+                            .map_err(|err| err.to_string())?;
+                        return Ok(Some(status));
+                    }
+                }
+                Some("json") => {
+                    let bytes = std::fs::read(&path)
+                        .map_err(|err| format!("read {}: {err}", path.display()))?;
+                    let snapshot: serde_json::Value = serde_json::from_slice(&bytes)
+                        .map_err(|err| format!("parse {}: {err}", path.display()))?;
+                    if let Some(raw) = snapshot
+                        .get("missions")
+                        .and_then(|missions| missions.get(&id))
+                        .and_then(|mission| mission.get("status"))
+                    {
+                        let status =
+                            serde_json::from_value(raw.clone()).map_err(|err| err.to_string())?;
+                        return Ok(Some(status));
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(None)
+    })
+    .await
+    .map_err(|err| err.to_string())?
+}
+
 /// Index every mission across all persisted stores by the first 8 hex
 /// chars of its id — the same prefix embedded in workspace dir names
 /// (`mission-<8hex>`) and exec scope units (`-m<8hex>-`). Shared by the

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -202,6 +202,146 @@ fn index_store_file_blocking(
     Ok(out)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PersistedMissionStoreKind {
+    Sqlite,
+    File,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PersistedMissionStoreLocation {
+    kind: PersistedMissionStoreKind,
+    user_key: String,
+    status: MissionStatus,
+}
+
+fn persisted_mission_store_location_blocking(
+    missions_dir: &std::path::Path,
+    mission_id: uuid::Uuid,
+) -> Result<Option<PersistedMissionStoreLocation>, String> {
+    let entries = match std::fs::read_dir(missions_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(format!("read {}: {err}", missions_dir.display())),
+    };
+    let id = mission_id.to_string();
+    for entry in entries {
+        let entry = entry.map_err(|err| err.to_string())?;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some(stem) = name.strip_prefix("missions-") else {
+            continue;
+        };
+        match path.extension().and_then(|ext| ext.to_str()) {
+            Some("db") => {
+                let Some(user_key) = stem.strip_suffix(".db") else {
+                    continue;
+                };
+                let conn = rusqlite::Connection::open_with_flags(
+                    &path,
+                    rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+                )
+                .map_err(|err| format!("open {}: {err}", path.display()))?;
+                let mut stmt = conn
+                    .prepare("SELECT status FROM missions WHERE id = ?1 LIMIT 1")
+                    .map_err(|err| format!("query {}: {err}", path.display()))?;
+                let mut rows = stmt
+                    .query([id.as_str()])
+                    .map_err(|err| format!("query {}: {err}", path.display()))?;
+                if let Some(row) = rows.next().map_err(|err| err.to_string())? {
+                    let raw: String = row.get(0).map_err(|err| err.to_string())?;
+                    let status = serde_json::from_value(serde_json::Value::String(raw))
+                        .map_err(|err| err.to_string())?;
+                    return Ok(Some(PersistedMissionStoreLocation {
+                        kind: PersistedMissionStoreKind::Sqlite,
+                        user_key: user_key.to_string(),
+                        status,
+                    }));
+                }
+            }
+            Some("json") => {
+                let Some(user_key) = stem.strip_suffix(".json") else {
+                    continue;
+                };
+                let bytes = std::fs::read(&path)
+                    .map_err(|err| format!("read {}: {err}", path.display()))?;
+                let snapshot: serde_json::Value = serde_json::from_slice(&bytes)
+                    .map_err(|err| format!("parse {}: {err}", path.display()))?;
+                if let Some(raw) = snapshot
+                    .get("missions")
+                    .and_then(|missions| missions.get(&id))
+                    .and_then(|mission| mission.get("status"))
+                {
+                    let status =
+                        serde_json::from_value(raw.clone()).map_err(|err| err.to_string())?;
+                    return Ok(Some(PersistedMissionStoreLocation {
+                        kind: PersistedMissionStoreKind::File,
+                        user_key: user_key.to_string(),
+                        status,
+                    }));
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(None)
+}
+
+/// Resolve one exact mission's owning store without requiring its user
+/// session to have booted in this process. The returned store can finalize
+/// durable work for an offline OAuth user without registering a second,
+/// filename-sanitized control session for that user.
+async fn persisted_mission_store_in_dir(
+    missions_dir: std::path::PathBuf,
+    mission_id: uuid::Uuid,
+) -> Result<Option<(Arc<dyn super::mission_store::MissionStore>, MissionStatus)>, String> {
+    let location = tokio::task::spawn_blocking({
+        let missions_dir = missions_dir.clone();
+        move || persisted_mission_store_location_blocking(&missions_dir, mission_id)
+    })
+    .await
+    .map_err(|err| err.to_string())??;
+    let Some(location) = location else {
+        return Ok(None);
+    };
+    if location.kind == PersistedMissionStoreKind::File {
+        // FileMissionStore rewrites its whole in-memory snapshot. Opening a
+        // second writer here could lose updates if the user's live session
+        // boots while recovery is polling. SQLite is safe for this use: WAL
+        // plus its configured busy timeout serializes the two connections.
+        return Err(
+            "offline durable mission recovery requires the SQLite mission store".to_string(),
+        );
+    }
+    let store: Arc<dyn super::mission_store::MissionStore> = Arc::from(
+        super::mission_store::create_mission_store(
+            super::mission_store::MissionStoreType::Sqlite,
+            missions_dir,
+            &location.user_key,
+        )
+        .await?,
+    );
+    let Some(mission) = store.get_mission(mission_id).await? else {
+        return Ok(None);
+    };
+    Ok(Some((store, mission.status)))
+}
+
+pub(crate) async fn persisted_mission_store(
+    state: &AppState,
+    mission_id: uuid::Uuid,
+) -> Result<Option<(Arc<dyn super::mission_store::MissionStore>, MissionStatus)>, String> {
+    persisted_mission_store_in_dir(
+        state
+            .config
+            .working_dir
+            .join(".sandboxed-sh")
+            .join("missions"),
+        mission_id,
+    )
+    .await
+}
+
 /// Resolve one exact mission from persisted stores without requiring its user
 /// session to have booted in this process. Remote-build admission uses this
 /// after restart so a still-running OAuth user's workspace is not rejected.
@@ -215,54 +355,10 @@ pub(crate) async fn persisted_mission_status(
         .join(".sandboxed-sh")
         .join("missions");
     tokio::task::spawn_blocking(move || {
-        let entries = match std::fs::read_dir(&missions_dir) {
-            Ok(entries) => entries,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(err) => return Err(format!("read {}: {err}", missions_dir.display())),
-        };
-        let id = mission_id.to_string();
-        for entry in entries {
-            let entry = entry.map_err(|err| err.to_string())?;
-            let path = entry.path();
-            match path.extension().and_then(|ext| ext.to_str()) {
-                Some("db") => {
-                    let conn = rusqlite::Connection::open_with_flags(
-                        &path,
-                        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-                    )
-                    .map_err(|err| format!("open {}: {err}", path.display()))?;
-                    let mut stmt = conn
-                        .prepare("SELECT status FROM missions WHERE id = ?1 LIMIT 1")
-                        .map_err(|err| format!("query {}: {err}", path.display()))?;
-                    let mut rows = stmt
-                        .query([id.as_str()])
-                        .map_err(|err| format!("query {}: {err}", path.display()))?;
-                    if let Some(row) = rows.next().map_err(|err| err.to_string())? {
-                        let raw: String = row.get(0).map_err(|err| err.to_string())?;
-                        let status = serde_json::from_value(serde_json::Value::String(raw))
-                            .map_err(|err| err.to_string())?;
-                        return Ok(Some(status));
-                    }
-                }
-                Some("json") => {
-                    let bytes = std::fs::read(&path)
-                        .map_err(|err| format!("read {}: {err}", path.display()))?;
-                    let snapshot: serde_json::Value = serde_json::from_slice(&bytes)
-                        .map_err(|err| format!("parse {}: {err}", path.display()))?;
-                    if let Some(raw) = snapshot
-                        .get("missions")
-                        .and_then(|missions| missions.get(&id))
-                        .and_then(|mission| mission.get("status"))
-                    {
-                        let status =
-                            serde_json::from_value(raw.clone()).map_err(|err| err.to_string())?;
-                        return Ok(Some(status));
-                    }
-                }
-                _ => {}
-            }
-        }
-        Ok(None)
+        Ok(
+            persisted_mission_store_location_blocking(&missions_dir, mission_id)?
+                .map(|location| location.status),
+        )
     })
     .await
     .map_err(|err| err.to_string())?
@@ -704,6 +800,7 @@ async fn directory_size_bytes(path: &std::path::Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::mission_store::{MissionStore, SqliteMissionStore};
 
     #[test]
     fn short_id_collisions_are_resolved_within_the_actual_workspace() {
@@ -750,5 +847,33 @@ mod tests {
             entry_for_workspace(&entries, workspace_id).unwrap().status,
             MissionStatus::Active
         );
+    }
+
+    #[tokio::test]
+    async fn persisted_owner_store_is_found_without_a_live_oauth_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMissionStore::new(dir.path().to_path_buf(), "github:42")
+            .await
+            .unwrap();
+        let mission = store
+            .create_mission(Some("offline owner"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        drop(store);
+
+        let location = persisted_mission_store_location_blocking(dir.path(), mission.id)
+            .unwrap()
+            .expect("persisted mission owner should be discoverable");
+
+        assert_eq!(location.kind, PersistedMissionStoreKind::Sqlite);
+        assert_eq!(location.user_key, "github_42");
+        assert_eq!(location.status, MissionStatus::Pending);
+        let (reopened, status) =
+            persisted_mission_store_in_dir(dir.path().to_path_buf(), mission.id)
+                .await
+                .unwrap()
+                .expect("offline persisted owner should be usable by the reconciler");
+        assert_eq!(status, MissionStatus::Pending);
+        assert!(reopened.get_mission(mission.id).await.unwrap().is_some());
     }
 }

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -135,8 +135,26 @@ fn protection_rank(status: &MissionStatus) -> u8 {
 /// read offline (read-only SQLite); if any store can't be read, `complete`
 /// is false and callers must skip their unknown-entry deletion branches.
 pub(crate) struct MissionIndex {
-    pub by_short: std::collections::HashMap<String, MissionIndexEntry>,
+    pub by_short: std::collections::HashMap<String, Vec<MissionIndexEntry>>,
     pub complete: bool,
+}
+
+/// Select the most protective mission that owns the directory/scope's actual
+/// workspace. Short ids are only eight hex characters, so entries from other
+/// workspaces must never influence collection on a collision.
+pub(crate) fn entry_for_workspace(
+    entries: &[MissionIndexEntry],
+    workspace_id: uuid::Uuid,
+) -> Option<&MissionIndexEntry> {
+    entries
+        .iter()
+        .filter(|entry| entry.workspace_id == workspace_id)
+        .max_by_key(|entry| {
+            (
+                protection_rank(&entry.status),
+                entry.updated_at.timestamp_micros(),
+            )
+        })
 }
 
 /// Read one persisted SQLite mission store without booting a session.
@@ -255,7 +273,7 @@ pub(crate) async fn persisted_mission_status(
 /// (`mission-<8hex>`) and exec scope units (`-m<8hex>-`). Shared by the
 /// orphan-dir sweep and the scope reaper.
 pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
-    let mut index: std::collections::HashMap<String, MissionIndexEntry> =
+    let mut index: std::collections::HashMap<String, Vec<MissionIndexEntry>> =
         std::collections::HashMap::new();
     let mut complete = true;
     let sessions = state.control.all_sessions().await;
@@ -293,14 +311,7 @@ pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
                     updated_at,
                     workspace_id: mission.workspace_id,
                 };
-                match index.get(&short) {
-                    Some(existing)
-                        if (protection_rank(&existing.status), existing.updated_at)
-                            >= (protection_rank(&entry.status), entry.updated_at) => {}
-                    _ => {
-                        index.insert(short, entry);
-                    }
-                }
+                index.entry(short).or_default().push(entry);
             }
             if page_len < LIST_PAGE_SIZE {
                 break;
@@ -357,14 +368,7 @@ pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
                 match rows {
                     Ok(rows) => {
                         for (short, entry) in rows {
-                            match index.get(&short) {
-                                Some(existing)
-                                    if (protection_rank(&existing.status), existing.updated_at)
-                                        >= (protection_rank(&entry.status), entry.updated_at) => {}
-                                _ => {
-                                    index.insert(short, entry);
-                                }
-                            }
+                            index.entry(short).or_default().push(entry);
                         }
                     }
                     Err(err) => {
@@ -525,11 +529,16 @@ async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut 
     let index = &index_full.by_short;
     // Any dir whose short id is referenced by a live exec scope is kept
     // unconditionally: a process may hold cwd/fds there.
-    let scope_protected: std::collections::HashSet<String> =
+    let scope_protected: std::collections::HashSet<(String, String)> =
         super::scope_reaper::list_exec_scope_units()
             .await
             .iter()
-            .filter_map(|u| crate::workspace_exec::mission_short_id_from_exec_unit(u))
+            .filter_map(|unit| {
+                Some((
+                    crate::workspace_exec::machine_name_from_exec_unit(unit)?,
+                    crate::workspace_exec::mission_short_id_from_exec_unit(unit)?,
+                ))
+            })
             .collect();
 
     for ws in state.workspaces.list().await {
@@ -549,7 +558,11 @@ async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut 
             if !entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
                 continue;
             }
-            if scope_protected.contains(short) {
+            let workspace_token = crate::workspace_exec::machine_name_for_path(&ws.path);
+            if workspace_token
+                .as_ref()
+                .is_some_and(|token| scope_protected.contains(&(token.clone(), short.to_string())))
+            {
                 tracing::debug!(path = %dir.display(), "mission GC: kept (live exec scope)");
                 continue;
             }
@@ -557,7 +570,10 @@ async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut 
                 Keep(&'static str),
                 Delete(&'static str, bool /*orphan*/, bool /*stopped*/),
             }
-            let verdict = match index.get(short) {
+            let indexed_entry = index
+                .get(short)
+                .and_then(|entries| entry_for_workspace(entries, ws.id));
+            let verdict = match indexed_entry {
                 Some(e) => match e.status {
                     MissionStatus::Active
                     | MissionStatus::Pending
@@ -683,4 +699,56 @@ async fn directory_size_bytes(path: &std::path::Path) -> u64 {
     })
     .await
     .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_collisions_are_resolved_within_the_actual_workspace() {
+        let workspace_a = uuid::Uuid::new_v4();
+        let workspace_b = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        let entries = vec![
+            MissionIndexEntry {
+                status: MissionStatus::Paused,
+                updated_at: now - chrono::Duration::days(40),
+                workspace_id: workspace_a,
+            },
+            MissionIndexEntry {
+                status: MissionStatus::Completed,
+                updated_at: now,
+                workspace_id: workspace_b,
+            },
+        ];
+
+        let selected = entry_for_workspace(&entries, workspace_b).unwrap();
+        assert_eq!(selected.workspace_id, workspace_b);
+        assert_eq!(selected.status, MissionStatus::Completed);
+        assert!(entry_for_workspace(&entries, uuid::Uuid::new_v4()).is_none());
+    }
+
+    #[test]
+    fn same_workspace_collision_keeps_the_most_protective_entry() {
+        let workspace_id = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        let entries = vec![
+            MissionIndexEntry {
+                status: MissionStatus::Completed,
+                updated_at: now,
+                workspace_id,
+            },
+            MissionIndexEntry {
+                status: MissionStatus::Active,
+                updated_at: now - chrono::Duration::days(1),
+                workspace_id,
+            },
+        ];
+
+        assert_eq!(
+            entry_for_workspace(&entries, workspace_id).unwrap().status,
+            MissionStatus::Active
+        );
+    }
 }

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -127,15 +127,71 @@ fn protection_rank(status: &MissionStatus) -> u8 {
     }
 }
 
-/// Index every mission across all live sessions' stores by the first 8 hex
+/// Cross-store mission index keyed by 8-hex short id.
+///
+/// `complete` is the load-bearing bit: "no index hit" is only usable as
+/// evidence that a dir/scope is orphaned when every persisted store on disk
+/// was actually indexed. Stores belonging to users with no live session are
+/// read offline (read-only SQLite); if any store can't be read, `complete`
+/// is false and callers must skip their unknown-entry deletion branches.
+pub(crate) struct MissionIndex {
+    pub by_short: std::collections::HashMap<String, MissionIndexEntry>,
+    pub complete: bool,
+}
+
+/// Read one persisted SQLite mission store without booting a session.
+fn index_store_file_blocking(
+    path: &std::path::Path,
+) -> Result<Vec<(String, MissionIndexEntry)>, String> {
+    let conn =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| e.to_string())?;
+    let mut stmt = conn
+        .prepare("SELECT id, status, updated_at, workspace_id FROM missions")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (id, status, updated_at, workspace_id) = row.map_err(|e| e.to_string())?;
+        if id.len() < 8 {
+            continue;
+        }
+        // Unknown status strings deserialize to the most protective value.
+        let status: MissionStatus = serde_json::from_value(serde_json::Value::String(status))
+            .unwrap_or(MissionStatus::Active);
+        let updated_at = DateTime::parse_from_rfc3339(&updated_at)
+            .map(|ts| ts.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now());
+        let workspace_id = uuid::Uuid::parse_str(&workspace_id).unwrap_or(uuid::Uuid::nil());
+        out.push((
+            id[..8].to_ascii_lowercase(),
+            MissionIndexEntry {
+                status,
+                updated_at,
+                workspace_id,
+            },
+        ));
+    }
+    Ok(out)
+}
+
+/// Index every mission across all persisted stores by the first 8 hex
 /// chars of its id — the same prefix embedded in workspace dir names
 /// (`mission-<8hex>`) and exec scope units (`-m<8hex>-`). Shared by the
 /// orphan-dir sweep and the scope reaper.
-pub(crate) async fn build_mission_index(
-    state: &Arc<AppState>,
-) -> std::collections::HashMap<String, MissionIndexEntry> {
+pub(crate) async fn build_mission_index(state: &Arc<AppState>) -> MissionIndex {
     let mut index: std::collections::HashMap<String, MissionIndexEntry> =
         std::collections::HashMap::new();
+    let mut complete = true;
     let sessions = state.control.all_sessions().await;
     for session in sessions {
         let store = session.mission_store.clone();
@@ -182,7 +238,78 @@ pub(crate) async fn build_mission_index(
             offset += page_len;
         }
     }
-    index
+
+    // Offline pass: persisted stores whose user has no live session (e.g.
+    // OAuth users who haven't connected since restart). Their missions must
+    // still protect their dirs/scopes.
+    let live_users: std::collections::HashSet<String> = state
+        .control
+        .session_user_ids()
+        .await
+        .iter()
+        .map(|u| super::mission_store::sanitize_filename(u))
+        .collect();
+    let missions_dir = state
+        .config
+        .working_dir
+        .join(".sandboxed-sh")
+        .join("missions");
+    if let Ok(mut rd) = tokio::fs::read_dir(&missions_dir).await {
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(stem) = name.strip_prefix("missions-") else {
+                continue;
+            };
+            if let Some(user) = stem.strip_suffix(".db") {
+                if live_users.contains(user) {
+                    continue;
+                }
+                let path = entry.path();
+                let rows = tokio::task::spawn_blocking({
+                    let path = path.clone();
+                    move || index_store_file_blocking(&path)
+                })
+                .await
+                .unwrap_or_else(|e| Err(e.to_string()));
+                match rows {
+                    Ok(rows) => {
+                        for (short, entry) in rows {
+                            match index.get(&short) {
+                                Some(existing)
+                                    if (protection_rank(&existing.status), existing.updated_at)
+                                        >= (protection_rank(&entry.status), entry.updated_at) => {}
+                                _ => {
+                                    index.insert(short, entry);
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            store = %path.display(),
+                            err,
+                            "mission index: offline store read failed; index marked incomplete"
+                        );
+                        complete = false;
+                    }
+                }
+            } else if stem.ends_with(".json") {
+                // File-store format: not offline-indexed; play safe.
+                if !live_users.contains(stem.trim_end_matches(".json")) {
+                    tracing::warn!(
+                        store = name,
+                        "mission index: uncovered file-store; index marked incomplete"
+                    );
+                    complete = false;
+                }
+            }
+        }
+    }
+
+    MissionIndex {
+        by_short: index,
+        complete,
+    }
 }
 
 #[derive(Default)]
@@ -302,7 +429,8 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
 /// its reason; deletion requires positive evidence of collectability, and a
 /// live exec scope always wins.
 async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut SweepReport) {
-    let index = build_mission_index(state).await;
+    let index_full = build_mission_index(state).await;
+    let index = &index_full.by_short;
     // Any dir whose short id is referenced by a live exec scope is kept
     // unconditionally: a process may hold cwd/fds there.
     let scope_protected: std::collections::HashSet<String> =
@@ -360,6 +488,8 @@ async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut 
                 None => {
                     if !params.orphans_enabled {
                         Verdict::Keep("orphan collection disabled")
+                    } else if !index_full.complete {
+                        Verdict::Keep("mission index incomplete; not trusting orphan verdicts")
                     } else {
                         // No mission anywhere claims this dir. Use the dir
                         // mtime as the age signal, with the normal retention

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -54,6 +54,7 @@ mod proxy_keys;
 pub(crate) mod proxy_liveness;
 mod routes;
 pub(crate) mod runners;
+pub mod scope_reaper;
 pub mod secrets;
 pub mod settings;
 pub(crate) mod spark;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -52,6 +52,7 @@ pub(crate) mod providers;
 pub(crate) mod proxy;
 mod proxy_keys;
 pub(crate) mod proxy_liveness;
+pub(crate) mod remote_build;
 mod routes;
 pub(crate) mod runners;
 pub mod scope_reaper;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,6 +28,7 @@ pub mod control_metrics;
 pub mod deferred_proxy;
 pub mod desktop;
 mod desktop_stream;
+pub mod disk_watch;
 pub mod durable_jobs;
 pub mod fido;
 mod fs;

--- a/src/api/monitoring.rs
+++ b/src/api/monitoring.rs
@@ -132,6 +132,59 @@ impl MemoryHealthLevel {
     }
 }
 
+/// Severity of host disk pressure, mirroring [`MemoryHealthLevel`].
+/// Warn at >= `DISK_WARN_PCT` (default 90), critical at >=
+/// `DISK_CRITICAL_PCT` (default 95). At critical, mission admission is
+/// refused (see the CreateMission preflight in control).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiskHealthLevel {
+    Ok,
+    Warn,
+    Critical,
+}
+
+fn disk_pct_threshold(var: &str, default: f32, slot: &'static std::sync::OnceLock<f32>) -> f32 {
+    *slot.get_or_init(|| {
+        std::env::var(var)
+            .ok()
+            .and_then(|v| v.trim().parse::<f32>().ok())
+            .filter(|v| (1.0..=100.0).contains(v))
+            .unwrap_or(default)
+    })
+}
+
+pub fn disk_warn_pct() -> f32 {
+    static SLOT: std::sync::OnceLock<f32> = std::sync::OnceLock::new();
+    disk_pct_threshold("DISK_WARN_PCT", 90.0, &SLOT)
+}
+
+pub fn disk_critical_pct() -> f32 {
+    static SLOT: std::sync::OnceLock<f32> = std::sync::OnceLock::new();
+    disk_pct_threshold("DISK_CRITICAL_PCT", 95.0, &SLOT)
+}
+
+impl DiskHealthLevel {
+    pub fn from_percent(disk_percent: f32) -> Self {
+        if disk_percent >= disk_critical_pct() {
+            DiskHealthLevel::Critical
+        } else if disk_percent >= disk_warn_pct() {
+            DiskHealthLevel::Warn
+        } else {
+            DiskHealthLevel::Ok
+        }
+    }
+}
+
+/// Fresh snapshot of root-filesystem usage as `(used, total, percent)`.
+/// Standalone (its own sysinfo read) so admission checks, fleet health and
+/// the disk watcher can call it without the monitoring collector's state.
+pub fn current_disk_usage() -> (u64, u64, f32) {
+    let disks = Disks::new_with_refreshed_list();
+    let (used, total) = root_disk_usage(&disks);
+    (used, total, pct(used, total))
+}
+
 /// Percentage of `used` over `total` (0 when `total` is 0).
 fn pct(used: u64, total: u64) -> f32 {
     if total > 0 {

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -232,6 +232,10 @@ struct RemoteBuildAcceptedResponse {
     node_id: String,
 }
 
+fn should_reprobe_after_placement_failure(status: Option<&RemoteNodeStatus>) -> bool {
+    !matches!(status, Some(RemoteNodeStatus::Online))
+}
+
 /// Resolve the target node: explicit id or capacity-aware auto placement.
 /// All misses map to `503` so the wrapper can fall back to a local build —
 /// except an explicitly named unknown node, which is a caller bug (`400`).
@@ -252,26 +256,28 @@ async fn resolve_node(
         let picked = match first {
             Ok(picked) => picked,
             Err(initial_err) => {
-                // The monitor can be disabled, or the first request can race
-                // its initial tick. Probe only cold nodes, then retry placement
-                // once so on-demand mode remains usable without masking a real
-                // capacity/label rejection from fresh heartbeat data.
-                let cold: Vec<_> = settings
+                // The monitor can be disabled, its initial tick can race this
+                // request, or a node can have recovered since a cached miss.
+                // Re-probe missing and non-online nodes, then retry placement
+                // once without masking capacity/label rejection from nodes
+                // whose latest heartbeat still says they are online.
+                let retry_nodes: Vec<_> = settings
                     .nodes
                     .iter()
                     .filter(|node| {
-                        state
-                            .fleet
-                            .get(&node.id)
-                            .is_none_or(|cached| cached.status == RemoteNodeStatus::Unknown)
+                        let cached = state.fleet.get(&node.id);
+                        should_reprobe_after_placement_failure(
+                            cached.as_ref().map(|cached| &cached.status),
+                        )
                     })
                     .collect();
-                if cold.is_empty() {
+                if retry_nodes.is_empty() {
                     return Err((StatusCode::SERVICE_UNAVAILABLE, initial_err.to_string()));
                 }
                 let client = RemoteNodeClient::default();
                 futures::future::join_all(
-                    cold.into_iter()
+                    retry_nodes
+                        .into_iter()
                         .map(|node| crate::remote_node::probe_node(&state.fleet, &client, node)),
                 )
                 .await;
@@ -648,5 +654,21 @@ mod tests {
             submit_error_status(&RemoteNodeError::Request("offline".to_string())),
             StatusCode::SERVICE_UNAVAILABLE
         );
+    }
+
+    #[test]
+    fn failed_auto_placement_reprobes_every_non_online_cache_state() {
+        assert!(should_reprobe_after_placement_failure(None));
+        for status in [
+            RemoteNodeStatus::Unknown,
+            RemoteNodeStatus::Degraded,
+            RemoteNodeStatus::Offline,
+            RemoteNodeStatus::Disabled,
+        ] {
+            assert!(should_reprobe_after_placement_failure(Some(&status)));
+        }
+        assert!(!should_reprobe_after_placement_failure(Some(
+            &RemoteNodeStatus::Online
+        )));
     }
 }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -648,6 +648,94 @@ async fn get_remote_build(
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn run_remote_build_wrapper_with_http_status(status: u16) -> std::process::ExitStatus {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("create wrapper test directory");
+        let repo = temp.path().join("repo");
+        let bin = temp.path().join("bin");
+        std::fs::create_dir_all(&repo).expect("create test repo");
+        std::fs::create_dir_all(&bin).expect("create fake bin directory");
+
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--quiet"]);
+        git(&["config", "user.name", "Remote Build Test"]);
+        git(&["config", "user.email", "remote-build@example.invalid"]);
+        std::fs::write(repo.join("README.md"), "test\n").expect("write tracked file");
+        git(&["add", "README.md"]);
+        git(&[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            "test",
+        ]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://example.invalid/repo.git",
+        ]);
+
+        let fake_curl = bin.join("curl");
+        std::fs::write(
+            &fake_curl,
+            r#"#!/bin/sh
+output=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        output="$1"
+    fi
+    shift
+done
+printf '{}' > "$output"
+printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
+"#,
+        )
+        .expect("write fake curl");
+        let mut permissions = std::fs::metadata(&fake_curl)
+            .expect("stat fake curl")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_curl, permissions).expect("make fake curl executable");
+
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        std::process::Command::new("bash")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/remote-lean-build"
+            ))
+            .current_dir(repo)
+            .env("PATH", path)
+            .env(
+                "REMOTE_BUILD_URL",
+                "http://example.invalid/api/remote-build",
+            )
+            .env("REMOTE_BUILD_TOKEN", "expired-test-token")
+            .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
+            .env("REMOTE_BUILD_TEST_HTTP_STATUS", status.to_string())
+            .status()
+            .expect("run remote-build wrapper")
+    }
+
     #[test]
     fn token_round_trips_and_is_mission_and_domain_scoped() {
         let mission = Uuid::new_v4();
@@ -776,6 +864,25 @@ mod tests {
             submit_error_status(&RemoteNodeError::Request("offline".to_string())),
             StatusCode::SERVICE_UNAVAILABLE
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_treats_host_capability_auth_failures_as_temporary() {
+        for status in [401, 403, 503] {
+            assert_eq!(
+                run_remote_build_wrapper_with_http_status(status).code(),
+                Some(75),
+                "HTTP {status} should request local fallback"
+            );
+        }
+        for status in [400, 422] {
+            assert_eq!(
+                run_remote_build_wrapper_with_http_status(status).code(),
+                Some(1),
+                "HTTP {status} remains a caller error"
+            );
+        }
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -329,14 +329,24 @@ fn spawn_remote_build_observer(
     mission_id: Uuid,
     job_id: Uuid,
     started_at: chrono::DateTime<chrono::Utc>,
+    cancel_requested: bool,
 ) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(WAIT_POLL_INTERVAL).await;
-            match RemoteNodeClient::default()
-                .get_job(&node, &shared_token, job_id)
-                .await
-            {
+            let client = RemoteNodeClient::default();
+            if cancel_requested {
+                if let Err(error) = client.cancel_job(&node, &shared_token, job_id).await {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        node_id = %node.id,
+                        job_id = %job_id,
+                        ?error,
+                        "remote build cancellation failed; observer will retry"
+                    );
+                }
+            }
+            match client.get_job(&node, &shared_token, job_id).await {
                 Ok(status)
                     if matches!(
                         status.state.as_str(),
@@ -476,7 +486,19 @@ async fn submit_remote_build(
     )
     .await
     {
-        let _ = client.cancel_job(&node, &shared_token, job_id).await;
+        // No durable recovery handle exists, so retain the accepted ids in an
+        // in-process observer and retry cancellation until the node confirms a
+        // terminal state. A single best-effort cancel can fail during the same
+        // outage that prevented ledger persistence and leak node capacity.
+        spawn_remote_build_observer(
+            Arc::clone(&state),
+            node.clone(),
+            shared_token.clone(),
+            req.mission_id,
+            job_id,
+            started_at,
+            true,
+        );
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("remote build accepted but recovery handle could not be persisted: {err}"),
@@ -492,6 +514,7 @@ async fn submit_remote_build(
             req.mission_id,
             job_id,
             started_at,
+            false,
         );
         return (
             StatusCode::ACCEPTED,
@@ -548,6 +571,7 @@ async fn submit_remote_build(
         req.mission_id,
         job_id,
         started_at,
+        false,
     );
     (
         StatusCode::GATEWAY_TIMEOUT,

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -432,6 +432,29 @@ async fn submit_remote_build(
             .into_response();
     }
 
+    // Persist before entering the request-local poll loop. If the handler is
+    // aborted or the API restarts, startup recovery can still observe the
+    // accepted node job through to a terminal state instead of orphaning it.
+    if let Err(err) = crate::remote_node::job_ledger::record(
+        &state.config.working_dir,
+        crate::remote_node::job_ledger::JobHandle {
+            mission_id: req.mission_id,
+            node_id: node.id.clone(),
+            job_id,
+            started_at,
+            kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
+        },
+    )
+    .await
+    {
+        let _ = client.cancel_job(&node, &shared_token, job_id).await;
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("remote build accepted but recovery handle could not be persisted: {err}"),
+        )
+            .into_response();
+    }
+
     // Poll to completion (3s interval, capped at 2h client-side; the node
     // enforces its own SANDBOXED_NODE_MAX_JOB_SECS on the job itself).
     for _ in 0..WAIT_MAX_POLLS {
@@ -450,6 +473,7 @@ async fn submit_remote_build(
                 status.error.clone(),
                 true,
             ));
+            crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
             let duration_secs = (chrono::Utc::now() - started_at).num_seconds().max(0) as u64;
             return Json(RemoteBuildWaitResponse {
                 exit_code: status.exit_code,

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -322,6 +322,46 @@ fn node_shared_token(node: &RemoteNodeConfig) -> Result<String, (StatusCode, Str
         ))
 }
 
+fn spawn_remote_build_observer(
+    state: Arc<AppState>,
+    node: RemoteNodeConfig,
+    shared_token: String,
+    mission_id: Uuid,
+    job_id: Uuid,
+    started_at: chrono::DateTime<chrono::Utc>,
+) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(WAIT_POLL_INTERVAL).await;
+            match RemoteNodeClient::default()
+                .get_job(&node, &shared_token, job_id)
+                .await
+            {
+                Ok(status)
+                    if matches!(
+                        status.state.as_str(),
+                        "succeeded" | "failed" | "cancelled" | "lost"
+                    ) =>
+                {
+                    state.fleet.record_outcome(DispatchOutcome {
+                        mission_id,
+                        node_id: node.id.clone(),
+                        job_id: Some(job_id),
+                        state: status.state,
+                        exit_code: status.exit_code,
+                        error: status.error,
+                        started_at,
+                        finished_at: Some(chrono::Utc::now()),
+                    });
+                    crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+                    return;
+                }
+                Ok(_) | Err(_) => {}
+            }
+        }
+    });
+}
+
 async fn submit_remote_build(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RemoteBuildRequest>,
@@ -421,20 +461,9 @@ async fn submit_remote_build(
         "remote build dispatched"
     );
 
-    if !req.wait {
-        return (
-            StatusCode::ACCEPTED,
-            Json(RemoteBuildAcceptedResponse {
-                job_id,
-                node_id: node.id.clone(),
-            }),
-        )
-            .into_response();
-    }
-
-    // Persist before entering the request-local poll loop. If the handler is
-    // aborted or the API restarts, startup recovery can still observe the
-    // accepted node job through to a terminal state instead of orphaning it.
+    // Persist every accepted build before either returning 202 or entering a
+    // request-local wait. Startup recovery can therefore observe it through
+    // terminal state even if the caller or API disappears.
     if let Err(err) = crate::remote_node::job_ledger::record(
         &state.config.working_dir,
         crate::remote_node::job_ledger::JobHandle {
@@ -451,6 +480,25 @@ async fn submit_remote_build(
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("remote build accepted but recovery handle could not be persisted: {err}"),
+        )
+            .into_response();
+    }
+
+    if !req.wait {
+        spawn_remote_build_observer(
+            Arc::clone(&state),
+            node.clone(),
+            shared_token.clone(),
+            req.mission_id,
+            job_id,
+            started_at,
+        );
+        return (
+            StatusCode::ACCEPTED,
+            Json(RemoteBuildAcceptedResponse {
+                job_id,
+                node_id: node.id.clone(),
+            }),
         )
             .into_response();
     }
@@ -493,43 +541,14 @@ async fn submit_remote_build(
         Some("client-side wait cap (2h) exceeded".to_string()),
         true,
     ));
-    let observer_state = Arc::clone(&state);
-    let observer_node = node.clone();
-    let observer_token = shared_token.clone();
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(WAIT_POLL_INTERVAL).await;
-            match RemoteNodeClient::default()
-                .get_job(&observer_node, &observer_token, job_id)
-                .await
-            {
-                Ok(status)
-                    if matches!(
-                        status.state.as_str(),
-                        "succeeded" | "failed" | "cancelled" | "lost"
-                    ) =>
-                {
-                    observer_state.fleet.record_outcome(DispatchOutcome {
-                        mission_id: req.mission_id,
-                        node_id: observer_node.id.clone(),
-                        job_id: Some(job_id),
-                        state: status.state,
-                        exit_code: status.exit_code,
-                        error: status.error,
-                        started_at,
-                        finished_at: Some(chrono::Utc::now()),
-                    });
-                    crate::remote_node::job_ledger::remove(
-                        &observer_state.config.working_dir,
-                        job_id,
-                    )
-                    .await;
-                    return;
-                }
-                Ok(_) | Err(_) => {}
-            }
-        }
-    });
+    spawn_remote_build_observer(
+        Arc::clone(&state),
+        node.clone(),
+        shared_token.clone(),
+        req.mission_id,
+        job_id,
+        started_at,
+    );
     (
         StatusCode::GATEWAY_TIMEOUT,
         format!("remote build {job_id} on '{}' did not finish within the 2h wait cap; poll GET /api/remote-build/{job_id}?node_id={}", node.id, node.id),

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -304,7 +304,7 @@ async fn resolve_node(
 fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
     match err {
         RemoteNodeError::Rejected { status, .. }
-            if (400..500).contains(status) && !matches!(*status, 408 | 429) =>
+            if (400..500).contains(status) && !matches!(*status, 401 | 403 | 408 | 429) =>
         {
             StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_REQUEST)
         }
@@ -763,6 +763,15 @@ mod tests {
             }),
             StatusCode::SERVICE_UNAVAILABLE
         );
+        for status in [401, 403] {
+            assert_eq!(
+                submit_error_status(&RemoteNodeError::Rejected {
+                    status,
+                    body: "node token rejected".to_string(),
+                }),
+                StatusCode::SERVICE_UNAVAILABLE
+            );
+        }
         assert_eq!(
             submit_error_status(&RemoteNodeError::Request("offline".to_string())),
             StatusCode::SERVICE_UNAVAILABLE

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -29,7 +29,8 @@ use uuid::Uuid;
 use super::routes::AppState;
 use crate::remote_node::{
     ArtifactEntry, DispatchOutcome, JobPayload, JobSource, LeaseClaims, NodeJobStatus,
-    RemoteNodeClient, RemoteNodeConfig, SubmitJobRequest, SCOPE_JOB_SUBMIT,
+    RemoteNodeClient, RemoteNodeConfig, RemoteNodeError, RemoteNodeStatus, SubmitJobRequest,
+    SCOPE_JOB_SUBMIT,
 };
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -234,7 +235,7 @@ struct RemoteBuildAcceptedResponse {
 /// Resolve the target node: explicit id or capacity-aware auto placement.
 /// All misses map to `503` so the wrapper can fall back to a local build —
 /// except an explicitly named unknown node, which is a caller bug (`400`).
-fn resolve_node(
+async fn resolve_node(
     state: &AppState,
     node_id: &str,
     requirements: &[String],
@@ -247,10 +248,39 @@ fn resolve_node(
         ));
     }
     if node_id.eq_ignore_ascii_case("auto") {
-        let picked = state
-            .fleet
-            .place_auto(settings, requirements)
-            .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+        let first = state.fleet.place_auto(settings, requirements);
+        let picked = match first {
+            Ok(picked) => picked,
+            Err(initial_err) => {
+                // The monitor can be disabled, or the first request can race
+                // its initial tick. Probe only cold nodes, then retry placement
+                // once so on-demand mode remains usable without masking a real
+                // capacity/label rejection from fresh heartbeat data.
+                let cold: Vec<_> = settings
+                    .nodes
+                    .iter()
+                    .filter(|node| {
+                        state
+                            .fleet
+                            .get(&node.id)
+                            .is_none_or(|cached| cached.status == RemoteNodeStatus::Unknown)
+                    })
+                    .collect();
+                if cold.is_empty() {
+                    return Err((StatusCode::SERVICE_UNAVAILABLE, initial_err.to_string()));
+                }
+                let client = RemoteNodeClient::default();
+                futures::future::join_all(
+                    cold.into_iter()
+                        .map(|node| crate::remote_node::probe_node(&state.fleet, &client, node)),
+                )
+                .await;
+                state
+                    .fleet
+                    .place_auto(settings, requirements)
+                    .map_err(|err| (StatusCode::SERVICE_UNAVAILABLE, err.to_string()))?
+            }
+        };
         return settings.node(&picked).cloned().ok_or((
             StatusCode::SERVICE_UNAVAILABLE,
             format!("placed node '{picked}' vanished from configuration"),
@@ -260,6 +290,17 @@ fn resolve_node(
         StatusCode::BAD_REQUEST,
         format!("remote node '{node_id}' is not configured"),
     ))
+}
+
+fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
+    match err {
+        RemoteNodeError::Rejected { status, .. }
+            if (400..500).contains(status) && !matches!(*status, 408 | 429) =>
+        {
+            StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_REQUEST)
+        }
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    }
 }
 
 fn node_shared_token(node: &RemoteNodeConfig) -> Result<String, (StatusCode, String)> {
@@ -296,7 +337,7 @@ async fn submit_remote_build(
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
     }
 
-    let node = match resolve_node(&state, &req.node_id, &req.requirements) {
+    let node = match resolve_node(&state, &req.node_id, &req.requirements).await {
         Ok(node) => node,
         Err((status, message)) => return (status, message).into_response(),
     };
@@ -340,12 +381,12 @@ async fn submit_remote_build(
     let accepted = match client.submit_job(&node, &shared_token, &submit).await {
         Ok(accepted) => accepted,
         Err(err) => {
-            // 503, not 502: a node that went down after placement is a
-            // transient fleet-capacity condition, and 503 is the documented
-            // signal the remote-lean-build wrapper maps to EX_TEMPFAIL
-            // (fall back to a local build).
+            // Transport outages and queue saturation remain 503 so the wrapper
+            // can fall back locally. Node-side caller validation stays 4xx and
+            // must not be disguised as a fleet outage.
+            let status = submit_error_status(&err);
             return (
-                StatusCode::SERVICE_UNAVAILABLE,
+                status,
                 format!("remote node '{}' did not accept the build: {err}", node.id),
             )
                 .into_response();
@@ -578,5 +619,34 @@ mod tests {
         assert_eq!(req.cwd_rel.as_deref(), Some("verity"));
         assert_eq!(req.timeout_secs, Some(1200));
         assert_eq!(req.artifacts, vec![".lake/build/lib/*"]);
+    }
+
+    #[test]
+    fn submit_errors_preserve_caller_failures_only() {
+        assert_eq!(
+            submit_error_status(&RemoteNodeError::Rejected {
+                status: 400,
+                body: "invalid payload".to_string(),
+            }),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            submit_error_status(&RemoteNodeError::Rejected {
+                status: 422,
+                body: "invalid payload".to_string(),
+            }),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(
+            submit_error_status(&RemoteNodeError::Rejected {
+                status: 429,
+                body: "queue full".to_string(),
+            }),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            submit_error_status(&RemoteNodeError::Request("offline".to_string())),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -232,8 +232,11 @@ struct RemoteBuildAcceptedResponse {
     node_id: String,
 }
 
-fn should_reprobe_after_placement_failure(status: Option<&RemoteNodeStatus>) -> bool {
-    !matches!(status, Some(RemoteNodeStatus::Online))
+fn should_reprobe_after_placement_failure(_status: Option<&RemoteNodeStatus>) -> bool {
+    // A cached Online heartbeat can still contain stale load, disk, or memory
+    // figures. Placement has already rejected every cached candidate, so one
+    // fresh probe of every configured node is the authoritative retry.
+    true
 }
 
 /// Resolve the target node: explicit id or capacity-aware auto placement.
@@ -258,9 +261,9 @@ async fn resolve_node(
             Err(initial_err) => {
                 // The monitor can be disabled, its initial tick can race this
                 // request, or a node can have recovered since a cached miss.
-                // Re-probe missing and non-online nodes, then retry placement
-                // once without masking capacity/label rejection from nodes
-                // whose latest heartbeat still says they are online.
+                // Re-probe every configured node, including cached Online
+                // nodes whose load/resource figures may now be stale, then
+                // retry placement once.
                 let retry_nodes: Vec<_> = settings
                     .nodes
                     .iter()
@@ -767,7 +770,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_auto_placement_reprobes_every_non_online_cache_state() {
+    fn failed_auto_placement_reprobes_every_cache_state() {
         assert!(should_reprobe_after_placement_failure(None));
         for status in [
             RemoteNodeStatus::Unknown,
@@ -777,7 +780,7 @@ mod tests {
         ] {
             assert!(should_reprobe_after_placement_failure(Some(&status)));
         }
-        assert!(!should_reprobe_after_placement_failure(Some(
+        assert!(should_reprobe_after_placement_failure(Some(
             &RemoteNodeStatus::Online
         )));
     }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -493,6 +493,43 @@ async fn submit_remote_build(
         Some("client-side wait cap (2h) exceeded".to_string()),
         true,
     ));
+    let observer_state = Arc::clone(&state);
+    let observer_node = node.clone();
+    let observer_token = shared_token.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(WAIT_POLL_INTERVAL).await;
+            match RemoteNodeClient::default()
+                .get_job(&observer_node, &observer_token, job_id)
+                .await
+            {
+                Ok(status)
+                    if matches!(
+                        status.state.as_str(),
+                        "succeeded" | "failed" | "cancelled" | "lost"
+                    ) =>
+                {
+                    observer_state.fleet.record_outcome(DispatchOutcome {
+                        mission_id: req.mission_id,
+                        node_id: observer_node.id.clone(),
+                        job_id: Some(job_id),
+                        state: status.state,
+                        exit_code: status.exit_code,
+                        error: status.error,
+                        started_at,
+                        finished_at: Some(chrono::Utc::now()),
+                    });
+                    crate::remote_node::job_ledger::remove(
+                        &observer_state.config.working_dir,
+                        job_id,
+                    )
+                    .await;
+                    return;
+                }
+                Ok(_) | Err(_) => {}
+            }
+        }
+    });
     (
         StatusCode::GATEWAY_TIMEOUT,
         format!("remote build {job_id} on '{}' did not finish within the 2h wait cap; poll GET /api/remote-build/{job_id}?node_id={}", node.id, node.id),
@@ -551,6 +588,12 @@ async fn get_remote_build(
             StatusCode::FORBIDDEN,
             "job does not belong to this mission".to_string(),
         ));
+    }
+    if matches!(
+        status.state.as_str(),
+        "succeeded" | "failed" | "cancelled" | "lost"
+    ) {
+        crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
     }
     Ok(Json(status))
 }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -340,6 +340,11 @@ fn spawn_remote_build_observer(
             let client = RemoteNodeClient::default();
             if cancel_requested {
                 if let Err(error) = client.cancel_job(&node, &shared_token, job_id).await {
+                    if error.is_not_found() {
+                        crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id)
+                            .await;
+                        return;
+                    }
                     tracing::warn!(
                         mission_id = %mission_id,
                         node_id = %node.id,
@@ -366,6 +371,10 @@ fn spawn_remote_build_observer(
                         started_at,
                         finished_at: Some(chrono::Utc::now()),
                     });
+                    crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+                    return;
+                }
+                Err(error) if cancel_requested && error.is_not_found() => {
                     crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
                     return;
                 }
@@ -437,6 +446,24 @@ async fn submit_remote_build(
 
     let client = RemoteNodeClient::default();
     let started_at = chrono::Utc::now();
+    if let Err(error) = crate::remote_node::job_ledger::record(
+        &state.config.working_dir,
+        crate::remote_node::job_ledger::JobHandle {
+            mission_id: req.mission_id,
+            node_id: node.id.clone(),
+            job_id,
+            started_at,
+            kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
+        },
+    )
+    .await
+    {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("remote build recovery handle could not be prepared: {error}"),
+        )
+            .into_response();
+    }
     let accepted = match client.submit_job(&node, &shared_token, &submit).await {
         Ok(accepted) => accepted,
         Err(err) => {
@@ -444,6 +471,19 @@ async fn submit_remote_build(
             // can fall back locally. Node-side caller validation stays 4xx and
             // must not be disguised as a fleet outage.
             let status = submit_error_status(&err);
+            if matches!(&err, RemoteNodeError::Request(_)) {
+                spawn_remote_build_observer(
+                    Arc::clone(&state),
+                    node.clone(),
+                    shared_token.clone(),
+                    req.mission_id,
+                    job_id,
+                    started_at,
+                    true,
+                );
+            } else {
+                crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+            }
             return (
                 status,
                 format!("remote node '{}' did not accept the build: {err}", node.id),
@@ -489,10 +529,9 @@ async fn submit_remote_build(
     )
     .await
     {
-        // No durable recovery handle exists, so retain the accepted ids in an
-        // in-process observer and retry cancellation until the node confirms a
-        // terminal state. A single best-effort cancel can fail during the same
-        // outage that prevented ledger persistence and leak node capacity.
+        // The tentative pre-submit entry remains the restart fallback, but it
+        // cannot authorize normal observation of an accepted build. Cancel it
+        // immediately and retry until the node confirms terminal state.
         spawn_remote_build_observer(
             Arc::clone(&state),
             node.clone(),

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -154,7 +154,19 @@ async fn mission_accepts_remote_build(state: &AppState, mission_id: Uuid) -> boo
             );
         }
     }
-    false
+    match super::mission_workspace_gc::persisted_mission_status(state, mission_id).await {
+        Ok(Some(status)) => matches!(
+            status,
+            super::control::MissionStatus::Active
+                | super::control::MissionStatus::Pending
+                | super::control::MissionStatus::WaitingBackground
+        ),
+        Ok(None) => false,
+        Err(err) => {
+            tracing::warn!(mission_id = %mission_id, ?err, "remote-build persisted mission lookup failed");
+            false
+        }
+    }
 }
 
 fn default_requirements() -> Vec<String> {

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1,0 +1,455 @@
+//! Remote lean-build dispatch endpoint.
+//!
+//! A harness inside a mission workspace calls `POST /api/remote-build` (over
+//! the host veth link, like `POST /api/spark/offload`) to run a declarative
+//! `lean_build` job on a remote runner node. The HOST holds the node bearer
+//! tokens (`SANDBOXED_REMOTE_NODE_<ID>_TOKEN`), so workspaces never carry
+//! them — the wrapper only holds a per-mission HMAC capability token.
+//!
+//! Flow: resolve a node (capacity-aware `place_auto` by default), mint a
+//! `job:submit` lease, submit the `lean_build` job, and either poll it to
+//! completion (`wait: true`, default) or return `{job_id, node_id}`
+//! immediately. Responds `503` when remote nodes are unavailable or no node
+//! qualifies, so the in-workspace `remote-lean-build` wrapper can fall back
+//! to a local build (exit 75).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::routes::AppState;
+use crate::remote_node::{
+    ArtifactEntry, DispatchOutcome, JobPayload, JobSource, LeaseClaims, NodeJobStatus,
+    RemoteNodeClient, RemoteNodeConfig, SubmitJobRequest, SCOPE_JOB_SUBMIT,
+};
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/", post(submit_remote_build))
+        .route("/:job_id", get(get_remote_build))
+}
+
+/// Client-side cap on a waited build: poll every 3s for at most 2 hours.
+const WAIT_POLL_INTERVAL: Duration = Duration::from_secs(3);
+const WAIT_MAX_POLLS: u32 = 2 * 60 * 60 / 3;
+
+/// Secret used to sign the per-mission remote-build capability token. Same
+/// source as the spark-offload token (`src/api/spark.rs`).
+fn remote_build_secret() -> Option<String> {
+    std::env::var("SANDBOXED_INTERNAL_ACTION_SECRET")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("JWT_SECRET")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+}
+
+/// Domain-separated HMAC over the mission id (pure; unit-tested).
+fn sign_remote_build_token(secret: &str, mission_id: Uuid) -> Option<String> {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+    mac.update(b"remote-build:");
+    mac.update(mission_id.as_bytes());
+    Some(hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Mint a per-mission, scope-bound capability token for remote builds. The
+/// domain prefix (`remote-build:`) separates it from the spark-offload token
+/// signed with the same secret, so neither can be replayed as the other.
+/// Returns `None` when no signing secret is configured.
+pub fn build_remote_build_token(mission_id: Uuid) -> Option<String> {
+    sign_remote_build_token(&remote_build_secret()?, mission_id)
+}
+
+fn verify_remote_build_token(mission_id: Uuid, token: &str) -> bool {
+    let Some(expected) = build_remote_build_token(mission_id) else {
+        return false;
+    };
+    super::auth::constant_time_eq(&expected, token.trim())
+}
+
+fn default_requirements() -> Vec<String> {
+    vec!["lean".to_string()]
+}
+
+fn default_node_id() -> String {
+    "auto".to_string()
+}
+
+fn default_wait() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RemoteBuildRequest {
+    /// Mission this build belongs to; `token` must be the capability token
+    /// minted for exactly this mission.
+    pub mission_id: Uuid,
+    pub token: String,
+    /// Git clone/fetch URL; the node fetches it itself.
+    pub repo: String,
+    /// Full 40-char lowercase hex commit SHA.
+    pub commit: String,
+    /// Build cwd relative to the checkout root.
+    #[serde(default)]
+    pub cwd_rel: Option<String>,
+    /// Build argv (`["lake", "build"]` etc.); validated on the node.
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    /// Node label requirements for auto placement.
+    #[serde(default = "default_requirements")]
+    pub requirements: Vec<String>,
+    /// Explicit node id, or `"auto"` (default) for capacity-aware placement.
+    #[serde(default = "default_node_id")]
+    pub node_id: String,
+    /// Wait for the build to finish (default). `false` returns
+    /// `{job_id, node_id}` immediately; poll `GET /api/remote-build/:job_id`.
+    #[serde(default = "default_wait")]
+    pub wait: bool,
+    /// Artifact patterns (relative to the checkout root) to digest after a
+    /// successful build.
+    #[serde(default)]
+    pub artifacts: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct RemoteBuildWaitResponse {
+    exit_code: Option<i32>,
+    state: String,
+    duration_secs: u64,
+    log_tail: String,
+    node_id: String,
+    job_id: Uuid,
+    artifacts: Vec<ArtifactEntry>,
+}
+
+#[derive(Serialize)]
+struct RemoteBuildAcceptedResponse {
+    job_id: Uuid,
+    node_id: String,
+}
+
+/// Resolve the target node: explicit id or capacity-aware auto placement.
+/// All misses map to `503` so the wrapper can fall back to a local build —
+/// except an explicitly named unknown node, which is a caller bug (`400`).
+fn resolve_node(
+    state: &AppState,
+    node_id: &str,
+    requirements: &[String],
+) -> Result<RemoteNodeConfig, (StatusCode, String)> {
+    let settings = &state.config.remote_nodes;
+    if !settings.enabled || settings.nodes.is_empty() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "remote build nodes are not configured".to_string(),
+        ));
+    }
+    if node_id.eq_ignore_ascii_case("auto") {
+        let picked = state
+            .fleet
+            .place_auto(settings, requirements)
+            .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+        return settings.node(&picked).cloned().ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("placed node '{picked}' vanished from configuration"),
+        ));
+    }
+    settings.node(node_id).cloned().ok_or((
+        StatusCode::BAD_REQUEST,
+        format!("remote node '{node_id}' is not configured"),
+    ))
+}
+
+fn node_shared_token(node: &RemoteNodeConfig) -> Result<String, (StatusCode, String)> {
+    std::env::var(&node.token_env)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "remote node '{}' has no token in {}",
+                node.id, node.token_env
+            ),
+        ))
+}
+
+async fn submit_remote_build(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RemoteBuildRequest>,
+) -> axum::response::Response {
+    // Auth: per-mission, scope-bound capability token (NOT the dashboard JWT
+    // and NOT a node bearer token) — a leak only authorizes remote builds
+    // for this one mission. Same trust model as the spark offload endpoint.
+    if !verify_remote_build_token(req.mission_id, &req.token) {
+        return (StatusCode::UNAUTHORIZED, "invalid remote build token").into_response();
+    }
+    if req.command.is_empty() {
+        return (StatusCode::BAD_REQUEST, "command argv required").into_response();
+    }
+
+    let node = match resolve_node(&state, &req.node_id, &req.requirements) {
+        Ok(node) => node,
+        Err((status, message)) => return (status, message).into_response(),
+    };
+    let shared_token = match node_shared_token(&node) {
+        Ok(token) => token,
+        Err((status, message)) => return (status, message).into_response(),
+    };
+
+    let job_id = Uuid::new_v4();
+    let claims = LeaseClaims {
+        mission_id: req.mission_id,
+        node_id: node.id.clone(),
+        scope: SCOPE_JOB_SUBMIT.to_string(),
+        expires_at: (chrono::Utc::now() + chrono::Duration::minutes(15)).timestamp(),
+        job_id: Some(job_id),
+    };
+    let lease_token = match crate::remote_node::create_lease_token(&claims, &shared_token) {
+        Ok(token) => token,
+        Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+    };
+    let submit = SubmitJobRequest {
+        job_id,
+        mission_id: req.mission_id,
+        lease_token,
+        payload: JobPayload::LeanBuild {
+            source: JobSource {
+                repo: req.repo.clone(),
+                commit: req.commit.clone(),
+            },
+            cwd_rel: req.cwd_rel.clone(),
+            command: req.command.clone(),
+            timeout_secs: req.timeout_secs,
+            cache_key: None,
+            artifacts: req.artifacts.clone(),
+            env: Default::default(),
+        },
+    };
+
+    let client = RemoteNodeClient::default();
+    let started_at = chrono::Utc::now();
+    let accepted = match client.submit_job(&node, &shared_token, &submit).await {
+        Ok(accepted) => accepted,
+        Err(err) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("remote node '{}' rejected the build: {err}", node.id),
+            )
+                .into_response()
+        }
+    };
+    let outcome = |state: &str, exit_code: Option<i32>, error: Option<String>, terminal: bool| {
+        DispatchOutcome {
+            mission_id: req.mission_id,
+            node_id: node.id.clone(),
+            job_id: Some(job_id),
+            state: state.to_string(),
+            exit_code,
+            error,
+            started_at,
+            finished_at: terminal.then(chrono::Utc::now),
+        }
+    };
+    state
+        .fleet
+        .record_outcome(outcome(&accepted.state, None, None, false));
+    tracing::info!(
+        mission_id = %req.mission_id,
+        node_id = %node.id,
+        job_id = %job_id,
+        wait = req.wait,
+        "remote build dispatched"
+    );
+
+    if !req.wait {
+        return (
+            StatusCode::ACCEPTED,
+            Json(RemoteBuildAcceptedResponse {
+                job_id,
+                node_id: node.id.clone(),
+            }),
+        )
+            .into_response();
+    }
+
+    // Poll to completion (3s interval, capped at 2h client-side; the node
+    // enforces its own SANDBOXED_NODE_MAX_JOB_SECS on the job itself).
+    for _ in 0..WAIT_MAX_POLLS {
+        tokio::time::sleep(WAIT_POLL_INTERVAL).await;
+        let status = match client.get_job(&node, &shared_token, job_id).await {
+            Ok(status) => status,
+            Err(_) => continue, // transient poll failure; the job keeps running
+        };
+        if matches!(
+            status.state.as_str(),
+            "succeeded" | "failed" | "cancelled" | "lost"
+        ) {
+            state.fleet.record_outcome(outcome(
+                &status.state,
+                status.exit_code,
+                status.error.clone(),
+                true,
+            ));
+            let duration_secs = (chrono::Utc::now() - started_at).num_seconds().max(0) as u64;
+            return Json(RemoteBuildWaitResponse {
+                exit_code: status.exit_code,
+                state: status.state,
+                duration_secs,
+                log_tail: status.log_tail.unwrap_or_default(),
+                node_id: node.id.clone(),
+                job_id,
+                artifacts: status.artifacts,
+            })
+            .into_response();
+        }
+    }
+    state.fleet.record_outcome(outcome(
+        "lost",
+        None,
+        Some("client-side wait cap (2h) exceeded".to_string()),
+        true,
+    ));
+    (
+        StatusCode::GATEWAY_TIMEOUT,
+        format!("remote build {job_id} on '{}' did not finish within the 2h wait cap; poll GET /api/remote-build/{job_id}?node_id={}", node.id, node.id),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RemoteBuildStatusQuery {
+    pub mission_id: Uuid,
+    pub token: String,
+    #[serde(default = "default_node_id")]
+    pub node_id: String,
+}
+
+/// `GET /api/remote-build/:job_id?mission_id=...&token=...&node_id=...` —
+/// job status for a build submitted with `wait: false`. Authenticated with
+/// the same per-mission capability token (query params, since the wrapper's
+/// GET has no body).
+async fn get_remote_build(
+    State(state): State<Arc<AppState>>,
+    Path(job_id): Path<Uuid>,
+    Query(query): Query<RemoteBuildStatusQuery>,
+) -> Result<Json<NodeJobStatus>, (StatusCode, String)> {
+    if !verify_remote_build_token(query.mission_id, &query.token) {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "invalid remote build token".to_string(),
+        ));
+    }
+    if query.node_id.eq_ignore_ascii_case("auto") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "node_id is required to poll a build".to_string(),
+        ));
+    }
+    let settings = &state.config.remote_nodes;
+    let node = settings.node(&query.node_id).cloned().ok_or((
+        StatusCode::BAD_REQUEST,
+        format!("remote node '{}' is not configured", query.node_id),
+    ))?;
+    let shared_token = node_shared_token(&node)?;
+    let status = RemoteNodeClient::default()
+        .get_job(&node, &shared_token, job_id)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    // The capability token is mission-scoped: never leak another mission's
+    // job status through it.
+    if status.mission_id != query.mission_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "job does not belong to this mission".to_string(),
+        ));
+    }
+    Ok(Json(status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_round_trips_and_is_mission_and_domain_scoped() {
+        let mission = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let token = sign_remote_build_token("secret", mission).unwrap();
+        assert_eq!(
+            sign_remote_build_token("secret", mission).unwrap(),
+            token,
+            "token must be deterministic for (secret, mission)"
+        );
+        assert_ne!(sign_remote_build_token("secret", other).unwrap(), token);
+        assert_ne!(
+            sign_remote_build_token("other-secret", mission).unwrap(),
+            token
+        );
+        // Domain separation from the spark-offload token (same secret,
+        // different prefix).
+        // Spark: HMAC("spark-offload:" || mission); ours must differ.
+        {
+            use hmac::{Hmac, Mac};
+            use sha2::Sha256;
+            let mut mac = Hmac::<Sha256>::new_from_slice(b"secret").unwrap();
+            mac.update(b"spark-offload:");
+            mac.update(mission.as_bytes());
+            let spark_token = hex::encode(mac.finalize().into_bytes());
+            assert_ne!(spark_token, token);
+        }
+    }
+
+    #[test]
+    fn request_deserialization_applies_defaults() {
+        let mission = Uuid::new_v4();
+        let req: RemoteBuildRequest = serde_json::from_value(serde_json::json!({
+            "mission_id": mission,
+            "token": "t",
+            "repo": "https://github.com/example/verity.git",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"],
+        }))
+        .unwrap();
+        assert_eq!(req.mission_id, mission);
+        assert_eq!(req.node_id, "auto");
+        assert!(req.wait);
+        assert_eq!(req.requirements, vec!["lean".to_string()]);
+        assert_eq!(req.cwd_rel, None);
+        assert_eq!(req.timeout_secs, None);
+        assert!(req.artifacts.is_empty());
+
+        let req: RemoteBuildRequest = serde_json::from_value(serde_json::json!({
+            "mission_id": mission,
+            "token": "t",
+            "repo": "https://x.git",
+            "commit": "b".repeat(40),
+            "command": ["lake", "build", "Verity"],
+            "cwd_rel": "verity",
+            "timeout_secs": 1200,
+            "requirements": ["lean", "bigmem"],
+            "node_id": "babylon",
+            "wait": false,
+            "artifacts": [".lake/build/lib/*"],
+        }))
+        .unwrap();
+        assert_eq!(req.node_id, "babylon");
+        assert!(!req.wait);
+        assert_eq!(req.requirements, vec!["lean", "bigmem"]);
+        assert_eq!(req.cwd_rel.as_deref(), Some("verity"));
+        assert_eq!(req.timeout_secs, Some(1200));
+        assert_eq!(req.artifacts, vec![".lake/build/lib/*"]);
+    }
+}

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -55,14 +55,38 @@ fn remote_build_secret() -> Option<String> {
         })
 }
 
-/// Domain-separated HMAC over the mission id (pure; unit-tested).
-fn sign_remote_build_token(secret: &str, mission_id: Uuid) -> Option<String> {
+#[derive(Debug, Serialize, Deserialize)]
+struct RemoteBuildCapability {
+    mission_id: Uuid,
+    expires_at: i64,
+}
+
+fn remote_build_token_ttl_secs() -> i64 {
+    std::env::var("REMOTE_BUILD_TOKEN_TTL_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i64>().ok())
+        .filter(|seconds| *seconds >= 300)
+        .unwrap_or(6 * 60 * 60)
+}
+
+/// Domain-separated, expiring HMAC capability (pure; unit-tested).
+fn sign_remote_build_token(secret: &str, mission_id: Uuid, expires_at: i64) -> Option<String> {
+    use base64::Engine;
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
+    let claims = RemoteBuildCapability {
+        mission_id,
+        expires_at,
+    };
+    let payload =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).ok()?);
     let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
     mac.update(b"remote-build:");
-    mac.update(mission_id.as_bytes());
-    Some(hex::encode(mac.finalize().into_bytes()))
+    mac.update(payload.as_bytes());
+    Some(format!(
+        "{payload}.{}",
+        hex::encode(mac.finalize().into_bytes())
+    ))
 }
 
 /// Mint a per-mission, scope-bound capability token for remote builds. The
@@ -70,14 +94,67 @@ fn sign_remote_build_token(secret: &str, mission_id: Uuid) -> Option<String> {
 /// signed with the same secret, so neither can be replayed as the other.
 /// Returns `None` when no signing secret is configured.
 pub fn build_remote_build_token(mission_id: Uuid) -> Option<String> {
-    sign_remote_build_token(&remote_build_secret()?, mission_id)
+    sign_remote_build_token(
+        &remote_build_secret()?,
+        mission_id,
+        chrono::Utc::now().timestamp() + remote_build_token_ttl_secs(),
+    )
+}
+
+fn verify_remote_build_token_with_secret(
+    secret: &str,
+    mission_id: Uuid,
+    token: &str,
+    now: i64,
+) -> bool {
+    use base64::Engine;
+    let Some((payload, signature)) = token.trim().split_once('.') else {
+        return false;
+    };
+    let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) else {
+        return false;
+    };
+    let Ok(claims) = serde_json::from_slice::<RemoteBuildCapability>(&bytes) else {
+        return false;
+    };
+    if claims.mission_id != mission_id || claims.expires_at < now {
+        return false;
+    }
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(b"remote-build:");
+    mac.update(payload.as_bytes());
+    let expected = hex::encode(mac.finalize().into_bytes());
+    super::auth::constant_time_eq(&expected, signature)
 }
 
 fn verify_remote_build_token(mission_id: Uuid, token: &str) -> bool {
-    let Some(expected) = build_remote_build_token(mission_id) else {
+    let Some(secret) = remote_build_secret() else {
         return false;
     };
-    super::auth::constant_time_eq(&expected, token.trim())
+    verify_remote_build_token_with_secret(
+        &secret,
+        mission_id,
+        token,
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+async fn mission_accepts_remote_build(state: &AppState, mission_id: Uuid) -> bool {
+    for session in state.control.all_sessions().await {
+        if let Ok(Some(mission)) = session.mission_store.get_mission(mission_id).await {
+            return matches!(
+                mission.status,
+                super::control::MissionStatus::Active
+                    | super::control::MissionStatus::Pending
+                    | super::control::MissionStatus::WaitingBackground
+            );
+        }
+    }
+    false
 }
 
 fn default_requirements() -> Vec<String> {
@@ -195,6 +272,13 @@ async fn submit_remote_build(
     // for this one mission. Same trust model as the spark offload endpoint.
     if !verify_remote_build_token(req.mission_id, &req.token) {
         return (StatusCode::UNAUTHORIZED, "invalid remote build token").into_response();
+    }
+    if !mission_accepts_remote_build(&state, req.mission_id).await {
+        return (
+            StatusCode::FORBIDDEN,
+            "remote builds require a live mission",
+        )
+            .into_response();
     }
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
@@ -336,21 +420,26 @@ async fn submit_remote_build(
 #[derive(Debug, Deserialize)]
 pub struct RemoteBuildStatusQuery {
     pub mission_id: Uuid,
-    pub token: String,
     #[serde(default = "default_node_id")]
     pub node_id: String,
 }
 
-/// `GET /api/remote-build/:job_id?mission_id=...&token=...&node_id=...` —
+/// `GET /api/remote-build/:job_id?mission_id=...&node_id=...` —
 /// job status for a build submitted with `wait: false`. Authenticated with
-/// the same per-mission capability token (query params, since the wrapper's
-/// GET has no body).
+/// the same per-mission capability token in `Authorization: Bearer ...` so
+/// credentials never enter request URLs or access logs.
 async fn get_remote_build(
     State(state): State<Arc<AppState>>,
     Path(job_id): Path<Uuid>,
     Query(query): Query<RemoteBuildStatusQuery>,
+    headers: HeaderMap,
 ) -> Result<Json<NodeJobStatus>, (StatusCode, String)> {
-    if !verify_remote_build_token(query.mission_id, &query.token) {
+    let token = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .unwrap_or_default();
+    if !verify_remote_build_token(query.mission_id, token) {
         return Err((
             StatusCode::UNAUTHORIZED,
             "invalid remote build token".to_string(),
@@ -391,15 +480,14 @@ mod tests {
     fn token_round_trips_and_is_mission_and_domain_scoped() {
         let mission = Uuid::new_v4();
         let other = Uuid::new_v4();
-        let token = sign_remote_build_token("secret", mission).unwrap();
-        assert_eq!(
-            sign_remote_build_token("secret", mission).unwrap(),
-            token,
-            "token must be deterministic for (secret, mission)"
-        );
-        assert_ne!(sign_remote_build_token("secret", other).unwrap(), token);
+        let expires_at = chrono::Utc::now().timestamp() + 600;
+        let token = sign_remote_build_token("secret", mission, expires_at).unwrap();
         assert_ne!(
-            sign_remote_build_token("other-secret", mission).unwrap(),
+            sign_remote_build_token("secret", other, expires_at).unwrap(),
+            token
+        );
+        assert_ne!(
+            sign_remote_build_token("other-secret", mission, expires_at).unwrap(),
             token
         );
         // Domain separation from the spark-offload token (same secret,
@@ -414,6 +502,29 @@ mod tests {
             let spark_token = hex::encode(mac.finalize().into_bytes());
             assert_ne!(spark_token, token);
         }
+    }
+
+    #[test]
+    fn token_expiry_is_enforced() {
+        let mission = Uuid::new_v4();
+        let now = chrono::Utc::now().timestamp();
+        let token = sign_remote_build_token("secret", mission, now + 60).unwrap();
+        let expired = sign_remote_build_token("secret", mission, now - 1).unwrap();
+        assert!(verify_remote_build_token_with_secret(
+            "secret", mission, &token, now
+        ));
+        assert!(!verify_remote_build_token_with_secret(
+            "secret", mission, &expired, now
+        ));
+        assert!(!verify_remote_build_token_with_secret(
+            "secret",
+            Uuid::new_v4(),
+            &token,
+            now
+        ));
+        assert!(!verify_remote_build_token_with_secret(
+            "wrong", mission, &token, now
+        ));
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -244,11 +244,15 @@ async fn submit_remote_build(
     let accepted = match client.submit_job(&node, &shared_token, &submit).await {
         Ok(accepted) => accepted,
         Err(err) => {
+            // 503, not 502: a node that went down after placement is a
+            // transient fleet-capacity condition, and 503 is the documented
+            // signal the remote-lean-build wrapper maps to EX_TEMPFAIL
+            // (fall back to a local build).
             return (
-                StatusCode::BAD_GATEWAY,
-                format!("remote node '{}' rejected the build: {err}", node.id),
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("remote node '{}' did not accept the build: {err}", node.id),
             )
-                .into_response()
+                .into_response();
         }
     };
     let outcome = |state: &str, exit_code: Option<i32>, error: Option<String>, terminal: bool| {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -565,6 +565,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // it's safe to always spawn.
     super::mission_workspace_gc::spawn(Arc::clone(&state));
 
+    // Disk-usage watcher: logs + Paloma-webhook alerts on Warn/Critical
+    // crossings, recovery notice on the way back down.
+    super::disk_watch::spawn(Arc::clone(&state));
+
     // Start background OAuth token refresher task
     {
         let ai_providers = Arc::clone(&state.ai_providers);

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -679,7 +679,11 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         // (verify_spark_offload_token), NOT the dashboard JWT — so it must
         // bypass require_auth like the /v1 proxy, otherwise the in-workspace
         // spark-build wrapper's token is rejected at the auth layer.
-        .nest("/api/spark", super::spark::routes());
+        .nest("/api/spark", super::spark::routes())
+        // Remote lean-build dispatch: same per-mission HMAC capability-token
+        // model as spark (domain-separated), verified inside the handlers,
+        // so it also bypasses require_auth.
+        .nest("/api/remote-build", super::remote_build::routes());
 
     // File upload routes with increased body limit (10GB)
     let upload_route = Router::new()

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -154,6 +154,9 @@ pub struct AppState {
     /// an active probe on dashboard demand and by passive `model_cooldown`
     /// capture on the proxy path. See [`super::codex_usage`].
     pub codex_usage: Arc<super::codex_usage::CodexUsageStore>,
+    /// Cached remote-runner-node statuses + recent dispatch outcomes, kept
+    /// fresh by the background fleet monitor (see `remote_node::monitor`).
+    pub fleet: Arc<crate::remote_node::FleetMonitor>,
 }
 
 /// Start the HTTP server.
@@ -523,7 +526,19 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         control_metrics: Arc::new(super::control_metrics::ControlMetrics::new()),
         provider_usage_cache: super::provider_usage_cache::ProviderUsageCache::new(),
         codex_usage: super::codex_usage::CodexUsageStore::new(),
+        fleet: Arc::new(crate::remote_node::FleetMonitor::new()),
     });
+
+    // Remote-node fleet monitor: periodic heartbeat polling so
+    // `/api/remote-nodes` and dispatch decisions read cached statuses
+    // (REMOTE_NODE_MONITOR_SECS, default 15s, 0 disables). Only spawned when
+    // remote nodes are enabled and configured.
+    if config.remote_nodes.enabled && !config.remote_nodes.nodes.is_empty() {
+        crate::remote_node::spawn_fleet_monitor(
+            Arc::clone(&state.fleet),
+            config.remote_nodes.clone(),
+        );
+    }
 
     // Start background refresh of provider rate-limit / usage info so the
     // dashboard always reads a fresh-enough cache.
@@ -1396,47 +1411,33 @@ async fn health(State(state): State<Arc<AppState>>) -> (HeaderMap, Json<HealthRe
     )
 }
 
-/// List configured remote runner nodes with live heartbeat status.
+/// List configured remote runner nodes with cached fleet status.
+///
+/// Statuses come from the background fleet monitor's cache. A node the
+/// monitor has never probed (monitor disabled via `REMOTE_NODE_MONITOR_SECS=0`
+/// or just started) is probed on demand once so the endpoint stays useful,
+/// and the result seeds the shared cache.
 async fn list_remote_nodes(
     State(state): State<Arc<AppState>>,
-) -> Json<Vec<crate::remote_node::NodeStatus>> {
-    let client = crate::remote_node::RemoteNodeClient::default();
-    let mut statuses = Vec::new();
-    for node in &state.config.remote_nodes.nodes {
-        let mut status = crate::remote_node::NodeStatus {
-            id: node.id.clone(),
-            base_url: node.base_url.clone(),
-            token_env: node.token_env.clone(),
-            online: false,
-            capacity_total: None,
-            capacity_available: None,
-            active_leases: None,
-            version: None,
-            error: None,
-        };
-        match std::env::var(&node.token_env)
-            .ok()
-            .filter(|token| !token.trim().is_empty())
-        {
-            Some(token) => match client.heartbeat(node, &token).await {
-                Ok(heartbeat) => {
-                    status.online = heartbeat.online;
-                    status.capacity_total = Some(heartbeat.capacity_total);
-                    status.capacity_available = Some(heartbeat.capacity_available);
-                    status.active_leases = Some(heartbeat.active_leases);
-                    status.version = Some(heartbeat.version);
-                }
-                Err(err) => {
-                    status.error = Some(err.to_string());
-                }
-            },
-            None => {
-                status.error = Some(format!("missing token env {}", node.token_env));
-            }
+) -> Json<crate::remote_node::RemoteNodesResponse> {
+    let settings = &state.config.remote_nodes;
+    let mut nodes = Vec::new();
+    for node in &settings.nodes {
+        if state.fleet.get(&node.id).is_none() {
+            let client = crate::remote_node::RemoteNodeClient::default();
+            crate::remote_node::probe_node(&state.fleet, &client, node).await;
         }
-        statuses.push(status);
+        let cached = state.fleet.get(&node.id);
+        nodes.push(crate::remote_node::RemoteNodeView::from_cache(
+            node,
+            cached.as_ref(),
+        ));
     }
-    Json(statuses)
+    Json(crate::remote_node::RemoteNodesResponse {
+        enabled: settings.enabled,
+        nodes,
+        recent_jobs: state.fleet.recent_outcomes(10),
+    })
 }
 
 /// Optional query parameters for the stats endpoint.

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -588,6 +588,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // mission no longer needs a live harness (see scope_reaper docs).
     super::scope_reaper::spawn(Arc::clone(&state));
 
+    // Re-attach poll loops for async remote jobs that were in flight when
+    // the previous process exited (durable handles in remote-jobs.json).
+    super::control::spawn_remote_job_reconciler(Arc::clone(&state));
+
     // Start background OAuth token refresher task
     {
         let ai_providers = Arc::clone(&state.ai_providers);

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -569,6 +569,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // crossings, recovery notice on the way back down.
     super::disk_watch::spawn(Arc::clone(&state));
 
+    // Zombie-scope reaper: stops leftover sandboxed-exec-*.scope units whose
+    // mission no longer needs a live harness (see scope_reaper docs).
+    super::scope_reaper::spawn(Arc::clone(&state));
+
     // Start background OAuth token refresher task
     {
         let ai_providers = Arc::clone(&state.ai_providers);

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -1251,6 +1251,12 @@ pub fn run_claudecode_turn<'a>(
         if let Some(spark_vars) = workspace.spark_offload_env(mission_id) {
             env.extend(spark_vars);
         }
+        // Remote lean-build dispatch — see Workspace::remote_build_env. Lets
+        // the in-workspace `remote-lean-build` wrapper ship builds to remote
+        // runner nodes; node credentials stay on the host.
+        if let Some(remote_build_vars) = workspace.remote_build_env(mission_id) {
+            env.extend(remote_build_vars);
+        }
 
         // Inject Telegram action environment variables when processing a Telegram message.
         // These are needed by the telegram-action CLI helper inside the container to schedule

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -978,6 +978,13 @@ pub async fn run_codex_turn(
         extra_env.extend(spark_env);
     }
 
+    // Remote lean-build dispatch — see Workspace::remote_build_env. Exported
+    // so the in-workspace `remote-lean-build` wrapper can reach the host
+    // /api/remote-build endpoint.
+    if let Some(remote_build_env) = workspace.remote_build_env(mission_id) {
+        extra_env.extend(remote_build_env);
+    }
+
     let codex_config = crate::backend::codex::client::CodexConfig {
         cli_path,
         model_effort: model_effort.map(|s| s.to_string()),

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -85,6 +85,7 @@ fn prepare_codex_per_mission_home(
         }
     }
     let mut env = HashMap::new();
+    env.insert("MISSION_ID".to_string(), mission_id.to_string());
     env.insert(
         "HOME".to_string(),
         workspace_exec.translate_path_for_container(mission_work_dir),

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -36,25 +36,6 @@ fn copy_file_if_exists(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn copy_dir_recursive_if_exists(src: &Path, dst: &Path) -> std::io::Result<()> {
-    if !src.exists() {
-        return Ok(());
-    }
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            copy_dir_recursive_if_exists(&src_path, &dst_path)?;
-        } else if ty.is_file() {
-            copy_file_if_exists(&src_path, &dst_path)?;
-        }
-    }
-    Ok(())
-}
-
 fn prepare_codex_per_mission_home(
     workspace: &Workspace,
     workspace_exec: &WorkspaceExec,
@@ -85,10 +66,10 @@ fn prepare_codex_per_mission_home(
         }
     }
 
-    // Only copy user/auth material from the shared Codex home. The generated
-    // `config.toml` contains mission-scoped MCP env and is written separately
-    // into the mission workspace; copying a stale shared config can point
-    // automation-manager/orchestrator at another mission.
+    // Only copy user/auth material from the shared Codex home. Generated
+    // config.toml and native skills are written directly into this mission's
+    // .codex directory during workspace preparation; copying shared versions
+    // could point orchestrator/automation-manager at another mission.
     for file_name in ["auth.json"] {
         if let Err(e) = copy_file_if_exists(
             &source_codex_dir.join(file_name),
@@ -103,19 +84,6 @@ fn prepare_codex_per_mission_home(
             );
         }
     }
-    if let Err(e) = copy_dir_recursive_if_exists(
-        &source_codex_dir.join("skills"),
-        &mission_codex_dir.join("skills"),
-    ) {
-        tracing::warn!(
-            mission_id = %mission_id,
-            source = %source_codex_dir.join("skills").display(),
-            dest = %mission_codex_dir.join("skills").display(),
-            error = %e,
-            "Failed to copy Codex skills into per-mission home"
-        );
-    }
-
     let mut env = HashMap::new();
     env.insert(
         "HOME".to_string(),

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -525,11 +525,11 @@ pub async fn run_opencode_turn(
     // Allow opting out of the per-mission XDG override when an operator
     // explicitly wants the opencode CLI to share storage with the host (e.g.
     // for debugging with `opencode session list` on the host shell).
-    if std::env::var("SANDBOXED_SH_OPENCODE_SHARED_XDG")
+    let shared_opencode_xdg = std::env::var("SANDBOXED_SH_OPENCODE_SHARED_XDG")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .is_some()
-    {
+        .is_some();
+    if shared_opencode_xdg {
         env.remove("XDG_CONFIG_HOME");
         env.remove("XDG_DATA_HOME");
         env.remove("XDG_STATE_HOME");
@@ -583,7 +583,8 @@ pub async fn run_opencode_turn(
         env.insert("PATH".to_string(), path_parts.join(":"));
     }
 
-    let opencode_auth = sync_opencode_auth_to_workspace(workspace, app_working_dir);
+    let opencode_auth =
+        sync_opencode_auth_to_workspace(workspace, app_working_dir, work_dir, shared_opencode_xdg);
 
     // Allow per-mission OpenCode server port; default to an allocated free port.
     let requested_port = std::env::var("SANDBOXED_SH_OPENCODE_SERVER_PORT")

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -455,6 +455,12 @@ pub async fn run_opencode_turn(
     if let Some(spark_vars) = workspace.spark_offload_env(mission_id) {
         env.extend(spark_vars);
     }
+    // Remote lean-build dispatch — see Workspace::remote_build_env. Exported
+    // so the in-workspace `remote-lean-build` wrapper can reach the host
+    // /api/remote-build endpoint.
+    if let Some(remote_build_vars) = workspace.remote_build_env(mission_id) {
+        env.extend(remote_build_vars);
+    }
     if let Some(public_url) = public_api_base_url_from_env() {
         env.insert("API_URL".to_string(), public_url);
     } else if let Some(local_url) = workspace_api_base_url(workspace) {

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -170,10 +170,12 @@ async fn stop_unit(unit: &str, reason: &str) -> bool {
 /// (caps disabled) — the unit list is simply empty.
 pub async fn stop_mission_exec_scopes(mission_id: Uuid, reason: &str) -> usize {
     let short = mission_id.to_string()[..8].to_string();
-    let needle = format!("-m{short}-");
     let mut stopped = 0;
     for unit in list_exec_scope_units().await {
-        if unit.contains(&needle) && stop_unit(&unit, reason).await {
+        if crate::workspace_exec::mission_short_id_from_exec_unit(&unit).as_deref()
+            == Some(short.as_str())
+            && stop_unit(&unit, reason).await
+        {
             stopped += 1;
         }
     }

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 use super::control::{AgentEvent, MissionStatus};
 use super::mission_store::MissionStore;
-use super::mission_workspace_gc::build_mission_index;
+use super::mission_workspace_gc::{build_mission_index, entry_for_workspace};
 use super::routes::AppState;
 use crate::workspace_exec::{
     machine_name_for_path, machine_name_from_exec_unit, mission_short_id_from_exec_unit,
@@ -302,17 +302,20 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
     let index = &index_full.by_short;
     // Two token sets over this instance's workspaces (machine-name tokens,
     // cf. `WorkspaceExec::mission_scope_match_token`):
-    // - `known_workspace_tokens`: OWNERSHIP filter. systemd units are
+    // - `workspace_ids_by_token`: OWNERSHIP filter and collision-safe lookup.
+    //   systemd units are
     //   host-global; when prod and dev instances share a host, each must
     //   only ever act on scopes of its own workspaces — a unit whose token
     //   we can't attribute to one of our workspaces is not ours to stop.
     // - `live_workspace_tokens`: workspaces with a scope-keeping mission,
     //   for the legacy-naming policy (no mission id in the unit name).
-    let mut known_workspace_tokens: HashSet<String> = HashSet::new();
+    let mut workspace_ids_by_token: std::collections::HashMap<String, Uuid> =
+        std::collections::HashMap::new();
     let mut live_workspace_tokens: HashSet<String> = HashSet::new();
     let workspaces = state.workspaces.list().await;
     let live_workspace_ids: HashSet<Uuid> = index
         .values()
+        .flatten()
         .filter(|e| status_keeps_scopes(&e.status))
         .map(|e| e.workspace_id)
         .collect();
@@ -321,7 +324,7 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
             if live_workspace_ids.contains(&ws.id) {
                 live_workspace_tokens.insert(token.clone());
             }
-            known_workspace_tokens.insert(token);
+            workspace_ids_by_token.insert(token, ws.id);
         }
     }
     let max_age = zombie_max_age();
@@ -329,16 +332,20 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
     for unit in units {
         report.scanned += 1;
         let unit_machine = machine_name_from_exec_unit(&unit);
-        let ours = unit_machine
+        let unit_workspace_id = unit_machine
             .as_ref()
-            .is_some_and(|machine| known_workspace_tokens.contains(machine));
-        if !ours {
+            .and_then(|machine| workspace_ids_by_token.get(machine))
+            .copied();
+        let Some(unit_workspace_id) = unit_workspace_id else {
             tracing::debug!(unit, "reaper: kept (scope not owned by this instance)");
             report.kept += 1;
             continue;
-        }
+        };
         match mission_short_id_from_exec_unit(&unit) {
-            Some(short) => match index.get(&short) {
+            Some(short) => match index
+                .get(&short)
+                .and_then(|entries| entry_for_workspace(entries, unit_workspace_id))
+            {
                 Some(entry) if status_keeps_scopes(&entry.status) => {
                     report.kept += 1;
                 }

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -27,6 +27,7 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use super::control::{AgentEvent, MissionStatus};
+use super::mission_store::MissionStore;
 use super::mission_workspace_gc::build_mission_index;
 use super::routes::AppState;
 use crate::workspace_exec::{machine_name_for_path, mission_short_id_from_exec_unit};
@@ -167,7 +168,10 @@ pub async fn stop_mission_exec_scopes(mission_id: Uuid, reason: &str) -> usize {
 /// Event-driven teardown: stop a mission's scopes as soon as its status
 /// stops needing them. Spawned once per control session next to the other
 /// event listeners (telegram alerts, paloma forwarder).
-pub fn spawn_status_listener(mut events: broadcast::Receiver<AgentEvent>) {
+pub fn spawn_status_listener(
+    mut events: broadcast::Receiver<AgentEvent>,
+    mission_store: Arc<dyn MissionStore>,
+) {
     tokio::spawn(async move {
         loop {
             match events.recv().await {
@@ -177,12 +181,29 @@ pub fn spawn_status_listener(mut events: broadcast::Receiver<AgentEvent>) {
                     if status_triggers_teardown(&status) {
                         // Detached so the grace sleep never stalls this
                         // receiver into broadcast lag.
+                        let store = Arc::clone(&mission_store);
                         tokio::spawn(async move {
                             let reason = format!("mission status {status:?}");
                             // Small grace: let the harness's own shutdown
                             // path run first so we usually stop an
                             // already-empty scope instead of racing it.
                             tokio::time::sleep(Duration::from_secs(5)).await;
+                            // Re-check the CURRENT status: within the grace
+                            // window the mission may have been promoted
+                            // (AwaitingUser → WaitingBackground by the
+                            // background watcher, or resumed to Active) —
+                            // stopping then would kill live work.
+                            match store.get_mission(mission_id).await {
+                                Ok(Some(m)) if status_keeps_scopes(&m.status) => {
+                                    tracing::debug!(
+                                        %mission_id,
+                                        status = ?m.status,
+                                        "scope teardown skipped: status changed during grace"
+                                    );
+                                    return;
+                                }
+                                _ => {}
+                            }
                             stop_mission_exec_scopes(mission_id, &reason).await;
                         });
                     }
@@ -258,7 +279,8 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
     if units.is_empty() {
         return report;
     }
-    let index = build_mission_index(state).await;
+    let index_full = build_mission_index(state).await;
+    let index = &index_full.by_short;
     // Two token sets over this instance's workspaces (machine-name tokens,
     // cf. `WorkspaceExec::mission_scope_match_token`):
     // - `known_workspace_tokens`: OWNERSHIP filter. systemd units are
@@ -309,7 +331,13 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
                     }
                 }
                 None => {
-                    if stop_unit(&unit, "reaper: mission unknown to any store").await {
+                    if !index_full.complete {
+                        tracing::debug!(
+                            unit,
+                            "reaper: kept (mission unknown but index incomplete)"
+                        );
+                        report.kept += 1;
+                    } else if stop_unit(&unit, "reaper: mission unknown to any store").await {
                         report.stopped += 1;
                     } else {
                         report.errors += 1;

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -67,6 +67,21 @@ fn reaper_interval() -> Duration {
     Duration::from_secs(minutes * 60)
 }
 
+/// Grace between a stopping status event and the actual scope stop. Must be
+/// comfortably LONGER than the background watcher's 10s reconciliation poll
+/// (`bg_autoresume::BG_POLL_INTERVAL`): a mission that parks AwaitingUser
+/// right after launching a background job is only promoted to
+/// WaitingBackground on the watcher's next tick, and the pre-stop status
+/// recheck must observe that promotion.
+fn teardown_grace() -> Duration {
+    let secs = std::env::var("SCOPE_TEARDOWN_GRACE_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|s| *s >= 1)
+        .unwrap_or(30);
+    Duration::from_secs(secs)
+}
+
 fn zombie_max_age() -> Duration {
     let hours = std::env::var("SCOPE_ZOMBIE_MAX_AGE_HOURS")
         .ok()
@@ -184,10 +199,12 @@ pub fn spawn_status_listener(
                         let store = Arc::clone(&mission_store);
                         tokio::spawn(async move {
                             let reason = format!("mission status {status:?}");
-                            // Small grace: let the harness's own shutdown
-                            // path run first so we usually stop an
-                            // already-empty scope instead of racing it.
-                            tokio::time::sleep(Duration::from_secs(5)).await;
+                            // Grace: let the harness's own shutdown path run
+                            // first, and — critically — outlast the
+                            // background watcher's 10s poll so an
+                            // AwaitingUser→WaitingBackground promotion is
+                            // visible to the recheck below.
+                            tokio::time::sleep(teardown_grace()).await;
                             // Re-check the CURRENT status: within the grace
                             // window the mission may have been promoted
                             // (AwaitingUser → WaitingBackground by the

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -30,7 +30,9 @@ use super::control::{AgentEvent, MissionStatus};
 use super::mission_store::MissionStore;
 use super::mission_workspace_gc::build_mission_index;
 use super::routes::AppState;
-use crate::workspace_exec::{machine_name_for_path, mission_short_id_from_exec_unit};
+use crate::workspace_exec::{
+    machine_name_for_path, machine_name_from_exec_unit, mission_short_id_from_exec_unit,
+};
 
 fn env_flag(var: &str, default: bool) -> bool {
     match std::env::var(var) {
@@ -328,9 +330,10 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
 
     for unit in units {
         report.scanned += 1;
-        let ours = known_workspace_tokens
-            .iter()
-            .any(|token| unit.contains(token.as_str()));
+        let unit_machine = machine_name_from_exec_unit(&unit);
+        let ours = unit_machine
+            .as_ref()
+            .is_some_and(|machine| known_workspace_tokens.contains(machine));
         if !ours {
             tracing::debug!(unit, "reaper: kept (scope not owned by this instance)");
             report.kept += 1;
@@ -374,9 +377,9 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
                     report.kept += 1;
                     continue;
                 }
-                let owned_by_live_ws = live_workspace_tokens
-                    .iter()
-                    .any(|token| unit.contains(token.as_str()));
+                let owned_by_live_ws = unit_machine
+                    .as_ref()
+                    .is_some_and(|machine| live_workspace_tokens.contains(machine));
                 if owned_by_live_ws {
                     report.kept += 1;
                     continue;

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -259,8 +259,15 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
         return report;
     }
     let index = build_mission_index(state).await;
-    // Workspaces with any scope-keeping mission, keyed by machine token, for
-    // the legacy-naming policy (no mission id in the unit name).
+    // Two token sets over this instance's workspaces (machine-name tokens,
+    // cf. `WorkspaceExec::mission_scope_match_token`):
+    // - `known_workspace_tokens`: OWNERSHIP filter. systemd units are
+    //   host-global; when prod and dev instances share a host, each must
+    //   only ever act on scopes of its own workspaces — a unit whose token
+    //   we can't attribute to one of our workspaces is not ours to stop.
+    // - `live_workspace_tokens`: workspaces with a scope-keeping mission,
+    //   for the legacy-naming policy (no mission id in the unit name).
+    let mut known_workspace_tokens: HashSet<String> = HashSet::new();
     let mut live_workspace_tokens: HashSet<String> = HashSet::new();
     let workspaces = state.workspaces.list().await;
     let live_workspace_ids: HashSet<Uuid> = index
@@ -269,18 +276,25 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
         .map(|e| e.workspace_id)
         .collect();
     for ws in &workspaces {
-        // Same token every scope of this workspace embeds (the machine
-        // name), cf. `WorkspaceExec::mission_scope_match_token`.
         if let Some(token) = machine_name_for_path(&ws.path) {
             if live_workspace_ids.contains(&ws.id) {
-                live_workspace_tokens.insert(token);
+                live_workspace_tokens.insert(token.clone());
             }
+            known_workspace_tokens.insert(token);
         }
     }
     let max_age = zombie_max_age();
 
     for unit in units {
         report.scanned += 1;
+        let ours = known_workspace_tokens
+            .iter()
+            .any(|token| unit.contains(token.as_str()));
+        if !ours {
+            tracing::debug!(unit, "reaper: kept (scope not owned by this instance)");
+            report.kept += 1;
+            continue;
+        }
         match mission_short_id_from_exec_unit(&unit) {
             Some(short) => match index.get(&short) {
                 Some(entry) if status_keeps_scopes(&entry.status) => {

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -1,0 +1,336 @@
+//! Lifecycle for per-exec transient scopes (`sandboxed-exec-*.scope`).
+//!
+//! Harness processes (codex app-server, claude, …) are spawned into
+//! transient scopes via `systemd-run --scope --collect` + `nsenter`. Killing
+//! the local child only kills the nsenter wrapper — the payload inside the
+//! container PID namespace survives, and `--collect` never collects a scope
+//! that still has processes. On prod this leaked 312 zombie app-server
+//! scopes pinning ~250 mission workspace dirs.
+//!
+//! Two mechanisms fix it:
+//! - an event listener stops a mission's scopes the moment the mission
+//!   reaches a stopping status (terminal always; AwaitingUser/Paused behind
+//!   default-on toggles — resume re-spawns the harness, it never reattaches
+//!   to a live process);
+//! - a periodic reaper sweeps zombies the listener missed (crashes,
+//!   restarts, legacy-named scopes from before the mission tag existed).
+//!
+//! `WaitingBackground` is always exempt: those missions park with live
+//! background shell jobs that DO live in an exec scope.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use super::control::{AgentEvent, MissionStatus};
+use super::mission_workspace_gc::build_mission_index;
+use super::routes::AppState;
+use crate::workspace_exec::{machine_name_for_path, mission_short_id_from_exec_unit};
+
+fn env_flag(var: &str, default: bool) -> bool {
+    match std::env::var(var) {
+        Ok(v) => {
+            let v = v.trim();
+            if default {
+                v != "0" && !v.eq_ignore_ascii_case("false")
+            } else {
+                v == "1" || v.eq_ignore_ascii_case("true")
+            }
+        }
+        Err(_) => default,
+    }
+}
+
+fn stop_on_awaiting_user() -> bool {
+    env_flag("SCOPE_STOP_ON_AWAITING_USER", true)
+}
+
+fn stop_on_pause() -> bool {
+    env_flag("SCOPE_STOP_ON_PAUSE", true)
+}
+
+fn reaper_enabled() -> bool {
+    env_flag("SCOPE_REAPER_ENABLED", true)
+}
+
+fn reaper_interval() -> Duration {
+    let minutes = std::env::var("SCOPE_REAPER_INTERVAL_MINUTES")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|m| *m >= 1)
+        .unwrap_or(15);
+    Duration::from_secs(minutes * 60)
+}
+
+fn zombie_max_age() -> Duration {
+    let hours = std::env::var("SCOPE_ZOMBIE_MAX_AGE_HOURS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(12);
+    Duration::from_secs(hours * 3600)
+}
+
+/// Statuses whose scopes must never be touched: the mission is running or
+/// parked with live background work.
+fn status_keeps_scopes(status: &MissionStatus) -> bool {
+    match status {
+        MissionStatus::Active | MissionStatus::Pending | MissionStatus::WaitingBackground => true,
+        MissionStatus::AwaitingUser => !stop_on_awaiting_user(),
+        MissionStatus::Paused => !stop_on_pause(),
+        _ => false,
+    }
+}
+
+/// True when a status transition should trigger immediate scope teardown.
+fn status_triggers_teardown(status: &MissionStatus) -> bool {
+    match status {
+        MissionStatus::Completed
+        | MissionStatus::Failed
+        | MissionStatus::Interrupted
+        | MissionStatus::Blocked
+        | MissionStatus::NotFeasible
+        | MissionStatus::Acknowledged => true,
+        MissionStatus::AwaitingUser => stop_on_awaiting_user(),
+        MissionStatus::Paused => stop_on_pause(),
+        MissionStatus::Active | MissionStatus::Pending | MissionStatus::WaitingBackground => false,
+    }
+}
+
+/// List all `sandboxed-exec-*.scope` unit names currently known to systemd.
+async fn list_exec_scope_units() -> Vec<String> {
+    let output = Command::new("systemctl")
+        .args([
+            "list-units",
+            "--plain",
+            "--no-legend",
+            "--all",
+            "sandboxed-exec-*.scope",
+        ])
+        .output()
+        .await;
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|unit| unit.starts_with("sandboxed-exec-") && unit.ends_with(".scope"))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+async fn stop_unit(unit: &str, reason: &str) -> bool {
+    match Command::new("systemctl")
+        .args(["stop", unit])
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => {
+            tracing::info!(unit, reason, "stopped exec scope");
+            true
+        }
+        Ok(o) => {
+            tracing::warn!(
+                unit,
+                reason,
+                stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                "failed to stop exec scope"
+            );
+            false
+        }
+        Err(err) => {
+            tracing::warn!(unit, reason, ?err, "systemctl stop failed");
+            false
+        }
+    }
+}
+
+/// Stop every exec scope tagged with `mission_id`'s short id. Returns the
+/// number of scopes stopped. No-op when the host has no systemd scopes
+/// (caps disabled) — the unit list is simply empty.
+pub async fn stop_mission_exec_scopes(mission_id: Uuid, reason: &str) -> usize {
+    let short = mission_id.to_string()[..8].to_string();
+    let needle = format!("-m{short}-");
+    let mut stopped = 0;
+    for unit in list_exec_scope_units().await {
+        if unit.contains(&needle) && stop_unit(&unit, reason).await {
+            stopped += 1;
+        }
+    }
+    stopped
+}
+
+/// Event-driven teardown: stop a mission's scopes as soon as its status
+/// stops needing them. Spawned once per control session next to the other
+/// event listeners (telegram alerts, paloma forwarder).
+pub fn spawn_status_listener(mut events: broadcast::Receiver<AgentEvent>) {
+    tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(AgentEvent::MissionStatusChanged {
+                    mission_id, status, ..
+                }) => {
+                    if status_triggers_teardown(&status) {
+                        // Detached so the grace sleep never stalls this
+                        // receiver into broadcast lag.
+                        tokio::spawn(async move {
+                            let reason = format!("mission status {status:?}");
+                            // Small grace: let the harness's own shutdown
+                            // path run first so we usually stop an
+                            // already-empty scope instead of racing it.
+                            tokio::time::sleep(Duration::from_secs(5)).await;
+                            stop_mission_exec_scopes(mission_id, &reason).await;
+                        });
+                    }
+                }
+                Ok(_) => {}
+                Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                    tracing::warn!(dropped, "scope teardown listener lagged; continuing");
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
+/// Age of a unit, from systemd's monotonic activation timestamp compared to
+/// the host uptime. Monotonic avoids parsing locale/timezone-formatted
+/// wall-clock strings and is immune to clock adjustments.
+async fn unit_age(unit: &str) -> Option<Duration> {
+    let output = Command::new("systemctl")
+        .args([
+            "show",
+            "-p",
+            "ActiveEnterTimestampMonotonic",
+            "--value",
+            unit,
+        ])
+        .output()
+        .await
+        .ok()?;
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let entered_us: u64 = raw.parse().ok().filter(|v| *v > 0)?;
+    let uptime = tokio::fs::read_to_string("/proc/uptime").await.ok()?;
+    let uptime_secs: f64 = uptime.split_whitespace().next()?.parse().ok()?;
+    let uptime_us = (uptime_secs * 1_000_000.0) as u64;
+    Some(Duration::from_micros(uptime_us.saturating_sub(entered_us)))
+}
+
+/// Spawn the periodic zombie reaper. Safe to call once at server start.
+pub fn spawn(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(reaper_interval());
+        interval.tick().await; // skip boot tick
+        loop {
+            interval.tick().await;
+            if !reaper_enabled() {
+                continue;
+            }
+            let report = run_once(&state).await;
+            if report.stopped > 0 || report.errors > 0 {
+                tracing::info!(
+                    scanned = report.scanned,
+                    stopped = report.stopped,
+                    kept = report.kept,
+                    errors = report.errors,
+                    "scope reaper sweep finished"
+                );
+            }
+        }
+    });
+}
+
+#[derive(Default)]
+pub struct ReaperReport {
+    pub scanned: usize,
+    pub stopped: usize,
+    pub kept: usize,
+    pub errors: usize,
+}
+
+async fn run_once(state: &Arc<AppState>) -> ReaperReport {
+    let mut report = ReaperReport::default();
+    let units = list_exec_scope_units().await;
+    if units.is_empty() {
+        return report;
+    }
+    let index = build_mission_index(state).await;
+    // Workspaces with any scope-keeping mission, keyed by machine token, for
+    // the legacy-naming policy (no mission id in the unit name).
+    let mut live_workspace_tokens: HashSet<String> = HashSet::new();
+    let workspaces = state.workspaces.list().await;
+    let live_workspace_ids: HashSet<Uuid> = index
+        .values()
+        .filter(|e| status_keeps_scopes(&e.status))
+        .map(|e| e.workspace_id)
+        .collect();
+    for ws in &workspaces {
+        // Same token every scope of this workspace embeds (the machine
+        // name), cf. `WorkspaceExec::mission_scope_match_token`.
+        if let Some(token) = machine_name_for_path(&ws.path) {
+            if live_workspace_ids.contains(&ws.id) {
+                live_workspace_tokens.insert(token);
+            }
+        }
+    }
+    let max_age = zombie_max_age();
+
+    for unit in units {
+        report.scanned += 1;
+        match mission_short_id_from_exec_unit(&unit) {
+            Some(short) => match index.get(&short) {
+                Some(entry) if status_keeps_scopes(&entry.status) => {
+                    report.kept += 1;
+                }
+                Some(entry) => {
+                    let reason = format!("reaper: mission {short} status {:?}", entry.status);
+                    if stop_unit(&unit, &reason).await {
+                        report.stopped += 1;
+                    } else {
+                        report.errors += 1;
+                    }
+                }
+                None => {
+                    if stop_unit(&unit, "reaper: mission unknown to any store").await {
+                        report.stopped += 1;
+                    } else {
+                        report.errors += 1;
+                    }
+                }
+            },
+            None => {
+                // Legacy naming (or task-tagged): stop only when old enough
+                // AND the owning workspace has no scope-keeping mission.
+                let Some(age) = unit_age(&unit).await else {
+                    report.kept += 1;
+                    continue;
+                };
+                if age < max_age {
+                    report.kept += 1;
+                    continue;
+                }
+                let owned_by_live_ws = live_workspace_tokens
+                    .iter()
+                    .any(|token| unit.contains(token.as_str()));
+                if owned_by_live_ws {
+                    report.kept += 1;
+                    continue;
+                }
+                let reason = format!(
+                    "reaper: legacy-named scope older than {}h in workspace with no live mission",
+                    max_age.as_secs() / 3600
+                );
+                if stop_unit(&unit, &reason).await {
+                    report.stopped += 1;
+                } else {
+                    report.errors += 1;
+                }
+            }
+        }
+    }
+    report
+}

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -101,7 +101,7 @@ fn status_triggers_teardown(status: &MissionStatus) -> bool {
 }
 
 /// List all `sandboxed-exec-*.scope` unit names currently known to systemd.
-async fn list_exec_scope_units() -> Vec<String> {
+pub(crate) async fn list_exec_scope_units() -> Vec<String> {
     let output = Command::new("systemctl")
         .args([
             "list-units",

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -171,11 +171,9 @@ async fn stop_unit(unit: &str, reason: &str) -> bool {
 /// number of scopes stopped. No-op when the host has no systemd scopes
 /// (caps disabled) — the unit list is simply empty.
 pub async fn stop_mission_exec_scopes(mission_id: Uuid, reason: &str) -> usize {
-    let short = mission_id.to_string()[..8].to_string();
     let mut stopped = 0;
     for unit in list_exec_scope_units().await {
-        if crate::workspace_exec::mission_short_id_from_exec_unit(&unit).as_deref()
-            == Some(short.as_str())
+        if crate::workspace_exec::exec_unit_belongs_to_mission(&unit, mission_id)
             && stop_unit(&unit, reason).await
         {
             stopped += 1;

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -118,6 +118,15 @@ fn status_triggers_teardown(status: &MissionStatus) -> bool {
     }
 }
 
+fn legacy_scope_is_reapable(
+    mission_index_complete: bool,
+    age: Option<Duration>,
+    max_age: Duration,
+    owned_by_live_workspace: bool,
+) -> bool {
+    mission_index_complete && age.is_some_and(|age| age >= max_age) && !owned_by_live_workspace
+}
+
 /// List all `sandboxed-exec-*.scope` unit names currently known to systemd.
 pub(crate) async fn list_exec_scope_units() -> Vec<String> {
     let output = Command::new("systemctl")
@@ -373,19 +382,20 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
             },
             None => {
                 // Legacy naming (or task-tagged): stop only when old enough
-                // AND the owning workspace has no scope-keeping mission.
-                let Some(age) = unit_age(&unit).await else {
-                    report.kept += 1;
-                    continue;
-                };
-                if age < max_age {
-                    report.kept += 1;
-                    continue;
-                }
+                // AND the owning workspace has no scope-keeping mission. An
+                // incomplete cross-store index cannot prove that absence, so
+                // fail closed just like the mission-tagged branch above.
+                let age = unit_age(&unit).await;
                 let owned_by_live_ws = unit_machine
                     .as_ref()
                     .is_some_and(|machine| live_workspace_tokens.contains(machine));
-                if owned_by_live_ws {
+                if !legacy_scope_is_reapable(index_full.complete, age, max_age, owned_by_live_ws) {
+                    if !index_full.complete {
+                        tracing::debug!(
+                            unit,
+                            "reaper: kept (legacy scope but mission index incomplete)"
+                        );
+                    }
                     report.kept += 1;
                     continue;
                 }
@@ -402,4 +412,26 @@ async fn run_once(state: &Arc<AppState>) -> ReaperReport {
         }
     }
     report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_scopes_fail_closed_when_mission_index_is_incomplete() {
+        let max_age = Duration::from_secs(12 * 3600);
+        let old = Some(max_age + Duration::from_secs(1));
+
+        assert!(!legacy_scope_is_reapable(false, old, max_age, false));
+        assert!(legacy_scope_is_reapable(true, old, max_age, false));
+        assert!(!legacy_scope_is_reapable(true, old, max_age, true));
+        assert!(!legacy_scope_is_reapable(
+            true,
+            Some(max_age - Duration::from_secs(1)),
+            max_age,
+            false
+        ));
+        assert!(!legacy_scope_is_reapable(true, None, max_age, false));
+    }
 }

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -38,6 +38,8 @@ pub struct SettingsResponse {
     pub max_concurrent_tasks: Option<usize>,
     pub auto_cleanup_enabled: Option<bool>,
     pub auto_cleanup_days: Option<u32>,
+    pub auto_cleanup_stopped_days: Option<u32>,
+    pub auto_cleanup_orphans_enabled: Option<bool>,
     pub ask_assistant_model: Option<String>,
     pub metadata_model: Option<String>,
 }
@@ -51,6 +53,8 @@ impl From<Settings> for SettingsResponse {
             max_concurrent_tasks: settings.max_concurrent_tasks,
             auto_cleanup_enabled: settings.auto_cleanup_enabled,
             auto_cleanup_days: settings.auto_cleanup_days,
+            auto_cleanup_stopped_days: settings.auto_cleanup_stopped_days,
+            auto_cleanup_orphans_enabled: settings.auto_cleanup_orphans_enabled,
             ask_assistant_model: settings.ask_assistant_model,
             metadata_model: settings.metadata_model,
         }
@@ -72,6 +76,10 @@ pub struct UpdateSettingsRequest {
     pub auto_cleanup_enabled: Option<bool>,
     #[serde(default)]
     pub auto_cleanup_days: Option<u32>,
+    #[serde(default)]
+    pub auto_cleanup_stopped_days: Option<u32>,
+    #[serde(default)]
+    pub auto_cleanup_orphans_enabled: Option<bool>,
     /// Double-Option so a present `null` clears it (back to env/default).
     #[serde(default)]
     pub ask_assistant_model: Option<Option<String>>,
@@ -223,6 +231,19 @@ async fn update_settings(
             ));
         }
         new_settings.auto_cleanup_days = Some(value);
+    }
+    if let Some(value) = req.auto_cleanup_stopped_days {
+        // Same floor as auto_cleanup_days, for the same reason.
+        if value < 1 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "auto_cleanup_stopped_days must be at least 1".to_string(),
+            ));
+        }
+        new_settings.auto_cleanup_stopped_days = Some(value);
+    }
+    if let Some(value) = req.auto_cleanup_orphans_enabled {
+        new_settings.auto_cleanup_orphans_enabled = Some(value);
     }
     let mut metadata_model_changed = false;
     if let Some(value) = req.metadata_model {

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3567,6 +3567,35 @@ fn stream_deploy(
         }
         yield sse("log", format!("Backups: {}, {}, {}", bkp_main, bkp_mcp, bkp_assistant_mcp), Some(88));
 
+        // Prune old backups now that every install succeeded. The rollback
+        // paths above consume this deploy's backups via rename, so pruning
+        // must stay on the success path only. Each deploy adds one ~440MB
+        // copy per binary; unbounded, this filled the prod disk.
+        let keep = deploy_backup_keep();
+        let mut pruned_total = 0usize;
+        let mut freed_total = 0u64;
+        for dest in [
+            &install_dest_main,
+            &install_dest_mcp,
+            &install_dest_assistant_mcp,
+        ] {
+            let (pruned, freed) = prune_deploy_backups(dest, keep).await;
+            pruned_total += pruned.len();
+            freed_total = freed_total.saturating_add(freed);
+        }
+        if pruned_total > 0 {
+            yield sse(
+                "log",
+                format!(
+                    "Pruned {} old pre-deploy backups ({} MB freed, keeping {} per binary)",
+                    pruned_total,
+                    freed_total / (1024 * 1024),
+                    keep
+                ),
+                Some(89),
+            );
+        }
+
         // Schedule the restart in a fully detached process so this SSE
         // response can flush its final event before systemd SIGTERMs us.
         // `setsid` + `nohup` + `&` puts the restart in a new session that
@@ -3603,6 +3632,65 @@ fn stream_deploy(
         // restart tears down our TCP connection.
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     }
+}
+
+/// How many `.pre-deploy-<sha>` backups to keep per deployed binary.
+/// Env `DEPLOY_BACKUP_KEEP`, default 2, clamped to at least 1 so the
+/// most recent rollback point always survives.
+fn deploy_backup_keep() -> usize {
+    std::env::var("DEPLOY_BACKUP_KEEP")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .map(|v| v.max(1))
+        .unwrap_or(2)
+}
+
+/// Remove all but the `keep` newest `.pre-deploy-*` backups of `dest`.
+/// Returns (pruned file names, bytes freed). Matches on the exact
+/// `<basename>.pre-deploy-` prefix — the dot anchors the name, so pruning
+/// `sandboxed-sh` never touches `sandboxed-sh-prod` backups. Failures are
+/// swallowed: pruning must never fail a deploy that already succeeded.
+async fn prune_deploy_backups(dest: &str, keep: usize) -> (Vec<String>, u64) {
+    let dest_path = std::path::Path::new(dest);
+    let (Some(dir), Some(name)) = (dest_path.parent(), dest_path.file_name()) else {
+        return (Vec::new(), 0);
+    };
+    let prefix = format!("{}.pre-deploy-", name.to_string_lossy());
+    let Ok(mut rd) = tokio::fs::read_dir(dir).await else {
+        return (Vec::new(), 0);
+    };
+    let mut backups: Vec<(std::path::PathBuf, std::time::SystemTime, u64)> = Vec::new();
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let fname = entry.file_name().to_string_lossy().into_owned();
+        if !fname.starts_with(&prefix) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata().await else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        backups.push((entry.path(), mtime, meta.len()));
+    }
+    backups.sort_by(|a, b| b.1.cmp(&a.1));
+    let mut pruned = Vec::new();
+    let mut freed = 0u64;
+    for (path, _, size) in backups.into_iter().skip(keep) {
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {
+                freed = freed.saturating_add(size);
+                if let Some(n) = path.file_name() {
+                    pruned.push(n.to_string_lossy().into_owned());
+                }
+            }
+            Err(err) => {
+                tracing::warn!(path = %path.display(), ?err, "failed to prune deploy backup");
+            }
+        }
+    }
+    (pruned, freed)
 }
 
 /// Install a new binary into a versioned dir and flip a symlink at
@@ -4565,10 +4653,40 @@ mod tests {
     use super::{
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
         hermes_config_base_url, hermes_config_model_label, hermes_uses_native_codex,
-        is_safe_repo_path, normalize_repo_path, select_repo_path,
+        is_safe_repo_path, normalize_repo_path, prune_deploy_backups, select_repo_path,
         systemd_service_component_from_states, ComponentStatus, DebounceDecision, DeployRefusal,
         DEPLOY_DEBOUNCE_SECS,
     };
+
+    #[tokio::test]
+    async fn prune_deploy_backups_keeps_newest_and_anchors_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("sandboxed-sh");
+        let mk = |name: &str, age_secs: u64| {
+            let p = dir.path().join(name);
+            std::fs::write(&p, b"x").unwrap();
+            let t = std::time::SystemTime::now() - std::time::Duration::from_secs(age_secs);
+            let f = std::fs::OpenOptions::new().write(true).open(&p).unwrap();
+            f.set_modified(t).unwrap();
+            p
+        };
+        // Four backups of `sandboxed-sh`, oldest last.
+        mk("sandboxed-sh.pre-deploy-aaaa", 10);
+        mk("sandboxed-sh.pre-deploy-bbbb", 20);
+        let old1 = mk("sandboxed-sh.pre-deploy-cccc", 30);
+        let old2 = mk("sandboxed-sh.pre-deploy-dddd", 40);
+        // A different binary sharing the prefix chars must NOT be touched.
+        let other = mk("sandboxed-sh-prod.pre-deploy-eeee", 99);
+
+        let (pruned, freed) = prune_deploy_backups(dest.to_string_lossy().as_ref(), 2).await;
+        assert_eq!(pruned.len(), 2);
+        assert!(freed >= 2);
+        assert!(!old1.exists());
+        assert!(!old2.exists());
+        assert!(other.exists(), "prefix must be dot-anchored per basename");
+        assert!(dir.path().join("sandboxed-sh.pre-deploy-aaaa").exists());
+        assert!(dir.path().join("sandboxed-sh.pre-deploy-bbbb").exists());
+    }
 
     #[test]
     fn hermes_config_model_label_prefers_provider_and_default() {

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1204,7 +1204,9 @@ mcp_servers:
       JWT_SECRET: {jwt_secret}
       HERMES_ASSISTANT_USER_ID: {user_id}
       HERMES_DEFAULT_WORKSPACE_ID: {default_workspace_id}
-    timeout: 120
+    # Ask turns can make multiple sequential LLM/tool calls. Keep the MCP
+    # request alive long enough for the synchronous /ask endpoint to finish.
+    timeout: 600
     connect_timeout: 15
     tools:
       include:
@@ -1214,6 +1216,7 @@ mcp_servers:
         - get_mission_events
         - start_mission
         - send_message_to_mission
+        - ask_mission
         - cancel_mission
         - list_workspaces
       prompts: false
@@ -4652,11 +4655,30 @@ fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::conve
 mod tests {
     use super::{
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
-        hermes_config_base_url, hermes_config_model_label, hermes_uses_native_codex,
-        is_safe_repo_path, normalize_repo_path, prune_deploy_backups, select_repo_path,
-        systemd_service_component_from_states, ComponentStatus, DebounceDecision, DeployRefusal,
-        DEPLOY_DEBOUNCE_SECS,
+        hermes_config_base_url, hermes_config_model_label, hermes_config_yaml,
+        hermes_uses_native_codex, is_safe_repo_path, normalize_repo_path, prune_deploy_backups,
+        select_repo_path, systemd_service_component_from_states, ComponentStatus, DebounceDecision,
+        DeployRefusal, DEPLOY_DEBOUNCE_SECS,
     };
+
+    #[test]
+    fn generated_hermes_config_allows_long_ask_turns() {
+        let yaml = hermes_config_yaml(
+            "hermes-test",
+            "model",
+            "http://api.invalid",
+            "test-key",
+            "/usr/local/bin/assistant-mcp",
+            "http://127.0.0.1:3000",
+            "test-jwt-secret",
+            "test-user",
+            "00000000-0000-0000-0000-000000000000",
+        );
+
+        assert!(yaml.contains("    timeout: 600\n"));
+        assert!(!yaml.contains("    timeout: 120\n"));
+        assert!(yaml.contains("        - ask_mission\n"));
+    }
 
     #[tokio::test]
     async fn prune_deploy_backups_keeps_newest_and_anchors_prefix() {

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3674,7 +3674,7 @@ async fn prune_deploy_backups(dest: &str, keep: usize) -> (Vec<String>, u64) {
         let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
         backups.push((entry.path(), mtime, meta.len()));
     }
-    backups.sort_by(|a, b| b.1.cmp(&a.1));
+    backups.sort_by_key(|(_, mtime, _)| std::cmp::Reverse(*mtime));
     let mut pruned = Vec::new();
     let mut freed = 0u64;
     for (path, _, size) in backups.into_iter().skip(keep) {

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -398,7 +398,12 @@ async fn send_message_streaming_app_server(
         // the common case (transient OOM kill, network blip) without
         // hiding a persistent failure.
         const MAX_RECONNECTS: u32 = 1;
+        const PENDING_TOOL_RECONCILE_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
         let mut reconnect_attempts: u32 = 0;
+        let mut pending_tool_reconciliation: Option<(
+            tokio::time::Instant,
+            std::collections::HashSet<String>,
+        )> = None;
 
         'outer: loop {
             loop {
@@ -443,6 +448,41 @@ async fn send_message_streaming_app_server(
                         Some(m) => m,
                         None => break, // inner loop → check whether to reconnect
                     },
+                    _ = async {
+                        if let Some((deadline, _)) = pending_tool_reconciliation.as_ref() {
+                            tokio::time::sleep_until(*deadline).await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    } => {
+                        let (_, interrupted_ids) = pending_tool_reconciliation
+                            .take()
+                            .expect("reconciliation timer fired without pending state");
+                        let interrupted =
+                            translator.reconcile_interrupted_tools(&interrupted_ids);
+                        if interrupted.is_empty() {
+                            continue;
+                        }
+                        let names = interrupted
+                            .iter()
+                            .filter_map(|event| match event {
+                                ExecutionEvent::ToolResult { name, .. } => Some(name.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        let _ = tx
+                            .send(ExecutionEvent::Error {
+                                message: format!(
+                                    "codex app-server transport interrupted while pending tool calls ({names}) could not be reconciled after thread/resume; synthetic infra_transport_interrupted results were emitted and commands were not replayed"
+                                ),
+                            })
+                            .await;
+                        for event in interrupted {
+                            let _ = tx.send(event).await;
+                        }
+                        break 'outer;
+                    }
                 };
 
                 match msg {
@@ -581,10 +621,34 @@ async fn send_message_streaming_app_server(
             };
             session_arc = new_session;
             inbound = new_inbound;
+            let interrupted_ids = translator.pending_tool_ids();
+            if !interrupted_ids.is_empty() {
+                tracing::warn!(
+                    pending_tool_count = interrupted_ids.len(),
+                    grace_seconds = PENDING_TOOL_RECONCILE_GRACE.as_secs(),
+                    "codex app-server resumed with in-flight tool calls; waiting for completion replay before synthetic terminalization"
+                );
+                pending_tool_reconciliation = Some((
+                    tokio::time::Instant::now() + PENDING_TOOL_RECONCILE_GRACE,
+                    interrupted_ids,
+                ));
+            }
             tracing::info!("codex app-server reconnected via thread/resume");
         }
 
         if stream_closed_unexpectedly {
+            let interrupted_ids = translator.pending_tool_ids();
+            let interrupted = translator.reconcile_interrupted_tools(&interrupted_ids);
+            if !interrupted.is_empty() {
+                let _ = tx
+                    .send(ExecutionEvent::Error {
+                        message: "codex app-server stream closed while tool calls were pending; synthetic infra_transport_interrupted results were emitted and commands were not replayed".to_string(),
+                    })
+                    .await;
+                for event in interrupted {
+                    let _ = tx.send(event).await;
+                }
+            }
             let _ = tx
                 .send(ExecutionEvent::Error {
                     message: "codex app-server stream closed before mission terminated".to_string(),
@@ -652,6 +716,12 @@ struct AppServerEventTranslator {
     /// Set after a terminal goal update (`complete` / `budgetLimited`). The
     /// stream becomes terminal once the active turn completes.
     goal_terminal_seen: bool,
+    /// Tool calls emitted to consumers but not yet paired with a terminal
+    /// result. Persisted across an app-server reconnect within this driver so
+    /// a resumed stream can replay completion or be terminalized exactly once.
+    pending_tool_calls: std::collections::HashMap<String, String>,
+    emitted_tool_call_ids: std::collections::HashSet<String>,
+    emitted_tool_result_ids: std::collections::HashSet<String>,
 }
 
 struct TranslateOutcome {
@@ -698,6 +768,37 @@ fn codex_usage_from_turn_params(params: &serde_json::Value) -> Option<(u64, u64)
 }
 
 impl AppServerEventTranslator {
+    fn pending_tool_ids(&self) -> std::collections::HashSet<String> {
+        self.pending_tool_calls.keys().cloned().collect()
+    }
+
+    fn reconcile_interrupted_tools(
+        &mut self,
+        interrupted_ids: &std::collections::HashSet<String>,
+    ) -> Vec<ExecutionEvent> {
+        let mut ids: Vec<_> = interrupted_ids.iter().cloned().collect();
+        ids.sort();
+        let mut events = Vec::new();
+        for id in ids {
+            let Some(name) = self.pending_tool_calls.remove(&id) else {
+                continue;
+            };
+            if self.emitted_tool_result_ids.insert(id.clone()) {
+                events.push(ExecutionEvent::ToolResult {
+                    id,
+                    name,
+                    result: serde_json::json!({
+                        "status": "infra_transport_interrupted",
+                        "synthetic": true,
+                        "command_replayed": false,
+                        "message": "app-server stream closed before the tool result was observed",
+                    }),
+                });
+            }
+        }
+        events
+    }
+
     fn handle_notification(
         &mut self,
         method: &str,
@@ -782,14 +883,24 @@ impl AppServerEventTranslator {
                                     .or_else(|| item.get("input"))
                                     .cloned()
                                     .unwrap_or(serde_json::Value::Null);
-                                events.push(ExecutionEvent::ToolCall { id, name, args });
+                                if !self.emitted_tool_result_ids.contains(&id) {
+                                    self.pending_tool_calls.insert(id.clone(), name.clone());
+                                }
+                                if !self.emitted_tool_result_ids.contains(&id)
+                                    && self.emitted_tool_call_ids.insert(id.clone())
+                                {
+                                    events.push(ExecutionEvent::ToolCall { id, name, args });
+                                }
                             } else {
                                 let result = item
                                     .get("result")
                                     .or_else(|| item.get("output"))
                                     .cloned()
                                     .unwrap_or(serde_json::Value::Null);
-                                events.push(ExecutionEvent::ToolResult { id, name, result });
+                                self.pending_tool_calls.remove(&id);
+                                if self.emitted_tool_result_ids.insert(id.clone()) {
+                                    events.push(ExecutionEvent::ToolResult { id, name, result });
+                                }
                             }
                         }
                         "commandExecution" => {
@@ -801,22 +912,33 @@ impl AppServerEventTranslator {
                                 .cloned()
                                 .unwrap_or(serde_json::Value::Null);
                             if method == "item/started" {
-                                events.push(ExecutionEvent::ToolCall {
-                                    id,
-                                    name: "bash".to_string(),
-                                    args: serde_json::json!({ "command": command }),
-                                });
+                                if !self.emitted_tool_result_ids.contains(&id) {
+                                    self.pending_tool_calls
+                                        .insert(id.clone(), "bash".to_string());
+                                }
+                                if !self.emitted_tool_result_ids.contains(&id)
+                                    && self.emitted_tool_call_ids.insert(id.clone())
+                                {
+                                    events.push(ExecutionEvent::ToolCall {
+                                        id,
+                                        name: "bash".to_string(),
+                                        args: serde_json::json!({ "command": command }),
+                                    });
+                                }
                             } else {
                                 let result = item
                                     .get("aggregatedOutput")
                                     .or_else(|| item.get("output"))
                                     .cloned()
                                     .unwrap_or(serde_json::Value::Null);
-                                events.push(ExecutionEvent::ToolResult {
-                                    id,
-                                    name: "bash".to_string(),
-                                    result,
-                                });
+                                self.pending_tool_calls.remove(&id);
+                                if self.emitted_tool_result_ids.insert(id.clone()) {
+                                    events.push(ExecutionEvent::ToolResult {
+                                        id,
+                                        name: "bash".to_string(),
+                                        result,
+                                    });
+                                }
                             }
                         }
                         // Other item types (assistantMessage, userMessage, etc.)
@@ -1136,6 +1258,7 @@ mod tests {
             goal_objective: String::new(),
             goal_turn_active: false,
             goal_terminal_seen: false,
+            ..Default::default()
         };
 
         let notify = |item_id: &str, delta: &str| {
@@ -1220,6 +1343,7 @@ mod tests {
             goal_objective: String::new(),
             goal_turn_active: false,
             goal_terminal_seen: false,
+            ..Default::default()
         };
 
         let outcome = translator.handle_notification(
@@ -1290,6 +1414,117 @@ mod tests {
             true,
         );
         assert!(turn_completed.terminal);
+    }
+
+    #[test]
+    fn interrupted_tool_is_reconciled_exactly_once_without_replay() {
+        let mut translator = AppServerEventTranslator::default();
+        let started = translator.handle_notification(
+            "item/started",
+            &json!({
+                "item": {
+                    "id": "tool-1",
+                    "type": "toolCall",
+                    "name": "write_file",
+                    "arguments": {"path": "proof.lean"}
+                }
+            }),
+            false,
+        );
+        assert!(matches!(
+            started.events.as_slice(),
+            [ExecutionEvent::ToolCall { id, name, .. }]
+                if id == "tool-1" && name == "write_file"
+        ));
+
+        let interrupted = translator.pending_tool_ids();
+        let reconciled = translator.reconcile_interrupted_tools(&interrupted);
+        assert!(matches!(
+            reconciled.as_slice(),
+            [ExecutionEvent::ToolResult { id, name, result }]
+                if id == "tool-1"
+                    && name == "write_file"
+                    && result.get("status").and_then(|v| v.as_str())
+                        == Some("infra_transport_interrupted")
+                    && result.get("command_replayed").and_then(|v| v.as_bool()) == Some(false)
+        ));
+        assert!(translator.pending_tool_ids().is_empty());
+        assert!(translator
+            .reconcile_interrupted_tools(&interrupted)
+            .is_empty());
+    }
+
+    #[test]
+    fn resumed_real_completion_wins_over_synthetic_reconciliation() {
+        let mut translator = AppServerEventTranslator::default();
+        let params = json!({
+            "item": {
+                "id": "cmd-1",
+                "type": "commandExecution",
+                "command": "lake env lean proof.lean",
+                "aggregatedOutput": "ok"
+            }
+        });
+
+        assert_eq!(
+            translator
+                .handle_notification("item/started", &params, false)
+                .events
+                .len(),
+            1
+        );
+        let interrupted = translator.pending_tool_ids();
+        let completed = translator.handle_notification("item/completed", &params, false);
+        assert!(matches!(
+            completed.events.as_slice(),
+            [ExecutionEvent::ToolResult { id, name, result }]
+                if id == "cmd-1" && name == "bash" && result == "ok"
+        ));
+        assert!(translator
+            .reconcile_interrupted_tools(&interrupted)
+            .is_empty());
+    }
+
+    #[test]
+    fn replayed_tool_lifecycle_notifications_are_deduplicated() {
+        let mut translator = AppServerEventTranslator::default();
+        let params = json!({
+            "item": {
+                "id": "tool-2",
+                "type": "function_call",
+                "name": "read_file",
+                "input": {"path": "proof.lean"},
+                "output": "contents"
+            }
+        });
+
+        assert_eq!(
+            translator
+                .handle_notification("item/started", &params, false)
+                .events
+                .len(),
+            1
+        );
+        assert!(translator
+            .handle_notification("item/started", &params, false)
+            .events
+            .is_empty());
+        assert_eq!(
+            translator
+                .handle_notification("item/completed", &params, false)
+                .events
+                .len(),
+            1
+        );
+        assert!(translator
+            .handle_notification("item/completed", &params, false)
+            .events
+            .is_empty());
+        assert!(translator
+            .handle_notification("item/started", &params, false)
+            .events
+            .is_empty());
+        assert!(translator.pending_tool_ids().is_empty());
     }
 
     #[tokio::test]

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -496,6 +496,21 @@ async fn send_message_streaming_app_server(
                             }
                         }
                         if outcome.terminal {
+                            let interrupted = reconcile_pending_before_terminal(
+                                &mut translator,
+                                &mut pending_tool_reconciliation,
+                            );
+                            if !interrupted.is_empty() {
+                                let _ = tx
+                                    .send(ExecutionEvent::Error {
+                                        message: "codex app-server resumed with pending tool calls but emitted a terminal turn before replaying their completion; synthetic infra_transport_interrupted results were emitted"
+                                            .to_string(),
+                                    })
+                                    .await;
+                                for event in interrupted {
+                                    let _ = tx.send(event).await;
+                                }
+                            }
                             terminal = true;
                         }
                     }
@@ -727,6 +742,16 @@ struct AppServerEventTranslator {
 struct TranslateOutcome {
     events: Vec<ExecutionEvent>,
     terminal: bool,
+}
+
+fn reconcile_pending_before_terminal(
+    translator: &mut AppServerEventTranslator,
+    pending: &mut Option<(tokio::time::Instant, std::collections::HashSet<String>)>,
+) -> Vec<ExecutionEvent> {
+    let Some((_, interrupted_ids)) = pending.take() else {
+        return Vec::new();
+    };
+    translator.reconcile_interrupted_tools(&interrupted_ids)
 }
 
 fn usage_tokens(usage: &serde_json::Value, keys: &[&str]) -> u64 {
@@ -1452,6 +1477,35 @@ mod tests {
         assert!(translator
             .reconcile_interrupted_tools(&interrupted)
             .is_empty());
+    }
+
+    #[test]
+    fn terminal_resume_reconciles_pending_tool_before_exit() {
+        let mut translator = AppServerEventTranslator::default();
+        translator.handle_notification(
+            "item/started",
+            &json!({
+                "item": {
+                    "id": "tool-terminal",
+                    "type": "toolCall",
+                    "name": "bash",
+                    "arguments": {"command": "lake build"}
+                }
+            }),
+            false,
+        );
+        let ids = translator.pending_tool_ids();
+        let mut pending = Some((tokio::time::Instant::now(), ids));
+
+        let events = reconcile_pending_before_terminal(&mut translator, &mut pending);
+
+        assert!(pending.is_none());
+        assert!(translator.pending_tool_ids().is_empty());
+        assert!(matches!(
+            events.as_slice(),
+            [ExecutionEvent::ToolResult { id, name, .. }]
+                if id == "tool-terminal" && name == "bash"
+        ));
     }
 
     #[test]

--- a/src/bin/automation_manager_mcp.rs
+++ b/src/bin/automation_manager_mcp.rs
@@ -294,6 +294,19 @@ impl AutomationManagerMcp {
                             "type": "object",
                             "description": "Optional variable substitutions",
                             "additionalProperties": {"type": "string"}
+                        },
+                        "stop_policy": {
+                            "type": "object",
+                            "description": "Optional lifecycle policy. One-shot durable wakeups use {\"type\":\"after_first_fire\"}.",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["never", "when_failing_consecutively", "when_all_issues_closed_and_prs_merged", "after_first_fire"]
+                                },
+                                "count": {"type": "integer", "minimum": 1},
+                                "repo": {"type": "string"}
+                            },
+                            "required": ["type"]
                         }
                     }
                 }),
@@ -324,9 +337,22 @@ impl AutomationManagerMcp {
                             "description": "New retry configuration (optional)"
                         },
                         "stop_policy": {
+                            "type": "object",
+                            "description": "New lifecycle policy (optional)",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["never", "when_failing_consecutively", "when_all_issues_closed_and_prs_merged", "after_first_fire"]
+                                },
+                                "count": {"type": "integer", "minimum": 1},
+                                "repo": {"type": "string"}
+                            },
+                            "required": ["type"]
+                        },
+                        "fresh_session": {
                             "type": "string",
-                            "description": "New stop policy (optional)",
-                            "enum": ["never", "on_mission_completed", "on_terminal_any"]
+                            "enum": ["keep", "always", "switch"],
+                            "description": "New session policy (optional)"
                         },
                         "active": {"type": "boolean", "description": "Enable or disable automation"}
                     }
@@ -851,5 +877,40 @@ async fn main() {
             eprintln!("[automation-mcp] Failed to serialize response");
         }
         stdout.flush().ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_schema_matches_tagged_stop_policy_contract() {
+        let tool = AutomationManagerMcp::get_tools()
+            .into_iter()
+            .find(|tool| tool.name == "update_automation")
+            .expect("update_automation tool");
+        let policy = &tool.input_schema["properties"]["stop_policy"];
+
+        assert_eq!(policy["type"], "object");
+        let variants = policy["properties"]["type"]["enum"]
+            .as_array()
+            .expect("stop policy variants");
+        assert!(variants.iter().any(|value| value == "after_first_fire"));
+        assert!(variants
+            .iter()
+            .any(|value| value == "when_failing_consecutively"));
+
+        let params: UpdateAutomationParams = serde_json::from_value(json!({
+            "id": Uuid::nil().to_string(),
+            "stop_policy": {"type": "after_first_fire"},
+            "fresh_session": "keep"
+        }))
+        .expect("schema-advertised payload must deserialize");
+        assert!(matches!(
+            params.stop_policy,
+            Some(StopPolicy::AfterFirstFire)
+        ));
+        assert!(matches!(params.fresh_session, Some(FreshSession::Keep)));
     }
 }

--- a/src/bin/automation_manager_mcp.rs
+++ b/src/bin/automation_manager_mcp.rs
@@ -199,6 +199,14 @@ struct ScheduleWakeupParams {
     reason: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ScheduleJobWakeupParams {
+    #[serde(rename = "jobId", alias = "job_id")]
+    job_id: String,
+    prompt: String,
+    reason: String,
+}
+
 const WAKEUP_MIN_SECONDS: u64 = 60;
 const WAKEUP_MAX_SECONDS: u64 = 3600;
 
@@ -246,7 +254,7 @@ impl AutomationManagerMcp {
                     "  \"trigger\": { \"type\": \"cron\", \"expression\": \"0 8 * * *\", \"timezone\": \"Europe/Paris\" },\n",
                     "  \"fresh_session\": \"always\"\n",
                     "}\n",
-                    "Trigger types: cron (expression + timezone), interval (seconds).\n",
+                    "Trigger types: cron (expression + timezone), interval (seconds), durable_job_terminal (job_id).\n",
                     "Command source types: inline (content), library (name), local_file (path).\n",
                     "Cron examples: '0 8 * * *' daily 8am, '0 9 * * 1' Mon 9am, '*/30 * * * *' every 30min."
                 ).to_string(),
@@ -269,10 +277,11 @@ impl AutomationManagerMcp {
                             "type": "object",
                             "description": "When to trigger. Use {\"type\": \"cron\", \"expression\": \"0 8 * * *\", \"timezone\": \"Europe/Paris\"} for cron schedules.",
                             "properties": {
-                                "type": {"type": "string", "description": "One of: cron, interval, agent_finished, webhook"},
+                                "type": {"type": "string", "description": "One of: cron, interval, durable_job_terminal, agent_finished, webhook"},
                                 "expression": {"type": "string", "description": "Cron expression: minute hour day-of-month month day-of-week (when type=cron)"},
                                 "timezone": {"type": "string", "description": "IANA timezone like Europe/Paris (when type=cron, defaults to UTC)"},
-                                "seconds": {"type": "number", "description": "Interval in seconds (when type=interval)"}
+                                "seconds": {"type": "number", "description": "Interval in seconds (when type=interval)"},
+                                "job_id": {"type": "string", "description": "Durable job UUID owned by this mission (when type=durable_job_terminal)"}
                             },
                             "required": ["type"]
                         },
@@ -350,8 +359,8 @@ impl AutomationManagerMcp {
                 description: concat!(
                     "Schedule a one-shot wake-up that delivers `prompt` back into this ",
                     "mission after `delaySeconds`. Use this when you need to pause and ",
-                    "resume work later (polling a build, checking back after a wait, ",
-                    "self-paced iteration). The wake-up fires exactly once and then ",
+                    "resume work at a wall-clock time. For builds and other durable ",
+                    "jobs, use schedule_job_wakeup instead. The wake-up fires exactly once and then ",
                     "auto-disables — call schedule_wakeup again from the resumed turn ",
                     "to keep looping. delaySeconds is clamped to [60, 3600]."
                 ).to_string(),
@@ -372,6 +381,35 @@ impl AutomationManagerMcp {
                         "reason": {
                             "type": "string",
                             "description": "One short sentence explaining the chosen delay (for telemetry / UI)."
+                        }
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "schedule_job_wakeup".to_string(),
+                description: concat!(
+                    "Wake this mission exactly once when one of its durable jobs becomes ",
+                    "terminal. Prefer this over repeated schedule_wakeup polling for builds, ",
+                    "benchmark runs, test suites, and other long compute. The wakeup survives ",
+                    "API restarts and fires for completed, failed, cancelled, unknown, or ",
+                    "otherwise dead jobs."
+                )
+                .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["jobId", "prompt", "reason"],
+                    "properties": {
+                        "jobId": {
+                            "type": "string",
+                            "description": "Durable job UUID returned by the durable job launcher."
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "Message delivered after the job becomes terminal."
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Short telemetry/UI explanation."
                         }
                     }
                 }),
@@ -564,6 +602,10 @@ impl AutomationManagerMcp {
 
         let mut variables = HashMap::new();
         variables.insert("__wakeup_reason".to_string(), params.reason.clone());
+        variables.insert(
+            "__wakeup_source".to_string(),
+            "automation-manager".to_string(),
+        );
 
         let body = json!({
             "command_source": { "type": "inline", "content": params.prompt },
@@ -602,6 +644,52 @@ impl AutomationManagerMcp {
         }))
     }
 
+    async fn schedule_job_wakeup(&self, params: ScheduleJobWakeupParams) -> Result<Value, String> {
+        let job_id = Uuid::parse_str(&params.job_id)
+            .map_err(|_| "Invalid durable job ID format".to_string())?;
+        let client = reqwest::Client::new();
+        let url = format!(
+            "{}/api/control/missions/{}/automations",
+            self.api_url, self.mission_id
+        );
+        let mut variables = HashMap::new();
+        variables.insert("__wakeup_reason".to_string(), params.reason.clone());
+        variables.insert(
+            "__wakeup_source".to_string(),
+            "durable-job-terminal".to_string(),
+        );
+        let body = json!({
+            "command_source": { "type": "inline", "content": params.prompt },
+            "trigger": { "type": "durable_job_terminal", "job_id": job_id },
+            "stop_policy": { "type": "after_first_fire" },
+            "fresh_session": "keep",
+            "variables": variables,
+            "start_immediately": false,
+        });
+        let mut request = client.post(&url).json(&body);
+        if let Some(ref token) = self.api_token {
+            request = request.header("Authorization", format!("Bearer {}", token));
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|e| format!("HTTP request failed: {e}"))?;
+        if !response.status().is_success() {
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(format!("API returned error: {error_text}"));
+        }
+        let automation: Automation = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse response: {e}"))?;
+        Ok(json!({
+            "automation_id": automation.id,
+            "job_id": job_id,
+            "reason": params.reason,
+            "fires_once": true,
+        }))
+    }
+
     async fn handle_call(&self, method: &str, params: Value) -> Result<Value, String> {
         match method {
             "list_automations" => {
@@ -633,6 +721,11 @@ impl AutomationManagerMcp {
                 let params: ScheduleWakeupParams =
                     serde_json::from_value(params).map_err(|e| format!("Invalid params: {}", e))?;
                 self.schedule_wakeup(params).await
+            }
+            "schedule_job_wakeup" => {
+                let params: ScheduleJobWakeupParams =
+                    serde_json::from_value(params).map_err(|e| format!("Invalid params: {e}"))?;
+                self.schedule_job_wakeup(params).await
             }
             _ => Err(format!("Unknown method: {}", method)),
         }

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -552,13 +552,13 @@ impl OrchestratorMcp {
             },
             ToolDefinition {
                 name: "durable_job_start".to_string(),
-                description: "Start a long-running server-managed background command that survives ephemeral agent session cleanup. Use this for multi-hour builds, large test suites, image builds, and similar work.".to_string(),
+                description: "REQUIRED for any command that may outlive one tool call (long builds, benchmark arms, test suites, image builds). It runs inside the caller's workspace with its CPU/RAM scope, durable status, and file-backed logs. Never use shell `&`, nohup, or setsid for such work: those descendants remain owned by the ephemeral harness scope and are killed when the turn disconnects.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["command"],
                     "properties": {
                         "command": {"type": "string", "description": "Shell command to run."},
-                        "cwd": {"type": "string", "description": "Working directory. Relative paths resolve from the server working directory."},
+                        "cwd": {"type": "string", "description": "Working directory inside the caller's workspace. Relative paths resolve from the workspace root."},
                         "env": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Environment variables to add."}
                     }
                 }),
@@ -1567,11 +1567,16 @@ impl OrchestratorMcp {
                 .ok()
                 .or_else(|| std::env::var("SANDBOXED_SH_WORKSPACE").ok())
         });
+        let workspace_id = self
+            .boss_workspace_id()
+            .await
+            .ok_or_else(|| "Mission has no resolvable workspace_id; refusing to launch a host-leaking durable job".to_string())?;
         let body = json!({
             "command": params.command,
             "cwd": cwd,
             "env": params.env,
             "started_by_mission_id": self.mission_id,
+            "workspace_id": workspace_id,
         });
         let response = self.api_post("/api/durable-jobs", body).await?;
         if !response.status().is_success() {

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -402,7 +402,7 @@ async fn cancel_job(
     AxumPath(id): AxumPath<Uuid>,
 ) -> Result<Json<CancelJobResponse>, (StatusCode, String)> {
     check_auth(&headers, &state)?;
-    let cancel_requested = state.runner.cancel(id);
+    let cancel_requested = state.runner.cancel(id).await.map_err(internal_error)?;
     let record = state
         .jobs
         .get(id)

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -1,19 +1,23 @@
 use axum::{
-    extract::State,
+    extract::{Path as AxumPath, Query, State},
     http::{HeaderMap, StatusCode},
     routing::{get, post},
     Json, Router,
 };
+use sandboxed_sh::node::{read_log_tail, JobRecord, JobRunner, JobStore, DEFAULT_MAX_JOB_SECS};
 use sandboxed_sh::remote_node::{
-    bearer_token, node_token_matches, parse_labels, run_lease_command, ExecuteResponse,
-    LeaseRequest, NodeHeartbeat, NODE_PROTOCOL_VERSION,
+    bearer_token, node_token_matches, parse_labels, run_lease_command, validate_lease_token,
+    CancelJobResponse, ExecuteResponse, LeaseClaims, LeaseRequest, NodeHeartbeat, NodeJobStatus,
+    RemoteNodeError, SubmitJobRequest, SubmitJobResponse, NODE_PROTOCOL_VERSION, SCOPE_JOB_SUBMIT,
 };
+use serde::Deserialize;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use uuid::Uuid;
 
 struct NodeState {
     node_id: String,
@@ -25,6 +29,8 @@ struct NodeState {
     work_root: PathBuf,
     capacity_total: u32,
     active_leases: AtomicU32,
+    jobs: JobStore,
+    runner: Arc<JobRunner>,
 }
 
 #[tokio::main]
@@ -61,7 +67,25 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .and_then(|raw| raw.parse::<u32>().ok())
         .unwrap_or(1);
+    let max_job_secs = std::env::var("SANDBOXED_NODE_MAX_JOB_SECS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MAX_JOB_SECS);
     tokio::fs::create_dir_all(&work_root).await?;
+
+    // Durable job store + runner. Jobs left in flight by a previous process
+    // lifetime are flipped to `lost` before we accept new work.
+    let jobs = JobStore::open(&work_root).await?;
+    let recovered = jobs.recover_on_start().await?;
+    if recovered > 0 {
+        warn!("marked {recovered} in-flight job(s) from a previous run as lost");
+    }
+    let runner = JobRunner::spawn(
+        jobs.clone(),
+        work_root.clone(),
+        capacity_total,
+        max_job_secs,
+    );
 
     let state = Arc::new(NodeState {
         node_id,
@@ -71,10 +95,15 @@ async fn main() -> anyhow::Result<()> {
         work_root,
         capacity_total,
         active_leases: AtomicU32::new(0),
+        jobs,
+        runner,
     });
     let app = Router::new()
         .route("/heartbeat", get(heartbeat))
         .route("/execute", post(execute))
+        .route("/jobs", post(submit_job).get(list_jobs))
+        .route("/jobs/:id", get(get_job))
+        .route("/jobs/:id/cancel", post(cancel_job))
         .with_state(state);
 
     info!("starting sandboxed-node on {bind}");
@@ -164,10 +193,38 @@ async fn heartbeat(
         mem_available_bytes: resources.mem_available_bytes,
         disk_total_bytes: resources.disk_total_bytes,
         disk_available_bytes: resources.disk_available_bytes,
-        active_jobs: 0,
-        queued_jobs: 0,
+        active_jobs: state.runner.active_count(),
+        queued_jobs: state.runner.queued_count(),
         cached_toolchains: vec![],
     }))
+}
+
+/// Signing secrets accepted for lease validation: the current token plus,
+/// during rotation, the previous one.
+fn lease_secrets(state: &NodeState) -> Vec<&str> {
+    let mut secrets = vec![state.shared_token.as_str()];
+    if let Some(previous) = state.previous_token.as_deref() {
+        secrets.push(previous);
+    }
+    secrets
+}
+
+/// Validate a lease token against any accepted signing secret, returning the
+/// claims and the secret that validated it.
+fn validate_lease_any<'a>(
+    state: &'a NodeState,
+    token: &str,
+    scope: &str,
+) -> Result<(LeaseClaims, &'a str), RemoteNodeError> {
+    let now = chrono::Utc::now();
+    let mut last_err = RemoteNodeError::InvalidLease("no signing secret".to_string());
+    for secret in lease_secrets(state) {
+        match validate_lease_token(token, secret, &state.node_id, scope, now) {
+            Ok(claims) => return Ok((claims, secret)),
+            Err(err) => last_err = err,
+        }
+    }
+    Err(last_err)
 }
 
 async fn execute(
@@ -176,10 +233,19 @@ async fn execute(
     Json(request): Json<LeaseRequest>,
 ) -> Result<Json<ExecuteResponse>, (StatusCode, String)> {
     check_auth(&headers, &state)?;
+    // Leases may be signed with the previous token during rotation; pick the
+    // secret that validates (run_lease_command re-validates internally).
+    let signing_secret = validate_lease_any(
+        &state,
+        &request.lease_token,
+        sandboxed_sh::remote_node::SCOPE_MISSION_EXECUTE,
+    )
+    .map(|(_, secret)| secret.to_string())
+    .unwrap_or_else(|_| state.shared_token.clone());
     state.active_leases.fetch_add(1, Ordering::AcqRel);
     let result = run_lease_command(
         &state.node_id,
-        &state.shared_token,
+        &signing_secret,
         state.work_root.clone(),
         request,
     )
@@ -192,6 +258,136 @@ async fn execute(
             Err((StatusCode::BAD_REQUEST, err.to_string()))
         }
     }
+}
+
+fn job_status_from_record(record: &JobRecord, log_tail: Option<String>) -> NodeJobStatus {
+    NodeJobStatus {
+        job_id: record.id,
+        mission_id: record.mission_id,
+        state: record.state.as_str().to_string(),
+        exit_code: record.exit_code,
+        created_at: record.created_at.clone(),
+        started_at: record.started_at.clone(),
+        finished_at: record.finished_at.clone(),
+        error: record.error.clone(),
+        log_tail,
+    }
+}
+
+/// `POST /jobs` — queue an async job. Requires the shared bearer token plus a
+/// per-job lease scoped to `job:submit` and bound to the mission (and job id
+/// when present in the claims).
+async fn submit_job(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+    Json(request): Json<SubmitJobRequest>,
+) -> Result<(StatusCode, Json<SubmitJobResponse>), (StatusCode, String)> {
+    check_auth(&headers, &state)?;
+    let (claims, _) = validate_lease_any(&state, &request.lease_token, SCOPE_JOB_SUBMIT)
+        .map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))?;
+    if claims.mission_id != request.mission_id {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "lease is scoped to a different mission".to_string(),
+        ));
+    }
+    if claims.job_id.is_some_and(|job_id| job_id != request.job_id) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "lease is scoped to a different job".to_string(),
+        ));
+    }
+    if state
+        .jobs
+        .get(request.job_id)
+        .await
+        .map_err(internal_error)?
+        .is_some()
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            format!("job {} already exists", request.job_id),
+        ));
+    }
+    state
+        .runner
+        .submit(request.job_id, request.mission_id, request.payload)
+        .await
+        .map_err(internal_error)?;
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(SubmitJobResponse {
+            job_id: request.job_id,
+            state: "queued".to_string(),
+        }),
+    ))
+}
+
+/// `GET /jobs/:id` — full job status including up to 64 KiB of log tail.
+async fn get_job(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<Uuid>,
+) -> Result<Json<NodeJobStatus>, (StatusCode, String)> {
+    check_auth(&headers, &state)?;
+    let record = state
+        .jobs
+        .get(id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("job {id} not found")))?;
+    let log_tail = match record.log_path.as_deref() {
+        Some(path) => read_log_tail(Path::new(path)).await,
+        None => None,
+    };
+    Ok(Json(job_status_from_record(&record, log_tail)))
+}
+
+/// `POST /jobs/:id/cancel` — request cancellation of a queued/running job.
+async fn cancel_job(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<Uuid>,
+) -> Result<Json<CancelJobResponse>, (StatusCode, String)> {
+    check_auth(&headers, &state)?;
+    let cancel_requested = state.runner.cancel(id);
+    let record = state
+        .jobs
+        .get(id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("job {id} not found")))?;
+    Ok(Json(CancelJobResponse {
+        job_id: id,
+        state: record.state.as_str().to_string(),
+        cancel_requested,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct ListJobsQuery {
+    limit: Option<usize>,
+}
+
+/// `GET /jobs?limit=N` — recent jobs, newest first (default 20, no log tails).
+async fn list_jobs(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+    Query(query): Query<ListJobsQuery>,
+) -> Result<Json<Vec<NodeJobStatus>>, (StatusCode, String)> {
+    check_auth(&headers, &state)?;
+    let limit = query.limit.unwrap_or(20).clamp(1, 200);
+    let records = state.jobs.recent(limit).await.map_err(internal_error)?;
+    Ok(Json(
+        records
+            .iter()
+            .map(|record| job_status_from_record(record, None))
+            .collect(),
+    ))
+}
+
+fn internal_error(err: anyhow::Error) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
 }
 
 #[cfg(test)]
@@ -212,7 +408,9 @@ mod tests {
         headers
     }
 
-    fn test_state(work_root: PathBuf) -> Arc<NodeState> {
+    async fn test_state(work_root: PathBuf) -> Arc<NodeState> {
+        let jobs = JobStore::open(&work_root).await.expect("job store");
+        let runner = JobRunner::spawn(jobs.clone(), work_root.clone(), 2, DEFAULT_MAX_JOB_SECS);
         Arc::new(NodeState {
             node_id: "test-node".to_string(),
             shared_token: "node-secret".to_string(),
@@ -221,13 +419,15 @@ mod tests {
             work_root,
             capacity_total: 2,
             active_leases: AtomicU32::new(0),
+            jobs,
+            runner,
         })
     }
 
-    #[test]
-    fn check_auth_accepts_current_and_previous_tokens() {
+    #[tokio::test]
+    async fn check_auth_accepts_current_and_previous_tokens() {
         let work_root = tempfile::tempdir().expect("tempdir");
-        let state = test_state(work_root.path().to_path_buf());
+        let state = test_state(work_root.path().to_path_buf()).await;
         assert!(check_auth(&auth_headers("node-secret"), &state).is_ok());
         assert!(check_auth(&auth_headers("node-secret-old"), &state).is_ok());
         assert!(check_auth(&auth_headers("wrong"), &state).is_err());
@@ -237,13 +437,14 @@ mod tests {
     #[tokio::test]
     async fn heartbeat_reports_active_lease_capacity() {
         let work_root = tempfile::tempdir().expect("tempdir");
-        let state = test_state(work_root.path().to_path_buf());
+        let state = test_state(work_root.path().to_path_buf()).await;
         let mission_id = Uuid::new_v4();
         let claims = LeaseClaims {
             mission_id,
             node_id: state.node_id.clone(),
             scope: SCOPE_MISSION_EXECUTE.to_string(),
             expires_at: (chrono::Utc::now() + chrono::Duration::minutes(1)).timestamp(),
+            job_id: None,
         };
         let request = LeaseRequest {
             mission_id,
@@ -285,5 +486,104 @@ mod tests {
         let idle = heartbeat(State(state), headers).await.expect("heartbeat").0;
         assert_eq!(idle.active_leases, 0);
         assert_eq!(idle.capacity_available, 2);
+    }
+
+    #[tokio::test]
+    async fn job_submission_requires_job_scoped_lease_and_runs_async() {
+        let work_root = tempfile::tempdir().expect("tempdir");
+        let state = test_state(work_root.path().to_path_buf()).await;
+        let headers = auth_headers(&state.shared_token);
+        let mission_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        let payload = sandboxed_sh::remote_node::JobPayload::RawCommand {
+            command: "echo job-ok".to_string(),
+            timeout_secs: Some(30),
+            env: None,
+        };
+
+        // A mission:execute lease must be rejected for job submission.
+        let wrong_scope = LeaseClaims {
+            mission_id,
+            node_id: state.node_id.clone(),
+            scope: SCOPE_MISSION_EXECUTE.to_string(),
+            expires_at: (chrono::Utc::now() + chrono::Duration::minutes(1)).timestamp(),
+            job_id: Some(job_id),
+        };
+        let rejected = submit_job(
+            State(state.clone()),
+            headers.clone(),
+            Json(SubmitJobRequest {
+                job_id,
+                mission_id,
+                lease_token: create_lease_token(&wrong_scope, &state.shared_token)
+                    .expect("lease token"),
+                payload: payload.clone(),
+            }),
+        )
+        .await;
+        assert_eq!(rejected.unwrap_err().0, StatusCode::BAD_REQUEST);
+
+        // A properly scoped lease is accepted with 202/queued.
+        let claims = LeaseClaims {
+            scope: SCOPE_JOB_SUBMIT.to_string(),
+            ..wrong_scope
+        };
+        let (status, accepted) = submit_job(
+            State(state.clone()),
+            headers.clone(),
+            Json(SubmitJobRequest {
+                job_id,
+                mission_id,
+                lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
+                payload: payload.clone(),
+            }),
+        )
+        .await
+        .expect("job accepted");
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(accepted.0.state, "queued");
+
+        // Poll until terminal and check the captured log tail.
+        let mut final_status = None;
+        for _ in 0..200 {
+            let snapshot = get_job(State(state.clone()), headers.clone(), AxumPath(job_id))
+                .await
+                .expect("job status")
+                .0;
+            if matches!(snapshot.state.as_str(), "succeeded" | "failed" | "lost") {
+                final_status = Some(snapshot);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let final_status = final_status.expect("job should finish");
+        assert_eq!(final_status.state, "succeeded");
+        assert_eq!(final_status.exit_code, Some(0));
+        assert!(final_status.log_tail.unwrap_or_default().contains("job-ok"));
+
+        // Duplicate submissions conflict.
+        let duplicate = submit_job(
+            State(state.clone()),
+            headers.clone(),
+            Json(SubmitJobRequest {
+                job_id,
+                mission_id,
+                lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
+                payload,
+            }),
+        )
+        .await;
+        assert_eq!(duplicate.unwrap_err().0, StatusCode::CONFLICT);
+
+        // The job shows up in the recent list.
+        let listed = list_jobs(
+            State(state),
+            headers,
+            Query(ListJobsQuery { limit: Some(5) }),
+        )
+        .await
+        .expect("job list")
+        .0;
+        assert!(listed.iter().any(|job| job.job_id == job_id));
     }
 }

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -5,10 +5,11 @@ use axum::{
     Json, Router,
 };
 use sandboxed_sh::remote_node::{
-    bearer_token, run_lease_command, ExecuteResponse, LeaseRequest, NodeHeartbeat,
+    bearer_token, node_token_matches, parse_labels, run_lease_command, ExecuteResponse,
+    LeaseRequest, NodeHeartbeat, NODE_PROTOCOL_VERSION,
 };
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -17,6 +18,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 struct NodeState {
     node_id: String,
     shared_token: String,
+    /// Optional previous token accepted during rotation
+    /// (`SANDBOXED_NODE_TOKEN_PREVIOUS`).
+    previous_token: Option<String>,
+    labels: Vec<String>,
     work_root: PathBuf,
     capacity_total: u32,
     active_leases: AtomicU32,
@@ -37,8 +42,17 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .filter(|s| !s.trim().is_empty())
         .ok_or_else(|| anyhow::anyhow!("SANDBOXED_NODE_TOKEN must be set"))?;
+    let previous_token = std::env::var("SANDBOXED_NODE_TOKEN_PREVIOUS")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    let labels = std::env::var("SANDBOXED_NODE_LABELS")
+        .map(|raw| parse_labels(&raw))
+        .unwrap_or_default();
+    // Default to loopback: reaching the node over a network requires an
+    // explicit SANDBOXED_NODE_BIND (e.g. a tailscale interface IP), so a
+    // node is never exposed on all interfaces by accident.
     let bind = std::env::var("SANDBOXED_NODE_BIND")
-        .unwrap_or_else(|_| "0.0.0.0:3088".to_string())
+        .unwrap_or_else(|_| "127.0.0.1:3088".to_string())
         .parse::<SocketAddr>()?;
     let work_root = std::env::var("SANDBOXED_NODE_WORK_DIR")
         .map(PathBuf::from)
@@ -52,6 +66,8 @@ async fn main() -> anyhow::Result<()> {
     let state = Arc::new(NodeState {
         node_id,
         shared_token,
+        previous_token,
+        labels,
         work_root,
         capacity_total,
         active_leases: AtomicU32::new(0),
@@ -69,8 +85,61 @@ async fn main() -> anyhow::Result<()> {
 
 fn check_auth(headers: &HeaderMap, state: &NodeState) -> Result<(), (StatusCode, String)> {
     match bearer_token(headers) {
-        Some(token) if token == state.shared_token => Ok(()),
+        Some(token)
+            if node_token_matches(token, &state.shared_token, state.previous_token.as_deref()) =>
+        {
+            Ok(())
+        }
         _ => Err((StatusCode::UNAUTHORIZED, "invalid node token".to_string())),
+    }
+}
+
+/// Host resource figures reported in heartbeat v2.
+struct HostResources {
+    cpu_total: u32,
+    mem_total_bytes: u64,
+    mem_available_bytes: u64,
+    disk_total_bytes: u64,
+    disk_available_bytes: u64,
+}
+
+/// Snapshot CPU/memory/disk of the host. Disk figures come from the
+/// filesystem backing `work_root` (longest matching mount point), falling
+/// back to `/` or the largest visible filesystem.
+fn host_resources(work_root: &Path) -> HostResources {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    let cpu_total = std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(0);
+
+    let disks = sysinfo::Disks::new_with_refreshed_list();
+    let mut best: Option<(usize, u64, u64)> = None; // (mount depth, total, available)
+    let mut largest: Option<(u64, u64)> = None;
+    for disk in disks.list() {
+        let total = disk.total_space();
+        let available = disk.available_space();
+        if work_root.starts_with(disk.mount_point()) {
+            let depth = disk.mount_point().components().count();
+            if best.map(|(d, _, _)| depth > d).unwrap_or(true) {
+                best = Some((depth, total, available));
+            }
+        }
+        if largest.map(|(t, _)| total > t).unwrap_or(true) {
+            largest = Some((total, available));
+        }
+    }
+    let (disk_total_bytes, disk_available_bytes) = best
+        .map(|(_, total, available)| (total, available))
+        .or(largest)
+        .unwrap_or((0, 0));
+
+    HostResources {
+        cpu_total,
+        mem_total_bytes: sys.total_memory(),
+        mem_available_bytes: sys.available_memory(),
+        disk_total_bytes,
+        disk_available_bytes,
     }
 }
 
@@ -80,6 +149,7 @@ async fn heartbeat(
 ) -> Result<Json<NodeHeartbeat>, (StatusCode, String)> {
     check_auth(&headers, &state)?;
     let active_leases = state.active_leases.load(Ordering::Acquire);
+    let resources = host_resources(&state.work_root);
     Ok(Json(NodeHeartbeat {
         node_id: state.node_id.clone(),
         online: true,
@@ -87,6 +157,16 @@ async fn heartbeat(
         capacity_available: state.capacity_total.saturating_sub(active_leases),
         active_leases,
         version: env!("CARGO_PKG_VERSION").to_string(),
+        protocol_version: NODE_PROTOCOL_VERSION,
+        labels: state.labels.clone(),
+        cpu_total: resources.cpu_total,
+        mem_total_bytes: resources.mem_total_bytes,
+        mem_available_bytes: resources.mem_available_bytes,
+        disk_total_bytes: resources.disk_total_bytes,
+        disk_available_bytes: resources.disk_available_bytes,
+        active_jobs: 0,
+        queued_jobs: 0,
+        cached_toolchains: vec![],
     }))
 }
 
@@ -118,7 +198,7 @@ async fn execute(
 mod tests {
     use super::*;
     use axum::http::header::AUTHORIZATION;
-    use sandboxed_sh::remote_node::{create_lease_token, LeaseClaims};
+    use sandboxed_sh::remote_node::{create_lease_token, LeaseClaims, SCOPE_MISSION_EXECUTE};
     use uuid::Uuid;
 
     fn auth_headers(token: &str) -> HeaderMap {
@@ -132,21 +212,37 @@ mod tests {
         headers
     }
 
+    fn test_state(work_root: PathBuf) -> Arc<NodeState> {
+        Arc::new(NodeState {
+            node_id: "test-node".to_string(),
+            shared_token: "node-secret".to_string(),
+            previous_token: Some("node-secret-old".to_string()),
+            labels: vec!["test".to_string()],
+            work_root,
+            capacity_total: 2,
+            active_leases: AtomicU32::new(0),
+        })
+    }
+
+    #[test]
+    fn check_auth_accepts_current_and_previous_tokens() {
+        let work_root = tempfile::tempdir().expect("tempdir");
+        let state = test_state(work_root.path().to_path_buf());
+        assert!(check_auth(&auth_headers("node-secret"), &state).is_ok());
+        assert!(check_auth(&auth_headers("node-secret-old"), &state).is_ok());
+        assert!(check_auth(&auth_headers("wrong"), &state).is_err());
+        assert!(check_auth(&HeaderMap::new(), &state).is_err());
+    }
+
     #[tokio::test]
     async fn heartbeat_reports_active_lease_capacity() {
         let work_root = tempfile::tempdir().expect("tempdir");
-        let state = Arc::new(NodeState {
-            node_id: "test-node".to_string(),
-            shared_token: "node-secret".to_string(),
-            work_root: work_root.path().to_path_buf(),
-            capacity_total: 2,
-            active_leases: AtomicU32::new(0),
-        });
+        let state = test_state(work_root.path().to_path_buf());
         let mission_id = Uuid::new_v4();
         let claims = LeaseClaims {
             mission_id,
             node_id: state.node_id.clone(),
-            scope: "mission:execute".to_string(),
+            scope: SCOPE_MISSION_EXECUTE.to_string(),
             expires_at: (chrono::Utc::now() + chrono::Duration::minutes(1)).timestamp(),
         };
         let request = LeaseRequest {
@@ -179,6 +275,8 @@ mod tests {
         let busy = observed_busy.expect("heartbeat should observe active execute");
         assert_eq!(busy.capacity_total, 2);
         assert_eq!(busy.capacity_available, 1);
+        assert_eq!(busy.protocol_version, NODE_PROTOCOL_VERSION);
+        assert_eq!(busy.labels, vec!["test".to_string()]);
         let _response = running
             .await
             .expect("execute task")

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -4,7 +4,9 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use sandboxed_sh::node::{read_log_tail, JobRecord, JobRunner, JobStore, DEFAULT_MAX_JOB_SECS};
+use sandboxed_sh::node::{
+    read_log_tail, JobRecord, JobRunner, JobStore, NodeQueueFull, DEFAULT_MAX_JOB_SECS,
+};
 use sandboxed_sh::remote_node::{
     bearer_token, node_token_matches, parse_labels, run_lease_command, validate_lease_token,
     CancelJobResponse, ExecuteResponse, LeaseClaims, LeaseRequest, NodeHeartbeat, NodeJobStatus,
@@ -42,6 +44,19 @@ async fn main() -> anyhow::Result<()> {
         )
         .with(tracing_subscriber::fmt::layer())
         .init();
+
+    #[cfg(unix)]
+    {
+        let running_as_root = unsafe { libc::geteuid() == 0 };
+        let allow_root = std::env::var("SANDBOXED_NODE_ALLOW_ROOT")
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if running_as_root && !allow_root {
+            anyhow::bail!(
+                "sandboxed-node refuses to run as root; use the dedicated sandboxed-node service account (SANDBOXED_NODE_ALLOW_ROOT=1 is an emergency-only override)"
+            );
+        }
+    }
 
     let node_id = std::env::var("SANDBOXED_NODE_ID").unwrap_or_else(|_| "local-node".to_string());
     let shared_token = std::env::var("SANDBOXED_NODE_TOKEN")
@@ -322,7 +337,13 @@ async fn submit_job(
         .runner
         .submit(request.job_id, request.mission_id, request.payload)
         .await
-        .map_err(internal_error)?;
+        .map_err(|err| {
+            if err.downcast_ref::<NodeQueueFull>().is_some() {
+                (StatusCode::TOO_MANY_REQUESTS, err.to_string())
+            } else {
+                internal_error(err)
+            }
+        })?;
     Ok((
         StatusCode::ACCEPTED,
         Json(SubmitJobResponse {

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -321,6 +321,8 @@ async fn submit_job(
             "lease is scoped to a different job".to_string(),
         ));
     }
+    validate_job_payload(&request.payload)
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     if state
         .jobs
         .get(request.job_id)
@@ -351,6 +353,26 @@ async fn submit_job(
             state: "queued".to_string(),
         }),
     ))
+}
+
+fn validate_job_payload(payload: &sandboxed_sh::remote_node::JobPayload) -> Result<(), String> {
+    if let sandboxed_sh::remote_node::JobPayload::LeanBuild {
+        source,
+        cwd_rel,
+        command,
+        env,
+        ..
+    } = payload
+    {
+        sandboxed_sh::node::lean::validate_lean_build(
+            source,
+            cwd_rel.as_deref(),
+            command,
+            env,
+            &sandboxed_sh::node::lean::env_allowlist_from_env(),
+        )?;
+    }
+    Ok(())
 }
 
 /// `GET /jobs/:id` — full job status including up to 64 KiB of log tail.
@@ -558,6 +580,31 @@ mod tests {
             scope: SCOPE_JOB_SUBMIT.to_string(),
             ..wrong_scope
         };
+        let invalid = submit_job(
+            State(state.clone()),
+            headers.clone(),
+            Json(SubmitJobRequest {
+                job_id,
+                mission_id,
+                lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
+                payload: sandboxed_sh::remote_node::JobPayload::LeanBuild {
+                    source: sandboxed_sh::remote_node::JobSource {
+                        repo: "/node/local/repo".to_string(),
+                        commit: "a".repeat(40),
+                    },
+                    cwd_rel: None,
+                    command: vec!["lake".to_string(), "build".to_string()],
+                    timeout_secs: None,
+                    cache_key: None,
+                    artifacts: vec![],
+                    env: Default::default(),
+                },
+            }),
+        )
+        .await;
+        assert_eq!(invalid.unwrap_err().0, StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(state.jobs.get(job_id).await.unwrap().is_none());
+
         let (status, accepted) = submit_job(
             State(state.clone()),
             headers.clone(),

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -87,6 +87,10 @@ async fn main() -> anyhow::Result<()> {
         max_job_secs,
     );
 
+    // Periodic disk GC for lean-build checkouts and lake cache slots
+    // (SANDBOXED_NODE_MIN_FREE_GB, default 10).
+    sandboxed_sh::node::spawn_cache_gc(work_root.clone());
+
     let state = Arc::new(NodeState {
         node_id,
         shared_token,
@@ -195,7 +199,7 @@ async fn heartbeat(
         disk_available_bytes: resources.disk_available_bytes,
         active_jobs: state.runner.active_count(),
         queued_jobs: state.runner.queued_count(),
-        cached_toolchains: vec![],
+        cached_toolchains: sandboxed_sh::node::cached_toolchains(&state.work_root),
     }))
 }
 
@@ -271,6 +275,11 @@ fn job_status_from_record(record: &JobRecord, log_tail: Option<String>) -> NodeJ
         finished_at: record.finished_at.clone(),
         error: record.error.clone(),
         log_tail,
+        artifacts: record
+            .artifacts_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok())
+            .unwrap_or_default(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod cost;
 pub mod github_connection;
 pub mod library;
 pub mod mcp;
+pub mod node;
 pub mod nspawn;
 pub mod opencode;
 pub mod opencode_config;

--- a/src/node/job_store.rs
+++ b/src/node/job_store.rs
@@ -1,0 +1,341 @@
+//! Durable job store for the `sandboxed-node` runner.
+//!
+//! Jobs live in a small SQLite database at `<workdir>/jobs.db` so job state
+//! survives node restarts. All rusqlite calls run under
+//! `tokio::task::spawn_blocking`.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rusqlite::{params, Connection, OptionalExtension, Row};
+use uuid::Uuid;
+
+/// Lifecycle state of a node job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobState {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    /// The node restarted while the job was queued or running; its process
+    /// (if any) is gone and its true outcome is unknown.
+    Lost,
+}
+
+impl JobState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Lost => "lost",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        Some(match raw {
+            "queued" => Self::Queued,
+            "running" => Self::Running,
+            "succeeded" => Self::Succeeded,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            "lost" => Self::Lost,
+            _ => return None,
+        })
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::Lost
+        )
+    }
+}
+
+/// One persisted job row.
+#[derive(Debug, Clone)]
+pub struct JobRecord {
+    pub id: Uuid,
+    pub mission_id: Uuid,
+    pub payload_json: String,
+    pub state: JobState,
+    pub exit_code: Option<i32>,
+    pub created_at: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub log_path: Option<String>,
+    pub error: Option<String>,
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// SQLite-backed job store; cheap to clone.
+#[derive(Clone)]
+pub struct JobStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl JobStore {
+    /// Open (creating if needed) `<workdir>/jobs.db` and ensure the schema.
+    pub async fn open(work_dir: &Path) -> anyhow::Result<Self> {
+        let work_dir = work_dir.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&work_dir)?;
+            let conn = Connection::open(work_dir.join("jobs.db"))?;
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS jobs (
+                    id TEXT PRIMARY KEY,
+                    mission_id TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    exit_code INTEGER,
+                    created_at TEXT NOT NULL,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    log_path TEXT,
+                    error TEXT
+                );",
+            )?;
+            Ok(Self {
+                conn: Arc::new(Mutex::new(conn)),
+            })
+        })
+        .await?
+    }
+
+    async fn with_conn<T, F>(&self, f: F) -> anyhow::Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
+    {
+        let conn = Arc::clone(&self.conn);
+        let result = tokio::task::spawn_blocking(move || {
+            let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+            f(&guard)
+        })
+        .await?;
+        Ok(result?)
+    }
+
+    /// Flip any job left `queued` or `running` by a previous process lifetime
+    /// to `lost`. Returns the number of recovered rows.
+    pub async fn recover_on_start(&self) -> anyhow::Result<usize> {
+        self.with_conn(|conn| {
+            conn.execute(
+                "UPDATE jobs
+                 SET state = 'lost', finished_at = ?1,
+                     error = 'node restarted while the job was in flight'
+                 WHERE state IN ('queued', 'running')",
+                params![now_rfc3339()],
+            )
+        })
+        .await
+    }
+
+    /// Insert a new job in `queued` state.
+    pub async fn create(
+        &self,
+        id: Uuid,
+        mission_id: Uuid,
+        payload_json: String,
+        log_path: String,
+    ) -> anyhow::Result<()> {
+        self.with_conn(move |conn| {
+            conn.execute(
+                "INSERT INTO jobs (id, mission_id, payload_json, state, created_at, log_path)
+                 VALUES (?1, ?2, ?3, 'queued', ?4, ?5)",
+                params![
+                    id.to_string(),
+                    mission_id.to_string(),
+                    payload_json,
+                    now_rfc3339(),
+                    log_path
+                ],
+            )
+            .map(|_| ())
+        })
+        .await
+    }
+
+    pub async fn mark_running(&self, id: Uuid) -> anyhow::Result<()> {
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE jobs SET state = 'running', started_at = ?2 WHERE id = ?1",
+                params![id.to_string(), now_rfc3339()],
+            )
+            .map(|_| ())
+        })
+        .await
+    }
+
+    /// Record a terminal state for the job.
+    pub async fn finish(
+        &self,
+        id: Uuid,
+        state: JobState,
+        exit_code: Option<i32>,
+        error: Option<String>,
+    ) -> anyhow::Result<()> {
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE jobs SET state = ?2, exit_code = ?3, error = ?4, finished_at = ?5
+                 WHERE id = ?1",
+                params![
+                    id.to_string(),
+                    state.as_str(),
+                    exit_code,
+                    error,
+                    now_rfc3339()
+                ],
+            )
+            .map(|_| ())
+        })
+        .await
+    }
+
+    pub async fn get(&self, id: Uuid) -> anyhow::Result<Option<JobRecord>> {
+        self.with_conn(move |conn| {
+            conn.query_row(
+                "SELECT id, mission_id, payload_json, state, exit_code, created_at,
+                        started_at, finished_at, log_path, error
+                 FROM jobs WHERE id = ?1",
+                params![id.to_string()],
+                row_to_record,
+            )
+            .optional()
+        })
+        .await
+    }
+
+    /// Most recently created jobs, newest first.
+    pub async fn recent(&self, limit: usize) -> anyhow::Result<Vec<JobRecord>> {
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, mission_id, payload_json, state, exit_code, created_at,
+                        started_at, finished_at, log_path, error
+                 FROM jobs ORDER BY created_at DESC, id DESC LIMIT ?1",
+            )?;
+            let rows = stmt.query_map(params![limit as i64], row_to_record)?;
+            rows.collect()
+        })
+        .await
+    }
+}
+
+fn row_to_record(row: &Row<'_>) -> rusqlite::Result<JobRecord> {
+    let parse_uuid = |idx: usize| -> rusqlite::Result<Uuid> {
+        let raw: String = row.get(idx)?;
+        Uuid::parse_str(&raw).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(idx, rusqlite::types::Type::Text, Box::new(e))
+        })
+    };
+    let state_raw: String = row.get(3)?;
+    Ok(JobRecord {
+        id: parse_uuid(0)?,
+        mission_id: parse_uuid(1)?,
+        payload_json: row.get(2)?,
+        state: JobState::parse(&state_raw).unwrap_or(JobState::Lost),
+        exit_code: row.get(4)?,
+        created_at: row.get(5)?,
+        started_at: row.get(6)?,
+        finished_at: row.get(7)?,
+        log_path: row.get(8)?,
+        error: row.get(9)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn job_state_machine_create_run_succeed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JobStore::open(dir.path()).await.unwrap();
+        let job_id = Uuid::new_v4();
+        let mission_id = Uuid::new_v4();
+        store
+            .create(
+                job_id,
+                mission_id,
+                "{\"kind\":\"raw_command\",\"command\":\"true\"}".to_string(),
+                "logs/test.log".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let record = store.get(job_id).await.unwrap().unwrap();
+        assert_eq!(record.state, JobState::Queued);
+        assert_eq!(record.mission_id, mission_id);
+        assert!(record.started_at.is_none());
+        assert!(!record.state.is_terminal());
+
+        store.mark_running(job_id).await.unwrap();
+        let record = store.get(job_id).await.unwrap().unwrap();
+        assert_eq!(record.state, JobState::Running);
+        assert!(record.started_at.is_some());
+        assert!(record.finished_at.is_none());
+
+        store
+            .finish(job_id, JobState::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+        let record = store.get(job_id).await.unwrap().unwrap();
+        assert_eq!(record.state, JobState::Succeeded);
+        assert_eq!(record.exit_code, Some(0));
+        assert!(record.finished_at.is_some());
+        assert!(record.state.is_terminal());
+
+        // Unknown job ids read as None.
+        assert!(store.get(Uuid::new_v4()).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn recover_on_start_flips_inflight_jobs_to_lost() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JobStore::open(dir.path()).await.unwrap();
+        let queued = Uuid::new_v4();
+        let running = Uuid::new_v4();
+        let done = Uuid::new_v4();
+        for id in [queued, running, done] {
+            store
+                .create(
+                    id,
+                    Uuid::new_v4(),
+                    "{}".to_string(),
+                    "logs/x.log".to_string(),
+                )
+                .await
+                .unwrap();
+        }
+        store.mark_running(running).await.unwrap();
+        store
+            .finish(done, JobState::Succeeded, Some(0), None)
+            .await
+            .unwrap();
+
+        // Simulate a restart: reopen the same database and recover.
+        drop(store);
+        let store = JobStore::open(dir.path()).await.unwrap();
+        let recovered = store.recover_on_start().await.unwrap();
+        assert_eq!(recovered, 2);
+
+        for id in [queued, running] {
+            let record = store.get(id).await.unwrap().unwrap();
+            assert_eq!(record.state, JobState::Lost);
+            assert!(record.finished_at.is_some());
+            assert!(record.error.as_deref().unwrap_or("").contains("restarted"));
+        }
+        // Terminal jobs are untouched.
+        let record = store.get(done).await.unwrap().unwrap();
+        assert_eq!(record.state, JobState::Succeeded);
+
+        let recent = store.recent(10).await.unwrap();
+        assert_eq!(recent.len(), 3);
+    }
+}

--- a/src/node/job_store.rs
+++ b/src/node/job_store.rs
@@ -68,6 +68,9 @@ pub struct JobRecord {
     pub finished_at: Option<String>,
     pub log_path: Option<String>,
     pub error: Option<String>,
+    /// JSON-encoded `Vec<ArtifactEntry>` recorded after a successful build
+    /// job; `None` for raw commands and unfinished/failed jobs.
+    pub artifacts_json: Option<String>,
 }
 
 fn now_rfc3339() -> String {
@@ -98,9 +101,13 @@ impl JobStore {
                     started_at TEXT,
                     finished_at TEXT,
                     log_path TEXT,
-                    error TEXT
+                    error TEXT,
+                    artifacts_json TEXT
                 );",
             )?;
+            // Migration for jobs.db files created before artifacts shipped.
+            // "duplicate column name" on already-migrated DBs is expected.
+            let _ = conn.execute("ALTER TABLE jobs ADD COLUMN artifacts_json TEXT", []);
             Ok(Self {
                 conn: Arc::new(Mutex::new(conn)),
             })
@@ -181,16 +188,32 @@ impl JobStore {
         exit_code: Option<i32>,
         error: Option<String>,
     ) -> anyhow::Result<()> {
+        self.finish_with_artifacts(id, state, exit_code, error, None)
+            .await
+    }
+
+    /// Record a terminal state plus (for successful build jobs) the resolved
+    /// artifact manifest as JSON.
+    pub async fn finish_with_artifacts(
+        &self,
+        id: Uuid,
+        state: JobState,
+        exit_code: Option<i32>,
+        error: Option<String>,
+        artifacts_json: Option<String>,
+    ) -> anyhow::Result<()> {
         self.with_conn(move |conn| {
             conn.execute(
-                "UPDATE jobs SET state = ?2, exit_code = ?3, error = ?4, finished_at = ?5
+                "UPDATE jobs SET state = ?2, exit_code = ?3, error = ?4, finished_at = ?5,
+                        artifacts_json = ?6
                  WHERE id = ?1",
                 params![
                     id.to_string(),
                     state.as_str(),
                     exit_code,
                     error,
-                    now_rfc3339()
+                    now_rfc3339(),
+                    artifacts_json,
                 ],
             )
             .map(|_| ())
@@ -202,7 +225,7 @@ impl JobStore {
         self.with_conn(move |conn| {
             conn.query_row(
                 "SELECT id, mission_id, payload_json, state, exit_code, created_at,
-                        started_at, finished_at, log_path, error
+                        started_at, finished_at, log_path, error, artifacts_json
                  FROM jobs WHERE id = ?1",
                 params![id.to_string()],
                 row_to_record,
@@ -217,7 +240,7 @@ impl JobStore {
         self.with_conn(move |conn| {
             let mut stmt = conn.prepare(
                 "SELECT id, mission_id, payload_json, state, exit_code, created_at,
-                        started_at, finished_at, log_path, error
+                        started_at, finished_at, log_path, error, artifacts_json
                  FROM jobs ORDER BY created_at DESC, id DESC LIMIT ?1",
             )?;
             let rows = stmt.query_map(params![limit as i64], row_to_record)?;
@@ -246,6 +269,7 @@ fn row_to_record(row: &Row<'_>) -> rusqlite::Result<JobRecord> {
         finished_at: row.get(7)?,
         log_path: row.get(8)?,
         error: row.get(9)?,
+        artifacts_json: row.get(10)?,
     })
 }
 

--- a/src/node/job_store.rs
+++ b/src/node/job_store.rs
@@ -180,6 +180,35 @@ impl JobStore {
         .await
     }
 
+    /// Atomically claim a queued job for execution. Returns false when a
+    /// concurrent cancellation already made the row terminal.
+    pub async fn mark_running_if_queued(&self, id: Uuid) -> anyhow::Result<bool> {
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE jobs SET state = 'running', started_at = ?2
+                 WHERE id = ?1 AND state = 'queued'",
+                params![id.to_string(), now_rfc3339()],
+            )
+            .map(|updated| updated == 1)
+        })
+        .await
+    }
+
+    /// Atomically cancel a job only while it is queued. Running jobs are
+    /// stopped by their cancellation token and finish through the runner.
+    pub async fn cancel_if_queued(&self, id: Uuid) -> anyhow::Result<bool> {
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE jobs SET state = 'cancelled', finished_at = ?2,
+                        error = 'cancelled before start'
+                 WHERE id = ?1 AND state = 'queued'",
+                params![id.to_string(), now_rfc3339()],
+            )
+            .map(|updated| updated == 1)
+        })
+        .await
+    }
+
     /// Record a terminal state for the job.
     pub async fn finish(
         &self,

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -332,6 +332,26 @@ fn segment_matches(name: &str, pattern: &str) -> bool {
     rest.len() >= parts[last].len() && rest.ends_with(parts[last])
 }
 
+/// Return metadata only when every component below `root` is present and is
+/// not a symlink. Artifact paths come from an untrusted build, so following a
+/// link at either an intermediate directory or the final file would escape the
+/// checkout confinement promised by this API.
+fn symlink_free_metadata(root: &Path, rel: &Path) -> Option<std::fs::Metadata> {
+    let mut current = root.to_path_buf();
+    let mut metadata = std::fs::symlink_metadata(&current).ok()?;
+    if metadata.file_type().is_symlink() {
+        return None;
+    }
+    for component in rel.components() {
+        current.push(component);
+        metadata = std::fs::symlink_metadata(&current).ok()?;
+        if metadata.file_type().is_symlink() {
+            return None;
+        }
+    }
+    Some(metadata)
+}
+
 /// Resolve artifact patterns to existing files below `root`.
 ///
 /// Deliberately tiny glob: `*` is supported within a single path segment
@@ -350,6 +370,9 @@ pub fn resolve_artifact_paths(root: &Path, patterns: &[String]) -> Result<Vec<St
             let mut next = Vec::new();
             for rel in &current {
                 if segment.contains('*') {
+                    if !symlink_free_metadata(root, rel).is_some_and(|metadata| metadata.is_dir()) {
+                        continue;
+                    }
                     let Ok(entries) = std::fs::read_dir(root.join(rel)) else {
                         continue;
                     };
@@ -368,7 +391,7 @@ pub fn resolve_artifact_paths(root: &Path, patterns: &[String]) -> Result<Vec<St
             current = next;
         }
         for rel in current {
-            if root.join(&rel).is_file() {
+            if symlink_free_metadata(root, &rel).is_some_and(|metadata| metadata.is_file()) {
                 out.insert(rel.to_string_lossy().into_owned());
             }
         }
@@ -388,8 +411,23 @@ pub async fn collect_artifacts(
         rels.into_iter()
             .map(|rel| {
                 let full = root.join(&rel);
-                let mut file =
-                    std::fs::File::open(&full).map_err(|e| format!("open artifact {rel}: {e}"))?;
+                if !symlink_free_metadata(&root, Path::new(&rel))
+                    .is_some_and(|metadata| metadata.is_file())
+                {
+                    return Err(format!(
+                        "artifact path is not a symlink-free regular file: {rel}"
+                    ));
+                }
+                let mut options = std::fs::OpenOptions::new();
+                options.read(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    options.custom_flags(libc::O_NOFOLLOW);
+                }
+                let mut file = options
+                    .open(&full)
+                    .map_err(|e| format!("open artifact {rel}: {e}"))?;
                 let mut hasher = Sha256::new();
                 let size_bytes = std::io::copy(&mut file, &mut hasher)
                     .map_err(|e| format!("hash artifact {rel}: {e}"))?;
@@ -1237,6 +1275,40 @@ mod tests {
             artifacts[0].sha256,
             "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn artifact_collection_rejects_symlinked_files_and_directories() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.olean"), b"secret").unwrap();
+        symlink(
+            outside.path().join("secret.olean"),
+            dir.path().join("linked.olean"),
+        )
+        .unwrap();
+        symlink(outside.path(), dir.path().join("linked-dir")).unwrap();
+
+        let resolved = resolve_artifact_paths(
+            dir.path(),
+            &["*.olean".to_string(), "linked-dir/*.olean".to_string()],
+        )
+        .unwrap();
+        assert!(resolved.is_empty());
+
+        let artifacts = collect_artifacts(
+            dir.path(),
+            &[
+                "linked.olean".to_string(),
+                "linked-dir/secret.olean".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+        assert!(artifacts.is_empty());
     }
 
     #[tokio::test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1,7 +1,7 @@
 //! Declarative `lean_build` job execution for the `sandboxed-node` runner.
 //!
 //! A lean-build job carries only a git source (repo + pinned commit), a
-//! constrained argv (`lake`/`lean`/`elan`), and artifact patterns. The node
+//! constrained argv (`lake build`/`lean`), and artifact patterns. The node
 //! materializes a content-addressed checkout, restores shared elan/lake
 //! caches, runs the build, syncs the lake cache back on success, and records
 //! artifact digests. No workspace sync with core, no shell interpretation of
@@ -11,10 +11,8 @@
 //! - `checkouts/<sha256(repo)[..16]>/<commit>/` — immutable-ish checkouts
 //! - `caches/elan/` (`ELAN_HOME`), `caches/xdg/` (`XDG_CACHE_HOME`),
 //!   `caches/home/` (`HOME`) — shared toolchain caches
-//! - `caches/lake/<cache_key>/` — lake build cache slots, hardlink-copied
-//!   (`cp -al`) into `<build cwd>/.lake` before a build and refreshed after a
-//!   successful one. Accepted caveat: hardlink copies preserve inode mtimes,
-//!   so mtime drift can cause partial rebuilds — never wrong artifacts.
+//! - `caches/lake/<cache_key>/` — lake build cache slots, copied into
+//!   `<build cwd>/.lake` before a build and refreshed after a successful one.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -33,7 +31,7 @@ use crate::remote_node::{ArtifactEntry, JobPayload, JobSource};
 pub const DEFAULT_ENV_ALLOWLIST: &str = "LEAN_NUM_THREADS,LAKE_JOBS";
 
 /// Binaries a lean-build argv may start with (basename of argv[0]).
-pub const ALLOWED_COMMANDS: [&str; 3] = ["lake", "lean", "elan"];
+pub const ALLOWED_COMMANDS: [&str; 2] = ["lake", "lean"];
 
 /// Default node GC threshold: keep at least this many GiB free on the
 /// filesystem backing the work dir (`SANDBOXED_NODE_MIN_FREE_GB` overrides).
@@ -166,6 +164,13 @@ pub fn validate_lean_build(
             "command '{argv0}' is not allowed; argv[0] must be one of {}",
             ALLOWED_COMMANDS.join("/")
         ));
+    }
+    // `lake env` and `elan run` are direct arbitrary-command escape hatches.
+    // Lake is therefore limited to its build operation. Repository builds are
+    // still untrusted code and must run under the dedicated, non-root node
+    // service account documented in REMOTE_NODES.md.
+    if argv0 == "lake" && command.get(1).map(String::as_str) != Some("build") {
+        return Err("lake command must use the 'build' subcommand".to_string());
     }
     for key in env.keys() {
         if !allowlist.iter().any(|allowed| allowed == key) {
@@ -523,17 +528,19 @@ async fn ensure_checkout(
     }
 }
 
-/// Hardlink-copy `src` to `dest` (`cp -al`). `dest` must not exist.
-async fn hardlink_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
+/// Copy `src` to `dest` without hardlinks. Builds mutate `.lake` in place, so
+/// hardlinks would let one checkout corrupt the shared slot or another build.
+/// `dest` must not exist.
+async fn isolated_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
     let output = tokio::process::Command::new("cp")
-        .arg("-al")
+        .arg("-a")
         .arg(src)
         .arg(dest)
         .output()
         .await?;
     if !output.status.success() {
         anyhow::bail!(
-            "cp -al {} -> {} failed: {}",
+            "cp -a {} -> {} failed: {}",
             src.display(),
             dest.display(),
             String::from_utf8_lossy(&output.stderr)
@@ -590,7 +597,7 @@ pub async fn execute_lean_build(
         anyhow::bail!("cwd_rel '{rel_clean}' does not exist in the checkout");
     }
 
-    // Lake cache restore: hardlink-copy the slot into `<cwd>/.lake` when the
+    // Lake cache restore: isolate the slot into `<cwd>/.lake` when the
     // checkout has no .lake yet. Slot mutation is guarded by a per-key flock
     // (shared across commits with the same toolchain+manifest).
     let effective_cache_key = cache_key
@@ -602,7 +609,7 @@ pub async fn execute_lean_build(
         let lake_dir = build_cwd.join(".lake");
         if !lake_dir.exists() && slot.is_dir() {
             let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
-            if let Err(err) = hardlink_copy(&slot, &lake_dir).await {
+            if let Err(err) = isolated_copy(&slot, &lake_dir).await {
                 tracing::warn!("lake cache restore failed (continuing cold): {err}");
                 let _ = tokio::fs::remove_dir_all(&lake_dir).await;
             }
@@ -610,9 +617,11 @@ pub async fn execute_lean_build(
     }
 
     // Run the build argv directly (no shell) with shared-cache env plus the
-    // allowlisted job env.
+    // allowlisted job env. Clear the node service environment first: bearer
+    // tokens, signing secrets and operator credentials must never reach code
+    // executed from a repository.
     let mut cmd = tokio::process::Command::new(&command[0]);
-    cmd.args(&command[1..]).current_dir(&build_cwd);
+    cmd.env_clear().args(&command[1..]).current_dir(&build_cwd);
     for (key, value) in cache_env(work_root) {
         cmd.env(key, value);
     }
@@ -625,7 +634,7 @@ pub async fn execute_lean_build(
 
     let mut result_artifacts = Vec::new();
     if success {
-        // Sync the lake cache back: hardlink-copy into a tmp slot, then swap
+        // Sync the lake cache back: copy into a tmp slot, then swap
         // it in under the per-key flock so readers never see a partial slot.
         if let Some(key) = effective_cache_key.as_deref() {
             if let Err(err) = sync_lake_cache_back(work_root, key, &build_cwd.join(".lake")).await {
@@ -661,7 +670,7 @@ async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> a
     tokio::fs::create_dir_all(parent).await?;
     let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
-    hardlink_copy(lake_dir, &tmp).await?;
+    isolated_copy(lake_dir, &tmp).await?;
     let old = parent.join(format!(".old-{}", uuid::Uuid::new_v4()));
     let had_old = tokio::fs::rename(&slot, &old).await.is_ok();
     if let Err(err) = tokio::fs::rename(&tmp, &slot).await {
@@ -955,6 +964,25 @@ mod tests {
     }
 
     #[test]
+    fn validation_rejects_command_execution_subcommands() {
+        for command in [
+            vec!["lake", "env", "bash"],
+            vec!["lake", "exe", "tool"],
+            vec!["elan", "run", "stable", "bash"],
+        ] {
+            let command: Vec<String> = command.into_iter().map(str::to_string).collect();
+            assert!(validate_lean_build(
+                &source(&"a".repeat(40)),
+                None,
+                &command,
+                &HashMap::new(),
+                &allowlist(),
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
     fn validation_rejects_env_keys_outside_allowlist() {
         let env: HashMap<String, String> = [("LD_PRELOAD".to_string(), "/tmp/evil.so".to_string())]
             .into_iter()
@@ -1126,6 +1154,27 @@ mod tests {
         assert_eq!(
             artifacts[0].sha256,
             "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_copy_is_isolated_from_build_mutations() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("slot");
+        let restored = dir.path().join("restored");
+        tokio::fs::create_dir_all(&slot).await.unwrap();
+        tokio::fs::write(slot.join("cache.bin"), b"shared")
+            .await
+            .unwrap();
+
+        isolated_copy(&slot, &restored).await.unwrap();
+        tokio::fs::write(restored.join("cache.bin"), b"mutated")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tokio::fs::read(slot.join("cache.bin")).await.unwrap(),
+            b"shared"
         );
     }
 

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -814,17 +814,22 @@ mod tests {
             ),
             Ok(())
         );
-        // Absolute argv[0] is judged by basename.
-        assert_eq!(
-            validate_lean_build(
-                &source(&"a".repeat(40)),
-                None,
-                &["/usr/local/bin/elan".to_string(), "show".to_string()],
-                &HashMap::new(),
-                &allowlist(),
-            ),
-            Ok(())
-        );
+        // Path-form argv[0] is rejected even when the basename is allowed:
+        // `./lake` or an absolute path would execute an arbitrary file from
+        // the checkout / node fs instead of the PATH-resolved tool.
+        for path_argv in ["/usr/local/bin/elan", "./lake", "subdir/lake"] {
+            assert!(
+                validate_lean_build(
+                    &source(&"a".repeat(40)),
+                    None,
+                    &[path_argv.to_string(), "show".to_string()],
+                    &HashMap::new(),
+                    &allowlist(),
+                )
+                .is_err(),
+                "{path_argv} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -255,6 +255,31 @@ pub fn derive_cache_key(build_cwd: &Path) -> Option<String> {
     Some(hex::encode(hasher.finalize()))
 }
 
+/// Namespace a dependency cache key by the project and requested build. A
+/// toolchain/manifest digest alone is shared by unrelated repositories and
+/// can therefore restore stale `.lake` outputs that the current job never
+/// produced.
+fn project_cache_key(
+    dependency_key: &str,
+    source: &JobSource,
+    cwd_rel: &str,
+    command: &[String],
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"lake-cache-v2\0dependency\0");
+    hasher.update(dependency_key.as_bytes());
+    hasher.update(b"\0repo\0");
+    hasher.update(source.repo.trim().as_bytes());
+    hasher.update(b"\0cwd\0");
+    hasher.update(cwd_rel.as_bytes());
+    hasher.update(b"\0command\0");
+    for arg in command {
+        hasher.update((arg.len() as u64).to_be_bytes());
+        hasher.update(arg.as_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
 /// Toolchain directory names under the shared elan cache, for heartbeat
 /// `cached_toolchains` (empty when the cache does not exist yet).
 pub fn cached_toolchains(work_root: &Path) -> Vec<String> {
@@ -616,7 +641,8 @@ pub async fn execute_lean_build(
     let effective_cache_key = cache_key
         .clone()
         .filter(|key| !key.trim().is_empty())
-        .or_else(|| derive_cache_key(&build_cwd));
+        .or_else(|| derive_cache_key(&build_cwd))
+        .map(|key| project_cache_key(&key, source, rel_clean, command));
     if let Some(key) = effective_cache_key.as_deref() {
         let slot = lake_cache_slot(work_root, key);
         let lake_dir = build_cwd.join(".lake");
@@ -1104,6 +1130,44 @@ mod tests {
         )
         .unwrap();
         assert_ne!(derive_cache_key(dir2.path()).unwrap(), with_manifest);
+    }
+
+    #[test]
+    fn lake_cache_key_is_partitioned_by_project_and_target() {
+        let dependency_key = "same-toolchain-and-manifest";
+        let source_a = JobSource {
+            repo: "https://example.com/a.git".to_string(),
+            commit: "a".repeat(40),
+        };
+        let source_a_next_commit = JobSource {
+            repo: source_a.repo.clone(),
+            commit: "b".repeat(40),
+        };
+        let source_b = JobSource {
+            repo: "https://example.com/b.git".to_string(),
+            commit: "a".repeat(40),
+        };
+        let build = vec!["lake".to_string(), "build".to_string(), "A".to_string()];
+        let build_b = vec!["lake".to_string(), "build".to_string(), "B".to_string()];
+
+        let key = project_cache_key(dependency_key, &source_a, "pkg", &build);
+        assert_eq!(
+            key,
+            project_cache_key(dependency_key, &source_a_next_commit, "pkg", &build),
+            "commits in the same project intentionally reuse incremental dependencies"
+        );
+        assert_ne!(
+            key,
+            project_cache_key(dependency_key, &source_b, "pkg", &build)
+        );
+        assert_ne!(
+            key,
+            project_cache_key(dependency_key, &source_a, "other", &build)
+        );
+        assert_ne!(
+            key,
+            project_cache_key(dependency_key, &source_a, "pkg", &build_b)
+        );
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -587,6 +587,19 @@ pub async fn execute_lean_build(
     let checkout_lock = FileLock::acquire(checkout.with_extension("lock")).await?;
     let checkout = ensure_checkout(work_root, source, log_path, token).await?;
 
+    // The content-addressed checkout is reused, but build outputs are mutable.
+    // Reset it before every invocation so a cancelled/different-target build
+    // cannot leave `.lake` files or artifacts that a later job mistakes for
+    // its own output.
+    run_git_step(
+        &["reset", "--hard", source.commit.as_str()],
+        &checkout,
+        log_path,
+        token,
+    )
+    .await?;
+    run_git_step(&["clean", "-ffdx"], &checkout, log_path, token).await?;
+
     let rel_clean = cwd_rel.as_deref().unwrap_or("").trim_matches('/');
     let build_cwd = if rel_clean.is_empty() {
         checkout.clone()
@@ -670,7 +683,10 @@ async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> a
     tokio::fs::create_dir_all(parent).await?;
     let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
-    isolated_copy(lake_dir, &tmp).await?;
+    if let Err(err) = isolated_copy(lake_dir, &tmp).await {
+        let _ = tokio::fs::remove_dir_all(&tmp).await;
+        return Err(err);
+    }
     let old = parent.join(format!(".old-{}", uuid::Uuid::new_v4()));
     let had_old = tokio::fs::rename(&slot, &old).await.is_ok();
     if let Err(err) = tokio::fs::rename(&tmp, &slot).await {

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -125,10 +125,18 @@ pub fn validate_lean_build(
     let Some(argv0) = command.first().filter(|argv0| !argv0.trim().is_empty()) else {
         return Err("command must be a non-empty argv".to_string());
     };
-    let basename = argv0.rsplit('/').next().unwrap_or(argv0);
-    if !ALLOWED_COMMANDS.contains(&basename) {
+    // Bare tool names only: a path like `./lake` or `subdir/lake` would make
+    // Command::new execute an attacker-controlled file from the checkout
+    // instead of the PATH-resolved tool, bypassing the allowlist.
+    if argv0.contains('/') || argv0.contains('\\') {
         return Err(format!(
-            "command '{basename}' is not allowed; argv[0] must be one of {}",
+            "argv[0] must be a bare tool name (one of {}), not a path: '{argv0}'",
+            ALLOWED_COMMANDS.join("/")
+        ));
+    }
+    if !ALLOWED_COMMANDS.contains(&argv0.as_str()) {
+        return Err(format!(
+            "command '{argv0}' is not allowed; argv[0] must be one of {}",
             ALLOWED_COMMANDS.join("/")
         ));
     }
@@ -733,13 +741,41 @@ fn gc_once(work_root: &Path) {
         "node cache GC: below free-space threshold, evicting LRU caches"
     );
     for dir in gc_candidates(work_root) {
+        // Take the same `<dir>.lock` the build path holds (checkout builds
+        // and lake-slot syncs) — try-lock so an in-flight build makes the
+        // sweep skip its directories instead of deleting them mid-build.
+        let lock_path = dir.with_extension("lock");
+        let lock_file = match std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+        {
+            Ok(file) => file,
+            Err(err) => {
+                tracing::warn!(
+                    "node cache GC: cannot open lock for {}: {err}",
+                    dir.display()
+                );
+                continue;
+            }
+        };
+        if fs2::FileExt::try_lock_exclusive(&lock_file).is_err() {
+            tracing::debug!(
+                "node cache GC: skipped {} (locked by active build)",
+                dir.display()
+            );
+            continue;
+        }
         match std::fs::remove_dir_all(&dir) {
             Ok(()) => tracing::info!("node cache GC: deleted {}", dir.display()),
             Err(err) => {
                 tracing::warn!("node cache GC: failed to delete {}: {err}", dir.display())
             }
         }
-        let _ = std::fs::remove_file(dir.with_extension("lock"));
+        let _ = fs2::FileExt::unlock(&lock_file);
+        drop(lock_file);
+        let _ = std::fs::remove_file(&lock_path);
         match fs2::available_space(work_root) {
             Ok(free) if free >= threshold => return,
             _ => {}

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1,0 +1,1041 @@
+//! Declarative `lean_build` job execution for the `sandboxed-node` runner.
+//!
+//! A lean-build job carries only a git source (repo + pinned commit), a
+//! constrained argv (`lake`/`lean`/`elan`), and artifact patterns. The node
+//! materializes a content-addressed checkout, restores shared elan/lake
+//! caches, runs the build, syncs the lake cache back on success, and records
+//! artifact digests. No workspace sync with core, no shell interpretation of
+//! the payload.
+//!
+//! Layout under `SANDBOXED_NODE_WORK_DIR`:
+//! - `checkouts/<sha256(repo)[..16]>/<commit>/` — immutable-ish checkouts
+//! - `caches/elan/` (`ELAN_HOME`), `caches/xdg/` (`XDG_CACHE_HOME`),
+//!   `caches/home/` (`HOME`) — shared toolchain caches
+//! - `caches/lake/<cache_key>/` — lake build cache slots, hardlink-copied
+//!   (`cp -al`) into `<build cwd>/.lake` before a build and refreshed after a
+//!   successful one. Accepted caveat: hardlink copies preserve inode mtimes,
+//!   so mtime drift can cause partial rebuilds — never wrong artifacts.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
+
+use super::job_store::JobState;
+use super::runner::{clamp_timeout, run_logged_command};
+use crate::remote_node::{ArtifactEntry, JobPayload, JobSource};
+
+/// Default allowlist for lean-build env keys
+/// (`SANDBOXED_NODE_ENV_ALLOWLIST` overrides, comma-separated).
+pub const DEFAULT_ENV_ALLOWLIST: &str = "LEAN_NUM_THREADS,LAKE_JOBS";
+
+/// Binaries a lean-build argv may start with (basename of argv[0]).
+pub const ALLOWED_COMMANDS: [&str; 3] = ["lake", "lean", "elan"];
+
+/// Default node GC threshold: keep at least this many GiB free on the
+/// filesystem backing the work dir (`SANDBOXED_NODE_MIN_FREE_GB` overrides).
+const DEFAULT_MIN_FREE_GB: u64 = 10;
+
+/// Interval between node-side cache GC passes.
+const GC_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+/// Per-step ceiling for git operations (fetch/submodules) inside a build.
+const GIT_STEP_TIMEOUT_SECS: u64 = 1800;
+
+/// Outcome of one lean-build job.
+pub struct LeanBuildResult {
+    pub state: JobState,
+    pub exit_code: Option<i32>,
+    pub error: Option<String>,
+    /// Resolved artifact digests; non-empty only after a successful build.
+    pub artifacts: Vec<ArtifactEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Validation (pure; unit-tested without network or git)
+// ---------------------------------------------------------------------------
+
+/// Parse a comma-separated env-key allowlist.
+pub fn parse_env_allowlist(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Env-key allowlist from `SANDBOXED_NODE_ENV_ALLOWLIST` (with default).
+pub fn env_allowlist_from_env() -> Vec<String> {
+    let raw = std::env::var("SANDBOXED_NODE_ENV_ALLOWLIST")
+        .ok()
+        .filter(|raw| !raw.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ENV_ALLOWLIST.to_string());
+    parse_env_allowlist(&raw)
+}
+
+/// Full 40-char lowercase hex commit SHA (branch names/short SHAs rejected).
+pub fn commit_is_valid(commit: &str) -> bool {
+    commit.len() == 40
+        && commit
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch))
+}
+
+/// Whether a slash-trimmed relative path is safe to use below a build root.
+///
+/// Copy of the check in `src/api/spark.rs` (`rel_path_is_safe`) — duplicated
+/// on purpose so the node runtime does not depend on the core API layer.
+/// Only `[A-Za-z0-9._-]` components, no `..`, no `-`-leading component
+/// (argv-flag smuggling). Empty = build root.
+pub fn rel_path_is_safe(rel_clean: &str) -> bool {
+    rel_clean.is_empty()
+        || rel_clean.split('/').all(|c| {
+            !c.is_empty()
+                && c != ".."
+                && !c.starts_with('-')
+                && c.chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+        })
+}
+
+/// Validate a lean-build payload before touching the filesystem or network.
+pub fn validate_lean_build(
+    source: &JobSource,
+    cwd_rel: Option<&str>,
+    command: &[String],
+    env: &HashMap<String, String>,
+    allowlist: &[String],
+) -> Result<(), String> {
+    if source.repo.trim().is_empty() {
+        return Err("source.repo is required".to_string());
+    }
+    if !commit_is_valid(&source.commit) {
+        return Err(format!(
+            "source.commit must be a full 40-char lowercase hex SHA (got '{}')",
+            source.commit
+        ));
+    }
+    let rel_clean = cwd_rel.unwrap_or("").trim_matches('/');
+    if !rel_path_is_safe(rel_clean) {
+        return Err(format!("invalid cwd_rel '{rel_clean}'"));
+    }
+    let Some(argv0) = command.first().filter(|argv0| !argv0.trim().is_empty()) else {
+        return Err("command must be a non-empty argv".to_string());
+    };
+    let basename = argv0.rsplit('/').next().unwrap_or(argv0);
+    if !ALLOWED_COMMANDS.contains(&basename) {
+        return Err(format!(
+            "command '{basename}' is not allowed; argv[0] must be one of {}",
+            ALLOWED_COMMANDS.join("/")
+        ));
+    }
+    for key in env.keys() {
+        if !allowlist.iter().any(|allowed| allowed == key) {
+            return Err(format!(
+                "env key '{key}' is not in the node allowlist ({})",
+                allowlist.join(",")
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Cache & checkout layout (pure path math, unit-tested)
+// ---------------------------------------------------------------------------
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+/// Content-addressed checkout directory for `(repo, commit)`.
+pub fn checkout_dir(work_root: &Path, repo: &str, commit: &str) -> PathBuf {
+    let repo_hash = sha256_hex(repo.as_bytes());
+    work_root
+        .join("checkouts")
+        .join(&repo_hash[..16])
+        .join(commit)
+}
+
+fn caches_dir(work_root: &Path) -> PathBuf {
+    work_root.join("caches")
+}
+
+fn lake_cache_slot(work_root: &Path, cache_key: &str) -> PathBuf {
+    caches_dir(work_root).join("lake").join(cache_key)
+}
+
+/// Shared-cache env for build steps: `ELAN_HOME`, `XDG_CACHE_HOME`, `HOME`
+/// under `<workdir>/caches/`, plus `PATH` with the shared elan bin prepended.
+fn cache_env(work_root: &Path) -> Vec<(String, String)> {
+    let caches = caches_dir(work_root);
+    let elan = caches.join("elan");
+    let mut path = elan.join("bin").display().to_string();
+    if let Ok(existing) = std::env::var("PATH") {
+        path.push(':');
+        path.push_str(&existing);
+    }
+    vec![
+        ("ELAN_HOME".to_string(), elan.display().to_string()),
+        (
+            "XDG_CACHE_HOME".to_string(),
+            caches.join("xdg").display().to_string(),
+        ),
+        (
+            "HOME".to_string(),
+            caches.join("home").display().to_string(),
+        ),
+        ("PATH".to_string(), path),
+    ]
+}
+
+/// Derive the default lake cache key from the build cwd: sha256 over the
+/// contents of `lean-toolchain` and `lake-manifest.json` (whichever exist).
+/// `None` when neither file is present (no cache slot is used then).
+pub fn derive_cache_key(build_cwd: &Path) -> Option<String> {
+    let toolchain = std::fs::read(build_cwd.join("lean-toolchain")).ok();
+    let manifest = std::fs::read(build_cwd.join("lake-manifest.json")).ok();
+    if toolchain.is_none() && manifest.is_none() {
+        return None;
+    }
+    let mut hasher = Sha256::new();
+    if let Some(bytes) = &toolchain {
+        hasher.update(b"lean-toolchain:");
+        hasher.update(bytes);
+    }
+    if let Some(bytes) = &manifest {
+        hasher.update(b"lake-manifest:");
+        hasher.update(bytes);
+    }
+    Some(hex::encode(hasher.finalize()))
+}
+
+/// Toolchain directory names under the shared elan cache, for heartbeat
+/// `cached_toolchains` (empty when the cache does not exist yet).
+pub fn cached_toolchains(work_root: &Path) -> Vec<String> {
+    let dir = caches_dir(work_root).join("elan").join("toolchains");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return vec![];
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect();
+    names.sort();
+    names
+}
+
+// ---------------------------------------------------------------------------
+// Artifact resolution (pure over a directory tree, unit-tested)
+// ---------------------------------------------------------------------------
+
+/// Whether an artifact pattern is safe: relative, no `..`/`.` components.
+pub fn artifact_pattern_is_safe(pattern: &str) -> bool {
+    !pattern.is_empty()
+        && !pattern.starts_with('/')
+        && pattern
+            .split('/')
+            .all(|component| !component.is_empty() && component != ".." && component != ".")
+}
+
+/// Match one path segment against a pattern where `*` matches any run of
+/// characters *within the segment* (never across `/`).
+fn segment_matches(name: &str, pattern: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        return name == pattern;
+    }
+    let Some(mut rest) = name.strip_prefix(parts[0]) else {
+        return false;
+    };
+    let last = parts.len() - 1;
+    for part in &parts[1..last] {
+        if part.is_empty() {
+            continue;
+        }
+        match rest.find(part) {
+            Some(idx) => rest = &rest[idx + part.len()..],
+            None => return false,
+        }
+    }
+    rest.len() >= parts[last].len() && rest.ends_with(parts[last])
+}
+
+/// Resolve artifact patterns to existing files below `root`.
+///
+/// Deliberately tiny glob: `*` is supported within a single path segment
+/// only; everything else is an exact relative path. Patterns with `..` (or
+/// absolute paths) are rejected, and expansion only ever joins validated
+/// segments below `root`, so results cannot escape the checkout.
+pub fn resolve_artifact_paths(root: &Path, patterns: &[String]) -> Result<Vec<String>, String> {
+    let mut out = std::collections::BTreeSet::new();
+    for pattern in patterns {
+        if !artifact_pattern_is_safe(pattern) {
+            return Err(format!("unsafe artifact pattern '{pattern}'"));
+        }
+        let segments: Vec<&str> = pattern.split('/').collect();
+        let mut current: Vec<PathBuf> = vec![PathBuf::new()];
+        for segment in &segments {
+            let mut next = Vec::new();
+            for rel in &current {
+                if segment.contains('*') {
+                    let Ok(entries) = std::fs::read_dir(root.join(rel)) else {
+                        continue;
+                    };
+                    for entry in entries.filter_map(|entry| entry.ok()) {
+                        let Ok(name) = entry.file_name().into_string() else {
+                            continue;
+                        };
+                        if segment_matches(&name, segment) {
+                            next.push(rel.join(name));
+                        }
+                    }
+                } else {
+                    next.push(rel.join(segment));
+                }
+            }
+            current = next;
+        }
+        for rel in current {
+            if root.join(&rel).is_file() {
+                out.insert(rel.to_string_lossy().into_owned());
+            }
+        }
+    }
+    Ok(out.into_iter().collect())
+}
+
+/// Resolve artifact patterns and compute sha256 + size for each match.
+pub async fn collect_artifacts(
+    root: &Path,
+    patterns: &[String],
+) -> Result<Vec<ArtifactEntry>, String> {
+    let root = root.to_path_buf();
+    let patterns = patterns.to_vec();
+    tokio::task::spawn_blocking(move || {
+        let rels = resolve_artifact_paths(&root, &patterns)?;
+        rels.into_iter()
+            .map(|rel| {
+                let full = root.join(&rel);
+                let mut file =
+                    std::fs::File::open(&full).map_err(|e| format!("open artifact {rel}: {e}"))?;
+                let mut hasher = Sha256::new();
+                let size_bytes = std::io::copy(&mut file, &mut hasher)
+                    .map_err(|e| format!("hash artifact {rel}: {e}"))?;
+                Ok(ArtifactEntry {
+                    path: rel,
+                    sha256: hex::encode(hasher.finalize()),
+                    size_bytes,
+                })
+            })
+            .collect()
+    })
+    .await
+    .map_err(|e| format!("artifact hashing task failed: {e}"))?
+}
+
+// ---------------------------------------------------------------------------
+// File locking (fs2 flock)
+// ---------------------------------------------------------------------------
+
+/// Exclusive advisory file lock; released on drop.
+struct FileLock {
+    file: std::fs::File,
+}
+
+impl FileLock {
+    async fn acquire(path: PathBuf) -> anyhow::Result<Self> {
+        tokio::task::spawn_blocking(move || {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .write(true)
+                .open(&path)?;
+            file.lock_exclusive()?;
+            Ok(Self { file })
+        })
+        .await?
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checkout materialization (network; not exercised by unit tests)
+// ---------------------------------------------------------------------------
+
+/// `GIT_SSH_COMMAND` when `SANDBOXED_NODE_GIT_SSH_KEY` points at a key file.
+fn git_ssh_env() -> Option<(String, String)> {
+    let key = std::env::var("SANDBOXED_NODE_GIT_SSH_KEY")
+        .ok()
+        .filter(|key| !key.trim().is_empty())?;
+    Some((
+        "GIT_SSH_COMMAND".to_string(),
+        format!("ssh -i {key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"),
+    ))
+}
+
+/// Run one git step, appending output to the job log. Returns an error with
+/// the step name when the command is cancelled, times out, or exits non-zero.
+async fn run_git_step(
+    args: &[&str],
+    cwd: &Path,
+    log_path: &Path,
+    token: &CancellationToken,
+) -> anyhow::Result<()> {
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.args(args).current_dir(cwd);
+    if let Some((key, value)) = git_ssh_env() {
+        cmd.env(key, value);
+    }
+    let outcome = run_logged_command(cmd, log_path, GIT_STEP_TIMEOUT_SECS, token).await?;
+    if !outcome.success() {
+        let (_, code, error) = outcome.into_job_result();
+        anyhow::bail!(
+            "git {} failed ({}, exit {code:?}); see job log",
+            args.first().copied().unwrap_or("?"),
+            error.unwrap_or_default(),
+        );
+    }
+    Ok(())
+}
+
+/// Ensure `<workdir>/checkouts/<repo-hash>/<commit>/` exists, fetching it if
+/// needed. Builds into a temp sibling and atomically renames so a partially
+/// fetched tree is never observed at the final path. Callers must hold the
+/// per-checkout flock.
+async fn ensure_checkout(
+    work_root: &Path,
+    source: &JobSource,
+    log_path: &Path,
+    token: &CancellationToken,
+) -> anyhow::Result<PathBuf> {
+    let dest = checkout_dir(work_root, &source.repo, &source.commit);
+    if dest.is_dir() {
+        return Ok(dest);
+    }
+    let parent = dest
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("checkout dir has no parent"))?;
+    tokio::fs::create_dir_all(parent).await?;
+    let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
+    tokio::fs::create_dir_all(&tmp).await?;
+
+    let fetch = async {
+        run_git_step(&["init", "--quiet"], &tmp, log_path, token).await?;
+        run_git_step(
+            &[
+                "fetch",
+                "--depth",
+                "1",
+                "--quiet",
+                source.repo.as_str(),
+                source.commit.as_str(),
+            ],
+            &tmp,
+            log_path,
+            token,
+        )
+        .await?;
+        run_git_step(
+            &["checkout", "--quiet", "--detach", "FETCH_HEAD"],
+            &tmp,
+            log_path,
+            token,
+        )
+        .await?;
+        // Best-effort: many Lean repos have no submodules and lakefile deps
+        // are fetched by lake itself.
+        let _ = run_git_step(
+            &["submodule", "update", "--init", "--depth", "1"],
+            &tmp,
+            log_path,
+            token,
+        )
+        .await;
+        anyhow::Ok(())
+    }
+    .await;
+
+    if let Err(err) = fetch {
+        let _ = tokio::fs::remove_dir_all(&tmp).await;
+        return Err(err);
+    }
+    match tokio::fs::rename(&tmp, &dest).await {
+        Ok(()) => Ok(dest),
+        // A concurrent build (other lock domain) won the rename; reuse theirs.
+        Err(_) if dest.is_dir() => {
+            let _ = tokio::fs::remove_dir_all(&tmp).await;
+            Ok(dest)
+        }
+        Err(err) => {
+            let _ = tokio::fs::remove_dir_all(&tmp).await;
+            Err(err.into())
+        }
+    }
+}
+
+/// Hardlink-copy `src` to `dest` (`cp -al`). `dest` must not exist.
+async fn hardlink_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
+    let output = tokio::process::Command::new("cp")
+        .arg("-al")
+        .arg(src)
+        .arg(dest)
+        .output()
+        .await?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "cp -al {} -> {} failed: {}",
+            src.display(),
+            dest.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Build execution
+// ---------------------------------------------------------------------------
+
+/// Execute a `lean_build` payload. Returns `Err` for validation/infra
+/// failures (persisted as a failed job) and `Ok` with the run outcome
+/// otherwise.
+pub async fn execute_lean_build(
+    work_root: &Path,
+    log_path: &Path,
+    payload: &JobPayload,
+    max_job_secs: u64,
+    token: &CancellationToken,
+) -> anyhow::Result<LeanBuildResult> {
+    let JobPayload::LeanBuild {
+        source,
+        cwd_rel,
+        command,
+        timeout_secs,
+        cache_key,
+        artifacts,
+        env,
+    } = payload
+    else {
+        anyhow::bail!("execute_lean_build called with a non-lean payload");
+    };
+
+    let allowlist = env_allowlist_from_env();
+    validate_lean_build(source, cwd_rel.as_deref(), command, env, &allowlist)
+        .map_err(|e| anyhow::anyhow!("invalid lean_build payload: {e}"))?;
+
+    // Serialize builds of the same (repo, commit): one flock guards both the
+    // checkout materialization and the build itself, so two jobs never run
+    // `lake` concurrently in one checkout.
+    let checkout = checkout_dir(work_root, &source.repo, &source.commit);
+    let checkout_lock = FileLock::acquire(checkout.with_extension("lock")).await?;
+    let checkout = ensure_checkout(work_root, source, log_path, token).await?;
+
+    let rel_clean = cwd_rel.as_deref().unwrap_or("").trim_matches('/');
+    let build_cwd = if rel_clean.is_empty() {
+        checkout.clone()
+    } else {
+        checkout.join(rel_clean)
+    };
+    if !build_cwd.is_dir() {
+        anyhow::bail!("cwd_rel '{rel_clean}' does not exist in the checkout");
+    }
+
+    // Lake cache restore: hardlink-copy the slot into `<cwd>/.lake` when the
+    // checkout has no .lake yet. Slot mutation is guarded by a per-key flock
+    // (shared across commits with the same toolchain+manifest).
+    let effective_cache_key = cache_key
+        .clone()
+        .filter(|key| !key.trim().is_empty())
+        .or_else(|| derive_cache_key(&build_cwd));
+    if let Some(key) = effective_cache_key.as_deref() {
+        let slot = lake_cache_slot(work_root, key);
+        let lake_dir = build_cwd.join(".lake");
+        if !lake_dir.exists() && slot.is_dir() {
+            let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
+            if let Err(err) = hardlink_copy(&slot, &lake_dir).await {
+                tracing::warn!("lake cache restore failed (continuing cold): {err}");
+                let _ = tokio::fs::remove_dir_all(&lake_dir).await;
+            }
+        }
+    }
+
+    // Run the build argv directly (no shell) with shared-cache env plus the
+    // allowlisted job env.
+    let mut cmd = tokio::process::Command::new(&command[0]);
+    cmd.args(&command[1..]).current_dir(&build_cwd);
+    for (key, value) in cache_env(work_root) {
+        cmd.env(key, value);
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    let limit_secs = clamp_timeout(*timeout_secs, max_job_secs);
+    let outcome = run_logged_command(cmd, log_path, limit_secs, token).await?;
+    let success = outcome.success();
+
+    let mut result_artifacts = Vec::new();
+    if success {
+        // Sync the lake cache back: hardlink-copy into a tmp slot, then swap
+        // it in under the per-key flock so readers never see a partial slot.
+        if let Some(key) = effective_cache_key.as_deref() {
+            if let Err(err) = sync_lake_cache_back(work_root, key, &build_cwd.join(".lake")).await {
+                tracing::warn!("lake cache sync-back failed: {err}");
+            }
+        }
+        if !artifacts.is_empty() {
+            result_artifacts = collect_artifacts(&checkout, artifacts)
+                .await
+                .map_err(|e| anyhow::anyhow!("artifact resolution failed: {e}"))?;
+        }
+    }
+    drop(checkout_lock);
+
+    let (state, exit_code, error) = outcome.into_job_result();
+    Ok(LeanBuildResult {
+        state,
+        exit_code,
+        error,
+        artifacts: result_artifacts,
+    })
+}
+
+/// Replace the lake cache slot for `key` with the contents of `lake_dir`.
+async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> anyhow::Result<()> {
+    if !lake_dir.is_dir() {
+        return Ok(());
+    }
+    let slot = lake_cache_slot(work_root, key);
+    let parent = slot
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("lake cache slot has no parent"))?;
+    tokio::fs::create_dir_all(parent).await?;
+    let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
+    let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
+    hardlink_copy(lake_dir, &tmp).await?;
+    let old = parent.join(format!(".old-{}", uuid::Uuid::new_v4()));
+    let had_old = tokio::fs::rename(&slot, &old).await.is_ok();
+    if let Err(err) = tokio::fs::rename(&tmp, &slot).await {
+        let _ = tokio::fs::remove_dir_all(&tmp).await;
+        if had_old {
+            let _ = tokio::fs::rename(&old, &slot).await;
+        }
+        return Err(err.into());
+    }
+    if had_old {
+        let _ = tokio::fs::remove_dir_all(&old).await;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Node-side cache GC
+// ---------------------------------------------------------------------------
+
+fn min_free_bytes() -> u64 {
+    let gb = std::env::var("SANDBOXED_NODE_MIN_FREE_GB")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MIN_FREE_GB);
+    gb.saturating_mul(1 << 30)
+}
+
+/// Spawn the periodic disk GC: every 30 minutes, when free space on the
+/// work-dir filesystem drops below `SANDBOXED_NODE_MIN_FREE_GB` (default 10),
+/// LRU-delete (by dir mtime) checkout dirs first, then lake cache slots,
+/// until the threshold is met or nothing is left.
+pub fn spawn_cache_gc(work_root: PathBuf) {
+    tokio::spawn(async move {
+        loop {
+            let root = work_root.clone();
+            let result = tokio::task::spawn_blocking(move || gc_once(&root)).await;
+            if let Err(err) = result {
+                tracing::warn!("node cache GC task panicked: {err}");
+            }
+            tokio::time::sleep(GC_INTERVAL).await;
+        }
+    });
+}
+
+/// Directories eligible for GC, LRU-ordered: checkouts before lake slots,
+/// each group by mtime ascending.
+fn gc_candidates(work_root: &Path) -> Vec<PathBuf> {
+    fn dirs_by_mtime(dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+        let mut with_mtime: Vec<(std::time::SystemTime, PathBuf)> = dirs
+            .into_iter()
+            .map(|dir| {
+                let mtime = std::fs::metadata(&dir)
+                    .and_then(|m| m.modified())
+                    .unwrap_or(std::time::UNIX_EPOCH);
+                (mtime, dir)
+            })
+            .collect();
+        with_mtime.sort();
+        with_mtime.into_iter().map(|(_, dir)| dir).collect()
+    }
+    fn subdirs(dir: &Path) -> Vec<PathBuf> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return vec![];
+        };
+        entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .filter(|path| {
+                // Skip in-flight tmp dirs and lock files.
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .map(|name| !name.starts_with('.'))
+                    .unwrap_or(false)
+            })
+            .collect()
+    }
+    // checkouts/<repo-hash>/<commit>
+    let mut checkouts = Vec::new();
+    for repo_dir in subdirs(&work_root.join("checkouts")) {
+        checkouts.extend(subdirs(&repo_dir));
+    }
+    let lake_slots = subdirs(&caches_dir(work_root).join("lake"));
+    let mut candidates = dirs_by_mtime(checkouts);
+    candidates.extend(dirs_by_mtime(lake_slots));
+    candidates
+}
+
+fn gc_once(work_root: &Path) {
+    let threshold = min_free_bytes();
+    let free = match fs2::available_space(work_root) {
+        Ok(free) => free,
+        Err(err) => {
+            tracing::warn!("node cache GC: cannot stat work dir: {err}");
+            return;
+        }
+    };
+    if free >= threshold {
+        return;
+    }
+    tracing::info!(
+        free_gb = free / (1 << 30),
+        threshold_gb = threshold / (1 << 30),
+        "node cache GC: below free-space threshold, evicting LRU caches"
+    );
+    for dir in gc_candidates(work_root) {
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => tracing::info!("node cache GC: deleted {}", dir.display()),
+            Err(err) => {
+                tracing::warn!("node cache GC: failed to delete {}: {err}", dir.display())
+            }
+        }
+        let _ = std::fs::remove_file(dir.with_extension("lock"));
+        match fs2::available_space(work_root) {
+            Ok(free) if free >= threshold => return,
+            _ => {}
+        }
+    }
+    tracing::warn!("node cache GC: still below threshold after evicting all caches");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(commit: &str) -> JobSource {
+        JobSource {
+            repo: "https://github.com/example/verity.git".to_string(),
+            commit: commit.to_string(),
+        }
+    }
+
+    fn allowlist() -> Vec<String> {
+        parse_env_allowlist(DEFAULT_ENV_ALLOWLIST)
+    }
+
+    #[test]
+    fn validation_accepts_a_well_formed_payload() {
+        let env: HashMap<String, String> = [("LEAN_NUM_THREADS".to_string(), "4".to_string())]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            validate_lean_build(
+                &source(&"a".repeat(40)),
+                Some("morpho-verity"),
+                &["lake".to_string(), "build".to_string()],
+                &env,
+                &allowlist(),
+            ),
+            Ok(())
+        );
+        // Absolute argv[0] is judged by basename.
+        assert_eq!(
+            validate_lean_build(
+                &source(&"a".repeat(40)),
+                None,
+                &["/usr/local/bin/elan".to_string(), "show".to_string()],
+                &HashMap::new(),
+                &allowlist(),
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn validation_rejects_bad_commits() {
+        for bad in [
+            "main",
+            "HEAD",
+            &"a".repeat(39),
+            &"a".repeat(41),
+            &"A".repeat(40), // uppercase hex rejected
+            &"g".repeat(40), // not hex
+            "",
+        ] {
+            let err = validate_lean_build(
+                &source(bad),
+                None,
+                &["lake".to_string(), "build".to_string()],
+                &HashMap::new(),
+                &allowlist(),
+            )
+            .unwrap_err();
+            assert!(err.contains("commit"), "bad commit {bad:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn validation_rejects_disallowed_argv() {
+        for bad in [
+            vec!["bash".to_string(), "-c".to_string(), "id".to_string()],
+            vec!["sh".to_string()],
+            vec!["/bin/bash".to_string()],
+            vec!["lakex".to_string()],
+            vec![],
+            vec!["".to_string()],
+        ] {
+            let err = validate_lean_build(
+                &source(&"a".repeat(40)),
+                None,
+                &bad,
+                &HashMap::new(),
+                &allowlist(),
+            )
+            .unwrap_err();
+            assert!(
+                err.contains("command") || err.contains("argv"),
+                "bad argv {bad:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validation_rejects_env_keys_outside_allowlist() {
+        let env: HashMap<String, String> = [("LD_PRELOAD".to_string(), "/tmp/evil.so".to_string())]
+            .into_iter()
+            .collect();
+        let err = validate_lean_build(
+            &source(&"a".repeat(40)),
+            None,
+            &["lake".to_string(), "build".to_string()],
+            &env,
+            &allowlist(),
+        )
+        .unwrap_err();
+        assert!(err.contains("LD_PRELOAD"), "{err}");
+
+        // Custom allowlists are honored.
+        let custom = parse_env_allowlist("LD_PRELOAD, FOO");
+        assert_eq!(
+            validate_lean_build(
+                &source(&"a".repeat(40)),
+                None,
+                &["lake".to_string(), "build".to_string()],
+                &env,
+                &custom,
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn validation_rejects_cwd_rel_escapes() {
+        for bad in ["../etc", "a/../../b", "a;b", "-flag", "a b", "$(id)"] {
+            let err = validate_lean_build(
+                &source(&"a".repeat(40)),
+                Some(bad),
+                &["lake".to_string(), "build".to_string()],
+                &HashMap::new(),
+                &allowlist(),
+            )
+            .unwrap_err();
+            assert!(err.contains("cwd_rel"), "bad cwd_rel {bad:?}: {err}");
+        }
+        // Leading/trailing slashes are trimmed, inner path must be clean.
+        assert!(validate_lean_build(
+            &source(&"a".repeat(40)),
+            Some("/verity/"),
+            &["lake".to_string(), "build".to_string()],
+            &HashMap::new(),
+            &allowlist(),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn checkout_dir_is_content_addressed_and_stable() {
+        let work_root = Path::new("/var/lib/node/work");
+        let commit = "c".repeat(40);
+        let a = checkout_dir(work_root, "https://x/repo-a.git", &commit);
+        let b = checkout_dir(work_root, "https://x/repo-b.git", &commit);
+        let a_again = checkout_dir(work_root, "https://x/repo-a.git", &commit);
+        assert_eq!(a, a_again);
+        assert_ne!(a, b);
+        assert!(a.starts_with(work_root.join("checkouts")));
+        assert_eq!(a.file_name().unwrap().to_str().unwrap(), commit);
+        // 16-hex-char repo hash segment.
+        let repo_segment = a.parent().unwrap().file_name().unwrap().to_str().unwrap();
+        assert_eq!(repo_segment.len(), 16);
+        assert!(repo_segment.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn cache_key_derivation_tracks_toolchain_and_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        // Neither file present: no cache key, no slot used.
+        assert_eq!(derive_cache_key(dir.path()), None);
+
+        std::fs::write(
+            dir.path().join("lean-toolchain"),
+            "leanprover/lean4:v4.15.0",
+        )
+        .unwrap();
+        let toolchain_only = derive_cache_key(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("lake-manifest.json"), "{\"packages\":[]}").unwrap();
+        let with_manifest = derive_cache_key(dir.path()).unwrap();
+        assert_ne!(toolchain_only, with_manifest);
+
+        // Same contents -> same key (stable across checkouts).
+        let dir2 = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir2.path().join("lean-toolchain"),
+            "leanprover/lean4:v4.15.0",
+        )
+        .unwrap();
+        std::fs::write(dir2.path().join("lake-manifest.json"), "{\"packages\":[]}").unwrap();
+        assert_eq!(derive_cache_key(dir2.path()).unwrap(), with_manifest);
+
+        // Toolchain bump changes the key.
+        std::fs::write(
+            dir2.path().join("lean-toolchain"),
+            "leanprover/lean4:v4.16.0",
+        )
+        .unwrap();
+        assert_ne!(derive_cache_key(dir2.path()).unwrap(), with_manifest);
+    }
+
+    #[test]
+    fn artifact_patterns_reject_traversal_and_absolute_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        for bad in ["../secrets", "a/../b", "/etc/passwd", "", "a//b", "./a"] {
+            let err = resolve_artifact_paths(dir.path(), &[bad.to_string()]).unwrap_err();
+            assert!(err.contains("unsafe"), "bad pattern {bad:?}: {err}");
+            assert!(!artifact_pattern_is_safe(bad), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn artifact_globs_match_within_a_single_segment_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".lake/build/lib")).unwrap();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join(".lake/build/lib/A.olean"), b"a").unwrap();
+        std::fs::write(root.join(".lake/build/lib/B.olean"), b"bb").unwrap();
+        std::fs::write(root.join(".lake/build/lib/notes.txt"), b"x").unwrap();
+        std::fs::write(root.join("sub/C.olean"), b"c").unwrap();
+
+        let matched = resolve_artifact_paths(
+            root,
+            &[
+                ".lake/build/lib/*.olean".to_string(),
+                "sub/C.olean".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            matched,
+            vec![
+                ".lake/build/lib/A.olean".to_string(),
+                ".lake/build/lib/B.olean".to_string(),
+                "sub/C.olean".to_string(),
+            ]
+        );
+
+        // `*` never crosses a `/`: this matches nothing (files live one level
+        // deeper), and missing exact paths resolve to nothing rather than
+        // erroring.
+        assert!(resolve_artifact_paths(root, &[".lake/*".to_string()])
+            .unwrap()
+            .is_empty());
+        assert!(resolve_artifact_paths(root, &["missing.olean".to_string()])
+            .unwrap()
+            .is_empty());
+        // Directories themselves are not artifacts.
+        assert!(resolve_artifact_paths(root, &["sub".to_string()])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn collect_artifacts_hashes_and_sizes_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("out.olean"), b"hello").unwrap();
+        let artifacts = collect_artifacts(dir.path(), &["*.olean".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].path, "out.olean");
+        assert_eq!(artifacts[0].size_bytes, 5);
+        assert_eq!(
+            artifacts[0].sha256,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn cached_toolchains_lists_elan_toolchain_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(cached_toolchains(dir.path()).is_empty());
+        let toolchains = dir.path().join("caches/elan/toolchains");
+        std::fs::create_dir_all(toolchains.join("leanprover--lean4---v4.15.0")).unwrap();
+        std::fs::create_dir_all(toolchains.join("leanprover--lean4---v4.16.0")).unwrap();
+        std::fs::write(toolchains.join("stray-file"), b"x").unwrap();
+        assert_eq!(
+            cached_toolchains(dir.path()),
+            vec![
+                "leanprover--lean4---v4.15.0".to_string(),
+                "leanprover--lean4---v4.16.0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn timeout_is_clamped_like_raw_command() {
+        assert_eq!(clamp_timeout(Some(600), 100), 100);
+        assert_eq!(clamp_timeout(Some(50), 100), 50);
+        assert_eq!(clamp_timeout(None, 100), 100);
+        assert_eq!(clamp_timeout(Some(0), 100), 1);
+    }
+}

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -827,7 +827,9 @@ fn gc_once(work_root: &Path) {
         }
         let _ = fs2::FileExt::unlock(&lock_file);
         drop(lock_file);
-        let _ = std::fs::remove_file(&lock_path);
+        // Keep the lock inode stable. Unlinking here can split the flock
+        // domain when a waiter already has this inode open while a later job
+        // recreates and locks a different inode at the same path.
         match fs2::available_space(work_root) {
             Ok(free) if free >= threshold => return,
             _ => {}

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -101,6 +101,26 @@ pub fn rel_path_is_safe(rel_clean: &str) -> bool {
         })
 }
 
+/// Only remote fetch sources: git happily fetches local paths and file://
+/// URLs, which would let a remote-build token holder exfiltrate node-local
+/// git data into a checkout.
+fn repo_url_is_remote(repo: &str) -> bool {
+    let repo = repo.trim();
+    if repo.starts_with("https://") || repo.starts_with("ssh://") {
+        return true;
+    }
+    // scp-like syntax: user@host:path (no scheme). Require the colon after
+    // the host part and forbid path-like prefixes.
+    if let Some((userhost, path)) = repo.split_once(':') {
+        return userhost.contains('@')
+            && !userhost.contains('/')
+            && !path.is_empty()
+            && !repo.starts_with('/')
+            && !repo.starts_with('.');
+    }
+    false
+}
+
 /// Validate a lean-build payload before touching the filesystem or network.
 pub fn validate_lean_build(
     source: &JobSource,
@@ -111,6 +131,13 @@ pub fn validate_lean_build(
 ) -> Result<(), String> {
     if source.repo.trim().is_empty() {
         return Err("source.repo is required".to_string());
+    }
+    if !repo_url_is_remote(&source.repo) {
+        return Err(format!(
+            "source.repo must be an https://, ssh:// or git@host: URL (got '{}'); \
+             local paths and file:// would expose node-local repositories",
+            source.repo
+        ));
     }
     if !commit_is_valid(&source.commit) {
         return Err(format!(
@@ -828,6 +855,53 @@ mod tests {
                 )
                 .is_err(),
                 "{path_argv} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validation_rejects_local_repo_sources() {
+        for bad in [
+            "/srv/git/private.git",
+            "file:///var/lib/sandboxed-node/checkouts",
+            "./repo",
+            "../repo",
+            "repo",
+            "C:/repos/x",
+        ] {
+            assert!(
+                validate_lean_build(
+                    &JobSource {
+                        repo: bad.to_string(),
+                        commit: "a".repeat(40),
+                    },
+                    None,
+                    &["lake".to_string(), "build".to_string()],
+                    &HashMap::new(),
+                    &allowlist(),
+                )
+                .is_err(),
+                "{bad} must be rejected"
+            );
+        }
+        for good in [
+            "https://github.com/lfglabs-dev/verity.git",
+            "ssh://git@github.com/lfglabs-dev/erc4337-verity.git",
+            "git@github.com:lfglabs-dev/erc4337-verity.git",
+        ] {
+            assert!(
+                validate_lean_build(
+                    &JobSource {
+                        repo: good.to_string(),
+                        commit: "a".repeat(40),
+                    },
+                    None,
+                    &["lake".to_string(), "build".to_string()],
+                    &HashMap::new(),
+                    &allowlist(),
+                )
+                .is_ok(),
+                "{good} must be accepted"
             );
         }
     }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,0 +1,10 @@
+//! Node-side runtime for the `sandboxed-node` runner binary.
+//!
+//! Lives in the library crate (rather than the binary) so the durable job
+//! store and the job runner are unit-testable with `cargo test --lib`.
+
+pub mod job_store;
+pub mod runner;
+
+pub use job_store::{JobRecord, JobState, JobStore};
+pub use runner::{read_log_tail, JobRunner, DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES};

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -9,4 +9,6 @@ pub mod runner;
 
 pub use job_store::{JobRecord, JobState, JobStore};
 pub use lean::{cached_toolchains, spawn_cache_gc};
-pub use runner::{read_log_tail, JobRunner, DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES};
+pub use runner::{
+    read_log_tail, JobRunner, NodeQueueFull, DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES,
+};

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -4,7 +4,9 @@
 //! store and the job runner are unit-testable with `cargo test --lib`.
 
 pub mod job_store;
+pub mod lean;
 pub mod runner;
 
 pub use job_store::{JobRecord, JobState, JobStore};
+pub use lean::{cached_toolchains, spawn_cache_gc};
 pub use runner::{read_log_tail, JobRunner, DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES};

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -162,19 +162,24 @@ impl JobRunner {
 
     async fn run_one(&self, job: QueuedJob) {
         let token = self.take_cancel_token(job.id);
-        let (state, exit_code, error) = if token.is_cancelled() {
+        let (state, exit_code, error, artifacts_json) = if token.is_cancelled() {
             (
                 JobState::Cancelled,
                 None,
                 Some("cancelled before start".to_string()),
+                None,
             )
         } else {
             match self.execute(&job, &token).await {
                 Ok(outcome) => outcome,
-                Err(err) => (JobState::Failed, None, Some(err.to_string())),
+                Err(err) => (JobState::Failed, None, Some(err.to_string()), None),
             }
         };
-        if let Err(err) = self.store.finish(job.id, state, exit_code, error).await {
+        if let Err(err) = self
+            .store
+            .finish_with_artifacts(job.id, state, exit_code, error, artifacts_json)
+            .await
+        {
             tracing::warn!(job_id = %job.id, "failed to persist job outcome: {err}");
         }
         self.drop_cancel_token(job.id);
@@ -184,79 +189,136 @@ impl JobRunner {
         &self,
         job: &QueuedJob,
         token: &CancellationToken,
-    ) -> anyhow::Result<(JobState, Option<i32>, Option<String>)> {
-        let JobPayload::RawCommand {
-            command,
-            timeout_secs,
-            env,
-        } = &job.payload;
-
-        let mission_dir = self.work_root.join(job.mission_id.to_string());
-        tokio::fs::create_dir_all(&mission_dir).await?;
+    ) -> anyhow::Result<(JobState, Option<i32>, Option<String>, Option<String>)> {
         let log_path = self.log_path(job.id);
-        if let Some(parent) = log_path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        let stdout_file = std::fs::File::create(&log_path)?;
-        let stderr_file = stdout_file.try_clone()?;
+        match &job.payload {
+            JobPayload::RawCommand {
+                command,
+                timeout_secs,
+                env,
+            } => {
+                let mission_dir = self.work_root.join(job.mission_id.to_string());
+                tokio::fs::create_dir_all(&mission_dir).await?;
 
-        self.store.mark_running(job.id).await?;
+                self.store.mark_running(job.id).await?;
 
-        let mut cmd = tokio::process::Command::new("bash");
-        cmd.arg("-lc")
-            .arg(command)
-            .current_dir(&mission_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::from(stdout_file))
-            .stderr(Stdio::from(stderr_file))
-            // New process group so cancel/timeout can kill the whole tree.
-            .process_group(0);
-        if let Some(env) = env {
-            for (key, value) in env {
-                cmd.env(key, value);
-            }
-        }
-        let mut child = cmd.spawn()?;
-        let pid = child.id();
-
-        let limit_secs = timeout_secs
-            .map(|requested| requested.min(self.max_job_secs))
-            .unwrap_or(self.max_job_secs)
-            .max(1);
-
-        let outcome = tokio::select! {
-            _ = token.cancelled() => {
-                kill_process_group(pid, &mut child).await;
-                (JobState::Cancelled, None, Some("cancelled".to_string()))
-            }
-            waited = tokio::time::timeout(Duration::from_secs(limit_secs), child.wait()) => {
-                match waited {
-                    Ok(Ok(status)) => {
-                        let code = status.code();
-                        if status.success() {
-                            (JobState::Succeeded, code, None)
-                        } else {
-                            (
-                                JobState::Failed,
-                                code,
-                                Some(format!("command exited with {code:?}")),
-                            )
-                        }
-                    }
-                    Ok(Err(err)) => (JobState::Failed, None, Some(err.to_string())),
-                    Err(_) => {
-                        kill_process_group(pid, &mut child).await;
-                        (
-                            JobState::Failed,
-                            None,
-                            Some(format!("timed out after {limit_secs}s")),
-                        )
+                let mut cmd = tokio::process::Command::new("bash");
+                cmd.arg("-lc").arg(command).current_dir(&mission_dir);
+                if let Some(env) = env {
+                    for (key, value) in env {
+                        cmd.env(key, value);
                     }
                 }
+                let limit_secs = clamp_timeout(*timeout_secs, self.max_job_secs);
+                let outcome = run_logged_command(cmd, &log_path, limit_secs, token).await?;
+                let (state, exit_code, error) = outcome.into_job_result();
+                Ok((state, exit_code, error, None))
             }
-        };
-        Ok(outcome)
+            JobPayload::LeanBuild { .. } => {
+                self.store.mark_running(job.id).await?;
+                let result = super::lean::execute_lean_build(
+                    &self.work_root,
+                    &log_path,
+                    &job.payload,
+                    self.max_job_secs,
+                    token,
+                )
+                .await?;
+                let artifacts_json = if result.artifacts.is_empty() {
+                    None
+                } else {
+                    Some(serde_json::to_string(&result.artifacts)?)
+                };
+                Ok((result.state, result.exit_code, result.error, artifacts_json))
+            }
+        }
     }
+}
+
+/// Clamp a client-requested timeout to the node ceiling (min 1s).
+pub(crate) fn clamp_timeout(requested: Option<u64>, max_job_secs: u64) -> u64 {
+    requested
+        .map(|requested| requested.min(max_job_secs))
+        .unwrap_or(max_job_secs)
+        .max(1)
+}
+
+/// Outcome of one supervised child process run (see [`run_logged_command`]).
+pub(crate) enum RunOutcome {
+    Exited(Option<i32>),
+    Cancelled,
+    TimedOut { limit_secs: u64 },
+}
+
+impl RunOutcome {
+    /// Whether the process ran to completion with exit code 0.
+    pub(crate) fn success(&self) -> bool {
+        matches!(self, RunOutcome::Exited(Some(0)))
+    }
+
+    /// Map a run outcome to the `(state, exit_code, error)` triple persisted
+    /// on the job record.
+    pub(crate) fn into_job_result(self) -> (JobState, Option<i32>, Option<String>) {
+        match self {
+            RunOutcome::Exited(Some(0)) => (JobState::Succeeded, Some(0), None),
+            RunOutcome::Exited(code) => (
+                JobState::Failed,
+                code,
+                Some(format!("command exited with {code:?}")),
+            ),
+            RunOutcome::Cancelled => (JobState::Cancelled, None, Some("cancelled".to_string())),
+            RunOutcome::TimedOut { limit_secs } => (
+                JobState::Failed,
+                None,
+                Some(format!("timed out after {limit_secs}s")),
+            ),
+        }
+    }
+}
+
+/// Spawn `cmd` in its own process group with combined stdout+stderr appended
+/// to `log_path`, honoring cancellation and a hard timeout. The whole process
+/// group is killed (SIGTERM, then SIGKILL after a grace period) on
+/// cancel/timeout. Shared by raw-command jobs and the lean-build steps.
+pub(crate) async fn run_logged_command(
+    mut cmd: tokio::process::Command,
+    log_path: &Path,
+    limit_secs: u64,
+    token: &CancellationToken,
+) -> anyhow::Result<RunOutcome> {
+    if let Some(parent) = log_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let stdout_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    let stderr_file = stdout_file.try_clone()?;
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file))
+        // New process group so cancel/timeout can kill the whole tree.
+        .process_group(0);
+    let mut child = cmd.spawn()?;
+    let pid = child.id();
+
+    let outcome = tokio::select! {
+        _ = token.cancelled() => {
+            kill_process_group(pid, &mut child).await;
+            RunOutcome::Cancelled
+        }
+        waited = tokio::time::timeout(Duration::from_secs(limit_secs.max(1)), child.wait()) => {
+            match waited {
+                Ok(Ok(status)) => RunOutcome::Exited(status.code()),
+                Ok(Err(err)) => return Err(err.into()),
+                Err(_) => {
+                    kill_process_group(pid, &mut child).await;
+                    RunOutcome::TimedOut { limit_secs }
+                }
+            }
+        }
+    };
+    Ok(outcome)
 }
 
 /// SIGTERM the job's process group, escalating to SIGKILL after a grace

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -396,12 +396,22 @@ pub(crate) async fn run_logged_command(
 fn contain_command(cmd: tokio::process::Command) -> (tokio::process::Command, Option<String>) {
     #[cfg(target_os = "linux")]
     {
-        if Path::new("/run/systemd/system").is_dir() {
+        if systemd_scopes_available() {
             let scope = format!("sandboxed-node-job-{}.scope", Uuid::new_v4().simple());
             return (systemd_scope_command(cmd, &scope), Some(scope));
         }
     }
     (cmd, None)
+}
+
+#[cfg(target_os = "linux")]
+fn systemd_scopes_available() -> bool {
+    // The node service is installed as root. Merely seeing systemd's runtime
+    // directory is insufficient in containers and CI runners: an unprivileged
+    // process can see it but cannot create system scopes, which would make the
+    // wrapper fail before the actual job starts.
+    // SAFETY: geteuid() is a side-effect-free syscall with no preconditions.
+    (unsafe { libc::geteuid() == 0 }) && Path::new("/run/systemd/system").is_dir()
 }
 
 #[cfg(target_os = "linux")]
@@ -749,7 +759,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn systemd_scope_kills_setsid_descendants() {
-        if !Path::new("/run/systemd/system").is_dir() {
+        if !systemd_scopes_available() {
             return;
         }
         let dir = tempfile::tempdir().unwrap();

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -3,15 +3,16 @@
 //! Jobs are submitted to an mpsc queue and executed under a capacity
 //! semaphore (`SANDBOXED_NODE_CAPACITY`). Each job runs `bash -lc <command>`
 //! in `<workdir>/<mission-id>/` with combined stdout+stderr captured to
-//! `<workdir>/logs/<job-id>.log`. Jobs are killed by process *group* on
-//! cancel or timeout (SIGTERM, then SIGKILL after 10s).
+//! `<workdir>/logs/<job-id>.log`. Every terminal path cleans up the process
+//! *group* (SIGTERM, then SIGKILL after 10s) so daemonized children cannot
+//! escape queue accounting.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
@@ -335,7 +336,8 @@ impl RunOutcome {
 /// Spawn `cmd` in its own process group with combined stdout+stderr appended
 /// to `log_path`, honoring cancellation and a hard timeout. The whole process
 /// group is killed (SIGTERM, then SIGKILL after a grace period) on
-/// cancel/timeout. Shared by raw-command jobs and the lean-build steps.
+/// cancel/timeout and after the leader exits normally. Shared by raw-command
+/// jobs and the lean-build steps.
 pub(crate) async fn run_logged_command(
     mut cmd: tokio::process::Command,
     log_path: &Path,
@@ -365,7 +367,13 @@ pub(crate) async fn run_logged_command(
         }
         waited = tokio::time::timeout(Duration::from_secs(limit_secs.max(1)), child.wait()) => {
             match waited {
-                Ok(Ok(status)) => RunOutcome::Exited(status.code()),
+                Ok(Ok(status)) => {
+                    // The process-group leader may exit after daemonizing a
+                    // child. A terminal job must not leave those descendants
+                    // consuming node resources outside queue accounting.
+                    kill_process_group(pid, &mut child).await;
+                    RunOutcome::Exited(status.code())
+                }
                 Ok(Err(err)) => return Err(err.into()),
                 Err(_) => {
                     kill_process_group(pid, &mut child).await;
@@ -384,17 +392,45 @@ async fn kill_process_group(pid: Option<u32>, child: &mut tokio::process::Child)
         unsafe {
             libc::kill(-(pid as i32), libc::SIGTERM);
         }
-        if tokio::time::timeout(KILL_GRACE, child.wait())
-            .await
-            .is_err()
-        {
+        if !wait_for_process_group_exit(pid, child, KILL_GRACE).await {
             unsafe {
                 libc::kill(-(pid as i32), libc::SIGKILL);
             }
-            let _ = child.wait().await;
+            if !wait_for_process_group_exit(pid, child, Duration::from_secs(1)).await {
+                tracing::warn!(
+                    process_group = pid,
+                    "job process group still exists after SIGKILL"
+                );
+            }
         }
+        let _ = child.wait().await;
     } else {
         let _ = child.kill().await;
+    }
+}
+
+fn process_group_exists(pid: u32) -> bool {
+    let result = unsafe { libc::kill(-(pid as i32), 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+async fn wait_for_process_group_exit(
+    pid: u32,
+    child: &mut tokio::process::Child,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        // Reap the leader promptly; an unreaped zombie keeps the process
+        // group observable even after every live process has exited.
+        let _ = child.try_wait();
+        if !process_group_exists(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 
@@ -576,6 +612,27 @@ mod tests {
         let record = wait_for_terminal(&store, job_id).await;
         assert_eq!(record.state, JobState::Failed);
         assert!(record.error.as_deref().unwrap_or("").contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn normal_exit_kills_background_process_group() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("background-survived");
+        let log = dir.path().join("job.log");
+        let mut cmd = tokio::process::Command::new("/bin/sh");
+        cmd.args(["-c", "(sleep 1; echo survived > \"$SURVIVOR_MARKER\") &"])
+            .env("SURVIVOR_MARKER", &marker);
+
+        let outcome = run_logged_command(cmd, &log, 30, &CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert!(outcome.success());
+        tokio::time::sleep(Duration::from_millis(1_250)).await;
+        assert!(
+            !marker.exists(),
+            "background descendant survived the terminal job"
+        );
     }
 
     async fn wait_for_terminal(store: &JobStore, job_id: Uuid) -> super::super::JobRecord {

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -211,13 +211,7 @@ impl JobRunner {
 
                 self.store.mark_running(job.id).await?;
 
-                let mut cmd = tokio::process::Command::new("bash");
-                cmd.arg("-lc").arg(command).current_dir(&mission_dir);
-                if let Some(env) = env {
-                    for (key, value) in env {
-                        cmd.env(key, value);
-                    }
-                }
+                let cmd = crate::remote_node::raw_command(command, &mission_dir, env.as_ref());
                 let limit_secs = clamp_timeout(*timeout_secs, self.max_job_secs);
                 let outcome = run_logged_command(cmd, &log_path, limit_secs, token).await?;
                 let (state, exit_code, error) = outcome.into_job_result();

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -235,6 +235,9 @@ impl JobRunner {
                 Err(err) => (JobState::Failed, None, Some(err.to_string()), None),
             }
         };
+        // Execution is over, so cancellation must no longer report that it
+        // reached a live job even while the terminal row is being persisted.
+        self.drop_cancel_token(job.id);
         if let Err(err) = self
             .store
             .finish_with_artifacts(job.id, state, exit_code, error, artifacts_json)
@@ -242,7 +245,6 @@ impl JobRunner {
         {
             tracing::warn!(job_id = %job.id, "failed to persist job outcome: {err}");
         }
-        self.drop_cancel_token(job.id);
     }
 
     async fn execute(
@@ -339,7 +341,7 @@ impl RunOutcome {
 /// cancel/timeout and after the leader exits normally. Shared by raw-command
 /// jobs and the lean-build steps.
 pub(crate) async fn run_logged_command(
-    mut cmd: tokio::process::Command,
+    cmd: tokio::process::Command,
     log_path: &Path,
     limit_secs: u64,
     token: &CancellationToken,
@@ -352,6 +354,7 @@ pub(crate) async fn run_logged_command(
         .append(true)
         .open(log_path)?;
     let stderr_file = stdout_file.try_clone()?;
+    let (mut cmd, systemd_scope) = contain_command(cmd);
     cmd.stdin(Stdio::null())
         .stdout(Stdio::from(stdout_file))
         .stderr(Stdio::from(stderr_file))
@@ -362,7 +365,7 @@ pub(crate) async fn run_logged_command(
 
     let outcome = tokio::select! {
         _ = token.cancelled() => {
-            kill_process_group(pid, &mut child).await;
+            kill_contained_process(systemd_scope.as_deref(), pid, &mut child).await;
             RunOutcome::Cancelled
         }
         waited = tokio::time::timeout(Duration::from_secs(limit_secs.max(1)), child.wait()) => {
@@ -371,18 +374,101 @@ pub(crate) async fn run_logged_command(
                     // The process-group leader may exit after daemonizing a
                     // child. A terminal job must not leave those descendants
                     // consuming node resources outside queue accounting.
-                    kill_process_group(pid, &mut child).await;
+                    kill_contained_process(systemd_scope.as_deref(), pid, &mut child).await;
                     RunOutcome::Exited(status.code())
                 }
                 Ok(Err(err)) => return Err(err.into()),
                 Err(_) => {
-                    kill_process_group(pid, &mut child).await;
+                    kill_contained_process(systemd_scope.as_deref(), pid, &mut child).await;
                     RunOutcome::TimedOut { limit_secs }
                 }
             }
         }
     };
     Ok(outcome)
+}
+
+/// Put node jobs in a transient systemd scope when the host has a running
+/// system manager. Process groups do not contain descendants that call
+/// `setsid`; a scope's cgroup does, so stopping the unit also reaps those
+/// daemonized descendants. The wrapper inherits the command environment
+/// directly, keeping secrets out of `systemd-run` argv.
+fn contain_command(cmd: tokio::process::Command) -> (tokio::process::Command, Option<String>) {
+    #[cfg(target_os = "linux")]
+    {
+        if Path::new("/run/systemd/system").is_dir() {
+            let scope = format!("sandboxed-node-job-{}.scope", Uuid::new_v4().simple());
+            return (systemd_scope_command(cmd, &scope), Some(scope));
+        }
+    }
+    (cmd, None)
+}
+
+#[cfg(target_os = "linux")]
+fn systemd_scope_command(cmd: tokio::process::Command, scope: &str) -> tokio::process::Command {
+    let command = cmd.as_std();
+    let program = command.get_program().to_os_string();
+    let args: Vec<_> = command.get_args().map(ToOwned::to_owned).collect();
+    let cwd = command.get_current_dir().map(ToOwned::to_owned);
+    let env: Vec<_> = command
+        .get_envs()
+        .map(|(key, value)| (key.to_os_string(), value.map(ToOwned::to_owned)))
+        .collect();
+
+    let mut scoped = tokio::process::Command::new("systemd-run");
+    scoped
+        .arg("--scope")
+        .arg("--quiet")
+        .arg("--collect")
+        .arg(format!("--unit={scope}"))
+        .arg("--property=KillMode=control-group")
+        .arg("--")
+        .arg(program)
+        .args(args);
+    if let Some(cwd) = cwd {
+        scoped.current_dir(cwd);
+    }
+    for (key, value) in env {
+        match value {
+            Some(value) => {
+                scoped.env(key, value);
+            }
+            None => {
+                scoped.env_remove(key);
+            }
+        }
+    }
+    scoped
+}
+
+async fn kill_contained_process(
+    _systemd_scope: Option<&str>,
+    pid: Option<u32>,
+    child: &mut tokio::process::Child,
+) {
+    #[cfg(target_os = "linux")]
+    if let Some(scope) = _systemd_scope {
+        let stop = tokio::process::Command::new("systemctl")
+            .arg("stop")
+            .arg(scope)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        match tokio::time::timeout(KILL_GRACE, stop).await {
+            Ok(Ok(status)) if !status.success() => {
+                tracing::warn!(scope, %status, "failed to stop node job systemd scope");
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(scope, %error, "could not stop node job systemd scope");
+            }
+            Err(_) => {
+                tracing::warn!(scope, "timed out stopping node job systemd scope");
+            }
+            Ok(Ok(_)) => {}
+        }
+    }
+    kill_process_group(pid, child).await;
 }
 
 /// SIGTERM the job's process group, escalating to SIGKILL after a grace
@@ -633,6 +719,56 @@ mod tests {
             !marker.exists(),
             "background descendant survived the terminal job"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn systemd_scope_wrapper_keeps_environment_out_of_argv() {
+        let mut cmd = tokio::process::Command::new("/bin/sh");
+        cmd.args(["-c", "printf ok"])
+            .current_dir("/")
+            .env("NODE_JOB_SECRET", "not-in-argv");
+
+        let scoped = systemd_scope_command(cmd, "sandboxed-node-job-test.scope");
+        let argv = scoped
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(argv.iter().any(|arg| arg == "/bin/sh"));
+        assert!(argv.iter().any(|arg| arg == "printf ok"));
+        assert!(!argv.iter().any(|arg| arg.contains("not-in-argv")));
+        assert_eq!(scoped.as_std().get_current_dir(), Some(Path::new("/")));
+        assert!(scoped
+            .as_std()
+            .get_envs()
+            .any(|(key, value)| key == "NODE_JOB_SECRET" && value == Some("not-in-argv".as_ref())));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn systemd_scope_kills_setsid_descendants() {
+        if !Path::new("/run/systemd/system").is_dir() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("setsid-survived");
+        let log = dir.path().join("job.log");
+        let mut cmd = tokio::process::Command::new("/bin/sh");
+        cmd.args([
+            "-c",
+            "setsid sh -c 'sleep 5; echo survived > \"$SURVIVOR_MARKER\"' &",
+        ])
+        .env("SURVIVOR_MARKER", &marker);
+
+        let outcome = run_logged_command(cmd, &log, 30, &CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert!(outcome.success());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(!marker.exists(), "setsid descendant escaped the job cgroup");
     }
 
     async fn wait_for_terminal(store: &JobStore, job_id: Uuid) -> super::super::JobRecord {

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -1,0 +1,418 @@
+//! Async job runner for the `sandboxed-node` binary.
+//!
+//! Jobs are submitted to an mpsc queue and executed under a capacity
+//! semaphore (`SANDBOXED_NODE_CAPACITY`). Each job runs `bash -lc <command>`
+//! in `<workdir>/<mission-id>/` with combined stdout+stderr captured to
+//! `<workdir>/logs/<job-id>.log`. Jobs are killed by process *group* on
+//! cancel or timeout (SIGTERM, then SIGKILL after 10s).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::{mpsc, Semaphore};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use super::job_store::{JobState, JobStore};
+use crate::remote_node::JobPayload;
+
+/// Default hard ceiling for a single job (4 hours), overridable via
+/// `SANDBOXED_NODE_MAX_JOB_SECS`.
+pub const DEFAULT_MAX_JOB_SECS: u64 = 14_400;
+
+/// Maximum log-tail bytes returned by job status endpoints (64 KiB).
+pub const LOG_TAIL_MAX_BYTES: u64 = 64 * 1024;
+
+/// Grace period between SIGTERM and SIGKILL when stopping a job.
+const KILL_GRACE: Duration = Duration::from_secs(10);
+
+struct QueuedJob {
+    id: Uuid,
+    mission_id: Uuid,
+    payload: JobPayload,
+}
+
+/// Shared job runner; construct with [`JobRunner::spawn`].
+pub struct JobRunner {
+    store: JobStore,
+    work_root: PathBuf,
+    max_job_secs: u64,
+    tx: mpsc::UnboundedSender<QueuedJob>,
+    cancels: Mutex<HashMap<Uuid, CancellationToken>>,
+    queued: AtomicU32,
+    active: AtomicU32,
+}
+
+impl JobRunner {
+    /// Start the dispatcher loop and return the shared runner handle.
+    pub fn spawn(
+        store: JobStore,
+        work_root: PathBuf,
+        capacity: u32,
+        max_job_secs: u64,
+    ) -> Arc<Self> {
+        let (tx, mut rx) = mpsc::unbounded_channel::<QueuedJob>();
+        let runner = Arc::new(Self {
+            store,
+            work_root,
+            max_job_secs: max_job_secs.max(1),
+            tx,
+            cancels: Mutex::new(HashMap::new()),
+            queued: AtomicU32::new(0),
+            active: AtomicU32::new(0),
+        });
+        let dispatcher = Arc::clone(&runner);
+        tokio::spawn(async move {
+            let semaphore = Arc::new(Semaphore::new(capacity.max(1) as usize));
+            while let Some(job) = rx.recv().await {
+                let permit = match Arc::clone(&semaphore).acquire_owned().await {
+                    Ok(permit) => permit,
+                    Err(_) => break, // semaphore closed: shutting down
+                };
+                let runner = Arc::clone(&dispatcher);
+                tokio::spawn(async move {
+                    runner.queued.fetch_sub(1, Ordering::AcqRel);
+                    runner.active.fetch_add(1, Ordering::AcqRel);
+                    runner.run_one(job).await;
+                    runner.active.fetch_sub(1, Ordering::AcqRel);
+                    drop(permit);
+                });
+            }
+        });
+        runner
+    }
+
+    pub fn queued_count(&self) -> u32 {
+        self.queued.load(Ordering::Acquire)
+    }
+
+    pub fn active_count(&self) -> u32 {
+        self.active.load(Ordering::Acquire)
+    }
+
+    /// Log file path for a job id.
+    pub fn log_path(&self, job_id: Uuid) -> PathBuf {
+        self.work_root.join("logs").join(format!("{job_id}.log"))
+    }
+
+    /// Persist a new queued job and enqueue it for execution.
+    pub async fn submit(
+        &self,
+        job_id: Uuid,
+        mission_id: Uuid,
+        payload: JobPayload,
+    ) -> anyhow::Result<()> {
+        let payload_json = serde_json::to_string(&payload)?;
+        let log_path = self.log_path(job_id);
+        self.store
+            .create(
+                job_id,
+                mission_id,
+                payload_json,
+                log_path.display().to_string(),
+            )
+            .await?;
+        self.cancels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(job_id, CancellationToken::new());
+        self.queued.fetch_add(1, Ordering::AcqRel);
+        self.tx
+            .send(QueuedJob {
+                id: job_id,
+                mission_id,
+                payload,
+            })
+            .map_err(|_| anyhow::anyhow!("job runner is shut down"))?;
+        Ok(())
+    }
+
+    /// Request cancellation of a queued or running job. Returns whether a
+    /// live job received the request.
+    pub fn cancel(&self, job_id: Uuid) -> bool {
+        let cancels = self.cancels.lock().unwrap_or_else(|e| e.into_inner());
+        match cancels.get(&job_id) {
+            Some(token) => {
+                token.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn take_cancel_token(&self, job_id: Uuid) -> CancellationToken {
+        self.cancels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&job_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn drop_cancel_token(&self, job_id: Uuid) {
+        self.cancels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&job_id);
+    }
+
+    async fn run_one(&self, job: QueuedJob) {
+        let token = self.take_cancel_token(job.id);
+        let (state, exit_code, error) = if token.is_cancelled() {
+            (
+                JobState::Cancelled,
+                None,
+                Some("cancelled before start".to_string()),
+            )
+        } else {
+            match self.execute(&job, &token).await {
+                Ok(outcome) => outcome,
+                Err(err) => (JobState::Failed, None, Some(err.to_string())),
+            }
+        };
+        if let Err(err) = self.store.finish(job.id, state, exit_code, error).await {
+            tracing::warn!(job_id = %job.id, "failed to persist job outcome: {err}");
+        }
+        self.drop_cancel_token(job.id);
+    }
+
+    async fn execute(
+        &self,
+        job: &QueuedJob,
+        token: &CancellationToken,
+    ) -> anyhow::Result<(JobState, Option<i32>, Option<String>)> {
+        let JobPayload::RawCommand {
+            command,
+            timeout_secs,
+            env,
+        } = &job.payload;
+
+        let mission_dir = self.work_root.join(job.mission_id.to_string());
+        tokio::fs::create_dir_all(&mission_dir).await?;
+        let log_path = self.log_path(job.id);
+        if let Some(parent) = log_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let stdout_file = std::fs::File::create(&log_path)?;
+        let stderr_file = stdout_file.try_clone()?;
+
+        self.store.mark_running(job.id).await?;
+
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.arg("-lc")
+            .arg(command)
+            .current_dir(&mission_dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout_file))
+            .stderr(Stdio::from(stderr_file))
+            // New process group so cancel/timeout can kill the whole tree.
+            .process_group(0);
+        if let Some(env) = env {
+            for (key, value) in env {
+                cmd.env(key, value);
+            }
+        }
+        let mut child = cmd.spawn()?;
+        let pid = child.id();
+
+        let limit_secs = timeout_secs
+            .map(|requested| requested.min(self.max_job_secs))
+            .unwrap_or(self.max_job_secs)
+            .max(1);
+
+        let outcome = tokio::select! {
+            _ = token.cancelled() => {
+                kill_process_group(pid, &mut child).await;
+                (JobState::Cancelled, None, Some("cancelled".to_string()))
+            }
+            waited = tokio::time::timeout(Duration::from_secs(limit_secs), child.wait()) => {
+                match waited {
+                    Ok(Ok(status)) => {
+                        let code = status.code();
+                        if status.success() {
+                            (JobState::Succeeded, code, None)
+                        } else {
+                            (
+                                JobState::Failed,
+                                code,
+                                Some(format!("command exited with {code:?}")),
+                            )
+                        }
+                    }
+                    Ok(Err(err)) => (JobState::Failed, None, Some(err.to_string())),
+                    Err(_) => {
+                        kill_process_group(pid, &mut child).await;
+                        (
+                            JobState::Failed,
+                            None,
+                            Some(format!("timed out after {limit_secs}s")),
+                        )
+                    }
+                }
+            }
+        };
+        Ok(outcome)
+    }
+}
+
+/// SIGTERM the job's process group, escalating to SIGKILL after a grace
+/// period. Falls back to killing the direct child when the pid is unknown.
+async fn kill_process_group(pid: Option<u32>, child: &mut tokio::process::Child) {
+    if let Some(pid) = pid {
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGTERM);
+        }
+        if tokio::time::timeout(KILL_GRACE, child.wait())
+            .await
+            .is_err()
+        {
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGKILL);
+            }
+            let _ = child.wait().await;
+        }
+    } else {
+        let _ = child.kill().await;
+    }
+}
+
+/// Read up to the last `LOG_TAIL_MAX_BYTES` of a job log file.
+pub async fn read_log_tail(path: &Path) -> Option<String> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        use std::io::{Read, Seek, SeekFrom};
+        let mut file = std::fs::File::open(&path).ok()?;
+        let len = file.metadata().ok()?.len();
+        let start = len.saturating_sub(LOG_TAIL_MAX_BYTES);
+        file.seek(SeekFrom::Start(start)).ok()?;
+        let mut buf = Vec::with_capacity((len - start) as usize);
+        file.read_to_end(&mut buf).ok()?;
+        Some(String::from_utf8_lossy(&buf).into_owned())
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn runs_a_job_and_captures_its_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JobStore::open(dir.path()).await.unwrap();
+        let runner = JobRunner::spawn(
+            store.clone(),
+            dir.path().to_path_buf(),
+            1,
+            DEFAULT_MAX_JOB_SECS,
+        );
+        let job_id = Uuid::new_v4();
+        let mission_id = Uuid::new_v4();
+        runner
+            .submit(
+                job_id,
+                mission_id,
+                JobPayload::RawCommand {
+                    command: "echo hello-from-job && pwd".to_string(),
+                    timeout_secs: Some(30),
+                    env: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let record = wait_for_terminal(&store, job_id).await;
+        assert_eq!(record.state, JobState::Succeeded);
+        assert_eq!(record.exit_code, Some(0));
+        let tail = read_log_tail(&runner.log_path(job_id)).await.unwrap();
+        assert!(tail.contains("hello-from-job"));
+        // The command ran inside the per-mission directory.
+        assert!(tail.contains(&mission_id.to_string()));
+        assert_eq!(runner.active_count(), 0);
+        assert_eq!(runner.queued_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_kills_a_running_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JobStore::open(dir.path()).await.unwrap();
+        let runner = JobRunner::spawn(
+            store.clone(),
+            dir.path().to_path_buf(),
+            1,
+            DEFAULT_MAX_JOB_SECS,
+        );
+        let job_id = Uuid::new_v4();
+        runner
+            .submit(
+                job_id,
+                Uuid::new_v4(),
+                JobPayload::RawCommand {
+                    command: "sleep 30".to_string(),
+                    timeout_secs: None,
+                    env: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Wait for the job to actually start, then cancel it.
+        for _ in 0..100 {
+            if matches!(
+                store.get(job_id).await.unwrap().map(|r| r.state),
+                Some(JobState::Running)
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(runner.cancel(job_id));
+
+        let record = wait_for_terminal(&store, job_id).await;
+        assert_eq!(record.state, JobState::Cancelled);
+        // Cancelling an already-finished (deregistered) job reports false.
+        assert!(!runner.cancel(job_id));
+    }
+
+    #[tokio::test]
+    async fn timeout_fails_the_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JobStore::open(dir.path()).await.unwrap();
+        // Node-level 1s ceiling clamps the requested timeout.
+        let runner = JobRunner::spawn(store.clone(), dir.path().to_path_buf(), 1, 1);
+        let job_id = Uuid::new_v4();
+        runner
+            .submit(
+                job_id,
+                Uuid::new_v4(),
+                JobPayload::RawCommand {
+                    command: "sleep 20".to_string(),
+                    timeout_secs: Some(600),
+                    env: None,
+                },
+            )
+            .await
+            .unwrap();
+        let record = wait_for_terminal(&store, job_id).await;
+        assert_eq!(record.state, JobState::Failed);
+        assert!(record.error.as_deref().unwrap_or("").contains("timed out"));
+    }
+
+    async fn wait_for_terminal(store: &JobStore, job_id: Uuid) -> super::super::JobRecord {
+        for _ in 0..600 {
+            if let Some(record) = store.get(job_id).await.unwrap() {
+                if record.state.is_terminal() {
+                    return record;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("job {job_id} did not reach a terminal state in time");
+    }
+}

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -41,7 +41,8 @@ pub struct JobRunner {
     store: JobStore,
     work_root: PathBuf,
     max_job_secs: u64,
-    tx: mpsc::Sender<QueuedJob>,
+    tx: mpsc::UnboundedSender<QueuedJob>,
+    max_queued: u32,
     cancels: Mutex<HashMap<Uuid, CancellationToken>>,
     queued: AtomicU32,
     active: AtomicU32,
@@ -60,12 +61,13 @@ impl JobRunner {
             .and_then(|raw| raw.trim().parse::<usize>().ok())
             .filter(|value| *value > 0)
             .unwrap_or_else(|| (capacity.max(1) as usize).saturating_mul(4));
-        let (tx, mut rx) = mpsc::channel::<QueuedJob>(max_queued);
+        let (tx, mut rx) = mpsc::unbounded_channel::<QueuedJob>();
         let runner = Arc::new(Self {
             store,
             work_root,
             max_job_secs: max_job_secs.max(1),
             tx,
+            max_queued: u32::try_from(max_queued).unwrap_or(u32::MAX),
             cancels: Mutex::new(HashMap::new()),
             queued: AtomicU32::new(0),
             active: AtomicU32::new(0),
@@ -74,12 +76,30 @@ impl JobRunner {
         tokio::spawn(async move {
             let semaphore = Arc::new(Semaphore::new(capacity.max(1) as usize));
             while let Some(job) = rx.recv().await {
-                let permit = match Arc::clone(&semaphore).acquire_owned().await {
-                    Ok(permit) => permit,
-                    Err(_) => break, // semaphore closed: shutting down
-                };
                 let runner = Arc::clone(&dispatcher);
+                let semaphore = Arc::clone(&semaphore);
                 tokio::spawn(async move {
+                    let permit = match semaphore.acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => {
+                            runner.queued.fetch_sub(1, Ordering::AcqRel);
+                            runner.drop_cancel_token(job.id);
+                            return;
+                        }
+                    };
+                    let claimed = match runner.store.mark_running_if_queued(job.id).await {
+                        Ok(claimed) => claimed,
+                        Err(err) => {
+                            runner.queued.fetch_sub(1, Ordering::AcqRel);
+                            runner.drop_cancel_token(job.id);
+                            tracing::warn!(job_id = %job.id, "failed to claim queued job: {err}");
+                            return;
+                        }
+                    };
+                    if !claimed {
+                        runner.drop_cancel_token(job.id);
+                        return;
+                    }
                     runner.queued.fetch_sub(1, Ordering::AcqRel);
                     runner.active.fetch_add(1, Ordering::AcqRel);
                     runner.run_one(job).await;
@@ -111,46 +131,76 @@ impl JobRunner {
         mission_id: Uuid,
         payload: JobPayload,
     ) -> anyhow::Result<()> {
-        // Reserve bounded queue capacity before persisting the queued row. The
-        // permit prevents concurrent submitters from all passing an advisory
-        // heartbeat check and growing memory/jobs.db without limit.
-        let permit = self.tx.try_reserve().map_err(|_| NodeQueueFull {
-            max_queued: self.tx.max_capacity(),
-        })?;
         let payload_json = serde_json::to_string(&payload)?;
+        // The dispatcher drains the mpsc channel into semaphore waiters so a
+        // cancelled queued job releases its channel slot immediately. Keep an
+        // explicit atomic bound across both locations.
+        self.queued
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |queued| {
+                (queued < self.max_queued).then_some(queued + 1)
+            })
+            .map_err(|_| NodeQueueFull {
+                max_queued: self.max_queued as usize,
+            })?;
         let log_path = self.log_path(job_id);
-        self.store
+        if let Err(error) = self
+            .store
             .create(
                 job_id,
                 mission_id,
                 payload_json,
                 log_path.display().to_string(),
             )
-            .await?;
+            .await
+        {
+            self.queued.fetch_sub(1, Ordering::AcqRel);
+            return Err(error);
+        }
         self.cancels
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .insert(job_id, CancellationToken::new());
-        self.queued.fetch_add(1, Ordering::AcqRel);
-        permit.send(QueuedJob {
-            id: job_id,
-            mission_id,
-            payload,
-        });
+        if self
+            .tx
+            .send(QueuedJob {
+                id: job_id,
+                mission_id,
+                payload,
+            })
+            .is_err()
+        {
+            self.queued.fetch_sub(1, Ordering::AcqRel);
+            self.drop_cancel_token(job_id);
+            self.store
+                .finish(
+                    job_id,
+                    JobState::Lost,
+                    None,
+                    Some("node dispatcher stopped before enqueue".to_string()),
+                )
+                .await?;
+            anyhow::bail!("node dispatcher stopped before enqueue");
+        }
         Ok(())
     }
 
     /// Request cancellation of a queued or running job. Returns whether a
     /// live job received the request.
-    pub fn cancel(&self, job_id: Uuid) -> bool {
-        let cancels = self.cancels.lock().unwrap_or_else(|e| e.into_inner());
-        match cancels.get(&job_id) {
-            Some(token) => {
-                token.cancel();
-                true
-            }
-            None => false,
+    pub async fn cancel(&self, job_id: Uuid) -> anyhow::Result<bool> {
+        let token = self
+            .cancels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&job_id)
+            .cloned();
+        let Some(token) = token else {
+            return Ok(false);
+        };
+        token.cancel();
+        if self.store.cancel_if_queued(job_id).await? {
+            self.queued.fetch_sub(1, Ordering::AcqRel);
         }
+        Ok(true)
     }
 
     fn take_cancel_token(&self, job_id: Uuid) -> CancellationToken {
@@ -209,8 +259,6 @@ impl JobRunner {
                 let mission_dir = self.work_root.join(job.mission_id.to_string());
                 tokio::fs::create_dir_all(&mission_dir).await?;
 
-                self.store.mark_running(job.id).await?;
-
                 let cmd = crate::remote_node::raw_command(command, &mission_dir, env.as_ref());
                 let limit_secs = clamp_timeout(*timeout_secs, self.max_job_secs);
                 let outcome = run_logged_command(cmd, &log_path, limit_secs, token).await?;
@@ -218,7 +266,6 @@ impl JobRunner {
                 Ok((state, exit_code, error, None))
             }
             JobPayload::LeanBuild { .. } => {
-                self.store.mark_running(job.id).await?;
                 let result = super::lean::execute_lean_build(
                     &self.work_root,
                     &log_path,
@@ -443,12 +490,68 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
-        assert!(runner.cancel(job_id));
+        assert!(runner.cancel(job_id).await.unwrap());
 
         let record = wait_for_terminal(&store, job_id).await;
         assert_eq!(record.state, JobState::Cancelled);
         // Cancelling an already-finished (deregistered) job reports false.
-        assert!(!runner.cancel(job_id));
+        assert!(!runner.cancel(job_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn cancelling_queued_job_is_terminal_and_releases_capacity_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = JobStore::open(dir.path()).await.unwrap();
+        let runner = JobRunner::spawn(
+            store.clone(),
+            dir.path().to_path_buf(),
+            1,
+            DEFAULT_MAX_JOB_SECS,
+        );
+        let running = Uuid::new_v4();
+        let queued = Uuid::new_v4();
+        for id in [running, queued] {
+            runner
+                .submit(
+                    id,
+                    Uuid::new_v4(),
+                    JobPayload::RawCommand {
+                        command: "sleep 30".to_string(),
+                        timeout_secs: None,
+                        env: None,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        for _ in 0..100 {
+            if matches!(
+                store.get(running).await.unwrap().map(|record| record.state),
+                Some(JobState::Running)
+            ) && matches!(
+                store.get(queued).await.unwrap().map(|record| record.state),
+                Some(JobState::Queued)
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(runner.queued_count(), 1);
+        assert!(runner.cancel(queued).await.unwrap());
+        let cancelled = store.get(queued).await.unwrap().unwrap();
+        assert_eq!(cancelled.state, JobState::Cancelled);
+        assert!(cancelled.finished_at.is_some());
+        assert_eq!(runner.queued_count(), 0);
+
+        assert!(runner.cancel(running).await.unwrap());
+        assert_eq!(
+            wait_for_terminal(&store, running).await.state,
+            JobState::Cancelled
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(runner.queued_count(), 0);
+        assert_eq!(runner.active_count(), 0);
     }
 
     #[tokio::test]

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -41,7 +41,7 @@ pub struct JobRunner {
     store: JobStore,
     work_root: PathBuf,
     max_job_secs: u64,
-    tx: mpsc::UnboundedSender<QueuedJob>,
+    tx: mpsc::Sender<QueuedJob>,
     cancels: Mutex<HashMap<Uuid, CancellationToken>>,
     queued: AtomicU32,
     active: AtomicU32,
@@ -55,7 +55,12 @@ impl JobRunner {
         capacity: u32,
         max_job_secs: u64,
     ) -> Arc<Self> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<QueuedJob>();
+        let max_queued = std::env::var("SANDBOXED_NODE_MAX_QUEUED")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or_else(|| (capacity.max(1) as usize).saturating_mul(4));
+        let (tx, mut rx) = mpsc::channel::<QueuedJob>(max_queued);
         let runner = Arc::new(Self {
             store,
             work_root,
@@ -106,6 +111,12 @@ impl JobRunner {
         mission_id: Uuid,
         payload: JobPayload,
     ) -> anyhow::Result<()> {
+        // Reserve bounded queue capacity before persisting the queued row. The
+        // permit prevents concurrent submitters from all passing an advisory
+        // heartbeat check and growing memory/jobs.db without limit.
+        let permit = self.tx.try_reserve().map_err(|_| NodeQueueFull {
+            max_queued: self.tx.max_capacity(),
+        })?;
         let payload_json = serde_json::to_string(&payload)?;
         let log_path = self.log_path(job_id);
         self.store
@@ -121,13 +132,11 @@ impl JobRunner {
             .unwrap_or_else(|e| e.into_inner())
             .insert(job_id, CancellationToken::new());
         self.queued.fetch_add(1, Ordering::AcqRel);
-        self.tx
-            .send(QueuedJob {
-                id: job_id,
-                mission_id,
-                payload,
-            })
-            .map_err(|_| anyhow::anyhow!("job runner is shut down"))?;
+        permit.send(QueuedJob {
+            id: job_id,
+            mission_id,
+            payload,
+        });
         Ok(())
     }
 
@@ -233,6 +242,12 @@ impl JobRunner {
             }
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("node job queue is full (maximum {max_queued} queued jobs)")]
+pub struct NodeQueueFull {
+    pub max_queued: usize,
 }
 
 /// Clamp a client-requested timeout to the node ceiling (min 1s).

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -146,7 +146,10 @@ impl RemoteNodeClient {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(RemoteNodeError::Request(format!("{status}: {body}")));
+            return Err(RemoteNodeError::Rejected {
+                status: status.as_u16(),
+                body,
+            });
         }
         response
             .json::<NodeJobStatus>()
@@ -173,7 +176,10 @@ impl RemoteNodeClient {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(RemoteNodeError::Request(format!("{status}: {body}")));
+            return Err(RemoteNodeError::Rejected {
+                status: status.as_u16(),
+                body,
+            });
         }
         response
             .json::<CancelJobResponse>()

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -85,7 +85,10 @@ impl RemoteNodeClient {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(RemoteNodeError::Rejected(format!("{status}: {body}")));
+            return Err(RemoteNodeError::Rejected {
+                status: status.as_u16(),
+                body,
+            });
         }
         response
             .json::<ExecuteResponse>()
@@ -113,7 +116,10 @@ impl RemoteNodeClient {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(RemoteNodeError::Rejected(format!("{status}: {body}")));
+            return Err(RemoteNodeError::Rejected {
+                status: status.as_u16(),
+                body,
+            });
         }
         response
             .json::<SubmitJobResponse>()

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -2,12 +2,23 @@
 
 use std::time::Duration;
 
-use super::protocol::{ExecuteResponse, LeaseRequest, NodeHeartbeat};
+use uuid::Uuid;
+
+use super::protocol::{
+    CancelJobResponse, ExecuteResponse, LeaseRequest, NodeHeartbeat, NodeJobStatus,
+    SubmitJobRequest, SubmitJobResponse,
+};
 use super::{RemoteNodeConfig, RemoteNodeError};
 
 /// Total request timeout for `/execute`, which blocks until the remote
 /// command completes.
 const EXECUTE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
+/// `POST /jobs` returns as soon as the job is queued.
+const SUBMIT_JOB_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Job status/cancel calls are cheap lookups.
+const JOB_STATUS_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct RemoteNodeClient {
@@ -78,6 +89,88 @@ impl RemoteNodeClient {
         }
         response
             .json::<ExecuteResponse>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+
+    /// Submit an async job (`POST /jobs`); returns once the node has queued it.
+    pub async fn submit_job(
+        &self,
+        node: &RemoteNodeConfig,
+        shared_token: &str,
+        request: &SubmitJobRequest,
+    ) -> Result<SubmitJobResponse, RemoteNodeError> {
+        let url = format!("{}/jobs", node.base_url);
+        let response = self
+            .http
+            .post(url)
+            .timeout(SUBMIT_JOB_TIMEOUT)
+            .bearer_auth(shared_token)
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RemoteNodeError::Rejected(format!("{status}: {body}")));
+        }
+        response
+            .json::<SubmitJobResponse>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+
+    /// Fetch one job's status (`GET /jobs/:id`), including its log tail.
+    pub async fn get_job(
+        &self,
+        node: &RemoteNodeConfig,
+        shared_token: &str,
+        job_id: Uuid,
+    ) -> Result<NodeJobStatus, RemoteNodeError> {
+        let url = format!("{}/jobs/{}", node.base_url, job_id);
+        let response = self
+            .http
+            .get(url)
+            .timeout(JOB_STATUS_TIMEOUT)
+            .bearer_auth(shared_token)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RemoteNodeError::Request(format!("{status}: {body}")));
+        }
+        response
+            .json::<NodeJobStatus>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+
+    /// Request cancellation of a job (`POST /jobs/:id/cancel`).
+    pub async fn cancel_job(
+        &self,
+        node: &RemoteNodeConfig,
+        shared_token: &str,
+        job_id: Uuid,
+    ) -> Result<CancelJobResponse, RemoteNodeError> {
+        let url = format!("{}/jobs/{}/cancel", node.base_url, job_id);
+        let response = self
+            .http
+            .post(url)
+            .timeout(JOB_STATUS_TIMEOUT)
+            .bearer_auth(shared_token)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RemoteNodeError::Request(format!("{status}: {body}")));
+        }
+        response
+            .json::<CancelJobResponse>()
             .await
             .map_err(|e| RemoteNodeError::Request(e.to_string()))
     }

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -1,0 +1,133 @@
+//! Core-side HTTP client for talking to `sandboxed-node` runners.
+
+use std::time::Duration;
+
+use super::protocol::{ExecuteResponse, LeaseRequest, NodeHeartbeat};
+use super::{RemoteNodeConfig, RemoteNodeError};
+
+/// Total request timeout for `/execute`, which blocks until the remote
+/// command completes.
+const EXECUTE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Clone)]
+pub struct RemoteNodeClient {
+    http: reqwest::Client,
+}
+
+impl Default for RemoteNodeClient {
+    fn default() -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .connect_timeout(Duration::from_secs(5))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl RemoteNodeClient {
+    pub async fn heartbeat(
+        &self,
+        node: &RemoteNodeConfig,
+        token: &str,
+    ) -> Result<NodeHeartbeat, RemoteNodeError> {
+        let url = format!("{}/heartbeat", node.base_url);
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(RemoteNodeError::Request(format!(
+                "heartbeat returned {}",
+                response.status()
+            )));
+        }
+        response
+            .json::<NodeHeartbeat>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+
+    pub async fn execute(
+        &self,
+        node: &RemoteNodeConfig,
+        shared_token: &str,
+        request: &LeaseRequest,
+    ) -> Result<ExecuteResponse, RemoteNodeError> {
+        let url = format!("{}/execute", node.base_url);
+        let response = self
+            .http
+            .post(url)
+            // Override the client-wide 30s timeout: remote commands
+            // (builds, tests) routinely run for minutes and the response
+            // only arrives once the command finishes.
+            .timeout(EXECUTE_TIMEOUT)
+            .bearer_auth(shared_token)
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RemoteNodeError::Rejected(format!("{status}: {body}")));
+        }
+        response
+            .json::<ExecuteResponse>()
+            .await
+            .map_err(|e| RemoteNodeError::Request(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_node::protocol::NODE_PROTOCOL_VERSION;
+    use axum::{routing::get, Json, Router};
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn heartbeat_client_reads_node_status() {
+        async fn heartbeat() -> Json<NodeHeartbeat> {
+            Json(NodeHeartbeat {
+                node_id: "babylon".to_string(),
+                online: true,
+                capacity_total: 2,
+                capacity_available: 1,
+                active_leases: 1,
+                version: "test".to_string(),
+                protocol_version: NODE_PROTOCOL_VERSION,
+                labels: vec!["lean".to_string()],
+                cpu_total: 8,
+                mem_total_bytes: 0,
+                mem_available_bytes: 0,
+                disk_total_bytes: 0,
+                disk_available_bytes: 0,
+                active_jobs: 0,
+                queued_jobs: 0,
+                cached_toolchains: vec![],
+            })
+        }
+        let app = Router::new().route("/heartbeat", get(heartbeat));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = RemoteNodeClient::default();
+        let node = RemoteNodeConfig {
+            id: "babylon".to_string(),
+            base_url: format!("http://{addr}"),
+            token_env: "TOKEN".to_string(),
+            labels: None,
+        };
+        let heartbeat = client.heartbeat(&node, "unused").await.unwrap();
+        assert_eq!(heartbeat.capacity_available, 1);
+        assert_eq!(heartbeat.labels, vec!["lean".to_string()]);
+    }
+}

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -13,12 +13,25 @@ use std::sync::OnceLock;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum JobHandleKind {
+    /// A raw remote mission whose terminal result finalizes the mission.
+    #[default]
+    Mission,
+    /// A waited `/api/remote-build` request. Recovery only observes the node
+    /// job and cleans up its handle; it must not finalize the agent mission.
+    RemoteBuild,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobHandle {
     pub mission_id: Uuid,
     pub node_id: String,
     pub job_id: Uuid,
     pub started_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default)]
+    pub kind: JobHandleKind,
 }
 
 fn ledger_path(working_dir: &Path) -> PathBuf {
@@ -99,6 +112,7 @@ mod tests {
             node_id: "node-a".to_string(),
             job_id,
             started_at: chrono::Utc::now(),
+            kind: JobHandleKind::Mission,
         };
 
         record(dir.path(), handle.clone()).await.unwrap();
@@ -121,9 +135,24 @@ mod tests {
                 node_id: "node-a".to_string(),
                 job_id: Uuid::new_v4(),
                 started_at: chrono::Utc::now(),
+                kind: JobHandleKind::Mission,
             },
         )
         .await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn legacy_handles_default_to_mission_kind() {
+        let raw = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "node_id": "node-a",
+            "job_id": Uuid::new_v4(),
+            "started_at": chrono::Utc::now(),
+        });
+
+        let handle: JobHandle = serde_json::from_value(raw).unwrap();
+
+        assert_eq!(handle.kind, JobHandleKind::Mission);
     }
 }

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -32,39 +32,45 @@ fn lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-pub async fn load(working_dir: &Path) -> Vec<JobHandle> {
+async fn load_result(working_dir: &Path) -> anyhow::Result<Vec<JobHandle>> {
     let path = ledger_path(working_dir);
     match tokio::fs::read(&path).await {
-        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|err| {
-            tracing::warn!(path = %path.display(), ?err, "remote job ledger unreadable; ignoring");
-            Vec::new()
-        }),
-        Err(_) => Vec::new(),
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|err| anyhow::anyhow!("parse {}: {err}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(err) => Err(anyhow::anyhow!("read {}: {err}", path.display())),
     }
 }
 
-async fn store(working_dir: &Path, handles: &[JobHandle]) {
+pub async fn load(working_dir: &Path) -> Vec<JobHandle> {
+    load_result(working_dir).await.unwrap_or_else(|err| {
+        tracing::warn!(
+            ?err,
+            "remote job ledger unreadable; keeping missions unchanged"
+        );
+        Vec::new()
+    })
+}
+
+async fn store(working_dir: &Path, handles: &[JobHandle]) -> anyhow::Result<()> {
     let path = ledger_path(working_dir);
-    let Ok(bytes) = serde_json::to_vec_pretty(handles) else {
-        return;
-    };
+    let bytes = serde_json::to_vec_pretty(handles)?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
     let tmp = path.with_extension("json.tmp");
-    if let Err(err) = tokio::fs::write(&tmp, &bytes).await {
-        tracing::warn!(path = %tmp.display(), ?err, "remote job ledger write failed");
-        return;
-    }
-    if let Err(err) = tokio::fs::rename(&tmp, &path).await {
-        tracing::warn!(path = %path.display(), ?err, "remote job ledger rename failed");
-    }
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, &path).await?;
+    Ok(())
 }
 
 /// Record a job handle (idempotent on job_id).
-pub async fn record(working_dir: &Path, handle: JobHandle) {
+pub async fn record(working_dir: &Path, handle: JobHandle) -> anyhow::Result<()> {
     let _guard = lock().lock().await;
-    let mut handles = load(working_dir).await;
+    let mut handles = load_result(working_dir).await?;
     handles.retain(|h| h.job_id != handle.job_id);
     handles.push(handle);
-    store(working_dir, &handles).await;
+    store(working_dir, &handles).await
 }
 
 /// Remove a job handle once its mission is finalized.
@@ -74,6 +80,50 @@ pub async fn remove(working_dir: &Path, job_id: Uuid) {
     let before = handles.len();
     handles.retain(|h| h.job_id != job_id);
     if handles.len() != before {
-        store(working_dir, &handles).await;
+        if let Err(err) = store(working_dir, &handles).await {
+            tracing::warn!(?err, "remote job ledger removal failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn record_is_durable_and_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let handle = JobHandle {
+            mission_id: Uuid::new_v4(),
+            node_id: "node-a".to_string(),
+            job_id,
+            started_at: chrono::Utc::now(),
+        };
+
+        record(dir.path(), handle.clone()).await.unwrap();
+        record(dir.path(), handle).await.unwrap();
+        let handles = load_result(dir.path()).await.unwrap();
+        assert_eq!(handles.len(), 1);
+        assert_eq!(handles[0].job_id, job_id);
+    }
+
+    #[tokio::test]
+    async fn record_surfaces_an_unwritable_ledger_path() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join(".sandboxed-sh"), b"not a directory")
+            .await
+            .unwrap();
+        let result = record(
+            dir.path(),
+            JobHandle {
+                mission_id: Uuid::new_v4(),
+                node_id: "node-a".to_string(),
+                job_id: Uuid::new_v4(),
+                started_at: chrono::Utc::now(),
+            },
+        )
+        .await;
+        assert!(result.is_err());
     }
 }

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -22,6 +22,10 @@ pub enum JobHandleKind {
     /// A waited `/api/remote-build` request. Recovery only observes the node
     /// job and cleans up its handle; it must not finalize the agent mission.
     RemoteBuild,
+    /// A submit request failed ambiguously after the node may have accepted
+    /// the generated job id. Recovery must cancel/poll this handle, but must
+    /// never finalize the owning mission from its result.
+    Tentative,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,5 +158,43 @@ mod tests {
         let handle: JobHandle = serde_json::from_value(raw).unwrap();
 
         assert_eq!(handle.kind, JobHandleKind::Mission);
+    }
+
+    #[test]
+    fn tentative_handles_round_trip() {
+        let raw = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "node_id": "node-a",
+            "job_id": Uuid::new_v4(),
+            "started_at": chrono::Utc::now(),
+            "kind": "tentative",
+        });
+
+        let handle: JobHandle = serde_json::from_value(raw).unwrap();
+
+        assert_eq!(handle.kind, JobHandleKind::Tentative);
+    }
+
+    #[tokio::test]
+    async fn accepted_handle_replaces_pre_submit_tentative_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let mission_id = Uuid::new_v4();
+        let mut handle = JobHandle {
+            mission_id,
+            node_id: "node-a".to_string(),
+            job_id,
+            started_at: chrono::Utc::now(),
+            kind: JobHandleKind::Tentative,
+        };
+        record(dir.path(), handle.clone()).await.unwrap();
+
+        handle.kind = JobHandleKind::Mission;
+        record(dir.path(), handle).await.unwrap();
+
+        let handles = load_result(dir.path()).await.unwrap();
+        assert_eq!(handles.len(), 1);
+        assert_eq!(handles[0].job_id, job_id);
+        assert_eq!(handles[0].kind, JobHandleKind::Mission);
     }
 }

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -42,14 +42,8 @@ async fn load_result(working_dir: &Path) -> anyhow::Result<Vec<JobHandle>> {
     }
 }
 
-pub async fn load(working_dir: &Path) -> Vec<JobHandle> {
-    load_result(working_dir).await.unwrap_or_else(|err| {
-        tracing::warn!(
-            ?err,
-            "remote job ledger unreadable; keeping missions unchanged"
-        );
-        Vec::new()
-    })
+pub async fn load(working_dir: &Path) -> anyhow::Result<Vec<JobHandle>> {
+    load_result(working_dir).await
 }
 
 async fn store(working_dir: &Path, handles: &[JobHandle]) -> anyhow::Result<()> {
@@ -76,7 +70,13 @@ pub async fn record(working_dir: &Path, handle: JobHandle) -> anyhow::Result<()>
 /// Remove a job handle once its mission is finalized.
 pub async fn remove(working_dir: &Path, job_id: Uuid) {
     let _guard = lock().lock().await;
-    let mut handles = load(working_dir).await;
+    let mut handles = match load_result(working_dir).await {
+        Ok(handles) => handles,
+        Err(err) => {
+            tracing::warn!(?err, "remote job ledger removal deferred");
+            return;
+        }
+    };
     let before = handles.len();
     handles.retain(|h| h.job_id != job_id);
     if handles.len() != before {

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -1,0 +1,79 @@
+//! Durable ledger of in-flight async remote jobs.
+//!
+//! `dispatch_remote_job` records a handle after the node accepts a job and
+//! removes it once the poll loop finalizes the mission. If the API process
+//! restarts in between, the startup reconciler reads this file and either
+//! re-attaches a poll loop to the still-Active mission or converges its
+//! state — without it, the only copy of (node_id, job_id) died with the
+//! in-memory task and the mission stayed Active forever.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobHandle {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    pub job_id: Uuid,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+}
+
+fn ledger_path(working_dir: &Path) -> PathBuf {
+    working_dir.join(".sandboxed-sh").join("remote-jobs.json")
+}
+
+/// Serializes read-modify-write cycles within this process. Cross-process
+/// concurrency is not a concern: one API instance owns its working dir.
+fn lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+pub async fn load(working_dir: &Path) -> Vec<JobHandle> {
+    let path = ledger_path(working_dir);
+    match tokio::fs::read(&path).await {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|err| {
+            tracing::warn!(path = %path.display(), ?err, "remote job ledger unreadable; ignoring");
+            Vec::new()
+        }),
+        Err(_) => Vec::new(),
+    }
+}
+
+async fn store(working_dir: &Path, handles: &[JobHandle]) {
+    let path = ledger_path(working_dir);
+    let Ok(bytes) = serde_json::to_vec_pretty(handles) else {
+        return;
+    };
+    let tmp = path.with_extension("json.tmp");
+    if let Err(err) = tokio::fs::write(&tmp, &bytes).await {
+        tracing::warn!(path = %tmp.display(), ?err, "remote job ledger write failed");
+        return;
+    }
+    if let Err(err) = tokio::fs::rename(&tmp, &path).await {
+        tracing::warn!(path = %path.display(), ?err, "remote job ledger rename failed");
+    }
+}
+
+/// Record a job handle (idempotent on job_id).
+pub async fn record(working_dir: &Path, handle: JobHandle) {
+    let _guard = lock().lock().await;
+    let mut handles = load(working_dir).await;
+    handles.retain(|h| h.job_id != handle.job_id);
+    handles.push(handle);
+    store(working_dir, &handles).await;
+}
+
+/// Remove a job handle once its mission is finalized.
+pub async fn remove(working_dir: &Path, job_id: Uuid) {
+    let _guard = lock().lock().await;
+    let mut handles = load(working_dir).await;
+    let before = handles.len();
+    handles.retain(|h| h.job_id != job_id);
+    if handles.len() != before {
+        store(working_dir, &handles).await;
+    }
+}

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -12,6 +12,7 @@
 //! `crate::remote_node::*` unchanged.
 
 pub mod client;
+pub mod job_ledger;
 pub mod monitor;
 pub mod protocol;
 

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -270,10 +270,7 @@ pub async fn run_lease_command(
     tokio::fs::create_dir_all(&mission_dir)
         .await
         .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
-    let output = Command::new("bash")
-        .arg("-lc")
-        .arg(&request.command)
-        .current_dir(&mission_dir)
+    let output = raw_command(&request.command, &mission_dir, None)
         .output()
         .await
         .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
@@ -285,10 +282,56 @@ pub async fn run_lease_command(
     })
 }
 
+/// Construct a raw command without inheriting the node service environment.
+/// The service bearer/signing tokens must never be visible to repository or
+/// mission code. Explicit payload env is added back after a minimal runtime
+/// baseline.
+pub(crate) fn raw_command(
+    command: &str,
+    cwd: &std::path::Path,
+    env: Option<&std::collections::HashMap<String, String>>,
+) -> Command {
+    let mut cmd = Command::new("bash");
+    cmd.arg("-lc")
+        .arg(command)
+        .current_dir(cwd)
+        .env_clear()
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string()),
+        )
+        .env("HOME", cwd)
+        .env("LANG", "C.UTF-8");
+    if let Some(env) = env {
+        cmd.envs(env);
+    }
+    cmd
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    #[tokio::test]
+    async fn raw_command_does_not_inherit_node_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret_name = "SANDBOXED_NODE_TEST_ONLY_SECRET_44EDEB08";
+        std::env::set_var(secret_name, "must-not-leak");
+
+        let output = raw_command(
+            &format!("test -z \"${secret_name:-}\" && printf safe"),
+            dir.path(),
+            None,
+        )
+        .output()
+        .await
+        .unwrap();
+        std::env::remove_var(secret_name);
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "safe");
+    }
 
     #[test]
     fn parses_env_node_list_with_default_token_env() {

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -103,8 +103,8 @@ pub enum RemoteNodeError {
     InvalidConfig(String),
     #[error("remote node request failed: {0}")]
     Request(String),
-    #[error("remote node rejected lease: {0}")]
-    Rejected(String),
+    #[error("remote node rejected request with HTTP {status}: {body}")]
+    Rejected { status: u16, body: String },
     #[error("invalid lease token: {0}")]
     InvalidLease(String),
 }

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -257,6 +257,7 @@ pub async fn run_lease_command(
         &request.lease_token,
         token_secret,
         node_id,
+        SCOPE_MISSION_EXECUTE,
         chrono::Utc::now(),
     )?;
     if claims.mission_id != request.mission_id {
@@ -321,6 +322,7 @@ mod tests {
             node_id: "babylon".to_string(),
             scope: SCOPE_MISSION_EXECUTE.to_string(),
             expires_at: chrono::Utc::now().timestamp() + 60,
+            job_id: None,
         };
         let token = create_lease_token(&claims, "node-secret").unwrap();
         let work_root = tempfile::tempdir().unwrap();

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -109,6 +109,12 @@ pub enum RemoteNodeError {
     InvalidLease(String),
 }
 
+impl RemoteNodeError {
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::Rejected { status: 404, .. })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoteNodeConfig {
     pub id: String,

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -1,15 +1,29 @@
+//! Remote runner nodes: core-side configuration, wire protocol, HTTP client
+//! and fleet monitoring for the `sandboxed-node` runner binary.
+//!
+//! Module layout:
+//! - [`protocol`]: shared wire types (heartbeat, leases, job payloads) used by
+//!   both core and the node binary.
+//! - [`client`]: core-side HTTP client for talking to nodes.
+//! - [`monitor`]: background fleet monitor caching per-node statuses and
+//!   recent dispatch outcomes.
+//!
+//! Everything public is re-exported here so call sites keep using
+//! `crate::remote_node::*` unchanged.
+
+pub mod client;
+pub mod monitor;
+pub mod protocol;
+
+pub use client::*;
+pub use monitor::*;
+pub use protocol::*;
+
 use axum::http::HeaderMap;
-use base64::Engine;
-use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
 use std::path::PathBuf;
-use std::time::Duration;
 use thiserror::Error;
 use tokio::process::Command;
-use uuid::Uuid;
-
-type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -58,14 +72,19 @@ impl RemoteNodeOverview {
                 "Remote node MVP is enabled for explicit selected-node missions.".to_string(),
             );
         }
+        let status = if settings.enabled {
+            // Derive the live status from the fleet monitor cache when
+            // available instead of the old hardcoded `Unknown`.
+            monitor::global_fleet()
+                .and_then(|fleet| fleet.aggregate_status())
+                .unwrap_or(RemoteNodeStatus::Unknown)
+        } else {
+            RemoteNodeStatus::Disabled
+        };
         Self {
             enabled: settings.enabled,
             configured_nodes: settings.nodes.len(),
-            status: if settings.enabled {
-                RemoteNodeStatus::Unknown
-            } else {
-                RemoteNodeStatus::Disabled
-            },
+            status,
             notes,
         }
     }
@@ -204,187 +223,6 @@ pub fn parse_node_list(raw: &str) -> Result<Vec<RemoteNodeConfig>, RemoteNodeErr
         .collect()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct NodeHeartbeat {
-    pub node_id: String,
-    pub online: bool,
-    pub capacity_total: u32,
-    pub capacity_available: u32,
-    pub active_leases: u32,
-    pub version: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct NodeStatus {
-    pub id: String,
-    pub base_url: String,
-    pub token_env: String,
-    pub online: bool,
-    pub capacity_total: Option<u32>,
-    pub capacity_available: Option<u32>,
-    pub active_leases: Option<u32>,
-    pub version: Option<String>,
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct LeaseClaims {
-    pub mission_id: Uuid,
-    pub node_id: String,
-    pub scope: String,
-    pub expires_at: i64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct LeaseRequest {
-    pub mission_id: Uuid,
-    pub node_id: String,
-    pub lease_token: String,
-    pub command: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ExecuteResponse {
-    pub accepted: bool,
-    pub exit_code: Option<i32>,
-    pub stdout: String,
-    pub stderr: String,
-}
-
-/// Total request timeout for `/execute`, which blocks until the remote
-/// command completes.
-const EXECUTE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
-
-#[derive(Clone)]
-pub struct RemoteNodeClient {
-    http: reqwest::Client,
-}
-
-impl Default for RemoteNodeClient {
-    fn default() -> Self {
-        Self {
-            http: reqwest::Client::builder()
-                .timeout(Duration::from_secs(30))
-                .connect_timeout(Duration::from_secs(5))
-                .build()
-                .unwrap_or_default(),
-        }
-    }
-}
-
-impl RemoteNodeClient {
-    pub async fn heartbeat(
-        &self,
-        node: &RemoteNodeConfig,
-        token: &str,
-    ) -> Result<NodeHeartbeat, RemoteNodeError> {
-        let url = format!("{}/heartbeat", node.base_url);
-        let response = self
-            .http
-            .get(url)
-            .bearer_auth(token)
-            .send()
-            .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
-        if !response.status().is_success() {
-            return Err(RemoteNodeError::Request(format!(
-                "heartbeat returned {}",
-                response.status()
-            )));
-        }
-        response
-            .json::<NodeHeartbeat>()
-            .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))
-    }
-
-    pub async fn execute(
-        &self,
-        node: &RemoteNodeConfig,
-        shared_token: &str,
-        request: &LeaseRequest,
-    ) -> Result<ExecuteResponse, RemoteNodeError> {
-        let url = format!("{}/execute", node.base_url);
-        let response = self
-            .http
-            .post(url)
-            // Override the client-wide 30s timeout: remote commands
-            // (builds, tests) routinely run for minutes and the response
-            // only arrives once the command finishes.
-            .timeout(EXECUTE_TIMEOUT)
-            .bearer_auth(shared_token)
-            .json(request)
-            .send()
-            .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(RemoteNodeError::Rejected(format!("{status}: {body}")));
-        }
-        response
-            .json::<ExecuteResponse>()
-            .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))
-    }
-}
-
-pub fn create_lease_token(claims: &LeaseClaims, secret: &str) -> Result<String, RemoteNodeError> {
-    if secret.trim().is_empty() {
-        return Err(RemoteNodeError::InvalidLease(
-            "empty signing secret".to_string(),
-        ));
-    }
-    let json =
-        serde_json::to_vec(claims).map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
-    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json);
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
-    mac.update(payload.as_bytes());
-    let signature = hex::encode(mac.finalize().into_bytes());
-    Ok(format!("{payload}.{signature}"))
-}
-
-pub fn validate_lease_token(
-    token: &str,
-    secret: &str,
-    expected_node_id: &str,
-    now: chrono::DateTime<chrono::Utc>,
-) -> Result<LeaseClaims, RemoteNodeError> {
-    let (payload, signature) = token
-        .split_once('.')
-        .ok_or_else(|| RemoteNodeError::InvalidLease("missing signature".to_string()))?;
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
-        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
-    mac.update(payload.as_bytes());
-    let expected = hex::encode(mac.finalize().into_bytes());
-    if !constant_time_eq(signature.as_bytes(), expected.as_bytes()) {
-        return Err(RemoteNodeError::InvalidLease("bad signature".to_string()));
-    }
-    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(payload)
-        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
-    let claims: LeaseClaims =
-        serde_json::from_slice(&bytes).map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
-    if claims.node_id != expected_node_id {
-        return Err(RemoteNodeError::InvalidLease("wrong node".to_string()));
-    }
-    if claims.expires_at <= now.timestamp() {
-        return Err(RemoteNodeError::InvalidLease("expired".to_string()));
-    }
-    if claims.scope != "mission:execute" {
-        return Err(RemoteNodeError::InvalidLease("wrong scope".to_string()));
-    }
-    Ok(claims)
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
-}
-
 pub fn placement_for_selected_node<'a>(
     settings: &'a RemoteNodeSettings,
     selected_node_id: Option<&str>,
@@ -448,8 +286,7 @@ pub async fn run_lease_command(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{routing::get, Json, Router};
-    use tokio::net::TcpListener;
+    use uuid::Uuid;
 
     #[test]
     fn parses_env_node_list_with_default_token_env() {
@@ -482,7 +319,7 @@ mod tests {
         let claims = LeaseClaims {
             mission_id: Uuid::new_v4(),
             node_id: "babylon".to_string(),
-            scope: "mission:execute".to_string(),
+            scope: SCOPE_MISSION_EXECUTE.to_string(),
             expires_at: chrono::Utc::now().timestamp() + 60,
         };
         let token = create_lease_token(&claims, "node-secret").unwrap();
@@ -502,55 +339,6 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, RemoteNodeError::InvalidLease(_)));
-    }
-
-    #[test]
-    fn validates_scoped_lease_token() {
-        let mission_id = Uuid::new_v4();
-        let claims = LeaseClaims {
-            mission_id,
-            node_id: "babylon".to_string(),
-            scope: "mission:execute".to_string(),
-            expires_at: chrono::Utc::now().timestamp() + 60,
-        };
-        let token = create_lease_token(&claims, "node-secret").unwrap();
-        let parsed =
-            validate_lease_token(&token, "node-secret", "babylon", chrono::Utc::now()).unwrap();
-        assert_eq!(parsed.mission_id, mission_id);
-        assert!(
-            validate_lease_token(&token, "other-secret", "babylon", chrono::Utc::now()).is_err()
-        );
-        assert!(validate_lease_token(&token, "node-secret", "nippur", chrono::Utc::now()).is_err());
-    }
-
-    #[tokio::test]
-    async fn heartbeat_client_reads_node_status() {
-        async fn heartbeat() -> Json<NodeHeartbeat> {
-            Json(NodeHeartbeat {
-                node_id: "babylon".to_string(),
-                online: true,
-                capacity_total: 2,
-                capacity_available: 1,
-                active_leases: 1,
-                version: "test".to_string(),
-            })
-        }
-        let app = Router::new().route("/heartbeat", get(heartbeat));
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let client = RemoteNodeClient::default();
-        let node = RemoteNodeConfig {
-            id: "babylon".to_string(),
-            base_url: format!("http://{addr}"),
-            token_env: "TOKEN".to_string(),
-            labels: None,
-        };
-        let heartbeat = client.heartbeat(&node, "unused").await.unwrap();
-        assert_eq!(heartbeat.capacity_available, 1);
     }
 
     #[test]

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -1,0 +1,424 @@
+//! Background fleet monitor: periodically polls every configured remote
+//! runner node's `/heartbeat` and caches per-node statuses plus a bounded
+//! history of recent dispatch outcomes.
+//!
+//! Status semantics:
+//! - `Online`: latest probe returned a fresh heartbeat.
+//! - `Degraded`: 1-2 consecutive missed probes.
+//! - `Offline`: 3 or more consecutive missed probes.
+//! - `Unknown`: never probed (monitor disabled or not yet run).
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, OnceLock, RwLock};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::client::RemoteNodeClient;
+use super::protocol::NodeHeartbeat;
+use super::{RemoteNodeConfig, RemoteNodeSettings, RemoteNodeStatus};
+
+/// Consecutive missed probes after which a node is considered `Offline`
+/// (fewer misses report `Degraded`).
+const OFFLINE_MISS_THRESHOLD: u32 = 3;
+
+/// Bounded length of the recent dispatch-outcome history.
+const RECENT_OUTCOMES_CAP: usize = 50;
+
+/// Cached status for one configured node.
+#[derive(Debug, Clone, Serialize)]
+pub struct CachedNodeStatus {
+    pub node_id: String,
+    pub status: RemoteNodeStatus,
+    /// Consecutive heartbeat misses (0 while online).
+    pub consecutive_misses: u32,
+    /// Last successfully parsed heartbeat payload.
+    pub last_heartbeat: Option<NodeHeartbeat>,
+    /// When the last successful heartbeat was received.
+    pub last_seen: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+}
+
+/// Outcome record for a remote dispatch (sync `/execute` or async job).
+#[derive(Debug, Clone, Serialize)]
+pub struct DispatchOutcome {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    /// Async job id; `None` for the synchronous `/execute` MVP path.
+    pub job_id: Option<Uuid>,
+    /// queued | running | succeeded | failed | cancelled | lost | executed
+    pub state: String,
+    pub exit_code: Option<i32>,
+    pub error: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+/// Pure status transition applied after one heartbeat probe.
+///
+/// Returns the new `(status, consecutive_misses)` pair given the previous
+/// miss count and whether the probe succeeded.
+pub fn status_after_probe(previous_misses: u32, probe_ok: bool) -> (RemoteNodeStatus, u32) {
+    if probe_ok {
+        return (RemoteNodeStatus::Online, 0);
+    }
+    let misses = previous_misses.saturating_add(1);
+    let status = if misses >= OFFLINE_MISS_THRESHOLD {
+        RemoteNodeStatus::Offline
+    } else {
+        RemoteNodeStatus::Degraded
+    };
+    (status, misses)
+}
+
+/// Shared cache of node statuses and recent dispatch outcomes.
+///
+/// Uses `std::sync::RwLock` (never held across `.await`) so synchronous
+/// callers like `RemoteNodeOverview::from_settings` can read it too.
+pub struct FleetMonitor {
+    statuses: RwLock<HashMap<String, CachedNodeStatus>>,
+    recent: RwLock<VecDeque<DispatchOutcome>>,
+}
+
+impl Default for FleetMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FleetMonitor {
+    pub fn new() -> Self {
+        Self {
+            statuses: RwLock::new(HashMap::new()),
+            recent: RwLock::new(VecDeque::new()),
+        }
+    }
+
+    /// Record a successful heartbeat probe.
+    pub fn record_heartbeat(&self, node_id: &str, heartbeat: NodeHeartbeat) {
+        let (status, misses) = status_after_probe(0, true);
+        let mut statuses = self.statuses.write().unwrap_or_else(|e| e.into_inner());
+        statuses.insert(
+            node_id.to_string(),
+            CachedNodeStatus {
+                node_id: node_id.to_string(),
+                status,
+                consecutive_misses: misses,
+                last_heartbeat: Some(heartbeat),
+                last_seen: Some(Utc::now()),
+                last_error: None,
+            },
+        );
+    }
+
+    /// Record a failed heartbeat probe (network error, auth failure, missing
+    /// token env, ...). Keeps the last known heartbeat payload for display.
+    pub fn record_miss(&self, node_id: &str, error: String) {
+        let mut statuses = self.statuses.write().unwrap_or_else(|e| e.into_inner());
+        let entry = statuses
+            .entry(node_id.to_string())
+            .or_insert_with(|| CachedNodeStatus {
+                node_id: node_id.to_string(),
+                status: RemoteNodeStatus::Unknown,
+                consecutive_misses: 0,
+                last_heartbeat: None,
+                last_seen: None,
+                last_error: None,
+            });
+        let (status, misses) = status_after_probe(entry.consecutive_misses, false);
+        entry.status = status;
+        entry.consecutive_misses = misses;
+        entry.last_error = Some(error);
+    }
+
+    pub fn get(&self, node_id: &str) -> Option<CachedNodeStatus> {
+        self.statuses
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(node_id)
+            .cloned()
+    }
+
+    /// Aggregate fleet status across all probed nodes; `None` when no node
+    /// has been probed yet.
+    pub fn aggregate_status(&self) -> Option<RemoteNodeStatus> {
+        let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
+        if statuses.is_empty() {
+            return None;
+        }
+        let online = statuses
+            .values()
+            .filter(|s| s.status == RemoteNodeStatus::Online)
+            .count();
+        Some(if online == statuses.len() {
+            RemoteNodeStatus::Online
+        } else if online > 0
+            || statuses
+                .values()
+                .any(|s| s.status == RemoteNodeStatus::Degraded)
+        {
+            RemoteNodeStatus::Degraded
+        } else {
+            RemoteNodeStatus::Offline
+        })
+    }
+
+    /// Record (or update, keyed by `job_id`) a dispatch outcome.
+    pub fn record_outcome(&self, outcome: DispatchOutcome) {
+        let mut recent = self.recent.write().unwrap_or_else(|e| e.into_inner());
+        if let Some(job_id) = outcome.job_id {
+            if let Some(existing) = recent.iter_mut().find(|entry| entry.job_id == Some(job_id)) {
+                *existing = outcome;
+                return;
+            }
+        }
+        recent.push_front(outcome);
+        recent.truncate(RECENT_OUTCOMES_CAP);
+    }
+
+    /// Most recent dispatch outcomes, newest first.
+    pub fn recent_outcomes(&self, limit: usize) -> Vec<DispatchOutcome> {
+        self.recent
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+}
+
+static GLOBAL_FLEET: OnceLock<Arc<FleetMonitor>> = OnceLock::new();
+
+/// Register the process-wide fleet monitor so synchronous status readers
+/// (e.g. `RemoteNodeOverview`) can consult the cache without `AppState`.
+pub fn register_global_fleet(fleet: &Arc<FleetMonitor>) {
+    let _ = GLOBAL_FLEET.set(Arc::clone(fleet));
+}
+
+pub fn global_fleet() -> Option<Arc<FleetMonitor>> {
+    GLOBAL_FLEET.get().cloned()
+}
+
+/// Per-node view merged from static config and the monitor cache, as served
+/// by `GET /api/remote-nodes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteNodeView {
+    pub id: String,
+    pub base_url: String,
+    pub token_env: String,
+    pub status: RemoteNodeStatus,
+    pub labels: Vec<String>,
+    pub version: Option<String>,
+    pub protocol_version: Option<u32>,
+    pub capacity_total: Option<u32>,
+    pub capacity_available: Option<u32>,
+    pub active_leases: Option<u32>,
+    pub active_jobs: Option<u32>,
+    pub queued_jobs: Option<u32>,
+    pub cpu_total: Option<u32>,
+    pub mem_total_bytes: Option<u64>,
+    pub mem_available_bytes: Option<u64>,
+    pub disk_total_bytes: Option<u64>,
+    pub disk_available_bytes: Option<u64>,
+    pub cached_toolchains: Vec<String>,
+    pub last_seen: Option<DateTime<Utc>>,
+    pub error: Option<String>,
+}
+
+impl RemoteNodeView {
+    pub fn from_cache(config: &RemoteNodeConfig, cached: Option<&CachedNodeStatus>) -> Self {
+        let heartbeat = cached.and_then(|c| c.last_heartbeat.as_ref());
+        let mut labels = heartbeat.map(|h| h.labels.clone()).unwrap_or_default();
+        if labels.is_empty() {
+            labels = config.labels.clone().unwrap_or_default();
+        }
+        Self {
+            id: config.id.clone(),
+            base_url: config.base_url.clone(),
+            token_env: config.token_env.clone(),
+            status: cached
+                .map(|c| c.status.clone())
+                .unwrap_or(RemoteNodeStatus::Unknown),
+            labels,
+            version: heartbeat.map(|h| h.version.clone()),
+            protocol_version: heartbeat.map(|h| h.protocol_version),
+            capacity_total: heartbeat.map(|h| h.capacity_total),
+            capacity_available: heartbeat.map(|h| h.capacity_available),
+            active_leases: heartbeat.map(|h| h.active_leases),
+            active_jobs: heartbeat.map(|h| h.active_jobs),
+            queued_jobs: heartbeat.map(|h| h.queued_jobs),
+            cpu_total: heartbeat.map(|h| h.cpu_total),
+            mem_total_bytes: heartbeat.map(|h| h.mem_total_bytes),
+            mem_available_bytes: heartbeat.map(|h| h.mem_available_bytes),
+            disk_total_bytes: heartbeat.map(|h| h.disk_total_bytes),
+            disk_available_bytes: heartbeat.map(|h| h.disk_available_bytes),
+            cached_toolchains: heartbeat
+                .map(|h| h.cached_toolchains.clone())
+                .unwrap_or_default(),
+            last_seen: cached.and_then(|c| c.last_seen),
+            error: cached.and_then(|c| c.last_error.clone()),
+        }
+    }
+}
+
+/// Response body for `GET /api/remote-nodes`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteNodesResponse {
+    pub enabled: bool,
+    pub nodes: Vec<RemoteNodeView>,
+    /// Last dispatch outcomes across the fleet, newest first (max 10).
+    pub recent_jobs: Vec<DispatchOutcome>,
+}
+
+/// Probe one node and record the result into the monitor cache.
+pub async fn probe_node(fleet: &FleetMonitor, client: &RemoteNodeClient, node: &RemoteNodeConfig) {
+    let token = std::env::var(&node.token_env)
+        .ok()
+        .filter(|token| !token.trim().is_empty());
+    match token {
+        Some(token) => match client.heartbeat(node, &token).await {
+            Ok(heartbeat) => fleet.record_heartbeat(&node.id, heartbeat),
+            Err(err) => fleet.record_miss(&node.id, err.to_string()),
+        },
+        None => fleet.record_miss(&node.id, format!("missing token env {}", node.token_env)),
+    }
+}
+
+/// Spawn the background fleet monitor loop.
+///
+/// Poll interval comes from `REMOTE_NODE_MONITOR_SECS` (default 15). Setting
+/// it to `0` disables the loop; the cache is then only fed on demand by
+/// `GET /api/remote-nodes`.
+pub fn spawn_fleet_monitor(fleet: Arc<FleetMonitor>, settings: RemoteNodeSettings) {
+    // Register unconditionally so on-demand probes still feed the same
+    // globally visible cache when the periodic loop is disabled.
+    register_global_fleet(&fleet);
+    let interval_secs = std::env::var("REMOTE_NODE_MONITOR_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(15);
+    if interval_secs == 0 {
+        tracing::info!("Fleet monitor disabled (REMOTE_NODE_MONITOR_SECS=0)");
+        return;
+    }
+    if !settings.enabled || settings.nodes.is_empty() {
+        return;
+    }
+    tracing::info!(
+        nodes = settings.nodes.len(),
+        interval_secs,
+        "Starting remote-node fleet monitor"
+    );
+    tokio::spawn(async move {
+        let client = RemoteNodeClient::default();
+        loop {
+            let probes = settings
+                .nodes
+                .iter()
+                .map(|node| probe_node(&fleet, &client, node));
+            futures::future::join_all(probes).await;
+            tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn heartbeat(node_id: &str) -> NodeHeartbeat {
+        serde_json::from_value(serde_json::json!({
+            "node_id": node_id,
+            "online": true,
+            "capacity_total": 1,
+            "capacity_available": 1,
+            "active_leases": 0,
+            "version": "test",
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn probe_transitions_follow_miss_thresholds() {
+        // Fresh heartbeat is always Online with the miss counter reset.
+        assert_eq!(status_after_probe(0, true), (RemoteNodeStatus::Online, 0));
+        assert_eq!(status_after_probe(7, true), (RemoteNodeStatus::Online, 0));
+        // 1-2 consecutive misses degrade, 3+ go offline.
+        assert_eq!(
+            status_after_probe(0, false),
+            (RemoteNodeStatus::Degraded, 1)
+        );
+        assert_eq!(
+            status_after_probe(1, false),
+            (RemoteNodeStatus::Degraded, 2)
+        );
+        assert_eq!(status_after_probe(2, false), (RemoteNodeStatus::Offline, 3));
+        assert_eq!(
+            status_after_probe(9, false),
+            (RemoteNodeStatus::Offline, 10)
+        );
+    }
+
+    #[test]
+    fn monitor_tracks_status_and_recovery() {
+        let fleet = FleetMonitor::new();
+        assert!(fleet.aggregate_status().is_none());
+
+        fleet.record_heartbeat("babylon", heartbeat("babylon"));
+        assert_eq!(
+            fleet.get("babylon").unwrap().status,
+            RemoteNodeStatus::Online
+        );
+        assert_eq!(fleet.aggregate_status(), Some(RemoteNodeStatus::Online));
+
+        fleet.record_miss("babylon", "timeout".to_string());
+        fleet.record_miss("babylon", "timeout".to_string());
+        let cached = fleet.get("babylon").unwrap();
+        assert_eq!(cached.status, RemoteNodeStatus::Degraded);
+        assert_eq!(cached.consecutive_misses, 2);
+        // Last heartbeat payload is preserved through misses.
+        assert!(cached.last_heartbeat.is_some());
+
+        fleet.record_miss("babylon", "timeout".to_string());
+        assert_eq!(
+            fleet.get("babylon").unwrap().status,
+            RemoteNodeStatus::Offline
+        );
+        assert_eq!(fleet.aggregate_status(), Some(RemoteNodeStatus::Offline));
+
+        // Recovery resets both status and the miss counter.
+        fleet.record_heartbeat("babylon", heartbeat("babylon"));
+        let cached = fleet.get("babylon").unwrap();
+        assert_eq!(cached.status, RemoteNodeStatus::Online);
+        assert_eq!(cached.consecutive_misses, 0);
+    }
+
+    #[test]
+    fn recent_outcomes_dedup_by_job_id_and_stay_bounded() {
+        let fleet = FleetMonitor::new();
+        let job_id = Uuid::new_v4();
+        let outcome = |state: &str, job: Option<Uuid>| DispatchOutcome {
+            mission_id: Uuid::new_v4(),
+            node_id: "babylon".to_string(),
+            job_id: job,
+            state: state.to_string(),
+            exit_code: None,
+            error: None,
+            started_at: Utc::now(),
+            finished_at: None,
+        };
+        fleet.record_outcome(outcome("queued", Some(job_id)));
+        fleet.record_outcome(outcome("succeeded", Some(job_id)));
+        let recent = fleet.recent_outcomes(10);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].state, "succeeded");
+
+        for _ in 0..(RECENT_OUTCOMES_CAP + 10) {
+            fleet.record_outcome(outcome("executed", None));
+        }
+        assert_eq!(fleet.recent_outcomes(usize::MAX).len(), RECENT_OUTCOMES_CAP);
+        assert_eq!(fleet.recent_outcomes(10).len(), 10);
+    }
+}

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -189,6 +189,149 @@ impl FleetMonitor {
     }
 }
 
+/// Placement thresholds (env-overridable defaults).
+const DEFAULT_MIN_DISK_GB: u64 = 20;
+const DEFAULT_MIN_MEM_GB: u64 = 8;
+
+fn env_gb_bytes(key: &str, default_gb: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(default_gb)
+        .saturating_mul(1 << 30)
+}
+
+/// Why auto placement found no eligible node. FAIL CLOSED: every configured
+/// node is listed with its own exclusion reason so the caller (and the
+/// wrapper's fallback logging) can see exactly what was ruled out and why.
+#[derive(Debug, Clone, Serialize)]
+pub struct PlacementError {
+    /// `(node_id, reason)` per configured node.
+    pub reasons: Vec<(String, String)>,
+}
+
+impl std::fmt::Display for PlacementError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.reasons.is_empty() {
+            return write!(f, "no remote nodes are configured");
+        }
+        let detail = self
+            .reasons
+            .iter()
+            .map(|(node, reason)| format!("{node}: {reason}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        write!(f, "no eligible remote node ({detail})")
+    }
+}
+
+impl std::error::Error for PlacementError {}
+
+/// Pure capacity-aware auto placement over cached node statuses.
+///
+/// A node is eligible when it is `Online` with a heartbeat, its labels cover
+/// every requirement, it has at least `min_disk_bytes` disk and
+/// `min_mem_bytes` memory available, and its in-flight load
+/// (`active_jobs + queued_jobs`) is below `2 * capacity_total`. Eligible
+/// nodes are ranked least-loaded first, breaking ties on the most available
+/// memory.
+pub fn select_node_auto(
+    nodes: &[RemoteNodeConfig],
+    statuses: &HashMap<String, CachedNodeStatus>,
+    requirements: &[String],
+    min_disk_bytes: u64,
+    min_mem_bytes: u64,
+) -> Result<String, PlacementError> {
+    let mut reasons: Vec<(String, String)> = Vec::new();
+    let mut eligible: Vec<(u32, u64, String)> = Vec::new(); // (load, mem_avail, id)
+    for node in nodes {
+        let cached = statuses.get(&node.id);
+        let status = cached
+            .map(|c| c.status.clone())
+            .unwrap_or(RemoteNodeStatus::Unknown);
+        if status != RemoteNodeStatus::Online {
+            reasons.push((node.id.clone(), format!("not online (status: {status:?})")));
+            continue;
+        }
+        let Some(heartbeat) = cached.and_then(|c| c.last_heartbeat.as_ref()) else {
+            reasons.push((node.id.clone(), "no heartbeat data".to_string()));
+            continue;
+        };
+        // Labels come from the heartbeat, falling back to static config for
+        // nodes that don't report any (mirrors RemoteNodeView).
+        let labels: &[String] = if heartbeat.labels.is_empty() {
+            node.labels.as_deref().unwrap_or(&[])
+        } else {
+            &heartbeat.labels
+        };
+        if let Some(missing) = requirements.iter().find(|req| !labels.contains(req)) {
+            reasons.push((node.id.clone(), format!("missing label '{missing}'")));
+            continue;
+        }
+        if heartbeat.disk_available_bytes < min_disk_bytes {
+            reasons.push((
+                node.id.clone(),
+                format!(
+                    "low disk ({} GiB available, {} GiB required)",
+                    heartbeat.disk_available_bytes / (1 << 30),
+                    min_disk_bytes / (1 << 30)
+                ),
+            ));
+            continue;
+        }
+        if heartbeat.mem_available_bytes < min_mem_bytes {
+            reasons.push((
+                node.id.clone(),
+                format!(
+                    "low memory ({} GiB available, {} GiB required)",
+                    heartbeat.mem_available_bytes / (1 << 30),
+                    min_mem_bytes / (1 << 30)
+                ),
+            ));
+            continue;
+        }
+        let load = heartbeat.active_jobs.saturating_add(heartbeat.queued_jobs);
+        if load >= heartbeat.capacity_total.saturating_mul(2) {
+            reasons.push((
+                node.id.clone(),
+                format!(
+                    "busy ({load} jobs in flight >= 2x capacity {})",
+                    heartbeat.capacity_total
+                ),
+            ));
+            continue;
+        }
+        eligible.push((load, heartbeat.mem_available_bytes, node.id.clone()));
+    }
+    eligible.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    eligible
+        .into_iter()
+        .next()
+        .map(|(_, _, id)| id)
+        .ok_or(PlacementError { reasons })
+}
+
+impl FleetMonitor {
+    /// Capacity-aware auto placement over the configured nodes, using cached
+    /// heartbeats and env thresholds (`REMOTE_NODE_MIN_DISK_GB`, default 20;
+    /// `REMOTE_NODE_MIN_MEM_GB`, default 8). Fails closed with a per-node
+    /// exclusion report when no node qualifies.
+    pub fn place_auto(
+        &self,
+        settings: &RemoteNodeSettings,
+        requirements: &[String],
+    ) -> Result<String, PlacementError> {
+        let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
+        select_node_auto(
+            &settings.nodes,
+            &statuses,
+            requirements,
+            env_gb_bytes("REMOTE_NODE_MIN_DISK_GB", DEFAULT_MIN_DISK_GB),
+            env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
+        )
+    }
+}
+
 static GLOBAL_FLEET: OnceLock<Arc<FleetMonitor>> = OnceLock::new();
 
 /// Register the process-wide fleet monitor so synchronous status readers
@@ -393,6 +536,176 @@ mod tests {
         let cached = fleet.get("babylon").unwrap();
         assert_eq!(cached.status, RemoteNodeStatus::Online);
         assert_eq!(cached.consecutive_misses, 0);
+    }
+
+    fn node_config(id: &str) -> RemoteNodeConfig {
+        RemoteNodeConfig {
+            id: id.to_string(),
+            base_url: format!("http://{id}:3088"),
+            token_env: "TOKEN".to_string(),
+            labels: None,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn cached_online(
+        id: &str,
+        labels: &[&str],
+        disk_gb: u64,
+        mem_gb: u64,
+        capacity: u32,
+        active: u32,
+        queued: u32,
+    ) -> CachedNodeStatus {
+        let heartbeat: NodeHeartbeat = serde_json::from_value(serde_json::json!({
+            "node_id": id,
+            "online": true,
+            "capacity_total": capacity,
+            "capacity_available": capacity.saturating_sub(active),
+            "active_leases": 0,
+            "version": "test",
+            "protocol_version": 2,
+            "labels": labels,
+            "mem_available_bytes": mem_gb * (1u64 << 30),
+            "disk_available_bytes": disk_gb * (1u64 << 30),
+            "active_jobs": active,
+            "queued_jobs": queued,
+        }))
+        .unwrap();
+        CachedNodeStatus {
+            node_id: id.to_string(),
+            status: RemoteNodeStatus::Online,
+            consecutive_misses: 0,
+            last_heartbeat: Some(heartbeat),
+            last_seen: Some(Utc::now()),
+            last_error: None,
+        }
+    }
+
+    const GIB: u64 = 1 << 30;
+
+    #[test]
+    fn place_auto_filters_by_status_labels_disk_mem_and_load() {
+        let nodes = vec![
+            node_config("offline"),
+            node_config("unlabeled"),
+            node_config("lowdisk"),
+            node_config("lowmem"),
+            node_config("busy"),
+            node_config("good"),
+        ];
+        let mut statuses = HashMap::new();
+        let mut offline = cached_online("offline", &["lean"], 100, 32, 2, 0, 0);
+        offline.status = RemoteNodeStatus::Offline;
+        statuses.insert("offline".to_string(), offline);
+        statuses.insert(
+            "unlabeled".to_string(),
+            cached_online("unlabeled", &["docker"], 100, 32, 2, 0, 0),
+        );
+        statuses.insert(
+            "lowdisk".to_string(),
+            cached_online("lowdisk", &["lean"], 5, 32, 2, 0, 0),
+        );
+        statuses.insert(
+            "lowmem".to_string(),
+            cached_online("lowmem", &["lean"], 100, 2, 2, 0, 0),
+        );
+        // capacity 2 -> load ceiling is 4; 3 active + 1 queued = at ceiling.
+        statuses.insert(
+            "busy".to_string(),
+            cached_online("busy", &["lean"], 100, 32, 2, 3, 1),
+        );
+        statuses.insert(
+            "good".to_string(),
+            cached_online("good", &["lean", "docker"], 100, 32, 2, 1, 0),
+        );
+
+        let requirements = vec!["lean".to_string()];
+        let picked = select_node_auto(&nodes, &statuses, &requirements, 20 * GIB, 8 * GIB).unwrap();
+        assert_eq!(picked, "good");
+
+        // Remove the only good node: fail closed with one reason per node.
+        let nodes_without_good = &nodes[..5];
+        let err = select_node_auto(
+            nodes_without_good,
+            &statuses,
+            &requirements,
+            20 * GIB,
+            8 * GIB,
+        )
+        .unwrap_err();
+        assert_eq!(err.reasons.len(), 5);
+        let reason_for = |id: &str| {
+            err.reasons
+                .iter()
+                .find(|(node, _)| node == id)
+                .map(|(_, reason)| reason.clone())
+                .unwrap()
+        };
+        assert!(reason_for("offline").contains("not online"));
+        assert!(reason_for("unlabeled").contains("missing label 'lean'"));
+        assert!(reason_for("lowdisk").contains("low disk"));
+        assert!(reason_for("lowmem").contains("low memory"));
+        assert!(reason_for("busy").contains("busy"));
+        let message = err.to_string();
+        assert!(message.contains("no eligible remote node"));
+        assert!(message.contains("lowdisk"));
+    }
+
+    #[test]
+    fn place_auto_prefers_least_loaded_then_most_free_memory() {
+        let nodes = vec![node_config("a"), node_config("b"), node_config("c")];
+        let mut statuses = HashMap::new();
+        statuses.insert(
+            "a".to_string(),
+            cached_online("a", &["lean"], 100, 64, 4, 2, 1),
+        );
+        statuses.insert(
+            "b".to_string(),
+            cached_online("b", &["lean"], 100, 16, 4, 1, 0),
+        );
+        statuses.insert(
+            "c".to_string(),
+            cached_online("c", &["lean"], 100, 48, 4, 1, 0),
+        );
+        let requirements = vec!["lean".to_string()];
+        // b and c tie on load (1); c wins on more available memory.
+        let picked = select_node_auto(&nodes, &statuses, &requirements, 20 * GIB, 8 * GIB).unwrap();
+        assert_eq!(picked, "c");
+
+        // Never-probed nodes are excluded (status Unknown), not crashed on.
+        let unknown_nodes = vec![node_config("ghost")];
+        let err = select_node_auto(
+            &unknown_nodes,
+            &HashMap::new(),
+            &requirements,
+            20 * GIB,
+            8 * GIB,
+        )
+        .unwrap_err();
+        assert!(err.reasons[0].1.contains("not online"));
+
+        // Config labels back a heartbeat that reports none.
+        let mut labeled_config = node_config("d");
+        labeled_config.labels = Some(vec!["lean".to_string()]);
+        let mut statuses = HashMap::new();
+        statuses.insert("d".to_string(), cached_online("d", &[], 100, 32, 2, 0, 0));
+        let picked = select_node_auto(
+            &[labeled_config],
+            &statuses,
+            &requirements,
+            20 * GIB,
+            8 * GIB,
+        )
+        .unwrap();
+        assert_eq!(picked, "d");
+
+        // No requirements: any healthy node qualifies, even without labels.
+        let mut statuses = HashMap::new();
+        statuses.insert("e".to_string(), cached_online("e", &[], 100, 32, 2, 0, 0));
+        let picked =
+            select_node_auto(&[node_config("e")], &statuses, &[], 20 * GIB, 8 * GIB).unwrap();
+        assert_eq!(picked, "e");
     }
 
     #[test]

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -232,7 +232,8 @@ impl std::error::Error for PlacementError {}
 /// A node is eligible when it is `Online` with a heartbeat, its labels cover
 /// every requirement, it has at least `min_disk_bytes` disk and
 /// `min_mem_bytes` memory available, and its in-flight load
-/// (`active_jobs + queued_jobs`) is below `2 * capacity_total`. Eligible
+/// (`active_jobs + queued_jobs + active_leases`) is below
+/// `2 * capacity_total`. Eligible
 /// nodes are ranked least-loaded first, breaking ties on the most available
 /// memory.
 pub fn select_node_auto(
@@ -290,12 +291,17 @@ pub fn select_node_auto(
             ));
             continue;
         }
-        let load = heartbeat.active_jobs.saturating_add(heartbeat.queued_jobs);
+        // Sync `/execute` dispatches surface as active_leases (not jobs) —
+        // count them too, or a node saturated by synchronous work looks idle.
+        let load = heartbeat
+            .active_jobs
+            .saturating_add(heartbeat.queued_jobs)
+            .saturating_add(heartbeat.active_leases);
         if load >= heartbeat.capacity_total.saturating_mul(2) {
             reasons.push((
                 node.id.clone(),
                 format!(
-                    "busy ({load} jobs in flight >= 2x capacity {})",
+                    "busy ({load} jobs/leases in flight >= 2x capacity {})",
                     heartbeat.capacity_total
                 ),
             ));

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -20,6 +20,9 @@ pub const NODE_PROTOCOL_VERSION: u32 = 2;
 /// Lease scope for the synchronous `/execute` path.
 pub const SCOPE_MISSION_EXECUTE: &str = "mission:execute";
 
+/// Lease scope for submitting async jobs (`POST /jobs`).
+pub const SCOPE_JOB_SUBMIT: &str = "job:submit";
+
 fn default_protocol_version() -> u32 {
     // Nodes predating heartbeat v2 don't send the field at all.
     1
@@ -87,6 +90,10 @@ pub struct LeaseClaims {
     pub node_id: String,
     pub scope: String,
     pub expires_at: i64,
+    /// Job the lease is bound to (async job submissions only). Tolerated as
+    /// absent so pre-job leases keep validating.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -103,6 +110,67 @@ pub struct ExecuteResponse {
     pub exit_code: Option<i32>,
     pub stdout: String,
     pub stderr: String,
+}
+
+/// Async job payload. Tagged so future kinds (e.g. `lean_build`) can be added
+/// without breaking the wire format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum JobPayload {
+    /// Run one shell command with `bash -lc` under the mission work dir —
+    /// same semantics as the synchronous `/execute` path.
+    RawCommand {
+        command: String,
+        /// Client-requested timeout; clamped to the node's
+        /// `SANDBOXED_NODE_MAX_JOB_SECS`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_secs: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        env: Option<std::collections::HashMap<String, String>>,
+    },
+}
+
+/// Body of `POST /jobs` on the node.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubmitJobRequest {
+    pub job_id: Uuid,
+    pub mission_id: Uuid,
+    pub lease_token: String,
+    pub payload: JobPayload,
+}
+
+/// `202 Accepted` body of `POST /jobs`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubmitJobResponse {
+    pub job_id: Uuid,
+    pub state: String,
+}
+
+/// Job status as returned by `GET /jobs/:id` and `GET /jobs`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeJobStatus {
+    pub job_id: Uuid,
+    pub mission_id: Uuid,
+    /// queued | running | succeeded | failed | cancelled | lost
+    pub state: String,
+    pub exit_code: Option<i32>,
+    pub created_at: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub error: Option<String>,
+    /// Up to the last 64 KiB of combined stdout+stderr (single-job status
+    /// only; omitted from list responses).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_tail: Option<String>,
+}
+
+/// Body of `POST /jobs/:id/cancel`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CancelJobResponse {
+    pub job_id: Uuid,
+    pub state: String,
+    /// Whether a cancellation was actually delivered to a live job.
+    pub cancel_requested: bool,
 }
 
 pub fn create_lease_token(claims: &LeaseClaims, secret: &str) -> Result<String, RemoteNodeError> {
@@ -125,6 +193,7 @@ pub fn validate_lease_token(
     token: &str,
     secret: &str,
     expected_node_id: &str,
+    expected_scope: &str,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<LeaseClaims, RemoteNodeError> {
     let (payload, signature) = token
@@ -148,7 +217,7 @@ pub fn validate_lease_token(
     if claims.expires_at <= now.timestamp() {
         return Err(RemoteNodeError::InvalidLease("expired".to_string()));
     }
-    if claims.scope != SCOPE_MISSION_EXECUTE {
+    if claims.scope != expected_scope {
         return Err(RemoteNodeError::InvalidLease("wrong scope".to_string()));
     }
     Ok(claims)
@@ -194,15 +263,142 @@ mod tests {
             node_id: "babylon".to_string(),
             scope: SCOPE_MISSION_EXECUTE.to_string(),
             expires_at: chrono::Utc::now().timestamp() + 60,
+            job_id: None,
         };
         let token = create_lease_token(&claims, "node-secret").unwrap();
-        let parsed =
-            validate_lease_token(&token, "node-secret", "babylon", chrono::Utc::now()).unwrap();
+        let parsed = validate_lease_token(
+            &token,
+            "node-secret",
+            "babylon",
+            SCOPE_MISSION_EXECUTE,
+            chrono::Utc::now(),
+        )
+        .unwrap();
         assert_eq!(parsed.mission_id, mission_id);
-        assert!(
-            validate_lease_token(&token, "other-secret", "babylon", chrono::Utc::now()).is_err()
+        assert!(validate_lease_token(
+            &token,
+            "other-secret",
+            "babylon",
+            SCOPE_MISSION_EXECUTE,
+            chrono::Utc::now()
+        )
+        .is_err());
+        assert!(validate_lease_token(
+            &token,
+            "node-secret",
+            "nippur",
+            SCOPE_MISSION_EXECUTE,
+            chrono::Utc::now()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn lease_scopes_are_not_interchangeable() {
+        let now = chrono::Utc::now();
+        let claims_for = |scope: &str, job_id: Option<Uuid>| LeaseClaims {
+            mission_id: Uuid::new_v4(),
+            node_id: "babylon".to_string(),
+            scope: scope.to_string(),
+            expires_at: now.timestamp() + 60,
+            job_id,
+        };
+
+        // A mission:execute lease must be rejected for job submission.
+        let execute_token =
+            create_lease_token(&claims_for(SCOPE_MISSION_EXECUTE, None), "node-secret").unwrap();
+        assert!(validate_lease_token(
+            &execute_token,
+            "node-secret",
+            "babylon",
+            SCOPE_MISSION_EXECUTE,
+            now
+        )
+        .is_ok());
+        assert!(matches!(
+            validate_lease_token(
+                &execute_token,
+                "node-secret",
+                "babylon",
+                SCOPE_JOB_SUBMIT,
+                now
+            ),
+            Err(RemoteNodeError::InvalidLease(_))
+        ));
+
+        // ... and a job:submit lease must be rejected for /execute.
+        let job_token = create_lease_token(
+            &claims_for(SCOPE_JOB_SUBMIT, Some(Uuid::new_v4())),
+            "node-secret",
+        )
+        .unwrap();
+        let parsed =
+            validate_lease_token(&job_token, "node-secret", "babylon", SCOPE_JOB_SUBMIT, now)
+                .unwrap();
+        assert!(parsed.job_id.is_some());
+        assert!(matches!(
+            validate_lease_token(
+                &job_token,
+                "node-secret",
+                "babylon",
+                SCOPE_MISSION_EXECUTE,
+                now
+            ),
+            Err(RemoteNodeError::InvalidLease(_))
+        ));
+    }
+
+    #[test]
+    fn lease_claims_without_job_id_still_parse() {
+        // Tokens minted before the job API existed have no job_id claim.
+        let raw = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "node_id": "babylon",
+            "scope": SCOPE_MISSION_EXECUTE,
+            "expires_at": 1_900_000_000,
+        });
+        let claims: LeaseClaims = serde_json::from_value(raw).unwrap();
+        assert_eq!(claims.job_id, None);
+    }
+
+    #[test]
+    fn job_payload_round_trips_with_kind_tag() {
+        let payload = JobPayload::RawCommand {
+            command: "cargo test".to_string(),
+            timeout_secs: Some(600),
+            env: Some(
+                [("RUST_LOG".to_string(), "info".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["kind"], "raw_command");
+        assert_eq!(json["command"], "cargo test");
+        let parsed: JobPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, payload);
+
+        // Minimal payload: optional fields default.
+        let minimal: JobPayload = serde_json::from_value(serde_json::json!({
+            "kind": "raw_command",
+            "command": "true",
+        }))
+        .unwrap();
+        assert_eq!(
+            minimal,
+            JobPayload::RawCommand {
+                command: "true".to_string(),
+                timeout_secs: None,
+                env: None,
+            }
         );
-        assert!(validate_lease_token(&token, "node-secret", "nippur", chrono::Utc::now()).is_err());
+
+        // Unknown kinds are rejected, leaving room for future variants.
+        assert!(serde_json::from_value::<JobPayload>(serde_json::json!({
+            "kind": "lean_build",
+            "command": "true",
+        }))
+        .is_err());
     }
 
     #[test]

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -1,0 +1,277 @@
+//! Shared wire types for the core <-> `sandboxed-node` protocol.
+//!
+//! Both the core backend and the node binary (`src/bin/sandboxed_node.rs`)
+//! import these from the library crate so request/response shapes cannot
+//! drift apart.
+
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use uuid::Uuid;
+
+use super::RemoteNodeError;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Protocol version reported by heartbeat v2 nodes.
+pub const NODE_PROTOCOL_VERSION: u32 = 2;
+
+/// Lease scope for the synchronous `/execute` path.
+pub const SCOPE_MISSION_EXECUTE: &str = "mission:execute";
+
+fn default_protocol_version() -> u32 {
+    // Nodes predating heartbeat v2 don't send the field at all.
+    1
+}
+
+/// Node heartbeat payload (v2).
+///
+/// All fields beyond the original v1 set are `#[serde(default)]`-tolerant so
+/// core can parse heartbeats from nodes that were not yet upgraded, and old
+/// cores simply ignore the extra fields of new nodes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeHeartbeat {
+    pub node_id: String,
+    pub online: bool,
+    pub capacity_total: u32,
+    pub capacity_available: u32,
+    pub active_leases: u32,
+    pub version: String,
+    /// Heartbeat protocol version; `1` when absent (pre-v2 node).
+    #[serde(default = "default_protocol_version")]
+    pub protocol_version: u32,
+    /// Operator-assigned labels (`SANDBOXED_NODE_LABELS`).
+    #[serde(default)]
+    pub labels: Vec<String>,
+    /// Number of logical CPU cores on the node.
+    #[serde(default)]
+    pub cpu_total: u32,
+    #[serde(default)]
+    pub mem_total_bytes: u64,
+    #[serde(default)]
+    pub mem_available_bytes: u64,
+    /// Disk figures for the filesystem backing the node work dir (or root).
+    #[serde(default)]
+    pub disk_total_bytes: u64,
+    #[serde(default)]
+    pub disk_available_bytes: u64,
+    /// Async jobs currently executing (0 until the job API is in use).
+    #[serde(default)]
+    pub active_jobs: u32,
+    /// Async jobs queued behind the capacity semaphore.
+    #[serde(default)]
+    pub queued_jobs: u32,
+    /// Prewarmed toolchains cached on the node (empty until S3).
+    #[serde(default)]
+    pub cached_toolchains: Vec<String>,
+}
+
+/// Legacy per-node status shape (kept for API compatibility).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeStatus {
+    pub id: String,
+    pub base_url: String,
+    pub token_env: String,
+    pub online: bool,
+    pub capacity_total: Option<u32>,
+    pub capacity_available: Option<u32>,
+    pub active_leases: Option<u32>,
+    pub version: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaseClaims {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    pub scope: String,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaseRequest {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    pub lease_token: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecuteResponse {
+    pub accepted: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub fn create_lease_token(claims: &LeaseClaims, secret: &str) -> Result<String, RemoteNodeError> {
+    if secret.trim().is_empty() {
+        return Err(RemoteNodeError::InvalidLease(
+            "empty signing secret".to_string(),
+        ));
+    }
+    let json =
+        serde_json::to_vec(claims).map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json);
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    mac.update(payload.as_bytes());
+    let signature = hex::encode(mac.finalize().into_bytes());
+    Ok(format!("{payload}.{signature}"))
+}
+
+pub fn validate_lease_token(
+    token: &str,
+    secret: &str,
+    expected_node_id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<LeaseClaims, RemoteNodeError> {
+    let (payload, signature) = token
+        .split_once('.')
+        .ok_or_else(|| RemoteNodeError::InvalidLease("missing signature".to_string()))?;
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    mac.update(payload.as_bytes());
+    let expected = hex::encode(mac.finalize().into_bytes());
+    if !constant_time_eq(signature.as_bytes(), expected.as_bytes()) {
+        return Err(RemoteNodeError::InvalidLease("bad signature".to_string()));
+    }
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    let claims: LeaseClaims =
+        serde_json::from_slice(&bytes).map_err(|e| RemoteNodeError::InvalidLease(e.to_string()))?;
+    if claims.node_id != expected_node_id {
+        return Err(RemoteNodeError::InvalidLease("wrong node".to_string()));
+    }
+    if claims.expires_at <= now.timestamp() {
+        return Err(RemoteNodeError::InvalidLease("expired".to_string()));
+    }
+    if claims.scope != SCOPE_MISSION_EXECUTE {
+        return Err(RemoteNodeError::InvalidLease("wrong scope".to_string()));
+    }
+    Ok(claims)
+}
+
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// Constant-time bearer-token check supporting one-step token rotation: the
+/// presented token is accepted when it matches the current token OR the
+/// (optional, non-empty) previous token still being phased out.
+pub fn node_token_matches(presented: &str, current: &str, previous: Option<&str>) -> bool {
+    let matches_current = constant_time_eq(presented.as_bytes(), current.as_bytes());
+    let matches_previous = previous
+        .filter(|prev| !prev.trim().is_empty())
+        .is_some_and(|prev| constant_time_eq(presented.as_bytes(), prev.as_bytes()));
+    matches_current || matches_previous
+}
+
+/// Parse a comma-separated label list (`SANDBOXED_NODE_LABELS`) into a
+/// trimmed, non-empty vector.
+pub fn parse_labels(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_scoped_lease_token() {
+        let mission_id = Uuid::new_v4();
+        let claims = LeaseClaims {
+            mission_id,
+            node_id: "babylon".to_string(),
+            scope: SCOPE_MISSION_EXECUTE.to_string(),
+            expires_at: chrono::Utc::now().timestamp() + 60,
+        };
+        let token = create_lease_token(&claims, "node-secret").unwrap();
+        let parsed =
+            validate_lease_token(&token, "node-secret", "babylon", chrono::Utc::now()).unwrap();
+        assert_eq!(parsed.mission_id, mission_id);
+        assert!(
+            validate_lease_token(&token, "other-secret", "babylon", chrono::Utc::now()).is_err()
+        );
+        assert!(validate_lease_token(&token, "node-secret", "nippur", chrono::Utc::now()).is_err());
+    }
+
+    #[test]
+    fn token_rotation_accepts_current_or_previous() {
+        // Current token always matches.
+        assert!(node_token_matches("tok-new", "tok-new", None));
+        assert!(node_token_matches("tok-new", "tok-new", Some("tok-old")));
+        // Previous token matches only while configured and non-empty.
+        assert!(node_token_matches("tok-old", "tok-new", Some("tok-old")));
+        assert!(!node_token_matches("tok-old", "tok-new", None));
+        assert!(!node_token_matches("tok-old", "tok-new", Some("")));
+        assert!(!node_token_matches("tok-old", "tok-new", Some("   ")));
+        // Anything else is rejected.
+        assert!(!node_token_matches("wrong", "tok-new", Some("tok-old")));
+        assert!(!node_token_matches("", "tok-new", Some("tok-old")));
+    }
+
+    #[test]
+    fn heartbeat_v1_payload_parses_with_defaults() {
+        // A pre-v2 node sends only the original field set.
+        let raw = serde_json::json!({
+            "node_id": "babylon",
+            "online": true,
+            "capacity_total": 2,
+            "capacity_available": 1,
+            "active_leases": 1,
+            "version": "1.2.0",
+        });
+        let heartbeat: NodeHeartbeat = serde_json::from_value(raw).unwrap();
+        assert_eq!(heartbeat.protocol_version, 1);
+        assert!(heartbeat.labels.is_empty());
+        assert_eq!(heartbeat.cpu_total, 0);
+        assert_eq!(heartbeat.mem_total_bytes, 0);
+        assert_eq!(heartbeat.disk_available_bytes, 0);
+        assert_eq!(heartbeat.active_jobs, 0);
+        assert_eq!(heartbeat.queued_jobs, 0);
+        assert!(heartbeat.cached_toolchains.is_empty());
+        // v1 fields still round-trip.
+        assert_eq!(heartbeat.capacity_available, 1);
+    }
+
+    #[test]
+    fn heartbeat_v2_round_trips() {
+        let heartbeat = NodeHeartbeat {
+            node_id: "babylon".to_string(),
+            online: true,
+            capacity_total: 4,
+            capacity_available: 3,
+            active_leases: 1,
+            version: "1.3.0".to_string(),
+            protocol_version: NODE_PROTOCOL_VERSION,
+            labels: vec!["gpu".to_string(), "lean".to_string()],
+            cpu_total: 16,
+            mem_total_bytes: 64 << 30,
+            mem_available_bytes: 32 << 30,
+            disk_total_bytes: 512 << 30,
+            disk_available_bytes: 100 << 30,
+            active_jobs: 1,
+            queued_jobs: 2,
+            cached_toolchains: vec![],
+        };
+        let json = serde_json::to_string(&heartbeat).unwrap();
+        let parsed: NodeHeartbeat = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, heartbeat);
+    }
+
+    #[test]
+    fn parses_label_lists() {
+        assert_eq!(parse_labels("gpu, lean ,,x"), vec!["gpu", "lean", "x"]);
+        assert!(parse_labels("  ").is_empty());
+    }
+}

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -112,8 +112,27 @@ pub struct ExecuteResponse {
     pub stderr: String,
 }
 
-/// Async job payload. Tagged so future kinds (e.g. `lean_build`) can be added
-/// without breaking the wire format.
+/// Git source of a declarative build job: the node fetches exactly this
+/// commit itself, so no workspace sync between core and node is needed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobSource {
+    /// Clone/fetch URL (https or ssh).
+    pub repo: String,
+    /// Full 40-char lowercase hex commit SHA. Branch names are rejected so a
+    /// job always builds a pinned, reproducible tree.
+    pub commit: String,
+}
+
+/// One artifact produced by a build job, relative to the checkout root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactEntry {
+    pub path: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+/// Async job payload. Tagged so future kinds can be added without breaking
+/// the wire format.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum JobPayload {
@@ -127,6 +146,36 @@ pub enum JobPayload {
         timeout_secs: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         env: Option<std::collections::HashMap<String, String>>,
+    },
+    /// Declarative Lean build: the node checks out `source` into a
+    /// content-addressed checkout, restores shared elan/lake caches, runs a
+    /// constrained `lake`/`lean`/`elan` argv, and reports artifact digests.
+    /// See `src/node/lean.rs` for validation and execution.
+    LeanBuild {
+        source: JobSource,
+        /// Build cwd relative to the checkout root (validated: no traversal,
+        /// no shell metacharacters). `None`/empty = checkout root.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd_rel: Option<String>,
+        /// Argv executed directly (no shell). argv[0] must be one of
+        /// `lake`/`lean`/`elan` on the node.
+        command: Vec<String>,
+        /// Client-requested timeout; clamped to the node's
+        /// `SANDBOXED_NODE_MAX_JOB_SECS`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_secs: Option<u64>,
+        /// Lake cache slot key. Defaults to a digest of the checkout's
+        /// `lean-toolchain` + `lake-manifest.json` contents.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_key: Option<String>,
+        /// Artifact patterns relative to the checkout root (exact paths or a
+        /// single-segment `*` glob), resolved after a successful build.
+        #[serde(default)]
+        artifacts: Vec<String>,
+        /// Extra env for the build command; keys must be allowlisted on the
+        /// node (`SANDBOXED_NODE_ENV_ALLOWLIST`).
+        #[serde(default)]
+        env: std::collections::HashMap<String, String>,
     },
 }
 
@@ -162,6 +211,10 @@ pub struct NodeJobStatus {
     /// only; omitted from list responses).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_tail: Option<String>,
+    /// Artifact digests recorded after a successful build job (empty for raw
+    /// commands and for pre-artifact nodes).
+    #[serde(default)]
+    pub artifacts: Vec<ArtifactEntry>,
 }
 
 /// Body of `POST /jobs/:id/cancel`.
@@ -395,10 +448,84 @@ mod tests {
 
         // Unknown kinds are rejected, leaving room for future variants.
         assert!(serde_json::from_value::<JobPayload>(serde_json::json!({
-            "kind": "lean_build",
+            "kind": "gpu_render",
             "command": "true",
         }))
         .is_err());
+    }
+
+    #[test]
+    fn lean_build_payload_round_trips_with_defaults() {
+        let payload = JobPayload::LeanBuild {
+            source: JobSource {
+                repo: "https://github.com/example/verity.git".to_string(),
+                commit: "a".repeat(40),
+            },
+            cwd_rel: Some("morpho-verity".to_string()),
+            command: vec!["lake".to_string(), "build".to_string()],
+            timeout_secs: Some(3600),
+            cache_key: Some("abc123".to_string()),
+            artifacts: vec![".lake/build/lib/*".to_string()],
+            env: [("LEAN_NUM_THREADS".to_string(), "4".to_string())]
+                .into_iter()
+                .collect(),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["kind"], "lean_build");
+        assert_eq!(json["source"]["commit"], "a".repeat(40));
+        let parsed: JobPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, payload);
+
+        // Minimal payload: only source + command; the rest defaults.
+        let minimal: JobPayload = serde_json::from_value(serde_json::json!({
+            "kind": "lean_build",
+            "source": {"repo": "https://x.git", "commit": "b".repeat(40)},
+            "command": ["lake", "build"],
+        }))
+        .unwrap();
+        match minimal {
+            JobPayload::LeanBuild {
+                cwd_rel,
+                timeout_secs,
+                cache_key,
+                artifacts,
+                env,
+                ..
+            } => {
+                assert_eq!(cwd_rel, None);
+                assert_eq!(timeout_secs, None);
+                assert_eq!(cache_key, None);
+                assert!(artifacts.is_empty());
+                assert!(env.is_empty());
+            }
+            other => panic!("expected lean_build, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn job_status_artifacts_default_for_old_nodes() {
+        // A pre-artifact node omits the field entirely.
+        let raw = serde_json::json!({
+            "job_id": Uuid::new_v4(),
+            "mission_id": Uuid::new_v4(),
+            "state": "succeeded",
+            "exit_code": 0,
+            "created_at": "2026-07-12T00:00:00Z",
+            "started_at": null,
+            "finished_at": null,
+            "error": null,
+        });
+        let status: NodeJobStatus = serde_json::from_value(raw).unwrap();
+        assert!(status.artifacts.is_empty());
+
+        let entry = ArtifactEntry {
+            path: ".lake/build/lib/Verity.olean".to_string(),
+            sha256: "0".repeat(64),
+            size_bytes: 42,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        let parsed: ArtifactEntry = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, entry);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -59,6 +59,16 @@ pub struct Settings {
     /// older than this becomes eligible for GC. When None, defaults to 7.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_cleanup_days: Option<u32>,
+    /// Long-stop retention (days) for AwaitingUser/Paused mission workspace
+    /// dirs. These are exempt from the normal window (the user may come
+    /// back) but not forever. When None, defaults to 30.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_cleanup_stopped_days: Option<u32>,
+    /// Whether the GC also removes `mission-*` dirs that match no mission in
+    /// any store (hard-deleted missions, legacy DBs). When None, follows
+    /// `auto_cleanup_enabled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_cleanup_orphans_enabled: Option<bool>,
     /// Model for the Ask assistant (sidecar co-pilot). When None, falls back to
     /// the `ASK_ASSISTANT_MODEL` env var, then the built-in default
     /// (`gpt-oss-120b`).
@@ -139,6 +149,8 @@ impl SettingsStore {
             max_concurrent_tasks,
             auto_cleanup_enabled: None,
             auto_cleanup_days: None,
+            auto_cleanup_stopped_days: None,
+            auto_cleanup_orphans_enabled: None,
             ask_assistant_model: std::env::var("ASK_ASSISTANT_MODEL").ok(),
             metadata_model: None,
         }

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -988,12 +988,18 @@ pub(crate) struct CodexMcpEntry {
 }
 
 fn resolve_codex_dir(
-    _workspace_dir: &Path,
-    workspace_root: &Path,
-    workspace_type: WorkspaceType,
-    workspace_env: &HashMap<String, String>,
+    workspace_dir: &Path,
+    _workspace_root: &Path,
+    _workspace_type: WorkspaceType,
+    _workspace_env: &HashMap<String, String>,
 ) -> PathBuf {
-    super::resolve_workspace_home_root(workspace_root, workspace_type, workspace_env).join(".codex")
+    // Codex runs with a per-mission HOME rooted at `workspace_dir`. Writing
+    // generated MCP configuration into the shared workspace/container home
+    // leaves the live mission with only Codex's trust stanza and no MCP tools,
+    // while concurrent mission preparation can overwrite another mission's
+    // MISSION_ID. Keep config and native skills beside the mission HOME that
+    // the runner actually exports.
+    workspace_dir.join(".codex")
 }
 
 fn resolve_claudecode_dir(
@@ -1336,5 +1342,26 @@ pub async fn write_backend_config(
             )
             .await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_generated_state_is_mission_scoped() {
+        let workspace_root = Path::new("/srv/workspace-root");
+        let mission_dir = workspace_root.join("workspaces/mission-deadbeef");
+
+        assert_eq!(
+            resolve_codex_dir(
+                &mission_dir,
+                workspace_root,
+                WorkspaceType::Container,
+                &HashMap::new(),
+            ),
+            mission_dir.join(".codex")
+        );
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -319,6 +319,49 @@ impl Workspace {
         Some(m)
     }
 
+    /// Whether remote runner nodes are configured for this deployment
+    /// (`SANDBOXED_REMOTE_NODES_ENABLED` + a non-empty node list).
+    fn remote_nodes_enabled() -> bool {
+        crate::remote_node::RemoteNodeSettings::from_env()
+            .map(|settings| settings.enabled && !settings.nodes.is_empty())
+            .unwrap_or(false)
+    }
+
+    /// Env vars that let the in-workspace `remote-lean-build` wrapper dispatch
+    /// a build for `mission_id` to a remote runner node via the host
+    /// `POST /api/remote-build` endpoint — or `None` when neither remote
+    /// nodes nor spark offload are enabled, or no signing secret is
+    /// available. Mirrors [`Self::spark_offload_env`]: the exposed token is a
+    /// per-mission, scope-bound capability token (domain-separated from the
+    /// spark token), never a node bearer token or the dashboard JWT.
+    pub fn remote_build_env(&self, mission_id: Uuid) -> Option<HashMap<String, String>> {
+        // Gate on either build-offload backend being available: the endpoint
+        // itself answers 503 when remote nodes are absent, letting the
+        // wrapper fall back to a local (or spark) build.
+        if !Self::remote_nodes_enabled() && !self.spark_offload_enabled() {
+            return None;
+        }
+        let token = crate::api::remote_build::build_remote_build_token(mission_id)?;
+        let port = std::env::var("PORT")
+            .ok()
+            .filter(|s| !s.trim().is_empty())?;
+        let mut m = HashMap::new();
+        m.insert(
+            "REMOTE_BUILD_URL".to_string(),
+            format!(
+                "http://{}:{}/api/remote-build",
+                self.host_ip_from_workspace(),
+                port
+            ),
+        );
+        m.insert("REMOTE_BUILD_TOKEN".to_string(), token);
+        m.insert(
+            "REMOTE_BUILD_MISSION_ID".to_string(),
+            mission_id.to_string(),
+        );
+        Some(m)
+    }
+
     /// Create the default host workspace.
     pub fn default_host(working_dir: PathBuf) -> Self {
         Self {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2203,6 +2203,21 @@ pub async fn prepare_mission_workspace_with_skills_backend(
                         );
                     }
                 }
+                // Service MCPs mint short-lived JWTs from JWT_SECRET. Preserve
+                // the deployment's authoritative single-tenant identity so
+                // they address the same persisted mission store as the API;
+                // otherwise container env filtering makes them fall back to
+                // the unrelated `default` store after a restart.
+                if let Ok(user_id) = std::env::var("SANDBOXED_SINGLE_TENANT_USER_ID")
+                    .or_else(|_| std::env::var("SINGLE_TENANT_USER_ID"))
+                {
+                    if !user_id.trim().is_empty() {
+                        env.insert(
+                            "SANDBOXED_SINGLE_TENANT_USER_ID".to_string(),
+                            user_id.trim().to_string(),
+                        );
+                    }
+                }
                 // Use the server's own address so MCPs can reach the API.
                 // Private-network containers (Tailscale veth) cannot reach
                 // the host on 127.0.0.1 — use the veth gateway address there.

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -173,17 +173,22 @@ fn mission_scope_unit(machine_name: &str) -> String {
 /// unit names so mission-end teardown and the zombie reaper can select one
 /// mission's scopes without a process registry.
 pub fn mission_tag_from_path(cwd: &Path) -> Option<String> {
+    let mut below_workspaces = false;
     for comp in cwd.components() {
         let Some(name) = comp.as_os_str().to_str() else {
+            below_workspaces = false;
             continue;
         };
-        for (prefix, tag) in [("mission-", 'm'), ("task-", 't')] {
-            if let Some(rest) = name.strip_prefix(prefix) {
-                if rest.len() == 8 && rest.chars().all(|c| c.is_ascii_hexdigit()) {
-                    return Some(format!("{tag}{}", rest.to_ascii_lowercase()));
+        if below_workspaces {
+            for (prefix, tag) in [("mission-", 'm'), ("task-", 't')] {
+                if let Some(rest) = name.strip_prefix(prefix) {
+                    if rest.len() == 8 && rest.chars().all(|c| c.is_ascii_hexdigit()) {
+                        return Some(format!("{tag}{}", rest.to_ascii_lowercase()));
+                    }
                 }
             }
         }
+        below_workspaces = name == "workspaces";
     }
     None
 }
@@ -476,6 +481,19 @@ mod tests {
         );
         assert_eq!(
             mission_tag_from_path(Path::new("/workspaces/mission-123456789")),
+            None
+        );
+        // User-controlled parent names must not override the actual mission
+        // directory immediately below `workspaces`.
+        assert_eq!(
+            mission_tag_from_path(Path::new(
+                "/srv/mission-deadbeef/containers/workspaces/mission-4EFDA364/repo"
+            ))
+            .as_deref(),
+            Some("m4efda364")
+        );
+        assert_eq!(
+            mission_tag_from_path(Path::new("/srv/mission-deadbeef/repo")),
             None
         );
         assert_eq!(mission_tag_from_path(Path::new("/srv/monorepo")), None);

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -1964,7 +1964,7 @@ impl WorkspaceExec {
         })
     }
 
-    /// Build the `(program, args)` for an *interactive* shell that joins this
+    /// Build the `(program, args, env)` for an *interactive* shell that joins this
     /// workspace's shared persistent container leader via `nsenter` — the same
     /// mechanism mission harnesses use (see [`Self::spawn_streaming_pty`]).
     ///
@@ -1982,7 +1982,7 @@ impl WorkspaceExec {
         program: &str,
         args: &[String],
         extra_env: HashMap<String, String>,
-    ) -> anyhow::Result<Option<(String, Vec<String>)>> {
+    ) -> anyhow::Result<Option<(String, Vec<String>, HashMap<String, String>)>> {
         if !(self.workspace.workspace_type == WorkspaceType::Container
             && use_nspawn_for_workspace(&self.workspace))
         {
@@ -1996,7 +1996,7 @@ impl WorkspaceExec {
         let invocation = self
             .build_container_nsenter_invocation(cwd, program, args, &mut env)
             .await?;
-        Ok(Some(invocation))
+        Ok(Some((invocation.0, invocation.1, env)))
     }
 
     /// Build the (program, args) tuple for spawning a command inside an

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -272,7 +272,7 @@ pub fn machine_name_from_exec_unit(unit: &str) -> Option<String> {
         return None;
     }
     if let Some((machine, tag)) = before_rand.rsplit_once('-') {
-        let tagged = tag.len() == 9
+        let tagged = matches!(tag.len(), 9 | 33)
             && matches!(tag.as_bytes().first(), Some(b'm' | b't'))
             && tag[1..].chars().all(|c| c.is_ascii_hexdigit());
         if tagged {
@@ -619,6 +619,10 @@ mod tests {
         assert_eq!(
             mission_short_id_from_exec_unit(&unit).as_deref(),
             Some("deadbeef")
+        );
+        assert_eq!(
+            machine_name_from_exec_unit(&format!("{unit}.scope")).as_deref(),
+            Some("sandboxed-dumbcontracts-634e6d35")
         );
         let legacy = exec_scope_unit(
             "sandboxed-dumbcontracts-634e6d35",
@@ -2010,9 +2014,13 @@ impl WorkspaceExec {
         // --scope keeps the payload as its own foreground child, so PTY
         // semantics and group-kill teardown are preserved.
         let caps = self.mission_resource_caps();
-        let exec_unit = exec_scope_unit(
+        let mission_id = env
+            .get("MISSION_ID")
+            .and_then(|value| uuid::Uuid::parse_str(value).ok());
+        let exec_unit = exec_scope_unit_for_mission(
             &self.machine_name().unwrap_or_else(|| "unknown".to_string()),
             Some(cwd),
+            mission_id,
         );
         if let Some(scope_args) = caps.scope_run_args(&exec_unit) {
             let mut args = scope_args;

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -1043,9 +1043,17 @@ impl WorkspaceExec {
         escaped
     }
 
+    fn valid_env_key(key: &str) -> bool {
+        !key.trim().is_empty()
+            && key
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    }
+
     /// Build a shell command with optional env var exports.
-    /// When `env` is provided, all env vars are exported before running the program.
-    /// This is needed for nsenter where env vars don't propagate into the container.
+    /// When `env` is provided, all env vars are exported before running the
+    /// program. nsenter callers intentionally pass `None` and use the child
+    /// process environment so credentials never appear in argv.
     fn build_shell_command_with_env(
         rel_cwd: &str,
         program: &str,
@@ -1068,7 +1076,7 @@ impl WorkspaceExec {
                 if k.trim().is_empty() {
                     continue;
                 }
-                if !k.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+                if !Self::valid_env_key(k) {
                     tracing::warn!(key = %k, "Skipping env var with invalid key characters");
                     continue;
                 }
@@ -1444,8 +1452,21 @@ impl WorkspaceExec {
             "nsenter"
         };
         let rel_cwd = self.rel_path_in_container(cwd);
-        // Build shell command with env exports - nsenter doesn't pass env vars
-        // into the container namespace, so we need to export them in the shell.
+        // nsenter preserves its caller's environment. Pass workspace variables
+        // through the process environment instead of embedding them in the
+        // shell argument: transient scope descriptions and process listings
+        // expose argv, and workspace variables commonly contain credentials.
+        let env: HashMap<_, _> = env
+            .into_iter()
+            .filter(|(key, _)| {
+                let valid = Self::valid_env_key(key);
+                if !valid {
+                    tracing::warn!(key = %key, "Skipping env var with invalid key characters");
+                }
+                valid
+            })
+            .collect();
+        let empty_env = HashMap::new();
         let shell_cmd = if tailscale_bootstrap {
             tracing::info!(
                 workspace = %self.workspace.name,
@@ -1456,13 +1477,12 @@ impl WorkspaceExec {
                 &rel_cwd,
                 program,
                 args,
-                &env,
+                &empty_env,
                 true,
                 tailnet_only,
             )
         } else {
-            let env_ref = if env.is_empty() { None } else { Some(&env) };
-            Self::build_shell_command_with_env(&rel_cwd, program, args, env_ref)
+            Self::build_shell_command_with_env(&rel_cwd, program, args, None)
         };
         // Per-mission isolation, nsenter edition. `nsenter` only enters the
         // container's *namespaces* — the spawned process stays in the
@@ -1530,8 +1550,7 @@ impl WorkspaceExec {
         }
         cmd.args(["/bin/sh", "-lc"]);
         cmd.arg(shell_cmd);
-        // Note: env vars are now exported in the shell command, not here.
-        // Setting them here with cmd.envs() doesn't propagate into the container.
+        cmd.env_clear().envs(env);
         cmd.stdin(stdin).stdout(stdout).stderr(stderr);
         Ok(cmd)
     }
@@ -1939,8 +1958,8 @@ impl WorkspaceExec {
     /// Build the (program, args) tuple for spawning a command inside an
     /// nspawn container via nsenter. Also mutates `env` to add container
     /// defaults (HOME, SSH_AUTH_SOCK). The returned args end with
-    /// `"/bin/sh", "-lc", <shell_cmd>` where `shell_cmd` re-exports env and
-    /// execs the target program.
+    /// `"/bin/sh", "-lc", <shell_cmd>`. nsenter inherits the environment
+    /// applied to the returned command by [`Self::spawn_unix_pty`].
     async fn build_container_nsenter_invocation(
         &self,
         cwd: &Path,
@@ -1978,18 +1997,18 @@ impl WorkspaceExec {
         }
         .to_string();
         let rel_cwd = self.rel_path_in_container(cwd);
+        let empty_env = HashMap::new();
         let shell_cmd = if needs_tailscale_bootstrap {
             Self::build_tailscale_bootstrap_command(
                 &rel_cwd,
                 program,
                 args,
-                env,
+                &empty_env,
                 true,
                 nsenter_tailnet_only,
             )
         } else {
-            let env_ref = if env.is_empty() { None } else { Some(&*env) };
-            Self::build_shell_command_with_env(&rel_cwd, program, args, env_ref)
+            Self::build_shell_command_with_env(&rel_cwd, program, args, None)
         };
 
         let nsenter_args = vec![
@@ -2083,9 +2102,14 @@ impl WorkspaceExec {
         if !args.is_empty() {
             cmd.args(args);
         }
-        // Inherit parent env, then apply workspace/mission overrides.
+        // Container commands must not inherit API-service credentials. The
+        // complete workspace environment is applied here and inherited by
+        // nsenter without ever appearing in its argv.
+        if self.workspace.workspace_type == WorkspaceType::Container {
+            cmd.env_clear();
+        }
         for (k, v) in env {
-            if k.trim().is_empty() {
+            if !Self::valid_env_key(k) {
                 continue;
             }
             cmd.env(k, v);

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -199,9 +199,20 @@ pub fn mission_tag_from_path(cwd: &Path) -> Option<String> {
 /// `list_workspace_scope_units` stays intact), the optional mission/task tag
 /// second (per-mission teardown), and a short random suffix for uniqueness.
 pub fn exec_scope_unit(machine_name: &str, cwd: Option<&Path>) -> String {
+    exec_scope_unit_for_mission(machine_name, cwd, None)
+}
+
+fn exec_scope_unit_for_mission(
+    machine_name: &str,
+    cwd: Option<&Path>,
+    mission_id: Option<uuid::Uuid>,
+) -> String {
     let rand = uuid::Uuid::new_v4().simple().to_string();
     let rand8 = &rand[..8];
-    match cwd.and_then(mission_tag_from_path) {
+    let tag = mission_id
+        .map(|id| format!("m{}", id.simple()))
+        .or_else(|| cwd.and_then(mission_tag_from_path));
+    match tag {
         Some(tag) => format!("sandboxed-exec-{machine_name}-{tag}-{rand8}"),
         None => format!("sandboxed-exec-{machine_name}-{rand8}"),
     }
@@ -225,11 +236,27 @@ pub fn mission_short_id_from_exec_unit(unit: &str) -> Option<String> {
     let _rand = segs.next()?;
     let tag = segs.next()?;
     let rest = tag.strip_prefix('m')?;
-    if rest.len() == 8 && rest.chars().all(|c| c.is_ascii_hexdigit()) {
-        Some(rest.to_string())
+    if matches!(rest.len(), 8 | 32) && rest.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(rest[..8].to_string())
     } else {
         None
     }
+}
+
+/// Exact ownership check for newly generated exec scopes. Legacy 8-hex tags
+/// intentionally do not match: stopping them immediately would reintroduce
+/// the collision this check prevents; the ownership-aware periodic reaper
+/// handles those old scopes instead.
+pub fn exec_unit_belongs_to_mission(unit: &str, mission_id: uuid::Uuid) -> bool {
+    let name = unit.strip_suffix(".scope").unwrap_or(unit);
+    let mut segments = name.rsplit('-');
+    let _random = segments.next();
+    let Some(tag) = segments.next().and_then(|tag| tag.strip_prefix('m')) else {
+        return false;
+    };
+    tag.len() == 32
+        && tag.eq_ignore_ascii_case(&mission_id.simple().to_string())
+        && tag.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// Recover the exact machine token from a per-exec scope name. Parsing from
@@ -462,9 +489,10 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 mod tests {
     use super::{
         ca_env_scrub_prelude, durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
-        machine_name_from_exec_unit, mission_short_id_from_exec_unit, mission_tag_from_path,
-        normalize_container_path, resolv_conf_bind_args, synthesized_container_resolv_conf,
-        WorkspaceExec, CA_BUNDLE_ENV_VARS,
+        exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
+        mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
+        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
+        CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::path::Path;
@@ -574,6 +602,29 @@ mod tests {
         );
         assert_eq!(mission_short_id_from_exec_unit(&unit), None);
         assert!(!unit.starts_with("sandboxed-exec-"));
+    }
+
+    #[test]
+    fn full_mission_scope_tag_prevents_short_id_collisions() {
+        let first = uuid::Uuid::parse_str("deadbeef-0000-4000-8000-000000000001").unwrap();
+        let collision = uuid::Uuid::parse_str("deadbeef-0000-4000-8000-000000000002").unwrap();
+        let unit = exec_scope_unit_for_mission(
+            "sandboxed-dumbcontracts-634e6d35",
+            Some(Path::new("/workspaces/mission-deadbeef")),
+            Some(first),
+        );
+
+        assert!(exec_unit_belongs_to_mission(&unit, first));
+        assert!(!exec_unit_belongs_to_mission(&unit, collision));
+        assert_eq!(
+            mission_short_id_from_exec_unit(&unit).as_deref(),
+            Some("deadbeef")
+        );
+        let legacy = exec_scope_unit(
+            "sandboxed-dumbcontracts-634e6d35",
+            Some(Path::new("/workspaces/mission-deadbeef")),
+        );
+        assert!(!exec_unit_belongs_to_mission(&legacy, first));
     }
 
     #[test]
@@ -1422,10 +1473,14 @@ impl WorkspaceExec {
         // mission tag so mission-end teardown can stop exactly this
         // mission's scopes.
         let caps = self.mission_resource_caps();
+        let mission_id = env
+            .get("MISSION_ID")
+            .and_then(|value| uuid::Uuid::parse_str(value).ok());
         let exec_unit = scope_unit.map(str::to_owned).unwrap_or_else(|| {
-            exec_scope_unit(
+            exec_scope_unit_for_mission(
                 &self.machine_name().unwrap_or_else(|| "unknown".to_string()),
                 Some(cwd),
+                mission_id,
             )
         });
         let mut cmd = if let Some(scope_args) = caps.scope_run_args(&exec_unit) {

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -24,6 +24,7 @@ const CONTAINER_KEEPALIVE_ENV_KEY: &str = "SANDBOXED_SH_CONTAINER_KEEPALIVE";
 const CONTAINER_KEEPALIVE_ENV_VALUE: &str = "1";
 const ALLOW_TRANSIENT_CONTAINER_NSENTER_ENV: &str =
     "SANDBOXED_SH_ALLOW_TRANSIENT_CONTAINER_NSENTER";
+const NSENTER_USE_TARGET_ROOT_ENV: &str = "SANDBOXED_SH_NSENTER_USE_TARGET_ROOT";
 
 /// TLS CA-bundle env vars that point at a filesystem path. When the host
 /// process that launches a container mission (e.g. the sandboxed.sh daemon
@@ -118,6 +119,12 @@ fn environ_has_keepalive_marker(environ: &[u8]) -> bool {
     environ
         .split(|byte| *byte == 0)
         .any(|entry| entry == expected.as_bytes())
+}
+
+fn append_nsenter_target_root_arg(args: &mut Vec<String>, enabled: bool) {
+    if enabled {
+        args.push("--root".to_string());
+    }
 }
 
 /// Stable container identity for a workspace, derived from its path. Every
@@ -488,11 +495,11 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ca_env_scrub_prelude, durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
-        exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
-        mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
-        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
-        CA_BUNDLE_ENV_VARS,
+        append_nsenter_target_root_arg, ca_env_scrub_prelude, durable_scope_unit,
+        environ_has_keepalive_marker, exec_scope_unit, exec_scope_unit_for_mission,
+        exec_unit_belongs_to_mission, machine_name_from_exec_unit, mission_short_id_from_exec_unit,
+        mission_tag_from_path, normalize_container_path, resolv_conf_bind_args,
+        synthesized_container_resolv_conf, WorkspaceExec, CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::path::Path;
@@ -777,6 +784,18 @@ mod tests {
         assert!(!environ_has_keepalive_marker(
             b"PATH=/usr/bin\0SANDBOXED_SH_CONTAINER_KEEPALIVE=0\0HOME=/root\0"
         ));
+    }
+
+    #[test]
+    fn pty_nsenter_target_root_guard_precedes_shell_payload() {
+        let mut args = vec!["--pid".to_string()];
+        append_nsenter_target_root_arg(&mut args, true);
+        args.extend(["/bin/sh".to_string(), "-lc".to_string()]);
+        assert_eq!(args, ["--pid", "--root", "/bin/sh", "-lc"]);
+
+        let mut disabled = vec!["--pid".to_string()];
+        append_nsenter_target_root_arg(&mut disabled, false);
+        assert_eq!(disabled, ["--pid"]);
     }
 }
 
@@ -1533,15 +1552,7 @@ impl WorkspaceExec {
         // existing deployment doesn't break on upgrade; once a host is
         // verified, set `SANDBOXED_SH_NSENTER_USE_TARGET_ROOT=1` in the env
         // file to flip the safe default on.
-        let use_target_root = std::env::var("SANDBOXED_SH_NSENTER_USE_TARGET_ROOT")
-            .ok()
-            .map(|v| {
-                matches!(
-                    v.trim().to_lowercase().as_str(),
-                    "1" | "true" | "yes" | "on"
-                )
-            })
-            .unwrap_or(false);
+        let use_target_root = env_var_bool(NSENTER_USE_TARGET_ROOT_ENV, false);
         if use_target_root {
             // `--root` with no arg = use the *target* process's root, i.e.
             // the container rootfs. After this flag the new shell can only
@@ -2011,7 +2022,7 @@ impl WorkspaceExec {
             Self::build_shell_command_with_env(&rel_cwd, program, args, None)
         };
 
-        let nsenter_args = vec![
+        let mut nsenter_args = vec![
             "--target".to_string(),
             leader,
             "--mount".to_string(),
@@ -2019,10 +2030,15 @@ impl WorkspaceExec {
             "--ipc".to_string(),
             "--net".to_string(),
             "--pid".to_string(),
-            "/bin/sh".to_string(),
-            "-lc".to_string(),
-            shell_cmd,
         ];
+        // Keep PTY launches under the same target-root guard as non-PTY
+        // nsenter. Entering only the mount namespace still retains the host
+        // root directory, allowing absolute paths to escape the container.
+        append_nsenter_target_root_arg(
+            &mut nsenter_args,
+            env_var_bool(NSENTER_USE_TARGET_ROOT_ENV, false),
+        );
+        nsenter_args.extend(["/bin/sh".to_string(), "-lc".to_string(), shell_cmd]);
 
         // Same cgroup-escape hatch as build_nsenter_command, PTY edition:
         // this invocation is what launches harness CLIs (claude/codex/…) for

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -1663,6 +1663,43 @@ impl WorkspaceExec {
         Ok(child)
     }
 
+    /// Spawn a workspace-aware command with caller-provided stdio.
+    ///
+    /// Durable jobs use file-backed stdout/stderr rather than pipes so they
+    /// can outlive the agent turn that launched them without blocking on an
+    /// abandoned pipe reader.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn spawn_with_stdio(
+        &self,
+        cwd: &Path,
+        program: &str,
+        args: &[String],
+        env: HashMap<String, String>,
+        stdin: Stdio,
+        stdout: Stdio,
+        stderr: Stdio,
+    ) -> anyhow::Result<Child> {
+        let env = self.build_env(env);
+        let mut cmd = self
+            .build_command(cwd, program, args, env, stdin, stdout, stderr)
+            .await
+            .context("Failed to build workspace command")?;
+        // Durable-job cancellation targets the spawned process group. Give
+        // every workspace-aware launch its own session so cancelling a job
+        // cannot signal the API service's process group. Descendants of a
+        // systemd-run/nsenter wrapper inherit this group as well.
+        #[cfg(unix)]
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        cmd.spawn().context("Failed to spawn workspace command")
+    }
+
     pub async fn spawn_streaming_pty(
         &self,
         cwd: &Path,

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -207,6 +207,14 @@ pub fn exec_scope_unit(machine_name: &str, cwd: Option<&Path>) -> String {
     }
 }
 
+/// Unit name for a durable job scope. Durable scopes deliberately use a
+/// separate prefix and contain no mission tag: mission-end teardown only owns
+/// `sandboxed-exec-*`, while the durable-job registry owns and cancels these
+/// scopes explicitly.
+pub fn durable_scope_unit(machine_name: &str, job_id: uuid::Uuid) -> String {
+    format!("sandboxed-durable-{machine_name}-{}", job_id.simple())
+}
+
 /// Recover the 8-hex mission short id from an exec scope unit name produced
 /// by [`exec_scope_unit`]. Parses from the END (`…-m<8hex>-<rand8>.scope`) so
 /// machine-name segments can never false-positive. Returns `None` for
@@ -453,7 +461,7 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ca_env_scrub_prelude, environ_has_keepalive_marker, exec_scope_unit,
+        ca_env_scrub_prelude, durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
         machine_name_from_exec_unit, mission_short_id_from_exec_unit, mission_tag_from_path,
         normalize_container_path, resolv_conf_bind_args, synthesized_container_resolv_conf,
         WorkspaceExec, CA_BUNDLE_ENV_VARS,
@@ -553,6 +561,19 @@ mod tests {
             .as_deref(),
             Some("sandboxed-dumbcontracts-634e6d35")
         );
+    }
+
+    #[test]
+    fn durable_scope_is_not_owned_by_mission_reaper() {
+        let id = uuid::Uuid::parse_str("df71826d-2060-44bd-b674-0ab16083e3b3").unwrap();
+        let unit = durable_scope_unit("sandboxed-dumbcontracts-634e6d35", id);
+
+        assert_eq!(
+            unit,
+            "sandboxed-durable-sandboxed-dumbcontracts-634e6d35-df71826d206044bdb6740ab16083e3b3"
+        );
+        assert_eq!(mission_short_id_from_exec_unit(&unit), None);
+        assert!(!unit.starts_with("sandboxed-exec-"));
     }
 
     #[test]
@@ -1118,7 +1139,7 @@ impl WorkspaceExec {
         cmd
     }
 
-    fn machine_name(&self) -> Option<String> {
+    pub(crate) fn machine_name(&self) -> Option<String> {
         machine_name_for_path(&self.workspace.path)
     }
 
@@ -1360,6 +1381,7 @@ impl WorkspaceExec {
         stdin: Stdio,
         stdout: Stdio,
         stderr: Stdio,
+        scope_unit: Option<&str>,
     ) -> anyhow::Result<Command> {
         let nsenter = if Path::new("/usr/bin/nsenter").exists() {
             "/usr/bin/nsenter"
@@ -1400,10 +1422,12 @@ impl WorkspaceExec {
         // mission tag so mission-end teardown can stop exactly this
         // mission's scopes.
         let caps = self.mission_resource_caps();
-        let exec_unit = exec_scope_unit(
-            &self.machine_name().unwrap_or_else(|| "unknown".to_string()),
-            Some(cwd),
-        );
+        let exec_unit = scope_unit.map(str::to_owned).unwrap_or_else(|| {
+            exec_scope_unit(
+                &self.machine_name().unwrap_or_else(|| "unknown".to_string()),
+                Some(cwd),
+            )
+        });
         let mut cmd = if let Some(scope_args) = caps.scope_run_args(&exec_unit) {
             let mut c = Command::new("systemd-run");
             c.args(&scope_args);
@@ -1463,6 +1487,7 @@ impl WorkspaceExec {
         stdin: Stdio,
         stdout: Stdio,
         stderr: Stdio,
+        scope_unit: Option<&str>,
     ) -> anyhow::Result<Command> {
         match self.workspace.workspace_type {
             WorkspaceType::Host => {
@@ -1553,6 +1578,7 @@ impl WorkspaceExec {
                     stdin,
                     stdout,
                     stderr,
+                    scope_unit,
                 )
             }
         }
@@ -1587,6 +1613,7 @@ impl WorkspaceExec {
                     Stdio::null(),
                     Stdio::piped(),
                     Stdio::piped(),
+                    None,
                 )
                 .await
                 .context("Failed to build workspace command")?;
@@ -1655,6 +1682,7 @@ impl WorkspaceExec {
                 Stdio::piped(), // Pipe stdin for processes that read input (e.g., Claude Code --print)
                 Stdio::piped(),
                 Stdio::piped(),
+                None,
             )
             .await
             .context("Failed to build workspace command")?;
@@ -1678,10 +1706,23 @@ impl WorkspaceExec {
         stdin: Stdio,
         stdout: Stdio,
         stderr: Stdio,
+        durable_job_id: uuid::Uuid,
     ) -> anyhow::Result<Child> {
         let env = self.build_env(env);
+        let scope_unit = self
+            .machine_name()
+            .map(|machine| durable_scope_unit(&machine, durable_job_id));
         let mut cmd = self
-            .build_command(cwd, program, args, env, stdin, stdout, stderr)
+            .build_command(
+                cwd,
+                program,
+                args,
+                env,
+                stdin,
+                stdout,
+                stderr,
+                scope_unit.as_deref(),
+            )
             .await
             .context("Failed to build workspace command")?;
         // Durable-job cancellation targets the spawned process group. Give

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -219,6 +219,29 @@ pub fn mission_short_id_from_exec_unit(unit: &str) -> Option<String> {
     }
 }
 
+/// Recover the exact machine token from a per-exec scope name. Parsing from
+/// the right avoids ambiguous substring/prefix ownership matches when two
+/// user-controlled workspace names overlap.
+pub fn machine_name_from_exec_unit(unit: &str) -> Option<String> {
+    let name = unit
+        .strip_suffix(".scope")
+        .unwrap_or(unit)
+        .strip_prefix("sandboxed-exec-")?;
+    let (before_rand, rand) = name.rsplit_once('-')?;
+    if !matches!(rand.len(), 8 | 32) || !rand.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    if let Some((machine, tag)) = before_rand.rsplit_once('-') {
+        let tagged = tag.len() == 9
+            && matches!(tag.as_bytes().first(), Some(b'm' | b't'))
+            && tag[1..].chars().all(|c| c.is_ascii_hexdigit());
+        if tagged {
+            return Some(machine.to_string());
+        }
+    }
+    Some(before_rand.to_string())
+}
+
 /// systemd slice that hosts every mission scope. Putting all mission scopes
 /// under one slice makes them cgroup *siblings* of the API service instead of
 /// children, and lets ops pin an **aggregate** memory cap on the slice so the
@@ -426,9 +449,9 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 mod tests {
     use super::{
         ca_env_scrub_prelude, environ_has_keepalive_marker, exec_scope_unit,
-        mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
-        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
-        CA_BUNDLE_ENV_VARS,
+        machine_name_from_exec_unit, mission_short_id_from_exec_unit, mission_tag_from_path,
+        normalize_container_path, resolv_conf_bind_args, synthesized_container_resolv_conf,
+        WorkspaceExec, CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::path::Path;
@@ -492,6 +515,26 @@ mod tests {
         let bare = exec_scope_unit("sandboxed-misc-deadbeef", None);
         assert_eq!(mission_short_id_from_exec_unit(&bare), None);
         assert!(bare.starts_with("sandboxed-exec-sandboxed-misc-deadbeef-"));
+
+        assert_eq!(
+            machine_name_from_exec_unit(&format!("{unit}.scope")).as_deref(),
+            Some("sandboxed-dumbcontracts-634e6d35")
+        );
+        assert_eq!(
+            machine_name_from_exec_unit(&task_unit).as_deref(),
+            Some("sandboxed-misc-deadbeef")
+        );
+        assert_eq!(
+            machine_name_from_exec_unit(&bare).as_deref(),
+            Some("sandboxed-misc-deadbeef")
+        );
+        assert_eq!(
+            machine_name_from_exec_unit(
+                "sandboxed-exec-sandboxed-dumbcontracts-634e6d35-000b8543a2244e49875a6bf64594dbc5.scope"
+            )
+            .as_deref(),
+            Some("sandboxed-dumbcontracts-634e6d35")
+        );
     }
 
     #[test]

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -30,6 +30,11 @@ fn replace_command_env(cmd: &mut Command, env: HashMap<String, String>) {
     cmd.env_clear().envs(env);
 }
 
+fn durable_command_runs_on_api_host(workspace_type: WorkspaceType, uses_nspawn: bool) -> bool {
+    workspace_type == WorkspaceType::Host
+        || (workspace_type == WorkspaceType::Container && !uses_nspawn)
+}
+
 /// TLS CA-bundle env vars that point at a filesystem path. When the host
 /// process that launches a container mission (e.g. the sandboxed.sh daemon
 /// started from a Python venv) has one of these set, the value leaks into the
@@ -499,12 +504,12 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_nsenter_target_root_arg, ca_env_scrub_prelude, durable_scope_unit,
-        environ_has_keepalive_marker, exec_scope_unit, exec_scope_unit_for_mission,
-        exec_unit_belongs_to_mission, machine_name_from_exec_unit, mission_short_id_from_exec_unit,
-        mission_tag_from_path, normalize_container_path, replace_command_env,
-        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
-        CA_BUNDLE_ENV_VARS,
+        append_nsenter_target_root_arg, ca_env_scrub_prelude, durable_command_runs_on_api_host,
+        durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
+        exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
+        mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
+        replace_command_env, resolv_conf_bind_args, synthesized_container_resolv_conf,
+        WorkspaceExec, WorkspaceType, CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::path::Path;
@@ -632,6 +637,19 @@ mod tests {
         assert!(stdout.lines().any(|line| line == "WORKSPACE_VALUE=visible"));
         assert!(!stdout.contains("API_ONLY_SECRET"));
         assert!(!stdout.contains("must-not-leak"));
+    }
+
+    #[test]
+    fn durable_container_fallback_replaces_service_environment() {
+        assert!(durable_command_runs_on_api_host(
+            WorkspaceType::Container,
+            false
+        ));
+        assert!(durable_command_runs_on_api_host(WorkspaceType::Host, false));
+        assert!(!durable_command_runs_on_api_host(
+            WorkspaceType::Container,
+            true
+        ));
     }
 
     #[test]
@@ -1821,8 +1839,11 @@ impl WorkspaceExec {
         durable_job_id: uuid::Uuid,
     ) -> anyhow::Result<Child> {
         let env = self.build_env(env);
-        let host_env =
-            matches!(self.workspace.workspace_type, WorkspaceType::Host).then(|| env.clone());
+        let host_env = durable_command_runs_on_api_host(
+            self.workspace.workspace_type,
+            use_nspawn_for_workspace(&self.workspace),
+        )
+        .then(|| env.clone());
         let scope_unit = self
             .machine_name()
             .map(|machine| durable_scope_unit(&machine, durable_job_id));
@@ -1839,11 +1860,12 @@ impl WorkspaceExec {
             )
             .await
             .context("Failed to build workspace command")?;
-        // Host durable jobs execute in the API host namespace, so unlike an
-        // nspawn/nsenter command there is no isolation boundary that drops
-        // the service process environment. Replace it explicitly with the
-        // workspace/job allowlist before spawning; otherwise a workspace
-        // owner could read API credentials through a durable job's logs.
+        // Host and container-fallback durable jobs execute in the API host
+        // namespace, so unlike an nspawn/nsenter command there is no
+        // isolation boundary that drops the service process environment.
+        // Replace it explicitly with the workspace/job allowlist before
+        // spawning; otherwise a workspace owner could read API credentials
+        // through a durable job's logs.
         if let Some(host_env) = host_env {
             replace_command_env(&mut cmd, host_env);
         }

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -26,6 +26,10 @@ const ALLOW_TRANSIENT_CONTAINER_NSENTER_ENV: &str =
     "SANDBOXED_SH_ALLOW_TRANSIENT_CONTAINER_NSENTER";
 const NSENTER_USE_TARGET_ROOT_ENV: &str = "SANDBOXED_SH_NSENTER_USE_TARGET_ROOT";
 
+fn replace_command_env(cmd: &mut Command, env: HashMap<String, String>) {
+    cmd.env_clear().envs(env);
+}
+
 /// TLS CA-bundle env vars that point at a filesystem path. When the host
 /// process that launches a container mission (e.g. the sandboxed.sh daemon
 /// started from a Python venv) has one of these set, the value leaks into the
@@ -498,11 +502,13 @@ mod tests {
         append_nsenter_target_root_arg, ca_env_scrub_prelude, durable_scope_unit,
         environ_has_keepalive_marker, exec_scope_unit, exec_scope_unit_for_mission,
         exec_unit_belongs_to_mission, machine_name_from_exec_unit, mission_short_id_from_exec_unit,
-        mission_tag_from_path, normalize_container_path, resolv_conf_bind_args,
-        synthesized_container_resolv_conf, WorkspaceExec, CA_BUNDLE_ENV_VARS,
+        mission_tag_from_path, normalize_container_path, replace_command_env,
+        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
+        CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::path::Path;
+    use tokio::process::Command;
 
     #[test]
     fn mission_tag_extracted_from_workspace_cwd() {
@@ -609,6 +615,23 @@ mod tests {
         );
         assert_eq!(mission_short_id_from_exec_unit(&unit), None);
         assert!(!unit.starts_with("sandboxed-exec-"));
+    }
+
+    #[tokio::test]
+    async fn durable_host_environment_replaces_service_environment() {
+        let mut cmd = Command::new("/usr/bin/env");
+        cmd.env("API_ONLY_SECRET", "must-not-leak");
+        replace_command_env(
+            &mut cmd,
+            HashMap::from([("WORKSPACE_VALUE".to_string(), "visible".to_string())]),
+        );
+
+        let output = cmd.output().await.unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.lines().any(|line| line == "WORKSPACE_VALUE=visible"));
+        assert!(!stdout.contains("API_ONLY_SECRET"));
+        assert!(!stdout.contains("must-not-leak"));
     }
 
     #[test]
@@ -1798,6 +1821,8 @@ impl WorkspaceExec {
         durable_job_id: uuid::Uuid,
     ) -> anyhow::Result<Child> {
         let env = self.build_env(env);
+        let host_env =
+            matches!(self.workspace.workspace_type, WorkspaceType::Host).then(|| env.clone());
         let scope_unit = self
             .machine_name()
             .map(|machine| durable_scope_unit(&machine, durable_job_id));
@@ -1814,6 +1839,14 @@ impl WorkspaceExec {
             )
             .await
             .context("Failed to build workspace command")?;
+        // Host durable jobs execute in the API host namespace, so unlike an
+        // nspawn/nsenter command there is no isolation boundary that drops
+        // the service process environment. Replace it explicitly with the
+        // workspace/job allowlist before spawning; otherwise a workspace
+        // owner could read API credentials through a durable job's logs.
+        if let Some(host_env) = host_env {
+            replace_command_env(&mut cmd, host_env);
+        }
         // Durable-job cancellation targets the spawned process group. Give
         // every workspace-aware launch its own session so cancelling a job
         // cannot signal the API service's process group. Descendants of a

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -166,6 +166,59 @@ fn mission_scope_unit(machine_name: &str) -> String {
     format!("sandboxed-mission-{sanitized}.scope")
 }
 
+/// Mission/task tag derived from an exec working directory. Per-mission dirs
+/// are `.../workspaces/mission-<first-8-hex-of-uuid>/…` (see
+/// `workspace::mission_workspace_dir_for_root`), so the tag is recoverable
+/// from any cwd inside a mission workspace. It is embedded in exec scope
+/// unit names so mission-end teardown and the zombie reaper can select one
+/// mission's scopes without a process registry.
+pub fn mission_tag_from_path(cwd: &Path) -> Option<String> {
+    for comp in cwd.components() {
+        let Some(name) = comp.as_os_str().to_str() else {
+            continue;
+        };
+        for (prefix, tag) in [("mission-", 'm'), ("task-", 't')] {
+            if let Some(rest) = name.strip_prefix(prefix) {
+                if rest.len() == 8 && rest.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Some(format!("{tag}{}", rest.to_ascii_lowercase()));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Unit name for a per-exec transient scope:
+/// `sandboxed-exec-<machine>[-m<8hex>|-t<8hex>]-<rand8>`.
+/// The machine token comes first (workspace-level substring discovery by
+/// `list_workspace_scope_units` stays intact), the optional mission/task tag
+/// second (per-mission teardown), and a short random suffix for uniqueness.
+pub fn exec_scope_unit(machine_name: &str, cwd: Option<&Path>) -> String {
+    let rand = uuid::Uuid::new_v4().simple().to_string();
+    let rand8 = &rand[..8];
+    match cwd.and_then(mission_tag_from_path) {
+        Some(tag) => format!("sandboxed-exec-{machine_name}-{tag}-{rand8}"),
+        None => format!("sandboxed-exec-{machine_name}-{rand8}"),
+    }
+}
+
+/// Recover the 8-hex mission short id from an exec scope unit name produced
+/// by [`exec_scope_unit`]. Parses from the END (`…-m<8hex>-<rand8>.scope`) so
+/// machine-name segments can never false-positive. Returns `None` for
+/// legacy-named units (pre-mission-tag) and task-tagged units.
+pub fn mission_short_id_from_exec_unit(unit: &str) -> Option<String> {
+    let name = unit.strip_suffix(".scope").unwrap_or(unit);
+    let mut segs = name.rsplit('-');
+    let _rand = segs.next()?;
+    let tag = segs.next()?;
+    let rest = tag.strip_prefix('m')?;
+    if rest.len() == 8 && rest.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(rest.to_string())
+    } else {
+        None
+    }
+}
+
 /// systemd slice that hosts every mission scope. Putting all mission scopes
 /// under one slice makes them cgroup *siblings* of the API service instead of
 /// children, and lets ops pin an **aggregate** memory cap on the slice so the
@@ -372,12 +425,74 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ca_env_scrub_prelude, environ_has_keepalive_marker, normalize_container_path,
+        ca_env_scrub_prelude, environ_has_keepalive_marker, exec_scope_unit,
+        mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
         resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec,
         CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::path::Path;
+
+    #[test]
+    fn mission_tag_extracted_from_workspace_cwd() {
+        assert_eq!(
+            mission_tag_from_path(Path::new(
+                "/root/.sandboxed-sh/containers/dumbcontracts/workspaces/mission-4efda364/repo"
+            ))
+            .as_deref(),
+            Some("m4efda364")
+        );
+        assert_eq!(
+            mission_tag_from_path(Path::new("/workspaces/task-deadbeef")).as_deref(),
+            Some("tdeadbeef")
+        );
+        // Not 8 hex chars → no tag.
+        assert_eq!(
+            mission_tag_from_path(Path::new("/workspaces/mission-xyz")),
+            None
+        );
+        assert_eq!(
+            mission_tag_from_path(Path::new("/workspaces/mission-123456789")),
+            None
+        );
+        assert_eq!(mission_tag_from_path(Path::new("/srv/monorepo")), None);
+    }
+
+    #[test]
+    fn exec_scope_unit_roundtrips_mission_short_id() {
+        let unit = exec_scope_unit(
+            "sandboxed-dumbcontracts-634e6d35",
+            Some(Path::new("/workspaces/mission-4efda364")),
+        );
+        assert!(unit.starts_with("sandboxed-exec-sandboxed-dumbcontracts-634e6d35-m4efda364-"));
+        assert_eq!(
+            mission_short_id_from_exec_unit(&format!("{unit}.scope")).as_deref(),
+            Some("4efda364")
+        );
+        assert_eq!(
+            mission_short_id_from_exec_unit(&unit).as_deref(),
+            Some("4efda364")
+        );
+
+        // Legacy naming (32-char random suffix, no tag) must not parse — the
+        // machine hash segment is 8 hex but lacks the `m` prefix.
+        assert_eq!(
+            mission_short_id_from_exec_unit(
+                "sandboxed-exec-sandboxed-dumbcontracts-634e6d35-000b8543a2244e49875a6bf64594dbc5.scope"
+            ),
+            None
+        );
+        // Task tags are not mission ids.
+        let task_unit = exec_scope_unit(
+            "sandboxed-misc-deadbeef",
+            Some(Path::new("/workspaces/task-01234567")),
+        );
+        assert_eq!(mission_short_id_from_exec_unit(&task_unit), None);
+        // No cwd → no tag, still unique-suffixed.
+        let bare = exec_scope_unit("sandboxed-misc-deadbeef", None);
+        assert_eq!(mission_short_id_from_exec_unit(&bare), None);
+        assert!(bare.starts_with("sandboxed-exec-sandboxed-misc-deadbeef-"));
+    }
 
     #[test]
     fn synthesized_resolv_conf_uses_public_dns_before_magic_dns() {
@@ -1220,12 +1335,13 @@ impl WorkspaceExec {
         // container's own scope sat at 24G/2MB). Wrap each attach in its
         // own capped transient scope when `MISSION_MEMORY_MAX` is set.
         // The unit embeds the machine name so the API layer can find and
-        // retune every scope belonging to one workspace at runtime.
+        // retune every scope belonging to one workspace at runtime, plus the
+        // mission tag so mission-end teardown can stop exactly this
+        // mission's scopes.
         let caps = self.mission_resource_caps();
-        let exec_unit = format!(
-            "sandboxed-exec-{}-{}",
-            self.machine_name().unwrap_or_else(|| "unknown".to_string()),
-            uuid::Uuid::new_v4().simple()
+        let exec_unit = exec_scope_unit(
+            &self.machine_name().unwrap_or_else(|| "unknown".to_string()),
+            Some(cwd),
         );
         let mut cmd = if let Some(scope_args) = caps.scope_run_args(&exec_unit) {
             let mut c = Command::new("systemd-run");
@@ -1700,10 +1816,9 @@ impl WorkspaceExec {
         // --scope keeps the payload as its own foreground child, so PTY
         // semantics and group-kill teardown are preserved.
         let caps = self.mission_resource_caps();
-        let exec_unit = format!(
-            "sandboxed-exec-{}-{}",
-            self.machine_name().unwrap_or_else(|| "unknown".to_string()),
-            uuid::Uuid::new_v4().simple()
+        let exec_unit = exec_scope_unit(
+            &self.machine_name().unwrap_or_else(|| "unknown".to_string()),
+            Some(cwd),
         );
         if let Some(scope_args) = caps.scope_run_args(&exec_unit) {
             let mut args = scope_args;


### PR DESCRIPTION
## Context

2026-07-12: the prod root filesystem hit 100%, blocking Hermes controllers and crashing the supervisor (ENOSPC). Forensics found four structural leaks; this PR fixes them and productizes the remote-node fleet (Phase 0).

## Shipped (first wave)

1. **Deploy backup pruning** — `/api/system/deploy` keeps `DEPLOY_BACKUP_KEEP` (default 2) `.pre-deploy-*` backups per binary; ~500 of them held 114 GB on prod.
2. **Disk preflight + alerting** — `DiskHealthLevel` (warn 90 / crit 95), actor-level CreateMission admission gate (covers HTTP/Ask/Telegram), `GET /api/health/fleet` now reports `disk_*`, and a `disk_watch` task pushes HMAC-signed webhook alerts with hysteresis + recovery notice.
3. **Exec-scope lifecycle** — scope units now embed the mission short id (`-m<8hex>-`); an event listener stops a mission's scopes when its status stops needing a harness (resume always re-spawns); a periodic reaper drains zombies incl. 312 legacy-named ones on prod (age + no-live-mission-in-workspace policy). `WaitingBackground` always exempt.
4. **Workspace GC v2** — disk-driven orphan sweep reconciling `mission-*` dirs against a cross-store mission index: hard-deleted/legacy dirs, dirs under re-created workspaces, and AwaitingUser/Paused past a 30-day long-stop retention (`auto_cleanup_stopped_days`, `auto_cleanup_orphans_enabled`).

## Coming in this PR (second wave)

Remote-node fleet Phase 0 (S1 security+heartbeat v2+monitor, S2 async jobs, S3 declarative lean_build with shared caches, S4 capacity-aware auto placement + `POST /api/remote-build` + `remote-lean-build` wrapper).

Do not merge — deployed and verified from this branch; review via @codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to mission admission, remote dispatch/reconciliation, and durable-job execution touch production capacity and security; misconfiguration or edge cases in job ledgers or terminal finalization could strand missions or leak work onto nodes.
> 
> **Overview**
> **Disk and fleet hygiene** adds configurable warn/critical thresholds, a background `disk_watch` loop with HMAC webhook alerts, **mission creation refused** at critical root-disk usage (actor-level gate), and **disk metrics** on fleet health. Settings/dashboard surface **`auto_cleanup_stopped_days`** and **`auto_cleanup_orphans_enabled`**; `.env.example` documents remote-node, disk, scope, and deploy-backup knobs.
> 
> **Remote runner Phase 0** expands core dispatch: **`remote_node_id: "auto"`** with label/resource floors and on-demand reprobes, **async node jobs** (durable ledger, poll loops, startup reconciler, cancellation paths) replacing blocking `/execute` for mission remote commands, plus **`POST /api/remote-build`**, mission capability tokens, and the **`scripts/remote-lean-build`** client. **`docs/REMOTE_NODES.md`** documents heartbeat v2, job API, lean builds, placement, and hardening.
> 
> **Durable jobs & automations**: jobs must run in a **workspace** with caller auth; completion can drive **`durable_job_terminal`** triggers and background-task auto-resume; tool results from **`durable_job_start`** are parsed into the background registry. Dashboard/API types add **cron**, **telegram**, and durable-job trigger labels; wakeup supersession keys generalize beyond Claude built-ins.
> 
> **Container/Ask fixes**: Ask isolated-copy sandboxes use correct **host vs guest paths** in nspawn; console shells get explicit workspace env; OpenCode **version sync** into containers and isolated auth/PATH behavior; Hermes example adds **`ask_mission`** and longer MCP timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fecb8f8e0a2af62cf097ffea6dff00ce6ce5cd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->