### PR TITLE
feat: add official Grok 4.5 support

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -284,8 +284,12 @@ Configure your mission:
    - **Claude Code**: use a raw model ID (e.g., `claude-opus-4-7`)
    - **Codex**: use a raw model ID (e.g., `gpt-5.5` or `gpt-5.3-codex`)
    - **Gemini**: use a raw model ID (e.g., `gemini-3.1-pro-preview`)
-   - **Grok**: use a raw model ID (e.g., `grok-4.5`)
-   - **OpenCode**: use `provider/model` (e.g., `openai/gpt-5.5`)
+   - **Grok**: use the canonical raw CLI model ID `grok-4.5`; availability is
+     account- and region-dependent (including in the EU), so confirm with
+     `grok models` if the CLI rejects it
+   - **OpenCode**: use `provider/model` (e.g., `xai/grok-4.5` with an xAI API
+     key, or `openai/gpt-5.5`); the official xAI API aliases
+     `xai/grok-4.5-latest` and `xai/grok-build-latest` are also accepted
    - **Model effort**: set effort separately (`low`, `medium`, `high`, `xhigh`) instead of encoding it in the model ID
 
 4. **Config Profile** - Override settings (optional):

--- a/docs/install-native.md
+++ b/docs/install-native.md
@@ -347,9 +347,16 @@ Gemini CLI login flow. Gemini missions use raw model ids such as
 
 ### 3.5.3 Grok
 
