### PR TITLE
feat: let Hermes manage workspaces

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1177,6 +1177,7 @@ export interface McpServerConfig {
   scope: McpScope;
   description: string | null;
   enabled: boolean;
+  workspace_env_allowlist: string[];
   version: string | null;
   tools: string[];
   created_at: string;
@@ -1247,6 +1248,7 @@ export interface UpdateMcpRequest {
   enabled?: boolean;
   transport?: McpTransport;
   scope?: McpScope;
+  workspace_env_allowlist?: string[];
 }
 
 export async function updateMcp(

--- a/docs-site/content/library.mdx
+++ b/docs-site/content/library.mdx
@@ -154,7 +154,9 @@ MCP (Model Context Protocol) servers provide tools and resources to agents.
 }
 ```
 
-MCP servers run on the host and are available to all missions.
+Workspace-scoped MCP servers run beside the harness in the selected host or
+container workspace. Stdio servers receive a clean, explicitly allowlisted
+environment; they do not inherit every workspace credential.
 
 ## Workspace Templates
 
@@ -185,7 +187,7 @@ Create workspaces from templates for consistent, reproducible environments.
 | Commands | Global | Available everywhere |
 | Rules | Global | All missions |
 | Agents | Global | Selectable per-mission |
-| MCPs | Global | Run on host |
+| MCP definitions | Global registry | Selected per workspace; run in its execution context |
 | Templates | Per-workspace | Container creation |
 
 ## Syncing

--- a/docs-site/content/workspaces.mdx
+++ b/docs-site/content/workspaces.mdx
@@ -5,7 +5,10 @@ description: Isolated environments for agent tasks
 
 # Workspaces
 
-Workspaces are isolated environments where agents execute tasks. Each workspace has its own file system, installed software, and configuration.
+Workspaces are reusable execution environments where agents run missions. A
+workspace owns the filesystem, installed software, toolchains, network policy,
+and intentionally shared project paths. Each mission still receives its own
+working directory and generated harness configuration.
 
 ## Types
 
@@ -78,6 +81,18 @@ pending → building → ready → (in use) → (destroyed)
 | `ready` | Available for missions |
 | `error` | Build failed (check logs) |
 
+## Multiple Missions
+
+Several missions can target the same workspace. Sandboxed.sh creates
+`workspaces/mission-<short-id>` for each mission, so their default file effects
+and OpenCode/Claude/Codex configuration remain separate. They reuse the
+workspace's container, installed toolchain, and explicit shared paths such as a
+canonical repository or read-only cache.
+
+For concurrent writers, create a clone or worktree per mission. Sharing a
+workspace is intended to avoid repeated provisioning, not to make agents write
+to the same checkout.
+
 ## Configuration
 
 ### Skills and Tools
@@ -91,7 +106,8 @@ Workspaces can have skills and tools from your Library:
 }
 ```
 
-These are synced to `.opencode/skill/` and `.opencode/tool/` inside the workspace.
+These are synced to the backend-specific directory inside each mission:
+`.opencode`, `.claude`, or `.codex`.
 
 ### Environment Variables
 
@@ -145,6 +161,23 @@ curl -X POST "https://agent.yourdomain.com/api/workspaces" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"name": "my-project", "template": "fullstack"}'
 ```
+
+Applying an updated template replaces the fields controlled by that template;
+rebuilding then recreates the container. Assistant-facing template reads redact
+all environment values. If an encrypted value cannot be decrypted, Sandboxed.sh
+refuses to apply or patch-save the template instead of persisting a placeholder.
+
+## MCP Security
+
+Stdio MCP servers run in the selected workspace through a mission-local launcher
+with mode `0700`. The launcher clears inherited variables and restores only the
+MCP's own environment plus workspace keys explicitly named in
+`workspace_env_allowlist`. Secret values do not appear in generated harness
+configuration or process arguments.
+
+The wildcard `"*"` is reserved for the built-in `workspace-mcp` compatibility
+proxy. Third-party MCPs should receive the smallest practical allowlist, such as
+`PATH`, `ELAN_HOME`, and `LEAN_PROJECT_PATH` for a Lean language server.
 
 ## Executing Commands
 
@@ -210,6 +243,8 @@ If a container build fails:
 2. **Create templates for repeated setups.** Don't rebuild the same environment.
 3. **Keep init scripts idempotent.** Should work on re-run.
 4. **Version your templates.** They're in your Library git repo.
+5. **Pin external tools and use absolute helper paths.** Template init runs
+   before generic harness bootstrap and runtime launchers use a clean environment.
 
 ## Next Steps
 

--- a/docs/HARNESS_SYSTEM.md
+++ b/docs/HARNESS_SYSTEM.md
@@ -49,6 +49,9 @@ missions. Sandboxed.sh currently supports:
 - **Native bash works** because the harness runs inside the workspace.
 - **No host proxy bash tools** are required for standard missions.
 - **Per-workspace isolation** prevents cross-workspace file effects.
+- **Per-mission working directories** isolate generated config and default file
+  effects while allowing several missions to reuse one workspace's installed
+  toolchain and explicitly shared project paths.
 
 ## Backend registry (metadata)
 
@@ -111,6 +114,12 @@ Codex is executed **per workspace** using the Codex CLI/app-server driver:
   and rotated when rate limits require it.
 - Goal-mode missions keep the raw `/goal <objective>` prefix so the Codex
   driver can route through goal APIs instead of a plain turn.
+
+Model overrides must be exact IDs supported by the authenticated account.
+`gpt-5.5-sol`, for example, is not a valid Codex/ChatGPT model and is rejected
+when the mission is created instead of failing after dispatch. Use
+`gpt-5.6-terra` with `model_effort=medium` when the Terra lane is intended;
+Sandboxed.sh does not silently substitute a different model.
 
 ## Gemini and Grok harnesses
 
@@ -179,14 +188,31 @@ MCP tools (desktop/playwright/workspace) can be enabled when needed.
 
 ## MCP execution scope (current)
 
-Workspace-scoped MCP servers (desktop/playwright/workspace) run **alongside the
-harness process**:
+Workspace-scoped MCP servers run **alongside the harness process**:
 
 - When the harness runs inside a container (per-workspace runner enabled), MCPs
   execute directly in that container.
 - When the harness runs on the host (`SANDBOXED_SH_PER_WORKSPACE_RUNNER=false`),
   container workspaces wrap MCP commands with systemd-nspawn (when available) so
   tools still execute inside the container.
+
+Every stdio MCP is started through a mission-local `0700` launcher. The launcher
+clears inherited harness variables and restores only:
+
+- the MCP transport's own `env` map;
+- mission/runtime metadata required by Sandboxed.sh; and
+- workspace variables named in `workspace_env_allowlist`.
+
+The generated OpenCode, Claude, and Codex configs contain the launcher path, not
+secret values. Launcher names include the MCP configuration UUID so names that
+normalize to the same key cannot overwrite one another. `"*"` access is granted
+implicitly only when the `workspace` entry still points to the built-in
+`workspace-mcp` executable; repointing that entry revokes the implicit wildcard.
+
+Codex app-server reports MCP operations as `mcpToolCall` items, distinct from
+generic `toolCall` items. The driver translates both lifecycle forms into the
+unified tool stream so tool-required missions are not retried or marked stalled
+after a successful MCP call.
 
 Desktop streaming note:
 - The UI streams X11 from the **host** (Xvfb + MJPEG).

--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -77,6 +77,7 @@ Tools:
 - `get_workspace`
 - `create_workspace`
 - `update_workspace`
+- `delete_workspace` — requires explicit confirmation
 - `list_workspace_templates`
 - `get_workspace_template`
 - `save_workspace_template`

--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -64,6 +64,7 @@ Tools:
 - `list_active_missions`
 - `list_missions`
 - `get_mission`
+- `get_mission_digest`
 - `get_mission_events`
 - `get_mission_health` — diagnose stalls/loops/errors + a one-line recommendation
 - `get_mission_diagnostics` — tool-call timeline, repeated calls, error events
@@ -73,6 +74,14 @@ Tools:
 - `resume_mission` — restart an interrupted/blocked/failed mission, optionally with a steering hint
 - `cancel_mission`
 - `list_workspaces`
+- `get_workspace`
+- `create_workspace`
+- `update_workspace`
+- `list_workspace_templates`
+- `get_workspace_template`
+- `save_workspace_template`
+- `delete_workspace_template` — requires explicit confirmation
+- `rebuild_workspace_from_template` — reapplies template fields and force-rebuilds; requires explicit confirmation
 - `workspace_bash`
 
 Configuration:

--- a/docs/PALOMACTL.md
+++ b/docs/PALOMACTL.md
@@ -20,15 +20,23 @@ The CLI never writes live mission or PR state back into project markdown.
 ```bash
 cargo run --bin palomactl -- status
 cargo run --bin palomactl -- reconcile
-cargo run --bin palomactl -- pr-gates <owner/repo> <number>
+cargo run --bin palomactl -- pr-gates <owner/repo> <number> [--worker-head <sha>]
 cargo run --bin palomactl -- set-mode <project> <mode> --until <iso>
 cargo run --bin palomactl -- dispatch-plan --project <slug>
 ```
 
 `pr-gates` reads `.paloma/fixtures/pr-<number>.json` first. If no fixture is
-available, it performs a read-only `gh pr view` and reports draft, mergeability,
-conflict state, checks, and whether Bugbot comments are visible. A PR with green
-checks but conflicts reports `needs_conflict_resolution`.
+available, it performs read-only `gh pr view` and `gh run list` queries and
+reports draft, mergeability, conflict state, the complete current-head check
+rollup, workflow runs, and whether Bugbot comments are visible. The workflow
+query matters because GitHub can conclude a run as `action_required` before it
+creates any job; such a run is absent from `statusCheckRollup`.
+
+Controllers should always pass the SHA validated by the worker through
+`--worker-head`. If automation has since derived a new PR head, the
+recommendation becomes `head_changed_since_worker` and the old local proof or
+review must not be reused. A PR with green checks but conflicts still reports
+`needs_conflict_resolution`.
 
 ## Thomas natural-language mapping
 

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -1,8 +1,9 @@
 # Workspaces
 
 Workspaces are isolated execution environments where AI agents run missions.
-Each workspace defines where commands execute, what tools are available, and
-what secrets the agent can access.
+Each workspace defines where commands execute, which long-lived project assets
+and toolchains are shared, what tools are available, and what secrets the
+mission process can access.
 
 ## Concepts
 
@@ -52,16 +53,36 @@ without recreating the base filesystem.
 
 Each mission targets a specific workspace. When a mission starts, Sandboxed.sh:
 
-1. Uses the workspace root as the working directory (missions share a workspace
-   directory).
-2. Syncs skills, tools, and MCP server configs from the Library into the
-   workspace.
-3. Launches the chosen AI harness (Claude Code, OpenCode, Codex, Gemini, or
-   Grok) inside the workspace.
+1. Creates a mission directory under `workspaces/mission-<short-id>` inside the
+   selected workspace.
+2. Syncs skills, rules, and backend-specific configuration into that mission
+   directory.
+3. Launches the selected harness with that mission directory as its working
+   directory, inside the workspace's host or container execution context.
 
 The harness runs natively in the workspace context --- shell commands, file
 operations, and git all execute inside the container (for container workspaces)
 or on the host (for host workspaces).
+
+Several missions can target the same logical workspace. They reuse its root
+filesystem, installed packages, toolchains, and intentionally shared project
+paths, while keeping harness configuration and default file effects in separate
+mission directories. A project template can expose a canonical checkout such as
+`/workspace/verity/base` and helpers that create private clones for writers.
+Sharing a workspace therefore saves setup time and cache space; it does not make
+the missions share one mutable working directory by default.
+
+### Workspace and Template Management
+
+Workspaces and templates can be managed from the dashboard, the HTTP API, or
+Hermes through `assistant-mcp`. Updating a workspace changes its persisted
+configuration. Applying a template replaces template-controlled fields; a
+container rebuild then recreates the environment from that definition.
+
+Template reads exposed to an assistant redact every `env_vars` value. If an
+encrypted value cannot be decrypted, Sandboxed.sh refuses to apply or
+patch-save that template instead of replacing a previously valid secret with a
+decryption-error placeholder.
 
 ## Networking
 
@@ -99,6 +120,17 @@ The template's init script installs Tailscale and creates helper scripts:
 on the host. See the installation guide (section 8.3) for the `iptables`
 setup.
 
+`tailscale_mode` selects the routing policy:
+
+- `exit_node` keeps `TS_EXIT_NODE` routing enabled.
+- `tailnet_only` joins the tailnet but explicitly clears any configured or
+  persisted exit node, then restores the container's normal default route.
+
+The bootstrap tolerates a read-only `/etc/resolv.conf`, which is expected when
+systemd-nspawn bind-mounts the host resolver configuration. DNS/provider
+preflights should still be part of project templates that depend on external
+model APIs.
+
 ### When to Use Each
 
 | Scenario | Networking | Why |
@@ -125,6 +157,26 @@ that Sandboxed.sh's MCP servers need:
 
 The init script ensures these are installed and available in the container's
 `PATH`.
+
+Project-specific templates must install every CLI they invoke themselves. The
+generic harness bootstrap runs later and is not a dependency of the template
+init script. Pin external repositories and tool versions, and install runtime
+helpers with absolute executable paths so MCP launchers do not depend on an
+interactive shell's `PATH`.
+
+## MCP Environment Isolation
+
+Stdio MCP servers do not inherit the harness or workspace environment. Each MCP
+runs through a mission-local launcher with mode `0700`; the launcher clears the
+inherited environment, restores MCP-specific values plus explicitly allowlisted
+workspace keys, and then executes the server. Secret values are not serialized
+into generated backend configuration or process arguments.
+
+Configure `workspace_env_allowlist` on an MCP when it needs values such as
+`PATH`, `ELAN_HOME`, or `LEAN_PROJECT_PATH`. The wildcard `"*"` is reserved for
+the known built-in `workspace-mcp` compatibility proxy. A custom server merely
+named `workspace` does not receive that grant. Native harness bash is preferred
+for ordinary commands and receives the workspace environment directly.
 
 ## Template Reference
 
@@ -189,6 +241,11 @@ and `TS_EXIT_NODE` in env vars.
 automation. Includes Java 21, Maven, Gradle, X11/i3 desktop stack, Shard
 launcher, mc-cli, Playwright, and pre-configured Fabric + NeoForge profiles.
 
+**verity-lean** --- Reproducible Verity environment pinned to Lean 4.24, a
+specific Verity revision, `lean-lsp-mcp`, GitHub CLI, and audit/isolated-clone
+helpers. The canonical checkout is warmed for reads; writer missions should use
+`verity-isolated-clone` so mutable `.lake` state is not shared.
+
 ## Recommendations
 
 **Start with the `ubuntu` template.** It includes everything most agents need:
@@ -220,6 +277,7 @@ endpoints:
 | List workspaces | GET | `/api/workspaces` |
 | Create workspace | POST | `/api/workspaces` |
 | Build container | POST | `/api/workspaces/:id/build` |
+| Apply template fields | POST | `/api/workspaces/:id/apply-template` |
 | Execute command | POST | `/api/workspaces/:id/exec` |
 | Re-run init script | POST | `/api/workspaces/:id/rerun-init` |
 | Get init log | GET | `/api/workspaces/:id/init-log` |

--- a/docs/WORKSPACE_API.md
+++ b/docs/WORKSPACE_API.md
@@ -27,6 +27,11 @@ POST /api/workspaces
   "template": "template-name",
   "distro": "ubuntu-noble",
   "env_vars": {"KEY": "VALUE"},
+  "shared_network": false,
+  "tailscale_mode": "tailnet_only",
+  "mcps": ["lean_lsp"],
+  "mcps_replace_defaults": false,
+  "config_profile": "default",
   "init_script": "#!/bin/bash\napt install -y nodejs"
 }
 ```
@@ -41,6 +46,11 @@ POST /api/workspaces
 | `template` | string | No | Template name (forces `container` type) |
 | `distro` | string | No | Linux distro for containers |
 | `env_vars` | object | No | Environment variables |
+| `shared_network` | boolean/null | No | `false` enables an isolated veth; `true`/`null` uses the host network |
+| `tailscale_mode` | string/null | No | `exit_node` or `tailnet_only` for isolated Tailscale workspaces |
+| `mcps` | string[] | No | MCP config names enabled for missions in this workspace |
+| `mcps_replace_defaults` | boolean | No | When true, do not add default-enabled MCPs |
+| `config_profile` | string/null | No | Default backend config profile |
 | `init_script` | string | No | Script to run on container build |
 
 **Distro options**: `ubuntu-noble`, `ubuntu-jammy`, `debian-bookworm`, `arch-linux`
@@ -70,11 +80,40 @@ PUT /api/workspaces/:id
   "template": "template-name",
   "distro": "ubuntu-noble",
   "env_vars": {"KEY": "VALUE"},
