### PR TITLE
Fix idle systemd-nspawn CPU spin

### DIFF
--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -11,6 +11,24 @@ use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+pub(crate) const SYSTEMD_SERVICE_ENV_VARS: &[&str] = &[
+    "MEMORY_PRESSURE_WATCH",
+    "MEMORY_PRESSURE_WRITE",
+    "NOTIFY_SOCKET",
+    "WATCHDOG_USEC",
+    "WATCHDOG_PID",
+    "LISTEN_FDS",
+    "LISTEN_PID",
+    "LISTEN_FDNAMES",
+];
+
+/// Prevent systemd service-manager state from leaking into a child process.
+pub(crate) fn scrub_systemd_service_environment(command: &mut Command) {
+    for name in SYSTEMD_SERVICE_ENV_VARS {
+        command.env_remove(name);
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum NspawnError {
     #[error("Failed to create container directory: {0}")]
@@ -557,14 +575,16 @@ fn scope_wrapped_nspawn_command(path: &Path, env: &HashMap<String, String>) -> C
     let token =
         crate::workspace_exec::machine_name_for_path(path).unwrap_or_else(|| "unknown".to_string());
     let unit = format!("sandboxed-exec-{}-{}", token, uuid::Uuid::new_v4().simple());
-    if let Some(scope_args) = caps.scope_run_args(&unit) {
+    let mut command = if let Some(scope_args) = caps.scope_run_args(&unit) {
         let mut c = Command::new("systemd-run");
         c.args(&scope_args);
         c.arg("systemd-nspawn");
         c
     } else {
         Command::new("systemd-nspawn")
-    }
+    };
+    scrub_systemd_service_environment(&mut command);
+    command
 }
 
 /// Execute a command inside a container using systemd-nspawn.
@@ -985,16 +1005,7 @@ mod tests {
     use std::ffi::OsStr;
     use std::path::Path;
 
-    const SYSTEMD_SERVICE_ENV_VARS: &[&str] = &[
-        "MEMORY_PRESSURE_WATCH",
-        "MEMORY_PRESSURE_WRITE",
-        "NOTIFY_SOCKET",
-        "WATCHDOG_USEC",
-        "WATCHDOG_PID",
-        "LISTEN_FDS",
-        "LISTEN_PID",
-        "LISTEN_FDNAMES",
-    ];
+    use super::SYSTEMD_SERVICE_ENV_VARS;
 
     #[test]
     fn headless_nspawn_command_uses_pipe_console_and_scrubs_service_environment() {

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -584,6 +584,7 @@ fn scope_wrapped_nspawn_command(path: &Path, env: &HashMap<String, String>) -> C
         Command::new("systemd-nspawn")
     };
     scrub_systemd_service_environment(&mut command);
+    command.arg("--console=pipe");
     command
 }
 

--- a/src/nspawn.rs
+++ b/src/nspawn.rs
@@ -977,3 +977,42 @@ async fn unmount_all_under(root: &Path) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::scope_wrapped_nspawn_command;
+    use std::collections::HashMap;
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    const SYSTEMD_SERVICE_ENV_VARS: &[&str] = &[
+        "MEMORY_PRESSURE_WATCH",
+        "MEMORY_PRESSURE_WRITE",
+        "NOTIFY_SOCKET",
+        "WATCHDOG_USEC",
+        "WATCHDOG_PID",
+        "LISTEN_FDS",
+        "LISTEN_PID",
+        "LISTEN_FDNAMES",
+    ];
+
+    #[test]
+    fn headless_nspawn_command_uses_pipe_console_and_scrubs_service_environment() {
+        let command = scope_wrapped_nspawn_command(Path::new("/tmp/workspace"), &HashMap::new());
+        let command = command.as_std();
+
+        assert!(command
+            .get_args()
+            .any(|arg| arg == OsStr::new("--console=pipe")));
+        for name in SYSTEMD_SERVICE_ENV_VARS {
+            assert_eq!(
+                command
+                    .get_envs()
+                    .find(|(key, _)| *key == OsStr::new(name))
+                    .map(|(_, value)| value),
+                Some(None),
+                "{name} must be explicitly removed"
+            );
+        }
+    }
+}

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -565,6 +565,19 @@ pub(crate) fn resolv_conf_nspawn_args() -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn persistent_nspawn_command(scope_args: Option<&[String]>) -> Command {
+    let mut command = if let Some(scope_args) = scope_args {
+        let mut command = Command::new("systemd-run");
+        command.args(scope_args);
+        command.arg("systemd-nspawn");
+        command
+    } else {
+        Command::new("systemd-nspawn")
+    };
+    nspawn::scrub_systemd_service_environment(&mut command);
+    command
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -572,10 +585,11 @@ mod tests {
         durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
         exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
         mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
-        nspawn_directory_from_cmdline, replace_command_env, resolv_conf_bind_args,
+        nspawn_directory_from_cmdline, persistent_nspawn_command, replace_command_env, resolv_conf_bind_args,
         synthesized_container_resolv_conf, WorkspaceExec, WorkspaceType, CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
+    use std::ffi::OsStr;
     use std::path::{Path, PathBuf};
     use tokio::process::Command;
 
@@ -714,6 +728,22 @@ mod tests {
             WorkspaceType::Container,
             true
         ));
+    }
+
+    #[test]
+    fn persistent_nspawn_boot_scrubs_service_environment() {
+        let command = persistent_nspawn_command(Some(&["--scope".to_string()]));
+        for name in nspawn::SYSTEMD_SERVICE_ENV_VARS {
+            assert_eq!(
+                command
+                    .as_std()
+                    .get_envs()
+                    .find(|(key, _)| *key == OsStr::new(name))
+                    .map(|(_, value)| value),
+                Some(None),
+                "{name} must be explicitly removed"
+            );
+        }
     }
 
     #[test]
@@ -1526,16 +1556,7 @@ impl WorkspaceExec {
         // path).
         let caps = self.mission_resource_caps();
         let scope_args = caps.scope_run_args(&mission_scope_unit(&name));
-        let mut cmd = if let Some(scope_args) = scope_args {
-            let mut c = Command::new("systemd-run");
-            c.args(&scope_args);
-            // systemd-nspawn's own scope-creation is disabled below via
-            // --register=no/--keep-unit, so it joins this scope's cgroup.
-            c.arg("systemd-nspawn");
-            c
-        } else {
-            Command::new("systemd-nspawn")
-        };
+        let mut cmd = persistent_nspawn_command(scope_args.as_deref());
         cmd.arg("-D").arg(root);
         cmd.arg(format!("--machine={}", name));
         cmd.arg("--quiet");

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -575,18 +575,22 @@ fn persistent_nspawn_command(scope_args: Option<&[String]>) -> Command {
         Command::new("systemd-nspawn")
     };
     nspawn::scrub_systemd_service_environment(&mut command);
+    command.arg("--console=pipe");
     command
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::nspawn;
+
     use super::{
         append_nsenter_target_root_arg, ca_env_scrub_prelude, durable_command_runs_on_api_host,
         durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
         exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
         mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
-        nspawn_directory_from_cmdline, persistent_nspawn_command, replace_command_env, resolv_conf_bind_args,
-        synthesized_container_resolv_conf, WorkspaceExec, WorkspaceType, CA_BUNDLE_ENV_VARS,
+        nspawn_directory_from_cmdline, persistent_nspawn_command, replace_command_env,
+        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec, WorkspaceType,
+        CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::ffi::OsStr;
@@ -733,6 +737,14 @@ mod tests {
     #[test]
     fn persistent_nspawn_boot_scrubs_service_environment() {
         let command = persistent_nspawn_command(Some(&["--scope".to_string()]));
+        assert!(command
+            .as_std()
+            .get_args()
+            .any(|arg| arg == OsStr::new("systemd-nspawn")));
+        assert!(command
+            .as_std()
+            .get_args()
+            .any(|arg| arg == OsStr::new("--console=pipe")));
         for name in nspawn::SYSTEMD_SERVICE_ENV_VARS {
             assert_eq!(
                 command
@@ -1561,7 +1573,6 @@ impl WorkspaceExec {
         cmd.arg(format!("--machine={}", name));
         cmd.arg("--quiet");
         cmd.arg("--timezone=off");
-        cmd.arg("--console=pipe");
         cmd.arg("--register=no");
         cmd.arg("--keep-unit");
 


### PR DESCRIPTION
## Summary

- scrub inherited systemd notification, watchdog, socket-activation, and memory-pressure variables from every nspawn launch path
- select pipe consoles for headless nspawn execution
- add regression coverage for command isolation and environment scrubbing

## Root cause

Mission containers inherited service-manager environment that is meaningful only to the parent service. In combination with the default console mode, idle nspawn children could spin on memory-pressure/systemd integration paths.

## Validation

- targeted nspawn/workspace execution tests
- cargo fmt --all
- full CI requested on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted process-launch hygiene and console mode for existing nspawn paths, with regression tests and no auth or data-model changes.
> 
> **Overview**
> Addresses **idle `systemd-nspawn` CPU use** when the API runs under systemd by ensuring container launches no longer inherit parent-only variables (notify socket, watchdog, socket activation, memory-pressure fds) and by using a **headless pipe console** instead of the default console mode.
> 
> **`nspawn`**: Adds `scrub_systemd_service_environment` for a fixed set of service env vars and applies it in `scope_wrapped_nspawn_command`, together with `--console=pipe`, for scoped one-shot runs (init scripts, template builds).
> 
> **`workspace_exec`**: Introduces `persistent_nspawn_command` with the same scrub and console flag, and routes **mission container boot** through it so behavior matches the one-shot path.
> 
> **Tests** assert both builders pass `--console=pipe` and explicitly remove each listed systemd service variable from the child command environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c59f771c26204120b1cc286736fc6ab60e0729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->