### PR TITLE
Fix shared container reuse and Anthropic OpenCode routing

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4987,9 +4987,20 @@ pub(crate) fn ensure_opencode_provider_for_model(
         serde_json::json!({ "name": model_id })
     };
 
-    // Only inject definitions for providers that need it.
-    // OpenAI, Anthropic, Google are natively supported by OpenCode.
+    // Only inject definitions for providers that need it. OpenCode 1.17 no
+    // longer materializes the Anthropic provider from OAuth credentials alone:
+    // the auth entry is present, but `opencode models anthropic` reports
+    // "Provider not found" until a provider definition exists in the workspace
+    // config. Keep the credentials in auth.json and declare the native adapter
+    // here so provider-prefixed model overrides remain valid.
     let provider_def: Option<serde_json::Value> = match provider_id {
+        "anthropic" => Some(serde_json::json!({
+            "npm": "@ai-sdk/anthropic",
+            "name": "Anthropic",
+            "models": {
+                model_id: model_entry.clone()
+            }
+        })),
         "zai" => {
             let base_url = std::env::var("ZAI_BASE_URL")
                 .unwrap_or_else(|_| "https://api.z.ai/api/coding/paas/v4".to_string());
@@ -9641,6 +9652,35 @@ mod tests {
         assert_eq!(
             provider["models"]["glm-5.2"]["capabilities"]["interleaved"]["field"],
             "reasoning_content"
+        );
+    }
+
+    #[test]
+    fn ensure_provider_for_model_injects_anthropic_native_adapter() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app_dir = temp_dir.path().join("app");
+        let config_dir = temp_dir.path().join("opencode");
+        fs::create_dir_all(&app_dir).expect("app dir");
+        fs::create_dir_all(&config_dir).expect("config dir");
+
+        ensure_opencode_provider_for_model(
+            &config_dir,
+            &app_dir,
+            "anthropic/claude-sonnet-4-5",
+            "127.0.0.1",
+            None,
+        );
+
+        let opencode_json: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
+        )
+        .expect("parse opencode.json");
+        let provider = &opencode_json["provider"]["anthropic"];
+        assert_eq!(provider["npm"], "@ai-sdk/anthropic");
+        assert_eq!(provider["name"], "Anthropic");
+        assert_eq!(
+            provider["models"]["claude-sonnet-4-5"]["name"],
+            "claude-sonnet-4-5"
         );
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4987,20 +4987,10 @@ pub(crate) fn ensure_opencode_provider_for_model(
         serde_json::json!({ "name": model_id })
     };
 
-    // Only inject definitions for providers that need it. OpenCode 1.17 no
-    // longer materializes the Anthropic provider from OAuth credentials alone:
-    // the auth entry is present, but `opencode models anthropic` reports
-    // "Provider not found" until a provider definition exists in the workspace
-    // config. Keep the credentials in auth.json and declare the native adapter
-    // here so provider-prefixed model overrides remain valid.
+    // Only inject definitions for providers that need it.
+    // OpenAI, Anthropic, Google are natively supported by OpenCode and their
+    // OAuth plugins are installed by the runner when credentials are present.
     let provider_def: Option<serde_json::Value> = match provider_id {
-        "anthropic" => Some(serde_json::json!({
-            "npm": "@ai-sdk/anthropic",
-            "name": "Anthropic",
-            "models": {
-                model_id: model_entry.clone()
-            }
-        })),
         "zai" => {
             let base_url = std::env::var("ZAI_BASE_URL")
                 .unwrap_or_else(|_| "https://api.z.ai/api/coding/paas/v4".to_string());
@@ -5384,6 +5374,24 @@ fn write_json_file(path: &std::path::Path, value: &serde_json::Value) -> std::io
     std::fs::write(path, contents)
 }
 
+fn overlay_opencode_auth(current: &mut Option<serde_json::Value>, overlay: serde_json::Value) {
+    let mut merged = match current.take() {
+        Some(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+    if let serde_json::Value::Object(entries) = overlay {
+        // The AI provider store is managed by Sandboxed.sh and refreshed by
+        // the runner before this function is called. It must win over stale
+        // host auth.json and legacy per-provider files.
+        merged.extend(entries);
+    }
+    *current = if merged.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(merged))
+    };
+}
+
 fn selected_opencode_auth_path(
     work_dir: &std::path::Path,
     shared_path: Option<std::path::PathBuf>,
@@ -5461,17 +5469,15 @@ pub(crate) fn sync_opencode_auth_to_workspace(
         }
     }
 
-    if auth_json.is_none() {
-        auth_json = build_opencode_auth_from_ai_providers(app_working_dir);
-        if let Some(ref value) = auth_json {
-            if let Some(dest_path) = auth_path.as_ref() {
-                if let Err(e) = write_json_file(dest_path, value) {
-                    tracing::warn!(
-                        "Failed to write OpenCode auth.json to workspace {}: {}",
-                        dest_path.display(),
-                        e
-                    );
-                }
+    if let Some(managed_auth) = build_opencode_auth_from_ai_providers(app_working_dir) {
+        overlay_opencode_auth(&mut auth_json, managed_auth);
+        if let (Some(value), Some(dest_path)) = (auth_json.as_ref(), auth_path.as_ref()) {
+            if let Err(e) = write_json_file(dest_path, value) {
+                tracing::warn!(
+                    "Failed to write managed OpenCode auth.json to workspace {}: {}",
+                    dest_path.display(),
+                    e
+                );
             }
         }
     }
@@ -8359,21 +8365,22 @@ mod tests {
         is_success_path_provider_payload_error, is_success_path_rate_limited_error,
         is_tool_call_only_output, opencode_goal_terminal_status,
         opencode_idle_timeout_result_message, opencode_output_needs_fallback,
-        opencode_session_exists_in_data_home, opencode_session_token_from_line, parse_cli_semver,
-        parse_opencode_goal_objective, parse_opencode_session_token, parse_opencode_sse_event,
-        parse_opencode_stderr_text_part, preferred_model_for_cost, preferred_opencode_bin_dir,
-        prepend_unique_path_entry, record_codex_error_message,
-        replace_filepath_artifact_with_tool_output, running_health, sanitized_opencode_stdout,
-        selected_opencode_auth_path, selected_opencode_provider_auth_dir,
-        set_codex_account_cooldown, should_sync_container_opencode, stall_severity,
-        strip_ansi_codes, strip_opencode_banner_lines, strip_think_tags,
-        summarize_codex_usage_caps, summarize_recent_opencode_stderr,
-        text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
-        truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
-        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
-        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
-        OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
-        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        opencode_session_exists_in_data_home, opencode_session_token_from_line,
+        overlay_opencode_auth, parse_cli_semver, parse_opencode_goal_objective,
+        parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
+        preferred_model_for_cost, preferred_opencode_bin_dir, prepend_unique_path_entry,
+        record_codex_error_message, replace_filepath_artifact_with_tool_output, running_health,
+        sanitized_opencode_stdout, selected_opencode_auth_path,
+        selected_opencode_provider_auth_dir, set_codex_account_cooldown,
+        should_sync_container_opencode, stall_severity, strip_ansi_codes,
+        strip_opencode_banner_lines, strip_think_tags, summarize_codex_usage_caps,
+        summarize_recent_opencode_stderr, text_buffer_stream_looks_degenerate,
+        thinking_overlaps_visible_answer, tls_error_hint, truncate_garbled_output,
+        use_thinking_only_fallback, utf8_safe_prefix, ClaudeIncompleteTurnContext,
+        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
+        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState,
+        CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN, CODEX_RATE_LIMIT_COOLDOWN,
+        STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -8411,6 +8418,25 @@ mod tests {
             selected_opencode_provider_auth_dir(work_dir, Some(shared_providers.clone()), true),
             Some(shared_providers)
         );
+    }
+
+    #[test]
+    fn managed_opencode_auth_overrides_stale_host_credentials() {
+        let mut current = Some(json!({
+            "anthropic": {"type": "oauth", "access": "stale", "expires": 1},
+            "unmanaged": {"type": "api_key", "key": "preserved"}
+        }));
+        overlay_opencode_auth(
+            &mut current,
+            json!({
+                "anthropic": {"type": "oauth", "access": "fresh", "expires": 2}
+            }),
+        );
+
+        let merged = current.expect("merged auth");
+        assert_eq!(merged["anthropic"]["access"], "fresh");
+        assert_eq!(merged["anthropic"]["expires"], 2);
+        assert_eq!(merged["unmanaged"]["key"], "preserved");
     }
 
     #[test]
@@ -9652,35 +9678,6 @@ mod tests {
         assert_eq!(
             provider["models"]["glm-5.2"]["capabilities"]["interleaved"]["field"],
             "reasoning_content"
-        );
-    }
-
-    #[test]
-    fn ensure_provider_for_model_injects_anthropic_native_adapter() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let app_dir = temp_dir.path().join("app");
-        let config_dir = temp_dir.path().join("opencode");
-        fs::create_dir_all(&app_dir).expect("app dir");
-        fs::create_dir_all(&config_dir).expect("config dir");
-
-        ensure_opencode_provider_for_model(
-            &config_dir,
-            &app_dir,
-            "anthropic/claude-sonnet-4-5",
-            "127.0.0.1",
-            None,
-        );
-
-        let opencode_json: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(config_dir.join("opencode.json")).expect("opencode.json"),
-        )
-        .expect("parse opencode.json");
-        let provider = &opencode_json["provider"]["anthropic"];
-        assert_eq!(provider["npm"], "@ai-sdk/anthropic");
-        assert_eq!(provider["name"], "Anthropic");
-        assert_eq!(
-            provider["models"]["claude-sonnet-4-5"]["name"],
-            "claude-sonnet-4-5"
         );
     }
 

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -296,6 +296,22 @@ pub async fn run_opencode_turn(
         )
         .await;
     }
+    if has_anthropic {
+        // OpenCode 1.17 does not load its Anthropic OAuth transport merely
+        // because auth.json contains an OAuth credential. Without the plugin,
+        // the provider is absent from the model catalog (or the plain AI SDK
+        // adapter asks for an API key instead of using the OAuth token).
+        let anthropic_plugin = "opencode-anthropic-auth@latest";
+        ensure_opencode_plugin_specs(&opencode_config_dir_host, &[anthropic_plugin]);
+        ensure_opencode_plugin_installed(
+            &workspace_exec,
+            work_dir,
+            &opencode_config_dir_host,
+            &opencode_config_dir_env,
+            anthropic_plugin,
+        )
+        .await;
+    }
     if has_openai {
         let openai_plugin = "opencode-openai-codex-auth@latest";
         ensure_opencode_plugin_specs(&opencode_config_dir_host, &[openai_plugin]);

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -154,7 +154,7 @@ fn nspawn_directory_from_cmdline(cmdline: &[u8]) -> Option<PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
-fn find_nspawn_pid_by_canonical_root(root: &Path) -> Option<String> {
+fn find_nspawn_by_canonical_root(root: &Path) -> Option<(String, PathBuf)> {
     let expected = root.canonicalize().ok()?;
     for entry in std::fs::read_dir("/proc").ok()?.flatten() {
         let pid = entry.file_name();
@@ -171,15 +171,19 @@ fn find_nspawn_pid_by_canonical_root(root: &Path) -> Option<String> {
             continue;
         };
         if directory.canonicalize().ok().as_deref() == Some(expected.as_path()) {
-            return Some(pid.to_string());
+            return Some((pid.to_string(), directory));
         }
     }
     None
 }
 
 #[cfg(not(target_os = "linux"))]
-fn find_nspawn_pid_by_canonical_root(_root: &Path) -> Option<String> {
+fn find_nspawn_by_canonical_root(_root: &Path) -> Option<(String, PathBuf)> {
     None
+}
+
+fn find_nspawn_pid_by_canonical_root(root: &Path) -> Option<String> {
+    find_nspawn_by_canonical_root(root).map(|(pid, _)| pid)
 }
 
 fn append_nsenter_target_root_arg(args: &mut Vec<String>, enabled: bool) {
@@ -195,7 +199,15 @@ fn append_nsenter_target_root_arg(args: &mut Vec<String>, enabled: bool) {
 /// Keep all scope-naming sites in sync with this — a divergent token makes a
 /// scope invisible to live stats, retune, and the OOM watchdog.
 pub fn machine_name_for_path(path: &Path) -> Option<String> {
-    let base = path
+    // When prod and dev refer to the same container through different
+    // symlinks, adopt the spelling used by the already-running nspawn. Its
+    // boot and exec scopes were hashed from that spelling, so using the local
+    // alias here would make those scopes invisible to stats, live retunes,
+    // mission GC, and the OOM watchdog.
+    let identity_path = find_nspawn_by_canonical_root(path)
+        .map(|(_, directory)| directory)
+        .unwrap_or_else(|| path.to_path_buf());
+    let base = identity_path
         .file_name()
         .and_then(|n| n.to_str())
         .map(|s| s.trim())
@@ -212,7 +224,7 @@ pub fn machine_name_for_path(path: &Path) -> Option<String> {
         .collect();
 
     let mut hasher = DefaultHasher::new();
-    path.hash(&mut hasher);
+    identity_path.hash(&mut hasher);
     let suffix = format!("{:08x}", hasher.finish() as u32);
 
     Some(format!("sandboxed-{}-{}", sanitized, suffix))

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -130,6 +130,58 @@ fn environ_has_keepalive_marker(environ: &[u8]) -> bool {
         .any(|entry| entry == expected.as_bytes())
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn nspawn_directory_from_cmdline(cmdline: &[u8]) -> Option<PathBuf> {
+    let args: Vec<&[u8]> = cmdline
+        .split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .collect();
+    let program = std::str::from_utf8(args.first()?).ok()?;
+    if Path::new(program).file_name()?.to_str()? != "systemd-nspawn" {
+        return None;
+    }
+    for (index, arg) in args.iter().enumerate().skip(1) {
+        if *arg == b"-D" || *arg == b"--directory" {
+            return std::str::from_utf8(args.get(index + 1)?)
+                .ok()
+                .map(PathBuf::from);
+        }
+        if let Some(value) = arg.strip_prefix(b"--directory=") {
+            return std::str::from_utf8(value).ok().map(PathBuf::from);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn find_nspawn_pid_by_canonical_root(root: &Path) -> Option<String> {
+    let expected = root.canonicalize().ok()?;
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let pid = entry.file_name();
+        let Some(pid) = pid.to_str() else {
+            continue;
+        };
+        if !pid.bytes().all(|byte| byte.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(cmdline) = std::fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        let Some(directory) = nspawn_directory_from_cmdline(&cmdline) else {
+            continue;
+        };
+        if directory.canonicalize().ok().as_deref() == Some(expected.as_path()) {
+            return Some(pid.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn find_nspawn_pid_by_canonical_root(_root: &Path) -> Option<String> {
+    None
+}
+
 fn append_nsenter_target_root_arg(args: &mut Vec<String>, enabled: bool) {
     if enabled {
         args.push("--root".to_string());
@@ -508,11 +560,11 @@ mod tests {
         durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
         exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
         mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
-        replace_command_env, resolv_conf_bind_args, synthesized_container_resolv_conf,
-        WorkspaceExec, WorkspaceType, CA_BUNDLE_ENV_VARS,
+        nspawn_directory_from_cmdline, replace_command_env, resolv_conf_bind_args,
+        synthesized_container_resolv_conf, WorkspaceExec, WorkspaceType, CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use tokio::process::Command;
 
     #[test]
@@ -825,6 +877,26 @@ mod tests {
         assert!(!environ_has_keepalive_marker(
             b"PATH=/usr/bin\0SANDBOXED_SH_CONTAINER_KEEPALIVE=0\0HOME=/root\0"
         ));
+    }
+
+    #[test]
+    fn nspawn_cmdline_directory_supports_short_and_long_forms() {
+        assert_eq!(
+            nspawn_directory_from_cmdline(
+                b"/usr/bin/systemd-nspawn\0-D\0/var/lib/containers/assistant\0--quiet\0"
+            ),
+            Some(PathBuf::from("/var/lib/containers/assistant"))
+        );
+        assert_eq!(
+            nspawn_directory_from_cmdline(
+                b"systemd-nspawn\0--directory=/root/.sandboxed-sh/containers/assistant\0"
+            ),
+            Some(PathBuf::from("/root/.sandboxed-sh/containers/assistant"))
+        );
+        assert_eq!(
+            nspawn_directory_from_cmdline(b"/usr/bin/bash\0-D\0/tmp/not-a-container\0"),
+            None
+        );
     }
 
     #[test]
@@ -1318,7 +1390,14 @@ impl WorkspaceExec {
                 }
             }
         }
-        let nspawn_pid = nspawn_pid?;
+        // Multiple API services can refer to the same container through
+        // different symlinked roots (for example prod and dev). pgrep only
+        // sees the spelling used by the service that started nspawn, so fall
+        // back to canonicalizing every live nspawn `-D` argument before
+        // deciding that no durable leader exists. Starting a second nspawn on
+        // the same root otherwise waits and eventually fails as "tree busy".
+        let nspawn_pid =
+            nspawn_pid.or_else(|| find_nspawn_pid_by_canonical_root(&self.workspace.path))?;
         let child_pids = Command::new("pgrep")
             .args(["-P", &nspawn_pid])
             .output()


### PR DESCRIPTION
## Summary
- discover durable systemd-nspawn leaders by canonicalizing live container roots, including symlink aliases shared by prod and dev
- reuse the existing leader instead of attempting a second nspawn on the same tree
- declare the native Anthropic adapter in per-workspace OpenCode config when an Anthropic model is selected, so OAuth credentials work with OpenCode 1.17

## Validation
- cargo fmt --all --check
- git diff --check
- targeted workspace_exec and Anthropic provider tests
- cargo clippy --all-targets --all-features -- -D warnings
- Linux validation on Thomas
- production smoke: shared canonical container leader reused successfully
- direct OpenCode catalog probe: Anthropic provider exposes Sonnet 4.5 after generated adapter declaration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Container identity and leader discovery changes affect multi-service deployments; auth overlay touches credential files but is scoped to OpenCode workspace config with explicit merge rules.
> 
> **Overview**
> Fixes **shared container reuse** when prod and dev point at the same nspawn tree via different symlink paths. The runner now scans live `systemd-nspawn` processes, matches `-D` roots by **canonical path**, and uses that spelling for `machine_name_for_path` hashing and durable-leader discovery when `pgrep` only sees one alias—avoiding a second nspawn that fails as “tree busy” and keeping systemd scope names aligned with the running leader.
> 
> For **OpenCode Anthropic OAuth**, the runner installs `opencode-anthropic-auth@latest` when Anthropic credentials are present (OpenCode 1.17 does not enable OAuth transport from `auth.json` alone). **Managed credentials** from Sandboxed.sh’s AI provider store are always **merged** into workspace `auth.json` via `overlay_opencode_auth`, so fresh managed tokens override stale host entries while unrelated provider keys are kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c49ab0f36135b3581f3866b74fcbc451b84399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->