### PR TITLE
fix(codex): normalize harness-qualified worker models

### DIFF
--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -472,12 +472,19 @@ async fn spawn_task_worker(
     task: &BoardTask,
     workspace_id: Uuid,
 ) -> Result<Uuid, String> {
+    // Board tasks bypass the public create-mission handler, so apply the same
+    // backend-aware normalization here as a defensive migration for tasks that
+    // were persisted before upsert started normalizing them.
+    let model_override = task
+        .model_override
+        .as_deref()
+        .and_then(|model| super::normalize_model_override_for_backend(Some(&task.backend), model));
     let mission = mission_store
         .create_mission_with_parent(
             Some(&format!("[{}] {}", task.task_key, task.title)),
             Some(workspace_id),
             None,
-            task.model_override.as_deref(),
+            model_override.as_deref(),
             task.model_effort.as_deref(),
             Some(&task.backend),
             None,
@@ -487,6 +494,7 @@ async fn spawn_task_worker(
         .await?;
 
     let mut t = task.clone();
+    t.model_override = model_override;
     t.worker_mission_id = Some(mission.id);
     t.status = BoardTaskStatus::Running;
     t.attempts += 1;

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3609,12 +3609,12 @@ pub async fn upsert_mission_board_tasks(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
-    Json(req): Json<BoardUpsertRequest>,
+    Json(mut req): Json<BoardUpsertRequest>,
 ) -> Result<Json<BoardResponse>, (StatusCode, String)> {
     if req.tasks.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "tasks is required".to_string()));
     }
-    for t in &req.tasks {
+    for t in &mut req.tasks {
         if t.task_key.trim().is_empty() || t.prompt.trim().is_empty() {
             return Err((
                 StatusCode::BAD_REQUEST,
@@ -3641,6 +3641,10 @@ pub async fn upsert_mission_board_tasks(
                 ),
             ));
         }
+        t.model_override = t
+            .model_override
+            .as_deref()
+            .and_then(|model| normalize_model_override_for_backend(Some(&t.backend), model));
     }
 
     let control = control_for_user(&state, &user).await;
@@ -5066,6 +5070,17 @@ fn normalize_model_override_for_backend(backend: Option<&str>, raw_model: &str) 
     Some(trimmed.to_string())
 }
 
+fn native_backend_prefix(raw_model: &str) -> Option<&str> {
+    let (prefix, model_id) = raw_model.trim().split_once('/')?;
+    if model_id.trim().is_empty() {
+        return None;
+    }
+    match prefix {
+        "codex" | "claudecode" | "gemini" | "grok" => Some(prefix),
+        _ => None,
+    }
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -5138,6 +5153,30 @@ pub async fn create_mission(
     if let Some(value) = model_effort.as_ref() {
         if value.trim().is_empty() {
             model_effort = None;
+        }
+    }
+
+    // Native harness-qualified model IDs (for example
+    // `codex/gpt-5.6-terra`) carry an unambiguous backend. Hermes and older
+    // orchestrator clients use this compact form. Resolve it before applying
+    // the server default, otherwise the model is incorrectly validated against
+    // that default backend's catalog (commonly Anthropic/Claude Code).
+    if let Some(model) = model_override.as_deref() {
+        if let Some(prefixed_backend) = native_backend_prefix(model) {
+            match backend.as_deref() {
+                None => backend = Some(prefixed_backend.to_string()),
+                Some("opencode") => {}
+                Some(selected) if selected != prefixed_backend => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "Model '{}' selects backend '{}', but mission backend is '{}'",
+                            model, prefixed_backend, selected
+                        ),
+                    ));
+                }
+                Some(_) => {}
+            }
         }
     }
 
@@ -21553,6 +21592,21 @@ And the report:
             normalize_model_override_for_backend(Some("opencode"), "openai/gpt-5.6"),
             Some("openai/gpt-5.6".to_string())
         );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("codex"), "codex/gpt-5.6-terra"),
+            Some("gpt-5.6-terra".to_string())
+        );
+    }
+
+    #[test]
+    fn test_native_backend_prefix_only_accepts_harness_qualifiers() {
+        assert_eq!(native_backend_prefix("codex/gpt-5.6-terra"), Some("codex"));
+        assert_eq!(
+            native_backend_prefix("claudecode/claude-opus-4-7"),
+            Some("claudecode")
+        );
+        assert_eq!(native_backend_prefix("openai/gpt-5.6-terra"), None);
+        assert_eq!(native_backend_prefix("codex/"), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes Hermes/task-board workers using values such as `codex/gpt-5.6-terra` being routed through the default backend catalog.

- infer the native backend from legacy harness-qualified model IDs before default-backend validation
- reject explicit backend/prefix mismatches with a clear error
- normalize board task models both on upsert and defensively at spawn time
- preserve provider-prefixed OpenCode models

Validation:
- `cargo fmt --all --check`
- `cargo test --lib test_normalize_model_override`
- `cargo test --lib test_native_backend_prefix`
- `cargo test --lib api::control::board::tests`
- `cargo check --all-targets`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission creation and board worker routing for model/backend resolution; behavior change for clients using prefixed model IDs, with explicit mismatch errors and targeted tests.
> 
> **Overview**
> Fixes **Hermes / task-board** workers that send harness-qualified model IDs like `codex/gpt-5.6-terra` being validated against the **default** backend catalog instead of Codex.
> 
> **Mission create** now parses native harness prefixes (`codex`, `claudecode`, `gemini`, `grok`) from `model_override` **before** the default backend is chosen, sets the backend when omitted, and returns a clear **400** when an explicit backend disagrees with the prefix. OpenCode provider-prefixed models (e.g. `openai/...`) are unchanged.
> 
> **Board tasks** get the same `normalize_model_override_for_backend` treatment on **upsert**, and again at **worker spawn** for rows saved before upsert started normalizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c999d448773a5399889f55b125e8588190c93672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->