+  "shared_network": false,
+  "tailscale_mode": "tailnet_only",
+  "mcps": ["lean_lsp"],
+  "mcps_replace_defaults": true,
+  "config_profile": "lean",
   "init_script": "#!/bin/bash\napt install -y nodejs"
 }
 ```
 
 **Response**: `Workspace` object.
+
+Updates persist workspace configuration but do not implicitly rebuild a
+container. Use `/build` with `rebuild: true` when filesystem provisioning must
+be recreated.
+
+## Apply a Template
+
+```
+POST /api/workspaces/:id/apply-template
+```
+
+**Body**:
+
+```json
+{"template": "verity-lean"}
+```
+
+The template name is optional when the workspace already references one.
+Template-controlled fields replace the corresponding workspace fields. This
+endpoint does not rebuild the container by itself.
+
+If any encrypted template value failed to decrypt, the request returns an error
+and leaves the workspace unchanged. It never persists a
+`[DECRYPTION_FAILED]` placeholder over an existing secret.
 
 ## Delete Workspace
 
@@ -128,6 +167,16 @@ Note: Mission workspaces generate backend-specific config on execution:
 - **Gemini/Grok**: OpenCode-style MCP/tool config for the native CLI backend
 
 Skills are written to the backend-specific skill directory during mission setup.
+
+The logical workspace can host multiple missions. Each mission gets a directory
+under `workspaces/mission-<short-id>` for generated configuration and default
+file effects. Installed packages, toolchains, and explicitly shared project
+paths remain reusable at the logical workspace level.
+
+Stdio MCP configs point at `0700` mission-local launchers. The launchers clear
+the inherited environment and restore only MCP-specific values plus workspace
+keys allowed by `workspace_env_allowlist`; credentials are not embedded in
+backend config or process arguments.
 
 ## Execute Command
 

--- a/docs/examples/hermes-config.yaml.example
+++ b/docs/examples/hermes-config.yaml.example
@@ -30,6 +30,7 @@ mcp_servers:
         - list_active_missions
         - list_missions
         - get_mission
+        - get_mission_digest
         - get_mission_events
         - get_mission_health
         - get_mission_diagnostics
@@ -40,6 +41,14 @@ mcp_servers:
         - resume_mission
         - cancel_mission
         - list_workspaces
+        - get_workspace
+        - create_workspace
+        - update_workspace
+        - list_workspace_templates
+        - get_workspace_template
+        - save_workspace_template
+        - delete_workspace_template
+        - rebuild_workspace_from_template
         - workspace_bash
       prompts: false
       resources: false

--- a/docs/examples/hermes-config.yaml.example
+++ b/docs/examples/hermes-config.yaml.example
@@ -44,6 +44,7 @@ mcp_servers:
         - get_workspace
         - create_workspace
         - update_workspace
+        - delete_workspace
         - list_workspace_templates
         - get_workspace_template
         - save_workspace_template

--- a/scripts/workspace_templates/verity-lean.sh
+++ b/scripts/workspace_templates/verity-lean.sh
@@ -88,7 +88,7 @@ fi
 # --dissociate shares download work only. Git objects and the complete `.lake`
 # package tree are private to this mission after the command returns.
 git clone --reference-if-able "$ROOT/base" --dissociate \
-  git@github.com:lfglabs-dev/verity.git "$dest"
+  https://github.com/lfglabs-dev/verity.git "$dest"
 git -C "$dest" fetch origin "$ref"
 if [[ -n "$branch" ]]; then
   git -C "$dest" checkout -B "$branch" FETCH_HEAD

--- a/scripts/workspace_templates/verity-lean.sh
+++ b/scripts/workspace_templates/verity-lean.sh
@@ -92,7 +92,7 @@ install -m 0755 /dev/stdin /usr/local/bin/verity-isolated-clone <<'SCRIPT'
 set -euo pipefail
 readonly ROOT="/workspace/verity"
 name="${1:?usage: verity-isolated-clone <name> [git-ref] [branch]}"
-ref="${2:-origin/main}"
+ref="${2:-main}"
 branch="${3:-}"
 if [[ ! "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
   echo "invalid clone name: $name" >&2
@@ -108,7 +108,11 @@ fi
 # package tree are private to this mission after the command returns.
 git clone --reference-if-able "$ROOT/base" --dissociate \
   https://github.com/lfglabs-dev/verity.git "$dest"
-git -C "$dest" fetch origin "$ref"
+# `git fetch <remote> <refspec>` expects the remote ref (`main`), not the
+# local remote-tracking name (`origin/main`). Accept both forms because Hermes
+# historically supplied the latter.
+fetch_ref="${ref#origin/}"
+git -C "$dest" fetch origin "$fetch_ref"
 if [[ -n "$branch" ]]; then
   git -C "$dest" checkout -B "$branch" FETCH_HEAD
 else

--- a/scripts/workspace_templates/verity-lean.sh
+++ b/scripts/workspace_templates/verity-lean.sh
@@ -7,13 +7,32 @@ set -euo pipefail
 readonly VERITY_REF="538c4a9ce2baa25b56062bdc727eb0191ad9e67f"
 readonly LEAN_LSP_MCP_REF="83b0286574ac46101567f2971c29d55abb2483f9"
 readonly LEAN4_SKILLS_REF="5a331e22c7f9416ef40594e2f076f91306c78b16"
+readonly UV_VERSION="0.11.28"
 readonly ROOT="/workspace/verity"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y --no-install-recommends \
-  build-essential ca-certificates ccache cmake curl git jq libffi-dev \
+  build-essential ca-certificates ccache cmake curl git gnupg jq libffi-dev \
   libgmp-dev ninja-build pkg-config python3 python3-venv ripgrep zlib1g-dev
+
+if ! command -v gh >/dev/null 2>&1; then
+  install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    -o /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  printf '%s\n' \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+  apt-get update -qq
+  apt-get install -y --no-install-recommends gh
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh
+fi
+test "$(uv --version | awk '{print $2}')" = "$UV_VERSION"
 
 mkdir -p "$ROOT"/{base,bin,tools,worktrees}
 

--- a/scripts/workspace_templates/verity-lean.sh
+++ b/scripts/workspace_templates/verity-lean.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproducible production template for the dedicated Verity workspace. Keep
+# every external checkout pinned: a template rebuild must not silently change
+# Lean, the MCP server, or the agent guidance underneath an active roadmap.
+readonly VERITY_REF="538c4a9ce2baa25b56062bdc727eb0191ad9e67f"
+readonly LEAN_LSP_MCP_REF="83b0286574ac46101567f2971c29d55abb2483f9"
+readonly LEAN4_SKILLS_REF="5a331e22c7f9416ef40594e2f076f91306c78b16"
+readonly ROOT="/workspace/verity"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+  build-essential ca-certificates ccache cmake curl git jq libffi-dev \
+  libgmp-dev ninja-build pkg-config python3 python3-venv ripgrep zlib1g-dev
+
+mkdir -p "$ROOT"/{base,bin,tools,worktrees}
+
+clone_pinned() {
+  local url="$1" dest="$2" ref="$3"
+  if [[ ! -d "$dest/.git" ]]; then
+    rm -rf "$dest"
+    git clone "$url" "$dest"
+  fi
+  git -C "$dest" fetch --tags origin
+  git -C "$dest" checkout --detach "$ref"
+  test "$(git -C "$dest" rev-parse HEAD)" = "$ref"
+}
+
+clone_pinned https://github.com/lfglabs-dev/verity.git "$ROOT/base" "$VERITY_REF"
+clone_pinned https://github.com/oOo0oOo/lean-lsp-mcp.git \
+  "$ROOT/tools/lean-lsp-mcp" "$LEAN_LSP_MCP_REF"
+clone_pinned https://github.com/cameronfreer/lean4-skills.git \
+  "$ROOT/tools/lean4-skills" "$LEAN4_SKILLS_REF"
+
+export ELAN_HOME="$ROOT/.elan"
+if [[ ! -x "$ELAN_HOME/bin/elan" ]]; then
+  curl --proto '=https' --tlsv1.2 -sSf \
+    https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y --default-toolchain none
+fi
+export UV_TOOL_DIR="$ROOT/.uv-tools"
+export UV_TOOL_BIN_DIR="$ROOT/bin"
+export PATH="$ELAN_HOME/bin:$UV_TOOL_BIN_DIR:$PATH"
+
+elan toolchain install "$(<"$ROOT/base/lean-toolchain")"
+elan default "$(<"$ROOT/base/lean-toolchain")"
+uv tool install --force --from "$ROOT/tools/lean-lsp-mcp" lean-lsp-mcp
+
+# The MCP registry is shared across workspaces, so its command path must be
+# stable while project/tool locations come from each workspace's explicit
+# non-secret allowlist.
+install -m 0755 /dev/stdin /usr/local/bin/lean-lsp-mcp-workspace <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${LEAN_PROJECT_PATH:?LEAN_PROJECT_PATH is required}"
+exec lean-lsp-mcp --lean-project-path "$LEAN_PROJECT_PATH" "$@"
+SCRIPT
+
+# Warm and validate the canonical checkout. Workers never use this mutable
+# `.lake` tree: verity-isolated-clone below creates a fresh package graph for
+# every mission. This deliberately chooses complete isolation over hardlinks,
+# shared worktree caches, or partially copied package repositories.
+(
+  cd "$ROOT/base"
+  lake exe cache get
+  lake build
+)
+
+install -m 0755 /dev/stdin /usr/local/bin/verity-isolated-clone <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+readonly ROOT="/workspace/verity"
+name="${1:?usage: verity-isolated-clone <name> [git-ref] [branch]}"
+ref="${2:-origin/main}"
+branch="${3:-}"
+if [[ ! "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "invalid clone name: $name" >&2
+  exit 2
+fi
+dest="$ROOT/worktrees/$name"
+if [[ -e "$dest" ]]; then
+  echo "destination already exists: $dest" >&2
+  exit 3
+fi
+
+# --dissociate shares download work only. Git objects and the complete `.lake`
+# package tree are private to this mission after the command returns.
+git clone --reference-if-able "$ROOT/base" --dissociate \
+  git@github.com:lfglabs-dev/verity.git "$dest"
+git -C "$dest" fetch origin "$ref"
+if [[ -n "$branch" ]]; then
+  git -C "$dest" checkout -B "$branch" FETCH_HEAD
+else
+  git -C "$dest" checkout --detach FETCH_HEAD
+fi
+rm -rf "$dest/.lake"
+(
+  cd "$dest"
+  lake exe cache get
+  mkdir -p .lake
+  printf '%s\n' "$name" > .lake/sandboxed-cache-owner
+  test -d .lake/packages
+  test ! -L .lake/packages
+)
+printf '%s\n' "$dest"
+SCRIPT
+
+install -m 0755 /dev/stdin /usr/local/bin/verity-audit <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+repo="${1:-$PWD}"
+cd "$repo"
+printf 'head=%s\n' "$(git rev-parse HEAD)"
+printf 'toolchain=%s\n' "$(<lean-toolchain)"
+lean --version
+lake --version
+gh auth status --hostname github.com >/dev/null
+python3 scripts/check_paths.py
+git status --short
+SCRIPT
+
+# Fail template creation rather than registering a workspace with half-working
+# proof tooling.
+test "$(<"$ROOT/base/lean-toolchain")" = "leanprover/lean4:v4.24.0"
+lean --version | grep -F 'version 4.24.0'
+lake --version
+lean-lsp-mcp --help >/dev/null
+LEAN_PROJECT_PATH="$ROOT/base" /usr/local/bin/lean-lsp-mcp-workspace --help >/dev/null
+gh --version >/dev/null
+test "$(git -C "$ROOT/base" rev-parse HEAD)" = "$VERITY_REF"

--- a/scripts/workspace_templates/verity-lean.sh
+++ b/scripts/workspace_templates/verity-lean.sh
@@ -74,7 +74,8 @@ install -m 0755 /dev/stdin /usr/local/bin/lean-lsp-mcp-workspace <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
 : "${LEAN_PROJECT_PATH:?LEAN_PROJECT_PATH is required}"
-exec lean-lsp-mcp --lean-project-path "$LEAN_PROJECT_PATH" "$@"
+exec /workspace/verity/bin/lean-lsp-mcp \
+  --lean-project-path "$LEAN_PROJECT_PATH" "$@"
 SCRIPT
 
 # Warm and validate the canonical checkout. Workers never use this mutable
@@ -83,8 +84,8 @@ SCRIPT
 # shared worktree caches, or partially copied package repositories.
 (
   cd "$ROOT/base"
-  lake exe cache get
-  lake build
+  "$ELAN_HOME/bin/lake" exe cache get
+  "$ELAN_HOME/bin/lake" build
 )
 
 install -m 0755 /dev/stdin /usr/local/bin/verity-isolated-clone <<'SCRIPT'
@@ -106,22 +107,22 @@ fi
 
 # --dissociate shares download work only. Git objects and the complete `.lake`
 # package tree are private to this mission after the command returns.
-git clone --reference-if-able "$ROOT/base" --dissociate \
+/usr/bin/git clone --reference-if-able "$ROOT/base" --dissociate \
   https://github.com/lfglabs-dev/verity.git "$dest"
 # `git fetch <remote> <refspec>` expects the remote ref (`main`), not the
 # local remote-tracking name (`origin/main`). Accept both forms because Hermes
 # historically supplied the latter.
 fetch_ref="${ref#origin/}"
-git -C "$dest" fetch origin "$fetch_ref"
+/usr/bin/git -C "$dest" fetch origin "$fetch_ref"
 if [[ -n "$branch" ]]; then
-  git -C "$dest" checkout -B "$branch" FETCH_HEAD
+  /usr/bin/git -C "$dest" checkout -B "$branch" FETCH_HEAD
 else
-  git -C "$dest" checkout --detach FETCH_HEAD
+  /usr/bin/git -C "$dest" checkout --detach FETCH_HEAD
 fi
 rm -rf "$dest/.lake"
 (
   cd "$dest"
-  lake exe cache get
+  "$ROOT/.elan/bin/lake" exe cache get
   mkdir -p .lake
   printf '%s\n' "$name" > .lake/sandboxed-cache-owner
   test -d .lake/packages
@@ -133,23 +134,24 @@ SCRIPT
 install -m 0755 /dev/stdin /usr/local/bin/verity-audit <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
+readonly ROOT="/workspace/verity"
 repo="${1:-$PWD}"
 cd "$repo"
-printf 'head=%s\n' "$(git rev-parse HEAD)"
+printf 'head=%s\n' "$(/usr/bin/git rev-parse HEAD)"
 printf 'toolchain=%s\n' "$(<lean-toolchain)"
-lean --version
-lake --version
-gh auth status --hostname github.com >/dev/null
-python3 scripts/check_paths.py
-git status --short
+"$ROOT/.elan/bin/lean" --version
+"$ROOT/.elan/bin/lake" --version
+/usr/bin/gh auth status --hostname github.com >/dev/null
+/usr/bin/python3 scripts/check_paths.py
+/usr/bin/git status --short
 SCRIPT
 
 # Fail template creation rather than registering a workspace with half-working
 # proof tooling.
 test "$(<"$ROOT/base/lean-toolchain")" = "leanprover/lean4:v4.24.0"
-lean --version | grep -F 'version 4.24.0'
-lake --version
-lean-lsp-mcp --help >/dev/null
+"$ELAN_HOME/bin/lean" --version | grep -F 'version 4.24.0'
+"$ELAN_HOME/bin/lake" --version
+"$ROOT/bin/lean-lsp-mcp" --help >/dev/null
 LEAN_PROJECT_PATH="$ROOT/base" /usr/local/bin/lean-lsp-mcp-workspace --help >/dev/null
-gh --version >/dev/null
+/usr/bin/gh --version >/dev/null
 test "$(git -C "$ROOT/base" rev-parse HEAD)" = "$VERITY_REF"

--- a/src/api/ask/http.rs
+++ b/src/api/ask/http.rs
@@ -80,10 +80,21 @@ pub struct AskThreadDetail {
 fn resolve_base_work_dir(
     working_directory: Option<&str>,
     workspace_path: &std::path::Path,
+    nspawn_container: bool,
     mission_id: Uuid,
 ) -> std::path::PathBuf {
     if let Some(dir) = working_directory.map(std::path::PathBuf::from) {
-        if dir.exists() {
+        // Mission metadata records the path as the harness saw it. In an
+        // nspawn workspace that is a guest path such as
+        // `/workspaces/mission-abcd/repo`, not a host path. Checking it on the
+        // host either fails (and silently selects the wrong directory) or,
+        // for generic paths such as `/tmp`, accidentally selects a host tree.
+        if nspawn_container && dir.is_absolute() && !dir.starts_with(workspace_path) {
+            let host_dir = workspace_path.join(dir.strip_prefix("/").unwrap_or(&dir));
+            if host_dir.exists() {
+                return host_dir;
+            }
+        } else if dir.exists() {
             return dir;
         }
     }
@@ -160,9 +171,12 @@ pub async fn ask_send(
         Some(mission.workspace_id),
     )
     .await;
+    let nspawn_container = workspace.workspace_type == crate::workspace::WorkspaceType::Container
+        && crate::workspace::use_nspawn_for_workspace(&workspace);
     let base_work_dir = resolve_base_work_dir(
         mission.working_directory.as_deref(),
         &workspace.path,
+        nspawn_container,
         mission_id,
     );
 
@@ -285,9 +299,12 @@ pub async fn ask_send_stream(
         Some(mission.workspace_id),
     )
     .await;
+    let nspawn_container = workspace.workspace_type == crate::workspace::WorkspaceType::Container
+        && crate::workspace::use_nspawn_for_workspace(&workspace);
     let base_work_dir = resolve_base_work_dir(
         mission.working_directory.as_deref(),
         &workspace.path,
+        nspawn_container,
         mission_id,
     );
 
@@ -431,4 +448,39 @@ pub async fn delete_ask_thread(
     Ok(Json(
         serde_json::json!({ "ok": true, "deleted": thread_id }),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn nspawn_working_directory_is_resolved_inside_container_root() {
+        let root = tempdir().unwrap();
+        let guest = "/workspaces/mission-abcd/repo";
+        let host = root.path().join("workspaces/mission-abcd/repo");
+        std::fs::create_dir_all(&host).unwrap();
+        let resolved = resolve_base_work_dir(
+            Some(guest),
+            root.path(),
+            true,
+            Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
+        );
+        assert_eq!(resolved, host);
+    }
+
+    #[test]
+    fn host_working_directory_is_left_unchanged() {
+        let root = tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let resolved = resolve_base_work_dir(
+            repo.to_str(),
+            root.path(),
+            false,
+            Uuid::parse_str("abcd0000-0000-4000-8000-000000000000").unwrap(),
+        );
+        assert_eq!(resolved, repo);
+    }
 }

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1442,9 +1442,9 @@ pub async fn prepare_sandbox(exec: &WorkspaceExec, base_work_dir: &Path) -> Opti
         let copy_cmd = format!(
             "set -e; test -d {b}; rm -rf {s}; mkdir -p {s}; \
              if command -v rsync >/dev/null 2>&1; then \
-               rsync -a --exclude .git --exclude node_modules --exclude target --exclude .next -- {b}/ {s}/; \
+               rsync -a --exclude .git --exclude .lake --exclude node_modules --exclude target --exclude .next -- {b}/ {s}/; \
              else \
-               (cd {b} && tar --exclude .git --exclude node_modules --exclude target --exclude .next -cf - .) | (cd {s} && tar -xf -); \
+               (cd {b} && tar --exclude .git --exclude .lake --exclude node_modules --exclude target --exclude .next -cf - .) | (cd {s} && tar -xf -); \
              fi; echo SANDBOX_OK",
             b = single_quote(&base_str),
             s = single_quote(&sandbox_str)

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5091,6 +5091,40 @@ fn native_backend_agent(raw_agent: &str) -> Option<&'static str> {
     }
 }
 
+/// Consume native harness names used through the legacy `agent` field.
+///
+/// These values select a backend; they are not library/sub-agent names and
+/// must not reach the native CLI (Claude Code would otherwise receive e.g.
+/// `--agent claudecode`). OpenCode remains the exception because it can have a
+/// real library agent named `codex`.
+fn apply_native_backend_agent_selector(
+    agent: &mut Option<String>,
+    backend: &mut Option<String>,
+) -> Result<(), String> {
+    let Some(agent_backend) = agent.as_deref().and_then(native_backend_agent) else {
+        return Ok(());
+    };
+
+    match backend.as_deref() {
+        None => {
+            *backend = Some(agent_backend.to_string());
+            *agent = None;
+        }
+        Some("opencode") => {}
+        Some(selected) if selected != agent_backend => {
+            return Err(format!(
+                "Agent '{}' selects backend '{}', but mission backend is '{}'",
+                agent.as_deref().unwrap_or_default(),
+                agent_backend,
+                selected
+            ));
+        }
+        Some(_) => *agent = None,
+    }
+
+    Ok(())
+}
+
 fn is_fable_model(model: Option<&str>) -> bool {
     model
         .map(str::to_ascii_lowercase)
@@ -5187,7 +5221,7 @@ pub async fn create_mission(
 
     let title = req.title.clone();
     let workspace_id = req.workspace_id;
-    let agent = req.agent.clone();
+    let mut agent = req.agent.clone();
     let config_profile = req.config_profile.clone();
     let mut backend = req.backend.clone();
     let mut model_override = req.model_override.clone();
@@ -5212,24 +5246,8 @@ pub async fn create_mission(
     // while leaving `backend` unset. Treat native harness agent names as an
     // unambiguous backend hint before applying the server default. Library
     // agent names such as `build` or `plan` remain independent of the backend.
-    if let Some(agent_backend) = agent.as_deref().and_then(native_backend_agent) {
-        match backend.as_deref() {
-            None => backend = Some(agent_backend.to_string()),
-            // OpenCode may legitimately have a library agent named `codex`.
-            Some("opencode") => {}
-            Some(selected) if selected != agent_backend => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!(
-                        "Agent '{}' selects backend '{}', but mission backend is '{}'",
-                        agent.as_deref().unwrap_or_default(),
-                        agent_backend,
-                        selected
-                    ),
-                ));
-            }
-            Some(_) => {}
-        }
+    if let Err(error) = apply_native_backend_agent_selector(&mut agent, &mut backend) {
+        return Err((StatusCode::BAD_REQUEST, error));
     }
 
     // Native harness-qualified model IDs (for example
@@ -21726,6 +21744,38 @@ And the report:
         assert_eq!(native_backend_agent("build"), None);
         assert_eq!(native_backend_agent("plan"), None);
         assert_eq!(native_backend_agent("opencode"), None);
+    }
+
+    #[test]
+    fn native_backend_agent_selector_is_consumed_for_native_harnesses() {
+        let mut agent = Some("ClaudeCode".to_string());
+        let mut backend = None;
+        apply_native_backend_agent_selector(&mut agent, &mut backend).unwrap();
+        assert_eq!(backend.as_deref(), Some("claudecode"));
+        assert_eq!(agent, None);
+
+        let mut agent = Some("codex".to_string());
+        let mut backend = Some("codex".to_string());
+        apply_native_backend_agent_selector(&mut agent, &mut backend).unwrap();
+        assert_eq!(agent, None);
+    }
+
+    #[test]
+    fn native_backend_agent_selector_preserves_real_opencode_agent() {
+        let mut agent = Some("codex".to_string());
+        let mut backend = Some("opencode".to_string());
+        apply_native_backend_agent_selector(&mut agent, &mut backend).unwrap();
+        assert_eq!(backend.as_deref(), Some("opencode"));
+        assert_eq!(agent.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn native_backend_agent_selector_rejects_conflicting_backend() {
+        let mut agent = Some("gemini".to_string());
+        let mut backend = Some("codex".to_string());
+        let error = apply_native_backend_agent_selector(&mut agent, &mut backend).unwrap_err();
+        assert!(error.contains("selects backend 'gemini'"));
+        assert_eq!(agent.as_deref(), Some("gemini"));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5091,6 +5091,48 @@ fn native_backend_agent(raw_agent: &str) -> Option<&'static str> {
     }
 }
 
+fn is_fable_model(model: Option<&str>) -> bool {
+    model
+        .map(str::to_ascii_lowercase)
+        .map(|model| model.contains("fable"))
+        .unwrap_or(false)
+}
+
+/// Fable is a research lane for mathematical hypothesis generation. A fleet
+/// controller must never hand it repository integration authority: an earlier
+/// cross-project routing incident sent a Beal review+merge mandate to Fable.
+fn fable_mandate_requests_integration(intent: Option<&str>, prompt: Option<&str>) -> bool {
+    let normalized = format!(
+        "{} {}",
+        intent.unwrap_or_default(),
+        prompt.unwrap_or_default()
+    )
+    .to_ascii_lowercase();
+    let tokens: std::collections::HashSet<&str> = normalized
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+    [
+        "review",
+        "reviewer",
+        "merge",
+        "merging",
+        "merged",
+        "rebase",
+        "rebasing",
+        "commit",
+        "committing",
+        "push",
+        "pushing",
+        "conflict",
+        "conflicts",
+        "integration",
+        "integrate",
+    ]
+    .iter()
+    .any(|token| tokens.contains(token))
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -5304,6 +5346,16 @@ pub async fn create_mission(
         {
             model_override = Some(default_model);
         }
+    }
+
+    if is_fable_model(model_override.as_deref())
+        && fable_mandate_requests_integration(req.intent.as_deref(), req.prompt.as_deref())
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Fable is restricted to mathematical hypothesis generation and cannot receive review, commit, push, conflict-resolution, or merge mandates. Use Codex or Claude Opus for repository integration."
+                .to_string(),
+        ));
     }
 
     // Validate the remote-node payload before persisting the mission so a
@@ -21630,6 +21682,27 @@ And the report:
             normalize_model_override_for_backend(Some("codex"), "codex/gpt-5.6-terra"),
             Some("gpt-5.6-terra".to_string())
         );
+    }
+
+    #[test]
+    fn fable_rejects_repository_integration_mandates() {
+        assert!(is_fable_model(Some("claude-fable-5")));
+        assert!(fable_mandate_requests_integration(
+            Some("review_merge_pr"),
+            Some("Review PR #2 and merge it")
+        ));
+        assert!(fable_mandate_requests_integration(
+            None,
+            Some("Resolve the conflicts, commit, and push")
+        ));
+    }
+
+    #[test]
+    fn fable_allows_hypothesis_generation() {
+        assert!(!fable_mandate_requests_integration(
+            Some("hypothesis_generation"),
+            Some("Explore mathematical hypotheses for the Beal conjecture")
+        ));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5081,6 +5081,16 @@ fn native_backend_prefix(raw_model: &str) -> Option<&str> {
     }
 }
 
+fn native_backend_agent(raw_agent: &str) -> Option<&'static str> {
+    match raw_agent.trim().to_ascii_lowercase().as_str() {
+        "codex" => Some("codex"),
+        "claudecode" => Some("claudecode"),
+        "gemini" => Some("gemini"),
+        "grok" => Some("grok"),
+        _ => None,
+    }
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -5153,6 +5163,30 @@ pub async fn create_mission(
     if let Some(value) = model_effort.as_ref() {
         if value.trim().is_empty() {
             model_effort = None;
+        }
+    }
+
+    // Hermes historically used `agent="codex"` as the native harness selector
+    // while leaving `backend` unset. Treat native harness agent names as an
+    // unambiguous backend hint before applying the server default. Library
+    // agent names such as `build` or `plan` remain independent of the backend.
+    if let Some(agent_backend) = agent.as_deref().and_then(native_backend_agent) {
+        match backend.as_deref() {
+            None => backend = Some(agent_backend.to_string()),
+            // OpenCode may legitimately have a library agent named `codex`.
+            Some("opencode") => {}
+            Some(selected) if selected != agent_backend => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "Agent '{}' selects backend '{}', but mission backend is '{}'",
+                        agent.as_deref().unwrap_or_default(),
+                        agent_backend,
+                        selected
+                    ),
+                ));
+            }
+            Some(_) => {}
         }
     }
 
@@ -21607,6 +21641,18 @@ And the report:
         );
         assert_eq!(native_backend_prefix("openai/gpt-5.6-terra"), None);
         assert_eq!(native_backend_prefix("codex/"), None);
+    }
+
+    #[test]
+    fn test_native_backend_agent_only_accepts_native_harness_names() {
+        assert_eq!(native_backend_agent("codex"), Some("codex"));
+        assert_eq!(native_backend_agent(" Codex "), Some("codex"));
+        assert_eq!(native_backend_agent("claudecode"), Some("claudecode"));
+        assert_eq!(native_backend_agent("gemini"), Some("gemini"));
+        assert_eq!(native_backend_agent("grok"), Some("grok"));
+        assert_eq!(native_backend_agent("build"), None);
+        assert_eq!(native_backend_agent("plan"), None);
+        assert_eq!(native_backend_agent("opencode"), None);
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -13,7 +13,7 @@
 use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
@@ -40,6 +40,60 @@ use super::control::{
     ControlStatus, ExecutionProgress, FrontendToolHub,
 };
 use super::library::SharedLibrary;
+
+/// Resolve an orchestrator-supplied working directory to the host-side path
+/// consumed by [`WorkspaceExec`]. Container callers naturally refer to guest
+/// paths (for example `/workspace/verity/base`), while the API process must
+/// validate the corresponding path below the container rootfs.
+fn resolve_mission_working_directory(
+    workspace_root: &Path,
+    workspace_type: WorkspaceType,
+    requested: &str,
+) -> Result<PathBuf, String> {
+    let requested = requested.trim();
+    if requested.is_empty() {
+        return Err("working_directory is empty".to_string());
+    }
+
+    let requested_path = Path::new(requested);
+    let resolved = if workspace_type == WorkspaceType::Container {
+        if requested_path.is_absolute() && requested_path.starts_with(workspace_root) {
+            requested_path.to_path_buf()
+        } else if requested_path.is_absolute() {
+            workspace_root.join(requested_path.strip_prefix("/").unwrap_or(requested_path))
+        } else {
+            workspace_root.join(requested_path)
+        }
+    } else if requested_path.is_absolute() {
+        requested_path.to_path_buf()
+    } else {
+        workspace_root.join(requested_path)
+    };
+
+    if !resolved.is_dir() {
+        return Err(format!(
+            "working_directory does not exist or is not a directory: {}",
+            resolved.display()
+        ));
+    }
+
+    if workspace_type == WorkspaceType::Container {
+        let canonical_root = workspace_root
+            .canonicalize()
+            .map_err(|error| format!("failed to resolve workspace root: {error}"))?;
+        let canonical_resolved = resolved
+            .canonicalize()
+            .map_err(|error| format!("failed to resolve working_directory: {error}"))?;
+        if !canonical_resolved.starts_with(&canonical_root) {
+            return Err(format!(
+                "working_directory escapes workspace root {}",
+                workspace_root.display()
+            ));
+        }
+    }
+
+    Ok(resolved)
+}
 
 /// Build the synthetic `AgentResult::failure` produced when a turn is
 /// cancelled. If the process has begun a graceful shutdown, return a
@@ -3412,21 +3466,25 @@ async fn run_mission_turn(
 
     // Override with mission-specific working_directory (e.g. git worktree for orchestrated workers)
     let mission_work_dir = if let Some(ref wd) = mission_working_directory {
-        let wd_path = std::path::PathBuf::from(wd);
-        if wd_path.exists() {
-            tracing::info!(
-                "Mission {} using working_directory override: {}",
-                mission_id,
-                wd
-            );
-            wd_path
-        } else {
-            tracing::warn!(
-                "Mission {} working_directory does not exist: {}, using default",
-                mission_id,
-                wd
-            );
-            mission_work_dir
+        match resolve_mission_working_directory(&workspace.path, workspace.workspace_type, wd) {
+            Ok(wd_path) => {
+                tracing::info!(
+                    mission_id = %mission_id,
+                    requested_working_directory = %wd,
+                    resolved_working_directory = %wd_path.display(),
+                    "Using mission working_directory override"
+                );
+                wd_path
+            }
+            Err(error) => {
+                tracing::warn!(
+                    mission_id = %mission_id,
+                    requested_working_directory = %wd,
+                    error = %error,
+                    "Mission working_directory is invalid; using prepared mission directory"
+                );
+                mission_work_dir
+            }
         }
     } else {
         mission_work_dir
@@ -8369,18 +8427,18 @@ mod tests {
         overlay_opencode_auth, parse_cli_semver, parse_opencode_goal_objective,
         parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
         preferred_model_for_cost, preferred_opencode_bin_dir, prepend_unique_path_entry,
-        record_codex_error_message, replace_filepath_artifact_with_tool_output, running_health,
-        sanitized_opencode_stdout, selected_opencode_auth_path,
-        selected_opencode_provider_auth_dir, set_codex_account_cooldown,
-        should_sync_container_opencode, stall_severity, strip_ansi_codes,
-        strip_opencode_banner_lines, strip_think_tags, summarize_codex_usage_caps,
-        summarize_recent_opencode_stderr, text_buffer_stream_looks_degenerate,
-        thinking_overlaps_visible_answer, tls_error_hint, truncate_garbled_output,
-        use_thinking_only_fallback, utf8_safe_prefix, ClaudeIncompleteTurnContext,
-        ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy, ClaudeTurnWaitState,
-        MissionHealth, MissionRunState, MissionStallSeverity, OpencodeSseState,
-        CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN, CODEX_RATE_LIMIT_COOLDOWN,
-        STALL_SEVERE_SECS, STALL_WARN_SECS,
+        record_codex_error_message, replace_filepath_artifact_with_tool_output,
+        resolve_mission_working_directory, running_health, sanitized_opencode_stdout,
+        selected_opencode_auth_path, selected_opencode_provider_auth_dir,
+        set_codex_account_cooldown, should_sync_container_opencode, stall_severity,
+        strip_ansi_codes, strip_opencode_banner_lines, strip_think_tags,
+        summarize_codex_usage_caps, summarize_recent_opencode_stderr,
+        text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
+        truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
+        ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
+        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
+        OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
+        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -8390,11 +8448,45 @@ mod tests {
     use crate::agents::{AgentResult, CostSource, TerminalReason};
     use crate::cost::resolve_cost_cents_and_source;
     use crate::library::types::CommandParam;
+    use crate::workspace::WorkspaceType;
     use serde_json::json;
     use std::borrow::Cow;
     use std::fs;
     use std::time::Duration;
     use uuid::Uuid;
+
+    #[test]
+    fn mission_working_directory_maps_container_guest_absolute_path() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("workspace/verity/base");
+        fs::create_dir_all(&repo).unwrap();
+
+        assert_eq!(
+            resolve_mission_working_directory(
+                root.path(),
+                WorkspaceType::Container,
+                "/workspace/verity/base",
+            )
+            .unwrap(),
+            repo
+        );
+    }
+
+    #[test]
+    fn mission_working_directory_rejects_container_symlink_escape() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(outside.path(), root.path().join("escape")).unwrap();
+
+        #[cfg(unix)]
+        assert!(resolve_mission_working_directory(
+            root.path(),
+            WorkspaceType::Container,
+            "/escape",
+        )
+        .is_err());
+    }
 
     #[test]
     fn isolated_opencode_auth_follows_the_mission_xdg_paths() {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -2268,6 +2268,7 @@ pub async fn validate_model_override(
             }
         }
         "codex" => {
+            reject_known_unsupported_codex_model(model_override)?;
             // Codex expects raw model IDs from OpenAI
             let openai = providers.iter().find(|p| p.id == "openai");
             if let Some(provider) = openai {
@@ -2381,6 +2382,16 @@ pub async fn validate_model_override(
     }
 }
 
+fn reject_known_unsupported_codex_model(model_id: &str) -> Result<(), String> {
+    if model_id == "gpt-5.5-sol" {
+        return Err(
+            "Model 'gpt-5.5-sol' is not supported by Codex with ChatGPT authentication. Use 'gpt-5.6-terra' (recommended with model_effort='medium') or select an account-supported model explicitly."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 fn is_grok_backend_model_id(model_id: &str) -> bool {
     GROK_CLI_TEXT_MODEL_IDS.contains(&model_id)
 }
@@ -2452,6 +2463,14 @@ mod tests {
                 "bare/non-API slug should not be exposed: {invalid_id}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_invented_gpt_55_sol_variant_before_dispatch() {
+        let error = reject_known_unsupported_codex_model("gpt-5.5-sol")
+            .expect_err("invented model variant must be rejected");
+        assert!(error.contains("gpt-5.6-terra"));
+        assert!(reject_known_unsupported_codex_model("gpt-5.6-terra").is_ok());
     }
 
     #[test]

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3442,6 +3442,7 @@ fn stream_deploy(
         const MAIN_CARGO_BIN: &str = "sandboxed-sh";
         const MCP_CARGO_BIN: &str = "orchestrator-mcp";
         const ASSISTANT_MCP_CARGO_BIN: &str = "assistant-mcp";
+        const PALOMA_CARGO_BIN: &str = "palomactl";
         let install_dest_main = current_exe.to_string_lossy().to_string();
         // Match the MCP install location: same dir as the main binary, fixed name.
         let install_dest_mcp = current_exe
@@ -3452,12 +3453,23 @@ fn stream_deploy(
             .parent()
             .map(|p| p.join(ASSISTANT_MCP_CARGO_BIN).to_string_lossy().to_string())
             .unwrap_or_else(|| format!("/usr/local/bin/{}", ASSISTANT_MCP_CARGO_BIN));
+        let install_dest_paloma = std::env::var("PALOMACTL_INSTALL_PATH")
+            .ok()
+            .filter(|path| !path.trim().is_empty())
+            .unwrap_or_else(|| {
+                let hermes_path = std::path::Path::new("/var/lib/hermes-assistant/bin/palomactl");
+                if hermes_path.parent().is_some_and(std::path::Path::exists) {
+                    hermes_path.to_string_lossy().to_string()
+                } else {
+                    "/usr/local/bin/palomactl".to_string()
+                }
+            });
 
         if !req.skip_build {
-            yield sse("log", format!("Building {} + {} + {} (cargo build, debug)", MAIN_CARGO_BIN, MCP_CARGO_BIN, ASSISTANT_MCP_CARGO_BIN), Some(25));
+            yield sse("log", format!("Building {} + {} + {} + {} (cargo build, debug)", MAIN_CARGO_BIN, MCP_CARGO_BIN, ASSISTANT_MCP_CARGO_BIN, PALOMA_CARGO_BIN), Some(25));
             let build_cmd = format!(
-                "source /root/.cargo/env 2>/dev/null; cargo build --bin {} --bin {} --bin {}",
-                MAIN_CARGO_BIN, MCP_CARGO_BIN, ASSISTANT_MCP_CARGO_BIN
+                "source /root/.cargo/env 2>/dev/null; cargo build --bin {} --bin {} --bin {} --bin {}",
+                MAIN_CARGO_BIN, MCP_CARGO_BIN, ASSISTANT_MCP_CARGO_BIN, PALOMA_CARGO_BIN
             );
             match Command::new("bash")
                 .args(["-c", &build_cmd])
@@ -3493,6 +3505,7 @@ fn stream_deploy(
             .join("target")
             .join("debug")
             .join(ASSISTANT_MCP_CARGO_BIN);
+        let src_paloma = repo_path.join("target").join("debug").join(PALOMA_CARGO_BIN);
         if !src_main.exists() {
             yield sse("error", format!("Build artifact missing: {}. Either set skip_build=false, or point repo_path at a checkout that has been built.", src_main.display()), None);
             return;
@@ -3503,6 +3516,10 @@ fn stream_deploy(
         }
         if !src_assistant_mcp.exists() {
             yield sse("error", format!("Build artifact missing: {}. Either set skip_build=false, or point repo_path at a checkout that has been built.", src_assistant_mcp.display()), None);
+            return;
+        }
+        if !src_paloma.exists() {
+            yield sse("error", format!("Build artifact missing: {}. Either set skip_build=false, or point repo_path at a checkout that has been built.", src_paloma.display()), None);
             return;
         }
 
@@ -3612,7 +3629,38 @@ fn stream_deploy(
                 return;
             }
         }
-        yield sse("log", format!("Backups: {}, {}, {}", bkp_main, bkp_mcp, bkp_assistant_mcp), Some(88));
+
+        yield sse("log", format!("Installing {} → {}", src_paloma.display(), install_dest_paloma), Some(87));
+        let bkp_paloma = format!("{}.pre-deploy-{}", install_dest_paloma, sha);
+        if std::path::Path::new(&install_dest_paloma).exists() {
+            let _ = tokio::fs::copy(&install_dest_paloma, &bkp_paloma).await;
+        }
+        let install_paloma = Command::new("install")
+            .args([
+                "-m", "0755",
+                src_paloma.to_string_lossy().as_ref(),
+                &install_dest_paloma,
+            ])
+            .output()
+            .await;
+        match install_paloma {
+            Ok(o) if o.status.success() => {}
+            Ok(o) => {
+                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
+                let _ = tokio::fs::rename(&bkp_mcp, &install_dest_mcp).await;
+                let _ = tokio::fs::rename(&bkp_assistant_mcp, &install_dest_assistant_mcp).await;
+                yield sse("error", format!("Install of palomactl failed (service binaries rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
+                return;
+            }
+            Err(e) => {
+                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
+                let _ = tokio::fs::rename(&bkp_mcp, &install_dest_mcp).await;
+                let _ = tokio::fs::rename(&bkp_assistant_mcp, &install_dest_assistant_mcp).await;
+                yield sse("error", format!("install command error for palomactl (service binaries rolled back): {}", e), None);
+                return;
+            }
+        }
+        yield sse("log", format!("Backups: {}, {}, {}, {}", bkp_main, bkp_mcp, bkp_assistant_mcp, bkp_paloma), Some(88));
 
         // Prune old backups now that every install succeeded. The rollback
         // paths above consume this deploy's backups via rename, so pruning
@@ -3625,6 +3673,7 @@ fn stream_deploy(
             &install_dest_main,
             &install_dest_mcp,
             &install_dest_assistant_mcp,
+            &install_dest_paloma,
         ] {
             let (pruned, freed) = prune_deploy_backups(dest, keep).await;
             pruned_total += pruned.len();

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3457,9 +3457,17 @@ fn stream_deploy(
             .ok()
             .filter(|path| !path.trim().is_empty())
             .unwrap_or_else(|| {
-                let hermes_path = std::path::Path::new("/var/lib/hermes-assistant/bin/palomactl");
-                if hermes_path.parent().is_some_and(std::path::Path::exists) {
-                    hermes_path.to_string_lossy().to_string()
+                let hermes_bin = std::path::Path::new("/var/lib/hermes-assistant/bin");
+                let wrapper = hermes_bin.join("palomactl-wrapper");
+                let real = hermes_bin.join("palomactl.real");
+                if wrapper.exists() || real.exists() {
+                    // Hermes may layer project/health/review-thread commands in
+                    // a stable wrapper whose REAL target is palomactl.real.
+                    // Updating `palomactl` itself would silently erase those
+                    // operator integrations on every sandboxed.sh deploy.
+                    real.to_string_lossy().to_string()
+                } else if hermes_bin.exists() {
+                    hermes_bin.join("palomactl").to_string_lossy().to_string()
                 } else {
                     "/usr/local/bin/palomactl".to_string()
                 }

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1227,6 +1227,7 @@ mcp_servers:
         - get_workspace
         - create_workspace
         - update_workspace
+        - delete_workspace
         - list_workspace_templates
         - get_workspace_template
         - save_workspace_template
@@ -4696,6 +4697,7 @@ mod tests {
             "get_workspace",
             "create_workspace",
             "update_workspace",
+            "delete_workspace",
             "list_workspace_templates",
             "get_workspace_template",
             "save_workspace_template",

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3328,20 +3328,49 @@ pub async fn deploy_sandboxed_sh(
     ))))
 }
 
+fn sandboxed_service_name_from_path(path: &std::path::Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy();
+    if !name.starts_with("sandboxed-sh") {
+        return None;
+    }
+    Some(format!("{}.service", name.trim_end_matches(".service")))
+}
+
 fn current_sandboxed_service_name() -> Result<String, String> {
+    // argv[0] preserves the systemd ExecStart symlink name
+    // (`sandboxed-sh-prod`) while current_exe() resolves that symlink to the
+    // versioned artifact's generic `sandboxed-sh` filename.
+    if let Some(service) = std::env::args_os()
+        .next()
+        .as_deref()
+        .map(std::path::Path::new)
+        .and_then(sandboxed_service_name_from_path)
+    {
+        return Ok(service);
+    }
+
+    // Fall back to the systemd cgroup for launchers that replace argv[0].
+    // A v2 entry looks like `0::/system.slice/sandboxed-sh-prod.service`.
+    if let Ok(cgroup) = std::fs::read_to_string("/proc/self/cgroup") {
+        if let Some(service) = cgroup
+            .lines()
+            .flat_map(|line| line.rsplit('/'))
+            .find(|component| {
+                component.starts_with("sandboxed-sh") && component.ends_with(".service")
+            })
+        {
+            return Ok(service.to_string());
+        }
+    }
+
     let current_exe = std::env::current_exe()
         .map_err(|e| format!("Failed to detect current binary path: {}", e))?;
-    let exe_name = current_exe
-        .file_name()
-        .ok_or_else(|| {
-            format!(
-                "Current binary path has no file name: {}",
-                current_exe.display()
-            )
-        })?
-        .to_string_lossy()
-        .to_string();
-    Ok(format!("{}.service", exe_name))
+    sandboxed_service_name_from_path(&current_exe).ok_or_else(|| {
+        format!(
+            "Cannot derive a sandboxed.sh service from executable path {}",
+            current_exe.display()
+        )
+    })
 }
 
 /// The actual deploy stream — git checkout (optional), build (optional),
@@ -4672,8 +4701,8 @@ mod tests {
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
         hermes_config_base_url, hermes_config_model_label, hermes_config_yaml,
         hermes_uses_native_codex, is_safe_repo_path, normalize_repo_path, prune_deploy_backups,
-        select_repo_path, systemd_service_component_from_states, ComponentStatus, DebounceDecision,
-        DeployRefusal, DEPLOY_DEBOUNCE_SECS,
+        sandboxed_service_name_from_path, select_repo_path, systemd_service_component_from_states,
+        ComponentStatus, DebounceDecision, DeployRefusal, DEPLOY_DEBOUNCE_SECS,
     };
 
     #[test]
@@ -5061,6 +5090,32 @@ mod tests {
     fn select_repo_path_uses_default_when_empty() {
         let result = select_repo_path(Some("  ".to_string()), Some("".to_string()));
         assert_eq!(result, crate::settings::DEFAULT_SANDBOXED_REPO_PATH);
+    }
+
+    #[test]
+    fn service_name_uses_execstart_symlink_instead_of_versioned_target_name() {
+        assert_eq!(
+            sandboxed_service_name_from_path(std::path::Path::new(
+                "/usr/local/bin/sandboxed-sh-prod"
+            )),
+            Some("sandboxed-sh-prod.service".to_string())
+        );
+        assert_eq!(
+            sandboxed_service_name_from_path(std::path::Path::new(
+                "/usr/local/bin/sandboxed-sh-dev"
+            )),
+            Some("sandboxed-sh-dev.service".to_string())
+        );
+        assert_eq!(
+            sandboxed_service_name_from_path(std::path::Path::new(
+                "/usr/local/lib/sandboxed-sh/abc123/sandboxed-sh"
+            )),
+            Some("sandboxed-sh.service".to_string())
+        );
+        assert_eq!(
+            sandboxed_service_name_from_path(std::path::Path::new("/usr/bin/other")),
+            None
+        );
     }
 
     #[test]

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1213,12 +1213,26 @@ mcp_servers:
         - list_active_missions
         - list_missions
         - get_mission
+        - get_mission_digest
         - get_mission_events
+        - get_mission_health
+        - get_mission_diagnostics
         - start_mission
         - send_message_to_mission
         - ask_mission
+        - update_mission_settings
+        - resume_mission
         - cancel_mission
         - list_workspaces
+        - get_workspace
+        - create_workspace
+        - update_workspace
+        - list_workspace_templates
+        - get_workspace_template
+        - save_workspace_template
+        - delete_workspace_template
+        - rebuild_workspace_from_template
+        - workspace_bash
       prompts: false
       resources: false
 
@@ -4662,7 +4676,7 @@ mod tests {
     };
 
     #[test]
-    fn generated_hermes_config_allows_long_ask_turns() {
+    fn generated_hermes_config_allows_long_ask_turns_and_workspace_management() {
         let yaml = hermes_config_yaml(
             "hermes-test",
             "model",
@@ -4678,6 +4692,22 @@ mod tests {
         assert!(yaml.contains("    timeout: 600\n"));
         assert!(!yaml.contains("    timeout: 120\n"));
         assert!(yaml.contains("        - ask_mission\n"));
+        for tool in [
+            "get_workspace",
+            "create_workspace",
+            "update_workspace",
+            "list_workspace_templates",
+            "get_workspace_template",
+            "save_workspace_template",
+            "delete_workspace_template",
+            "rebuild_workspace_from_template",
+            "workspace_bash",
+        ] {
+            assert!(
+                yaml.contains(&format!("        - {tool}\n")),
+                "generated Hermes config missing {tool}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -826,6 +826,19 @@ fn apply_template_fields(
     template_name: &str,
     template: WorkspaceTemplate,
 ) -> Result<(), (StatusCode, String)> {
+    if template
+        .env_vars
+        .values()
+        .any(|value| value.starts_with("[DECRYPTION_FAILED]"))
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "Template '{template_name}' contains env vars that could not be decrypted; workspace configuration was left unchanged"
+            ),
+        ));
+    }
+
     workspace.template = Some(template_name.to_string());
     workspace.distro = template
         .distro
@@ -2417,5 +2430,42 @@ mod tests {
         assert_eq!(workspace.mcps, vec!["lean-lsp"]);
         assert!(!workspace.mcps_replace_defaults);
         assert_eq!(workspace.config_profile, None);
+    }
+
+    #[test]
+    fn apply_template_fields_rejects_failed_decryption_without_mutating_workspace() {
+        let mut workspace =
+            Workspace::new_container("demo".to_string(), PathBuf::from("/tmp/demo"));
+        workspace.template = Some("working".to_string());
+        workspace.env_vars = HashMap::from([("TOKEN".to_string(), "valid".to_string())]);
+
+        let template = WorkspaceTemplate {
+            name: "broken".to_string(),
+            description: None,
+            path: "workspace-template/broken.json".to_string(),
+            distro: Some("ubuntu-noble".to_string()),
+            skills: Vec::new(),
+            env_vars: HashMap::from([(
+                "TOKEN".to_string(),
+                "[DECRYPTION_FAILED]<encrypted>ciphertext</encrypted>".to_string(),
+            )]),
+            encrypted_keys: vec!["TOKEN".to_string()],
+            init_scripts: Vec::new(),
+            init_script: "echo should-not-run".to_string(),
+            shared_network: None,
+            tailscale_mode: None,
+            mcps: Vec::new(),
+            mcps_replace_defaults: true,
+            config_profile: None,
+        };
+
+        let error = apply_template_fields(&mut workspace, "broken", template).unwrap_err();
+        assert_eq!(error.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(workspace.template.as_deref(), Some("working"));
+        assert_eq!(
+            workspace.env_vars.get("TOKEN").map(String::as_str),
+            Some("valid")
+        );
+        assert!(workspace.init_script.is_none());
     }
 }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -31,6 +31,7 @@ pub fn routes() -> Router<Arc<super::routes::AppState>> {
         .route("/:id", get(get_workspace))
         .route("/:id", put(update_workspace))
         .route("/:id", delete(delete_workspace))
+        .route("/:id/apply-template", post(apply_workspace_template))
         .route("/:id/build", post(build_workspace))
         .route("/:id/sync", post(sync_workspace))
         .route("/:id/exec", post(exec_workspace_command))
@@ -127,6 +128,12 @@ pub struct UpdateWorkspaceRequest {
     pub config_profile: Option<String>,
     /// Freeform workspace configuration (merged with existing config).
     pub config: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ApplyWorkspaceTemplateRequest {
+    /// Template to apply. Defaults to the workspace's current template.
+    pub template: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -746,6 +753,97 @@ async fn update_workspace(
     tracing::info!("Updated workspace: {} ({})", workspace.name, id);
 
     Ok(Json(workspace.into()))
+}
+
+/// POST /api/workspaces/:id/apply-template - Reapply the latest template fields.
+async fn apply_workspace_template(
+    State(state): State<Arc<super::routes::AppState>>,
+    AxumPath(id): AxumPath<Uuid>,
+    Json(req): Json<ApplyWorkspaceTemplateRequest>,
+) -> Result<Json<WorkspaceResponse>, (StatusCode, String)> {
+    let mut workspace = require_workspace(&state.workspaces, id).await?;
+
+    if workspace.workspace_type != WorkspaceType::Container {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Only container workspaces can apply templates".to_string(),
+        ));
+    }
+    if workspace.status == WorkspaceStatus::Building {
+        return Err((
+            StatusCode::CONFLICT,
+            "Workspace build already in progress".to_string(),
+        ));
+    }
+
+    let template_name = req
+        .template
+        .as_deref()
+        .or(workspace.template.as_deref())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "No template supplied and workspace has no template".to_string(),
+            )
+        })?
+        .to_string();
+
+    let library = clone_library(&state.library).await.ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Library not initialized".to_string(),
+        )
+    })?;
+    let template = library
+        .get_workspace_template(&template_name)
+        .await
+        .map_err(|error| (StatusCode::NOT_FOUND, error.to_string()))?;
+
+    apply_template_fields(&mut workspace, &template_name, template)?;
+    state.workspaces.update(workspace.clone()).await;
+
+    if let Err(error) = workspace::sync_workspace_skills(&workspace, &library).await {
+        tracing::warn!(
+            workspace = %workspace.name,
+            error = %error,
+            "Failed to sync skills after applying workspace template"
+        );
+    }
+
+    tracing::info!(
+        workspace = %workspace.name,
+        template = %template_name,
+        "Applied workspace template"
+    );
+
+    Ok(Json(workspace.into()))
+}
+
+fn apply_template_fields(
+    workspace: &mut Workspace,
+    template_name: &str,
+    template: WorkspaceTemplate,
+) -> Result<(), (StatusCode, String)> {
+    workspace.template = Some(template_name.to_string());
+    workspace.distro = template
+        .distro
+        .as_deref()
+        .map(normalize_distro_value)
+        .transpose()?;
+    workspace.skills = sanitize_skill_list(template.skills);
+    workspace.env_vars = sanitize_env_vars(template.env_vars);
+    workspace.init_scripts = template.init_scripts;
+    workspace.init_script = normalize_init_script(Some(template.init_script));
+    workspace.shared_network = template.shared_network;
+    workspace.tailscale_mode = template.tailscale_mode;
+    workspace.mcps = template.mcps;
+    workspace.mcps_replace_defaults = template.mcps_replace_defaults;
+    workspace.config_profile = template
+        .config_profile
+        .and_then(|profile| (!profile.trim().is_empty()).then(|| profile.trim().to_string()));
+    Ok(())
 }
 
 /// POST /api/workspaces/:id/sync - Manually sync skills and tools to workspace.
@@ -2276,5 +2374,48 @@ mod tests {
     #[test]
     fn test_validate_workspace_name_rejects_empty() {
         assert!(validate_workspace_name("").is_err());
+    }
+
+    #[test]
+    fn apply_template_fields_replaces_template_controlled_configuration() {
+        let mut workspace =
+            Workspace::new_container("demo".to_string(), PathBuf::from("/tmp/demo"));
+        workspace.distro = Some("ubuntu:22.04".to_string());
+        workspace.skills = vec!["old-skill".to_string()];
+        workspace.env_vars = HashMap::from([("OLD".to_string(), "value".to_string())]);
+        workspace.tailscale_mode = Some(TailscaleMode::ExitNode);
+        workspace.config_profile = Some("old".to_string());
+
+        let template = WorkspaceTemplate {
+            name: "lean".to_string(),
+            description: Some("Lean workspace".to_string()),
+            path: "workspace-template/lean.json".to_string(),
+            distro: Some("ubuntu-noble".to_string()),
+            skills: vec!["lean".to_string()],
+            env_vars: HashMap::from([("LEAN_VERSION".to_string(), "4.24.0".to_string())]),
+            encrypted_keys: Vec::new(),
+            init_scripts: vec!["base".to_string(), "lean".to_string()],
+            init_script: "echo ready".to_string(),
+            shared_network: Some(false),
+            tailscale_mode: None,
+            mcps: vec!["lean-lsp".to_string()],
+            mcps_replace_defaults: false,
+            config_profile: None,
+        };
+
+        apply_template_fields(&mut workspace, "lean", template).unwrap();
+
+        assert_eq!(workspace.template.as_deref(), Some("lean"));
+        assert_eq!(workspace.distro.as_deref(), Some("ubuntu-noble"));
+        assert_eq!(workspace.skills, vec!["lean"]);
+        assert_eq!(workspace.env_vars.get("LEAN_VERSION").unwrap(), "4.24.0");
+        assert!(!workspace.env_vars.contains_key("OLD"));
+        assert_eq!(workspace.init_scripts, vec!["base", "lean"]);
+        assert_eq!(workspace.init_script.as_deref(), Some("echo ready"));
+        assert_eq!(workspace.shared_network, Some(false));
+        assert_eq!(workspace.tailscale_mode, None);
+        assert_eq!(workspace.mcps, vec!["lean-lsp"]);
+        assert!(!workspace.mcps_replace_defaults);
+        assert_eq!(workspace.config_profile, None);
     }
 }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1341,17 +1341,7 @@ async fn exec_workspace_command(
     let timeout_secs = req.timeout_secs.unwrap_or(300).clamp(1, 600);
 
     // Determine working directory
-    let cwd = match &req.cwd {
-        Some(path) => {
-            let path = Path::new(path);
-            if path.is_absolute() {
-                path.to_path_buf()
-            } else {
-                workspace.path.join(path)
-            }
-        }
-        None => workspace.path.clone(),
-    };
+    let cwd = resolve_workspace_exec_cwd(&workspace, req.cwd.as_deref())?;
 
     // `timeout(1)` enforces the limit inside the workspace: TERM at expiry,
     // escalating to KILL 5s later (`-k`) so TERM-ignoring commands still die
@@ -1399,6 +1389,47 @@ async fn exec_workspace_command(
             timed_out: true,
         })),
     }
+}
+
+fn resolve_workspace_exec_cwd(
+    workspace: &Workspace,
+    requested: Option<&str>,
+) -> Result<PathBuf, (StatusCode, String)> {
+    let Some(requested) = requested else {
+        return Ok(workspace.path.clone());
+    };
+    let requested = Path::new(requested);
+
+    if workspace.workspace_type != WorkspaceType::Container {
+        return Ok(if requested.is_absolute() {
+            requested.to_path_buf()
+        } else {
+            workspace.path.join(requested)
+        });
+    }
+
+    // WorkspaceExec accepts host paths and translates them back into guest
+    // paths. Hermes/users naturally supply guest-absolute paths such as
+    // `/workspace/verity/base`; map those under the container root first.
+    let resolved = if requested.is_absolute() {
+        if requested.starts_with(&workspace.path) {
+            requested.to_path_buf()
+        } else {
+            workspace
+                .path
+                .join(requested.strip_prefix("/").unwrap_or(requested))
+        }
+    } else {
+        workspace.path.join(requested)
+    };
+
+    if !path_within(&workspace.path, &resolved) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Working directory must remain inside the workspace".to_string(),
+        ));
+    }
+    Ok(resolved)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2467,5 +2498,39 @@ mod tests {
             Some("valid")
         );
         assert!(workspace.init_script.is_none());
+    }
+
+    #[test]
+    fn container_exec_cwd_maps_guest_absolute_path_under_workspace_root() {
+        let root = TempDir::new().unwrap();
+        let workspace = Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+
+        let cwd = resolve_workspace_exec_cwd(&workspace, Some("/workspace/verity/base"))
+            .expect("guest path should map into the container root");
+
+        assert_eq!(cwd, root.path().join("workspace/verity/base"));
+    }
+
+    #[test]
+    fn container_exec_cwd_accepts_host_path_inside_workspace() {
+        let root = TempDir::new().unwrap();
+        let workspace = Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+        let host_path = root.path().join("workspace/verity/base");
+
+        let cwd = resolve_workspace_exec_cwd(&workspace, host_path.to_str())
+            .expect("host path inside the workspace should remain unchanged");
+
+        assert_eq!(cwd, host_path);
+    }
+
+    #[test]
+    fn container_exec_cwd_rejects_relative_escape() {
+        let root = TempDir::new().unwrap();
+        let workspace = Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+
+        let error = resolve_workspace_exec_cwd(&workspace, Some("../../etc"))
+            .expect_err("relative traversal must not leave the workspace");
+
+        assert_eq!(error.0, StatusCode::BAD_REQUEST);
     }
 }

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -928,6 +928,51 @@ impl AppServerEventTranslator {
                                 }
                             }
                         }
+                        "mcpToolCall" | "mcp_tool_call" => {
+                            // Codex app-server v2 models MCP calls as their own
+                            // thread-item kind (rather than a generic
+                            // `toolCall`).  Missing this lifecycle made real,
+                            // successful MCP activity invisible to the runner,
+                            // which then falsely failed tool-required turns as
+                            // stalled and retried an expensive Lean query.
+                            let server =
+                                item.get("server").and_then(|v| v.as_str()).unwrap_or("mcp");
+                            let tool = item
+                                .get("tool")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown_tool");
+                            let name = format!("mcp__{server}__{tool}");
+                            if method == "item/started" {
+                                let args = item
+                                    .get("arguments")
+                                    .cloned()
+                                    .unwrap_or(serde_json::Value::Null);
+                                if !self.emitted_tool_result_ids.contains(&id) {
+                                    self.pending_tool_calls.insert(id.clone(), name.clone());
+                                }
+                                if !self.emitted_tool_result_ids.contains(&id)
+                                    && self.emitted_tool_call_ids.insert(id.clone())
+                                {
+                                    events.push(ExecutionEvent::ToolCall { id, name, args });
+                                }
+                            } else {
+                                let result = item
+                                    .get("result")
+                                    .filter(|value| !value.is_null())
+                                    .cloned()
+                                    .or_else(|| {
+                                        item.get("error")
+                                            .filter(|value| !value.is_null())
+                                            .cloned()
+                                            .map(|error| serde_json::json!({ "error": error }))
+                                    })
+                                    .unwrap_or(serde_json::Value::Null);
+                                self.pending_tool_calls.remove(&id);
+                                if self.emitted_tool_result_ids.insert(id.clone()) {
+                                    events.push(ExecutionEvent::ToolResult { id, name, result });
+                                }
+                            }
+                        }
                         "commandExecution" => {
                             // Bash-like commands. Surface as a synthetic
                             // tool call named "bash" to match the exec-mode
@@ -1576,6 +1621,61 @@ mod tests {
             .is_empty());
         assert!(translator
             .handle_notification("item/started", &params, false)
+            .events
+            .is_empty());
+        assert!(translator.pending_tool_ids().is_empty());
+    }
+
+    #[test]
+    fn mcp_tool_call_lifecycle_is_surfaced_and_deduplicated() {
+        let mut translator = AppServerEventTranslator::default();
+        let started = json!({
+            "item": {
+                "id": "mcp-1",
+                "type": "mcpToolCall",
+                "server": "lean_lsp",
+                "tool": "lean_diagnostic_messages",
+                "arguments": {"file_path": "/workspace/verity/Main.lean"},
+                "status": "inProgress"
+            }
+        });
+        let completed = json!({
+            "item": {
+                "id": "mcp-1",
+                "type": "mcpToolCall",
+                "server": "lean_lsp",
+                "tool": "lean_diagnostic_messages",
+                "arguments": {"file_path": "/workspace/verity/Main.lean"},
+                "status": "completed",
+                "result": {"content": [{"type": "text", "text": "ok"}]},
+                "error": null
+            }
+        });
+
+        let call = translator.handle_notification("item/started", &started, false);
+        assert!(matches!(
+            call.events.as_slice(),
+            [ExecutionEvent::ToolCall { id, name, args }]
+                if id == "mcp-1"
+                    && name == "mcp__lean_lsp__lean_diagnostic_messages"
+                    && args.get("file_path").and_then(|value| value.as_str())
+                        == Some("/workspace/verity/Main.lean")
+        ));
+        assert!(translator
+            .handle_notification("item/started", &started, false)
+            .events
+            .is_empty());
+
+        let result = translator.handle_notification("item/completed", &completed, false);
+        assert!(matches!(
+            result.events.as_slice(),
+            [ExecutionEvent::ToolResult { id, name, result }]
+                if id == "mcp-1"
+                    && name == "mcp__lean_lsp__lean_diagnostic_messages"
+                    && result.get("content").is_some()
+        ));
+        assert!(translator
+            .handle_notification("item/completed", &completed, false)
             .events
             .is_empty());
         assert!(translator.pending_tool_ids().is_empty());

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -193,6 +193,13 @@ struct WorkspaceIdParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct DeleteWorkspaceParams {
+    workspace_id: String,
+    #[serde(default)]
+    confirm: bool,
+}
+
+#[derive(Debug, Deserialize)]
 struct CreateWorkspaceParams {
     name: String,
     #[serde(default)]
@@ -922,6 +929,18 @@ impl AssistantMcp {
                 }),
             },
             ToolDefinition {
+                name: "delete_workspace".to_string(),
+                description: "Delete a sandboxed.sh workspace and its managed container data. Requires confirm=true; active missions that reference it are not deleted.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["workspace_id", "confirm"],
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "confirm": {"type": "boolean", "description": "Must be true to perform deletion."}
+                    }
+                }),
+            },
+            ToolDefinition {
                 name: "list_workspace_templates".to_string(),
                 description: "List reusable sandboxed.sh workspace templates from the Library.".to_string(),
                 input_schema: json!({"type": "object", "properties": {}}),
@@ -1417,6 +1436,16 @@ impl AssistantMcp {
         let response = self.api_put(&format!("/api/workspaces/{id}"), body).await?;
         let workspace = Self::response_value(response, "Update workspace").await?;
         Ok(json!({"workspace": workspace}))
+    }
+
+    async fn delete_workspace(&self, params: DeleteWorkspaceParams) -> Result<Value, String> {
+        if !params.confirm {
+            return Err("Workspace deletion requires confirm=true".to_string());
+        }
+        let id = parse_uuid(&params.workspace_id)?;
+        let response = self.api_delete(&format!("/api/workspaces/{id}")).await?;
+        Self::response_value(response, "Delete workspace").await?;
+        Ok(json!({"deleted": true, "workspace_id": id.to_string()}))
     }
 
     async fn list_workspace_templates(&self) -> Result<Value, String> {
@@ -1925,6 +1954,11 @@ impl AssistantMcp {
                 let params: UpdateWorkspaceParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
                 self.update_workspace(params).await
+            }
+            "delete_workspace" => {
+                let params: DeleteWorkspaceParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.delete_workspace(params).await
             }
             "list_workspace_templates" => self.list_workspace_templates().await,
             "get_workspace_template" => {
@@ -2738,6 +2772,7 @@ mod tests {
             "get_workspace",
             "create_workspace",
             "update_workspace",
+            "delete_workspace",
             "list_workspace_templates",
             "get_workspace_template",
             "save_workspace_template",
@@ -2748,6 +2783,7 @@ mod tests {
         }
 
         for destructive in [
+            "delete_workspace",
             "delete_workspace_template",
             "rebuild_workspace_from_template",
         ] {

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -157,6 +157,16 @@ struct StartMissionParams {
     next_check_at: Option<String>,
 }
 
+fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
+    match agent?.trim().to_ascii_lowercase().as_str() {
+        "codex" => Some("codex".to_string()),
+        "claudecode" => Some("claudecode".to_string()),
+        "gemini" => Some("gemini".to_string()),
+        "grok" => Some("grok".to_string()),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct SendMessageParams {
     mission_id: String,
@@ -807,7 +817,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "start_mission".to_string(),
-                description: "Create a new sandboxed.sh mission and send its initial prompt. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title).".to_string(),
+                description: "Create a new sandboxed.sh mission and send its initial prompt. Set backend explicitly when possible. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["title", "prompt"],
@@ -1268,10 +1278,13 @@ impl AssistantMcp {
 
     async fn start_mission(&self, params: StartMissionParams) -> Result<Value, String> {
         let workspace_id = resolve_default_workspace_id(params.workspace_id);
+        let backend = params
+            .backend
+            .or_else(|| native_backend_from_agent(params.agent.as_deref()));
         let body = json!({
             "title": params.title,
             "workspace_id": workspace_id,
-            "backend": params.backend,
+            "backend": backend,
             "model_override": params.model_override,
             "model_effort": params.model_effort,
             "config_profile": params.config_profile,
@@ -2616,6 +2629,20 @@ mod tests {
 
         assert_eq!(workspace_id.as_deref(), Some("assistant-workspace"));
         clear_env();
+    }
+
+    #[test]
+    fn native_agent_names_select_the_matching_backend() {
+        assert_eq!(
+            native_backend_from_agent(Some("codex")).as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            native_backend_from_agent(Some(" ClaudeCode ")).as_deref(),
+            Some("claudecode")
+        );
+        assert_eq!(native_backend_from_agent(Some("build")), None);
+        assert_eq!(native_backend_from_agent(None), None);
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -4,6 +4,7 @@
 //! control-plane tools a personal assistant needs without deployment or
 //! durable-job capabilities.
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
@@ -187,6 +188,125 @@ struct WorkspaceBashParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct WorkspaceIdParams {
+    workspace_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateWorkspaceParams {
+    name: String,
+    #[serde(default)]
+    workspace_type: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    skills: Option<Vec<String>>,
+    #[serde(default)]
+    plugins: Option<Vec<String>>,
+    #[serde(default)]
+    template: Option<String>,
+    #[serde(default)]
+    distro: Option<String>,
+    #[serde(default)]
+    env_vars: Option<HashMap<String, String>>,
+    #[serde(default)]
+    init_script: Option<String>,
+    #[serde(default)]
+    shared_network: Option<bool>,
+    #[serde(default)]
+    tailscale_mode: Option<String>,
+    #[serde(default)]
+    mcps: Option<Vec<String>>,
+    #[serde(default)]
+    mcps_replace_defaults: Option<bool>,
+    #[serde(default)]
+    config_profile: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateWorkspaceParams {
+    workspace_id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    skills: Option<Vec<String>>,
+    #[serde(default)]
+    plugins: Option<Vec<String>>,
+    #[serde(default)]
+    template: Option<String>,
+    #[serde(default)]
+    distro: Option<String>,
+    #[serde(default)]
+    env_vars: Option<HashMap<String, String>>,
+    #[serde(default)]
+    init_script: Option<String>,
+    #[serde(default)]
+    init_scripts: Option<Vec<String>>,
+    #[serde(default)]
+    shared_network: Option<bool>,
+    #[serde(default)]
+    tailscale_mode: Option<String>,
+    #[serde(default)]
+    mcps: Option<Vec<String>>,
+    #[serde(default)]
+    mcps_replace_defaults: Option<bool>,
+    #[serde(default)]
+    config_profile: Option<String>,
+    #[serde(default)]
+    config: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceTemplateNameParams {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SaveWorkspaceTemplateParams {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    distro: Option<String>,
+    #[serde(default)]
+    skills: Option<Vec<String>>,
+    #[serde(default)]
+    env_vars: Option<HashMap<String, String>>,
+    #[serde(default)]
+    encrypted_keys: Option<Vec<String>>,
+    #[serde(default)]
+    init_scripts: Option<Vec<String>>,
+    #[serde(default)]
+    init_script: Option<String>,
+    #[serde(default)]
+    shared_network: Option<bool>,
+    #[serde(default)]
+    tailscale_mode: Option<String>,
+    #[serde(default)]
+    mcps: Option<Vec<String>>,
+    #[serde(default)]
+    mcps_replace_defaults: Option<bool>,
+    #[serde(default)]
+    config_profile: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeleteWorkspaceTemplateParams {
+    name: String,
+    #[serde(default)]
+    confirm: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RebuildWorkspaceFromTemplateParams {
+    workspace_id: String,
+    #[serde(default)]
+    template: Option<String>,
+    #[serde(default)]
+    confirm: bool,
+}
+
+#[derive(Debug, Deserialize)]
 struct UpdateSettingsParams {
     mission_id: String,
     #[serde(default)]
@@ -243,6 +363,105 @@ fn default_limit() -> usize {
 
 fn default_event_limit() -> usize {
     40
+}
+
+fn insert_optional<T: Serialize>(
+    body: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: Option<T>,
+) -> Result<(), String> {
+    if let Some(value) = value {
+        body.insert(
+            key.to_string(),
+            serde_json::to_value(value)
+                .map_err(|error| format!("Failed to encode {key}: {error}"))?,
+        );
+    }
+    Ok(())
+}
+
+fn require_resource_name(name: &str, resource: &str) -> Result<String, String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(format!("{resource} name cannot be empty"));
+    }
+    Ok(name.to_string())
+}
+
+fn create_workspace_body(params: CreateWorkspaceParams) -> Result<Value, String> {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "name".to_string(),
+        json!(require_resource_name(&params.name, "Workspace")?),
+    );
+    insert_optional(&mut body, "workspace_type", params.workspace_type)?;
+    insert_optional(&mut body, "path", params.path)?;
+    insert_optional(&mut body, "skills", params.skills)?;
+    insert_optional(&mut body, "plugins", params.plugins)?;
+    insert_optional(&mut body, "template", params.template)?;
+    insert_optional(&mut body, "distro", params.distro)?;
+    insert_optional(&mut body, "env_vars", params.env_vars)?;
+    insert_optional(&mut body, "init_script", params.init_script)?;
+    insert_optional(&mut body, "shared_network", params.shared_network)?;
+    insert_optional(&mut body, "tailscale_mode", params.tailscale_mode)?;
+    insert_optional(&mut body, "mcps", params.mcps)?;
+    insert_optional(
+        &mut body,
+        "mcps_replace_defaults",
+        params.mcps_replace_defaults,
+    )?;
+    insert_optional(&mut body, "config_profile", params.config_profile)?;
+    Ok(Value::Object(body))
+}
+
+fn update_workspace_body(params: UpdateWorkspaceParams) -> Result<(Uuid, Value), String> {
+    let id = parse_uuid(&params.workspace_id)?;
+    let mut body = serde_json::Map::new();
+    insert_optional(&mut body, "name", params.name)?;
+    insert_optional(&mut body, "skills", params.skills)?;
+    insert_optional(&mut body, "plugins", params.plugins)?;
+    insert_optional(&mut body, "template", params.template)?;
+    insert_optional(&mut body, "distro", params.distro)?;
+    insert_optional(&mut body, "env_vars", params.env_vars)?;
+    insert_optional(&mut body, "init_script", params.init_script)?;
+    insert_optional(&mut body, "init_scripts", params.init_scripts)?;
+    insert_optional(&mut body, "shared_network", params.shared_network)?;
+    insert_optional(&mut body, "tailscale_mode", params.tailscale_mode)?;
+    insert_optional(&mut body, "mcps", params.mcps)?;
+    insert_optional(
+        &mut body,
+        "mcps_replace_defaults",
+        params.mcps_replace_defaults,
+    )?;
+    insert_optional(&mut body, "config_profile", params.config_profile)?;
+    insert_optional(&mut body, "config", params.config)?;
+    if body.is_empty() {
+        return Err("No workspace fields supplied to update".to_string());
+    }
+    Ok((id, Value::Object(body)))
+}
+
+fn apply_template_patch(
+    template: &mut serde_json::Map<String, Value>,
+    params: SaveWorkspaceTemplateParams,
+) -> Result<(), String> {
+    insert_optional(template, "description", params.description)?;
+    insert_optional(template, "distro", params.distro)?;
+    insert_optional(template, "skills", params.skills)?;
+    insert_optional(template, "env_vars", params.env_vars)?;
+    insert_optional(template, "encrypted_keys", params.encrypted_keys)?;
+    insert_optional(template, "init_scripts", params.init_scripts)?;
+    insert_optional(template, "init_script", params.init_script)?;
+    insert_optional(template, "shared_network", params.shared_network)?;
+    insert_optional(template, "tailscale_mode", params.tailscale_mode)?;
+    insert_optional(template, "mcps", params.mcps)?;
+    insert_optional(
+        template,
+        "mcps_replace_defaults",
+        params.mcps_replace_defaults,
+    )?;
+    insert_optional(template, "config_profile", params.config_profile)?;
+    Ok(())
 }
 
 fn default_artifact_dir() -> PathBuf {
@@ -448,6 +667,51 @@ impl AssistantMcp {
             .map_err(|error| format!("HTTP request failed: {error}"))
     }
 
+    async fn api_put(&self, path: &str, body: Value) -> Result<reqwest::Response, String> {
+        let mut req = self
+            .client
+            .put(format!("{}{}", self.api_url, path))
+            .json(&body);
+        if let Some((name, value)) = self.auth_header() {
+            req = req.header(name, value);
+        }
+        req.send()
+            .await
+            .map_err(|error| format!("HTTP request failed: {error}"))
+    }
+
+    async fn api_delete(&self, path: &str) -> Result<reqwest::Response, String> {
+        let mut req = self.client.delete(format!("{}{}", self.api_url, path));
+        if let Some((name, value)) = self.auth_header() {
+            req = req.header(name, value);
+        }
+        req.send()
+            .await
+            .map_err(|error| format!("HTTP request failed: {error}"))
+    }
+
+    async fn response_value(response: reqwest::Response, operation: &str) -> Result<Value, String> {
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| format!("Failed to read {operation} response: {error}"))?;
+        if !status.is_success() {
+            let detail = String::from_utf8_lossy(&bytes);
+            return Err(format!("{operation} failed ({status}): {detail}"));
+        }
+        if bytes.is_empty() {
+            return Ok(json!({"success": true}));
+        }
+        match serde_json::from_slice(&bytes) {
+            Ok(value) => Ok(value),
+            Err(_) => Ok(json!({
+                "success": true,
+                "message": String::from_utf8_lossy(&bytes).trim(),
+            })),
+        }
+    }
+
     fn tools() -> Vec<ToolDefinition> {
         vec![
             ToolDefinition {
@@ -598,6 +862,126 @@ impl AssistantMcp {
                 name: "list_workspaces".to_string(),
                 description: "List sandboxed.sh workspaces so new missions can target the right environment.".to_string(),
                 input_schema: json!({"type": "object", "properties": {}}),
+            },
+            ToolDefinition {
+                name: "get_workspace".to_string(),
+                description: "Get the complete configuration and current build status of one sandboxed.sh workspace.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["workspace_id"],
+                    "properties": {"workspace_id": {"type": "string", "description": "Workspace UUID."}}
+                }),
+            },
+            ToolDefinition {
+                name: "create_workspace".to_string(),
+                description: "Create a sandboxed.sh workspace. A template always creates an isolated container and starts its build automatically; a host workspace requires a path inside the server working directory.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": {"type": "string"},
+                        "workspace_type": {"type": "string", "enum": ["host", "container"], "description": "Defaults to host unless template is set."},
+                        "path": {"type": "string", "description": "Required for host workspaces; omit for the standard container path."},
+                        "skills": {"type": "array", "items": {"type": "string"}},
+                        "plugins": {"type": "array", "items": {"type": "string"}},
+                        "template": {"type": "string", "description": "Workspace template name. Forces container type and starts a build."},
+                        "distro": {"type": "string"},
+                        "env_vars": {"type": "object", "additionalProperties": {"type": "string"}},
+                        "init_script": {"type": "string"},
+                        "shared_network": {"type": "boolean"},
+                        "tailscale_mode": {"type": "string", "enum": ["exit_node", "tailnet_only"]},
+                        "mcps": {"type": "array", "items": {"type": "string"}},
+                        "mcps_replace_defaults": {"type": "boolean"},
+                        "config_profile": {"type": "string"}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "update_workspace".to_string(),
+                description: "Update only the supplied fields of an existing workspace. Setting template changes the association but does not reapply template contents; use rebuild_workspace_from_template for that.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["workspace_id"],
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "name": {"type": "string"},
+                        "skills": {"type": "array", "items": {"type": "string"}},
+                        "plugins": {"type": "array", "items": {"type": "string"}},
+                        "template": {"type": "string", "description": "Empty string clears the association."},
+                        "distro": {"type": "string", "description": "Empty string clears the override."},
+                        "env_vars": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Replaces the workspace env map."},
+                        "init_script": {"type": "string"},
+                        "init_scripts": {"type": "array", "items": {"type": "string"}},
+                        "shared_network": {"type": "boolean"},
+                        "tailscale_mode": {"type": "string", "enum": ["exit_node", "tailnet_only"]},
+                        "mcps": {"type": "array", "items": {"type": "string"}},
+                        "mcps_replace_defaults": {"type": "boolean"},
+                        "config_profile": {"type": "string", "description": "Empty string clears the profile."},
+                        "config": {"type": "object", "description": "Shallow-merged into freeform workspace config."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "list_workspace_templates".to_string(),
+                description: "List reusable sandboxed.sh workspace templates from the Library.".to_string(),
+                input_schema: json!({"type": "object", "properties": {}}),
+            },
+            ToolDefinition {
+                name: "get_workspace_template".to_string(),
+                description: "Get a reusable workspace template. Sensitive values are redacted from the tool result.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {"name": {"type": "string"}}
+                }),
+            },
+            ToolDefinition {
+                name: "save_workspace_template".to_string(),
+                description: "Create or update a reusable workspace template. Existing templates are patch-updated: omitted fields are preserved, while supplied arrays/maps replace that field.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": {"type": "string"},
+                        "description": {"type": "string"},
+                        "distro": {"type": "string"},
+                        "skills": {"type": "array", "items": {"type": "string"}},
+                        "env_vars": {"type": "object", "additionalProperties": {"type": "string"}},
+                        "encrypted_keys": {"type": "array", "items": {"type": "string"}, "description": "Env var keys to encrypt at rest."},
+                        "init_scripts": {"type": "array", "items": {"type": "string"}},
+                        "init_script": {"type": "string"},
+                        "shared_network": {"type": "boolean"},
+                        "tailscale_mode": {"type": "string", "enum": ["exit_node", "tailnet_only"]},
+                        "mcps": {"type": "array", "items": {"type": "string"}},
+                        "mcps_replace_defaults": {"type": "boolean"},
+                        "config_profile": {"type": "string"}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "delete_workspace_template".to_string(),
+                description: "Delete a reusable workspace template. Requires confirm=true and does not delete workspaces already created from it.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["name", "confirm"],
+                    "properties": {
+                        "name": {"type": "string"},
+                        "confirm": {"type": "boolean", "description": "Must be true to perform deletion."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "rebuild_workspace_from_template".to_string(),
+                description: "Reapply the latest template definition to an existing container workspace, replacing template-controlled fields, then force-rebuild its container. Requires confirm=true because container state may be replaced.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["workspace_id", "confirm"],
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "template": {"type": "string", "description": "Optional template name; defaults to the workspace's current template."},
+                        "confirm": {"type": "boolean", "description": "Must be true to force rebuild."}
+                    }
+                }),
             },
             ToolDefinition {
                 name: "workspace_bash".to_string(),
@@ -1014,6 +1398,143 @@ impl AssistantMcp {
         Ok(json!({ "workspaces": workspaces }))
     }
 
+    async fn get_workspace(&self, params: WorkspaceIdParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.workspace_id)?;
+        let response = self.api_get(&format!("/api/workspaces/{id}")).await?;
+        let workspace = Self::response_value(response, "Get workspace").await?;
+        Ok(json!({"workspace": workspace}))
+    }
+
+    async fn create_workspace(&self, params: CreateWorkspaceParams) -> Result<Value, String> {
+        let body = create_workspace_body(params)?;
+        let response = self.api_post("/api/workspaces", body).await?;
+        let workspace = Self::response_value(response, "Create workspace").await?;
+        Ok(json!({"workspace": workspace}))
+    }
+
+    async fn update_workspace(&self, params: UpdateWorkspaceParams) -> Result<Value, String> {
+        let (id, body) = update_workspace_body(params)?;
+        let response = self.api_put(&format!("/api/workspaces/{id}"), body).await?;
+        let workspace = Self::response_value(response, "Update workspace").await?;
+        Ok(json!({"workspace": workspace}))
+    }
+
+    async fn list_workspace_templates(&self) -> Result<Value, String> {
+        let response = self.api_get("/api/library/workspace-template").await?;
+        let templates = Self::response_value(response, "List workspace templates").await?;
+        Ok(json!({"templates": templates}))
+    }
+
+    async fn get_workspace_template(
+        &self,
+        params: WorkspaceTemplateNameParams,
+    ) -> Result<Value, String> {
+        let name = require_resource_name(&params.name, "Workspace template")?;
+        let encoded = urlencoding::encode(&name);
+        let response = self
+            .api_get(&format!("/api/library/workspace-template/{encoded}"))
+            .await?;
+        let template = Self::response_value(response, "Get workspace template").await?;
+        Ok(json!({"template": template}))
+    }
+
+    async fn save_workspace_template(
+        &self,
+        params: SaveWorkspaceTemplateParams,
+    ) -> Result<Value, String> {
+        let name = require_resource_name(&params.name, "Workspace template")?;
+        let encoded = urlencoding::encode(&name);
+        let path = format!("/api/library/workspace-template/{encoded}");
+        let response = self.api_get(&path).await?;
+        let has_env_override = params.env_vars.is_some();
+        let mut template = if response.status().is_success() {
+            let current = Self::response_value(response, "Get workspace template").await?;
+            if !has_env_override
+                && current
+                    .get("env_vars")
+                    .and_then(Value::as_object)
+                    .is_some_and(|env| {
+                        env.values().any(|value| {
+                            value
+                                .as_str()
+                                .is_some_and(|raw| raw.starts_with("[DECRYPTION_FAILED]"))
+                        })
+                    })
+            {
+                return Err(
+                    "Template contains env vars that could not be decrypted; supply a complete env_vars replacement before saving"
+                        .to_string(),
+                );
+            }
+            current.as_object().cloned().ok_or_else(|| {
+                "Existing workspace template response was not an object".to_string()
+            })?
+        } else if response.status() == reqwest::StatusCode::NOT_FOUND {
+            serde_json::Map::new()
+        } else {
+            return match Self::response_value(response, "Get workspace template").await {
+                Err(error) => Err(error),
+                Ok(_) => Err("Unexpected successful template response".to_string()),
+            };
+        };
+        template.remove("name");
+        template.remove("path");
+        apply_template_patch(&mut template, params)?;
+
+        let response = self.api_put(&path, Value::Object(template)).await?;
+        Self::response_value(response, "Save workspace template").await?;
+        let response = self.api_get(&path).await?;
+        let saved = Self::response_value(response, "Read saved workspace template").await?;
+        Ok(json!({"saved": true, "template": saved}))
+    }
+
+    async fn delete_workspace_template(
+        &self,
+        params: DeleteWorkspaceTemplateParams,
+    ) -> Result<Value, String> {
+        if !params.confirm {
+            return Err("Template deletion requires confirm=true".to_string());
+        }
+        let name = require_resource_name(&params.name, "Workspace template")?;
+        let encoded = urlencoding::encode(&name);
+        let response = self
+            .api_delete(&format!("/api/library/workspace-template/{encoded}"))
+            .await?;
+        Self::response_value(response, "Delete workspace template").await?;
+        Ok(json!({"deleted": true, "name": name}))
+    }
+
+    async fn rebuild_workspace_from_template(
+        &self,
+        params: RebuildWorkspaceFromTemplateParams,
+    ) -> Result<Value, String> {
+        if !params.confirm {
+            return Err("Forced workspace rebuild requires confirm=true".to_string());
+        }
+        let id = parse_uuid(&params.workspace_id)?;
+        let apply_response = self
+            .api_post(
+                &format!("/api/workspaces/{id}/apply-template"),
+                json!({"template": params.template}),
+            )
+            .await?;
+        let applied = Self::response_value(apply_response, "Apply workspace template").await?;
+
+        let build_response = self
+            .api_post(
+                &format!("/api/workspaces/{id}/build"),
+                json!({"rebuild": true}),
+            )
+            .await?;
+        let build = Self::response_value(build_response, "Rebuild workspace").await?;
+        Ok(json!({
+            "workspace_id": id.to_string(),
+            "template_applied": applied.get("template").cloned().unwrap_or(Value::Null),
+            "status": build.get("status").cloned().unwrap_or(Value::Null),
+            "rebuild_started": true,
+        }))
+    }
+
     async fn update_mission_settings(&self, params: UpdateSettingsParams) -> Result<Value, String> {
         let id = parse_uuid(&params.mission_id)?;
         let mut body = serde_json::Map::new();
@@ -1390,6 +1911,42 @@ impl AssistantMcp {
                 self.cancel_mission(params).await
             }
             "list_workspaces" => self.list_workspaces().await,
+            "get_workspace" => {
+                let params: WorkspaceIdParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.get_workspace(params).await
+            }
+            "create_workspace" => {
+                let params: CreateWorkspaceParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.create_workspace(params).await
+            }
+            "update_workspace" => {
+                let params: UpdateWorkspaceParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.update_workspace(params).await
+            }
+            "list_workspace_templates" => self.list_workspace_templates().await,
+            "get_workspace_template" => {
+                let params: WorkspaceTemplateNameParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.get_workspace_template(params).await
+            }
+            "save_workspace_template" => {
+                let params: SaveWorkspaceTemplateParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.save_workspace_template(params).await
+            }
+            "delete_workspace_template" => {
+                let params: DeleteWorkspaceTemplateParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.delete_workspace_template(params).await
+            }
+            "rebuild_workspace_from_template" => {
+                let params: RebuildWorkspaceFromTemplateParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.rebuild_workspace_from_template(params).await
+            }
             "workspace_bash" => {
                 let params: WorkspaceBashParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
@@ -2171,5 +2728,103 @@ mod tests {
         assert!(output_dir_for_shared_file(&mission_id, Some("/var/tmp".to_string())).is_err());
         // Relative paths are rejected.
         assert!(output_dir_for_shared_file(&mission_id, Some("tmp/x".to_string())).is_err());
+    }
+
+    #[test]
+    fn workspace_management_tools_are_exposed_with_destructive_confirmations() {
+        let tools = AssistantMcp::tools();
+        let names: Vec<_> = tools.iter().map(|tool| tool.name.as_str()).collect();
+        for expected in [
+            "get_workspace",
+            "create_workspace",
+            "update_workspace",
+            "list_workspace_templates",
+            "get_workspace_template",
+            "save_workspace_template",
+            "delete_workspace_template",
+            "rebuild_workspace_from_template",
+        ] {
+            assert!(names.contains(&expected), "missing tool {expected}");
+        }
+
+        for destructive in [
+            "delete_workspace_template",
+            "rebuild_workspace_from_template",
+        ] {
+            let schema = &tools
+                .iter()
+                .find(|tool| tool.name == destructive)
+                .unwrap()
+                .input_schema;
+            assert!(schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("confirm")));
+        }
+    }
+
+    #[test]
+    fn create_workspace_body_omits_unspecified_defaults_and_keeps_false() {
+        let params: CreateWorkspaceParams = serde_json::from_value(json!({
+            "name": "  hermes-test  ",
+            "shared_network": false,
+            "mcps": []
+        }))
+        .unwrap();
+
+        let body = create_workspace_body(params).unwrap();
+
+        assert_eq!(body["name"], "hermes-test");
+        assert_eq!(body["shared_network"], false);
+        assert_eq!(body["mcps"], json!([]));
+        assert!(body.get("workspace_type").is_none());
+        assert!(body.get("skills").is_none());
+    }
+
+    #[test]
+    fn update_workspace_body_requires_a_change_and_preserves_explicit_empty_values() {
+        let id = Uuid::new_v4();
+        let empty: UpdateWorkspaceParams =
+            serde_json::from_value(json!({"workspace_id": id})).unwrap();
+        assert!(update_workspace_body(empty).is_err());
+
+        let params: UpdateWorkspaceParams = serde_json::from_value(json!({
+            "workspace_id": id,
+            "skills": [],
+            "shared_network": false,
+            "config_profile": ""
+        }))
+        .unwrap();
+        let (parsed_id, body) = update_workspace_body(params).unwrap();
+        assert_eq!(parsed_id, id);
+        assert_eq!(body["skills"], json!([]));
+        assert_eq!(body["shared_network"], false);
+        assert_eq!(body["config_profile"], "");
+    }
+
+    #[test]
+    fn template_patch_preserves_omitted_fields_and_replaces_supplied_fields() {
+        let mut current = json!({
+            "description": "existing",
+            "skills": ["old"],
+            "env_vars": {"TOKEN": "secret"},
+            "mcps_replace_defaults": true
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let params: SaveWorkspaceTemplateParams = serde_json::from_value(json!({
+            "name": "lean",
+            "skills": ["lean", "github"],
+            "mcps_replace_defaults": false
+        }))
+        .unwrap();
+
+        apply_template_patch(&mut current, params).unwrap();
+
+        assert_eq!(current["description"], "existing");
+        assert_eq!(current["env_vars"]["TOKEN"], "secret");
+        assert_eq!(current["skills"], json!(["lean", "github"]));
+        assert_eq!(current["mcps_replace_defaults"], false);
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -826,7 +826,7 @@ impl AssistantMcp {
                         "prompt": {"type": "string"},
                         "workspace_id": {"type": "string"},
                         "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok"]},
-                        "model_override": {"type": "string"},
+                        "model_override": {"type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort. Never invent variants such as gpt-5.5-sol."},
                         "model_effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"]},
                         "config_profile": {"type": "string"},
                         "agent": {"type": "string"},

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -2409,7 +2409,15 @@ fn scrub_sensitive_json(value: &mut Value) {
     match value {
         Value::Object(map) => {
             for (key, child) in map.iter_mut() {
-                if is_sensitive_key(key) {
+                if key.eq_ignore_ascii_case("env_vars") {
+                    if let Value::Object(env_vars) = child {
+                        for env_value in env_vars.values_mut() {
+                            *env_value = Value::String("[redacted]".to_string());
+                        }
+                    } else {
+                        *child = Value::String("[redacted]".to_string());
+                    }
+                } else if is_sensitive_key(key) {
                     *child = Value::String("[redacted]".to_string());
                 } else {
                     scrub_sensitive_json(child);
@@ -2545,7 +2553,12 @@ mod tests {
             "mission": {
                 "title": "Hermes",
                 "api_key": "sk-test",
-                "notes": ["visible", "github_pat_123"]
+                "notes": ["visible", "github_pat_123"],
+                "env_vars": {
+                    "DATABASE_URL": "postgres://user:password@example.test/db",
+                    "AWS_ACCESS_KEY_ID": "not-matched-by-value-heuristics",
+                    "PATH": "/usr/local/bin:/usr/bin"
+                }
             },
             "token": "plain-token"
         });
@@ -2556,6 +2569,12 @@ mod tests {
         assert_eq!(value["mission"]["api_key"], "[redacted]");
         assert_eq!(value["mission"]["notes"][0], "visible");
         assert_eq!(value["mission"]["notes"][1], "[redacted]");
+        assert_eq!(value["mission"]["env_vars"]["DATABASE_URL"], "[redacted]");
+        assert_eq!(
+            value["mission"]["env_vars"]["AWS_ACCESS_KEY_ID"],
+            "[redacted]"
+        );
+        assert_eq!(value["mission"]["env_vars"]["PATH"], "[redacted]");
         assert_eq!(value["token"], "[redacted]");
     }
 

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -616,7 +616,7 @@ impl OrchestratorMcp {
                                     "title": { "type": "string" },
                                     "prompt": { "type": "string", "description": "Full worker prompt: exact scope, absolute paths, success condition, verification command" },
                                     "backend": { "type": "string", "description": "codex | opencode | grok (never claudecode)" },
-                                    "model_override": { "type": "string" },
+                                    "model_override": { "type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort. Never invent variants such as gpt-5.5-sol." },
                                     "model_effort": { "type": "string", "description": "low | medium | high | xhigh | max (codex)" },
                                     "working_directory": { "type": "string", "description": "Worker cwd; superseded by worktree.path if a worktree is given" },
                                     "depends_on": { "type": "array", "items": { "type": "string" }, "description": "task_keys that must settle successfully or be accepted first" },
@@ -712,7 +712,7 @@ impl OrchestratorMcp {
                         },
                         "model_override": {
                             "type": "string",
-                            "description": "Model to use. Must match the backend: Claude models (e.g. 'claude-opus-4-7') for claudecode, GPT models (e.g. 'gpt-5.6-sol') for codex, Gemini models for gemini, Grok models for grok, 'provider/model' format for opencode."
+                            "description": "Exact account-supported model ID. Must match the backend: Claude models (e.g. 'claude-opus-4-7') for claudecode, GPT models (e.g. 'gpt-5.6-terra', recommended with medium effort) for codex, Gemini models for gemini, Grok models for grok, 'provider/model' format for opencode. Never invent variants such as 'gpt-5.5-sol'."
                         },
                         "model_effort": {
                             "type": "string",
@@ -758,7 +758,7 @@ impl OrchestratorMcp {
                                 "properties": {
                                     "title": { "type": "string" },
                                     "backend": { "type": "string", "enum": ["claudecode", "codex", "gemini", "opencode", "grok"] },
-                                    "model_override": { "type": "string" },
+                                    "model_override": { "type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort; gpt-5.5-sol is unsupported." },
                                     "model_effort": { "type": "string", "enum": ["low", "medium", "high", "xhigh", "max"] },
                                     "agent": { "type": "string" },
                                     "config_profile": { "type": "string" },

--- a/src/bin/palomactl.rs
+++ b/src/bin/palomactl.rs
@@ -46,7 +46,8 @@ fn run(args: Vec<String>) -> Result<()> {
                 .ok_or_else(|| anyhow!("missing PR number"))?
                 .parse::<u64>()
                 .context("PR number must be numeric")?;
-            let gates = pr_gates(&root, repo, number)?;
+            let worker_head = value_after_flag(&args, "--worker-head");
+            let gates = pr_gates_with_worker_head(&root, repo, number, worker_head)?;
             println!("{}", serde_json::to_string_pretty(&gates)?);
             if let Some(rec) = gates.recommendation.as_deref() {
                 println!("recommendation={rec}");
@@ -81,7 +82,7 @@ fn run(args: Vec<String>) -> Result<()> {
 
 fn print_usage() {
     println!(
-        "usage:\n  palomactl status\n  palomactl reconcile\n  palomactl pr-gates <owner/repo> <number>\n  palomactl set-mode <project> <mode> --until <iso>\n  palomactl dispatch-plan --project <slug>"
+        "usage:\n  palomactl status\n  palomactl reconcile\n  palomactl pr-gates <owner/repo> <number> [--worker-head <sha>]\n  palomactl set-mode <project> <mode> --until <iso>\n  palomactl dispatch-plan --project <slug>"
     );
 }
 
@@ -449,6 +450,20 @@ struct CheckRun {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct WorkflowRun {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    head_sha: String,
+    #[serde(default)]
+    url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct PrGates {
     #[serde(default)]
     owner_repo: String,
@@ -468,6 +483,19 @@ struct PrGates {
     conflicting: bool,
     #[serde(default)]
     checks: Vec<CheckRun>,
+    /// GitHub's complete check rollup for the current PR head is represented by
+    /// `checks`. Workflow runs are kept separately because a run can conclude
+    /// `action_required` before creating any job, in which case it is absent
+    /// from `statusCheckRollup` entirely.
+    #[serde(default)]
+    workflow_runs: Vec<WorkflowRun>,
+    /// Head that GitHub currently associates with the PR.
+    #[serde(default, alias = "headRefOid")]
+    current_head: Option<String>,
+    /// Head on which the worker's local validation/review was performed.
+    /// Supplied by the controller through `--worker-head`.
+    #[serde(default)]
+    worker_head: Option<String>,
     #[serde(default)]
     bugbot_accessible: bool,
     #[serde(default)]
@@ -484,40 +512,84 @@ fn apply_pr_gate_recommendation(gates: &mut PrGates) {
     gates.conflicting = gates.conflicting
         || merge_state_status.as_deref() == Some("dirty")
         || (gates.mergeable == Some(false) && !blocked && !behind);
+    let accepted_check_conclusion = |conclusion: &str| {
+        matches!(
+            conclusion.to_ascii_lowercase().as_str(),
+            "success" | "skipped" | "neutral"
+        )
+    };
     let checks_green = !gates.checks.is_empty()
         && gates.checks.iter().all(|c| {
             c.status.eq_ignore_ascii_case("completed")
                 && c.conclusion
                     .as_deref()
-                    .map(|conclusion| conclusion.eq_ignore_ascii_case("success"))
+                    .map(accepted_check_conclusion)
                     .unwrap_or(false)
         });
+    let action_required = gates.workflow_runs.iter().any(|run| {
+        run.status.eq_ignore_ascii_case("completed")
+            && run
+                .conclusion
+                .as_deref()
+                .map(|value| value.eq_ignore_ascii_case("action_required"))
+                .unwrap_or(false)
+    });
+    let workflow_runs_green = gates.workflow_runs.is_empty()
+        || gates.workflow_runs.iter().all(|run| {
+            run.status.eq_ignore_ascii_case("completed")
+                && run
+                    .conclusion
+                    .as_deref()
+                    .map(accepted_check_conclusion)
+                    .unwrap_or(false)
+        });
+    let exact_head = match (&gates.worker_head, &gates.current_head) {
+        (Some(worker), Some(current)) => worker.eq_ignore_ascii_case(current),
+        _ => true,
+    };
     let closed = gates.state.eq_ignore_ascii_case("closed");
     gates.recommendation = if gates.merged {
         Some("already_merged".to_string())
     } else if gates.draft {
         Some("wait_for_ready_for_review".to_string())
+    } else if closed {
+        Some("closed_without_merge".to_string())
+    } else if !exact_head {
+        Some("head_changed_since_worker".to_string())
+    } else if action_required {
+        Some("action_required_external".to_string())
     } else if blocked {
         Some("blocked_by_policy".to_string())
     } else if behind {
         Some("needs_update_with_base".to_string())
     } else if gates.conflicting {
         Some("needs_conflict_resolution".to_string())
-    } else if closed {
-        Some("closed_without_merge".to_string())
-    } else if checks_green {
+    } else if checks_green && workflow_runs_green {
         Some("ready_for_review_or_merge".to_string())
     } else {
         Some("needs_checks_or_review".to_string())
     };
 }
 
+#[cfg(test)]
 fn pr_gates(root: &Path, owner_repo: &str, number: u64) -> Result<PrGates> {
+    pr_gates_with_worker_head(root, owner_repo, number, None)
+}
+
+fn pr_gates_with_worker_head(
+    root: &Path,
+    owner_repo: &str,
+    number: u64,
+    worker_head: Option<&str>,
+) -> Result<PrGates> {
     let mut gates = load_pr_fixture(root, owner_repo, number)
         .or_else(|| gh_pr_gates(owner_repo, number))
         .ok_or_else(|| anyhow!("could not read PR gates from fixture or gh"))?;
     gates.owner_repo = owner_repo.to_string();
     gates.number = number;
+    if let Some(head) = worker_head.map(str::trim).filter(|head| !head.is_empty()) {
+        gates.worker_head = Some(head.to_string());
+    }
     apply_pr_gate_recommendation(&mut gates);
     Ok(gates)
 }
@@ -648,6 +720,12 @@ fn parse_gh_pr_gates(owner_repo: &str, number: u64, value: &Value) -> PrGates {
             .map(|s| s.to_ascii_lowercase()),
         conflicting: false,
         checks,
+        workflow_runs: Vec::new(),
+        current_head: value
+            .get("headRefOid")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        worker_head: None,
         bugbot_accessible,
         recommendation: None,
     }
@@ -662,7 +740,7 @@ fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
             "--repo",
             owner_repo,
             "--json",
-            "state,isDraft,mergeable,mergeStateStatus,mergedAt,statusCheckRollup,comments",
+            "state,isDraft,mergeable,mergeStateStatus,mergedAt,headRefOid,statusCheckRollup,comments",
         ])
         .output()
         .ok()?;
@@ -670,7 +748,65 @@ fn gh_pr_gates(owner_repo: &str, number: u64) -> Option<PrGates> {
         return None;
     }
     let value: Value = serde_json::from_slice(&output.stdout).ok()?;
-    Some(parse_gh_pr_gates(owner_repo, number, &value))
+    let mut gates = parse_gh_pr_gates(owner_repo, number, &value);
+    if let Some(head) = gates.current_head.as_deref() {
+        let runs = Command::new("gh")
+            .args([
+                "run",
+                "list",
+                "--repo",
+                owner_repo,
+                "--commit",
+                head,
+                "--limit",
+                "100",
+                "--json",
+                "name,status,conclusion,headSha,url",
+            ])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| serde_json::from_slice::<Vec<Value>>(&output.stdout).ok())
+            .unwrap_or_default();
+        // `gh run list` is newest-first. Keep the latest run per workflow so a
+        // successfully approved/rerun workflow supersedes an older
+        // `action_required` attempt instead of blocking the PR forever.
+        let mut seen_workflows = BTreeSet::new();
+        gates.workflow_runs = runs
+            .into_iter()
+            .filter(|run| {
+                let name = run.get("name").and_then(Value::as_str).unwrap_or_default();
+                seen_workflows.insert(name.to_string())
+            })
+            .map(|run| WorkflowRun {
+                name: run
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                status: run
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_ascii_lowercase(),
+                conclusion: run
+                    .get("conclusion")
+                    .and_then(Value::as_str)
+                    .map(str::to_ascii_lowercase),
+                head_sha: run
+                    .get("headSha")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                url: run
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+            .collect();
+    }
+    Some(gates)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1131,6 +1267,75 @@ mod tests {
         assert_eq!(
             gates.recommendation.as_deref(),
             Some("ready_for_review_or_merge")
+        );
+    }
+
+    #[test]
+    fn skipped_and_neutral_rollup_entries_are_non_blocking() {
+        let tmp = tempdir().unwrap();
+        write(
+            &tmp.path().join(".paloma/fixtures/pr-109.json"),
+            r#"{
+              "state":"open",
+              "mergeable":true,
+              "checks":[
+                {"name":"build","status":"completed","conclusion":"success"},
+                {"name":"optional","status":"completed","conclusion":"skipped"},
+                {"name":"advisory","status":"completed","conclusion":"neutral"}
+              ]
+            }"#,
+        );
+        let gates = pr_gates(tmp.path(), "lfglabs-dev/verity", 109).unwrap();
+        assert_eq!(
+            gates.recommendation.as_deref(),
+            Some("ready_for_review_or_merge")
+        );
+    }
+
+    #[test]
+    fn action_required_run_without_jobs_is_blocked_external() {
+        let tmp = tempdir().unwrap();
+        write(
+            &tmp.path().join(".paloma/fixtures/pr-110.json"),
+            r#"{
+              "state":"open",
+              "mergeable":true,
+              "checks":[],
+              "workflow_runs":[{
+                "name":"Verify proofs",
+                "status":"completed",
+                "conclusion":"action_required",
+                "head_sha":"abc123"
+              }]
+            }"#,
+        );
+        let gates = pr_gates(tmp.path(), "lfglabs-dev/verity", 110).unwrap();
+        assert_eq!(
+            gates.recommendation.as_deref(),
+            Some("action_required_external")
+        );
+    }
+
+    #[test]
+    fn derived_head_invalidates_worker_evidence() {
+        let tmp = tempdir().unwrap();
+        write(
+            &tmp.path().join(".paloma/fixtures/pr-111.json"),
+            r#"{
+              "state":"open",
+              "mergeable":true,
+              "current_head":"derived456",
+              "checks":[{"name":"ci","status":"completed","conclusion":"success"}]
+            }"#,
+        );
+        let gates =
+            pr_gates_with_worker_head(tmp.path(), "lfglabs-dev/verity", 111, Some("worker123"))
+                .unwrap();
+        assert_eq!(gates.worker_head.as_deref(), Some("worker123"));
+        assert_eq!(gates.current_head.as_deref(), Some("derived456"));
+        assert_eq!(
+            gates.recommendation.as_deref(),
+            Some("head_changed_since_worker")
         );
     }
 

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -184,6 +184,10 @@ impl McpRegistry {
         );
         workspace.scope = McpScope::Workspace;
         workspace.default_enabled = true;
+        // workspace-mcp is a trusted compatibility shell/file proxy. It needs
+        // the same environment as the workspace commands it executes. Native
+        // harness bash remains the default for ordinary missions.
+        workspace.workspace_env_allowlist = vec!["*".to_string()];
         // Prefer bunx (Bun) when present, but fall back to npx for compatibility.
         let js_runner = if command_exists("bunx") {
             "bunx"
@@ -417,6 +421,24 @@ impl McpRegistry {
                 let _ = config_store
                     .update(id, |c| {
                         c.default_enabled = true;
+                    })
+                    .await;
+            }
+        }
+
+        // workspace-mcp is the only built-in compatibility proxy that needs
+        // the full workspace environment for commands it executes. Persist
+        // that trust decision explicitly so all other MCPs stay deny-by-default.
+        for config in configs
+            .iter_mut()
+            .filter(|config| config.name == "workspace")
+        {
+            if config.workspace_env_allowlist != ["*".to_string()] {
+                config.workspace_env_allowlist = vec!["*".to_string()];
+                let id = config.id;
+                let _ = config_store
+                    .update(id, |c| {
+                        c.workspace_env_allowlist = vec!["*".to_string()];
                     })
                     .await;
             }
@@ -693,6 +715,7 @@ impl McpRegistry {
         if let Some(default_enabled) = req.default_enabled {
             config.default_enabled = default_enabled;
         }
+        config.workspace_env_allowlist = req.workspace_env_allowlist;
 
         // Save to persistent store
         let config = self.config_store.add(config).await?;
@@ -818,6 +841,9 @@ impl McpRegistry {
                 }
                 if let Some(default_enabled) = req.default_enabled {
                     c.default_enabled = default_enabled;
+                }
+                if let Some(workspace_env_allowlist) = &req.workspace_env_allowlist {
+                    c.workspace_env_allowlist = workspace_env_allowlist.clone();
                 }
             })
             .await?;

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -65,6 +65,48 @@ fn command_exists(command: &str) -> bool {
     false
 }
 
+fn is_builtin_workspace_mcp(config: &McpServerConfig, working_dir: &Path) -> bool {
+    if config.name != "workspace" {
+        return false;
+    }
+
+    let McpTransport::Stdio { command, args, .. } = &config.transport else {
+        return false;
+    };
+    if !args.is_empty() {
+        return false;
+    }
+
+    let command_path = Path::new(command);
+    command == "workspace-mcp"
+        || command_path == Path::new("/usr/local/bin/workspace-mcp")
+        || command_path == working_dir.join("target/release/workspace-mcp")
+        || command_path == working_dir.join("target/debug/workspace-mcp")
+}
+
+/// Reconcile the implicit full-environment grant for the trusted built-in
+/// workspace proxy. A config merely named `workspace` is not trusted: an
+/// operator may have repointed it to an unrelated executable.
+fn reconcile_workspace_mcp_env_trust(config: &mut McpServerConfig, working_dir: &Path) -> bool {
+    if config.name != "workspace" {
+        return false;
+    }
+
+    if is_builtin_workspace_mcp(config, working_dir) {
+        if config.workspace_env_allowlist == ["*".to_string()] {
+            return false;
+        }
+        config.workspace_env_allowlist = vec!["*".to_string()];
+        return true;
+    }
+
+    let original_len = config.workspace_env_allowlist.len();
+    config
+        .workspace_env_allowlist
+        .retain(|entry| entry.trim() != "*");
+    config.workspace_env_allowlist.len() != original_len
+}
+
 /// Handle for a stdio MCP process
 struct StdioProcess {
     child: Child,
@@ -433,12 +475,12 @@ impl McpRegistry {
             .iter_mut()
             .filter(|config| config.name == "workspace")
         {
-            if config.workspace_env_allowlist != ["*".to_string()] {
-                config.workspace_env_allowlist = vec!["*".to_string()];
+            if reconcile_workspace_mcp_env_trust(config, working_dir) {
                 let id = config.id;
+                let allowlist = config.workspace_env_allowlist.clone();
                 let _ = config_store
-                    .update(id, |c| {
-                        c.workspace_env_allowlist = vec!["*".to_string()];
+                    .update(id, move |c| {
+                        c.workspace_env_allowlist = allowlist;
                     })
                     .await;
             }
@@ -1322,5 +1364,68 @@ impl McpRegistry {
         } else {
             prefixed_name.to_string()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_workspace_mcp_receives_full_workspace_environment() {
+        let mut config = McpServerConfig::new_stdio(
+            "workspace".to_string(),
+            "/usr/local/bin/workspace-mcp".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+
+        assert!(reconcile_workspace_mcp_env_trust(
+            &mut config,
+            Path::new("/srv/sandboxed")
+        ));
+        assert_eq!(config.workspace_env_allowlist, ["*"]);
+        assert!(!reconcile_workspace_mcp_env_trust(
+            &mut config,
+            Path::new("/srv/sandboxed")
+        ));
+    }
+
+    #[test]
+    fn repointed_workspace_mcp_loses_implicit_wildcard_grant() {
+        let mut config = McpServerConfig::new_stdio(
+            "workspace".to_string(),
+            "/opt/third-party/server".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+        config.workspace_env_allowlist = vec!["PATH".to_string(), "*".to_string()];
+
+        assert!(reconcile_workspace_mcp_env_trust(
+            &mut config,
+            Path::new("/srv/sandboxed")
+        ));
+        assert_eq!(config.workspace_env_allowlist, ["PATH"]);
+        assert!(!reconcile_workspace_mcp_env_trust(
+            &mut config,
+            Path::new("/srv/sandboxed")
+        ));
+    }
+
+    #[test]
+    fn same_basename_at_an_unknown_path_is_not_trusted() {
+        let mut config = McpServerConfig::new_stdio(
+            "workspace".to_string(),
+            "/opt/third-party/workspace-mcp".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+        config.workspace_env_allowlist = vec!["*".to_string()];
+
+        assert!(reconcile_workspace_mcp_env_trust(
+            &mut config,
+            Path::new("/srv/sandboxed")
+        ));
+        assert!(config.workspace_env_allowlist.is_empty());
     }
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -181,6 +181,15 @@ pub struct McpServerConfig {
     /// `default_enabled = true` are written into its config.
     #[serde(default)]
     pub default_enabled: bool,
+    /// Workspace environment variable names this MCP may receive.
+    ///
+    /// Stdio MCP processes are launched with a clean environment. Only their
+    /// transport-specific `env`, mission runtime metadata, and workspace keys
+    /// listed here are restored. `"*"` is reserved for trusted internal MCPs
+    /// that execute workspace commands and intentionally need the full
+    /// workspace environment.
+    #[serde(default)]
+    pub workspace_env_allowlist: Vec<String>,
     /// Optional version string
     pub version: Option<String>,
     /// Tool names exposed by this MCP (populated after connection)
@@ -209,6 +218,7 @@ impl McpServerConfig {
             description: None,
             enabled: true,
             default_enabled: false,
+            workspace_env_allowlist: Vec::new(),
             version: None,
             tools: Vec::new(),
             tool_descriptors: Vec::new(),
@@ -232,6 +242,7 @@ impl McpServerConfig {
             description: None,
             enabled: true,
             default_enabled: false,
+            workspace_env_allowlist: Vec::new(),
             version: None,
             tools: Vec::new(),
             tool_descriptors: Vec::new(),
@@ -301,6 +312,9 @@ pub struct AddMcpRequest {
     /// Whether this MCP is included by default in new workspaces.
     #[serde(default)]
     pub default_enabled: Option<bool>,
+    /// Workspace environment variables this MCP may receive.
+    #[serde(default)]
+    pub workspace_env_allowlist: Vec<String>,
 }
 
 /// Request to update an MCP server.
@@ -313,6 +327,8 @@ pub struct UpdateMcpRequest {
     pub scope: Option<McpScope>,
     /// Whether this MCP is included by default in new workspaces.
     pub default_enabled: Option<bool>,
+    /// Replace the workspace environment allowlist when present.
+    pub workspace_env_allowlist: Option<Vec<String>>,
 }
 
 /// MCP tool list response from server.

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -1452,4 +1452,53 @@ mod tests {
         assert!(!stdout.contains("GH_TOKEN"));
         assert!(!stdout.contains("inherited-harness-secret"));
     }
+
+    #[test]
+    fn sanitized_mcp_name_collisions_get_distinct_launchers() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path();
+        let mission_dir = workspace_root.join("workspaces/mission-deadbeef");
+        std::fs::create_dir_all(&mission_dir).unwrap();
+        let first = McpServerConfig::new_stdio(
+            "foo-bar".to_string(),
+            "/opt/mcp/first".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+        let second = McpServerConfig::new_stdio(
+            "foo_bar".to_string(),
+            "/opt/mcp/second".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+
+        let first_entry = opencode_entry_from_mcp(
+            &first,
+            &mission_dir,
+            workspace_root,
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+        )
+        .unwrap();
+        let second_entry = opencode_entry_from_mcp(
+            &second,
+            &mission_dir,
+            workspace_root,
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+        )
+        .unwrap();
+        let first_launcher = first_entry["command"][0].as_str().unwrap();
+        let second_launcher = second_entry["command"][0].as_str().unwrap();
+
+        assert_ne!(first_launcher, second_launcher);
+        assert!(std::fs::read_to_string(first_launcher)
+            .unwrap()
+            .contains("exec '/opt/mcp/first'"));
+        assert!(std::fs::read_to_string(second_launcher)
+            .unwrap()
+            .contains("exec '/opt/mcp/second'"));
+    }
 }

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -32,7 +32,6 @@ fn claude_entry_from_mcp(
     workspace_root: &Path,
     workspace_type: WorkspaceType,
     workspace_env: &HashMap<String, String>,
-    workspace_env_file: Option<&str>,
     shared_network: Option<bool>,
 ) -> serde_json::Value {
     match &config.transport {
@@ -79,15 +78,7 @@ fn claude_entry_from_mcp(
                 .get("environment")
                 .and_then(|v| v.as_object())
             {
-                let mut env_map = env.clone();
-                if let Some(env_file) = workspace_env_file {
-                    env_map.remove("SANDBOXED_SH_WORKSPACE_ENV_VARS");
-                    env_map.insert(
-                        "SANDBOXED_SH_WORKSPACE_ENV_VARS_FILE".to_string(),
-                        json!(env_file),
-                    );
-                }
-                entry.insert("env".to_string(), serde_json::Value::Object(env_map));
+                entry.insert("env".to_string(), serde_json::Value::Object(env.clone()));
             }
 
             serde_json::Value::Object(entry)
@@ -738,17 +729,6 @@ async fn write_claudecode_config(
     let claude_dir = workspace_dir.join(".claude");
     tokio::fs::create_dir_all(&claude_dir).await?;
 
-    let workspace_env_file = if !workspace_env.is_empty() {
-        let sandboxed_dir = workspace_dir.join(".sandboxed-sh");
-        tokio::fs::create_dir_all(&sandboxed_dir).await?;
-        let env_path = sandboxed_dir.join("workspace_env.json");
-        let payload = serde_json::to_string_pretty(workspace_env)?;
-        write_file_atomic(&env_path, payload)?;
-        Some(".sandboxed-sh/workspace_env.json".to_string())
-    } else {
-        None
-    };
-
     // Build MCP servers config in Claude Code format
     let mut mcp_servers = serde_json::Map::new();
     let mut used = std::collections::HashSet::new();
@@ -766,7 +746,6 @@ async fn write_claudecode_config(
                 workspace_root,
                 workspace_type,
                 workspace_env,
-                workspace_env_file.as_deref(),
                 shared_network,
             ),
         );
@@ -1363,5 +1342,96 @@ mod tests {
             ),
             mission_dir.join(".codex")
         );
+    }
+
+    #[test]
+    fn third_party_mcp_only_receives_allowlisted_workspace_env() {
+        let workspace_root = Path::new("/srv/workspace-root");
+        let mission_dir = workspace_root.join("workspaces/mission-deadbeef");
+        let mut mcp = McpServerConfig::new_stdio(
+            "lean_lsp".to_string(),
+            "/workspace/tools/lean-lsp-mcp".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+        mcp.workspace_env_allowlist = vec!["PATH".to_string(), "ELAN_HOME".to_string()];
+
+        let workspace_env = HashMap::from([
+            ("PATH".to_string(), "/root/.elan/bin:/usr/bin".to_string()),
+            ("ELAN_HOME".to_string(), "/root/.elan".to_string()),
+            ("GH_TOKEN".to_string(), "github-secret".to_string()),
+            ("SSH_PRIVATE_KEY_B64".to_string(), "ssh-secret".to_string()),
+            ("GPG_PRIVATE_KEY_B64".to_string(), "gpg-secret".to_string()),
+        ]);
+
+        let entry = codex_entry_from_mcp(
+            &mcp,
+            &mission_dir,
+            workspace_root,
+            WorkspaceType::Host,
+            &workspace_env,
+            None,
+            None,
+        )
+        .expect("stdio MCP entry");
+        let rendered = update_codex_mcp_config("", &[entry]);
+
+        assert!(rendered.contains("-i"));
+        assert!(rendered.contains("PATH=/root/.elan/bin:/usr/bin"));
+        assert!(rendered.contains("ELAN_HOME=/root/.elan"));
+        assert!(!rendered.contains("GH_TOKEN"));
+        assert!(!rendered.contains("github-secret"));
+        assert!(!rendered.contains("SSH_PRIVATE_KEY_B64"));
+        assert!(!rendered.contains("ssh-secret"));
+        assert!(!rendered.contains("GPG_PRIVATE_KEY_B64"));
+        assert!(!rendered.contains("gpg-secret"));
+        assert!(!rendered.contains("SANDBOXED_SH_WORKSPACE_ENV_VARS_FILE"));
+    }
+
+    #[test]
+    fn third_party_mcp_isolated_process_does_not_inherit_harness_env() {
+        let workspace_root = Path::new("/srv/workspace-root");
+        let mission_dir = workspace_root.join("workspaces/mission-deadbeef");
+        let mcp = McpServerConfig::new_stdio(
+            "third_party".to_string(),
+            "env".to_string(),
+            Vec::new(),
+            HashMap::new(),
+        );
+        let workspace_env = HashMap::from([(
+            "GH_TOKEN".to_string(),
+            "must-not-cross-boundary".to_string(),
+        )]);
+
+        let entry = opencode_entry_from_mcp(
+            &mcp,
+            &mission_dir,
+            workspace_root,
+            WorkspaceType::Host,
+            &workspace_env,
+            None,
+        );
+        let command = entry["command"].as_array().expect("command array");
+
+        assert_eq!(command[1], "-i");
+        assert!(command
+            .iter()
+            .any(|part| part.as_str().is_some_and(|part| part.starts_with("PATH="))));
+        assert!(!entry.to_string().contains("GH_TOKEN"));
+        assert!(!entry.to_string().contains("must-not-cross-boundary"));
+
+        let command_parts: Vec<&str> = command
+            .iter()
+            .map(|part| part.as_str().expect("string command part"))
+            .collect();
+        let output = std::process::Command::new(command_parts[0])
+            .args(&command_parts[1..])
+            .env("GH_TOKEN", "inherited-harness-secret")
+            .output()
+            .expect("run isolated MCP command");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(!stdout.contains("GH_TOKEN"));
+        assert!(!stdout.contains("inherited-harness-secret"));
     }
 }

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -33,7 +33,7 @@ fn claude_entry_from_mcp(
     workspace_type: WorkspaceType,
     workspace_env: &HashMap<String, String>,
     shared_network: Option<bool>,
-) -> serde_json::Value {
+) -> anyhow::Result<serde_json::Value> {
     match &config.transport {
         McpTransport::Http { endpoint, headers } => {
             let mut entry = serde_json::Map::new();
@@ -42,7 +42,7 @@ fn claude_entry_from_mcp(
             if !headers.is_empty() {
                 entry.insert("headers".to_string(), json!(headers));
             }
-            serde_json::Value::Object(entry)
+            Ok(serde_json::Value::Object(entry))
         }
         McpTransport::Stdio { .. } => {
             let opencode_entry = opencode_entry_from_mcp(
@@ -52,7 +52,7 @@ fn claude_entry_from_mcp(
                 workspace_type,
                 workspace_env,
                 shared_network,
-            );
+            )?;
 
             let command_vec = opencode_entry
                 .get("command")
@@ -81,7 +81,7 @@ fn claude_entry_from_mcp(
                 entry.insert("env".to_string(), serde_json::Value::Object(env.clone()));
             }
 
-            serde_json::Value::Object(entry)
+            Ok(serde_json::Value::Object(entry))
         }
     }
 }
@@ -123,7 +123,7 @@ pub(crate) async fn write_opencode_config(
                 workspace_type,
                 workspace_env,
                 shared_network,
-            ),
+            )?,
         );
     }
 
@@ -747,7 +747,7 @@ async fn write_claudecode_config(
                 workspace_type,
                 workspace_env,
                 shared_network,
-            ),
+            )?,
         );
     }
 
@@ -916,7 +916,7 @@ async fn write_codex_config(
             workspace_env,
             shared_network,
             None,
-        ) {
+        )? {
             entries.push(entry);
         }
     }
@@ -932,7 +932,7 @@ async fn write_codex_config(
                 workspace_env,
                 shared_network,
                 Some("filesystem".to_string()),
-            ) {
+            )? {
                 entries.push(entry);
             }
         }
@@ -998,7 +998,7 @@ fn codex_entry_from_mcp(
     workspace_env: &HashMap<String, String>,
     shared_network: Option<bool>,
     override_name: Option<String>,
-) -> Option<CodexMcpEntry> {
+) -> anyhow::Result<Option<CodexMcpEntry>> {
     let raw_name = override_name.unwrap_or_else(|| config.name.clone());
     let sanitized = sanitize_key(&raw_name);
     let name = if sanitized.is_empty() {
@@ -1007,14 +1007,14 @@ fn codex_entry_from_mcp(
         sanitized
     };
     match &config.transport {
-        McpTransport::Http { endpoint, headers } => Some(CodexMcpEntry {
+        McpTransport::Http { endpoint, headers } => Ok(Some(CodexMcpEntry {
             name,
             command: None,
             args: Vec::new(),
             env: HashMap::new(),
             url: Some(endpoint.clone()),
             headers: headers.clone(),
-        }),
+        })),
         McpTransport::Stdio { .. } => {
             let opencode_entry = opencode_entry_from_mcp(
                 config,
@@ -1023,7 +1023,7 @@ fn codex_entry_from_mcp(
                 workspace_type,
                 workspace_env,
                 shared_network,
-            );
+            )?;
             let command_vec = opencode_entry
                 .get("command")
                 .and_then(|v| v.as_array())
@@ -1049,14 +1049,14 @@ fn codex_entry_from_mcp(
                 })
                 .unwrap_or_default();
 
-            command.map(|cmd| CodexMcpEntry {
+            Ok(command.map(|cmd| CodexMcpEntry {
                 name,
                 command: Some(cmd),
                 args,
                 env,
                 url: None,
                 headers: HashMap::new(),
-            })
+            }))
         }
     }
 }
@@ -1346,8 +1346,10 @@ mod tests {
 
     #[test]
     fn third_party_mcp_only_receives_allowlisted_workspace_env() {
-        let workspace_root = Path::new("/srv/workspace-root");
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path();
         let mission_dir = workspace_root.join("workspaces/mission-deadbeef");
+        std::fs::create_dir_all(&mission_dir).unwrap();
         let mut mcp = McpServerConfig::new_stdio(
             "lean_lsp".to_string(),
             "/workspace/tools/lean-lsp-mcp".to_string(),
@@ -1373,12 +1375,13 @@ mod tests {
             None,
             None,
         )
+        .expect("MCP launcher generation")
         .expect("stdio MCP entry");
+        let launcher = entry.command.clone().expect("launcher command");
         let rendered = update_codex_mcp_config("", &[entry]);
 
-        assert!(rendered.contains("-i"));
-        assert!(rendered.contains("PATH=/root/.elan/bin:/usr/bin"));
-        assert!(rendered.contains("ELAN_HOME=/root/.elan"));
+        assert!(!rendered.contains("PATH=/root/.elan/bin:/usr/bin"));
+        assert!(!rendered.contains("ELAN_HOME=/root/.elan"));
         assert!(!rendered.contains("GH_TOKEN"));
         assert!(!rendered.contains("github-secret"));
         assert!(!rendered.contains("SSH_PRIVATE_KEY_B64"));
@@ -1386,12 +1389,29 @@ mod tests {
         assert!(!rendered.contains("GPG_PRIVATE_KEY_B64"));
         assert!(!rendered.contains("gpg-secret"));
         assert!(!rendered.contains("SANDBOXED_SH_WORKSPACE_ENV_VARS_FILE"));
+
+        let launcher_contents = std::fs::read_to_string(&launcher).unwrap();
+        assert!(launcher_contents.contains("PATH='/root/.elan/bin:/usr/bin'"));
+        assert!(launcher_contents.contains("ELAN_HOME='/root/.elan'"));
+        assert!(!launcher_contents.contains("github-secret"));
+        assert!(!launcher_contents.contains("ssh-secret"));
+        assert!(!launcher_contents.contains("gpg-secret"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&launcher).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
     }
 
     #[test]
     fn third_party_mcp_isolated_process_does_not_inherit_harness_env() {
-        let workspace_root = Path::new("/srv/workspace-root");
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path();
         let mission_dir = workspace_root.join("workspaces/mission-deadbeef");
+        std::fs::create_dir_all(&mission_dir).unwrap();
         let mcp = McpServerConfig::new_stdio(
             "third_party".to_string(),
             "env".to_string(),
@@ -1410,13 +1430,11 @@ mod tests {
             WorkspaceType::Host,
             &workspace_env,
             None,
-        );
+        )
+        .expect("MCP launcher generation");
         let command = entry["command"].as_array().expect("command array");
 
-        assert_eq!(command[1], "-i");
-        assert!(command
-            .iter()
-            .any(|part| part.as_str().is_some_and(|part| part.starts_with("PATH="))));
+        assert_eq!(command.len(), 1);
         assert!(!entry.to_string().contains("GH_TOKEN"));
         assert!(!entry.to_string().contains("must-not-cross-boundary"));
 

--- a/src/workspace/git_credentials.rs
+++ b/src/workspace/git_credentials.rs
@@ -111,6 +111,30 @@ impl GitCredentialConfig {
         })
     }
 
+    /// Build from workspace-scoped environment values. This is the fallback
+    /// used when no dashboard connection or service-level token exists. It is
+    /// intentionally resolved at process-spawn time so a secret refresher can
+    /// rotate `GH_TOKEN` without requiring a backend restart.
+    pub fn from_workspace_env(workspace_env: &HashMap<String, String>) -> Option<Self> {
+        let value = |key: &str| {
+            workspace_env
+                .get(key)
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty() && !value.starts_with("[DECRYPTION_FAILED]"))
+                .map(str::to_string)
+        };
+        let token = value("GITHUB_TOKEN").or_else(|| value("GH_TOKEN"))?;
+        let user_name = value("GIT_AUTHOR_NAME").or_else(|| value("GIT_USER_NAME"));
+        let user_email = value("GIT_AUTHOR_EMAIL").or_else(|| value("GIT_USER_EMAIL"));
+        Some(Self {
+            token,
+            user_name,
+            user_email,
+            login: None,
+        })
+    }
+
     /// Build from a dashboard-connected GitHub account. The commit identity is
     /// always derived from the account (profile name/email, falling back to the
     /// login and GitHub `noreply` form), so [`Self::has_identity`] is always
@@ -131,13 +155,26 @@ impl GitCredentialConfig {
     /// dashboard stores the connected account. Extra fallbacks cover legacy/dev
     /// layouts and direct `WorkspaceExec` calls that only have a workspace.
     pub fn resolve(workspace_root: &Path, app_working_dir: Option<&Path>) -> Option<Self> {
+        Self::resolve_with_workspace_env(workspace_root, app_working_dir, &HashMap::new())
+    }
+
+    /// Resolve a fresh credential for a workspace. Dashboard credentials have
+    /// precedence, followed by the service environment and finally the
+    /// workspace-scoped environment. Callers that spawn subprocesses should
+    /// use this path on every spawn rather than retaining a possibly stale
+    /// token in memory.
+    pub fn resolve_with_workspace_env(
+        workspace_root: &Path,
+        app_working_dir: Option<&Path>,
+        workspace_env: &HashMap<String, String>,
+    ) -> Option<Self> {
         let candidates = github_connection_candidates(workspace_root, app_working_dir);
         for path in &candidates {
             if let Some(conn) = GithubConnectionStore::read_from_path(path) {
                 return Some(Self::from_connection(&conn));
             }
         }
-        Self::from_env()
+        Self::from_env().or_else(|| Self::from_workspace_env(workspace_env))
     }
 
     /// Whether a commit identity is configured. Without it `git commit` fails
@@ -170,7 +207,9 @@ impl GitCredentialConfig {
         mission_id: Uuid,
         app_working_dir: Option<&Path>,
     ) {
-        let Some(creds) = Self::resolve(&workspace.path, app_working_dir) else {
+        let Some(creds) =
+            Self::resolve_with_workspace_env(&workspace.path, app_working_dir, &workspace.env_vars)
+        else {
             workspace.resolved_git_credentials = None;
             return;
         };
@@ -733,6 +772,28 @@ mod tests {
             "/root/.git-credentials"
         );
         assert!(!merged.values().any(|value| value.contains("gho_secret")));
+    }
+
+    #[test]
+    fn workspace_token_is_a_supported_last_resort() {
+        let mut env = HashMap::new();
+        env.insert("GH_TOKEN".into(), "workspace-token".into());
+        env.insert("GIT_AUTHOR_NAME".into(), "Ada".into());
+        env.insert("GIT_AUTHOR_EMAIL".into(), "ada@example.com".into());
+        let cfg = GitCredentialConfig::from_workspace_env(&env).unwrap();
+        assert_eq!(cfg.token(), "workspace-token");
+        assert_eq!(cfg.user_name(), Some("Ada"));
+        assert_eq!(cfg.user_email(), Some("ada@example.com"));
+    }
+
+    #[test]
+    fn decryption_failure_marker_is_never_used_as_a_token() {
+        let mut env = HashMap::new();
+        env.insert(
+            "GH_TOKEN".into(),
+            "[DECRYPTION_FAILED]encrypted-payload".into(),
+        );
+        assert!(GitCredentialConfig::from_workspace_env(&env).is_none());
     }
 
     #[test]

--- a/src/workspace/git_credentials.rs
+++ b/src/workspace/git_credentials.rs
@@ -168,13 +168,38 @@ impl GitCredentialConfig {
         app_working_dir: Option<&Path>,
         workspace_env: &HashMap<String, String>,
     ) -> Option<Self> {
+        Self::resolve_dashboard_connection(workspace_root, app_working_dir)
+            .or_else(Self::from_env)
+            .or_else(|| Self::from_workspace_env(workspace_env))
+    }
+
+    fn resolve_dashboard_connection(
+        workspace_root: &Path,
+        app_working_dir: Option<&Path>,
+    ) -> Option<Self> {
         let candidates = github_connection_candidates(workspace_root, app_working_dir);
         for path in &candidates {
             if let Some(conn) = GithubConnectionStore::read_from_path(path) {
                 return Some(Self::from_connection(&conn));
             }
         }
-        Self::from_env().or_else(|| Self::from_workspace_env(workspace_env))
+        None
+    }
+
+    /// Refresh credentials for a subprocess without replacing a connected
+    /// dashboard account with a lower-fidelity service/workspace token when
+    /// the connection store is temporarily undiscoverable from this spawn.
+    pub fn resolve_for_spawn(
+        workspace_root: &Path,
+        app_working_dir: Option<&Path>,
+        workspace_env: &HashMap<String, String>,
+        cached: Option<&Self>,
+    ) -> Option<Self> {
+        Self::resolve_dashboard_connection(workspace_root, app_working_dir)
+            .or_else(|| cached.filter(|creds| creds.login.is_some()).cloned())
+            .or_else(Self::from_env)
+            .or_else(|| Self::from_workspace_env(workspace_env))
+            .or_else(|| cached.cloned())
     }
 
     /// Whether a commit identity is configured. Without it `git commit` fails
@@ -784,6 +809,26 @@ mod tests {
         assert_eq!(cfg.token(), "workspace-token");
         assert_eq!(cfg.user_name(), Some("Ada"));
         assert_eq!(cfg.user_email(), Some("ada@example.com"));
+    }
+
+    #[test]
+    fn spawn_refresh_preserves_cached_dashboard_account_over_fallback_token() {
+        let root = tempfile::tempdir().unwrap();
+        let cached = GitCredentialConfig {
+            token: "dashboard-token".into(),
+            user_name: Some("Dashboard User".into()),
+            user_email: Some("dashboard@example.com".into()),
+            login: Some("dashboard-login".into()),
+        };
+        let mut env = HashMap::new();
+        env.insert("GH_TOKEN".into(), "workspace-fallback".into());
+
+        let resolved =
+            GitCredentialConfig::resolve_for_spawn(root.path(), None, &env, Some(&cached)).unwrap();
+
+        assert_eq!(resolved.token(), "dashboard-token");
+        assert_eq!(resolved.login.as_deref(), Some("dashboard-login"));
+        assert_eq!(resolved.user_name(), Some("Dashboard User"));
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1100,7 +1100,7 @@ fn opencode_entry_from_mcp(
                 };
                 let mut cmd = vec![env_command, "-i".to_string()];
                 let mut env_pairs: Vec<_> = merged_env.iter().collect();
-                env_pairs.sort_by(|(left, _), (right, _)| left.cmp(right));
+                env_pairs.sort_by_key(|(key, _)| *key);
                 cmd.extend(
                     env_pairs
                         .into_iter()

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -782,12 +782,13 @@ fn write_mcp_env_launcher(
     std::fs::create_dir_all(&launcher_dir)?;
     let sanitized_name = sanitize_key(&config.name);
     let launcher_name = format!(
-        "{}.sh",
+        "{}-{}.sh",
         if sanitized_name.is_empty() {
             "mcp"
         } else {
             &sanitized_name
-        }
+        },
+        config.id.simple()
     );
     let launcher_host_path = launcher_dir.join(launcher_name);
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -771,6 +771,34 @@ fn opencode_entry_from_mcp(
     workspace_env: &HashMap<String, String>,
     shared_network: Option<bool>,
 ) -> serde_json::Value {
+    fn allowed_workspace_env(
+        config: &McpServerConfig,
+        workspace_env: &HashMap<String, String>,
+    ) -> HashMap<String, String> {
+        if config
+            .workspace_env_allowlist
+            .iter()
+            .any(|key| key.trim() == "*")
+        {
+            return workspace_env.clone();
+        }
+
+        config
+            .workspace_env_allowlist
+            .iter()
+            .filter_map(|key| {
+                let key = key.trim();
+                if key.is_empty() {
+                    None
+                } else {
+                    workspace_env
+                        .get(key)
+                        .map(|value| (key.to_string(), value.clone()))
+                }
+            })
+            .collect()
+    }
+
     fn resolve_host_command_path(cmd: &str) -> String {
         let cmd_path = Path::new(cmd);
         if cmd_path.is_absolute() || cmd.contains('/') {
@@ -862,19 +890,31 @@ fn opencode_entry_from_mcp(
             let mut entry = serde_json::Map::new();
             entry.insert("type".to_string(), json!("local"));
 
+            // Do not implicitly forward a workspace's complete environment to
+            // every third-party MCP. Only MCP-specific env and explicitly
+            // allowlisted workspace keys cross this boundary.
+            let allowed_workspace_env = allowed_workspace_env(config, workspace_env);
             let mut merged_env = env.clone();
-            if !workspace_env.is_empty() {
-                for (key, value) in workspace_env {
+            if !allowed_workspace_env.is_empty() {
+                for (key, value) in &allowed_workspace_env {
                     merged_env
                         .entry(key.clone())
                         .or_insert_with(|| value.clone());
                 }
-                let workspace_env_json =
-                    serde_json::to_string(workspace_env).unwrap_or_else(|_| "{}".to_string());
+                let workspace_env_json = serde_json::to_string(&allowed_workspace_env)
+                    .unwrap_or_else(|_| "{}".to_string());
                 merged_env
                     .entry("SANDBOXED_SH_WORKSPACE_ENV_VARS".to_string())
                     .or_insert(workspace_env_json);
             }
+            // A predictable non-secret PATH keeps scripts with `/usr/bin/env`
+            // shebangs working without inheriting the harness environment.
+            merged_env.entry("PATH".to_string()).or_insert_with(|| {
+                "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()
+            });
+            merged_env
+                .entry("HOME".to_string())
+                .or_insert_with(|| workspace_dir.to_string_lossy().to_string());
             merged_env
                 .entry("SANDBOXED_SH_WORKSPACE".to_string())
                 .or_insert_with(|| workspace_dir.to_string_lossy().to_string());
@@ -934,6 +974,7 @@ fn opencode_entry_from_mcp(
                 nspawn_env.insert("SANDBOXED_SH_WORKSPACE".to_string(), rel_str.clone());
                 nspawn_env.insert("SANDBOXED_SH_WORKSPACE_ROOT".to_string(), "/".to_string());
                 nspawn_env.insert("WORKING_DIR".to_string(), rel_str.clone());
+                nspawn_env.insert("HOME".to_string(), rel_str.clone());
 
                 let mut cmd = vec![
                     resolve_host_command_path("systemd-nspawn"),
@@ -994,7 +1035,7 @@ fn opencode_entry_from_mcp(
                     cmd.push("--bind-ro=/etc/resolv.conf".to_string());
                 } else {
                     // Isolated network mode - check if Tailscale is configured
-                    let tailscale_args = nspawn::tailscale_nspawn_extra_args(&merged_env);
+                    let tailscale_args = nspawn::tailscale_nspawn_extra_args(workspace_env);
                     if tailscale_args.is_empty() {
                         // Tailscale not configured - fall back to binding resolv.conf for DNS
                         // This ensures DNS works even if the user sets shared_network=false
@@ -1030,7 +1071,8 @@ fn opencode_entry_from_mcp(
                     };
                     merged_env.insert("SANDBOXED_SH_WORKSPACE".to_string(), rel_str.clone());
                     merged_env.insert("SANDBOXED_SH_WORKSPACE_ROOT".to_string(), "/".to_string());
-                    merged_env.insert("WORKING_DIR".to_string(), rel_str);
+                    merged_env.insert("WORKING_DIR".to_string(), rel_str.clone());
+                    merged_env.insert("HOME".to_string(), rel_str);
                 }
 
                 let resolved_command = match workspace_type {
@@ -1042,12 +1084,31 @@ fn opencode_entry_from_mcp(
                     ),
                     WorkspaceType::Host => resolve_host_command_path(command),
                 };
-                let mut cmd = vec![resolved_command];
+                // Harness CLIs normally spawn MCPs as child processes, which
+                // would otherwise inherit every workspace credential even if
+                // the generated config omitted it. `env -i` makes the
+                // allowlist an actual process boundary rather than cosmetic
+                // config filtering.
+                let env_command = match workspace_type {
+                    WorkspaceType::Container => resolve_container_command_path(
+                        "env",
+                        workspace_root,
+                        container_fallback,
+                        per_workspace_runner,
+                    ),
+                    WorkspaceType::Host => resolve_host_command_path("env"),
+                };
+                let mut cmd = vec![env_command, "-i".to_string()];
+                let mut env_pairs: Vec<_> = merged_env.iter().collect();
+                env_pairs.sort_by(|(left, _), (right, _)| left.cmp(right));
+                cmd.extend(
+                    env_pairs
+                        .into_iter()
+                        .map(|(key, value)| format!("{}={}", key, value)),
+                );
+                cmd.push(resolved_command);
                 cmd.extend(args.clone());
                 entry.insert("command".to_string(), json!(cmd));
-                if !merged_env.is_empty() {
-                    entry.insert("environment".to_string(), json!(merged_env));
-                }
             }
             entry.insert("enabled".to_string(), json!(config.enabled));
             serde_json::Value::Object(entry)

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -763,6 +763,100 @@ pub fn task_workspace_dir_for_root(root: &Path, task_id: Uuid) -> PathBuf {
     workspaces_root_for(root).join(format!("task-{}", short_id))
 }
 
+fn mcp_launcher_shell_escape(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_mcp_env_launcher(
+    config: &McpServerConfig,
+    workspace_dir: &Path,
+    workspace_root: &Path,
+    workspace_type: WorkspaceType,
+    container_fallback: bool,
+    command: &str,
+    args: &[String],
+    env: &HashMap<String, String>,
+) -> anyhow::Result<String> {
+    let launcher_dir = workspace_dir.join(".sandboxed-sh").join("mcp-launchers");
+    std::fs::create_dir_all(&launcher_dir)?;
+    let sanitized_name = sanitize_key(&config.name);
+    let launcher_name = format!(
+        "{}.sh",
+        if sanitized_name.is_empty() {
+            "mcp"
+        } else {
+            &sanitized_name
+        }
+    );
+    let launcher_host_path = launcher_dir.join(launcher_name);
+
+    let mut script = String::from(
+        "#!/bin/bash\n\
+         while IFS='=' read -r _oa_key _oa_value; do\n\
+           [[ $_oa_key =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] && unset \"$_oa_key\" || true\n\
+         done < <(/usr/bin/env)\n\
+         unset _oa_key _oa_value\n",
+    );
+    let mut env_pairs: Vec<_> = env
+        .iter()
+        .filter(|(key, _)| {
+            let mut chars = key.chars();
+            matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+                && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        })
+        .collect();
+    env_pairs.sort_by_key(|(key, _)| *key);
+    for (key, value) in env_pairs {
+        script.push_str("export ");
+        script.push_str(key);
+        script.push('=');
+        script.push_str(&mcp_launcher_shell_escape(value));
+        script.push('\n');
+    }
+    script.push_str("exec ");
+    script.push_str(&mcp_launcher_shell_escape(command));
+    for arg in args {
+        script.push(' ');
+        script.push_str(&mcp_launcher_shell_escape(arg));
+    }
+    script.push('\n');
+
+    let temp_path = launcher_host_path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    let write_result = (|| -> std::io::Result<()> {
+        use std::io::Write;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o700);
+        }
+        let mut file = options.open(&temp_path)?;
+        file.write_all(script.as_bytes())?;
+        file.sync_all()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o700))?;
+        }
+        std::fs::rename(&temp_path, &launcher_host_path)
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    write_result?;
+
+    if workspace_type == WorkspaceType::Container && !container_fallback {
+        let relative = launcher_host_path
+            .strip_prefix(workspace_root)
+            .map_err(|_| anyhow::anyhow!("MCP launcher is outside the container workspace"))?;
+        Ok(format!("/{}", relative.to_string_lossy()))
+    } else {
+        Ok(launcher_host_path.to_string_lossy().to_string())
+    }
+}
+
 fn opencode_entry_from_mcp(
     config: &McpServerConfig,
     workspace_dir: &Path,
@@ -770,7 +864,7 @@ fn opencode_entry_from_mcp(
     workspace_type: WorkspaceType,
     workspace_env: &HashMap<String, String>,
     shared_network: Option<bool>,
-) -> serde_json::Value {
+) -> anyhow::Result<serde_json::Value> {
     fn allowed_workspace_env(
         config: &McpServerConfig,
         workspace_env: &HashMap<String, String>,
@@ -884,7 +978,7 @@ fn opencode_entry_from_mcp(
             if !headers.is_empty() {
                 entry.insert("headers".to_string(), json!(headers));
             }
-            json!(entry)
+            Ok(json!(entry))
         }
         McpTransport::Stdio { command, args, env } => {
             let mut entry = serde_json::Map::new();
@@ -960,6 +1054,41 @@ fn opencode_entry_from_mcp(
                 && !per_workspace_runner
                 && nspawn::nspawn_available();
 
+            if workspace_type == WorkspaceType::Container && !container_fallback {
+                let relative = workspace_dir
+                    .strip_prefix(workspace_root)
+                    .unwrap_or_else(|_| Path::new(""));
+                let guest_dir = if relative.as_os_str().is_empty() {
+                    "/".to_string()
+                } else {
+                    format!("/{}", relative.to_string_lossy())
+                };
+                merged_env.insert("SANDBOXED_SH_WORKSPACE".to_string(), guest_dir.clone());
+                merged_env.insert("SANDBOXED_SH_WORKSPACE_ROOT".to_string(), "/".to_string());
+                merged_env.insert("WORKING_DIR".to_string(), guest_dir.clone());
+                merged_env.insert("HOME".to_string(), guest_dir);
+            }
+
+            let resolved_command = match workspace_type {
+                WorkspaceType::Container => resolve_container_command_path(
+                    command,
+                    workspace_root,
+                    container_fallback,
+                    per_workspace_runner || use_nspawn,
+                ),
+                WorkspaceType::Host => resolve_host_command_path(command),
+            };
+            let launcher = write_mcp_env_launcher(
+                config,
+                workspace_dir,
+                workspace_root,
+                workspace_type,
+                container_fallback,
+                &resolved_command,
+                args,
+                &merged_env,
+            )?;
+
             if use_nspawn {
                 let rel = workspace_dir
                     .strip_prefix(workspace_root)
@@ -969,12 +1098,6 @@ fn opencode_entry_from_mcp(
                 } else {
                     format!("/{}", rel.to_string_lossy())
                 };
-
-                let mut nspawn_env = merged_env.clone();
-                nspawn_env.insert("SANDBOXED_SH_WORKSPACE".to_string(), rel_str.clone());
-                nspawn_env.insert("SANDBOXED_SH_WORKSPACE_ROOT".to_string(), "/".to_string());
-                nspawn_env.insert("WORKING_DIR".to_string(), rel_str.clone());
-                nspawn_env.insert("HOME".to_string(), rel_str.clone());
 
                 let mut cmd = vec![
                     resolve_host_command_path("systemd-nspawn"),
@@ -1016,14 +1139,6 @@ fn opencode_entry_from_mcp(
                         "--bind={}:/root/context",
                         global_context_root.display()
                     ));
-                    nspawn_env.insert(
-                        "SANDBOXED_SH_CONTEXT_ROOT".to_string(),
-                        "/root/context".to_string(),
-                    );
-                    nspawn_env.insert(
-                        "SANDBOXED_SH_CONTEXT_DIR_NAME".to_string(),
-                        context_dir_name,
-                    );
                 }
 
                 // Network configuration based on shared_network setting:
@@ -1046,72 +1161,17 @@ fn opencode_entry_from_mcp(
                         cmd.extend(tailscale_args);
                     }
                 }
-                for (key, value) in &nspawn_env {
-                    cmd.push(format!("--setenv={}={}", key, value));
-                }
-                cmd.push(command.clone());
-                cmd.extend(args.clone());
+                cmd.push(launcher);
                 entry.insert("command".to_string(), json!(cmd));
             } else {
-                // When per_workspace_runner is true and workspace is a container,
-                // the harness (Claude Code / OpenCode) runs inside the container
-                // and spawns MCP servers as subprocesses. Env vars must use
-                // container-relative paths, not host paths.
-                if workspace_type == WorkspaceType::Container
-                    && per_workspace_runner
-                    && !container_fallback
-                {
-                    let rel = workspace_dir
-                        .strip_prefix(workspace_root)
-                        .unwrap_or_else(|_| Path::new(""));
-                    let rel_str = if rel.as_os_str().is_empty() {
-                        "/".to_string()
-                    } else {
-                        format!("/{}", rel.to_string_lossy())
-                    };
-                    merged_env.insert("SANDBOXED_SH_WORKSPACE".to_string(), rel_str.clone());
-                    merged_env.insert("SANDBOXED_SH_WORKSPACE_ROOT".to_string(), "/".to_string());
-                    merged_env.insert("WORKING_DIR".to_string(), rel_str.clone());
-                    merged_env.insert("HOME".to_string(), rel_str);
-                }
-
-                let resolved_command = match workspace_type {
-                    WorkspaceType::Container => resolve_container_command_path(
-                        command,
-                        workspace_root,
-                        container_fallback,
-                        per_workspace_runner,
-                    ),
-                    WorkspaceType::Host => resolve_host_command_path(command),
-                };
-                // Harness CLIs normally spawn MCPs as child processes, which
-                // would otherwise inherit every workspace credential even if
-                // the generated config omitted it. `env -i` makes the
-                // allowlist an actual process boundary rather than cosmetic
-                // config filtering.
-                let env_command = match workspace_type {
-                    WorkspaceType::Container => resolve_container_command_path(
-                        "env",
-                        workspace_root,
-                        container_fallback,
-                        per_workspace_runner,
-                    ),
-                    WorkspaceType::Host => resolve_host_command_path("env"),
-                };
-                let mut cmd = vec![env_command, "-i".to_string()];
-                let mut env_pairs: Vec<_> = merged_env.iter().collect();
-                env_pairs.sort_by_key(|(key, _)| *key);
-                cmd.extend(
-                    env_pairs
-                        .into_iter()
-                        .map(|(key, value)| format!("{}={}", key, value)),
-                );
-                cmd.push(resolved_command);
-                cmd.extend(args.clone());
-                entry.insert("command".to_string(), json!(cmd));
+                // The launcher clears the inherited harness environment and
+                // restores only the allowlisted variables internally. Secret
+                // values live in a mode-0700 file, never in generated config
+                // or process argv (`ps` and /proc/*/cmdline).
+                entry.insert("command".to_string(), json!([launcher]));
             }
             entry.insert("enabled".to_string(), json!(config.enabled));
-            serde_json::Value::Object(entry)
+            Ok(serde_json::Value::Object(entry))
         }
     }
 }

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -757,6 +757,45 @@ mod tests {
     }
 
     #[test]
+    fn tailnet_only_bootstrap_clears_configured_exit_node() {
+        let command = WorkspaceExec::build_tailscale_bootstrap_command(
+            "/root",
+            "/bin/true",
+            &[],
+            &HashMap::from([
+                ("TS_AUTHKEY".to_string(), "secret".to_string()),
+                ("TS_EXIT_NODE".to_string(), "100.64.0.1".to_string()),
+            ]),
+            true,
+            true,
+        );
+
+        let clear_env = command
+            .find("export TS_EXIT_NODE='';")
+            .expect("tailnet-only mode must clear TS_EXIT_NODE before bootstrap");
+        let bootstrap = command
+            .find("/usr/local/bin/sandboxed-tailscale-up")
+            .expect("bootstrap command should be present");
+        assert!(clear_env < bootstrap);
+        assert!(command.contains("tailscale set --exit-node="));
+    }
+
+    #[test]
+    fn exit_node_bootstrap_preserves_configured_exit_node() {
+        let command = WorkspaceExec::build_tailscale_bootstrap_command(
+            "/root",
+            "/bin/true",
+            &[],
+            &HashMap::from([("TS_EXIT_NODE".to_string(), "100.64.0.1".to_string())]),
+            true,
+            false,
+        );
+
+        assert!(!command.contains("export TS_EXIT_NODE='';"));
+        assert!(!command.contains("tailscale set --exit-node="));
+    }
+
+    #[test]
     fn resolv_conf_bind_disables_nspawn_resolver_initialization() {
         assert_eq!(
             resolv_conf_bind_args(Path::new("/tmp/sandboxed-resolv.conf")),
@@ -1310,6 +1349,15 @@ impl WorkspaceExec {
             }
         }
 
+        // Tailnet-only workspaces may still carry TS_EXIT_NODE because the
+        // same template is also used for exit-node mode. Do not let the
+        // bootstrap enable policy routing through that node: replacing only
+        // the main-table default route afterwards does not undo Tailscale's
+        // policy rules and can leave DNS/public HTTPS unreachable.
+        if tailnet_only {
+            cmd.push_str("export TS_EXIT_NODE=''; ");
+        }
+
         // Run the Tailscale bootstrap script if it exists.
         // The script calls sandboxed-network-up (DHCP via udhcpc, which sets up
         // the IP, default route, and DNS), then starts tailscaled and authenticates.
@@ -1325,7 +1373,10 @@ impl WorkspaceExec {
             // regular internet traffic through the host gateway (not exit node).
             // This ensures the container can reach both tailnet devices AND the internet.
             cmd.push_str(
-                "_oa_ip=$(ip -4 addr show host0 2>/dev/null | sed -n 's/.*inet \\([0-9.]*\\).*/\\1/p' | head -1); \
+                "if command -v tailscale >/dev/null 2>&1; then \
+                 tailscale set --exit-node= >/dev/null 2>&1 || true; \
+                 fi; \
+                 _oa_ip=$(ip -4 addr show host0 2>/dev/null | sed -n 's/.*inet \\([0-9.]*\\).*/\\1/p' | head -1); \
                  _oa_gw=\"${_oa_ip%.*}.1\"; \
                  if [ -n \"$_oa_ip\" ]; then \
                    ip route del default 2>/dev/null || true; \

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -1157,13 +1157,12 @@ impl WorkspaceExec {
         // alive; retaining only the mission-prep snapshot leaves later Bash or
         // `gh` subprocesses unauthenticated. Refresh the credential files
         // silently, then expose only their non-secret paths through env.
-        let git_creds =
-            crate::workspace::git_credentials::GitCredentialConfig::resolve_with_workspace_env(
-                &self.workspace.path,
-                None,
-                &self.workspace.env_vars,
-            )
-            .or_else(|| self.workspace.resolved_git_credentials.clone());
+        let git_creds = crate::workspace::git_credentials::GitCredentialConfig::resolve_for_spawn(
+            &self.workspace.path,
+            None,
+            &self.workspace.env_vars,
+            self.workspace.resolved_git_credentials.as_ref(),
+        );
         if let Some(creds) = git_creds {
             if let Err(error) = creds.write_for_workspace(
                 &self.workspace.path,

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -1152,13 +1152,30 @@ impl WorkspaceExec {
         // (claudecode) launch the agent with HOME/XDG_CONFIG_HOME pointed at a
         // per-mission dir. Export non-secret pointers to those files so both
         // `gh` and `git` can still find them.
-        let git_creds = self.workspace.resolved_git_credentials.clone().or_else(|| {
-            crate::workspace::git_credentials::GitCredentialConfig::resolve(
+        // Resolve again for every spawned process. Connected GitHub/App tokens
+        // and workspace secrets may rotate while a long-running mission is
+        // alive; retaining only the mission-prep snapshot leaves later Bash or
+        // `gh` subprocesses unauthenticated. Refresh the credential files
+        // silently, then expose only their non-secret paths through env.
+        let git_creds =
+            crate::workspace::git_credentials::GitCredentialConfig::resolve_with_workspace_env(
                 &self.workspace.path,
                 None,
+                &self.workspace.env_vars,
             )
-        });
+            .or_else(|| self.workspace.resolved_git_credentials.clone());
         if let Some(creds) = git_creds {
+            if let Err(error) = creds.write_for_workspace(
+                &self.workspace.path,
+                self.workspace.workspace_type,
+                &self.workspace.env_vars,
+            ) {
+                tracing::debug!(
+                    workspace = %self.workspace.name,
+                    error = %error,
+                    "Could not refresh GitHub credential files before subprocess spawn"
+                );
+            }
             creds.apply_to_env(
                 &mut merged,
                 &self.workspace.path,


### PR DESCRIPTION
## Summary
- add Hermes tools to get/create/update/delete workspaces
- add Hermes tools to list/get/patch-save/delete reusable workspace templates
- add a confirmed rebuild flow that reapplies the latest template fields before force-rebuilding a container
- register the new tools in generated Hermes configs and documentation
- preserve omitted template fields, redact sensitive tool output, and require explicit confirmation for destructive actions

## Validation
- cargo fmt --all --check
- cargo test --bin assistant-mcp (20 passed)
- cargo test api::workspaces::tests (13 passed)
- generated Hermes config regression test
- cargo clippy --bin assistant-mcp -- -D warnings
- assistant-mcp JSON-RPC tools/list smoke test

## Production verification
Deployed commit 0cb5475ff588d0856b5fe9c6143cdca7e3cd7e8b temporarily to Thomas prod.

- sandboxed-sh-prod, hermes-assistant, and hermes-dashboard are active
- Hermes gateway loaded the exact versioned assistant-mcp executable
- template create / partial update / get / delete passed; omitted distro was preserved
- workspace create / update / get / delete passed
- rebuild_workspace_from_template passed building -> ready; the reapplied init script wrote a marker verified through workspace_bash
- all temporary workspaces and templates were removed
- zero backend/Hermes ERROR, panic, or traceback entries since deployment
- stateless /v1/chat/completions correctly refused privileged mutation without a verified owner identity; this guard was not bypassed

GitHub CI jobs are skipped while this PR remains draft; equivalent targeted Rust checks were run locally and the production Linux build passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive MCP env isolation, destructive workspace APIs, and container path resolution for missions/ask; changes are heavily tested and documented but misconfiguration could still break Lean/MCP workflows or Hermes automation.
> 
> **Overview**
> **Hermes / assistant-mcp** exposes workspace and template management end-to-end: get/create/update/delete workspaces, list/get/patch-save/delete templates, and `rebuild_workspace_from_template` (reapply template fields then force-rebuild). Destructive calls require `confirm=true`; template saves patch omitted fields, refuse decrypted-failed secrets, and redact `env_vars` in tool output. `start_mission` maps native `agent` names (`codex`, `claudecode`, etc.) to backends when `backend` is unset.
> 
> **HTTP API** adds `POST /api/workspaces/:id/apply-template` with the same decryption guard as Hermes. Container `exec` and mission/ask working directories now map **guest-absolute paths** under the container root instead of checking them on the host.
> 
> **MCP security** introduces `workspace_env_allowlist` on MCP configs (dashboard types included). Stdio MCPs start via mission-local **`0700` launchers** that clear inherited env and restore only MCP `env`, runtime metadata, and allowlisted workspace keys—secrets are not embedded in harness config. Wildcard `"*"` is reconciled only for the built-in `workspace-mcp` proxy; repointed `workspace` entries lose implicit full-env access.
> 
> **Mission control** resolves orchestrator `working_directory` for containers with canonicalize escape checks; **Fable** models are rejected when prompts/intents imply review/merge/push/conflict work; **Codex** rejects `gpt-5.5-sol` at create time and surfaces **`mcpToolCall`** lifecycle in the app-server driver so tool-required turns do not false-stall.
> 
> **Ops / templates**: new pinned **`verity-lean`** init script; deploy stream installs **`palomactl`** (Hermes wrapper-aware) and fixes systemd service name detection; **palomactl pr-gates** adds `--worker-head`, workflow-run rollup, and richer recommendations. Git credentials can fall back to workspace `GH_TOKEN` with spawn-time refresh rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e91728e15e83227a08e7279cecd5c754b14086c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->