### PR TITLE
feat(workspace): add dry-run lifecycle controls

### DIFF
--- a/docs/STORAGE_LIFECYCLE.md
+++ b/docs/STORAGE_LIFECYCLE.md
@@ -1,0 +1,45 @@
+# Storage lifecycle policy
+
+Sandboxed.sh treats cleanup as an approval workflow, not an automatic disk
+reclamation mechanism. The inventory is dry-run-only: it never deletes
+workspaces, mission directories, Lean/build caches, worktrees, images, or
+credentials. `--apply` is intentionally rejected.
+
+Run it against explicit roots and retain the JSONL output as the operator audit
+log:
+
+```bash
+python3 scripts/storage_inventory.py \
+  --missions-dir /root/.sandboxed-sh/missions \
+  --root /root/.sandboxed-sh/containers/example/workspaces \
+  --root /root/.cache \
+  --root /var/lib/machines \
+  --retention-days 30 \
+  --audit-log /var/log/sandboxed-sh/storage-inventory.jsonl
+```
+
+Each record identifies path, kind, size, age, persisted mission owner (the
+mission-store key when known), mission/workspace IDs and status, and a policy
+decision. `active`, `pending`, and `waiting_background` missions are always
+`keep`; an unreadable store remains unattributed and must not be treated as an
+approval candidate. Only an attributed, terminal `mission-*` directory past
+retention is emitted as `would_remove`; caches, worktrees, images, and every
+unattributed path remain `keep` until ownership is established. A
+`would_remove` record is a candidate list for the listed owner to review
+manually, not authority to delete.
+
+The inventory also finds nested Lean (`.lake`, `.lean`) and common build-cache
+directories under each supplied root. They receive their enclosing mission's
+owner when one exists, but are still retained as separate review records so
+their bytes can be attributed without authorizing cache deletion.
+
+The background mission-directory retention sweep is also dry-run by default.
+With cleanup enabled in Settings, it emits structured `mission GC audit` logs
+with `action=would_remove`, ownership identifiers, size, path, and reason. It
+will execute only if an operator explicitly sets `WORKSPACE_GC_EXECUTE=1` on
+the service and restarts it. Do not set that flag until the candidate report has
+been reviewed and backed up; it is deliberately off by default.
+
+Resource limits are separate from retention. Use `GET
+/api/workspaces/:id/resources` to inspect effective memory/swap/CPU limits and
+matching live scopes before changing a workspace shared by concurrent missions.

