### PR TITLE
fix: prevent concurrent PR writer missions

### DIFF
--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1037,6 +1037,9 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                      resolve the cause, then retry."
                         .to_string()
                 }
+                Ok(Ok(UserMessageAck::Rejected(reason))) => {
+                    format!("Error: the steering message was rejected: {reason}")
+                }
                 Ok(Err(_)) | Err(_) => {
                     // The control loop accepted the command but never confirmed —
                     // the message is most likely in flight; don't claim failure.

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -344,7 +344,7 @@ impl AgentEvent {
 /// `respond` channel. Distinguishes "delivered, a turn is starting" from
 /// "dropped" — both used to be `false`, which made drops invisible to
 /// callers that need delivery guarantees (e.g. the Copilot's steering tool).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UserMessageAck {
     /// The target is busy mid-turn; the message was queued and will be
     /// picked up at the next turn boundary.
@@ -355,6 +355,9 @@ pub enum UserMessageAck {
     /// rejected goal kickoff, …). An `AgentEvent::Error` with details was
     /// emitted on the event stream.
     Dropped,
+    /// The actor rejected the message after HTTP preflight. The reason is
+    /// returned to synchronous callers instead of being visible only on SSE.
+    Rejected(String),
 }
 
 /// Internal control commands (queued and processed by the actor).

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5524,17 +5524,65 @@ fn find_existing_pr_writer_in_sqlite(
     connection
         .busy_timeout(std::time::Duration::from_secs(2))
         .map_err(|error| error.to_string())?;
+    let table_columns = |table: &str| -> Result<std::collections::HashSet<String>, String> {
+        let mut statement = connection
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .map_err(|error| format!("inspect {table} in {}: {error}", path.display()))?;
+        let rows = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|error| error.to_string())?;
+        rows.collect::<Result<std::collections::HashSet<_>, _>>()
+            .map_err(|error| error.to_string())
+    };
+    let mission_columns = table_columns("missions")?;
+    if !mission_columns.contains("github_pr") {
+        // Stores that predate PR metadata cannot hold a PR-scoped lease.
+        return Ok(None);
+    }
+    if !mission_columns.contains("id") || !mission_columns.contains("status") {
+        return Err(format!(
+            "missions table in {} is missing identity/status columns",
+            path.display()
+        ));
+    }
+    let event_columns = table_columns("mission_events")?;
+    let events_have_prompt = ["mission_id", "sequence", "event_type", "content"]
+        .iter()
+        .all(|column| event_columns.contains(*column));
+    let optional_mission_column = |column: &str| {
+        if mission_columns.contains(column) {
+            format!("m.{column}")
+        } else {
+            "NULL".to_string()
+        }
+    };
+    let first_prompt = if events_have_prompt {
+        "(SELECT e.content FROM mission_events e \
+         WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
+         ORDER BY e.sequence ASC LIMIT 1)"
+            .to_string()
+    } else {
+        "NULL".to_string()
+    };
+    let first_prompt_file = if events_have_prompt && event_columns.contains("content_file") {
+        "(SELECT e.content_file FROM mission_events e \
+         WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
+         ORDER BY e.sequence ASC LIMIT 1)"
+            .to_string()
+    } else {
+        "NULL".to_string()
+    };
+    let query = format!(
+        "SELECT m.id, m.status, m.github_pr, {}, {}, {}, {}, {} \
+         FROM missions m WHERE m.github_pr IS NOT NULL",
+        optional_mission_column("intent"),
+        optional_mission_column("tags"),
+        optional_mission_column("deferred_goal"),
+        first_prompt,
+        first_prompt_file,
+    );
     let mut statement = connection