-Configure xAI credentials in **Settings → Providers**, set `XAI_API_KEY` or
-`GROK_CODE_XAI_API_KEY`, or run the Grok CLI login flow. Grok missions use raw
-model ids such as `grok-4.5`.
+For OpenCode/API-key routing, configure `XAI_API_KEY` in **Settings →
+Providers** and select `xai/grok-4.5`. The official rolling aliases are
+`xai/grok-4.5-latest` and `xai/grok-build-latest`.
+
+For the native `grok` backend, use the Grok CLI login flow (or its supported
+credential configuration) and select the raw canonical ID `grok-4.5`, not the
+`xai/`-prefixed form. Native CLI availability is discovered per account and
+can vary by region, including for EU accounts; run `grok models` on the server
+if the CLI reports an unknown or unavailable model. An account-level absence
+does not remove the official model from the global xAI API catalog.
 
 ---
 

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -72,9 +72,11 @@ const OPENROUTER_SEED_MODEL_IDS: &[&str] = &[
 /// Text/code model IDs accepted by the native Grok CLI backend for the current
 /// OAuth-based Grok Build path. This is intentionally narrower than xAI's
 /// OpenAI-compatible `/v1/models` catalog: API-routable models such as
-/// `grok-4.5` can still appear as `xai/grok-4.5` for the custom router, but the
-/// `grok` backend must only offer IDs that `grok --model ...` accepts.
+/// rolling aliases can still appear for the custom router, but the `grok`
+/// backend only offers canonical IDs documented for Grok Build. Actual access
+/// remains account/region-dependent and is diagnosed by the CLI at runtime.
 const GROK_CLI_TEXT_MODEL_IDS: &[&str] = &[
+    "grok-4.5",
     "grok-build-0.1",
     "grok-4.3",
     "grok-4.20-0309-reasoning",
@@ -2586,10 +2588,10 @@ mod tests {
         assert!(is_grok_backend_model_id("grok-4.20-0309-reasoning"));
         assert!(is_grok_backend_model_id("grok-4.20-0309-non-reasoning"));
         assert!(is_grok_backend_model_id("grok-4.20-multi-agent-0309"));
-        // xAI API/catalog IDs are not automatically valid for the native
-        // Grok CLI backend. Prod Grok CLI 0.2.93 currently rejects this one
-        // with "unknown model id".
-        assert!(!is_grok_backend_model_id("grok-4.5"));
+        assert!(is_grok_backend_model_id("grok-4.5"));
+        // API rolling aliases are not assumed to be native CLI model IDs.
+        assert!(!is_grok_backend_model_id("grok-4.5-latest"));
+        assert!(!is_grok_backend_model_id("grok-build-latest"));
         assert!(!is_grok_backend_model_id("grok-imagine-image"));
         // `composer-*` is a product name, not a Grok CLI model id.
         assert!(!is_grok_backend_model_id("composer-2.5"));
@@ -2612,7 +2614,7 @@ mod tests {
             .collect();
 
         assert!(option_ids.contains(&"grok-build-0.1"));
-        assert!(!option_ids.contains(&"grok-4.5"));
+        assert!(option_ids.contains(&"grok-4.5"));
         assert!(!option_ids.contains(&"composer-2.5"));
     }
 

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -959,9 +959,25 @@ fn default_providers_config() -> ProvidersConfig {
                 billing: "pay-per-token".to_string(),
                 description: "Grok models via xAI API key".to_string(),
                 models: vec![
-                    // These IDs must match what the Grok Build CLI accepts
-                    // (`grok models`) — the bare `grok-build` alias is rejected
-                    // by current CLIs. xAI API model IDs: https://docs.x.ai/docs/models
+                    ProviderModel {
+                        id: "grok-4.5".to_string(),
+                        name: "Grok 4.5".to_string(),
+                        description: Some("Latest flagship Grok model".to_string()),
+                    },
+                    ProviderModel {
+                        id: "grok-4.5-latest".to_string(),
+                        name: "Grok 4.5 (Latest)".to_string(),
+                        description: Some("Rolling alias for Grok 4.5".to_string()),
+                    },
+                    ProviderModel {
+                        id: "grok-build-latest".to_string(),
+                        name: "Grok Build (Latest)".to_string(),
+                        description: Some(
+                            "Rolling Grok Build alias backed by Grok 4.5".to_string(),
+                        ),
+                    },
+                    // Legacy IDs retained for accounts that still advertise them.
+                    // Native Grok CLI choices are filtered separately below.
                     ProviderModel {
                         id: "grok-build-0.1".to_string(),
                         name: "Grok Build".to_string(),
@@ -2554,11 +2570,13 @@ mod tests {
         // The CLI-valid coding model id (bare `grok-build` is rejected by
         // current CLIs). `composer-2.5` is intentionally NOT here: it's a
         // product name, not a valid xAI API id, and the API rejects it.
-        // `grok-4.5` is intentionally not seeded unless live account catalog
-        // discovery returns it; Grok CLI 0.2.93 rejects it with "unknown model id"
-        // for the current production OAuth/API token.
         assert!(xai.models.iter().any(|model| model.id == "grok-build-0.1"));
-        assert!(!xai.models.iter().any(|model| model.id == "grok-4.5"));
+        assert!(xai.models.iter().any(|model| model.id == "grok-4.5"));
+        assert!(xai.models.iter().any(|model| model.id == "grok-4.5-latest"));
+        assert!(xai
+            .models
+            .iter()
+            .any(|model| model.id == "grok-build-latest"));
         assert!(!xai.models.iter().any(|model| model.id == "composer-2.5"));
     }
 

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -5107,6 +5107,10 @@ mod tests {
         let e = parse_direct_model_entry("xai/grok-4.5").expect("known provider");
         assert_eq!(e.provider_id, "xai");
         assert_eq!(e.model_id, "grok-4.5");
+        let latest = parse_direct_model_entry("xai/grok-4.5-latest").expect("official xAI alias");
+        assert_eq!(latest.model_id, "grok-4.5-latest");
+        let build = parse_direct_model_entry("xai/grok-build-latest").expect("official xAI alias");
+        assert_eq!(build.model_id, "grok-build-latest");
         // Model ids may themselves contain slashes (kept after the first split).
         let e2 = parse_direct_model_entry("openai/codex-mini/latest").expect("known provider");
         assert_eq!(e2.provider_id, "openai");

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -258,7 +258,7 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
     },
     PricingEntry {
         canonical: "grok-4.5",
-        aliases: &["grok-4.5"],
+        aliases: &["grok-4.5", "grok-4.5-latest", "grok-build-latest"],
         pricing: pricing(2_000, 6_000, None, Some(500)),
     },
     PricingEntry {
@@ -598,6 +598,8 @@ mod tests {
         assert_eq!(normalize_model("grok-4-fast-reasoning"), "grok-4-fast");
         assert_eq!(normalize_model("xAI/Grok Inference"), "grok-4-fast");
         assert_eq!(normalize_model("xai/grok-4.5"), "grok-4.5");
+        assert_eq!(normalize_model("xai/grok-4.5-latest"), "grok-4.5");
+        assert_eq!(normalize_model("xai/grok-build-latest"), "grok-4.5");
         assert_eq!(normalize_model("grok-build"), "grok-build");
         assert_eq!(normalize_model("zai/glm-5"), "glm-5");
         assert_eq!(normalize_model("zai/glm-5.2"), "glm-5.2");


### PR DESCRIPTION
## Summary
- seed `grok-4.5`, `grok-4.5-latest`, and `grok-build-latest` in the xAI API-key catalog
- expose canonical `grok-4.5` to the native Grok backend while keeping API aliases out of the CLI allowlist
- normalize official aliases for pricing and cover direct xAI routing
- document raw CLI vs `xai/` API-key model selection and account/EU availability diagnostics

## Support boundaries
- OpenCode/direct xAI API routing: `xai/grok-4.5` (or either official prefixed alias), requiring an xAI API key
- native Grok backend: raw `grok-4.5`; the existing conservative default remains `grok-build-0.1`, and runtime access remains account/region-dependent
- product-only names such as `composer-2.5` remain rejected

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- local Rust test/check compilation attempted with Cargo 1.91; the shared host's monolithic project compile exceeded bounded local budgets without diagnostics
- no xAI API key or Grok CLI was available in this workspace, so no live canary was run

Starting master SHA: `646c16216af02235a26270563d12397f657b62bc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog, routing, pricing, and documentation changes only; native CLI still filters API aliases and runtime access remains account-dependent.
> 
> **Overview**
> Adds **official Grok 4.5** across the xAI API-key catalog, native Grok CLI allowlist, proxy routing, and cost normalization, and clarifies docs for **raw CLI vs `xai/` OpenCode** model IDs.
> 
> The default **xAI** provider catalog now seeds `grok-4.5`, `grok-4.5-latest`, and `grok-build-latest` (legacy IDs kept). **Native `grok` backend** picker includes canonical `grok-4.5` via `GROK_CLI_TEXT_MODEL_IDS`, while rolling API aliases stay out of the CLI allowlist. **Direct routing** accepts `xai/grok-4.5-latest` and `xai/grok-build-latest`; **pricing** maps those aliases to the `grok-4.5` canonical entry.
> 
> **Getting started** and **native install** docs explain `grok-4.5` for the Grok CLI, `xai/grok-4.5` (and aliases) for API-key/OpenCode paths, and account/region checks via `grok models`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42dd1cdda673c24a4509ad28e339051c25a16b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->