--- a/docs/WORKSPACE_API.md
+++ b/docs/WORKSPACE_API.md
@@ -192,6 +192,24 @@ curl -X POST "http://localhost:3000/api/workspaces/{id}/exec" \
 GET /api/workspaces/:id/shell
 ```
 
+## Resource limits
+
+```
+GET /api/workspaces/:id/resources
+POST /api/workspaces/:id/resources
+```
+
+`GET` is read-only and shows the effective per-mission `MemoryMax`,
+`MemoryHigh`, `MemorySwapMax`, `CPUWeight`, and `CPUQuota`, any workspace
+overrides, and matching live systemd scopes. Limits inherit from the process
+environment (`MISSION_MEMORY_MAX`, `MISSION_MEMORY_HIGH`,
+`MISSION_MEMORY_SWAP_MAX`, `MISSION_CPU_WEIGHT`, `MISSION_CPU_QUOTA`) unless a
+workspace override is present.
+
+`POST` updates those workspace overrides and can retune current scopes; see the
+request fields in the API response/schema. Use `GET` first when investigating a
+shared workspace so concurrent missions are visible before changing a cap.
+
 Opens an interactive PTY shell session via WebSocket.
 
 **Authentication**: Use `Sec-WebSocket-Protocol: sandboxed.sh` header with JWT token.

--- a/docs/WORKSPACE_API.md
+++ b/docs/WORKSPACE_API.md
@@ -201,10 +201,12 @@ POST /api/workspaces/:id/resources
 
 `GET` is read-only and shows the effective per-mission `MemoryMax`,
 `MemoryHigh`, `MemorySwapMax`, `CPUWeight`, and `CPUQuota`, any workspace
-overrides, and matching live systemd scopes. Limits inherit from the process
-environment (`MISSION_MEMORY_MAX`, `MISSION_MEMORY_HIGH`,
-`MISSION_MEMORY_SWAP_MAX`, `MISSION_CPU_WEIGHT`, `MISSION_CPU_QUOTA`) unless a
-workspace override is present.
+overrides, and matching live systemd scopes. If live scope discovery fails,
+`scope_list_error` is populated so an empty `running_scope_units` list is not
+mistaken for an idle workspace. Limits inherit from the process environment
+(`MISSION_MEMORY_MAX`, `MISSION_MEMORY_HIGH`, `MISSION_MEMORY_SWAP_MAX`,
+`MISSION_CPU_WEIGHT`, `MISSION_CPU_QUOTA`) unless a workspace override is
+present.
 
 `POST` updates those workspace overrides and can retune current scopes; see the
 request fields in the API response/schema. Use `GET` first when investigating a

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -40,6 +40,9 @@ def mission_index(missions_dir):
     if not missions_path.is_dir():
         print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(missions_path), "error": "missions directory is missing or unreadable"}), file=sys.stderr)
         return records, False
+    for legacy_store in missions_path.glob("missions-*.json"):
+        print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(legacy_store), "error": "legacy JSON mission store is not indexed"}), file=sys.stderr)
+        complete = False
     for db in missions_path.glob("missions-*.db"):
         try:
             conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -14,14 +14,16 @@ import sqlite3
 import sys
 
 ACTIVE = {"active", "pending", "waiting_background"}
+TERMINAL = {"completed", "acknowledged", "failed", "interrupted", "blocked", "not_feasible"}
 
 
 def iso_time(value):
     if not value:
         return None
     try:
-        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.replace(tzinfo=dt.timezone.utc) if parsed.tzinfo is None else parsed
+    except (AttributeError, ValueError):
         return None
 
 
@@ -132,6 +134,8 @@ def inventory(root, index, index_complete, cutoff):
         mission = mission_for_path(path, root, index)
         mtime = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
         active = bool(mission and mission["status"] in ACTIVE)
+        terminal = bool(mission and mission["status"] in TERMINAL)
+        mission_updated_at = iso_time(mission["updated_at"]) if mission else None
         # Only a terminal, attributed mission directory is ever proposed.
         # Caches, worktrees, images, and unattributed directories remain
         # inventory-only even when old: an operator must establish ownership
@@ -140,8 +144,9 @@ def inventory(root, index, index_complete, cutoff):
             kind == "mission_dir"
             and index_complete
             and mission
-            and not active
-            and mtime < cutoff
+            and terminal
+            and mission_updated_at is not None
+            and mission_updated_at < cutoff
         )
         if active:
             reason = "active_mission_protected"
@@ -151,6 +156,10 @@ def inventory(root, index, index_complete, cutoff):
             reason = "mission_attribution_incomplete"
         elif not mission:
             reason = "unattributed_requires_owner_approval"
+        elif not terminal:
+            reason = "non_terminal_mission_protected"
+        elif mission_updated_at is None:
+            reason = "mission_timestamp_invalid"
         elif eligible:
             reason = "terminal_mission_past_retention"
         else:

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Read-only, dry-run-first storage attribution for sandboxed.sh.
+
+This tool never removes data.  It inventories supplied roots, attributes
+mission directories to persisted mission stores where possible, protects active
+missions, and emits JSON Lines suitable for an operator audit trail.
+"""
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import sqlite3
+import sys
+
+ACTIVE = {"active", "pending", "waiting_background"}
+
+
+def iso_time(value):
+    if not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def mission_index(missions_dir):
+    """Return (prefix -> record, complete) from persisted stores, read-only.
+
+    ``complete`` is false if any discovered store could not be read.  Callers
+    must then retain every unowned directory: absence from a partial index is
+    not evidence that a directory is stale.
+    """
+    records = {}
+    complete = True
+    missions_path = Path(missions_dir)
+    if not missions_path.is_dir():
+        print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(missions_path), "error": "missions directory is missing or unreadable"}), file=sys.stderr)
+        return records, False
+    for db in missions_path.glob("missions-*.db"):
+        try:
+            conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+            rows = conn.execute("SELECT id, status, updated_at, workspace_id FROM missions")
+            for mission_id, status, updated_at, workspace_id in rows:
+                prefix = mission_id[:8].lower()
+                record = {"mission_id": mission_id, "status": status.lower(),
+                          "updated_at": updated_at, "workspace_id": workspace_id,
+                          "owner": db.stem.removeprefix("missions-")}
+                previous = records.get(prefix)
+                if previous is None or (record["status"] in ACTIVE and previous["status"] not in ACTIVE):
+                    records[prefix] = record
+            conn.close()
+        except (sqlite3.Error, OSError) as error:
+            # Fail closed: an unreadable store does not create a cleanup
+            # candidate; the corresponding directory remains unattributed.
+            print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(db), "error": str(error)}), file=sys.stderr)
+            complete = False
+    return records, complete
+
+
+def bytes_under(path):
+    total = 0
+    for root, _, files in os.walk(path, followlinks=False):
+        for filename in files:
+            try:
+                total += os.lstat(os.path.join(root, filename)).st_size
+            except OSError:
+                pass
+    return total
+
+
+def kind_for(path):
+    name = path.name.lower()
+    if name.startswith("mission-"):
+        return "mission_dir"
+    if name in {"target", ".cache", ".lean", ".lake", "cache"}:
+        return "build_cache"
+    if "image" in name or name in {"machines", "containers"}:
+        return "container_image"
+    if name in {"worktrees", ".git"} or (path / ".git").exists():
+        return "git_worktree"
+    return "unclassified"
+
+
+def paths_to_inventory(root):
+    """Yield direct children plus nested build-cache directories, once each.
+
+    Direct children make roots such as workspace/container/image directories
+    visible.  The targeted recursive walk captures `.lake`, `target`, and
+    other nested build caches without producing a record for every source
+    directory or following symlinks.
+    """
+    if root.name.startswith("mission-"):
+        yield root
+        return
+    seen = set()
+    for path in root.iterdir():
+        if path.is_dir() and path not in seen:
+            seen.add(path)
+            yield path
+    for current, dirs, _ in os.walk(root, followlinks=False):
+        dirs[:] = [name for name in dirs if not os.path.islink(os.path.join(current, name))]
+        for name in dirs:
+            path = Path(current, name)
+            if kind_for(path) == "build_cache" and path not in seen:
+                seen.add(path)
+                yield path
+
+
+def mission_for_path(path, root, index):
+    """Find a mission owner from this path or one of its ancestors."""
+    current = path
+    while True:
+        if current.name.startswith("mission-"):
+            return index.get(current.name.removeprefix("mission-").lower())
+        if current == root:
+            return None
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def inventory(root, index, index_complete, cutoff):
+    root = Path(root)
+    if not root.exists():
+        yield {"record_type": "audit", "action": "root_missing", "path": str(root)}
+        return
+    for path in paths_to_inventory(root):
+        kind = kind_for(path)
+        mission = mission_for_path(path, root, index)
+        mtime = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
+        active = bool(mission and mission["status"] in ACTIVE)
+        # Only a terminal, attributed mission directory is ever proposed.
+        # Caches, worktrees, images, and unattributed directories remain
+        # inventory-only even when old: an operator must establish ownership
+        # before any separate cleanup action can be approved.
+        eligible = bool(mission and not active and mtime < cutoff)
+        if active:
+            reason = "active_mission_protected"
+        elif kind != "mission_dir":
+            reason = "unattributed_requires_owner_approval"
+        elif not index_complete:
+            reason = "mission_attribution_incomplete"
+        elif not mission:
+            reason = "unattributed_requires_owner_approval"
+        elif eligible:
+            reason = "terminal_mission_past_retention"
+        else:
+            reason = "within_retention"
+        yield {
+            "record_type": "storage_item", "action": "would_remove" if eligible else "keep",
+            "path": str(path), "kind": kind, "owner": mission["owner"] if mission else "unattributed",
+            "mission_id": mission["mission_id"] if mission else None,
+            "workspace_id": mission["workspace_id"] if mission else None,
+            "mission_status": mission["status"] if mission else None,
+            "age_days": round((dt.datetime.now(dt.timezone.utc) - mtime).total_seconds() / 86400, 2),
+            "size_bytes": bytes_under(path), "reason": reason,
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read-only sandboxed.sh storage inventory (never deletes).")
+    parser.add_argument("--missions-dir", required=True, help="Directory containing missions-*.db")
+    parser.add_argument("--root", action="append", required=True, help="Root to inventory; repeat for workspaces, caches, images, or worktrees")
+    parser.add_argument("--retention-days", type=int, default=7)
+    parser.add_argument("--audit-log", help="Append JSONL audit records to this file")
+    parser.add_argument("--apply", action="store_true", help="Rejected: this tool is inventory-only")
+    args = parser.parse_args()
+    if args.apply:
+        parser.error("--apply is intentionally unsupported; inventory never deletes data")
+    now = dt.datetime.now(dt.timezone.utc)
+    cutoff = now - dt.timedelta(days=args.retention_days)
+    indexed, index_complete = mission_index(args.missions_dir)
+    records = [{"record_type": "audit", "action": "inventory_started", "dry_run": True,
+                "retention_days": args.retention_days, "at": now.isoformat()}]
+    for root in args.root:
+        records.extend(inventory(root, indexed, index_complete, cutoff))
+    output = "".join(json.dumps(record, sort_keys=True) + "\n" for record in records)
+    sys.stdout.write(output)
+    if args.audit_log:
+        with open(args.audit_log, "a", encoding="utf-8") as handle:
+            handle.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -14,7 +14,7 @@ import sqlite3
 import sys
 
 ACTIVE = {"active", "pending", "waiting_background"}
-TERMINAL = {"completed", "acknowledged", "failed", "interrupted", "blocked", "not_feasible"}
+TERMINAL = {"completed", "failed", "interrupted", "blocked", "not_feasible"}
 
 
 def iso_time(value):
@@ -28,20 +28,21 @@ def iso_time(value):
 
 
 def mission_index(missions_dir):
-    """Return (prefix -> record, complete) from persisted stores, read-only.
+    """Return (prefix -> record, complete, audit records) from persisted stores.
 
     ``complete`` is false if any discovered store could not be read.  Callers
     must then retain every unowned directory: absence from a partial index is
     not evidence that a directory is stale.
     """
     records = {}
+    audit_records = []
     complete = True
     missions_path = Path(missions_dir)
     if not missions_path.is_dir():
-        print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(missions_path), "error": "missions directory is missing or unreadable"}), file=sys.stderr)
-        return records, False
+        audit_records.append({"record_type": "audit", "action": "index_error", "path": str(missions_path), "error": "missions directory is missing or unreadable"})
+        return records, False, audit_records
     for legacy_store in missions_path.glob("missions-*.json"):
-        print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(legacy_store), "error": "legacy JSON mission store is not indexed"}), file=sys.stderr)
+        audit_records.append({"record_type": "audit", "action": "index_error", "path": str(legacy_store), "error": "legacy JSON mission store is not indexed"})
         complete = False
     for db in missions_path.glob("missions-*.db"):
         try:
@@ -63,9 +64,9 @@ def mission_index(missions_dir):
         except (sqlite3.Error, OSError) as error:
             # Fail closed: an unreadable store does not create a cleanup
             # candidate; the corresponding directory remains unattributed.
-            print(json.dumps({"record_type": "audit", "action": "index_error", "path": str(db), "error": str(error)}), file=sys.stderr)
+            audit_records.append({"record_type": "audit", "action": "index_error", "path": str(db), "error": str(error)})
             complete = False
-    return records, complete
+    return records, complete, audit_records
 
 
 def bytes_under(path):
@@ -198,9 +199,10 @@ def main():
         parser.error("--apply is intentionally unsupported; inventory never deletes data")
     now = dt.datetime.now(dt.timezone.utc)
     cutoff = now - dt.timedelta(days=args.retention_days)
-    indexed, index_complete = mission_index(args.missions_dir)
+    indexed, index_complete, index_audit_records = mission_index(args.missions_dir)
     records = [{"record_type": "audit", "action": "inventory_started", "dry_run": True,
                 "retention_days": args.retention_days, "at": now.isoformat()}]
+    records.extend(index_audit_records)
     for root in args.root:
         records.extend(inventory(root, indexed, index_complete, cutoff))
     output = "".join(json.dumps(record, sort_keys=True) + "\n" for record in records)

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -136,7 +136,7 @@ def inventory(root, index, index_complete, cutoff):
         # Caches, worktrees, images, and unattributed directories remain
         # inventory-only even when old: an operator must establish ownership
         # before any separate cleanup action can be approved.
-        eligible = bool(mission and not active and mtime < cutoff)
+        eligible = bool(index_complete and mission and not active and mtime < cutoff)
         if active:
             reason = "active_mission_protected"
         elif kind != "mission_dir":

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -48,8 +48,12 @@ def mission_index(missions_dir):
                 prefix = mission_id[:8].lower()
                 record = {"mission_id": mission_id, "status": status.lower(),
                           "updated_at": updated_at, "workspace_id": workspace_id,
-                          "owner": db.stem.removeprefix("missions-")}
+                          "owner": db.stem.removeprefix("missions-"),
+                          "short_id_collision": False}
                 previous = records.get(prefix)
+                if previous is not None:
+                    record["short_id_collision"] = True
+                    previous["short_id_collision"] = True
                 if previous is None or (record["status"] in ACTIVE and previous["status"] not in ACTIVE):
                     records[prefix] = record
             conn.close()
@@ -136,6 +140,7 @@ def inventory(root, index, index_complete, cutoff):
         active = bool(mission and mission["status"] in ACTIVE)
         terminal = bool(mission and mission["status"] in TERMINAL)
         mission_updated_at = iso_time(mission["updated_at"]) if mission else None
+        short_id_collision = bool(mission and mission["short_id_collision"])
         # Only a terminal, attributed mission directory is ever proposed.
         # Caches, worktrees, images, and unattributed directories remain
         # inventory-only even when old: an operator must establish ownership
@@ -144,6 +149,7 @@ def inventory(root, index, index_complete, cutoff):
             kind == "mission_dir"
             and index_complete
             and mission
+            and not short_id_collision
             and terminal
             and mission_updated_at is not None
             and mission_updated_at < cutoff
@@ -156,6 +162,8 @@ def inventory(root, index, index_complete, cutoff):
             reason = "mission_attribution_incomplete"
         elif not mission:
             reason = "unattributed_requires_owner_approval"
+        elif short_id_collision:
+            reason = "short_id_collision_protected"
         elif not terminal:
             reason = "non_terminal_mission_protected"
         elif mission_updated_at is None:

--- a/scripts/storage_inventory.py
+++ b/scripts/storage_inventory.py
@@ -136,7 +136,13 @@ def inventory(root, index, index_complete, cutoff):
         # Caches, worktrees, images, and unattributed directories remain
         # inventory-only even when old: an operator must establish ownership
         # before any separate cleanup action can be approved.
-        eligible = bool(index_complete and mission and not active and mtime < cutoff)
+        eligible = bool(
+            kind == "mission_dir"
+            and index_complete
+            and mission
+            and not active
+            and mtime < cutoff
+        )
         if active:
             reason = "active_mission_protected"
         elif kind != "mission_dir":

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -21,6 +21,8 @@ with tempfile.TemporaryDirectory() as temp:
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("dddddddd-dddd-dddd-dddd-dddddddddddd", "paused", "2025-01-01T00:00:00Z", "ws-d"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee", "awaiting_user", "2025-01-01T00:00:00Z", "ws-e"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("ffffffff-ffff-ffff-ffff-ffffffffffff", "failed", "not-a-timestamp", "ws-f"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("99999999-0000-0000-0000-000000000001", "completed", "2025-01-01T00:00:00Z", "ws-g"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("99999999-0000-0000-0000-000000000002", "paused", "2025-01-01T00:00:00Z", "ws-g"))
     conn.commit(); conn.close()
     workspaces = root / "workspaces"; workspaces.mkdir()
     active = workspaces / "mission-aaaaaaaa"; active.mkdir(); (active / "live").write_text("x")
@@ -29,11 +31,12 @@ with tempfile.TemporaryDirectory() as temp:
     paused = workspaces / "mission-dddddddd"; paused.mkdir()
     awaiting_user = workspaces / "mission-eeeeeeee"; awaiting_user.mkdir()
     invalid_timestamp = workspaces / "mission-ffffffff"; invalid_timestamp.mkdir()
+    collided = workspaces / "mission-99999999"; collided.mkdir()
     cache = workspaces / "cache"; cache.mkdir(); (cache / "artifact").write_text("x" * 32)
     lean_cache = old / ".lake"; lean_cache.mkdir(); (lean_cache / "olean").write_text("x" * 32)
     old_time = time.time() - 20 * 86400; __import__("os").utime(old, (old_time, old_time))
     __import__("os").utime(recently_updated, (old_time, old_time))
-    for path in (paused, awaiting_user, invalid_timestamp):
+    for path in (paused, awaiting_user, invalid_timestamp, collided):
         __import__("os").utime(path, (old_time, old_time))
     __import__("os").utime(cache, (old_time, old_time))
     # This reproduces the prior predicate bug: an old cache nested below a
@@ -53,6 +56,8 @@ with tempfile.TemporaryDirectory() as temp:
     assert items["mission-eeeeeeee"]["reason"] == "non_terminal_mission_protected"
     assert items["mission-ffffffff"]["action"] == "keep"
     assert items["mission-ffffffff"]["reason"] == "mission_timestamp_invalid"
+    assert items["mission-99999999"]["action"] == "keep"
+    assert items["mission-99999999"]["reason"] == "short_id_collision_protected"
     assert items["cache"]["action"] == "keep"
     assert items["cache"]["reason"] == "unattributed_requires_owner_approval"
     assert items[".lake"]["kind"] == "build_cache"

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+
+SCRIPT = Path(__file__).with_name("storage_inventory.py")
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    missions = root / "missions"; missions.mkdir()
+    db = missions / "missions-thomas.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE missions (id TEXT, status TEXT, updated_at TEXT, workspace_id TEXT)")
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "active", "2026-01-01T00:00:00Z", "ws-a"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "completed", "2025-01-01T00:00:00Z", "ws-b"))
+    conn.commit(); conn.close()
+    workspaces = root / "workspaces"; workspaces.mkdir()
+    active = workspaces / "mission-aaaaaaaa"; active.mkdir(); (active / "live").write_text("x")
+    old = workspaces / "mission-bbbbbbbb"; old.mkdir(); (old / "old").write_text("x" * 32)
+    cache = workspaces / "cache"; cache.mkdir(); (cache / "artifact").write_text("x" * 32)
+    lean_cache = old / ".lake"; lean_cache.mkdir(); (lean_cache / "olean").write_text("x" * 32)
+    old_time = time.time() - 20 * 86400; __import__("os").utime(old, (old_time, old_time))
+    __import__("os").utime(cache, (old_time, old_time))
+    result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    items = {Path(row["path"]).name: row for row in rows if row["record_type"] == "storage_item"}
+    assert items["mission-aaaaaaaa"]["action"] == "keep"
+    assert items["mission-aaaaaaaa"]["owner"] == "thomas"
+    assert items["mission-bbbbbbbb"]["action"] == "would_remove"
+    assert items["cache"]["action"] == "keep"
+    assert items["cache"]["reason"] == "unattributed_requires_owner_approval"
+    assert items[".lake"]["kind"] == "build_cache"
+    assert items[".lake"]["owner"] == "thomas"
+    assert items[".lake"]["action"] == "keep"
+print("storage inventory regression test passed")

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -36,4 +36,12 @@ with tempfile.TemporaryDirectory() as temp:
     assert items[".lake"]["kind"] == "build_cache"
     assert items[".lake"]["owner"] == "thomas"
     assert items[".lake"]["action"] == "keep"
+
+    broken = missions / "missions-broken.db"
+    broken.write_text("not sqlite")
+    result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    items = {Path(row["path"]).name: row for row in rows if row["record_type"] == "storage_item"}
+    assert items["mission-bbbbbbbb"]["action"] == "keep"
+    assert items["mission-bbbbbbbb"]["reason"] == "mission_attribution_incomplete"
 print("storage inventory regression test passed")

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -17,13 +17,24 @@ with tempfile.TemporaryDirectory() as temp:
     conn.execute("CREATE TABLE missions (id TEXT, status TEXT, updated_at TEXT, workspace_id TEXT)")
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "active", "2026-01-01T00:00:00Z", "ws-a"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "completed", "2025-01-01T00:00:00Z", "ws-b"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("cccccccc-cccc-cccc-cccc-cccccccccccc", "completed", "2999-01-01T00:00:00Z", "ws-c"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("dddddddd-dddd-dddd-dddd-dddddddddddd", "paused", "2025-01-01T00:00:00Z", "ws-d"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee", "awaiting_user", "2025-01-01T00:00:00Z", "ws-e"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("ffffffff-ffff-ffff-ffff-ffffffffffff", "failed", "not-a-timestamp", "ws-f"))
     conn.commit(); conn.close()
     workspaces = root / "workspaces"; workspaces.mkdir()
     active = workspaces / "mission-aaaaaaaa"; active.mkdir(); (active / "live").write_text("x")
     old = workspaces / "mission-bbbbbbbb"; old.mkdir(); (old / "old").write_text("x" * 32)
+    recently_updated = workspaces / "mission-cccccccc"; recently_updated.mkdir()
+    paused = workspaces / "mission-dddddddd"; paused.mkdir()
+    awaiting_user = workspaces / "mission-eeeeeeee"; awaiting_user.mkdir()
+    invalid_timestamp = workspaces / "mission-ffffffff"; invalid_timestamp.mkdir()
     cache = workspaces / "cache"; cache.mkdir(); (cache / "artifact").write_text("x" * 32)
     lean_cache = old / ".lake"; lean_cache.mkdir(); (lean_cache / "olean").write_text("x" * 32)
     old_time = time.time() - 20 * 86400; __import__("os").utime(old, (old_time, old_time))
+    __import__("os").utime(recently_updated, (old_time, old_time))
+    for path in (paused, awaiting_user, invalid_timestamp):
+        __import__("os").utime(path, (old_time, old_time))
     __import__("os").utime(cache, (old_time, old_time))
     # This reproduces the prior predicate bug: an old cache nested below a
     # terminal mission inherited its owner and was emitted as would_remove.
@@ -34,6 +45,14 @@ with tempfile.TemporaryDirectory() as temp:
     assert items["mission-aaaaaaaa"]["action"] == "keep"
     assert items["mission-aaaaaaaa"]["owner"] == "thomas"
     assert items["mission-bbbbbbbb"]["action"] == "would_remove"
+    assert items["mission-cccccccc"]["action"] == "keep"
+    assert items["mission-cccccccc"]["reason"] == "within_retention"
+    assert items["mission-dddddddd"]["action"] == "keep"
+    assert items["mission-dddddddd"]["reason"] == "non_terminal_mission_protected"
+    assert items["mission-eeeeeeee"]["action"] == "keep"
+    assert items["mission-eeeeeeee"]["reason"] == "non_terminal_mission_protected"
+    assert items["mission-ffffffff"]["action"] == "keep"
+    assert items["mission-ffffffff"]["reason"] == "mission_timestamp_invalid"
     assert items["cache"]["action"] == "keep"
     assert items["cache"]["reason"] == "unattributed_requires_owner_approval"
     assert items[".lake"]["kind"] == "build_cache"

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -75,6 +75,15 @@ with tempfile.TemporaryDirectory() as temp:
     for name in (".lake", "worktrees", "images", "unattributed-old"):
         assert items[name]["action"] == "keep", name
 
+    legacy = missions / "missions-legacy.json"
+    legacy.write_text('{"missions": {}}')
+    result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    items = {Path(row["path"]).name: row for row in rows if row["record_type"] == "storage_item"}
+    assert items["mission-bbbbbbbb"]["action"] == "keep"
+    assert items["mission-bbbbbbbb"]["reason"] == "mission_attribution_incomplete"
+    legacy.unlink()
+
     broken = missions / "missions-broken.db"
     broken.write_text("not sqlite")
     result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -20,6 +20,7 @@ with tempfile.TemporaryDirectory() as temp:
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("cccccccc-cccc-cccc-cccc-cccccccccccc", "completed", "2999-01-01T00:00:00Z", "ws-c"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("dddddddd-dddd-dddd-dddd-dddddddddddd", "paused", "2025-01-01T00:00:00Z", "ws-d"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee", "awaiting_user", "2025-01-01T00:00:00Z", "ws-e"))
+    conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("abababab-abab-abab-abab-abababababab", "acknowledged", "2025-01-01T00:00:00Z", "ws-ack"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("ffffffff-ffff-ffff-ffff-ffffffffffff", "failed", "not-a-timestamp", "ws-f"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("99999999-0000-0000-0000-000000000001", "completed", "2025-01-01T00:00:00Z", "ws-g"))
     conn.execute("INSERT INTO missions VALUES (?, ?, ?, ?)", ("99999999-0000-0000-0000-000000000002", "paused", "2025-01-01T00:00:00Z", "ws-g"))
@@ -30,13 +31,14 @@ with tempfile.TemporaryDirectory() as temp:
     recently_updated = workspaces / "mission-cccccccc"; recently_updated.mkdir()
     paused = workspaces / "mission-dddddddd"; paused.mkdir()
     awaiting_user = workspaces / "mission-eeeeeeee"; awaiting_user.mkdir()
+    acknowledged = workspaces / "mission-abababab"; acknowledged.mkdir()
     invalid_timestamp = workspaces / "mission-ffffffff"; invalid_timestamp.mkdir()
     collided = workspaces / "mission-99999999"; collided.mkdir()
     cache = workspaces / "cache"; cache.mkdir(); (cache / "artifact").write_text("x" * 32)
     lean_cache = old / ".lake"; lean_cache.mkdir(); (lean_cache / "olean").write_text("x" * 32)
     old_time = time.time() - 20 * 86400; __import__("os").utime(old, (old_time, old_time))
     __import__("os").utime(recently_updated, (old_time, old_time))
-    for path in (paused, awaiting_user, invalid_timestamp, collided):
+    for path in (paused, awaiting_user, acknowledged, invalid_timestamp, collided):
         __import__("os").utime(path, (old_time, old_time))
     __import__("os").utime(cache, (old_time, old_time))
     # This reproduces the prior predicate bug: an old cache nested below a
@@ -54,6 +56,8 @@ with tempfile.TemporaryDirectory() as temp:
     assert items["mission-dddddddd"]["reason"] == "non_terminal_mission_protected"
     assert items["mission-eeeeeeee"]["action"] == "keep"
     assert items["mission-eeeeeeee"]["reason"] == "non_terminal_mission_protected"
+    assert items["mission-abababab"]["action"] == "keep"
+    assert items["mission-abababab"]["reason"] == "non_terminal_mission_protected"
     assert items["mission-ffffffff"]["action"] == "keep"
     assert items["mission-ffffffff"]["reason"] == "mission_timestamp_invalid"
     assert items["mission-99999999"]["action"] == "keep"
@@ -77,8 +81,15 @@ with tempfile.TemporaryDirectory() as temp:
 
     legacy = missions / "missions-legacy.json"
     legacy.write_text('{"missions": {}}')
-    result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)
+    audit_log = root / "storage-audit.jsonl"
+    result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7", "--audit-log", str(audit_log)], check=True, capture_output=True, text=True)
     rows = [json.loads(line) for line in result.stdout.splitlines()]
+    audit_rows = [json.loads(line) for line in audit_log.read_text().splitlines()]
+    assert any(
+        row.get("action") == "index_error" and row.get("path") == str(legacy)
+        for row in rows
+    )
+    assert audit_rows == rows
     items = {Path(row["path"]).name: row for row in rows if row["record_type"] == "storage_item"}
     assert items["mission-bbbbbbbb"]["action"] == "keep"
     assert items["mission-bbbbbbbb"]["reason"] == "mission_attribution_incomplete"

--- a/scripts/test_storage_inventory.py
+++ b/scripts/test_storage_inventory.py
@@ -25,6 +25,9 @@ with tempfile.TemporaryDirectory() as temp:
     lean_cache = old / ".lake"; lean_cache.mkdir(); (lean_cache / "olean").write_text("x" * 32)
     old_time = time.time() - 20 * 86400; __import__("os").utime(old, (old_time, old_time))
     __import__("os").utime(cache, (old_time, old_time))
+    # This reproduces the prior predicate bug: an old cache nested below a
+    # terminal mission inherited its owner and was emitted as would_remove.
+    __import__("os").utime(lean_cache, (old_time, old_time))
     result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)
     rows = [json.loads(line) for line in result.stdout.splitlines()]
     items = {Path(row["path"]).name: row for row in rows if row["record_type"] == "storage_item"}
@@ -36,6 +39,17 @@ with tempfile.TemporaryDirectory() as temp:
     assert items[".lake"]["kind"] == "build_cache"
     assert items[".lake"]["owner"] == "thomas"
     assert items[".lake"]["action"] == "keep"
+
+    worktree = workspaces / "worktrees"; worktree.mkdir(); (worktree / ".git").write_text("gitdir: elsewhere")
+    image = workspaces / "images"; image.mkdir()
+    unknown = workspaces / "unattributed-old"; unknown.mkdir()
+    for path in (worktree, image, unknown):
+        __import__("os").utime(path, (old_time, old_time))
+    result = subprocess.run([sys.executable, str(SCRIPT), "--missions-dir", str(missions), "--root", str(workspaces), "--retention-days", "7"], check=True, capture_output=True, text=True)
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    items = {Path(row["path"]).name: row for row in rows if row["record_type"] == "storage_item"}
+    for name in (".lake", "worktrees", "images", "unattributed-old"):
+        assert items[name]["action"] == "keep", name
 
     broken = missions / "missions-broken.db"
     broken.write_text("not sqlite")

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -555,6 +555,7 @@ pub struct SweepParams {
 pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepReport {
     let cutoff = params.cutoff;
     let mut report = SweepReport::default();
+    let mut dry_run_candidates = std::collections::HashSet::new();
     let sessions = state.control.all_sessions().await;
     for session in sessions {
         let store = session.mission_store.clone();
@@ -603,6 +604,7 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                 }
                 let size = directory_size_bytes(&dir).await;
                 if params.dry_run {
+                    dry_run_candidates.insert(dir.clone());
                     report.proposed += 1;
                     tracing::info!(
                         action = "would_remove",
@@ -645,7 +647,7 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
         }
     }
 
-    orphan_sweep(state, params, &mut report).await;
+    orphan_sweep(state, params, &dry_run_candidates, &mut report).await;
 
     report
 }
@@ -653,7 +655,12 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
 /// Disk-driven reconciliation pass (phase 2). Every decision is logged with
 /// its reason; deletion requires positive evidence of collectability, and a
 /// live exec scope always wins.
-async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut SweepReport) {
+async fn orphan_sweep(
+    state: &Arc<AppState>,
+    params: &SweepParams,
+    dry_run_candidates: &std::collections::HashSet<std::path::PathBuf>,
+    report: &mut SweepReport,
+) {
     let index_full = build_mission_index(state).await;
     let index = &index_full.by_short;
     // Any dir whose short id is referenced by a live exec scope is kept
@@ -752,6 +759,14 @@ async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut 
                     tracing::debug!(path = %dir.display(), reason, "mission GC: kept");
                 }
                 Verdict::Delete(reason, orphan, stopped) => {
+                    if params.dry_run && dry_run_candidates.contains(&dir) {
+                        tracing::debug!(
+                            path = %dir.display(),
+                            reason,
+                            "mission GC: skipped duplicate dry-run candidate",
+                        );
+                        continue;
+                    }
                     let size = directory_size_bytes(&dir).await;
                     if params.dry_run {
                         report.proposed += 1;

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -179,9 +179,11 @@ fn indexed_mission_directory_is_collectible(
     entries: &[MissionIndexEntry],
     workspace_id: uuid::Uuid,
     cutoff: DateTime<Utc>,
+    index_complete: bool,
 ) -> bool {
-    entry_for_workspace(entries, workspace_id)
-        .is_some_and(|entry| is_gc_eligible_status(&entry.status) && entry.updated_at < cutoff)
+    index_complete
+        && entry_for_workspace(entries, workspace_id)
+            .is_some_and(|entry| is_gc_eligible_status(&entry.status) && entry.updated_at < cutoff)
 }
 
 /// Read one persisted SQLite mission store without booting a session.
@@ -667,7 +669,12 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                 }
                 let short = mission.id.simple().to_string()[..8].to_string();
                 if mission_index.by_short.get(&short).is_some_and(|entries| {
-                    !indexed_mission_directory_is_collectible(entries, workspace_id, cutoff)
+                    !indexed_mission_directory_is_collectible(
+                        entries,
+                        workspace_id,
+                        cutoff,
+                        mission_index.complete,
+                    )
                 }) {
                     tracing::debug!(
                         mission_id = %mission.id,
@@ -996,6 +1003,25 @@ mod tests {
             &entries,
             workspace_id,
             now - chrono::Duration::days(7),
+            true,
+        ));
+
+        let terminal_only = vec![MissionIndexEntry {
+            status: MissionStatus::Completed,
+            updated_at: now - chrono::Duration::days(40),
+            workspace_id,
+        }];
+        assert!(indexed_mission_directory_is_collectible(
+            &terminal_only,
+            workspace_id,
+            now - chrono::Duration::days(7),
+            true,
+        ));
+        assert!(!indexed_mission_directory_is_collectible(
+            &terminal_only,
+            workspace_id,
+            now - chrono::Duration::days(7),
+            false,
         ));
     }
 

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -172,6 +172,18 @@ pub(crate) fn entry_for_workspace(
         })
 }
 
+/// Whether the most protective known owner of a shared short-id directory is
+/// terminal and past retention. Phase 1 must use the same collision policy as
+/// the disk-driven sweep before proposing or removing the shared path.
+fn indexed_mission_directory_is_collectible(
+    entries: &[MissionIndexEntry],
+    workspace_id: uuid::Uuid,
+    cutoff: DateTime<Utc>,
+) -> bool {
+    entry_for_workspace(entries, workspace_id)
+        .is_some_and(|entry| is_gc_eligible_status(&entry.status) && entry.updated_at < cutoff)
+}
+
 /// Read one persisted SQLite mission store without booting a session.
 fn index_store_file_blocking(
     path: &std::path::Path,
@@ -606,6 +618,7 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
             .iter()
             .map(String::as_str),
     );
+    let mission_index = build_mission_index(state).await;
     let sessions = state.control.all_sessions().await;
     for session in sessions {
         let store = session.mission_store.clone();
@@ -650,6 +663,18 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                 };
                 let dir = workspace::mission_workspace_dir_for_root(&ws.path, mission.id);
                 if !dir.exists() {
+                    continue;
+                }
+                let short = mission.id.simple().to_string()[..8].to_string();
+                if mission_index.by_short.get(&short).is_some_and(|entries| {
+                    !indexed_mission_directory_is_collectible(entries, workspace_id, cutoff)
+                }) {
+                    tracing::debug!(
+                        mission_id = %mission.id,
+                        workspace_id = %workspace_id,
+                        path = %dir.display(),
+                        "mission GC: kept (short-id collision owner protected)",
+                    );
                     continue;
                 }
                 if mission_directory_candidate(&scope_protected, &ws.path, mission.id)
@@ -713,6 +738,7 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
         params,
         &dry_run_candidates,
         &scope_protected,
+        &mission_index,
         &mut report,
     )
     .await;
@@ -728,9 +754,9 @@ async fn orphan_sweep(
     params: &SweepParams,
     dry_run_candidates: &std::collections::HashSet<std::path::PathBuf>,
     scope_protected: &std::collections::HashSet<(String, String)>,
+    index_full: &MissionIndex,
     report: &mut SweepReport,
 ) {
-    let index_full = build_mission_index(state).await;
     let index = &index_full.by_short;
 
     for ws in state.workspaces.list().await {
@@ -966,6 +992,11 @@ mod tests {
             entry_for_workspace(&entries, workspace_id).unwrap().status,
             MissionStatus::Active
         );
+        assert!(!indexed_mission_directory_is_collectible(
+            &entries,
+            workspace_id,
+            now - chrono::Duration::days(7),
+        ));
     }
 
     #[test]

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -589,6 +589,12 @@ fn protected_exec_scopes<'a>(
         .collect()
 }
 
+fn protected_exec_scope_snapshot(
+    units: Result<Vec<String>, String>,
+) -> Result<std::collections::HashSet<(String, String)>, String> {
+    units.map(|units| protected_exec_scopes(units.iter().map(String::as_str)))
+}
+
 /// Whether a live exec scope protects one mission directory. This guard runs
 /// before phase 1 can propose or remove the directory.
 #[derive(Debug, PartialEq, Eq)]
@@ -626,12 +632,16 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
     // Snapshot live exec scopes before considering *any* mission directory.
     // A scope may have a process holding cwd/fds in the directory, so it wins
     // over terminal status in both dry-run and execution mode.
-    let scope_protected = protected_exec_scopes(
-        super::scope_reaper::list_exec_scope_units()
-            .await
-            .iter()
-            .map(String::as_str),
-    );
+    let scope_protected =
+        match protected_exec_scope_snapshot(super::scope_reaper::try_list_exec_scope_units().await)
+        {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                report.errors += 1;
+                tracing::warn!(%err, "mission GC: scope snapshot unavailable; skipping sweep");
+                return report;
+            }
+        };
     let mission_index = build_mission_index(state).await;
     let sessions = state.control.all_sessions().await;
     for session in sessions {
@@ -1057,6 +1067,13 @@ mod tests {
             mission_directory_candidate(&protected, workspace.path(), mission_id),
             MissionDirectoryCandidate::RetainLiveScope
         );
+    }
+
+    #[test]
+    fn unavailable_exec_scope_snapshot_disables_workspace_collection() {
+        let snapshot = protected_exec_scope_snapshot(Err("systemctl unavailable".to_string()));
+
+        assert!(snapshot.is_err());
     }
 
     #[tokio::test]

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -3,12 +3,12 @@
 //! When `auto_cleanup_enabled` is on in `SettingsStore`, this task wakes up
 //! once an hour, walks every live control session's mission store, and for
 //! each mission in a terminal status that hasn't been touched within the
-//! configured retention window (`auto_cleanup_days`), it deletes the
+//! configured retention window (`auto_cleanup_days`), it proposes cleanup of the
 //! per-mission workspace directory on disk
 //! (`{workspace_root}/workspaces/mission-{first-8-of-id}/`).
 //!
 //! The conversation history in the SQLite mission store is left intact —
-//! only the agent's sandboxed filesystem is collected. The mission can still
+//! only the agent's sandboxed filesystem is eligible. The mission can still
 //! be opened from the dashboard; "Load earlier messages" continues to work.
 //!
 //! Terminal statuses we collect:
@@ -39,6 +39,11 @@ pub const DEFAULT_STOPPED_RETENTION_DAYS: u32 = 30;
 /// memory even when a session has thousands of missions.
 const LIST_PAGE_SIZE: usize = 200;
 
+/// Deletion is deliberately opt-in. An enabled retention setting alone only
+/// produces auditable `would_remove` records. This makes rollout reversible
+/// and prevents a configuration migration from deleting historical work.
+const EXECUTE_ENV: &str = "WORKSPACE_GC_EXECUTE";
+
 /// Spawn the background GC loop. Safe to call once at server start.
 pub fn spawn(state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -64,10 +69,12 @@ async fn run_loop(state: Arc<AppState>) {
             cutoff: now - chrono::Duration::days(settings.days as i64),
             stopped_cutoff: now - chrono::Duration::days(settings.stopped_days as i64),
             orphans_enabled: settings.orphans_enabled,
+            dry_run: !gc_execution_enabled(),
         };
         let report = run_once(&state, &params).await;
         tracing::info!(
             removed = report.removed,
+            proposed = report.proposed,
             orphans_removed = report.orphans_removed,
             stopped_removed = report.stopped_removed,
             errors = report.errors,
@@ -76,9 +83,17 @@ async fn run_loop(state: Arc<AppState>) {
             duration_ms = started.elapsed().as_millis() as u64,
             retention_days = settings.days,
             stopped_retention_days = settings.stopped_days,
+            dry_run = params.dry_run,
             "mission workspace GC sweep finished",
         );
     }
+}
+
+fn gc_execution_enabled() -> bool {
+    matches!(
+        std::env::var(EXECUTE_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
 }
 
 struct GcSettings {
@@ -514,6 +529,9 @@ pub struct SweepReport {
     pub stopped_removed: usize,
     pub errors: usize,
     pub bytes_freed: u64,
+    /// Directories that passed policy but were retained because this sweep was
+    /// dry-run. These are approval candidates, never a deletion result.
+    pub proposed: usize,
 }
 
 /// Cutoffs and toggles for one sweep.
@@ -524,6 +542,8 @@ pub struct SweepParams {
     pub stopped_cutoff: DateTime<Utc>,
     /// Whether unmatched `mission-*` dirs are collected.
     pub orphans_enabled: bool,
+    /// When true, report candidates without touching the filesystem.
+    pub dry_run: bool,
 }
 
 /// One full pass. Phase 1 is DB-driven (mission → its recorded workspace →
@@ -582,6 +602,19 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                     continue;
                 }
                 let size = directory_size_bytes(&dir).await;
+                if params.dry_run {
+                    report.proposed += 1;
+                    tracing::info!(
+                        action = "would_remove",
+                        mission_id = %mission.id,
+                        workspace_id = %workspace_id,
+                        path = %dir.display(),
+                        bytes = size,
+                        reason = "terminal mission past retention",
+                        "mission GC audit",
+                    );
+                    continue;
+                }
                 match tokio::fs::remove_dir_all(&dir).await {
                     Ok(()) => {
                         report.removed += 1;
@@ -720,6 +753,21 @@ async fn orphan_sweep(state: &Arc<AppState>, params: &SweepParams, report: &mut 
                 }
                 Verdict::Delete(reason, orphan, stopped) => {
                     let size = directory_size_bytes(&dir).await;
+                    if params.dry_run {
+                        report.proposed += 1;
+                        tracing::info!(
+                            action = "would_remove",
+                            path = %dir.display(),
+                            workspace = %ws.name,
+                            workspace_id = %ws.id,
+                            bytes = size,
+                            reason,
+                            orphan,
+                            stopped,
+                            "mission GC audit",
+                        );
+                        continue;
+                    }
                     match tokio::fs::remove_dir_all(&dir).await {
                         Ok(()) => {
                             report.removed += 1;

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -546,6 +546,47 @@ pub struct SweepParams {
     pub dry_run: bool,
 }
 
+/// Convert systemd exec units into the exact workspace/mission pairs they
+/// protect. Malformed or legacy units without a mission tag cannot authorize
+/// removal and are ignored here; the scope reaper owns their separate policy.
+fn protected_exec_scopes<'a>(
+    units: impl IntoIterator<Item = &'a str>,
+) -> std::collections::HashSet<(String, String)> {
+    units
+        .into_iter()
+        .filter_map(|unit| {
+            Some((
+                crate::workspace_exec::machine_name_from_exec_unit(unit)?,
+                crate::workspace_exec::mission_short_id_from_exec_unit(unit)?,
+            ))
+        })
+        .collect()
+}
+
+/// Whether a live exec scope protects one mission directory. This guard runs
+/// before phase 1 can propose or remove the directory.
+#[derive(Debug, PartialEq, Eq)]
+enum MissionDirectoryCandidate {
+    RetainLiveScope,
+    Eligible,
+}
+
+fn mission_directory_candidate(
+    scope_protected: &std::collections::HashSet<(String, String)>,
+    workspace_path: &std::path::Path,
+    mission_id: uuid::Uuid,
+) -> MissionDirectoryCandidate {
+    let Some(workspace_token) = crate::workspace_exec::machine_name_for_path(workspace_path) else {
+        return MissionDirectoryCandidate::Eligible;
+    };
+    let mission_short = mission_id.simple().to_string()[..8].to_string();
+    if scope_protected.contains(&(workspace_token, mission_short)) {
+        MissionDirectoryCandidate::RetainLiveScope
+    } else {
+        MissionDirectoryCandidate::Eligible
+    }
+}
+
 /// One full pass. Phase 1 is DB-driven (mission → its recorded workspace →
 /// dir). Phase 2 is disk-driven (every `mission-*` dir under every known
 /// workspace root, reconciled against the mission index) — it catches what
@@ -556,6 +597,15 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
     let cutoff = params.cutoff;
     let mut report = SweepReport::default();
     let mut dry_run_candidates = std::collections::HashSet::new();
+    // Snapshot live exec scopes before considering *any* mission directory.
+    // A scope may have a process holding cwd/fds in the directory, so it wins
+    // over terminal status in both dry-run and execution mode.
+    let scope_protected = protected_exec_scopes(
+        super::scope_reaper::list_exec_scope_units()
+            .await
+            .iter()
+            .map(String::as_str),
+    );
     let sessions = state.control.all_sessions().await;
     for session in sessions {
         let store = session.mission_store.clone();
@@ -600,6 +650,17 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                 };
                 let dir = workspace::mission_workspace_dir_for_root(&ws.path, mission.id);
                 if !dir.exists() {
+                    continue;
+                }
+                if mission_directory_candidate(&scope_protected, &ws.path, mission.id)
+                    == MissionDirectoryCandidate::RetainLiveScope
+                {
+                    tracing::debug!(
+                        mission_id = %mission.id,
+                        workspace_id = %workspace_id,
+                        path = %dir.display(),
+                        "mission GC: kept (live exec scope)",
+                    );
                     continue;
                 }
                 let size = directory_size_bytes(&dir).await;
@@ -647,7 +708,14 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
         }
     }
 
-    orphan_sweep(state, params, &dry_run_candidates, &mut report).await;
+    orphan_sweep(
+        state,
+        params,
+        &dry_run_candidates,
+        &scope_protected,
+        &mut report,
+    )
+    .await;
 
     report
 }
@@ -659,23 +727,11 @@ async fn orphan_sweep(
     state: &Arc<AppState>,
     params: &SweepParams,
     dry_run_candidates: &std::collections::HashSet<std::path::PathBuf>,
+    scope_protected: &std::collections::HashSet<(String, String)>,
     report: &mut SweepReport,
 ) {
     let index_full = build_mission_index(state).await;
     let index = &index_full.by_short;
-    // Any dir whose short id is referenced by a live exec scope is kept
-    // unconditionally: a process may hold cwd/fds there.
-    let scope_protected: std::collections::HashSet<(String, String)> =
-        super::scope_reaper::list_exec_scope_units()
-            .await
-            .iter()
-            .filter_map(|unit| {
-                Some((
-                    crate::workspace_exec::machine_name_from_exec_unit(unit)?,
-                    crate::workspace_exec::mission_short_id_from_exec_unit(unit)?,
-                ))
-            })
-            .collect();
 
     for ws in state.workspaces.list().await {
         let root = workspace::workspaces_root_for(&ws.path);
@@ -909,6 +965,23 @@ mod tests {
         assert_eq!(
             entry_for_workspace(&entries, workspace_id).unwrap().status,
             MissionStatus::Active
+        );
+    }
+
+    #[test]
+    fn live_exec_scope_prevents_terminal_old_dir_from_becoming_a_gc_candidate() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mission_id = uuid::Uuid::parse_str("deadbeef-0000-0000-0000-000000000000").unwrap();
+        let machine = crate::workspace_exec::machine_name_for_path(workspace.path()).unwrap();
+        let scope = format!("sandboxed-exec-{machine}-mdeadbeef-12345678.scope");
+        let protected = protected_exec_scopes([scope.as_str()]);
+
+        // Phase 1 reaches this decision only after terminal status and age
+        // checks. Retaining here happens before either dry-run proposal or
+        // remove_dir_all, so neither mode can act on this directory.
+        assert_eq!(
+            mission_directory_candidate(&protected, workspace.path(), mission_id),
+            MissionDirectoryCandidate::RetainLiveScope
         );
     }
 

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -186,6 +186,18 @@ fn indexed_mission_directory_is_collectible(
             .is_some_and(|entry| is_gc_eligible_status(&entry.status) && entry.updated_at < cutoff)
 }
 
+fn phase_one_index_allows_collection(
+    index: &MissionIndex,
+    mission_short: &str,
+    workspace_id: uuid::Uuid,
+    cutoff: DateTime<Utc>,
+) -> bool {
+    index.complete
+        && index.by_short.get(mission_short).is_some_and(|entries| {
+            indexed_mission_directory_is_collectible(entries, workspace_id, cutoff, true)
+        })
+}
+
 /// Read one persisted SQLite mission store without booting a session.
 fn index_store_file_blocking(
     path: &std::path::Path,
@@ -668,14 +680,8 @@ pub async fn run_once(state: &Arc<AppState>, params: &SweepParams) -> SweepRepor
                     continue;
                 }
                 let short = mission.id.simple().to_string()[..8].to_string();
-                if mission_index.by_short.get(&short).is_some_and(|entries| {
-                    !indexed_mission_directory_is_collectible(
-                        entries,
-                        workspace_id,
-                        cutoff,
-                        mission_index.complete,
-                    )
-                }) {
+                if !phase_one_index_allows_collection(&mission_index, &short, workspace_id, cutoff)
+                {
                     tracing::debug!(
                         mission_id = %mission.id,
                         workspace_id = %workspace_id,
@@ -1022,6 +1028,17 @@ mod tests {
             workspace_id,
             now - chrono::Duration::days(7),
             false,
+        ));
+
+        let incomplete_empty = MissionIndex {
+            by_short: std::collections::HashMap::new(),
+            complete: false,
+        };
+        assert!(!phase_one_index_allows_collection(
+            &incomplete_empty,
+            "deadbeef",
+            workspace_id,
+            now - chrono::Duration::days(7),
         ));
     }
 

--- a/src/api/scope_reaper.rs
+++ b/src/api/scope_reaper.rs
@@ -128,7 +128,7 @@ fn legacy_scope_is_reapable(
 }
 
 /// List all `sandboxed-exec-*.scope` unit names currently known to systemd.
-pub(crate) async fn list_exec_scope_units() -> Vec<String> {
+pub(crate) async fn try_list_exec_scope_units() -> Result<Vec<String>, String> {
     let output = Command::new("systemctl")
         .args([
             "list-units",
@@ -138,16 +138,36 @@ pub(crate) async fn list_exec_scope_units() -> Vec<String> {
             "sandboxed-exec-*.scope",
         ])
         .output()
-        .await;
-    let Ok(output) = output else {
-        return Vec::new();
-    };
-    String::from_utf8_lossy(&output.stdout)
+        .await
+        .map_err(|err| format!("systemctl list-units failed: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "systemctl list-units exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let units: Vec<String> = stdout
         .lines()
         .filter_map(|line| line.split_whitespace().next())
         .filter(|unit| unit.starts_with("sandboxed-exec-") && unit.ends_with(".scope"))
         .map(|s| s.to_string())
-        .collect()
+        .collect();
+    if !stdout.trim().is_empty() && units.is_empty() {
+        return Err("systemctl list-units returned no parseable exec scopes".to_string());
+    }
+    Ok(units)
+}
+
+pub(crate) async fn list_exec_scope_units() -> Vec<String> {
+    match try_list_exec_scope_units().await {
+        Ok(units) => units,
+        Err(err) => {
+            tracing::warn!(%err, "could not list exec scopes");
+            Vec::new()
+        }
+    }
 }
 
 async fn stop_unit(unit: &str, reason: &str) -> bool {

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -44,7 +44,10 @@ pub fn routes() -> Router<Arc<super::routes::AppState>> {
         // Live + persisted memory caps (per-workspace override of the
         // MISSION_MEMORY_* defaults; applies to running scopes via
         // `systemctl set-property --runtime`)
-        .route("/:id/resources", post(update_workspace_resources))
+        .route(
+            "/:id/resources",
+            get(get_workspace_resources).post(update_workspace_resources),
+        )
         // Backend preflight checks
         .route(
             "/:id/backends/:backend_id/preflight",
@@ -1868,6 +1871,61 @@ pub struct UpdateWorkspaceResourcesResponse {
     pub memory_swap_max: Option<String>,
     pub cpu_weight: Option<String>,
     pub cpu_quota: Option<String>,
+}
+
+/// Read-only resource-limit visibility.  This intentionally reports both the
+/// effective values and whether each came from a workspace override or the
+/// process environment, so operators can distinguish an unset limit from an
+/// inherited one before changing a live mission.
+#[derive(Debug, Serialize)]
+pub struct WorkspaceResourcesResponse {
+    pub workspace_id: Uuid,
+    pub workspace_name: String,
+    pub memory_max: Option<String>,
+    pub memory_high: Option<String>,
+    pub memory_swap_max: Option<String>,
+    pub cpu_weight: Option<String>,
+    pub cpu_quota: Option<String>,
+    pub workspace_overrides: HashMap<String, String>,
+    pub running_scope_units: Vec<String>,
+}
+
+async fn get_workspace_resources(
+    AxumPath(id): AxumPath<Uuid>,
+    State(state): State<Arc<super::routes::AppState>>,
+) -> Result<Json<WorkspaceResourcesResponse>, (StatusCode, String)> {
+    let workspace = require_workspace(&state.workspaces, id).await?;
+    let caps = crate::workspace_exec::WorkspaceExec::new(workspace.clone()).mission_resource_caps();
+    let workspace_overrides = workspace
+        .env_vars
+        .iter()
+        .filter(|(key, _)| {
+            matches!(
+                key.as_str(),
+                "MISSION_MEMORY_MAX"
+                    | "MISSION_MEMORY_HIGH"
+                    | "MISSION_MEMORY_SWAP_MAX"
+                    | "MISSION_CPU_WEIGHT"
+                    | "MISSION_CPU_QUOTA"
+            )
+        })
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    let running_scope_units = list_workspace_scope_units(&workspace).await.unwrap_or_else(|err| {
+        tracing::warn!(workspace = %workspace.name, %err, "resource visibility: scope listing failed");
+        Vec::new()
+    });
+    Ok(Json(WorkspaceResourcesResponse {
+        workspace_id: workspace.id,
+        workspace_name: workspace.name,
+        memory_max: caps.max,
+        memory_high: caps.high,
+        memory_swap_max: caps.swap_max,
+        cpu_weight: caps.cpu_weight,
+        cpu_quota: caps.cpu_quota,
+        workspace_overrides,
+        running_scope_units,
+    }))
 }
 
 /// Validate a systemd memory size: bytes, suffixed (K/M/G/T), percentage,

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -1888,6 +1888,7 @@ pub struct WorkspaceResourcesResponse {
     pub cpu_quota: Option<String>,
     pub workspace_overrides: HashMap<String, String>,
     pub running_scope_units: Vec<String>,
+    pub scope_list_error: Option<String>,
 }
 
 async fn get_workspace_resources(
@@ -1911,10 +1912,14 @@ async fn get_workspace_resources(
         })
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect();
-    let running_scope_units = list_workspace_scope_units(&workspace).await.unwrap_or_else(|err| {
-        tracing::warn!(workspace = %workspace.name, %err, "resource visibility: scope listing failed");
-        Vec::new()
-    });
+    let (running_scope_units, scope_list_error) = match list_workspace_scope_units(&workspace).await
+    {
+        Ok(units) => (units, None),
+        Err(err) => {
+            tracing::warn!(workspace = %workspace.name, %err, "resource visibility: scope listing failed");
+            (Vec::new(), Some(err))
+        }
+    };
     Ok(Json(WorkspaceResourcesResponse {
         workspace_id: workspace.id,
         workspace_name: workspace.name,
@@ -1925,6 +1930,7 @@ async fn get_workspace_resources(
         cpu_quota: caps.cpu_quota,
         workspace_overrides,
         running_scope_units,
+        scope_list_error,
     }))
 }
 


### PR DESCRIPTION
## Summary
- add read-only workspace resource-limit visibility, including matching live scopes for shared workspaces
- make retention sweeps dry-run by default with structured `would_remove` audit records and an explicit execution gate
- add a read-only JSONL storage inventory with ownership, age, size, active-mission protection, and nested Lean/cache attribution

## Safety
- inventory rejects `--apply`; no existing data is deleted
- caches, images, worktrees, and unattributed paths remain retained pending owner approval
- no deployment was performed

## Validation
- `python3 scripts/test_storage_inventory.py`
- `python3 -m py_compile scripts/storage_inventory.py scripts/test_storage_inventory.py`
- `cargo fmt --check`
- Focused Rust test build was attempted with Cargo 1.93, but this workspace repeatedly reported an artifact-directory lock while compiling the fresh target cache; no test result was produced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission-directory GC behavior (dry-run default, scope-list failures skip sweeps) and documents opt-in deletion; inventory is read-only but operators must understand new gates before enabling `WORKSPACE_GC_EXECUTE`.
> 
> **Overview**
> Introduces **operator-first retention and visibility** so disk cleanup is an approval workflow, not silent deletion.
> 
> **Mission workspace GC** now runs in **dry-run by default**: eligible dirs emit structured `mission GC audit` logs with `action=would_remove` instead of `remove_dir_all`. Actual deletion requires **`WORKSPACE_GC_EXECUTE=1`** (or `true`). Sweeps **abort** if exec-scope discovery via `systemctl` fails (no longer treated as “no scopes”). Phase 1 adds **short-id collision** checks aligned with the orphan sweep and **live exec scope** protection before propose or delete.
> 
> **Read-only storage inventory** (`scripts/storage_inventory.py`) walks configured roots, attributes paths from SQLite mission stores, and writes JSONL with `keep` vs `would_remove`. Only **terminal, attributed `mission-*` dirs** past retention can be `would_remove`; caches, worktrees, images, and unattributed paths stay `keep`. **`--apply` is rejected**. Docs in `STORAGE_LIFECYCLE.md` describe the policy.
> 
> **Workspace API**: **`GET /api/workspaces/:id/resources`** returns effective memory/swap/CPU caps, workspace overrides, live scope units, and **`scope_list_error`** when listing fails—paired with existing `POST` for tuning shared workspaces.
> 
> **`try_list_exec_scope_units`** in `scope_reaper` surfaces list failures for GC; the reaper’s lenient `list_exec_scope_units` wrapper is unchanged for other callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffe6f2453063ae5b44d65b1e1c49f7adddfd123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->