-        .prepare(
-            "SELECT m.id, m.status, m.github_pr, m.intent, m.tags, m.deferred_goal, \
-             (SELECT e.content FROM mission_events e \
-              WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
-              ORDER BY e.sequence ASC LIMIT 1), \
-             (SELECT e.content_file FROM mission_events e \
-              WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
-              ORDER BY e.sequence ASC LIMIT 1) \
-             FROM missions m WHERE m.github_pr IS NOT NULL",
-        )
+        .prepare(&query)
         .map_err(|error| format!("query {}: {error}", path.display()))?;
     let rows = statement
         .query_map([], |row| {
@@ -19888,6 +19936,68 @@ mod tests {
 
         assert_eq!(found.id, mission_id);
         assert_eq!(found.status, MissionStatus::Pending);
+    }
+
+    #[test]
+    fn offline_sqlite_writer_scan_ignores_schema_without_pr_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions-legacy.db");
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (id TEXT PRIMARY KEY, status TEXT);
+                 CREATE TABLE mission_events (
+                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT
+                 );",
+            )
+            .unwrap();
+        drop(connection);
+
+        assert!(
+            find_existing_pr_writer_in_sqlite(&path, "owner/repo#42", None)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn offline_sqlite_writer_scan_adapts_to_missing_optional_columns() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions-partial.db");
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (
+                    id TEXT PRIMARY KEY, status TEXT, github_pr TEXT
+                 );
+                 CREATE TABLE mission_events (
+                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT
+                 );",
+            )
+            .unwrap();
+        let mission_id = Uuid::new_v4();
+        connection
+            .execute(
+                "INSERT INTO missions (id, status, github_pr)
+                 VALUES (?1, 'active', 'owner/repo#44')",
+                rusqlite::params![mission_id.to_string()],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO mission_events
+                 (mission_id, sequence, event_type, content)
+                 VALUES (?1, 1, 'user_message', 'Fix, commit and push this PR')",
+                rusqlite::params![mission_id.to_string()],
+            )
+            .unwrap();
+        drop(connection);
+
+        let found = find_existing_pr_writer_in_sqlite(&path, "owner/repo#44", None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.id, mission_id);
+        assert_eq!(found.status, MissionStatus::Active);
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13175,7 +13175,7 @@ async fn control_actor_loop(
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
-                                                &content,
+                                                &msg,
                                             )
                                             .await
                                             {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5175,14 +5175,30 @@ static PR_WRITER_CREATE_LOCK: std::sync::LazyLock<Mutex<()>> =
     std::sync::LazyLock::new(|| Mutex::new(()));
 
 fn canonical_github_pr(raw: &str) -> String {
-    let mut value = raw.trim().trim_end_matches('/').to_ascii_lowercase();
+    let mut value = raw
+        .trim()
+        .split(['?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/')
+        .to_ascii_lowercase();
     for prefix in ["https://github.com/", "http://github.com/", "github.com/"] {
         if let Some(stripped) = value.strip_prefix(prefix) {
             value = stripped.to_string();
             break;
         }
     }
-    value.replace("/pull/", "#")
+    if let Some((repository, tail)) = value.split_once("/pull/") {
+        let number = tail.split('/').next().unwrap_or_default();
+        return format!("{repository}#{number}");
+    }
+    // Preserve the compact `owner/repo#number` form while discarding a copied
+    // tab suffix such as `#123/files`.
+    if let Some((repository, tail)) = raw.trim().to_ascii_lowercase().split_once('#') {
+        let number = tail.split(['/', '?']).next().unwrap_or_default();
+        return format!("{}#{}", repository.trim_end_matches('/'), number);
+    }
+    value
 }
 
 fn inferred_pr_writer(explicit: Option<bool>, intent: Option<&str>, prompt: Option<&str>) -> bool {
@@ -5245,6 +5261,7 @@ fn mission_is_pr_writer(mission: &Mission) -> bool {
 async fn find_existing_pr_writer(
     store: &Arc<dyn MissionStore>,
     github_pr: &str,
+    exclude_id: Option<Uuid>,
 ) -> Result<Option<Mission>, String> {
     const PAGE_SIZE: usize = 200;
     let target = canonical_github_pr(github_pr);
@@ -5253,7 +5270,8 @@ async fn find_existing_pr_writer(
         let page = store.list_missions(PAGE_SIZE, offset).await?;
         let page_len = page.len();
         if let Some(mission) = page.into_iter().find(|mission| {
-            status_holds_pr_writer_lease(mission.status)
+            Some(mission.id) != exclude_id
+                && status_holds_pr_writer_lease(mission.status)
                 && mission
                     .project
                     .github_pr
@@ -5586,7 +5604,7 @@ pub async fn create_mission(
 
     let control = control_for_user(&state, &user).await;
     if let (Some(github_pr), Some(_guard)) = (req.github_pr.as_deref(), pr_writer_guard.as_ref()) {
-        if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr)
+        if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr, None)
             .await
             .map_err(internal_error)?
         {
@@ -5652,13 +5670,17 @@ pub async fn create_mission(
     {
         let capability =
             if inferred_pr_writer(req.writer, req.intent.as_deref(), req.prompt.as_deref()) {
-                "pr-writer"
+                Some("pr-writer")
+            } else if req.writer == Some(false) {
+                Some("pr-readonly")
             } else {
-                "pr-readonly"
+                None
             };
-        let tags = tags.get_or_insert_with(Vec::new);
-        if !tags.iter().any(|tag| tag == capability) {
-            tags.push(capability.to_string());
+        if let Some(capability) = capability {
+            let tags = tags.get_or_insert_with(Vec::new);
+            if !tags.iter().any(|tag| tag == capability) {
+                tags.push(capability.to_string());
+            }
         }
     }
     if project.is_some()
@@ -6713,7 +6735,7 @@ pub async fn update_mission_project(
     Json(req): Json<UpdateMissionProjectRequest>,
 ) -> Result<Json<Mission>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
-    control
+    let current = control
         .mission_store
         .get_mission(id)
         .await
@@ -6733,25 +6755,81 @@ pub async fn update_mission_project(
             })
         })
     };
-    let tags: Option<Vec<String>> = req.tags.map(|tags| {
+    let project = normalize(req.project);
+    let track = normalize(req.track);
+    let intent = normalize(req.intent);
+    let github_pr = normalize(req.github_pr);
+    let desired_state = normalize(req.desired_state);
+    let next_check_at = normalize(req.next_check_at);
+    let mut tags: Option<Vec<String>> = req.tags.map(|tags| {
         tags.into_iter()
             .map(|t| t.trim().to_string())
             .filter(|t| !t.is_empty())
             .collect()
     });
 
+    let effective_string = |patch: &Option<Option<String>>, current: &Option<String>| {
+        patch.clone().unwrap_or_else(|| current.clone())
+    };
+    let effective_github_pr = effective_string(&github_pr, &current.project.github_pr);
+    let effective_intent = effective_string(&intent, &current.project.intent);
+    let mut effective_tags = tags.clone().unwrap_or_else(|| current.project.tags.clone());
+    let explicitly_readonly = effective_tags.iter().any(|tag| tag == "pr-readonly");
+    let becomes_writer = effective_github_pr.is_some()
+        && !explicitly_readonly
+        && (effective_tags.iter().any(|tag| tag == "pr-writer")
+            || inferred_pr_writer(
+                None,
+                effective_intent.as_deref(),
+                current.history.first().map(|entry| entry.content.as_str()),
+            ));
+    if becomes_writer && !effective_tags.iter().any(|tag| tag == "pr-writer") {
+        effective_tags.push("pr-writer".to_string());
+        tags = Some(effective_tags.clone());
+    } else if tags.is_some() {
+        // Preserve the caller's normalized replacement even when it does not
+        // change writer capability.
+        if tags.as_ref() != Some(&effective_tags) {
+            tags = Some(effective_tags.clone());
+        }
+    }
+
+    let writer_guard = if becomes_writer {
+        Some(PR_WRITER_CREATE_LOCK.lock().await)
+    } else {
+        None
+    };
+    if let (Some(github_pr), Some(_guard)) = (effective_github_pr.as_deref(), writer_guard.as_ref())
+    {
+        if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr, Some(id))
+            .await
+            .map_err(internal_error)?
+        {
+            return Err((
+                StatusCode::CONFLICT,
+                format!(
+                    "PR writer lease is already held by mission {} (status={}); cannot assign mission {} as another writer for {}",
+                    existing.id,
+                    existing.status,
+                    id,
+                    canonical_github_pr(github_pr)
+                ),
+            ));
+        }
+    }
+
     control
         .mission_store
         .update_mission_project(
             id,
             crate::api::mission_store::MissionProjectPatch {
-                project: normalize(req.project),
-                track: normalize(req.track),
-                intent: normalize(req.intent),
-                github_pr: normalize(req.github_pr),
+                project,
+                track,
+                intent,
+                github_pr,
                 tags,
-                desired_state: normalize(req.desired_state),
-                next_check_at: normalize(req.next_check_at),
+                desired_state,
+                next_check_at,
             },
         )
         .await
@@ -19000,6 +19078,16 @@ mod tests {
         );
         assert_eq!(
             canonical_github_pr("LFGLABS-DEV/VERITY#2168"),
+            "lfglabs-dev/verity#2168"
+        );
+        assert_eq!(
+            canonical_github_pr(
+                "https://github.com/lfglabs-dev/verity/pull/2168/files?diff=split#discussion"
+            ),
+            "lfglabs-dev/verity#2168"
+        );
+        assert_eq!(
+            canonical_github_pr("lfglabs-dev/verity#2168/commits"),
             "lfglabs-dev/verity#2168"
         );
     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3279,6 +3279,13 @@ pub struct ControlHub {
     telegram_bridge: Option<super::telegram::SharedTelegramBridge>,
 }
 
+struct MissionStoreInventory {
+    live: Vec<Arc<dyn MissionStore>>,
+    offline_sqlite: Vec<PathBuf>,
+    offline_file_users: Vec<String>,
+    base_dir: PathBuf,
+}
+
 impl ControlHub {
     pub fn new(
         config: Config,
@@ -3385,12 +3392,11 @@ impl ControlHub {
         self.sessions.read().await.values().cloned().collect()
     }
 
-    /// Every live and persisted mission store. Writer leases are global to a
-    /// PR branch, not scoped to the authenticated dashboard user, so lease
-    /// checks must include stores whose user has no live control session.
-    pub async fn all_mission_stores(&self) -> Result<Vec<Arc<dyn MissionStore>>, String> {
+    /// Inventory every live and persisted mission store without opening
+    /// offline SQLite stores in read-write migration mode.
+    async fn mission_store_inventory(&self) -> Result<MissionStoreInventory, String> {
         let sessions = self.sessions.read().await;
-        let mut stores: Vec<Arc<dyn MissionStore>> = sessions
+        let live: Vec<Arc<dyn MissionStore>> = sessions
             .values()
             .map(|session| Arc::clone(&session.mission_store))
             .collect();
@@ -3407,9 +3413,18 @@ impl ControlHub {
             .join("missions");
         let mut entries = match tokio::fs::read_dir(&base_dir).await {
             Ok(entries) => entries,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(stores),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(MissionStoreInventory {
+                    live,
+                    offline_sqlite: Vec::new(),
+                    offline_file_users: Vec::new(),
+                    base_dir,
+                })
+            }
             Err(error) => return Err(format!("read {}: {error}", base_dir.display())),
         };
+        let mut offline_sqlite = Vec::new();
+        let mut offline_file_users = Vec::new();
         while let Some(entry) = entries
             .next_entry()
             .await
@@ -3423,19 +3438,20 @@ impl ControlHub {
                 if live_users.contains(user) {
                     continue;
                 }
-                stores.push(Arc::new(
-                    mission_store::SqliteMissionStore::new(base_dir.clone(), user).await?,
-                ));
+                offline_sqlite.push(entry.path());
             } else if let Some(user) = stem.strip_suffix(".json") {
                 if live_users.contains(user) {
                     continue;
                 }
-                stores.push(Arc::new(
-                    mission_store::FileMissionStore::new(base_dir.clone(), user).await?,
-                ));
+                offline_file_users.push(user.to_string());
             }
         }
-        Ok(stores)
+        Ok(MissionStoreInventory {
+            live,
+            offline_sqlite,
+            offline_file_users,
+            base_dir,
+        })
     }
 
     /// User ids of all live control sessions. Used by GC/reaper to decide
@@ -5387,11 +5403,24 @@ fn message_requests_pr_writer(mission: &Mission, content: &str) -> bool {
         )
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PrWriterLease {
+    id: Uuid,
+    status: MissionStatus,
+}
+
+fn pr_writer_lease(mission: &Mission) -> PrWriterLease {
+    PrWriterLease {
+        id: mission.id,
+        status: mission.status,
+    }
+}
+
 async fn find_existing_pr_writer(
     store: &Arc<dyn MissionStore>,
     github_pr: &str,
     exclude_id: Option<Uuid>,
-) -> Result<Option<Mission>, String> {
+) -> Result<Option<PrWriterLease>, String> {
     const PAGE_SIZE: usize = 200;
     let target = canonical_github_pr(github_pr);
     let mut offset = 0;
@@ -5410,20 +5439,20 @@ async fn find_existing_pr_writer(
                 continue;
             }
             if mission_is_pr_writer(&mission) {
-                return Ok(Some(mission));
+                return Ok(Some(pr_writer_lease(&mission)));
             }
             // SQLite list queries intentionally omit history. Load the full
             // mission before treating a legacy prompt-only writer as read-only.
             if let Some(full) = store.get_mission(mission.id).await? {
                 if mission_is_pr_writer(&full) {
-                    return Ok(Some(full));
+                    return Ok(Some(pr_writer_lease(&full)));
                 }
                 // Scheduled missions can carry their only prompt in the
                 // durable deferred goal until dispatch. Treat that prompt as
                 // capability evidence before declaring this lease read-only.
                 if let Some(goal) = store.get_deferred_goal(mission.id).await? {
                     if mission_is_pr_writer_with_prompt(&full, Some(&goal)) {
-                        return Ok(Some(full));
+                        return Ok(Some(pr_writer_lease(&full)));
                     }
                 }
             }
@@ -5435,14 +5464,98 @@ async fn find_existing_pr_writer(
     }
 }
 
+fn find_existing_pr_writer_in_sqlite(
+    path: &std::path::Path,
+    github_pr: &str,
+    exclude_id: Option<Uuid>,
+) -> Result<Option<PrWriterLease>, String> {
+    let connection =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| format!("open {} read-only: {error}", path.display()))?;
+    connection
+        .busy_timeout(std::time::Duration::from_secs(2))
+        .map_err(|error| error.to_string())?;
+    let mut statement = connection
+        .prepare(
+            "SELECT m.id, m.status, m.github_pr, m.intent, m.tags, m.deferred_goal, \
+             (SELECT e.content FROM mission_events e \
+              WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
+              ORDER BY e.sequence ASC LIMIT 1) \
+             FROM missions m WHERE m.github_pr IS NOT NULL",
+        )
+        .map_err(|error| format!("query {}: {error}", path.display()))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+            ))
+        })
+        .map_err(|error| error.to_string())?;
+    let target = canonical_github_pr(github_pr);
+    for row in rows {
+        let (id, status, candidate_pr, intent, tags, deferred_goal, first_prompt) =
+            row.map_err(|error| error.to_string())?;
+        let Ok(id) = Uuid::parse_str(&id) else {
+            continue;
+        };
+        if Some(id) == exclude_id || canonical_github_pr(&candidate_pr) != target {
+            continue;
+        }
+        let status = serde_json::from_value::<MissionStatus>(serde_json::Value::String(status))
+            .unwrap_or(MissionStatus::Active);
+        if !status_holds_pr_writer_lease(status) {
+            continue;
+        }
+        let tags: Vec<String> = tags
+            .as_deref()
+            .and_then(|value| serde_json::from_str(value).ok())
+            .unwrap_or_default();
+        if requested_pr_writer(
+            None,
+            Some(&tags),
+            intent.as_deref(),
+            first_prompt.as_deref().or(deferred_goal.as_deref()),
+        ) {
+            return Ok(Some(PrWriterLease { id, status }));
+        }
+    }
+    Ok(None)
+}
+
 async fn find_existing_pr_writer_global(
     state: &Arc<AppState>,
     github_pr: &str,
     exclude_id: Option<Uuid>,
-) -> Result<Option<Mission>, String> {
+) -> Result<Option<PrWriterLease>, String> {
     // Fail closed if any persisted store cannot be enumerated or read. A
     // partial cross-user scan cannot prove that a branch is writer-free.
-    for store in state.control.all_mission_stores().await? {
+    let inventory = state.control.mission_store_inventory().await?;
+    for store in inventory.live {
+        if let Some(mission) = find_existing_pr_writer(&store, github_pr, exclude_id).await? {
+            return Ok(Some(mission));
+        }
+    }
+    for path in inventory.offline_sqlite {
+        let github_pr = github_pr.to_string();
+        let found = tokio::task::spawn_blocking(move || {
+            find_existing_pr_writer_in_sqlite(&path, &github_pr, exclude_id)
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        if found.is_some() {
+            return Ok(found);
+        }
+    }
+    for user in inventory.offline_file_users {
+        let store: Arc<dyn MissionStore> = Arc::new(
+            mission_store::FileMissionStore::new(inventory.base_dir.clone(), &user).await?,
+        );
         if let Some(mission) = find_existing_pr_writer(&store, github_pr, exclude_id).await? {
             return Ok(Some(mission));
         }
@@ -19458,6 +19571,41 @@ mod tests {
             Some("integration_repair"),
             None
         ));
+    }
+
+    #[test]
+    fn offline_sqlite_writer_scan_reads_deferred_goal_without_migrations() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions-offline.db");
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (
+                    id TEXT PRIMARY KEY, status TEXT, github_pr TEXT,
+                    intent TEXT, tags TEXT, deferred_goal TEXT
+                 );
+                 CREATE TABLE mission_events (
+                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT
+                 );",
+            )
+            .unwrap();
+        let mission_id = Uuid::new_v4();
+        connection
+            .execute(
+                "INSERT INTO missions (id, status, github_pr, intent, tags, deferred_goal)
+                 VALUES (?1, 'pending', ?2, NULL, '[]', 'Fix, commit and push')",
+                rusqlite::params![mission_id.to_string(), "owner/repo#42"],
+            )
+            .unwrap();
+        drop(connection);
+
+        let found =
+            find_existing_pr_writer_in_sqlite(&path, "https://github.com/owner/repo/pull/42", None)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(found.id, mission_id);
+        assert_eq!(found.status, MissionStatus::Pending);
     }
 
     fn stored_test_event(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5442,7 +5442,9 @@ async fn find_existing_pr_writer(
                 // durable deferred goal until dispatch. Treat that prompt as
                 // capability evidence before declaring this lease read-only.
                 if let Some(goal) = store.get_deferred_goal(mission.id).await? {
-                    if mission_is_pr_writer_with_prompt(&full, Some(&goal)) {
+                    if mission_is_pr_writer_with_prompt(&full, Some(&goal))
+                        || message_requests_pr_writer(&full, &goal)
+                    {
                         return Ok(Some(pr_writer_lease(&full)));
                     }
                 }
@@ -5518,7 +5520,7 @@ fn find_existing_pr_writer_in_sqlite(
             ),
             _ => None,
         };
-        if requested_pr_writer(
+        let initial_prompt_requests_writer = requested_pr_writer(
             None,
             Some(&tags),
             intent.as_deref(),
@@ -5526,7 +5528,11 @@ fn find_existing_pr_writer_in_sqlite(
                 .as_deref()
                 .or(external_prompt.as_deref())
                 .or(deferred_goal.as_deref()),
-        ) {
+        );
+        let deferred_goal_requests_writer = deferred_goal
+            .as_deref()
+            .is_some_and(|goal| inferred_pr_writer(None, None, Some(goal)));
+        if initial_prompt_requests_writer || deferred_goal_requests_writer {
             return Ok(Some(PrWriterLease { id, status }));
         }
     }
@@ -5599,46 +5605,10 @@ async fn activate_mission_for_message(
     mission: &Mission,
     content: &str,
 ) -> Result<(), String> {
-    // A targeted message can resume terminal/acknowledged work without going
-    // through the explicit resume endpoint. Reacquire the writer lease under
-    // the same mutex as create/project/resume and keep it until Active is
-    // persisted, so message delivery cannot race a replacement writer.
-    let becomes_writer =
-        mission_is_pr_writer(mission) || message_requests_pr_writer(mission, content);
-    let _pr_writer_guard = if becomes_writer {
-        Some(PR_WRITER_CREATE_LOCK.lock().await)
-    } else {
-        None
-    };
-    if _pr_writer_guard.is_some() {
-        if let Some(github_pr) = mission.project.github_pr.as_deref() {
-            if let Some(existing) =
-                find_existing_pr_writer_global(control_hub, github_pr, Some(mission.id)).await?
-            {
-                return Err(format!(
-                    "PR writer lease is already held by mission {} (status={}); cannot activate mission {} as another writer for {}",
-                    existing.id,
-                    existing.status,
-                    mission.id,
-                    canonical_github_pr(github_pr)
-                ));
-            }
-        }
-        if !mission_is_pr_writer(mission) {
-            let mut tags = mission.project.tags.clone();
-            tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
-            tags.push("pr-writer".to_string());
-            store
-                .update_mission_project(
-                    mission.id,
-                    crate::api::mission_store::MissionProjectPatch {
-                        tags: Some(tags),
-                        ..Default::default()
-                    },
-                )
-                .await?;
-        }
-    }
+    // Keep the writer mutex until Active is persisted so a replacement writer
+    // cannot race a terminal mission's message-based reactivation.
+    let _pr_writer_guard =
+        acquire_pr_writer_lease_for_message(control_hub, store, mission, content).await?;
 
     if message_activates_mission(mission.status) {
         store
@@ -5651,6 +5621,78 @@ async fn activate_mission_for_message(
         });
     }
     Ok(())
+}
+
+struct MessageWriterLeaseGuard {
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+    retagged: bool,
+}
+
+async fn acquire_pr_writer_lease_for_message(
+    control_hub: &ControlHub,
+    store: &Arc<dyn MissionStore>,
+    mission: &Mission,
+    content: &str,
+) -> Result<Option<MessageWriterLeaseGuard>, String> {
+    let becomes_writer =
+        mission_is_pr_writer(mission) || message_requests_pr_writer(mission, content);
+    if !becomes_writer {
+        return Ok(None);
+    }
+
+    let guard = PR_WRITER_CREATE_LOCK.lock().await;
+    if let Some(github_pr) = mission.project.github_pr.as_deref() {
+        if let Some(existing) =
+            find_existing_pr_writer_global(control_hub, github_pr, Some(mission.id)).await?
+        {
+            return Err(format!(
+                "PR writer lease is already held by mission {} (status={}); cannot activate mission {} as another writer for {}",
+                existing.id,
+                existing.status,
+                mission.id,
+                canonical_github_pr(github_pr)
+            ));
+        }
+    }
+
+    let retagged = !mission_is_pr_writer(mission);
+    if retagged {
+        let mut tags = mission.project.tags.clone();
+        tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
+        tags.push("pr-writer".to_string());
+        store
+            .update_mission_project(
+                mission.id,
+                crate::api::mission_store::MissionProjectPatch {
+                    tags: Some(tags),
+                    ..Default::default()
+                },
+            )
+            .await?;
+    }
+
+    Ok(Some(MessageWriterLeaseGuard {
+        _guard: guard,
+        retagged,
+    }))
+}
+
+async fn rollback_message_writer_tag(
+    store: &Arc<dyn MissionStore>,
+    mission: &Mission,
+    lease: &Option<MessageWriterLeaseGuard>,
+) {
+    if lease.as_ref().is_some_and(|lease| lease.retagged) {
+        let _ = store
+            .update_mission_project(
+                mission.id,
+                crate::api::mission_store::MissionProjectPatch {
+                    tags: Some(mission.project.tags.clone()),
+                    ..Default::default()
+                },
+            )
+            .await;
+    }
 }
 
 pub async fn create_mission(
@@ -12804,14 +12846,36 @@ async fn control_actor_loop(
                                         if m.status == MissionStatus::Pending
                                             && !m.is_dispatchable_at(now)
                                         {
+                                            let writer_lease = match acquire_pr_writer_lease_for_message(
+                                                &control_hub,
+                                                &mission_store,
+                                                &m,
+                                                &content,
+                                            )
+                                            .await
+                                            {
+                                                Ok(lease) => lease,
+                                                Err(error) => {
+                                                    let _ = events_tx.send(AgentEvent::Error {
+                                                        message: format!(
+                                                            "Cannot reserve writer lease for mission {}: {}",
+                                                            tid, error
+                                                        ),
+                                                        mission_id: Some(tid),
+                                                        resumable: true,
+                                                    });
+                                                    let _ = respond.send(UserMessageAck::Dropped);
+                                                    continue;
+                                                }
+                                            };
                                             // Append to any previously-stashed goal so
                                             // multiple pre-dispatch messages aren't lost.
-                                            let combined = match mission_store
+                                            let previous_goal = mission_store
                                                 .get_deferred_goal(tid)
                                                 .await
                                                 .ok()
-                                                .flatten()
-                                            {
+                                                .flatten();
+                                            let combined = match previous_goal.as_deref() {
                                                 Some(prev) if !prev.is_empty() => {
                                                     format!("{prev}\n{content}")
                                                 }
@@ -12821,10 +12885,18 @@ async fn control_actor_loop(
                                                 .set_deferred_goal(tid, Some(combined))
                                                 .await
                                             {
+                                                rollback_message_writer_tag(
+                                                    &mission_store,
+                                                    &m,
+                                                    &writer_lease,
+                                                )
+                                                .await;
                                                 tracing::warn!(
                                                     mission_id = %tid,
                                                     "Failed to stash deferred goal: {e}"
                                                 );
+                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                continue;
                                             }
                                             // Surface the queued goal so the UI shows it
                                             // as pending until dispatch.
@@ -12938,12 +13010,53 @@ async fn control_actor_loop(
                                     // from a successful delivery. Stash the content as the
                                     // deferred goal instead — the scheduler pass re-injects
                                     // it as a normal targeted message once a slot frees.
-                                    let combined = match mission_store
+                                    let mission = match mission_store.get_mission(tid).await {
+                                        Ok(Some(mission)) => mission,
+                                        Ok(None) => {
+                                            let _ = respond.send(UserMessageAck::Dropped);
+                                            continue;
+                                        }
+                                        Err(error) => {
+                                            let _ = events_tx.send(AgentEvent::Error {
+                                                message: format!(
+                                                    "Cannot load mission {} before deferral: {}",
+                                                    tid, error
+                                                ),
+                                                mission_id: Some(tid),
+                                                resumable: true,
+                                            });
+                                            let _ = respond.send(UserMessageAck::Dropped);
+                                            continue;
+                                        }
+                                    };
+                                    let writer_lease = match acquire_pr_writer_lease_for_message(
+                                        &control_hub,
+                                        &mission_store,
+                                        &mission,
+                                        &content,
+                                    )
+                                    .await
+                                    {
+                                        Ok(lease) => lease,
+                                        Err(error) => {
+                                            let _ = events_tx.send(AgentEvent::Error {
+                                                message: format!(
+                                                    "Cannot reserve writer lease for mission {}: {}",
+                                                    tid, error
+                                                ),
+                                                mission_id: Some(tid),
+                                                resumable: true,
+                                            });
+                                            let _ = respond.send(UserMessageAck::Dropped);
+                                            continue;
+                                        }
+                                    };
+                                    let previous_goal = mission_store
                                         .get_deferred_goal(tid)
                                         .await
                                         .ok()
-                                        .flatten()
-                                    {
+                                        .flatten();
+                                    let combined = match previous_goal.as_deref() {
                                         Some(prev) if !prev.is_empty() => {
                                             format!("{prev}\n{content}")
                                         }
@@ -12967,6 +13080,12 @@ async fn control_actor_loop(
                                             let _ = respond.send(UserMessageAck::Queued);
                                         }
                                         Err(e) => {
+                                            rollback_message_writer_tag(
+                                                &mission_store,
+                                                &mission,
+                                                &writer_lease,
+                                            )
+                                            .await;
                                             tracing::warn!(
                                                 mission_id = %tid,
                                                 "Cannot start parallel mission (max {} reached) and \
@@ -19684,6 +19803,14 @@ mod tests {
                 "INSERT INTO missions (id, status, github_pr, intent, tags, deferred_goal)
                  VALUES (?1, 'pending', ?2, NULL, '[]', 'Fix, commit and push')",
                 rusqlite::params![mission_id.to_string(), "owner/repo#42"],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO mission_events
+                 (mission_id, sequence, event_type, content, content_file)
+                 VALUES (?1, 1, 'user_message', 'Inspect status only', NULL)",
+                rusqlite::params![mission_id.to_string()],
             )
             .unwrap();
         drop(connection);

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5307,6 +5307,7 @@ async fn acquire_durable_pr_writer_lock(
     let file = tokio::task::spawn_blocking(move || {
         let file = std::fs::OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&lock_path)
@@ -5470,11 +5471,11 @@ async fn find_existing_pr_writer(
         for mission in page {
             if Some(mission.id) == exclude_id
                 || !status_holds_pr_writer_lease(mission.status)
-                || !mission
+                || mission
                     .project
                     .github_pr
                     .as_deref()
-                    .is_some_and(|value| canonical_github_pr(value) == target)
+                    .is_none_or(|value| canonical_github_pr(value) != target)
             {
                 continue;
             }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3441,9 +3441,11 @@ impl ControlHub {
                 }
                 offline_sqlite.push(entry.path());
             } else if let Some(user) = stem.strip_suffix(".json") {
-                if live_users.contains(user) {
-                    continue;
-                }
+                // A live user can be backed by SQLite while a second process
+                // or an interrupted migration still owns missions in the
+                // legacy file store. Scanning it twice when the live store is
+                // itself file-backed is harmless; skipping it can miss a
+                // writer lease.
                 offline_file_users.push(user.to_string());
             }
         }
@@ -5498,9 +5500,10 @@ async fn find_existing_pr_writer(
                 // durable deferred goal until dispatch. Treat that prompt as
                 // capability evidence before declaring this lease read-only.
                 if let Some(goal) = store.get_deferred_goal(mission.id).await? {
-                    if mission_is_pr_writer_with_prompt(&full, Some(&goal))
-                        || message_requests_pr_writer(&full, &goal)
-                    {
+                    // This is the mission's initial mandate, not a later
+                    // steering message. Explicit `pr-readonly` must therefore
+                    // continue to win over inferred write verbs in the goal.
+                    if mission_is_pr_writer_with_prompt(&full, Some(&goal)) {
                         return Ok(Some(pr_writer_lease(&full)));
                     }
                 }
@@ -19799,7 +19802,7 @@ pub async fn telegram_webhook_receiver(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::mission_store::MissionMode;
+    use crate::api::mission_store::{MissionMode, MissionProjectPatch};
     use std::sync::Arc;
 
     static METADATA_REFRESH_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
@@ -19891,6 +19894,44 @@ mod tests {
             Some(&normalized),
             Some("read_only_audit"),
             None
+        ));
+    }
+
+    #[tokio::test]
+    async fn readonly_initial_goal_does_not_lease_but_followup_can_escalate() {
+        let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
+        let mission = store
+            .create_mission(
+                Some("Read-only PR audit"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .update_mission_project(
+                mission.id,
+                MissionProjectPatch {
+                    github_pr: Some(Some("owner/repo#42".to_string())),
+                    tags: Some(vec!["pr-readonly".to_string()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let mission = store.get_mission(mission.id).await.unwrap().unwrap();
+
+        assert!(!mission_is_pr_writer_with_prompt(
+            &mission,
+            Some("Fix and update the PR after review")
+        ));
+        assert!(message_requests_pr_writer(
+            &mission,
+            "Fix and update the PR after review"
         ));
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5314,6 +5314,28 @@ async fn find_existing_pr_writer(
     }
 }
 
+async fn ensure_pr_writer_resume_is_exclusive(
+    store: &Arc<dyn MissionStore>,
+    mission: &Mission,
+) -> Result<(), String> {
+    if !mission_is_pr_writer(mission) {
+        return Ok(());
+    }
+    let Some(github_pr) = mission.project.github_pr.as_deref() else {
+        return Ok(());
+    };
+    if let Some(existing) = find_existing_pr_writer(store, github_pr, Some(mission.id)).await? {
+        return Err(format!(
+            "PR writer lease is already held by mission {} (status={}); cannot resume mission {} as another writer for {}",
+            existing.id,
+            existing.status,
+            mission.id,
+            canonical_github_pr(github_pr)
+        ));
+    }
+    Ok(())
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -13706,6 +13728,14 @@ async fn control_actor_loop(
                         let _ = respond.send(running_list);
                     }
                     ControlCommand::ResumeMission { mission_id, clean_workspace, skip_message, respond } => {
+                        // Resumable terminal writers do not hold a lease, so a replacement
+                        // writer may have been created since this mission stopped. Serialize
+                        // the availability check with create/project updates and keep the
+                        // guard until the resumed mission has been made Active (or the
+                        // resume has failed). Otherwise a create can race between the check
+                        // and the status transition and start a second branch-changing
+                        // runner for the same PR.
+                        let _pr_writer_guard = PR_WRITER_CREATE_LOCK.lock().await;
                         // Resume an interrupted mission by building resume context
                         match resume_mission_impl(
                             &mission_store,
@@ -13715,6 +13745,15 @@ async fn control_actor_loop(
                         )
                         .await {
                             Ok((mission, resume_prompt)) => {
+                                if let Err(error) = ensure_pr_writer_resume_is_exclusive(
+                                    &mission_store,
+                                    &mission,
+                                )
+                                .await
+                                {
+                                    let _ = respond.send(Err(error));
+                                    continue;
+                                }
                                 let already_running_main =
                                     running.is_some() && running_mission_id == Some(mission_id);
                                 let already_running_parallel = parallel_runners

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3401,10 +3401,6 @@ impl ControlHub {
             .values()
             .map(|session| Arc::clone(&session.mission_store))
             .collect();
-        let live_users: HashSet<String> = sessions
-            .keys()
-            .map(|user| mission_store::sanitize_filename(user))
-            .collect();
         drop(sessions);
 
         let base_dir = self
@@ -3435,10 +3431,11 @@ impl ControlHub {
             let Some(stem) = name.strip_prefix("missions-") else {
                 continue;
             };
-            if let Some(user) = stem.strip_suffix(".db") {
-                if live_users.contains(user) {
-                    continue;
-                }
+            if let Some(_user) = stem.strip_suffix(".db") {
+                // The live session may be file-backed or an in-memory
+                // fallback, so it cannot prove that this persisted SQLite
+                // store is represented by `live`. A duplicate read-only scan
+                // is safer than admitting a second writer during migration.
                 offline_sqlite.push(entry.path());
             } else if let Some(user) = stem.strip_suffix(".json") {
                 // A live user can be backed by SQLite while a second process
@@ -7364,11 +7361,12 @@ pub async fn update_mission_project(
         .get_deferred_goal(id)
         .await
         .map_err(internal_error)?;
-    let writer_prompt = current
-        .history
-        .first()
-        .map(|entry| entry.content.as_str())
-        .or(deferred_goal.as_deref());
+    let initial_prompt = control
+        .mission_store
+        .get_initial_user_message(id)
+        .await
+        .map_err(internal_error)?;
+    let writer_prompt = initial_prompt.as_deref().or(deferred_goal.as_deref());
     let becomes_writer = effective_github_pr.is_some()
         && requested_pr_writer(
             req.writer,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5263,15 +5263,18 @@ fn status_holds_pr_writer_lease(status: MissionStatus) -> bool {
 }
 
 fn mission_is_pr_writer(mission: &Mission) -> bool {
+    mission_is_pr_writer_with_prompt(
+        mission,
+        mission.history.first().map(|entry| entry.content.as_str()),
+    )
+}
+
+fn mission_is_pr_writer_with_prompt(mission: &Mission, prompt: Option<&str>) -> bool {
     if mission.project.tags.iter().any(|tag| tag == "pr-readonly") {
         return false;
     }
     mission.project.tags.iter().any(|tag| tag == "pr-writer")
-        || inferred_pr_writer(
-            None,
-            mission.project.intent.as_deref(),
-            mission.history.first().map(|entry| entry.content.as_str()),
-        )
+        || inferred_pr_writer(None, mission.project.intent.as_deref(), prompt)
 }
 
 async fn find_existing_pr_writer(
@@ -5304,6 +5307,14 @@ async fn find_existing_pr_writer(
             if let Some(full) = store.get_mission(mission.id).await? {
                 if mission_is_pr_writer(&full) {
                     return Ok(Some(full));
+                }
+                // Scheduled missions can carry their only prompt in the
+                // durable deferred goal until dispatch. Treat that prompt as
+                // capability evidence before declaring this lease read-only.
+                if let Some(goal) = store.get_deferred_goal(mission.id).await? {
+                    if mission_is_pr_writer_with_prompt(&full, Some(&goal)) {
+                        return Ok(Some(full));
+                    }
                 }
             }
         }
@@ -5579,23 +5590,19 @@ pub async fn create_mission(
         ));
     }
 
-    // Serialize create+metadata so two controllers cannot race through the
-    // preflight and create concurrent writers for the same PR.
+    // Writer creation is checked once before actor creation and again while
+    // tagging the returned mission. Never hold this mutex while waiting on the
+    // control actor: actor commands also acquire it when resuming writers.
     let request_is_writer = requested_pr_writer(
         req.writer,
         req.tags.as_deref(),
         req.intent.as_deref(),
         req.prompt.as_deref(),
     );
-    let pr_writer_guard = if req
+    let request_needs_writer_lease = req
         .github_pr
         .as_deref()
-        .is_some_and(|github_pr| !github_pr.trim().is_empty() && request_is_writer)
-    {
-        Some(PR_WRITER_CREATE_LOCK.lock().await)
-    } else {
-        None
-    };
+        .is_some_and(|github_pr| !github_pr.trim().is_empty() && request_is_writer);
 
     // Validate the remote-node payload before persisting the mission so a
     // bad request cannot leave an orphaned pending mission behind.
@@ -5691,20 +5698,23 @@ pub async fn create_mission(
     }
 
     let control = control_for_user(&state, &user).await;
-    if let (Some(github_pr), Some(_guard)) = (req.github_pr.as_deref(), pr_writer_guard.as_ref()) {
-        if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr, None)
-            .await
-            .map_err(internal_error)?
-        {
-            return Err((
-                StatusCode::CONFLICT,
-                format!(
-                    "PR writer lease is already held by mission {} (status={}); acknowledge, interrupt, or complete it before creating another writer for {}",
-                    existing.id,
-                    existing.status,
-                    canonical_github_pr(github_pr)
-                ),
-            ));
+    if request_needs_writer_lease {
+        let _guard = PR_WRITER_CREATE_LOCK.lock().await;
+        if let Some(github_pr) = req.github_pr.as_deref() {
+            if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr, None)
+                .await
+                .map_err(internal_error)?
+            {
+                return Err((
+                    StatusCode::CONFLICT,
+                    format!(
+                        "PR writer lease is already held by mission {} (status={}); acknowledge, interrupt, or complete it before creating another writer for {}",
+                        existing.id,
+                        existing.status,
+                        canonical_github_pr(github_pr)
+                    ),
+                ));
+            }
         }
     }
     control
@@ -5730,6 +5740,48 @@ pub async fn create_mission(
         .map_err(session_unavailable)?;
 
     let mut mission = rx.await.map_err(recv_failed)?.map_err(internal_error)?;
+
+    // Close the preflight-to-create race under the store-only mutex. Exactly
+    // one concurrent creator wins; a loser is durably interrupted before it
+    // can receive a goal or become a writer.
+    let pr_writer_guard = if request_needs_writer_lease {
+        Some(PR_WRITER_CREATE_LOCK.lock().await)
+    } else {
+        None
+    };
+    if let (Some(github_pr), Some(_guard)) = (req.github_pr.as_deref(), pr_writer_guard.as_ref()) {
+        if let Some(existing) =
+            find_existing_pr_writer(&control.mission_store, github_pr, Some(mission.id))
+                .await
+                .map_err(internal_error)?
+        {
+            let reason = "pr_writer_lease_conflict";
+            control
+                .mission_store
+                .update_mission_status_with_reason(
+                    mission.id,
+                    MissionStatus::Interrupted,
+                    Some(reason),
+                )
+                .await
+                .map_err(internal_error)?;
+            let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
+                mission_id: mission.id,
+                status: MissionStatus::Interrupted,
+                summary: Some(reason.to_string()),
+            });
+            return Err((
+                StatusCode::CONFLICT,
+                format!(
+                    "PR writer lease is already held by mission {} (status={}); interrupted duplicate mission {} for {}",
+                    existing.id,
+                    existing.status,
+                    mission.id,
+                    canonical_github_pr(github_pr)
+                ),
+            ));
+        }
+    }
 
     // Apply project tagging metadata if provided at creation time. Empty/blank
     // strings are treated as unset; tags are trimmed and empties dropped.
@@ -5806,6 +5858,7 @@ pub async fn create_mission(
             mission.project.tags = v;
         }
     }
+    drop(pr_writer_guard);
 
     // Atomic create+start: stash the initial prompt as the deferred goal. The
     // FLEET-001 scheduler pass (every ~5s) dispatches pending missions with a

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5235,6 +5235,22 @@ fn inferred_pr_writer(explicit: Option<bool>, intent: Option<&str>, prompt: Opti
     .any(|token| tokens.contains(token))
 }
 
+fn requested_pr_writer(
+    explicit: Option<bool>,
+    tags: Option<&[String]>,
+    intent: Option<&str>,
+    prompt: Option<&str>,
+) -> bool {
+    if let Some(explicit) = explicit {
+        return explicit;
+    }
+    if tags.is_some_and(|tags| tags.iter().any(|tag| tag == "pr-readonly")) {
+        return false;
+    }
+    tags.is_some_and(|tags| tags.iter().any(|tag| tag == "pr-writer"))
+        || inferred_pr_writer(None, intent, prompt)
+}
+
 fn status_holds_pr_writer_lease(status: MissionStatus) -> bool {
     matches!(
         status,
@@ -5269,17 +5285,27 @@ async fn find_existing_pr_writer(
     loop {
         let page = store.list_missions(PAGE_SIZE, offset).await?;
         let page_len = page.len();
-        if let Some(mission) = page.into_iter().find(|mission| {
-            Some(mission.id) != exclude_id
-                && status_holds_pr_writer_lease(mission.status)
-                && mission
+        for mission in page {
+            if Some(mission.id) == exclude_id
+                || !status_holds_pr_writer_lease(mission.status)
+                || !mission
                     .project
                     .github_pr
                     .as_deref()
                     .is_some_and(|value| canonical_github_pr(value) == target)
-                && mission_is_pr_writer(mission)
-        }) {
-            return Ok(Some(mission));
+            {
+                continue;
+            }
+            if mission_is_pr_writer(&mission) {
+                return Ok(Some(mission));
+            }
+            // SQLite list queries intentionally omit history. Load the full
+            // mission before treating a legacy prompt-only writer as read-only.
+            if let Some(full) = store.get_mission(mission.id).await? {
+                if mission_is_pr_writer(&full) {
+                    return Ok(Some(full));
+                }
+            }
         }
         if page_len < PAGE_SIZE {
             return Ok(None);
@@ -5500,10 +5526,17 @@ pub async fn create_mission(
 
     // Serialize create+metadata so two controllers cannot race through the
     // preflight and create concurrent writers for the same PR.
-    let pr_writer_guard = if req.github_pr.as_deref().is_some_and(|github_pr| {
-        !github_pr.trim().is_empty()
-            && inferred_pr_writer(req.writer, req.intent.as_deref(), req.prompt.as_deref())
-    }) {
+    let request_is_writer = requested_pr_writer(
+        req.writer,
+        req.tags.as_deref(),
+        req.intent.as_deref(),
+        req.prompt.as_deref(),
+    );
+    let pr_writer_guard = if req
+        .github_pr
+        .as_deref()
+        .is_some_and(|github_pr| !github_pr.trim().is_empty() && request_is_writer)
+    {
         Some(PR_WRITER_CREATE_LOCK.lock().await)
     } else {
         None
@@ -5668,16 +5701,16 @@ pub async fn create_mission(
         .as_deref()
         .is_some_and(|value| !value.trim().is_empty())
     {
-        let capability =
-            if inferred_pr_writer(req.writer, req.intent.as_deref(), req.prompt.as_deref()) {
-                Some("pr-writer")
-            } else if req.writer == Some(false) {
-                Some("pr-readonly")
-            } else {
-                None
-            };
+        let capability = if request_is_writer {
+            Some("pr-writer")
+        } else if req.writer == Some(false) {
+            Some("pr-readonly")
+        } else {
+            None
+        };
         if let Some(capability) = capability {
             let tags = tags.get_or_insert_with(Vec::new);
+            tags.retain(|tag| tag != "pr-writer" && tag != "pr-readonly");
             if !tags.iter().any(|tag| tag == capability) {
                 tags.push(capability.to_string());
             }
@@ -6719,6 +6752,10 @@ pub struct UpdateMissionProjectRequest {
     pub intent: Option<Option<String>>,
     #[serde(default, deserialize_with = "deserialize_string_patch")]
     pub github_pr: Option<Option<String>>,
+    /// Explicit PR branch capability. `true` acquires the writer lease;
+    /// `false` marks the mission read-only.
+    #[serde(default)]
+    pub writer: Option<bool>,
     #[serde(default)]
     pub tags: Option<Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_string_patch")]
@@ -6774,24 +6811,21 @@ pub async fn update_mission_project(
     let effective_github_pr = effective_string(&github_pr, &current.project.github_pr);
     let effective_intent = effective_string(&intent, &current.project.intent);
     let mut effective_tags = tags.clone().unwrap_or_else(|| current.project.tags.clone());
-    let explicitly_readonly = effective_tags.iter().any(|tag| tag == "pr-readonly");
     let becomes_writer = effective_github_pr.is_some()
-        && !explicitly_readonly
-        && (effective_tags.iter().any(|tag| tag == "pr-writer")
-            || inferred_pr_writer(
-                None,
-                effective_intent.as_deref(),
-                current.history.first().map(|entry| entry.content.as_str()),
-            ));
-    if becomes_writer && !effective_tags.iter().any(|tag| tag == "pr-writer") {
+        && requested_pr_writer(
+            req.writer,
+            Some(&effective_tags),
+            effective_intent.as_deref(),
+            current.history.first().map(|entry| entry.content.as_str()),
+        );
+    if becomes_writer {
+        effective_tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
         effective_tags.push("pr-writer".to_string());
         tags = Some(effective_tags.clone());
-    } else if tags.is_some() {
-        // Preserve the caller's normalized replacement even when it does not
-        // change writer capability.
-        if tags.as_ref() != Some(&effective_tags) {
-            tags = Some(effective_tags.clone());
-        }
+    } else if effective_github_pr.is_some() && req.writer == Some(false) {
+        effective_tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
+        effective_tags.push("pr-readonly".to_string());
+        tags = Some(effective_tags.clone());
     }
 
     let writer_guard = if becomes_writer {
@@ -19108,6 +19142,18 @@ mod tests {
         assert!(inferred_pr_writer(
             Some(true),
             Some("read_only_audit"),
+            None
+        ));
+        assert!(requested_pr_writer(
+            Some(true),
+            Some(&["pr-readonly".to_string()]),
+            Some("read_only_audit"),
+            None
+        ));
+        assert!(!requested_pr_writer(
+            Some(false),
+            Some(&["pr-writer".to_string()]),
+            Some("integration_repair"),
             None
         ));
     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3632,7 +3632,12 @@ pub async fn post_message(
         // The wire response keeps its historical bool shape: `queued` is true
         // only when the message is waiting for the next turn boundary.
         // Dropped messages surface as an `AgentEvent::Error` on the stream.
-        Ok(ack) => ack == UserMessageAck::Queued,
+        Ok(UserMessageAck::Queued) => true,
+        Ok(UserMessageAck::Delivered) => false,
+        Ok(UserMessageAck::Dropped) => false,
+        Ok(UserMessageAck::Rejected(reason)) => {
+            return Err((StatusCode::CONFLICT, reason));
+        }
         Err(_) => {
             let status = control.status.read().await;
             status.state != ControlRunState::Idle
@@ -5485,7 +5490,8 @@ async fn find_existing_pr_writer(
             // SQLite list queries intentionally omit history. Load the full
             // mission before treating a legacy prompt-only writer as read-only.
             if let Some(full) = store.get_mission(mission.id).await? {
-                if mission_is_pr_writer(&full) {
+                let initial_prompt = store.get_initial_user_message(mission.id).await?;
+                if mission_is_pr_writer_with_prompt(&full, initial_prompt.as_deref()) {
                     return Ok(Some(pr_writer_lease(&full)));
                 }
                 // Scheduled missions can carry their only prompt in the
@@ -12881,7 +12887,7 @@ async fn control_actor_loop(
                                                         mission_id: Some(tid),
                                                         resumable: true,
                                                     });
-                                                    let _ = respond.send(UserMessageAck::Dropped);
+                                                    let _ = respond.send(UserMessageAck::Rejected(error));
                                                     continue;
                                                 }
                                             };
@@ -12958,7 +12964,7 @@ async fn control_actor_loop(
                                             mission_id: Some(tid),
                                             resumable: true,
                                         });
-                                        let _ = respond.send(UserMessageAck::Dropped);
+                                        let _ = respond.send(UserMessageAck::Rejected(error));
                                         continue;
                                     }
                                 }
@@ -13064,7 +13070,7 @@ async fn control_actor_loop(
                                                 mission_id: Some(tid),
                                                 resumable: true,
                                             });
-                                            let _ = respond.send(UserMessageAck::Dropped);
+                                            let _ = respond.send(UserMessageAck::Rejected(error));
                                             continue;
                                         }
                                     };
@@ -13157,7 +13163,7 @@ async fn control_actor_loop(
                                                     mission_id: Some(tid),
                                                     resumable: true,
                                                 });
-                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                let _ = respond.send(UserMessageAck::Rejected(error));
                                                 continue;
                                             }
                                             let mut runner = super::mission_runner::MissionRunner::new(
@@ -13287,7 +13293,7 @@ async fn control_actor_loop(
                                                 mission_id: Some(tid),
                                                 resumable: true,
                                             });
-                                            let _ = respond.send(UserMessageAck::Dropped);
+                                            let _ = respond.send(UserMessageAck::Rejected(error));
                                             continue;
                                         }
                                     }
@@ -13330,7 +13336,7 @@ async fn control_actor_loop(
                                                     mission_id: Some(tid),
                                                     resumable: true,
                                                 });
-                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                let _ = respond.send(UserMessageAck::Rejected(error));
                                                 continue;
                                             }
                                         }
@@ -13368,7 +13374,7 @@ async fn control_actor_loop(
                                                     mission_id: Some(tid),
                                                     resumable: true,
                                                 });
-                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                let _ = respond.send(UserMessageAck::Rejected(error));
                                                 continue;
                                             }
                                         }
@@ -13418,7 +13424,7 @@ async fn control_actor_loop(
                                             mission_id: Some(tid),
                                             resumable: true,
                                         });
-                                        let _ = respond.send(UserMessageAck::Dropped);
+                                        let _ = respond.send(UserMessageAck::Rejected(error));
                                         continue;
                                     }
                                 }
@@ -13515,7 +13521,7 @@ async fn control_actor_loop(
                                                     mission_id: Some(mid),
                                                     resumable: true,
                                                 });
-                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                let _ = respond.send(UserMessageAck::Rejected(error));
                                                 continue;
                                             }
                                             (

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3385,6 +3385,59 @@ impl ControlHub {
         self.sessions.read().await.values().cloned().collect()
     }
 
+    /// Every live and persisted mission store. Writer leases are global to a
+    /// PR branch, not scoped to the authenticated dashboard user, so lease
+    /// checks must include stores whose user has no live control session.
+    pub async fn all_mission_stores(&self) -> Result<Vec<Arc<dyn MissionStore>>, String> {
+        let sessions = self.sessions.read().await;
+        let mut stores: Vec<Arc<dyn MissionStore>> = sessions
+            .values()
+            .map(|session| Arc::clone(&session.mission_store))
+            .collect();
+        let live_users: HashSet<String> = sessions
+            .keys()
+            .map(|user| mission_store::sanitize_filename(user))
+            .collect();
+        drop(sessions);
+
+        let base_dir = self
+            .config
+            .working_dir
+            .join(".sandboxed-sh")
+            .join("missions");
+        let mut entries = match tokio::fs::read_dir(&base_dir).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(stores),
+            Err(error) => return Err(format!("read {}: {error}", base_dir.display())),
+        };
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|error| error.to_string())?
+        {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some(stem) = name.strip_prefix("missions-") else {
+                continue;
+            };
+            if let Some(user) = stem.strip_suffix(".db") {
+                if live_users.contains(user) {
+                    continue;
+                }
+                stores.push(Arc::new(
+                    mission_store::SqliteMissionStore::new(base_dir.clone(), user).await?,
+                ));
+            } else if let Some(user) = stem.strip_suffix(".json") {
+                if live_users.contains(user) {
+                    continue;
+                }
+                stores.push(Arc::new(
+                    mission_store::FileMissionStore::new(base_dir.clone(), user).await?,
+                ));
+            }
+        }
+        Ok(stores)
+    }
+
     /// User ids of all live control sessions. Used by GC/reaper to decide
     /// whether the cross-store mission index is complete (a persisted store
     /// with no live session means missions exist that the index can't see).
@@ -3503,6 +3556,53 @@ pub async fn post_message(
         reset_stall_guard(mid);
     }
     let control = control_for_user(&state, &user).await;
+    if let Some(mission_id) = target_mission_id {
+        if let Some(mission) = control
+            .mission_store
+            .get_mission(mission_id)
+            .await
+            .map_err(internal_error)?
+        {
+            let already_writer = mission_is_pr_writer(&mission);
+            if already_writer || message_requests_pr_writer(&mission, &content) {
+                let _guard = PR_WRITER_CREATE_LOCK.lock().await;
+                if let Some(github_pr) = mission.project.github_pr.as_deref() {
+                    if let Some(existing) =
+                        find_existing_pr_writer_global(&state, github_pr, Some(mission.id))
+                            .await
+                            .map_err(internal_error)?
+                    {
+                        return Err((
+                            StatusCode::CONFLICT,
+                            format!(
+                                "PR writer lease is already held by mission {} (status={}); cannot send a writer message to mission {} for {}",
+                                existing.id,
+                                existing.status,
+                                mission.id,
+                                canonical_github_pr(github_pr)
+                            ),
+                        ));
+                    }
+                }
+                if !already_writer {
+                    let mut tags = mission.project.tags.clone();
+                    tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
+                    tags.push("pr-writer".to_string());
+                    control
+                        .mission_store
+                        .update_mission_project(
+                            mission.id,
+                            crate::api::mission_store::MissionProjectPatch {
+                                tags: Some(tags),
+                                ..Default::default()
+                            },
+                        )
+                        .await
+                        .map_err(internal_error)?;
+                }
+            }
+        }
+    }
     let (queued_tx, queued_rx) = oneshot::channel();
     tracing::info!(
         user_id = %user.id,
@@ -5277,6 +5377,16 @@ fn mission_is_pr_writer_with_prompt(mission: &Mission, prompt: Option<&str>) -> 
         || inferred_pr_writer(None, mission.project.intent.as_deref(), prompt)
 }
 
+fn message_requests_pr_writer(mission: &Mission, content: &str) -> bool {
+    mission.project.github_pr.is_some()
+        && requested_pr_writer(
+            None,
+            Some(&mission.project.tags),
+            mission.project.intent.as_deref(),
+            Some(content),
+        )
+}
+
 async fn find_existing_pr_writer(
     store: &Arc<dyn MissionStore>,
     github_pr: &str,
@@ -5325,6 +5435,21 @@ async fn find_existing_pr_writer(
     }
 }
 
+async fn find_existing_pr_writer_global(
+    state: &Arc<AppState>,
+    github_pr: &str,
+    exclude_id: Option<Uuid>,
+) -> Result<Option<Mission>, String> {
+    // Fail closed if any persisted store cannot be enumerated or read. A
+    // partial cross-user scan cannot prove that a branch is writer-free.
+    for store in state.control.all_mission_stores().await? {
+        if let Some(mission) = find_existing_pr_writer(&store, github_pr, exclude_id).await? {
+            return Ok(Some(mission));
+        }
+    }
+    Ok(None)
+}
+
 async fn ensure_pr_writer_resume_is_exclusive(
     store: &Arc<dyn MissionStore>,
     mission: &Mission,
@@ -5351,6 +5476,7 @@ async fn activate_mission_for_message(
     store: &Arc<dyn MissionStore>,
     events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
     mission: &Mission,
+    content: &str,
 ) -> Result<(), String> {
     if !message_activates_mission(mission.status) {
         return Ok(());
@@ -5360,13 +5486,41 @@ async fn activate_mission_for_message(
     // through the explicit resume endpoint. Reacquire the writer lease under
     // the same mutex as create/project/resume and keep it until Active is
     // persisted, so message delivery cannot race a replacement writer.
-    let _pr_writer_guard = if mission_is_pr_writer(mission) {
+    let becomes_writer =
+        mission_is_pr_writer(mission) || message_requests_pr_writer(mission, content);
+    let _pr_writer_guard = if becomes_writer {
         Some(PR_WRITER_CREATE_LOCK.lock().await)
     } else {
         None
     };
     if _pr_writer_guard.is_some() {
-        ensure_pr_writer_resume_is_exclusive(store, mission).await?;
+        if let Some(github_pr) = mission.project.github_pr.as_deref() {
+            if let Some(existing) =
+                find_existing_pr_writer(store, github_pr, Some(mission.id)).await?
+            {
+                return Err(format!(
+                    "PR writer lease is already held by mission {} (status={}); cannot activate mission {} as another writer for {}",
+                    existing.id,
+                    existing.status,
+                    mission.id,
+                    canonical_github_pr(github_pr)
+                ));
+            }
+        }
+        if !mission_is_pr_writer(mission) {
+            let mut tags = mission.project.tags.clone();
+            tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
+            tags.push("pr-writer".to_string());
+            store
+                .update_mission_project(
+                    mission.id,
+                    crate::api::mission_store::MissionProjectPatch {
+                        tags: Some(tags),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+        }
     }
 
     store
@@ -5701,7 +5855,7 @@ pub async fn create_mission(
     if request_needs_writer_lease {
         let _guard = PR_WRITER_CREATE_LOCK.lock().await;
         if let Some(github_pr) = req.github_pr.as_deref() {
-            if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr, None)
+            if let Some(existing) = find_existing_pr_writer_global(&state, github_pr, None)
                 .await
                 .map_err(internal_error)?
             {
@@ -5750,10 +5904,9 @@ pub async fn create_mission(
         None
     };
     if let (Some(github_pr), Some(_guard)) = (req.github_pr.as_deref(), pr_writer_guard.as_ref()) {
-        if let Some(existing) =
-            find_existing_pr_writer(&control.mission_store, github_pr, Some(mission.id))
-                .await
-                .map_err(internal_error)?
+        if let Some(existing) = find_existing_pr_writer_global(&state, github_pr, Some(mission.id))
+            .await
+            .map_err(internal_error)?
         {
             let reason = "pr_writer_lease_conflict";
             control
@@ -6953,7 +7106,7 @@ pub async fn update_mission_project(
     };
     if let (Some(github_pr), Some(_guard)) = (effective_github_pr.as_deref(), writer_guard.as_ref())
     {
-        if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr, Some(id))
+        if let Some(existing) = find_existing_pr_writer_global(&state, github_pr, Some(id))
             .await
             .map_err(internal_error)?
         {
@@ -12694,6 +12847,7 @@ async fn control_actor_loop(
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
+                                                &content,
                                             )
                                             .await
                                             {
@@ -12822,6 +12976,7 @@ async fn control_actor_loop(
                                             &mission_store,
                                             &events_tx,
                                             &mission,
+                                            &content,
                                         )
                                         .await
                                         {
@@ -12863,6 +13018,7 @@ async fn control_actor_loop(
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
+                                                &content,
                                             )
                                             .await
                                             {
@@ -12899,6 +13055,7 @@ async fn control_actor_loop(
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
+                                                &content,
                                             )
                                             .await
                                             {
@@ -13018,6 +13175,7 @@ async fn control_actor_loop(
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
+                                                &content,
                                             )
                                             .await
                                             {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5336,6 +5336,39 @@ async fn ensure_pr_writer_resume_is_exclusive(
     Ok(())
 }
 
+async fn activate_mission_for_message(
+    store: &Arc<dyn MissionStore>,
+    events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
+    mission: &Mission,
+) -> Result<(), String> {
+    if !message_activates_mission(mission.status) {
+        return Ok(());
+    }
+
+    // A targeted message can resume terminal/acknowledged work without going
+    // through the explicit resume endpoint. Reacquire the writer lease under
+    // the same mutex as create/project/resume and keep it until Active is
+    // persisted, so message delivery cannot race a replacement writer.
+    let _pr_writer_guard = if mission_is_pr_writer(mission) {
+        Some(PR_WRITER_CREATE_LOCK.lock().await)
+    } else {
+        None
+    };
+    if _pr_writer_guard.is_some() {
+        ensure_pr_writer_resume_is_exclusive(store, mission).await?;
+    }
+
+    store
+        .update_mission_status(mission.id, MissionStatus::Active)
+        .await?;
+    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+        mission_id: mission.id,
+        status: MissionStatus::Active,
+        summary: None,
+    });
+    Ok(())
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -6833,12 +6866,22 @@ pub async fn update_mission_project(
     let effective_github_pr = effective_string(&github_pr, &current.project.github_pr);
     let effective_intent = effective_string(&intent, &current.project.intent);
     let mut effective_tags = tags.clone().unwrap_or_else(|| current.project.tags.clone());
+    let deferred_goal = control
+        .mission_store
+        .get_deferred_goal(id)
+        .await
+        .map_err(internal_error)?;
+    let writer_prompt = current
+        .history
+        .first()
+        .map(|entry| entry.content.as_str())
+        .or(deferred_goal.as_deref());
     let becomes_writer = effective_github_pr.is_some()
         && requested_pr_writer(
             req.writer,
             Some(&effective_tags),
             effective_intent.as_deref(),
-            current.history.first().map(|entry| entry.content.as_str()),
+            writer_prompt,
         );
     if becomes_writer {
         effective_tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
@@ -12594,21 +12637,23 @@ async fn control_actor_loop(
                                                 let _ = respond.send(UserMessageAck::Dropped);
                                                 continue;
                                             }
-                                            // Activate mission: if pending, interrupted, blocked, completed, or failed, update status to active
-                                            if message_activates_mission(mission.status) {
-                                                tracing::info!(
-                                                    "Activating parallel mission {} (was {})",
-                                                    tid, mission.status
-                                                );
-                                                if let Err(e) = mission_store.update_mission_status(tid, MissionStatus::Active).await {
-                                                    tracing::warn!("Failed to activate parallel mission {}: {}", tid, e);
-                                                } else {
-                                                    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                        mission_id: tid,
-                                                        status: MissionStatus::Active,
-                                                        summary: None,
-                                                    });
-                                                }
+                                            if let Err(error) = activate_mission_for_message(
+                                                &mission_store,
+                                                &events_tx,
+                                                &mission,
+                                            )
+                                            .await
+                                            {
+                                                let _ = events_tx.send(AgentEvent::Error {
+                                                    message: format!(
+                                                        "Cannot activate mission {}: {}",
+                                                        tid, error
+                                                    ),
+                                                    mission_id: Some(tid),
+                                                    resumable: true,
+                                                });
+                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                continue;
                                             }
                                             let mut runner = super::mission_runner::MissionRunner::new(
                                                 tid,
@@ -12720,21 +12765,23 @@ async fn control_actor_loop(
                                                 mission.history.len(), tid
                                             );
                                         }
-                                        // Activate mission if it was pending/interrupted/blocked/completed
-                                        if message_activates_mission(mission.status) {
-                                            tracing::info!(
-                                                "Activating main mission {} (was {})",
-                                                tid, mission.status
-                                            );
-                                            if let Err(e) = mission_store.update_mission_status(tid, MissionStatus::Active).await {
-                                                tracing::warn!("Failed to activate main mission {}: {}", tid, e);
-                                            } else {
-                                                let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                    mission_id: tid,
-                                                    status: MissionStatus::Active,
-                                                    summary: None,
-                                                });
-                                            }
+                                        if let Err(error) = activate_mission_for_message(
+                                            &mission_store,
+                                            &events_tx,
+                                            &mission,
+                                        )
+                                        .await
+                                        {
+                                            let _ = events_tx.send(AgentEvent::Error {
+                                                message: format!(
+                                                    "Cannot activate mission {}: {}",
+                                                    tid, error
+                                                ),
+                                                mission_id: Some(tid),
+                                                resumable: true,
+                                            });
+                                            let _ = respond.send(UserMessageAck::Dropped);
+                                            continue;
                                         }
                                     }
                                     *current_mission.write().await = Some(tid);
@@ -12759,21 +12806,23 @@ async fn control_actor_loop(
                                             for entry in &mission.history {
                                                 history.push((entry.role.clone(), entry.content.clone()));
                                             }
-                                            // Activate mission if it was pending/interrupted/blocked/completed
-                                            if message_activates_mission(mission.status) {
-                                                tracing::info!(
-                                                    "Activating switched mission {} (was {})",
-                                                    tid, mission.status
-                                                );
-                                                if let Err(e) = mission_store.update_mission_status(tid, MissionStatus::Active).await {
-                                                    tracing::warn!("Failed to activate switched mission {}: {}", tid, e);
-                                                } else {
-                                                    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                        mission_id: tid,
-                                                        status: MissionStatus::Active,
-                                                        summary: None,
-                                                    });
-                                                }
+                                            if let Err(error) = activate_mission_for_message(
+                                                &mission_store,
+                                                &events_tx,
+                                                &mission,
+                                            )
+                                            .await
+                                            {
+                                                let _ = events_tx.send(AgentEvent::Error {
+                                                    message: format!(
+                                                        "Cannot activate mission {}: {}",
+                                                        tid, error
+                                                    ),
+                                                    mission_id: Some(tid),
+                                                    resumable: true,
+                                                });
+                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                continue;
                                             }
                                         }
                                         *current_mission.write().await = Some(tid);
@@ -12793,21 +12842,23 @@ async fn control_actor_loop(
                                                     mission.history.len(), tid
                                                 );
                                             }
-                                            // Activate mission if it was pending/interrupted/blocked/completed (same mission, reloading)
-                                            if message_activates_mission(mission.status) {
-                                                tracing::info!(
-                                                    "Activating reloaded mission {} (was {})",
-                                                    tid, mission.status
-                                                );
-                                                if let Err(e) = mission_store.update_mission_status(tid, MissionStatus::Active).await {
-                                                    tracing::warn!("Failed to activate reloaded mission {}: {}", tid, e);
-                                                } else {
-                                                    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                        mission_id: tid,
-                                                        status: MissionStatus::Active,
-                                                        summary: None,
-                                                    });
-                                                }
+                                            if let Err(error) = activate_mission_for_message(
+                                                &mission_store,
+                                                &events_tx,
+                                                &mission,
+                                            )
+                                            .await
+                                            {
+                                                let _ = events_tx.send(AgentEvent::Error {
+                                                    message: format!(
+                                                        "Cannot activate mission {}: {}",
+                                                        tid, error
+                                                    ),
+                                                    mission_id: Some(tid),
+                                                    resumable: true,
+                                                });
+                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                continue;
                                             }
                                         }
                                     }
@@ -12910,22 +12961,23 @@ async fn control_actor_loop(
                                 let (workspace_id, model_override, model_effort, mission_agent, backend_id, session_id, mission_config_profile) = if let Some(mid) = mission_id {
                                     match mission_store.get_mission(mid).await {
                                         Ok(Some(mission)) => {
-                                            // Activate mission: if pending, interrupted, blocked, completed, or failed, update status to active
-                                            if message_activates_mission(mission.status) {
-                                                tracing::info!(
-                                                    "Activating mission {} (was {})",
-                                                    mid, mission.status
-                                                );
-                                                if let Err(e) = mission_store.update_mission_status(mid, MissionStatus::Active).await {
-                                                    tracing::warn!("Failed to activate mission {}: {}", mid, e);
-                                                } else {
-                                                    // Notify frontend of status change
-                                                    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                                        mission_id: mid,
-                                                        status: MissionStatus::Active,
-                                                        summary: None,
-                                                    });
-                                                }
+                                            if let Err(error) = activate_mission_for_message(
+                                                &mission_store,
+                                                &events_tx,
+                                                &mission,
+                                            )
+                                            .await
+                                            {
+                                                let _ = events_tx.send(AgentEvent::Error {
+                                                    message: format!(
+                                                        "Cannot activate mission {}: {}",
+                                                        mid, error
+                                                    ),
+                                                    mission_id: Some(mid),
+                                                    resumable: true,
+                                                });
+                                                let _ = respond.send(UserMessageAck::Dropped);
+                                                continue;
                                             }
                                             (
                                                 Some(mission.workspace_id),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3581,7 +3581,9 @@ pub async fn post_message(
             .map_err(internal_error)?
         {
             if mission_is_pr_writer(&mission) || message_requests_pr_writer(&mission, &content) {
-                let _guard = PR_WRITER_CREATE_LOCK.lock().await;
+                let _guard = acquire_durable_pr_writer_lock(&state.control)
+                    .await
+                    .map_err(internal_error)?;
                 if let Some(github_pr) = mission.project.github_pr.as_deref() {
                     if let Some(existing) =
                         find_existing_pr_writer_global(&state.control, github_pr, Some(mission.id))
@@ -5274,6 +5276,53 @@ fn fable_mandate_requests_integration(intent: Option<&str>, prompt: Option<&str>
 static PR_WRITER_CREATE_LOCK: std::sync::LazyLock<Mutex<()>> =
     std::sync::LazyLock::new(|| Mutex::new(()));
 
+struct DurablePrWriterLockGuard {
+    _process_guard: tokio::sync::MutexGuard<'static, ()>,
+    file: std::fs::File,
+}
+
+impl Drop for DurablePrWriterLockGuard {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
+
+async fn acquire_durable_pr_writer_lock(
+    control_hub: &ControlHub,
+) -> Result<DurablePrWriterLockGuard, String> {
+    // The async mutex prevents this process from blocking one of its runtime
+    // threads on flock while another local request owns the lease lock. The
+    // advisory file lock extends the same critical section across backend and
+    // Hermes/controller processes that share this mission store directory.
+    let process_guard = PR_WRITER_CREATE_LOCK.lock().await;
+    let lock_dir = control_hub
+        .config
+        .working_dir
+        .join(".sandboxed-sh")
+        .join("missions");
+    tokio::fs::create_dir_all(&lock_dir)
+        .await
+        .map_err(|error| format!("create PR writer lock directory: {error}"))?;
+    let lock_path = lock_dir.join(".pr-writer.lock");
+    let file = tokio::task::spawn_blocking(move || {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|error| format!("open {}: {error}", lock_path.display()))?;
+        fs2::FileExt::lock_exclusive(&file)
+            .map_err(|error| format!("lock {}: {error}", lock_path.display()))?;
+        Ok::<_, String>(file)
+    })
+    .await
+    .map_err(|error| format!("join PR writer lock task: {error}"))??;
+    Ok(DurablePrWriterLockGuard {
+        _process_guard: process_guard,
+        file,
+    })
+}
+
 fn canonical_github_pr(raw: &str) -> String {
     let mut value = raw
         .trim()
@@ -5624,7 +5673,7 @@ async fn activate_mission_for_message(
 }
 
 struct MessageWriterLeaseGuard {
-    _guard: tokio::sync::MutexGuard<'static, ()>,
+    _guard: DurablePrWriterLockGuard,
     retagged: bool,
 }
 
@@ -5640,7 +5689,7 @@ async fn acquire_pr_writer_lease_for_message(
         return Ok(None);
     }
 
-    let guard = PR_WRITER_CREATE_LOCK.lock().await;
+    let guard = acquire_durable_pr_writer_lock(control_hub).await?;
     if let Some(github_pr) = mission.project.github_pr.as_deref() {
         if let Some(existing) =
             find_existing_pr_writer_global(control_hub, github_pr, Some(mission.id)).await?
@@ -6015,7 +6064,9 @@ pub async fn create_mission(
 
     let control = control_for_user(&state, &user).await;
     if request_needs_writer_lease {
-        let _guard = PR_WRITER_CREATE_LOCK.lock().await;
+        let _guard = acquire_durable_pr_writer_lock(&state.control)
+            .await
+            .map_err(internal_error)?;
         if let Some(github_pr) = req.github_pr.as_deref() {
             if let Some(existing) = find_existing_pr_writer_global(&state.control, github_pr, None)
                 .await
@@ -6061,7 +6112,11 @@ pub async fn create_mission(
     // one concurrent creator wins; a loser is durably interrupted before it
     // can receive a goal or become a writer.
     let pr_writer_guard = if request_needs_writer_lease {
-        Some(PR_WRITER_CREATE_LOCK.lock().await)
+        Some(
+            acquire_durable_pr_writer_lock(&state.control)
+                .await
+                .map_err(internal_error)?,
+        )
     } else {
         None
     };
@@ -7258,7 +7313,11 @@ pub async fn update_mission_project(
     }
 
     let writer_guard = if becomes_writer {
-        Some(PR_WRITER_CREATE_LOCK.lock().await)
+        Some(
+            acquire_durable_pr_writer_lock(&state.control)
+                .await
+                .map_err(internal_error)?,
+        )
     } else {
         None
     };
@@ -8872,34 +8931,6 @@ pub async fn resume_mission(
     let control = control_for_user(&state, &user).await;
     tracing::info!(mission_id = %mission_id, actor = %actor, "FLEET-004 mission resume requested");
 
-    // FLEET-004: a Paused mission resumes its *prior work* from history, so it
-    // first transitions to Interrupted (the status `resume_mission_impl`
-    // accepts) and then falls through to the ResumeMission path below to rebuild
-    // context and restart the runner. (Pending would be wrong here: the FLEET-001
-    // dispatcher only dispatches `not_before`-scheduled missions that carry a
-    // fresh `deferred_goal`, not paused missions continuing from history.)
-    let was_paused = matches!(
-        control.mission_store.get_mission(mission_id).await,
-        Ok(Some(ref m)) if m.status == MissionStatus::Paused
-    );
-    if was_paused {
-        control
-            .mission_store
-            .update_mission_status(mission_id, MissionStatus::Interrupted)
-            .await
-            .map_err(internal_error)?;
-        // FLEET-004: leaving Paused clears the pause timestamp.
-        let _ = control
-            .mission_store
-            .set_mission_paused_at(mission_id, None)
-            .await;
-        let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
-            mission_id,
-            status: MissionStatus::Interrupted,
-            summary: None,
-        });
-    }
-
     let outcome: Result<Mission, (StatusCode, String)> = async {
         let (tx, rx) = oneshot::channel();
         control
@@ -8918,26 +8949,7 @@ pub async fn resume_mission(
     }
     .await;
 
-    match outcome {
-        Ok(mission) => Ok(Json(mission)),
-        Err(err) => {
-            // A failed resume must not leave a paused mission stranded in
-            // Interrupted: restore the operator-visible Paused state (best
-            // effort) before surfacing the error.
-            if was_paused {
-                let _ = control
-                    .mission_store
-                    .update_mission_status(mission_id, MissionStatus::Paused)
-                    .await;
-                let _ = control.events_tx.send(AgentEvent::MissionStatusChanged {
-                    mission_id,
-                    status: MissionStatus::Paused,
-                    summary: None,
-                });
-            }
-            Err(err)
-        }
-    }
+    outcome.map(Json)
 }
 
 /// Delete a mission by ID.
@@ -12655,11 +12667,15 @@ async fn control_actor_loop(
     ) -> Result<(Mission, String), String> {
         let mission = load_mission_record(mission_store, mission_id).await?;
 
-        // Check if mission can be resumed (interrupted, blocked, or failed)
+        // Check if mission can be resumed. Paused remains Paused until the
+        // actor has acquired the durable writer lock and accepted the resume.
         // Failed missions can be resumed to retry after transient errors (e.g., 529 overloaded)
         if !matches!(
             mission.status,
-            MissionStatus::Interrupted | MissionStatus::Blocked | MissionStatus::Failed
+            MissionStatus::Interrupted
+                | MissionStatus::Blocked
+                | MissionStatus::Failed
+                | MissionStatus::Paused
         ) {
             return Err(format!(
                 "Mission {} cannot be resumed (status: {})",
@@ -14309,7 +14325,13 @@ async fn control_actor_loop(
                         // resume has failed). Otherwise a create can race between the check
                         // and the status transition and start a second branch-changing
                         // runner for the same PR.
-                        let _pr_writer_guard = PR_WRITER_CREATE_LOCK.lock().await;
+                        let _pr_writer_guard = match acquire_durable_pr_writer_lock(&control_hub).await {
+                            Ok(guard) => guard,
+                            Err(error) => {
+                                let _ = respond.send(Err(error));
+                                continue;
+                            }
+                        };
                         // Resume an interrupted mission by building resume context
                         match resume_mission_impl(
                             &mission_store,
@@ -14347,11 +14369,38 @@ async fn control_actor_loop(
                                 // interrupted by the same service restart.
                                 if running.is_some() {
                                     if skip_message {
+                                        if mission.status == MissionStatus::Paused {
+                                            if let Err(error) = mission_store
+                                                .update_mission_status(
+                                                    mission_id,
+                                                    MissionStatus::Interrupted,
+                                                )
+                                                .await
+                                            {
+                                                let _ = respond.send(Err(error));
+                                                continue;
+                                            }
+                                            let _ = mission_store
+                                                .set_mission_paused_at(mission_id, None)
+                                                .await;
+                                            let _ = events_tx.send(
+                                                AgentEvent::MissionStatusChanged {
+                                                    mission_id,
+                                                    status: MissionStatus::Interrupted,
+                                                    summary: None,
+                                                },
+                                            );
+                                        }
                                         tracing::info!(
                                             mission_id = %mission_id,
                                             "Deferring parallel resume until the caller sends a custom message"
                                         );
-                                        let _ = respond.send(Ok(mission));
+                                        let mut updated_mission = mission;
+                                        if updated_mission.status == MissionStatus::Paused {
+                                            updated_mission.status = MissionStatus::Interrupted;
+                                            updated_mission.paused_at = None;
+                                        }
+                                        let _ = respond.send(Ok(updated_mission));
                                         continue;
                                     }
 
@@ -14423,6 +14472,11 @@ async fn control_actor_loop(
                                             e
                                         );
                                     } else {
+                                        if mission.status == MissionStatus::Paused {
+                                            let _ = mission_store
+                                                .set_mission_paused_at(mission_id, None)
+                                                .await;
+                                        }
                                         maybe_schedule_mission_metadata_refresh_for_status(
                                             &mission_store,
                                             &events_tx,
@@ -14467,6 +14521,11 @@ async fn control_actor_loop(
                                 {
                                     tracing::warn!("Failed to resume mission {}: {}", mission_id, e);
                                 } else {
+                                    if mission.status == MissionStatus::Paused {
+                                        let _ = mission_store
+                                            .set_mission_paused_at(mission_id, None)
+                                            .await;
+                                    }
                                     maybe_schedule_mission_metadata_refresh_for_status(
                                         &mission_store,
                                         &events_tx,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13412,7 +13412,68 @@ async fn control_actor_loop(
                                     let _ = respond.send(Err("Mission not currently executing".to_string()));
                                 }
                             } else {
-                                let _ = respond.send(Err(format!("Mission {} not found", mission_id)));
+                                // A mission can exist durably without owning a
+                                // runner yet (for example a scheduled/deferred
+                                // Pending mission). Cancellation must still
+                                // release it, otherwise deferred work and PR
+                                // writer leases can become impossible to clear.
+                                // Existing terminal rows are an idempotent
+                                // success so cleanup loops do not trip their
+                                // circuit breaker by cancelling twice.
+                                match mission_store.get_mission(mission_id).await {
+                                    Ok(Some(mission)) if mission.status == MissionStatus::Interrupted
+                                        || mission.status.is_terminal()
+                                        || mission.status == MissionStatus::Acknowledged =>
+                                    {
+                                        let _ = respond.send(Ok(()));
+                                    }
+                                    Ok(Some(_)) => {
+                                        let update = mission_store
+                                            .update_mission_status(
+                                                mission_id,
+                                                MissionStatus::Interrupted,
+                                            )
+                                            .await;
+                                        if let Err(error) = update {
+                                            let _ = respond.send(Err(error));
+                                            continue;
+                                        }
+                                        let _ = mission_store
+                                            .set_deferred_goal(mission_id, None)
+                                            .await;
+                                        let _ = events_tx.send(
+                                            AgentEvent::MissionStatusChanged {
+                                                mission_id,
+                                                status: MissionStatus::Interrupted,
+                                                summary: None,
+                                            },
+                                        );
+                                        close_mission_desktop_sessions(
+                                            &mission_store,
+                                            mission_id,
+                                            &config.working_dir,
+                                        )
+                                        .await;
+                                        cancel_child_missions(
+                                            mission_id,
+                                            &mission_store,
+                                            &mut parallel_runners,
+                                            &events_tx,
+                                            &config.working_dir,
+                                        )
+                                        .await;
+                                        let _ = respond.send(Ok(()));
+                                    }
+                                    Ok(None) => {
+                                        let _ = respond.send(Err(format!(
+                                            "Mission {} not found",
+                                            mission_id
+                                        )));
+                                    }
+                                    Err(error) => {
+                                        let _ = respond.send(Err(error));
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4945,6 +4945,10 @@ pub struct CreateMissionRequest {
     pub intent: Option<String>,
     /// Project tagging: associated GitHub PR ref (e.g. "owner/repo#123").
     pub github_pr: Option<String>,
+    /// Whether this mission may modify the associated PR branch. When omitted,
+    /// Sandboxed.sh infers writer intent from `intent`/`prompt`. At most one
+    /// non-terminal writer may own a PR at a time.
+    pub writer: Option<bool>,
     /// Project tagging: freeform tags.
     pub tags: Option<Vec<String>>,
     /// Track state, e.g. "waiting_ci" / "waiting_review" / "blocked_external".
@@ -5167,6 +5171,105 @@ fn fable_mandate_requests_integration(intent: Option<&str>, prompt: Option<&str>
     .any(|token| tokens.contains(token))
 }
 
+static PR_WRITER_CREATE_LOCK: std::sync::LazyLock<Mutex<()>> =
+    std::sync::LazyLock::new(|| Mutex::new(()));
+
+fn canonical_github_pr(raw: &str) -> String {
+    let mut value = raw.trim().trim_end_matches('/').to_ascii_lowercase();
+    for prefix in ["https://github.com/", "http://github.com/", "github.com/"] {
+        if let Some(stripped) = value.strip_prefix(prefix) {
+            value = stripped.to_string();
+            break;
+        }
+    }
+    value.replace("/pull/", "#")
+}
+
+fn inferred_pr_writer(explicit: Option<bool>, intent: Option<&str>, prompt: Option<&str>) -> bool {
+    if let Some(explicit) = explicit {
+        return explicit;
+    }
+    let text = format!(
+        "{} {}",
+        intent.unwrap_or_default(),
+        prompt.unwrap_or_default()
+    )
+    .to_ascii_lowercase();
+    let tokens: HashSet<&str> = text
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+    [
+        "write",
+        "edit",
+        "fix",
+        "repair",
+        "resolve",
+        "integrate",
+        "integration",
+        "rebase",
+        "merge",
+        "commit",
+        "push",
+        "implement",
+        "implementation",
+        "update",
+    ]
+    .iter()
+    .any(|token| tokens.contains(token))
+}
+
+fn status_holds_pr_writer_lease(status: MissionStatus) -> bool {
+    matches!(
+        status,
+        MissionStatus::Pending
+            | MissionStatus::Active
+            | MissionStatus::WaitingBackground
+            | MissionStatus::AwaitingUser
+            | MissionStatus::Paused
+    )
+}
+
+fn mission_is_pr_writer(mission: &Mission) -> bool {
+    if mission.project.tags.iter().any(|tag| tag == "pr-readonly") {
+        return false;
+    }
+    mission.project.tags.iter().any(|tag| tag == "pr-writer")
+        || inferred_pr_writer(
+            None,
+            mission.project.intent.as_deref(),
+            mission.history.first().map(|entry| entry.content.as_str()),
+        )
+}
+
+async fn find_existing_pr_writer(
+    store: &Arc<dyn MissionStore>,
+    github_pr: &str,
+) -> Result<Option<Mission>, String> {
+    const PAGE_SIZE: usize = 200;
+    let target = canonical_github_pr(github_pr);
+    let mut offset = 0;
+    loop {
+        let page = store.list_missions(PAGE_SIZE, offset).await?;
+        let page_len = page.len();
+        if let Some(mission) = page.into_iter().find(|mission| {
+            status_holds_pr_writer_lease(mission.status)
+                && mission
+                    .project
+                    .github_pr
+                    .as_deref()
+                    .is_some_and(|value| canonical_github_pr(value) == target)
+                && mission_is_pr_writer(mission)
+        }) {
+            return Ok(Some(mission));
+        }
+        if page_len < PAGE_SIZE {
+            return Ok(None);
+        }
+        offset += page_len;
+    }
+}
+
 pub async fn create_mission(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -5191,6 +5294,7 @@ pub async fn create_mission(
         track: None,
         intent: None,
         github_pr: None,
+        writer: None,
         tags: None,
         desired_state: None,
         next_check_at: None,
@@ -5376,6 +5480,17 @@ pub async fn create_mission(
         ));
     }
 
+    // Serialize create+metadata so two controllers cannot race through the
+    // preflight and create concurrent writers for the same PR.
+    let pr_writer_guard = if req.github_pr.as_deref().is_some_and(|github_pr| {
+        !github_pr.trim().is_empty()
+            && inferred_pr_writer(req.writer, req.intent.as_deref(), req.prompt.as_deref())
+    }) {
+        Some(PR_WRITER_CREATE_LOCK.lock().await)
+    } else {
+        None
+    };
+
     // Validate the remote-node payload before persisting the mission so a
     // bad request cannot leave an orphaned pending mission behind.
     let mut remote_node_id = req
@@ -5470,6 +5585,22 @@ pub async fn create_mission(
     }
 
     let control = control_for_user(&state, &user).await;
+    if let (Some(github_pr), Some(_guard)) = (req.github_pr.as_deref(), pr_writer_guard.as_ref()) {
+        if let Some(existing) = find_existing_pr_writer(&control.mission_store, github_pr)
+            .await
+            .map_err(internal_error)?
+        {
+            return Err((
+                StatusCode::CONFLICT,
+                format!(
+                    "PR writer lease is already held by mission {} (status={}); acknowledge, interrupt, or complete it before creating another writer for {}",
+                    existing.id,
+                    existing.status,
+                    canonical_github_pr(github_pr)
+                ),
+            ));
+        }
+    }
     control
         .cmd_tx
         .send(ControlCommand::CreateMission {
@@ -5508,12 +5639,28 @@ pub async fn create_mission(
     let github_pr = nonblank(&req.github_pr);
     let desired_state = nonblank(&req.desired_state);
     let next_check_at = nonblank(&req.next_check_at);
-    let tags: Option<Vec<String>> = req.tags.as_ref().map(|tags| {
+    let mut tags: Option<Vec<String>> = req.tags.as_ref().map(|tags| {
         tags.iter()
             .map(|t| t.trim().to_string())
             .filter(|t| !t.is_empty())
             .collect()
     });
+    if req
+        .github_pr
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        let capability =
+            if inferred_pr_writer(req.writer, req.intent.as_deref(), req.prompt.as_deref()) {
+                "pr-writer"
+            } else {
+                "pr-readonly"
+            };
+        let tags = tags.get_or_insert_with(Vec::new);
+        if !tags.iter().any(|tag| tag == capability) {
+            tags.push(capability.to_string());
+        }
+    }
     if project.is_some()
         || track.is_some()
         || intent.is_some()
@@ -8108,6 +8255,7 @@ pub async fn clone_mission(
         track: source.project.track.clone(),
         intent: source.project.intent.clone(),
         github_pr: source.project.github_pr.clone(),
+        writer: None,
         tags: if source.project.tags.is_empty() {
             None
         } else {
@@ -18781,6 +18929,38 @@ mod tests {
             .lock()
             .expect("metadata refresh baseline lock poisoned");
         baselines.clear();
+    }
+
+    #[test]
+    fn canonical_github_pr_equates_url_and_compact_forms() {
+        assert_eq!(
+            canonical_github_pr("https://github.com/lfglabs-dev/verity/pull/2168/"),
+            "lfglabs-dev/verity#2168"
+        );
+        assert_eq!(
+            canonical_github_pr("LFGLABS-DEV/VERITY#2168"),
+            "lfglabs-dev/verity#2168"
+        );
+    }
+
+    #[test]
+    fn pr_writer_inference_prefers_explicit_capability() {
+        assert!(inferred_pr_writer(None, Some("integration_repair"), None));
+        assert!(!inferred_pr_writer(
+            None,
+            Some("read_only_audit"),
+            Some("Inspect CI and report status")
+        ));
+        assert!(!inferred_pr_writer(
+            Some(false),
+            Some("review_merge_pr"),
+            None
+        ));
+        assert!(inferred_pr_writer(
+            Some(true),
+            Some("read_only_audit"),
+            None
+        ));
     }
 
     fn stored_test_event(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3354,6 +3354,7 @@ impl ControlHub {
             };
 
         let state = spawn_control_session(
+            self.clone(),
             self.config.clone(),
             Arc::clone(&self.root_agent),
             Arc::clone(&self.mcp),
@@ -3584,7 +3585,7 @@ pub async fn post_message(
                 let _guard = PR_WRITER_CREATE_LOCK.lock().await;
                 if let Some(github_pr) = mission.project.github_pr.as_deref() {
                     if let Some(existing) =
-                        find_existing_pr_writer_global(&state, github_pr, Some(mission.id))
+                        find_existing_pr_writer_global(&state.control, github_pr, Some(mission.id))
                             .await
                             .map_err(internal_error)?
                     {
@@ -5367,6 +5368,15 @@ fn requested_pr_writer(
         || inferred_pr_writer(None, intent, prompt)
 }
 
+fn normalize_mission_tags(tags: Option<&[String]>) -> Option<Vec<String>> {
+    tags.map(|tags| {
+        tags.iter()
+            .map(|tag| tag.trim().to_string())
+            .filter(|tag| !tag.is_empty())
+            .collect()
+    })
+}
+
 fn status_holds_pr_writer_lease(status: MissionStatus) -> bool {
     matches!(
         status,
@@ -5529,13 +5539,13 @@ fn find_existing_pr_writer_in_sqlite(
 }
 
 async fn find_existing_pr_writer_global(
-    state: &Arc<AppState>,
+    control_hub: &ControlHub,
     github_pr: &str,
     exclude_id: Option<Uuid>,
 ) -> Result<Option<PrWriterLease>, String> {
     // Fail closed if any persisted store cannot be enumerated or read. A
     // partial cross-user scan cannot prove that a branch is writer-free.
-    let inventory = state.control.mission_store_inventory().await?;
+    let inventory = control_hub.mission_store_inventory().await?;
     for store in inventory.live {
         if let Some(mission) = find_existing_pr_writer(&store, github_pr, exclude_id).await? {
             return Ok(Some(mission));
@@ -5564,7 +5574,7 @@ async fn find_existing_pr_writer_global(
 }
 
 async fn ensure_pr_writer_resume_is_exclusive(
-    store: &Arc<dyn MissionStore>,
+    control_hub: &ControlHub,
     mission: &Mission,
 ) -> Result<(), String> {
     if !mission_is_pr_writer(mission) {
@@ -5573,7 +5583,9 @@ async fn ensure_pr_writer_resume_is_exclusive(
     let Some(github_pr) = mission.project.github_pr.as_deref() else {
         return Ok(());
     };
-    if let Some(existing) = find_existing_pr_writer(store, github_pr, Some(mission.id)).await? {
+    if let Some(existing) =
+        find_existing_pr_writer_global(control_hub, github_pr, Some(mission.id)).await?
+    {
         return Err(format!(
             "PR writer lease is already held by mission {} (status={}); cannot resume mission {} as another writer for {}",
             existing.id,
@@ -5586,6 +5598,7 @@ async fn ensure_pr_writer_resume_is_exclusive(
 }
 
 async fn activate_mission_for_message(
+    control_hub: &ControlHub,
     store: &Arc<dyn MissionStore>,
     events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
     mission: &Mission,
@@ -5609,7 +5622,7 @@ async fn activate_mission_for_message(
     if _pr_writer_guard.is_some() {
         if let Some(github_pr) = mission.project.github_pr.as_deref() {
             if let Some(existing) =
-                find_existing_pr_writer(store, github_pr, Some(mission.id)).await?
+                find_existing_pr_writer_global(control_hub, github_pr, Some(mission.id)).await?
             {
                 return Err(format!(
                     "PR writer lease is already held by mission {} (status={}); cannot activate mission {} as another writer for {}",
@@ -5860,9 +5873,10 @@ pub async fn create_mission(
     // Writer creation is checked once before actor creation and again while
     // tagging the returned mission. Never hold this mutex while waiting on the
     // control actor: actor commands also acquire it when resuming writers.
+    let normalized_request_tags = normalize_mission_tags(req.tags.as_deref());
     let request_is_writer = requested_pr_writer(
         req.writer,
-        req.tags.as_deref(),
+        normalized_request_tags.as_deref(),
         req.intent.as_deref(),
         req.prompt.as_deref(),
     );
@@ -5968,7 +5982,7 @@ pub async fn create_mission(
     if request_needs_writer_lease {
         let _guard = PR_WRITER_CREATE_LOCK.lock().await;
         if let Some(github_pr) = req.github_pr.as_deref() {
-            if let Some(existing) = find_existing_pr_writer_global(&state, github_pr, None)
+            if let Some(existing) = find_existing_pr_writer_global(&state.control, github_pr, None)
                 .await
                 .map_err(internal_error)?
             {
@@ -6017,9 +6031,10 @@ pub async fn create_mission(
         None
     };
     if let (Some(github_pr), Some(_guard)) = (req.github_pr.as_deref(), pr_writer_guard.as_ref()) {
-        if let Some(existing) = find_existing_pr_writer_global(&state, github_pr, Some(mission.id))
-            .await
-            .map_err(internal_error)?
+        if let Some(existing) =
+            find_existing_pr_writer_global(&state.control, github_pr, Some(mission.id))
+                .await
+                .map_err(internal_error)?
         {
             let reason = "pr_writer_lease_conflict";
             control
@@ -6063,12 +6078,7 @@ pub async fn create_mission(
     let github_pr = nonblank(&req.github_pr);
     let desired_state = nonblank(&req.desired_state);
     let next_check_at = nonblank(&req.next_check_at);
-    let mut tags: Option<Vec<String>> = req.tags.as_ref().map(|tags| {
-        tags.iter()
-            .map(|t| t.trim().to_string())
-            .filter(|t| !t.is_empty())
-            .collect()
-    });
+    let mut tags = normalized_request_tags;
     if req
         .github_pr
         .as_deref()
@@ -7219,7 +7229,7 @@ pub async fn update_mission_project(
     };
     if let (Some(github_pr), Some(_guard)) = (effective_github_pr.as_deref(), writer_guard.as_ref())
     {
-        if let Some(existing) = find_existing_pr_writer_global(&state, github_pr, Some(id))
+        if let Some(existing) = find_existing_pr_writer_global(&state.control, github_pr, Some(id))
             .await
             .map_err(internal_error)?
         {
@@ -10124,6 +10134,7 @@ async fn paloma_webhook_forwarder_loop(
 /// Spawn the global control session actor.
 #[allow(clippy::too_many_arguments)]
 fn spawn_control_session(
+    control_hub: ControlHub,
     config: Config,
     root_agent: AgentRef,
     mcp: Arc<McpRegistry>,
@@ -10249,6 +10260,7 @@ fn spawn_control_session(
 
     // Spawn the main control actor
     tokio::spawn(control_actor_loop(
+        control_hub,
         config.clone(),
         root_agent,
         mcp,
@@ -12288,6 +12300,7 @@ async fn agent_finished_automation_messages(
     clippy::collapsible_else_if
 )]
 async fn control_actor_loop(
+    control_hub: ControlHub,
     config: Config,
     root_agent: AgentRef,
     mcp: Arc<McpRegistry>,
@@ -12957,6 +12970,7 @@ async fn control_actor_loop(
                                                 continue;
                                             }
                                             if let Err(error) = activate_mission_for_message(
+                                                &control_hub,
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
@@ -13086,6 +13100,7 @@ async fn control_actor_loop(
                                             );
                                         }
                                         if let Err(error) = activate_mission_for_message(
+                                            &control_hub,
                                             &mission_store,
                                             &events_tx,
                                             &mission,
@@ -13128,6 +13143,7 @@ async fn control_actor_loop(
                                                 history.push((entry.role.clone(), entry.content.clone()));
                                             }
                                             if let Err(error) = activate_mission_for_message(
+                                                &control_hub,
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
@@ -13165,6 +13181,7 @@ async fn control_actor_loop(
                                                 );
                                             }
                                             if let Err(error) = activate_mission_for_message(
+                                                &control_hub,
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
@@ -13285,6 +13302,7 @@ async fn control_actor_loop(
                                     match mission_store.get_mission(mid).await {
                                         Ok(Some(mission)) => {
                                             if let Err(error) = activate_mission_for_message(
+                                                &control_hub,
                                                 &mission_store,
                                                 &events_tx,
                                                 &mission,
@@ -14122,7 +14140,7 @@ async fn control_actor_loop(
                         .await {
                             Ok((mission, resume_prompt)) => {
                                 if let Err(error) = ensure_pr_writer_resume_is_exclusive(
-                                    &mission_store,
+                                    &control_hub,
                                     &mission,
                                 )
                                 .await
@@ -19569,6 +19587,15 @@ mod tests {
             Some(false),
             Some(&["pr-writer".to_string()]),
             Some("integration_repair"),
+            None
+        ));
+        let normalized =
+            normalize_mission_tags(Some(&[" pr-writer ".to_string(), " ".to_string()])).unwrap();
+        assert_eq!(normalized, ["pr-writer"]);
+        assert!(requested_pr_writer(
+            None,
+            Some(&normalized),
+            Some("read_only_audit"),
             None
         ));
     }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3580,8 +3580,7 @@ pub async fn post_message(
             .await
             .map_err(internal_error)?
         {
-            let already_writer = mission_is_pr_writer(&mission);
-            if already_writer || message_requests_pr_writer(&mission, &content) {
+            if mission_is_pr_writer(&mission) || message_requests_pr_writer(&mission, &content) {
                 let _guard = PR_WRITER_CREATE_LOCK.lock().await;
                 if let Some(github_pr) = mission.project.github_pr.as_deref() {
                     if let Some(existing) =
@@ -3600,22 +3599,6 @@ pub async fn post_message(
                             ),
                         ));
                     }
-                }
-                if !already_writer {
-                    let mut tags = mission.project.tags.clone();
-                    tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
-                    tags.push("pr-writer".to_string());
-                    control
-                        .mission_store
-                        .update_mission_project(
-                            mission.id,
-                            crate::api::mission_store::MissionProjectPatch {
-                                tags: Some(tags),
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                        .map_err(internal_error)?;
                 }
             }
         }
@@ -5405,12 +5388,10 @@ fn mission_is_pr_writer_with_prompt(mission: &Mission, prompt: Option<&str>) -> 
 
 fn message_requests_pr_writer(mission: &Mission, content: &str) -> bool {
     mission.project.github_pr.is_some()
-        && requested_pr_writer(
-            None,
-            Some(&mission.project.tags),
-            mission.project.intent.as_deref(),
-            Some(content),
-        )
+        // A follow-up message is a new capability request. A persisted
+        // `pr-readonly` tag describes the old mandate and must not suppress an
+        // explicit later instruction to fix/commit/push.
+        && inferred_pr_writer(None, None, Some(content))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -5618,10 +5599,6 @@ async fn activate_mission_for_message(
     mission: &Mission,
     content: &str,
 ) -> Result<(), String> {
-    if !message_activates_mission(mission.status) {
-        return Ok(());
-    }
-
     // A targeted message can resume terminal/acknowledged work without going
     // through the explicit resume endpoint. Reacquire the writer lease under
     // the same mutex as create/project/resume and keep it until Active is
@@ -5663,14 +5640,16 @@ async fn activate_mission_for_message(
         }
     }
 
-    store
-        .update_mission_status(mission.id, MissionStatus::Active)
-        .await?;
-    let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-        mission_id: mission.id,
-        status: MissionStatus::Active,
-        summary: None,
-    });
+    if message_activates_mission(mission.status) {
+        store
+            .update_mission_status(mission.id, MissionStatus::Active)
+            .await?;
+        let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+            mission_id: mission.id,
+            status: MissionStatus::Active,
+            summary: None,
+        });
+    }
     Ok(())
 }
 
@@ -12789,6 +12768,26 @@ async fn control_actor_loop(
                             }
                         }
 
+                        // Reject paused targets before writer capability is
+                        // acquired. Retagging a paused read-only audit for a
+                        // message that cannot run would create a phantom lease.
+                        if let Some(tid) = effective_target {
+                            if let Ok(Some(mission)) = mission_store.get_mission(tid).await {
+                                if mission.status == MissionStatus::Paused {
+                                    let _ = events_tx.send(AgentEvent::Error {
+                                        message: format!(
+                                            "Mission {} is paused; resume it before sending messages",
+                                            tid
+                                        ),
+                                        mission_id: Some(tid),
+                                        resumable: true,
+                                    });
+                                    let _ = respond.send(UserMessageAck::Dropped);
+                                    continue;
+                                }
+                            }
+                        }
+
                         // FLEET-001 scheduled-mission deferral: if the target is a
                         // Pending mission whose `not_before` is still in the future
                         // and it isn't already running, stash the goal and leave it
@@ -12852,6 +12851,28 @@ async fn control_actor_loop(
                         // Case 1: Target is already running in parallel_runners - queue to it
                         if let Some(tid) = effective_target {
                             if target_in_parallel {
+                                if let Ok(Some(mission)) = mission_store.get_mission(tid).await {
+                                    if let Err(error) = activate_mission_for_message(
+                                        &control_hub,
+                                        &mission_store,
+                                        &events_tx,
+                                        &mission,
+                                        &content,
+                                    )
+                                    .await
+                                    {
+                                        let _ = events_tx.send(AgentEvent::Error {
+                                            message: format!(
+                                                "Cannot apply writer lease for mission {}: {}",
+                                                tid, error
+                                            ),
+                                            mission_id: Some(tid),
+                                            resumable: true,
+                                        });
+                                        let _ = respond.send(UserMessageAck::Dropped);
+                                        continue;
+                                    }
+                                }
                                 if let Some(runner) = parallel_runners.get_mut(&tid) {
                                     let was_running = runner.is_running();
                                     runner.queue_message(id, content.clone(), msg_agent, source.clone());
@@ -13241,6 +13262,32 @@ async fn control_actor_loop(
                             Some(tid) => Some(tid),
                             None => *current_mission.read().await,
                         };
+                        if was_running {
+                            if let Some(tid) = target_mission_id {
+                                if let Ok(Some(mission)) = mission_store.get_mission(tid).await {
+                                    if let Err(error) = activate_mission_for_message(
+                                        &control_hub,
+                                        &mission_store,
+                                        &events_tx,
+                                        &mission,
+                                        &content,
+                                    )
+                                    .await
+                                    {
+                                        let _ = events_tx.send(AgentEvent::Error {
+                                            message: format!(
+                                                "Cannot apply writer lease for mission {}: {}",
+                                                tid, error
+                                            ),
+                                            mission_id: Some(tid),
+                                            resumable: true,
+                                        });
+                                        let _ = respond.send(UserMessageAck::Dropped);
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
                         queue.push_back((id, content, msg_agent, target_mission_id, source.clone()));
                         let status_mission_id = if running.is_some() {
                             running_mission_id

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5490,6 +5490,9 @@ fn find_existing_pr_writer_in_sqlite(
             "SELECT m.id, m.status, m.github_pr, m.intent, m.tags, m.deferred_goal, \
              (SELECT e.content FROM mission_events e \
               WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
+              ORDER BY e.sequence ASC LIMIT 1), \
+             (SELECT e.content_file FROM mission_events e \
+              WHERE e.mission_id = m.id AND e.event_type = 'user_message' \
               ORDER BY e.sequence ASC LIMIT 1) \
              FROM missions m WHERE m.github_pr IS NOT NULL",
         )
@@ -5504,12 +5507,13 @@ fn find_existing_pr_writer_in_sqlite(
                 row.get::<_, Option<String>>(4)?,
                 row.get::<_, Option<String>>(5)?,
                 row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
             ))
         })
         .map_err(|error| error.to_string())?;
     let target = canonical_github_pr(github_pr);
     for row in rows {
-        let (id, status, candidate_pr, intent, tags, deferred_goal, first_prompt) =
+        let (id, status, candidate_pr, intent, tags, deferred_goal, first_prompt, prompt_file) =
             row.map_err(|error| error.to_string())?;
         let Ok(id) = Uuid::parse_str(&id) else {
             continue;
@@ -5526,11 +5530,21 @@ fn find_existing_pr_writer_in_sqlite(
             .as_deref()
             .and_then(|value| serde_json::from_str(value).ok())
             .unwrap_or_default();
+        let external_prompt = match (first_prompt.as_deref(), prompt_file.as_deref()) {
+            (None, Some(path)) => Some(
+                std::fs::read_to_string(path)
+                    .map_err(|error| format!("read externalized mission prompt {path}: {error}"))?,
+            ),
+            _ => None,
+        };
         if requested_pr_writer(
             None,
             Some(&tags),
             intent.as_deref(),
-            first_prompt.as_deref().or(deferred_goal.as_deref()),
+            first_prompt
+                .as_deref()
+                .or(external_prompt.as_deref())
+                .or(deferred_goal.as_deref()),
         ) {
             return Ok(Some(PrWriterLease { id, status }));
         }
@@ -19612,7 +19626,8 @@ mod tests {
                     intent TEXT, tags TEXT, deferred_goal TEXT
                  );
                  CREATE TABLE mission_events (
-                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT
+                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT,
+                    content_file TEXT
                  );",
             )
             .unwrap();
@@ -19633,6 +19648,51 @@ mod tests {
 
         assert_eq!(found.id, mission_id);
         assert_eq!(found.status, MissionStatus::Pending);
+    }
+
+    #[test]
+    fn offline_sqlite_writer_scan_reads_externalized_initial_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions-offline.db");
+        let prompt_path = dir.path().join("initial-prompt.txt");
+        std::fs::write(&prompt_path, "Fix this PR, commit and push").unwrap();
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (
+                    id TEXT PRIMARY KEY, status TEXT, github_pr TEXT,
+                    intent TEXT, tags TEXT, deferred_goal TEXT
+                 );
+                 CREATE TABLE mission_events (
+                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT,
+                    content_file TEXT
+                 );",
+            )
+            .unwrap();
+        let mission_id = Uuid::new_v4();
+        connection
+            .execute(
+                "INSERT INTO missions (id, status, github_pr, intent, tags, deferred_goal)
+                 VALUES (?1, 'active', ?2, NULL, '[]', NULL)",
+                rusqlite::params![mission_id.to_string(), "owner/repo#43"],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO mission_events
+                 (mission_id, sequence, event_type, content, content_file)
+                 VALUES (?1, 1, 'user_message', NULL, ?2)",
+                rusqlite::params![mission_id.to_string(), prompt_path.to_string_lossy()],
+            )
+            .unwrap();
+        drop(connection);
+
+        let found = find_existing_pr_writer_in_sqlite(&path, "owner/repo#43", None)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(found.id, mission_id);
+        assert_eq!(found.status, MissionStatus::Active);
     }
 
     fn stored_test_event(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7366,14 +7366,22 @@ pub async fn update_mission_project(
         .get_initial_user_message(id)
         .await
         .map_err(internal_error)?;
-    let writer_prompt = initial_prompt.as_deref().or(deferred_goal.as_deref());
-    let becomes_writer = effective_github_pr.is_some()
-        && requested_pr_writer(
+    let initial_prompt_requests_writer = requested_pr_writer(
+        req.writer,
+        Some(&effective_tags),
+        effective_intent.as_deref(),
+        initial_prompt.as_deref(),
+    );
+    let deferred_goal_requests_writer = deferred_goal.as_deref().is_some_and(|goal| {
+        requested_pr_writer(
             req.writer,
             Some(&effective_tags),
             effective_intent.as_deref(),
-            writer_prompt,
-        );
+            Some(goal),
+        )
+    });
+    let becomes_writer = effective_github_pr.is_some()
+        && (initial_prompt_requests_writer || deferred_goal_requests_writer);
     if becomes_writer {
         effective_tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
         effective_tags.push("pr-writer".to_string());

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -3582,7 +3582,11 @@ pub async fn post_message(
             .await
             .map_err(internal_error)?
         {
-            if mission_is_pr_writer(&mission) || message_requests_pr_writer(&mission, &content) {
+            if mission_is_pr_writer_in_store(&control.mission_store, &mission)
+                .await
+                .map_err(internal_error)?
+                || message_requests_pr_writer(&mission, &content)
+            {
                 let _guard = acquire_durable_pr_writer_lock(&state.control)
                     .await
                     .map_err(internal_error)?;
@@ -5443,6 +5447,17 @@ fn mission_is_pr_writer_with_prompt(mission: &Mission, prompt: Option<&str>) -> 
         || inferred_pr_writer(None, mission.project.intent.as_deref(), prompt)
 }
 
+async fn mission_is_pr_writer_in_store(
+    store: &Arc<dyn MissionStore>,
+    mission: &Mission,
+) -> Result<bool, String> {
+    let initial_prompt = store.get_initial_user_message(mission.id).await?;
+    Ok(mission_is_pr_writer_with_prompt(
+        mission,
+        initial_prompt.as_deref(),
+    ))
+}
+
 fn message_requests_pr_writer(mission: &Mission, content: &str) -> bool {
     mission.project.github_pr.is_some()
         // A follow-up message is a new capability request. A persisted
@@ -5636,9 +5651,9 @@ fn find_existing_pr_writer_in_sqlite(
                 .or(external_prompt.as_deref())
                 .or(deferred_goal.as_deref()),
         );
-        let deferred_goal_requests_writer = deferred_goal
-            .as_deref()
-            .is_some_and(|goal| inferred_pr_writer(None, None, Some(goal)));
+        let deferred_goal_requests_writer = deferred_goal.as_deref().is_some_and(|goal| {
+            requested_pr_writer(None, Some(&tags), intent.as_deref(), Some(goal))
+        });
         if initial_prompt_requests_writer || deferred_goal_requests_writer {
             return Ok(Some(PrWriterLease { id, status }));
         }
@@ -5683,9 +5698,10 @@ async fn find_existing_pr_writer_global(
 
 async fn ensure_pr_writer_resume_is_exclusive(
     control_hub: &ControlHub,
+    store: &Arc<dyn MissionStore>,
     mission: &Mission,
 ) -> Result<(), String> {
-    if !mission_is_pr_writer(mission) {
+    if !mission_is_pr_writer_in_store(store, mission).await? {
         return Ok(());
     }
     let Some(github_pr) = mission.project.github_pr.as_deref() else {
@@ -5741,8 +5757,8 @@ async fn acquire_pr_writer_lease_for_message(
     mission: &Mission,
     content: &str,
 ) -> Result<Option<MessageWriterLeaseGuard>, String> {
-    let becomes_writer =
-        mission_is_pr_writer(mission) || message_requests_pr_writer(mission, content);
+    let was_writer = mission_is_pr_writer_in_store(store, mission).await?;
+    let becomes_writer = was_writer || message_requests_pr_writer(mission, content);
     if !becomes_writer {
         return Ok(None);
     }
@@ -5762,7 +5778,7 @@ async fn acquire_pr_writer_lease_for_message(
         }
     }
 
-    let retagged = !mission_is_pr_writer(mission);
+    let retagged = !was_writer;
     if retagged {
         let mut tags = mission.project.tags.clone();
         tags.retain(|tag| tag != "pr-readonly" && tag != "pr-writer");
@@ -14401,6 +14417,7 @@ async fn control_actor_loop(
                             Ok((mission, resume_prompt)) => {
                                 if let Err(error) = ensure_pr_writer_resume_is_exclusive(
                                     &control_hub,
+                                    &mission_store,
                                     &mission,
                                 )
                                 .await
@@ -19935,6 +19952,55 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn durable_writer_classification_survives_history_projection() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn MissionStore> = Arc::new(
+            mission_store::SqliteMissionStore::new(dir.path().to_path_buf(), "long-writer")
+                .await
+                .unwrap(),
+        );
+        let mission = store
+            .create_mission(Some("Legacy writer"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        store
+            .update_mission_project(
+                mission.id,
+                MissionProjectPatch {
+                    github_pr: Some(Some("owner/repo#46".to_string())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        for index in 0..206 {
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::UserMessage {
+                        id: Uuid::new_v4(),
+                        content: if index == 0 {
+                            "Fix, commit and push this PR".to_string()
+                        } else {
+                            format!("neutral follow-up {index}")
+                        },
+                        queued: false,
+                        mission_id: Some(mission.id),
+                        source: None,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let projected = store.get_mission(mission.id).await.unwrap().unwrap();
+        assert_eq!(projected.history.len(), 200);
+        assert!(!mission_is_pr_writer(&projected));
+        assert!(mission_is_pr_writer_in_store(&store, &projected)
+            .await
+            .unwrap());
+    }
+
     #[test]
     fn offline_sqlite_writer_scan_reads_deferred_goal_without_migrations() {
         let dir = tempfile::tempdir().unwrap();
@@ -19977,6 +20043,40 @@ mod tests {
 
         assert_eq!(found.id, mission_id);
         assert_eq!(found.status, MissionStatus::Pending);
+    }
+
+    #[test]
+    fn offline_sqlite_writer_scan_respects_readonly_deferred_goal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missions-readonly.db");
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE missions (
+                    id TEXT PRIMARY KEY, status TEXT, github_pr TEXT,
+                    intent TEXT, tags TEXT, deferred_goal TEXT
+                 );
+                 CREATE TABLE mission_events (
+                    mission_id TEXT, sequence INTEGER, event_type TEXT, content TEXT,
+                    content_file TEXT
+                 );",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO missions (id, status, github_pr, intent, tags, deferred_goal)
+                 VALUES (?1, 'pending', 'owner/repo#45', NULL, '[\"pr-readonly\"]',
+                         'Fix and update the PR after review')",
+                rusqlite::params![Uuid::new_v4().to_string()],
+            )
+            .unwrap();
+        drop(connection);
+
+        assert!(
+            find_existing_pr_writer_in_sqlite(&path, "owner/repo#45", None)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1476,6 +1476,18 @@ pub trait MissionStore: Send + Sync {
     /// Get a single mission by ID.
     async fn get_mission(&self, id: Uuid) -> Result<Option<Mission>, String>;
 
+    /// Load the oldest persisted user message without applying the history
+    /// projection/window used by `get_mission`.
+    async fn get_initial_user_message(&self, id: Uuid) -> Result<Option<String>, String> {
+        Ok(self.get_mission(id).await?.and_then(|mission| {
+            mission
+                .history
+                .into_iter()
+                .find(|entry| entry.role == "user")
+                .map(|entry| entry.content)
+        }))
+    }
+
     /// Create a new mission.
     async fn create_mission(
         &self,

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -2782,6 +2782,38 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn get_initial_user_message(&self, id: Uuid) -> Result<Option<String>, String> {
+        let conn = self.conn.clone();
+        let id_str = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let row = conn
+                .query_row(
+                    "SELECT content, content_file FROM mission_events
+                     WHERE mission_id = ?1 AND event_type = 'user_message'
+                     ORDER BY sequence ASC LIMIT 1",
+                    params![id_str],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(|error| error.to_string())?;
+            match row {
+                Some((Some(content), _)) => Ok(Some(content)),
+                Some((None, Some(path))) => std::fs::read_to_string(&path)
+                    .map(Some)
+                    .map_err(|error| format!("read initial mission prompt {path}: {error}")),
+                _ => Ok(None),
+            }
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
     async fn create_mission_with_parent(
         &self,
         title: Option<&str>,
@@ -14755,5 +14787,59 @@ mod tests {
             .await
             .expect("list")
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn initial_user_message_is_not_lost_beyond_history_window() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("Long mission"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+        for index in 0..206 {
+            let content = if index == 0 {
+                "Fix, commit and push the original PR".to_string()
+            } else {
+                format!("later message {index}")
+            };
+            store
+                .log_event(
+                    mission.id,
+                    &AgentEvent::UserMessage {
+                        id: Uuid::new_v4(),
+                        content,
+                        queued: false,
+                        mission_id: Some(mission.id),
+                        source: None,
+                    },
+                )
+                .await
+                .expect("persist user event");
+        }
+
+        let projected = store
+            .get_mission(mission.id)
+            .await
+            .expect("get mission")
+            .expect("mission exists");
+        assert_eq!(projected.history.len(), 200);
+        assert_ne!(
+            projected
+                .history
+                .first()
+                .map(|entry| entry.content.as_str()),
+            Some("Fix, commit and push the original PR")
+        );
+        assert_eq!(
+            store
+                .get_initial_user_message(mission.id)
+                .await
+                .expect("initial prompt")
+                .as_deref(),
+            Some("Fix, commit and push the original PR")
+        );
     }
 }

--- a/src/api/supervision/bg_autoresume.rs
+++ b/src/api/supervision/bg_autoresume.rs
@@ -561,6 +561,15 @@ pub(crate) async fn background_task_autoresume_loop(
                     );
                     continue;
                 }
+                Ok(UserMessageAck::Rejected(reason)) => {
+                    tracing::warn!(
+                        mission_id = %mission_id,
+                        task = %task.id,
+                        reason = %reason,
+                        "bg-autoresume: resume rejected; preserving task for retry"
+                    );
+                    continue;
+                }
                 Ok(_) => {
                     tracing::info!(
                         mission_id = %mission_id,

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -150,6 +150,8 @@ struct StartMissionParams {
     #[serde(default)]
     github_pr: Option<String>,
     #[serde(default)]
+    writer: Option<bool>,
+    #[serde(default)]
     tags: Option<Vec<String>>,
     #[serde(default)]
     desired_state: Option<String>,
@@ -817,7 +819,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "start_mission".to_string(),
-                description: "Create a new sandboxed.sh mission and send its initial prompt. Set backend explicitly when possible. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title).".to_string(),
+                description: "Create a new sandboxed.sh mission and send its initial prompt. Set backend explicitly when possible. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title). Mark PR-changing work with writer=true; the API rejects concurrent writers for the same PR.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["title", "prompt"],
@@ -834,6 +836,7 @@ impl AssistantMcp {
                         "track": {"type": "string", "description": "Track/workstream (e.g. \"core-c3\")."},
                         "intent": {"type": "string", "description": "Intent (e.g. \"review_merge_pr\")."},
                         "github_pr": {"type": "string", "description": "Associated PR ref (e.g. \"owner/repo#123\")."},
+                        "writer": {"type": "boolean", "description": "Whether this mission may modify the associated PR branch. Concurrent writers for one PR are rejected."},
                         "tags": {"type": "array", "items": {"type": "string"}},
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
                         "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."}
@@ -1300,6 +1303,7 @@ impl AssistantMcp {
             "track": params.track,
             "intent": params.intent,
             "github_pr": params.github_pr,
+            "writer": params.writer,
             "tags": params.tags,
             "desired_state": params.desired_state,
             "next_check_at": params.next_check_at,

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -695,18 +695,22 @@ mod tests {
                 .await
                 .unwrap();
         }
-        for _ in 0..100 {
-            if matches!(
-                store.get(running).await.unwrap().map(|record| record.state),
-                Some(JobState::Running)
-            ) && matches!(
-                store.get(queued).await.unwrap().map(|record| record.state),
-                Some(JobState::Queued)
-            ) {
-                break;
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if matches!(
+                    store.get(running).await.unwrap().map(|record| record.state),
+                    Some(JobState::Running)
+                ) && matches!(
+                    store.get(queued).await.unwrap().map(|record| record.state),
+                    Some(JobState::Queued)
+                ) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
             }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
+        })
+        .await
+        .expect("first job should start while the second remains queued");
 
         assert_eq!(runner.queued_count(), 1);
         assert!(runner.cancel(queued).await.unwrap());


### PR DESCRIPTION
Adds an API-level single-writer lease for GitHub PR missions so competing Hermes controllers cannot launch two branch-changing workers for the same PR.\n\n- canonicalizes PR URLs and owner/repo#number refs\n- adds an explicit writer capability to the API and assistant MCP\n- infers legacy writer intent for backward compatibility\n- persists pr-writer/pr-readonly tags\n- rejects conflicting active/pending/paused/awaiting writers with HTTP 409\n- serializes create+metadata to close concurrent request races\n\nValidation: cargo fmt --all, focused unit tests, cargo check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to mission lifecycle (create, message, resume, cancel) and cross-store locking; incorrect lease logic could block legitimate PR work or allow concurrent writers.
> 
> **Overview**
> Introduces a **single-writer lease per GitHub PR** so only one non-terminal mission may branch-changing work on a given PR at a time, including across Hermes controllers and persisted mission stores.
> 
> **Lease mechanics:** PR refs are **canonicalized** (URLs vs `owner/repo#n`). Missions get an explicit **`writer`** flag on create/update (and MCP `start_mission`), with **`pr-writer` / `pr-readonly`** tags and **keyword inference** on intent/prompt/deferred goals for legacy behavior. **`get_initial_user_message`** on SQLite avoids misclassifying writers when history is windowed.
> 
> **Enforcement:** A **process + flock** lock (`.pr-writer.lock`) serializes checks; **`mission_store_inventory`** scans live sessions plus offline SQLite/legacy file stores (read-only SQLite scan for cross-process safety). Conflicts return **HTTP 409** on create, project update, and control messages; duplicate creates can be **interrupted** after a post-create race. The control actor acquires leases before activating missions or stashing deferred goals, rolls back `pr-writer` tags on failed deferral, and **`UserMessageAck::Rejected(String)`** surfaces lease failures to sync callers (Ask steering, bg-autoresume) instead of only SSE.
> 
> **Related behavior:** Resume allows **Paused** missions and holds the writer lock through resume-to-Active; HTTP resume no longer pre-flips Paused→Interrupted. **Cancel** can interrupt missions with no in-memory runner (clears deferred goals). Node runner test uses a timeout instead of a fixed poll loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2458ebabb96d2a43ced2d5a1fcb1d3235c0b2d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->