### PR TITLE
Fix hardened remote node user scope access

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -145,9 +145,9 @@ Group=sandboxed-node
 WorkingDirectory=/var/lib/sandboxed-node
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectHome=true
-# ProtectHome also hides /run/user; expose only this runner's runtime directory
-# so systemd-run --user can reach the lingering user manager's bus.
+ProtectHome=tmpfs
+# The tmpfs mode hides home and runtime contents while allowing this narrow
+# bind, so systemd-run --user can reach the lingering user manager's bus.
 BindPaths=/run/user/%U
 ProtectSystem=strict
 ReadWritePaths=/var/lib/sandboxed-node

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -146,6 +146,9 @@ WorkingDirectory=/var/lib/sandboxed-node
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true
+# ProtectHome also hides /run/user; expose only this runner's runtime directory
+# so systemd-run --user can reach the lingering user manager's bus.
+BindPaths=/run/user/%U
 ProtectSystem=strict
 ReadWritePaths=/var/lib/sandboxed-node
 ProtectKernelTunables=true

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -437,7 +437,20 @@ fn systemd_scope_mode() -> Option<SystemdScopeMode> {
         return Some(SystemdScopeMode::System);
     }
     let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
-    user_systemd_scope_mode(Path::new(&runtime_dir)).ok()
+    match user_systemd_scope_mode(Path::new(&runtime_dir)) {
+        Ok(mode) => Some(mode),
+        Err(error) => {
+            static WARN_DEGRADED_CONTAINMENT: std::sync::Once = std::sync::Once::new();
+            WARN_DEGRADED_CONTAINMENT.call_once(|| {
+                tracing::warn!(
+                    bus = %Path::new(&runtime_dir).join("bus").display(),
+                    %error,
+                    "transient user scopes are unavailable; containment degraded to process groups; ProtectHome=true may be hiding /run/user (bind the runner's /run/user/%U into the unit)"
+                );
+            });
+            None
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -437,10 +437,16 @@ fn systemd_scope_mode() -> Option<SystemdScopeMode> {
         return Some(SystemdScopeMode::System);
     }
     let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
-    Path::new(&runtime_dir)
-        .join("bus")
-        .exists()
-        .then_some(SystemdScopeMode::User)
+    user_systemd_scope_mode(Path::new(&runtime_dir)).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn user_systemd_scope_mode(runtime_dir: &Path) -> std::io::Result<SystemdScopeMode> {
+    // Connecting verifies that the path is both visible and usable by this
+    // process. A metadata/existence check can pass for an inaccessible,
+    // stale, or non-socket path and make systemd-run fail later per job.
+    std::os::unix::net::UnixStream::connect(runtime_dir.join("bus"))?;
+    Ok(SystemdScopeMode::User)
 }
 
 #[cfg(target_os = "linux")]
@@ -804,6 +810,27 @@ mod tests {
             .as_std()
             .get_envs()
             .any(|(key, value)| key == "NODE_JOB_SECRET" && value == Some("not-in-argv".as_ref())));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn user_scope_probe_requires_an_accessible_bus_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bus"), b"not a socket").unwrap();
+
+        assert!(user_systemd_scope_mode(dir.path()).is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn user_scope_probe_selects_user_mode_for_accessible_bus() {
+        let dir = tempfile::tempdir().unwrap();
+        let _listener = std::os::unix::net::UnixListener::bind(dir.path().join("bus")).unwrap();
+
+        assert_eq!(
+            user_systemd_scope_mode(dir.path()).unwrap(),
+            SystemdScopeMode::User
+        );
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

- use `ProtectHome=tmpfs` and bind the non-root runner's `/run/user/%U` into the hardened unit so its user-manager bus remains reachable
- probe the bus by connecting to its Unix socket instead of checking path existence
- warn once when the runner must degrade from transient user scopes to process-group containment
- cover accessible and unusable bus paths with focused unit tests

## Why `ProtectHome=tmpfs` + `BindPaths=`

`systemd.exec(5)` documents that `ProtectHome=true` makes `/home`, `/root`, and `/run/user` inaccessible to the service. An inaccessible parent cannot be traversed to establish a nested `BindPaths=` mount, so combining `ProtectHome=true` with `BindPaths=/run/user/%U` would not restore the bus. The manual recommends the `tmpfs` mode when selected subdirectories must be exposed: it hides the original contents behind empty mounts while permitting a narrow bind mount below them. `ProtectHome=tmpfs` plus `BindPaths=/run/user/%U` therefore exposes only the runner user's runtime directory while keeping the remaining home and runtime contents hidden. `docs/install-native.md` already uses `ProtectHome=false`, so it does not have the same conflict.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace -- -D clippy::all`
- `cargo test --locked`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job containment and the documented production systemd unit; misconfiguration could silently weaken cgroup-based cleanup until operators notice the warning.
> 
> **Overview**
> **Hardened systemd units** for non-root `sandboxed-node` no longer use `ProtectHome=true`, which hid `/run/user` and broke `systemd-run --user`. They now use **`ProtectHome=tmpfs`** with a narrow **`BindPaths=/run/user/%U`** so the lingering user manager bus stays reachable while home/runtime stay locked down (`docs/REMOTE_NODES.md`).
> 
> **User-scope selection** in `runner.rs` no longer treats a present `…/bus` path as sufficient; it **`UnixStream::connect`s** the socket so invisible, stale, or non-socket paths do not defer failure to per-job `systemd-run`. On probe failure the runner **logs a one-time warning** and **degrades to process-group containment** instead of claiming user scopes.
> 
> **Tests** cover accessible vs unusable bus paths for `user_systemd_scope_mode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6934635dc0778e95389fb1ca594770bd7774537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->