### PR TITLE
Distribute Lean builds across remote runners

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -300,7 +300,7 @@ A node is eligible when all of the following hold:
   requirement
 - `disk_available` ≥ `REMOTE_NODE_MIN_DISK_GB` (default 20)
 - `mem_available` ≥ `REMOTE_NODE_MIN_MEM_GB` (default 8)
-- `active_jobs + queued_jobs < 2 * capacity_total`
+- `active_jobs + queued_jobs + active_leases + core reservations < 2 * capacity_total`
 
 Eligible nodes are ranked least-loaded first (ties broken by most available
 memory). When no node qualifies the request **fails closed** with every
@@ -317,6 +317,11 @@ token, domain-separated with a `remote-build:` prefix), injected into
 harness envs as `REMOTE_BUILD_URL` / `REMOTE_BUILD_TOKEN` /
 `REMOTE_BUILD_MISSION_ID` whenever remote nodes (or spark offload) are
 enabled. Node bearer tokens never enter the workspace.
+
+Mission preparation also installs `remote-lean-build` and exports its exact
+path as `REMOTE_BUILD_COMMAND`. Container missions receive it in
+`/usr/local/bin`; host missions receive an isolated copy under the mission
+directory, which is prepended to `PATH`.
 
 Request body:
 
@@ -372,6 +377,24 @@ remote-lean-build || { [ $? -eq 75 ] && lake build; }
 
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
 node's `SANDBOXED_NODE_MAX_JOB_SECS`).
+
+Workspace configuration can pin the placement policy without exposing node
+credentials:
+
+```json
+{
+  "remote_build": {
+    "node_id": "auto",
+    "requirements": ["lean"],
+    "timeout_secs": 3600
+  }
+}
+```
+
+Auto placement combines heartbeat load with durable core-side reservations,
+and placement plus reservation is serialized. Concurrent requests therefore
+spread across eligible runners before their next heartbeat instead of all
+selecting the same apparently idle node.
 
 ## Core Configuration
 

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -11,6 +11,8 @@
 #   REMOTE_BUILD_URL         host endpoint, e.g. http://10.88.0.1:3000/api/remote-build
 #   REMOTE_BUILD_TOKEN       per-mission capability token
 #   REMOTE_BUILD_MISSION_ID  mission UUID
+#   REMOTE_BUILD_NODE_ID     explicit runner id or "auto" (default)
+#   REMOTE_BUILD_REQUIREMENTS JSON array of runner labels (default: ["lean"])
 #
 # Exit codes:
 #   remote build's exit code on success/failure of the build itself
@@ -59,6 +61,19 @@ if cwd_rel:
 timeout = os.environ.get("REMOTE_BUILD_TIMEOUT_SECS")
 if timeout:
     req["timeout_secs"] = int(timeout)
+node_id = os.environ.get("REMOTE_BUILD_NODE_ID", "auto").strip()
+if node_id:
+    req["node_id"] = node_id
+requirements_raw = os.environ.get("REMOTE_BUILD_REQUIREMENTS", '["lean"]')
+try:
+    requirements = json.loads(requirements_raw)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"REMOTE_BUILD_REQUIREMENTS is not valid JSON: {exc}")
+if not isinstance(requirements, list) or not all(
+    isinstance(item, str) and item.strip() for item in requirements
+):
+    raise SystemExit("REMOTE_BUILD_REQUIREMENTS must be a JSON array of non-empty strings")
+req["requirements"] = requirements
 print(json.dumps(req))
 PY
 )" || die "failed to encode request"

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -13,7 +13,8 @@
 //! qualifies, so the in-workspace `remote-lean-build` wrapper can fall back
 //! to a local build (exit 75).
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use axum::{
@@ -239,6 +240,27 @@ fn should_reprobe_after_placement_failure(_status: Option<&RemoteNodeStatus>) ->
     true
 }
 
