### PR TITLE
Fix OpenCode PATH and remote-build reservation accounting

### DIFF
--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -252,13 +252,33 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
             for handle in handles {
                 *reservations.entry(handle.node_id).or_insert(0) += 1;
             }
-            reservations
+            let heartbeat_job_counts = reservations
+                .keys()
+                .filter_map(|node_id| {
+                    state.fleet.get(node_id).and_then(|status| {
+                        status.last_heartbeat.map(|heartbeat| {
+                            (
+                                node_id.clone(),
+                                heartbeat.active_jobs.saturating_add(heartbeat.queued_jobs),
+                            )
+                        })
+                    })
+                })
+                .collect();
+            reconcile_heartbeat_visible_jobs(reservations, &heartbeat_job_counts)
         }
         Err(error) => {
             tracing::warn!(?error, "remote job reservations could not be loaded");
             HashMap::new()
         }
     }
+}
+
+fn reconcile_heartbeat_visible_jobs(
+    ledger_counts: HashMap<String, u32>,
+    _heartbeat_job_counts: &HashMap<String, u32>,
+) -> HashMap<String, u32> {
+    ledger_counts
 }
 
 /// Resolve the target node: explicit id or capacity-aware auto placement.
@@ -716,6 +736,17 @@ async fn get_remote_build(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reservations_exclude_jobs_already_visible_in_heartbeat() {
+        let ledger = HashMap::from([("node-a".to_string(), 2), ("node-b".to_string(), 2)]);
+        let visible = HashMap::from([("node-a".to_string(), 1), ("node-b".to_string(), 3)]);
+
+        assert_eq!(
+            reconcile_heartbeat_visible_jobs(ledger, &visible),
+            HashMap::from([("node-a".to_string(), 1)])
+        );
+    }
 
     #[cfg(unix)]
     fn run_remote_build_wrapper_with_http_status(status: u16) -> std::process::ExitStatus {

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -275,9 +275,18 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
 }
 
 fn reconcile_heartbeat_visible_jobs(
-    ledger_counts: HashMap<String, u32>,
-    _heartbeat_job_counts: &HashMap<String, u32>,
+    mut ledger_counts: HashMap<String, u32>,
+    heartbeat_job_counts: &HashMap<String, u32>,
 ) -> HashMap<String, u32> {
+    ledger_counts.retain(|node_id, ledger_count| {
+        *ledger_count = ledger_count.saturating_sub(
+            heartbeat_job_counts
+                .get(node_id)
+                .copied()
+                .unwrap_or_default(),
+        );
+        *ledger_count > 0
+    });
     ledger_counts
 }
 

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -583,20 +583,12 @@ pub async fn run_opencode_turn(
 
     // Ensure OpenCode's install directory is available in PATH.
     {
-        let current_path = std::env::var("PATH").unwrap_or_default();
-        let bun_bins = "/root/.bun/bin:/root/.cache/.bun/bin";
-        let mut path_parts = Vec::new();
-        if !current_path.contains("/root/.bun/bin") {
-            path_parts.push(bun_bins.to_string());
-        }
-        path_parts.push(current_path);
-        // Append a dedicated bin subdirectory (not the workspace root) so
-        // `telegram-action` is findable as a bare command without letting
-        // arbitrary repo files shadow system binaries.
-        if telegram_action_helpers_enabled {
-            path_parts.push(format!("{}/.sandboxed-sh-bin", work_dir_arg));
-        }
-        env.insert("PATH".to_string(), path_parts.join(":"));
+        let path = opencode_path(
+            env.get("PATH").map(String::as_str),
+            &work_dir_arg,
+            telegram_action_helpers_enabled,
+        );
+        env.insert("PATH".to_string(), path);
     }
 
     let opencode_auth =
@@ -2089,4 +2081,40 @@ pub async fn run_opencode_turn(
     let _ = std::fs::remove_file(&prompt_file_host);
 
     result
+}
+
+fn opencode_path(
+    _mission_path: Option<&str>,
+    work_dir_arg: &str,
+    telegram_action_helpers_enabled: bool,
+) -> String {
+    let process_path = std::env::var("PATH").unwrap_or_default();
+    let current_path = process_path.as_str();
+    let bun_bins = "/root/.bun/bin:/root/.cache/.bun/bin";
+    let mut path_parts = Vec::new();
+    if !current_path.contains("/root/.bun/bin") {
+        path_parts.push(bun_bins.to_string());
+    }
+    path_parts.push(current_path.to_string());
+    if telegram_action_helpers_enabled {
+        path_parts.push(format!("{work_dir_arg}/.sandboxed-sh-bin"));
+    }
+    path_parts.join(":")
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::opencode_path;
+
+    #[test]
+    fn opencode_path_preserves_mission_path_prepends() {
+        let path = opencode_path(
+            Some("/mission/.sandboxed-sh/bin:/usr/bin"),
+            "/mission",
+            true,
+        );
+
+        assert!(path.contains("/mission/.sandboxed-sh/bin:/usr/bin"));
+        assert!(path.ends_with("/mission/.sandboxed-sh-bin"));
+    }
 }

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -2084,12 +2084,12 @@ pub async fn run_opencode_turn(
 }
 
 fn opencode_path(
-    _mission_path: Option<&str>,
+    mission_path: Option<&str>,
     work_dir_arg: &str,
     telegram_action_helpers_enabled: bool,
 ) -> String {
     let process_path = std::env::var("PATH").unwrap_or_default();
-    let current_path = process_path.as_str();
+    let current_path = mission_path.unwrap_or(&process_path);
     let bun_bins = "/root/.bun/bin:/root/.cache/.bun/bin";
     let mut path_parts = Vec::new();
     if !current_path.contains("/root/.bun/bin") {


### PR DESCRIPTION
## Summary

- preserve mission `PATH` prepends such as `remote-lean-build` when constructing the OpenCode environment
- exclude heartbeat-visible active and queued jobs from ledger-side reservation capacity accounting
- add focused regression tests for both still-valid findings from PR #598

## Reservation approach

For each node, placement subtracts `min(ledger_count, active_jobs + queued_jobs)` from the durable ledger count. Heartbeat active and queued load already contributes to placement, so only durable handles not yet reflected by the current heartbeat remain as core-side reservations. This is deterministic, saturates safely when heartbeat load exceeds the ledger count, and avoids clock comparison or timestamp coupling between the core and remote node.

## Test evidence

Regression tests were first committed with helpers that retained the unfixed behavior (`bc5a0ae7`), then the fixes were committed separately.

At head `ec96144d4927d9903a4bf9b2225fb512c1716b1e`:

- `cargo fmt --all`
- `cargo fmt --all -- --check` — CI Format passed
- `cargo clippy --locked --workspace -- -D clippy::all` — CI Clippy passed
- `cargo test --locked` — CI Test passed
- CI Harness Contract Tests passed
- CI Capability Matrix Contract Check passed
- CI Dashboard Unit Tests passed
