### PR TITLE
Make Lean build concurrency capability-aware

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -261,6 +261,10 @@ Validation (node-side, before anything runs):
   `lake build ...` and `lean ...`. The service environment is cleared before
   execution so node bearer/signing secrets are not inherited by build code.
 - `env` keys must be within `SANDBOXED_NODE_ENV_ALLOWLIST`.
+- When the payload omits `LEAN_NUM_THREADS` or `LAKE_JOBS`, the node defaults
+  each missing key to its usable logical-CPU count (`available_parallelism`,
+  including OS affinity/cgroup caps). Explicit allowlisted payload values take
+  precedence independently for each key.
 - `timeout_secs` is clamped to `SANDBOXED_NODE_MAX_JOB_SECS`.
 
 Execution model:

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -234,6 +234,24 @@ fn cache_env(work_root: &Path) -> Vec<(String, String)> {
     ]
 }
 
+/// Add Lean/Lake concurrency defaults derived from the node process's usable
+/// parallelism. `available_parallelism` accounts for OS affinity and cgroup
+/// limits, so operator-imposed CPU caps remain authoritative. Payload values
+/// are copied last and therefore always win, including independently setting
+/// only one of the two knobs.
+fn lean_concurrency_env(
+    payload_env: &HashMap<String, String>,
+    available_parallelism: usize,
+) -> HashMap<String, String> {
+    let default = available_parallelism.max(1).to_string();
+    let mut effective = HashMap::from([
+        ("LEAN_NUM_THREADS".to_string(), default.clone()),
+        ("LAKE_JOBS".to_string(), default),
+    ]);
+    effective.extend(payload_env.clone());
+    effective
+}
+
 /// Derive the default lake cache key from the build cwd: sha256 over the
 /// contents of `lean-toolchain` and `lake-manifest.json` (whichever exist).
 /// `None` when neither file is present (no cache slot is used then).
@@ -702,7 +720,10 @@ pub async fn execute_lean_build(
     for (key, value) in cache_env(work_root) {
         cmd.env(key, value);
     }
-    for (key, value) in env {
+    let available_parallelism = std::thread::available_parallelism()
+        .map(|parallelism| parallelism.get())
+        .unwrap_or(1);
+    for (key, value) in lean_concurrency_env(env, available_parallelism) {
         cmd.env(key, value);
     }
     let limit_secs = clamp_timeout(*timeout_secs, max_job_secs);
@@ -915,6 +936,24 @@ mod tests {
 
     fn allowlist() -> Vec<String> {
         parse_env_allowlist(DEFAULT_ENV_ALLOWLIST)
+    }
+
+    #[test]
+    fn concurrency_env_uses_capability_defaults_and_preserves_explicit_values() {
+        let defaults = lean_concurrency_env(&HashMap::new(), 12);
+        assert_eq!(defaults.get("LEAN_NUM_THREADS").map(String::as_str), Some("12"));
+        assert_eq!(defaults.get("LAKE_JOBS").map(String::as_str), Some("12"));
+
+        let explicit = HashMap::from([
+            ("LEAN_NUM_THREADS".to_string(), "3".to_string()),
+            ("LAKE_JOBS".to_string(), "5".to_string()),
+        ]);
+        let overridden = lean_concurrency_env(&explicit, 12);
+        assert_eq!(
+            overridden.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("3")
+        );
+        assert_eq!(overridden.get("LAKE_JOBS").map(String::as_str), Some("5"));
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -941,7 +941,10 @@ mod tests {
     #[test]
     fn concurrency_env_uses_capability_defaults_and_preserves_explicit_values() {
         let defaults = lean_concurrency_env(&HashMap::new(), 12);
-        assert_eq!(defaults.get("LEAN_NUM_THREADS").map(String::as_str), Some("12"));
+        assert_eq!(
+            defaults.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("12")
+        );
         assert_eq!(defaults.get("LAKE_JOBS").map(String::as_str), Some("12"));
 
         let explicit = HashMap::from([

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -957,6 +957,29 @@ mod tests {
             Some("3")
         );
         assert_eq!(overridden.get("LAKE_JOBS").map(String::as_str), Some("5"));
+
+        let only_threads = lean_concurrency_env(
+            &HashMap::from([("LEAN_NUM_THREADS".to_string(), "7".to_string())]),
+            12,
+        );
+        assert_eq!(
+            only_threads.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("7")
+        );
+        assert_eq!(
+            only_threads.get("LAKE_JOBS").map(String::as_str),
+            Some("12")
+        );
+
+        let only_lake = lean_concurrency_env(
+            &HashMap::from([("LAKE_JOBS".to_string(), "9".to_string())]),
+            12,
+        );
+        assert_eq!(
+            only_lake.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("12")
+        );
+        assert_eq!(only_lake.get("LAKE_JOBS").map(String::as_str), Some("9"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- derive default `LEAN_NUM_THREADS` and `LAKE_JOBS` from the node process's usable parallelism
- preserve explicit allowlisted payload values independently
- document the capability-aware remote-build policy
- add a regression test for derived defaults and caller precedence

## Locate evidence

- `src/node/lean.rs:31` allowlists both concurrency variables
- `src/node/lean.rs:700-707` previously constructed the build environment without defaults
- `src/bin/sandboxed_node.rs:160-162` already uses `available_parallelism` for node capability reporting
- `scripts/remote-lean-build:45` defaults to `lake build` without a jobs flag
- no fixed `lake -j 2` guidance was found in sandboxed.sh, `/root/.sandboxed-sh/library`, or Th0rgal/sandboxed-library

The library's `lean-slot` limit of two is a host-wide gate on simultaneous heavy Lean processes, not an internal Lake job count, so it is unchanged.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- exact-head CI: `cargo clippy --locked --workspace -- -D clippy::all`
- exact-head CI: `cargo test --locked --workspace`
- exact-head CI: all required and auxiliary checks green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to build concurrency env defaults on remote nodes; explicit allowlisted payload values are unchanged and host-wide lean-slot limits are untouched.
> 
> **Overview**
> Remote **`lean_build`** jobs now inject **`LEAN_NUM_THREADS`** and **`LAKE_JOBS`** when the payload omits them, using the node process’s **`std::thread::available_parallelism`** (respecting affinity/cgroup caps) with a floor of **1**.
> 
> Allowlisted values in the job **`env`** still win **per key**, so callers can set only one knob and leave the other defaulted. **`docs/REMOTE_NODES.md`** documents this policy; **`lean_concurrency_env`** and a unit test cover defaults, full override, and partial override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f380ae012cd929edae338846640f461177497b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->