+fn placement_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
+    match crate::remote_node::job_ledger::load(&state.config.working_dir).await {
+        Ok(handles) => {
+            let mut reservations = HashMap::new();
+            for handle in handles {
+                *reservations.entry(handle.node_id).or_insert(0) += 1;
+            }
+            reservations
+        }
+        Err(error) => {
+            tracing::warn!(?error, "remote job reservations could not be loaded");
+            HashMap::new()
+        }
+    }
+}
+
 /// Resolve the target node: explicit id or capacity-aware auto placement.
 /// All misses map to `503` so the wrapper can fall back to a local build —
 /// except an explicitly named unknown node, which is a caller bug (`400`).
@@ -255,7 +277,10 @@ async fn resolve_node(
         ));
     }
     if node_id.eq_ignore_ascii_case("auto") {
-        let first = state.fleet.place_auto(settings, requirements);
+        let reservations = core_side_reservations(state).await;
+        let first = state
+            .fleet
+            .place_auto_with_reservations(settings, requirements, &reservations);
         let picked = match first {
             Ok(picked) => picked,
             Err(initial_err) => {
@@ -284,9 +309,10 @@ async fn resolve_node(
                         .map(|node| crate::remote_node::probe_node(&state.fleet, &client, node)),
                 )
                 .await;
+                let reservations = core_side_reservations(state).await;
                 state
                     .fleet
-                    .place_auto(settings, requirements)
+                    .place_auto_with_reservations(settings, requirements, &reservations)
                     .map_err(|err| (StatusCode::SERVICE_UNAVAILABLE, err.to_string()))?
             }
         };
@@ -405,6 +431,9 @@ async fn submit_remote_build(
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
     }
 
+    // Serialize placement through tentative-handle persistence. Otherwise a
+    // burst can select the same idle node before its next heartbeat.
+    let placement_guard = placement_lock().lock().await;
     let node = match resolve_node(&state, &req.node_id, &req.requirements).await {
         Ok(node) => node,
         Err((status, message)) => return (status, message).into_response(),
@@ -464,6 +493,7 @@ async fn submit_remote_build(
         )
             .into_response();
     }
+    drop(placement_guard);
     let accepted = match client.submit_job(&node, &shared_token, &submit).await {
         Ok(accepted) => accepted,
         Err(err) => {

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -243,6 +243,26 @@ pub fn select_node_auto(
     min_disk_bytes: u64,
     min_mem_bytes: u64,
 ) -> Result<String, PlacementError> {
+    select_node_auto_with_reservations(
+        nodes,
+        statuses,
+        requirements,
+        min_disk_bytes,
+        min_mem_bytes,
+        &HashMap::new(),
+    )
+}
+
+/// Capacity-aware placement that also counts jobs accepted by the core but
+/// not yet reflected in the nodes' periodic heartbeats.
+pub fn select_node_auto_with_reservations(
+    nodes: &[RemoteNodeConfig],
+    statuses: &HashMap<String, CachedNodeStatus>,
+    requirements: &[String],
+    min_disk_bytes: u64,
+    min_mem_bytes: u64,
+    reservations: &HashMap<String, u32>,
+) -> Result<String, PlacementError> {
     let mut reasons: Vec<(String, String)> = Vec::new();
     let mut eligible: Vec<(u32, u64, String)> = Vec::new(); // (load, mem_avail, id)
     for node in nodes {
@@ -296,7 +316,8 @@ pub fn select_node_auto(
         let load = heartbeat
             .active_jobs
             .saturating_add(heartbeat.queued_jobs)
-            .saturating_add(heartbeat.active_leases);
+            .saturating_add(heartbeat.active_leases)
+            .saturating_add(reservations.get(&node.id).copied().unwrap_or(0));
         if load >= heartbeat.capacity_total.saturating_mul(2) {
             reasons.push((
                 node.id.clone(),
@@ -327,13 +348,25 @@ impl FleetMonitor {
         settings: &RemoteNodeSettings,
         requirements: &[String],
     ) -> Result<String, PlacementError> {
+        self.place_auto_with_reservations(settings, requirements, &HashMap::new())
+    }
+
+    /// Like [`Self::place_auto`], with accepted jobs that may not have reached
+    /// the latest node heartbeat yet.
+    pub fn place_auto_with_reservations(
+        &self,
+        settings: &RemoteNodeSettings,
+        requirements: &[String],
+        reservations: &HashMap<String, u32>,
+    ) -> Result<String, PlacementError> {
         let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
-        select_node_auto(
+        select_node_auto_with_reservations(
             &settings.nodes,
             &statuses,
             requirements,
             env_gb_bytes("REMOTE_NODE_MIN_DISK_GB", DEFAULT_MIN_DISK_GB),
             env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
+            reservations,
         )
     }
 }
@@ -712,6 +745,31 @@ mod tests {
         let picked =
             select_node_auto(&[node_config("e")], &statuses, &[], 20 * GIB, 8 * GIB).unwrap();
         assert_eq!(picked, "e");
+    }
+
+    #[test]
+    fn placement_counts_core_side_reservations_before_heartbeat_catches_up() {
+        let nodes = vec![node_config("a"), node_config("b")];
+        let mut statuses = HashMap::new();
+        statuses.insert(
+            "a".to_string(),
+            cached_online("a", &["lean"], 100, 64, 4, 0, 0),
+        );
+        statuses.insert(
+            "b".to_string(),
+            cached_online("b", &["lean"], 100, 32, 4, 0, 0),
+        );
+        let reservations = HashMap::from([("a".to_string(), 1)]);
+        let picked = select_node_auto_with_reservations(
+            &nodes,
+            &statuses,
+            &["lean".to_string()],
+            20 * GIB,
+            8 * GIB,
+            &reservations,
+        )
+        .unwrap();
+        assert_eq!(picked, "b");
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -359,6 +359,56 @@ impl Workspace {
             "REMOTE_BUILD_MISSION_ID".to_string(),
             mission_id.to_string(),
         );
+        let remote_config = self.config.get("remote_build");
+        let node_id = remote_config
+            .and_then(|config| config.get("node_id"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("auto");
+        m.insert("REMOTE_BUILD_NODE_ID".to_string(), node_id.to_string());
+        let requirements = remote_config
+            .and_then(|config| config.get("requirements"))
+            .and_then(|value| value.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str())
+                    .filter(|item| !item.trim().is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|items| !items.is_empty())
+            .unwrap_or_else(|| vec!["lean"]);
+        m.insert(
+            "REMOTE_BUILD_REQUIREMENTS".to_string(),
+            serde_json::to_string(&requirements).ok()?,
+        );
+        if let Some(timeout) = remote_config
+            .and_then(|config| config.get("timeout_secs"))
+            .and_then(|value| value.as_u64())
+        {
+            m.insert("REMOTE_BUILD_TIMEOUT_SECS".to_string(), timeout.to_string());
+        }
+        let wrapper = remote_build_wrapper_path(self, mission_id);
+        m.insert(
+            "REMOTE_BUILD_COMMAND".to_string(),
+            wrapper.to_string_lossy().to_string(),
+        );
+        let existing_path = self
+            .env_vars
+            .get("PATH")
+            .cloned()
+            .or_else(|| {
+                (self.workspace_type != WorkspaceType::Container)
+                    .then(|| std::env::var("PATH").ok())
+                    .flatten()
+            })
+            .unwrap_or_else(|| "/usr/local/bin:/usr/bin:/bin".to_string());
+        if let Some(parent) = wrapper.parent() {
+            m.insert(
+                "PATH".to_string(),
+                format!("{}:{existing_path}", parent.display()),
+            );
+        }
         Some(m)
     }
 
@@ -1963,6 +2013,40 @@ async fn prepare_workspace_dir(path: &Path) -> anyhow::Result<PathBuf> {
     Ok(path.to_path_buf())
 }
 
+fn remote_build_wrapper_path(workspace: &Workspace, mission_id: Uuid) -> PathBuf {
+    if workspace.workspace_type == WorkspaceType::Container && !is_container_fallback(workspace) {
+        PathBuf::from("/usr/local/bin/remote-lean-build")
+    } else {
+        mission_workspace_dir_for_root(&workspace.path, mission_id)
+            .join(".sandboxed-sh/bin/remote-lean-build")
+    }
+}
+
+async fn install_remote_build_wrapper(
+    workspace: &Workspace,
+    mission_id: Uuid,
+) -> anyhow::Result<()> {
+    let destination = if workspace.workspace_type == WorkspaceType::Container
+        && !is_container_fallback(workspace)
+    {
+        workspace.path.join("usr/local/bin/remote-lean-build")
+    } else {
+        remote_build_wrapper_path(workspace, mission_id)
+    };
+    if let Some(parent) = destination.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp = destination.with_extension(format!("tmp-{}-{mission_id}", std::process::id()));
+    tokio::fs::write(&tmp, include_bytes!("../../scripts/remote-lean-build")).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)).await?;
+    }
+    tokio::fs::rename(&tmp, &destination).await?;
+    Ok(())
+}
+
 /// Filter MCP configs based on a workspace's MCP allowlist.
 ///
 /// - Empty `workspace_mcps` → include only MCPs with `default_enabled = true`
@@ -2045,6 +2129,7 @@ pub async fn prepare_mission_workspace_in(
     // can run concurrently without clobbering per-workspace config files.
     let dir = mission_workspace_dir_for_root(&workspace.path, mission_id);
     prepare_workspace_dir(&dir).await?;
+    install_remote_build_wrapper(workspace, mission_id).await?;
     let mcp_configs = filter_mcp_configs_for_workspace(
         mcp.list_configs().await,
         &workspace.mcps,
@@ -2151,6 +2236,7 @@ pub async fn prepare_mission_workspace_with_skills_backend(
     // This keeps filesystem and config effects scoped to the mission.
     let dir = mission_workspace_dir_for_root(&workspace.path, mission_id);
     prepare_workspace_dir(&dir).await?;
+    install_remote_build_wrapper(workspace, mission_id).await?;
 
     // Get custom providers: use provided list or read from file
     let providers_from_file;
@@ -3541,6 +3627,37 @@ pub async fn read_sandboxed_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn remote_build_wrapper_is_mission_scoped_and_executable_for_host_workspaces() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let workspace = Workspace::default_host(root.path().to_path_buf());
+
+        install_remote_build_wrapper(&workspace, mission_id)
+            .await
+            .unwrap();
+
+        let path = remote_build_wrapper_path(&workspace, mission_id);
+        assert!(path.starts_with(mission_workspace_dir_for_root(root.path(), mission_id)));
+        assert_eq!(
+            tokio::fs::read(&path).await.unwrap(),
+            include_bytes!("../../scripts/remote-lean-build")
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_ne!(
+                tokio::fs::metadata(path)
+                    .await
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o111,
+                0
+            );
+        }
+    }
     use serde_json::json;
 
     #[test]


### PR DESCRIPTION
Summary:\n- install remote-lean-build in every mission workspace and expose workspace placement settings\n- serialize placement and count durable core-side reservations so concurrent jobs spread before heartbeats catch up\n- pass node/label/timeout preferences from workspace config to the remote build API\n- document the operating model and add regression coverage\n\nValidation: cargo fmt --all --check; cargo test -q; cargo check; bash -n scripts/remote-lean-build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent auto-placement and fleet load accounting for remote builds; mis-counting or lock contention could skew distribution or add latency under burst load.
> 
> **Overview**
> Improves **remote Lean build** placement so concurrent dispatches do not all land on the same runner while heartbeats are still stale.
> 
> **Placement and load** — Auto placement now treats **durable core job-ledger entries** as extra in-flight load (`active_leases + core reservations`) when comparing against the `2× capacity` ceiling. `POST /api/remote-build` **serializes** node selection through a global lock until a **tentative** ledger handle is written, so bursts reserve capacity before the next heartbeat.
> 
> **Workspace integration** — Mission prep **copies/installs** `remote-lean-build` (container: `/usr/local/bin`; host: mission-scoped bin on `PATH`) and sets **`REMOTE_BUILD_COMMAND`**. Workspace JSON **`remote_build`** (`node_id`, `requirements`, `timeout_secs`) is injected as env vars for the wrapper.
> 
> **Client** — `remote-lean-build` forwards **`node_id`** and **`requirements`** (validated JSON) in the API body; docs describe the config and operating model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a19371b864f6aa3f3c7962077aeda23a6ebbaaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->