### PR TITLE
Preserve unmatched remote-build reservations

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -6605,6 +6605,7 @@ async fn dispatch_remote_job(
             node_id: node.id.clone(),
             job_id,
             started_at: submit_started_at,
+            accepted_at: None,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
         },
     )
@@ -6648,6 +6649,7 @@ async fn dispatch_remote_job(
             node_id: node.id.clone(),
             job_id,
             started_at: submit_started_at,
+            accepted_at: Some(chrono::Utc::now()),
             kind: crate::remote_node::job_ledger::JobHandleKind::Mission,
         },
     )

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -250,11 +250,11 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
         Ok(handles) => {
             let mut reservations = HashMap::new();
             for handle in handles {
-                let heartbeat_seen_at = state
+                let heartbeat_started_at = state
                     .fleet
                     .get(&handle.node_id)
-                    .and_then(|status| status.last_seen);
-                if heartbeat_cannot_reflect(handle.started_at, heartbeat_seen_at) {
+                    .and_then(|status| status.last_probe_started_at);
+                if heartbeat_cannot_reflect(handle.started_at, heartbeat_started_at) {
                     *reservations.entry(handle.node_id).or_insert(0) += 1;
                 }
             }
@@ -269,9 +269,9 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
 
 fn heartbeat_cannot_reflect(
     handle_started_at: chrono::DateTime<chrono::Utc>,
-    heartbeat_seen_at: Option<chrono::DateTime<chrono::Utc>>,
+    heartbeat_started_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> bool {
-    heartbeat_seen_at.is_none_or(|seen_at| handle_started_at > seen_at)
+    heartbeat_started_at.is_none_or(|started_at| handle_started_at > started_at)
 }
 
 /// Resolve the target node: explicit id or capacity-aware auto placement.
@@ -731,18 +731,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reservations_only_include_jobs_newer_than_the_heartbeat() {
-        let heartbeat_seen_at = chrono::Utc::now();
+    fn reservations_only_exclude_jobs_older_than_the_heartbeat_probe() {
+        let heartbeat_started_at = chrono::Utc::now();
 
         assert!(!heartbeat_cannot_reflect(
-            heartbeat_seen_at - chrono::Duration::seconds(1),
-            Some(heartbeat_seen_at)
+            heartbeat_started_at - chrono::Duration::seconds(1),
+            Some(heartbeat_started_at)
         ));
         assert!(heartbeat_cannot_reflect(
-            heartbeat_seen_at + chrono::Duration::seconds(1),
-            Some(heartbeat_seen_at)
+            heartbeat_started_at + chrono::Duration::seconds(1),
+            Some(heartbeat_started_at)
         ));
-        assert!(heartbeat_cannot_reflect(heartbeat_seen_at, None));
+        assert!(heartbeat_cannot_reflect(heartbeat_started_at, None));
     }
 
     #[cfg(unix)]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -250,22 +250,15 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
         Ok(handles) => {
             let mut reservations = HashMap::new();
             for handle in handles {
-                *reservations.entry(handle.node_id).or_insert(0) += 1;
+                let heartbeat_seen_at = state
+                    .fleet
+                    .get(&handle.node_id)
+                    .and_then(|status| status.last_seen);
+                if heartbeat_cannot_reflect(handle.started_at, heartbeat_seen_at) {
+                    *reservations.entry(handle.node_id).or_insert(0) += 1;
+                }
             }
-            let heartbeat_job_counts = reservations
-                .keys()
-                .filter_map(|node_id| {
-                    state.fleet.get(node_id).and_then(|status| {
-                        status.last_heartbeat.map(|heartbeat| {
-                            (
-                                node_id.clone(),
-                                heartbeat.active_jobs.saturating_add(heartbeat.queued_jobs),
-                            )
-                        })
-                    })
-                })
-                .collect();
-            reconcile_heartbeat_visible_jobs(reservations, &heartbeat_job_counts)
+            reservations
         }
         Err(error) => {
             tracing::warn!(?error, "remote job reservations could not be loaded");
@@ -274,20 +267,11 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
     }
 }
 
-fn reconcile_heartbeat_visible_jobs(
-    mut ledger_counts: HashMap<String, u32>,
-    heartbeat_job_counts: &HashMap<String, u32>,
-) -> HashMap<String, u32> {
-    ledger_counts.retain(|node_id, ledger_count| {
-        *ledger_count = ledger_count.saturating_sub(
-            heartbeat_job_counts
-                .get(node_id)
-                .copied()
-                .unwrap_or_default(),
-        );
-        *ledger_count > 0
-    });
-    ledger_counts
+fn heartbeat_cannot_reflect(
+    handle_started_at: chrono::DateTime<chrono::Utc>,
+    heartbeat_seen_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> bool {
+    heartbeat_seen_at.is_none_or(|seen_at| handle_started_at > seen_at)
 }
 
 /// Resolve the target node: explicit id or capacity-aware auto placement.
@@ -747,14 +731,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reservations_exclude_jobs_already_visible_in_heartbeat() {
-        let ledger = HashMap::from([("node-a".to_string(), 2), ("node-b".to_string(), 2)]);
-        let visible = HashMap::from([("node-a".to_string(), 1), ("node-b".to_string(), 3)]);
+    fn reservations_only_include_jobs_newer_than_the_heartbeat() {
+        let heartbeat_seen_at = chrono::Utc::now();
 
-        assert_eq!(
-            reconcile_heartbeat_visible_jobs(ledger, &visible),
-            HashMap::from([("node-a".to_string(), 1)])
-        );
+        assert!(!heartbeat_cannot_reflect(
+            heartbeat_seen_at - chrono::Duration::seconds(1),
+            Some(heartbeat_seen_at)
+        ));
+        assert!(heartbeat_cannot_reflect(
+            heartbeat_seen_at + chrono::Duration::seconds(1),
+            Some(heartbeat_seen_at)
+        ));
+        assert!(heartbeat_cannot_reflect(heartbeat_seen_at, None));
     }
 
     #[cfg(unix)]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -250,11 +250,22 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
         Ok(handles) => {
             let mut reservations = HashMap::new();
             for handle in handles {
-                let heartbeat_started_at = state
-                    .fleet
-                    .get(&handle.node_id)
+                let cached = state.fleet.get(&handle.node_id);
+                let heartbeat_started_at = cached
+                    .as_ref()
                     .and_then(|status| status.last_probe_started_at);
-                if handle_needs_reservation(&handle, heartbeat_started_at) {
+                let heartbeat_has_job_counters = cached
+                    .as_ref()
+                    .and_then(|status| status.last_heartbeat.as_ref())
+                    .is_some_and(|heartbeat| {
+                        heartbeat.protocol_version
+                            >= crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+                    });
+                if handle_needs_reservation(
+                    &handle,
+                    heartbeat_started_at,
+                    heartbeat_has_job_counters,
+                ) {
                     *reservations.entry(handle.node_id).or_insert(0) += 1;
                 }
             }
@@ -277,7 +288,11 @@ fn heartbeat_cannot_reflect(
 fn handle_needs_reservation(
     handle: &crate::remote_node::job_ledger::JobHandle,
     heartbeat_started_at: Option<chrono::DateTime<chrono::Utc>>,
+    heartbeat_has_job_counters: bool,
 ) -> bool {
+    if !heartbeat_has_job_counters {
+        return true;
+    }
     handle
         .accepted_at
         .is_none_or(|accepted_at| heartbeat_cannot_reflect(accepted_at, heartbeat_started_at))
@@ -770,17 +785,25 @@ mod tests {
 
         assert!(handle_needs_reservation(
             &handle,
-            Some(now + chrono::Duration::seconds(1))
+            Some(now + chrono::Duration::seconds(1)),
+            true,
         ));
 
         handle.accepted_at = Some(now + chrono::Duration::seconds(2));
         assert!(handle_needs_reservation(
             &handle,
-            Some(now + chrono::Duration::seconds(1))
+            Some(now + chrono::Duration::seconds(1)),
+            true,
         ));
         assert!(!handle_needs_reservation(
             &handle,
-            Some(now + chrono::Duration::seconds(3))
+            Some(now + chrono::Duration::seconds(3)),
+            true,
+        ));
+        assert!(handle_needs_reservation(
+            &handle,
+            Some(now + chrono::Duration::seconds(3)),
+            false,
         ));
     }
 

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -254,7 +254,7 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
                     .fleet
                     .get(&handle.node_id)
                     .and_then(|status| status.last_probe_started_at);
-                if heartbeat_cannot_reflect(handle.started_at, heartbeat_started_at) {
+                if handle_needs_reservation(&handle, heartbeat_started_at) {
                     *reservations.entry(handle.node_id).or_insert(0) += 1;
                 }
             }
@@ -272,6 +272,15 @@ fn heartbeat_cannot_reflect(
     heartbeat_started_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> bool {
     heartbeat_started_at.is_none_or(|started_at| handle_started_at > started_at)
+}
+
+fn handle_needs_reservation(
+    handle: &crate::remote_node::job_ledger::JobHandle,
+    heartbeat_started_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> bool {
+    handle
+        .accepted_at
+        .is_none_or(|accepted_at| heartbeat_cannot_reflect(accepted_at, heartbeat_started_at))
 }
 
 /// Resolve the target node: explicit id or capacity-aware auto placement.
@@ -495,6 +504,7 @@ async fn submit_remote_build(
             node_id: node.id.clone(),
             job_id,
             started_at,
+            accepted_at: None,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
         },
     )
@@ -567,6 +577,7 @@ async fn submit_remote_build(
             node_id: node.id.clone(),
             job_id,
             started_at,
+            accepted_at: Some(chrono::Utc::now()),
             kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
         },
     )
@@ -743,6 +754,34 @@ mod tests {
             Some(heartbeat_started_at)
         ));
         assert!(heartbeat_cannot_reflect(heartbeat_started_at, None));
+    }
+
+    #[test]
+    fn tentative_handle_stays_reserved_across_overlapping_probe() {
+        let now = chrono::Utc::now();
+        let mut handle = crate::remote_node::job_ledger::JobHandle {
+            mission_id: Uuid::new_v4(),
+            node_id: "node-a".to_string(),
+            job_id: Uuid::new_v4(),
+            started_at: now,
+            accepted_at: None,
+            kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
+        };
+
+        assert!(handle_needs_reservation(
+            &handle,
+            Some(now + chrono::Duration::seconds(1))
+        ));
+
+        handle.accepted_at = Some(now + chrono::Duration::seconds(2));
+        assert!(handle_needs_reservation(
+            &handle,
+            Some(now + chrono::Duration::seconds(1))
+        ));
+        assert!(!handle_needs_reservation(
+            &handle,
+            Some(now + chrono::Duration::seconds(3))
+        ));
     }
 
     #[cfg(unix)]

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -34,6 +34,10 @@ pub struct JobHandle {
     pub node_id: String,
     pub job_id: Uuid,
     pub started_at: chrono::DateTime<chrono::Utc>,
+    /// When the node acceptance response was observed. Tentative and legacy
+    /// handles keep this empty and must remain conservatively reserved.
+    #[serde(default)]
+    pub accepted_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
     pub kind: JobHandleKind,
 }
@@ -116,6 +120,7 @@ mod tests {
             node_id: "node-a".to_string(),
             job_id,
             started_at: chrono::Utc::now(),
+            accepted_at: Some(chrono::Utc::now()),
             kind: JobHandleKind::Mission,
         };
 
@@ -139,6 +144,7 @@ mod tests {
                 node_id: "node-a".to_string(),
                 job_id: Uuid::new_v4(),
                 started_at: chrono::Utc::now(),
+                accepted_at: Some(chrono::Utc::now()),
                 kind: JobHandleKind::Mission,
             },
         )
@@ -158,6 +164,7 @@ mod tests {
         let handle: JobHandle = serde_json::from_value(raw).unwrap();
 
         assert_eq!(handle.kind, JobHandleKind::Mission);
+        assert_eq!(handle.accepted_at, None);
     }
 
     #[test]
@@ -185,11 +192,13 @@ mod tests {
             node_id: "node-a".to_string(),
             job_id,
             started_at: chrono::Utc::now(),
+            accepted_at: None,
             kind: JobHandleKind::Tentative,
         };
         record(dir.path(), handle.clone()).await.unwrap();
 
         handle.kind = JobHandleKind::Mission;
+        handle.accepted_at = Some(chrono::Utc::now());
         record(dir.path(), handle).await.unwrap();
 
         let handles = load_result(dir.path()).await.unwrap();

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -37,6 +37,10 @@ pub struct CachedNodeStatus {
     pub last_heartbeat: Option<NodeHeartbeat>,
     /// When the last successful heartbeat was received.
     pub last_seen: Option<DateTime<Utc>>,
+    /// When the request producing the last successful heartbeat started.
+    /// Reservations created after this instant cannot safely be assumed to
+    /// be represented by that heartbeat payload.
+    pub last_probe_started_at: Option<DateTime<Utc>>,
     pub last_error: Option<String>,
 }
 
@@ -97,6 +101,15 @@ impl FleetMonitor {
 
     /// Record a successful heartbeat probe.
     pub fn record_heartbeat(&self, node_id: &str, heartbeat: NodeHeartbeat) {
+        self.record_heartbeat_for_probe(node_id, heartbeat, Utc::now());
+    }
+
+    pub fn record_heartbeat_for_probe(
+        &self,
+        node_id: &str,
+        heartbeat: NodeHeartbeat,
+        probe_started_at: DateTime<Utc>,
+    ) {
         let (status, misses) = status_after_probe(0, true);
         let mut statuses = self.statuses.write().unwrap_or_else(|e| e.into_inner());
         statuses.insert(
@@ -107,6 +120,7 @@ impl FleetMonitor {
                 consecutive_misses: misses,
                 last_heartbeat: Some(heartbeat),
                 last_seen: Some(Utc::now()),
+                last_probe_started_at: Some(probe_started_at),
                 last_error: None,
             },
         );
@@ -124,6 +138,7 @@ impl FleetMonitor {
                 consecutive_misses: 0,
                 last_heartbeat: None,
                 last_seen: None,
+                last_probe_started_at: None,
                 last_error: None,
             });
         let (status, misses) = status_after_probe(entry.consecutive_misses, false);
@@ -460,10 +475,15 @@ pub async fn probe_node(fleet: &FleetMonitor, client: &RemoteNodeClient, node: &
         .ok()
         .filter(|token| !token.trim().is_empty());
     match token {
-        Some(token) => match client.heartbeat(node, &token).await {
-            Ok(heartbeat) => fleet.record_heartbeat(&node.id, heartbeat),
-            Err(err) => fleet.record_miss(&node.id, err.to_string()),
-        },
+        Some(token) => {
+            let probe_started_at = Utc::now();
+            match client.heartbeat(node, &token).await {
+                Ok(heartbeat) => {
+                    fleet.record_heartbeat_for_probe(&node.id, heartbeat, probe_started_at)
+                }
+                Err(err) => fleet.record_miss(&node.id, err.to_string()),
+            }
+        }
         None => fleet.record_miss(&node.id, format!("missing token env {}", node.token_env)),
     }
 }
@@ -617,6 +637,7 @@ mod tests {
             consecutive_misses: 0,
             last_heartbeat: Some(heartbeat),
             last_seen: Some(Utc::now()),
+            last_probe_started_at: Some(Utc::now()),
             last_error: None,
         }
     }


### PR DESCRIPTION
## Summary

- follow up merged PR #601 by keeping only durable job handles that the latest node heartbeat cannot yet reflect
- preserve newly-created tentative reservations even when a heartbeat contains unrelated or stale active jobs
- replace aggregate-count regression coverage with timestamp-boundary coverage

## Reservation approach

Each durable handle is compared with the fleet monitor's `last_seen` time for that node. Handles created after the last successful heartbeat (or before any heartbeat exists) remain core-side reservations; older handles are treated as reflected by heartbeat load. This avoids double-counting without allowing an unrelated heartbeat job count to erase a new tentative reservation.

## Test evidence

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- focused reservation test and full CI requested on this PR

This directly addresses the unresolved review finding on #601.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote node capacity is computed during auto-placement; incorrect boundaries could over- or under-count load, though tentative and legacy handles stay conservatively reserved.
> 
> **Overview**
> Follow-up to reservation accounting for remote auto-placement: **core-side slot reservations** no longer subtract heartbeat `active_jobs`/`queued_jobs` totals from the durable job ledger.
> 
> **`JobHandle`** gains optional **`accepted_at`** (set when node acceptance is observed; tentative pre-submit and legacy ledger rows keep it empty). Mission dispatch and remote-build paths record `accepted_at: None` on tentative handles and `Some(...)` after acceptance.
> 
> The fleet monitor records **`last_probe_started_at`** on successful heartbeats so placement can tell whether a cached heartbeat predates a job.
> 
> **`core_side_reservations`** counts a ledger handle only when **`handle_needs_reservation`** says the latest heartbeat cannot yet reflect it: always reserve without protocol job counters; with counters, reserve if `accepted_at` is missing (conservative) or is **after** the probe start time. Aggregate reconciliation is removed in favor of timestamp-boundary tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3822e819d8369bdcc6ac5cf29cde956dbcc5c757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->