### PR TITLE
fix(node): preserve cleared env in systemd scopes

### DIFF
--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -37,6 +37,10 @@ struct NodeState {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    if sandboxed_sh::node::maybe_exec_cleared_scope_payload()? {
+        return Ok(());
+    }
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -23,7 +23,7 @@ use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
 
 use super::job_store::JobState;
-use super::runner::{clamp_timeout, run_logged_command};
+use super::runner::{clamp_timeout, run_logged_command, CommandEnvironment};
 use crate::remote_node::{ArtifactEntry, JobPayload, JobSource};
 
 /// Default allowlist for lean-build env keys
@@ -504,7 +504,14 @@ async fn run_git_step(
     if let Some((key, value)) = git_ssh_env() {
         cmd.env(key, value);
     }
-    let outcome = run_logged_command(cmd, log_path, GIT_STEP_TIMEOUT_SECS, token).await?;
+    let outcome = run_logged_command(
+        cmd,
+        CommandEnvironment::Inherit,
+        log_path,
+        GIT_STEP_TIMEOUT_SECS,
+        token,
+    )
+    .await?;
     if !outcome.success() {
         let (_, code, error) = outcome.into_job_result();
         anyhow::bail!(
@@ -706,7 +713,8 @@ pub async fn execute_lean_build(
         cmd.env(key, value);
     }
     let limit_secs = clamp_timeout(*timeout_secs, max_job_secs);
-    let outcome = run_logged_command(cmd, log_path, limit_secs, token).await?;
+    let outcome =
+        run_logged_command(cmd, CommandEnvironment::Clear, log_path, limit_secs, token).await?;
     let success = outcome.success();
 
     let mut result_artifacts = Vec::new();

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -10,5 +10,6 @@ pub mod runner;
 pub use job_store::{JobRecord, JobState, JobStore};
 pub use lean::{cached_toolchains, spawn_cache_gc};
 pub use runner::{
-    read_log_tail, JobRunner, NodeQueueFull, DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES,
+    maybe_exec_cleared_scope_payload, read_log_tail, JobRunner, NodeQueueFull,
+    DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES,
 };

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -278,7 +278,14 @@ impl JobRunner {
 
                 let cmd = crate::remote_node::raw_command(command, &mission_dir, env.as_ref());
                 let limit_secs = clamp_timeout(*timeout_secs, self.max_job_secs);
-                let outcome = run_logged_command(cmd, &log_path, limit_secs, token).await?;
+                let outcome = run_logged_command(
+                    cmd,
+                    CommandEnvironment::Clear,
+                    &log_path,
+                    limit_secs,
+                    token,
+                )
+                .await?;
                 let (state, exit_code, error) = outcome.into_job_result();
                 Ok((state, exit_code, error, None))
             }
@@ -323,6 +330,12 @@ pub(crate) enum RunOutcome {
     TimedOut { limit_secs: u64 },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CommandEnvironment {
+    Inherit,
+    Clear,
+}
+
 impl RunOutcome {
     /// Whether the process ran to completion with exit code 0.
     pub(crate) fn success(&self) -> bool {
@@ -356,6 +369,7 @@ impl RunOutcome {
 /// jobs and the lean-build steps.
 pub(crate) async fn run_logged_command(
     cmd: tokio::process::Command,
+    environment: CommandEnvironment,
     log_path: &Path,
     limit_secs: u64,
     token: &CancellationToken,
@@ -368,7 +382,7 @@ pub(crate) async fn run_logged_command(
         .append(true)
         .open(log_path)?;
     let stderr_file = stdout_file.try_clone()?;
-    let (mut cmd, systemd_scope) = contain_command(cmd);
+    let (mut cmd, systemd_scope) = contain_command(cmd, environment);
     cmd.stdin(Stdio::null())
         .stdout(Stdio::from(stdout_file))
         .stderr(Stdio::from(stderr_file))
@@ -405,10 +419,11 @@ pub(crate) async fn run_logged_command(
 /// Put node jobs in a transient systemd scope when the host has a running
 /// system manager. Process groups do not contain descendants that call
 /// `setsid`; a scope's cgroup does, so stopping the unit also reaps those
-/// daemonized descendants. The wrapper inherits the command environment
-/// directly, keeping secrets out of `systemd-run` argv.
+/// daemonized descendants. Commands that clear their environment are marked
+/// explicitly because `std::process::Command` does not expose that setting.
 fn contain_command(
     cmd: tokio::process::Command,
+    environment: CommandEnvironment,
 ) -> (tokio::process::Command, Option<SystemdScope>) {
     #[cfg(target_os = "linux")]
     {
@@ -417,7 +432,7 @@ fn contain_command(
                 unit: format!("sandboxed-node-job-{}.scope", Uuid::new_v4().simple()),
                 mode,
             };
-            return (systemd_scope_command(cmd, &scope), Some(scope));
+            return (systemd_scope_command(cmd, environment, &scope), Some(scope));
         }
     }
     (cmd, None)
@@ -465,6 +480,7 @@ fn user_systemd_scope_mode(runtime_dir: &Path) -> std::io::Result<SystemdScopeMo
 #[cfg(target_os = "linux")]
 fn systemd_scope_command(
     cmd: tokio::process::Command,
+    environment: CommandEnvironment,
     scope: &SystemdScope,
 ) -> tokio::process::Command {
     let command = cmd.as_std();
@@ -486,19 +502,36 @@ fn systemd_scope_command(
         .arg("--collect")
         .arg(format!("--unit={}", scope.unit))
         .arg("--property=KillMode=control-group")
-        .arg("--")
-        .arg(program)
-        .args(args);
+        .arg("--");
+    if environment == CommandEnvironment::Clear {
+        // With --scope, systemd-run executes the payload itself, so the
+        // payload otherwise inherits the runner service's environment. Keep
+        // systemd-run's own environment intact for the user bus, but reset
+        // the environment at the payload boundary and add back only the
+        // command's explicitly configured entries.
+        scoped.arg("env").arg("-i");
+        for (key, value) in &env {
+            if let Some(value) = value {
+                let mut assignment = key.clone();
+                assignment.push("=");
+                assignment.push(value);
+                scoped.arg(assignment);
+            }
+        }
+    }
+    scoped.arg(program).args(args);
     if let Some(cwd) = cwd {
         scoped.current_dir(cwd);
     }
-    for (key, value) in env {
-        match value {
-            Some(value) => {
-                scoped.env(key, value);
-            }
-            None => {
-                scoped.env_remove(key);
+    if environment == CommandEnvironment::Inherit {
+        for (key, value) in env {
+            match value {
+                Some(value) => {
+                    scoped.env(key, value);
+                }
+                None => {
+                    scoped.env_remove(key);
+                }
             }
         }
     }
@@ -781,9 +814,15 @@ mod tests {
         cmd.args(["-c", "(sleep 1; echo survived > \"$SURVIVOR_MARKER\") &"])
             .env("SURVIVOR_MARKER", &marker);
 
-        let outcome = run_logged_command(cmd, &log, 30, &CancellationToken::new())
-            .await
-            .unwrap();
+        let outcome = run_logged_command(
+            cmd,
+            CommandEnvironment::Inherit,
+            &log,
+            30,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
 
         assert!(outcome.success());
         tokio::time::sleep(Duration::from_millis(1_250)).await;
@@ -803,6 +842,7 @@ mod tests {
 
         let scoped = systemd_scope_command(
             cmd,
+            CommandEnvironment::Inherit,
             &SystemdScope {
                 unit: "sandboxed-node-job-test.scope".to_string(),
                 mode: SystemdScopeMode::User,
@@ -833,6 +873,7 @@ mod tests {
 
         let scoped = systemd_scope_command(
             cmd,
+            CommandEnvironment::Clear,
             &SystemdScope {
                 unit: "sandboxed-node-job-test.scope".to_string(),
                 mode: SystemdScopeMode::User,
@@ -894,9 +935,15 @@ mod tests {
         ])
         .env("SURVIVOR_MARKER", &marker);
 
-        let outcome = run_logged_command(cmd, &log, 30, &CancellationToken::new())
-            .await
-            .unwrap();
+        let outcome = run_logged_command(
+            cmd,
+            CommandEnvironment::Inherit,
+            &log,
+            30,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
 
         assert!(outcome.success());
         tokio::time::sleep(Duration::from_millis(500)).await;

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -382,7 +382,7 @@ pub(crate) async fn run_logged_command(
         .append(true)
         .open(log_path)?;
     let stderr_file = stdout_file.try_clone()?;
-    let (mut cmd, systemd_scope) = contain_command(cmd, environment);
+    let (mut cmd, systemd_scope) = contain_command(cmd, environment)?;
     cmd.stdin(Stdio::null())
         .stdout(Stdio::from(stdout_file))
         .stderr(Stdio::from(stderr_file))
@@ -424,7 +424,7 @@ pub(crate) async fn run_logged_command(
 fn contain_command(
     cmd: tokio::process::Command,
     environment: CommandEnvironment,
-) -> (tokio::process::Command, Option<SystemdScope>) {
+) -> std::io::Result<(tokio::process::Command, Option<SystemdScope>)> {
     #[cfg(target_os = "linux")]
     {
         if let Some(mode) = systemd_scope_mode() {
@@ -432,10 +432,13 @@ fn contain_command(
                 unit: format!("sandboxed-node-job-{}.scope", Uuid::new_v4().simple()),
                 mode,
             };
-            return (systemd_scope_command(cmd, environment, &scope), Some(scope));
+            return Ok((
+                systemd_scope_command(cmd, environment, &scope)?,
+                Some(scope),
+            ));
         }
     }
-    (cmd, None)
+    Ok((cmd, None))
 }
 
 #[cfg(target_os = "linux")]
@@ -482,7 +485,7 @@ fn systemd_scope_command(
     cmd: tokio::process::Command,
     environment: CommandEnvironment,
     scope: &SystemdScope,
-) -> tokio::process::Command {
+) -> std::io::Result<tokio::process::Command> {
     let command = cmd.as_std();
     let program = command.get_program().to_os_string();
     let args: Vec<_> = command.get_args().map(ToOwned::to_owned).collect();
@@ -509,15 +512,15 @@ fn systemd_scope_command(
         // systemd-run's own environment intact for the user bus, but reset
         // the environment at the payload boundary and add back only the
         // command's explicitly configured entries.
-        scoped.arg("env").arg("-i");
+        scoped
+            .arg(std::env::current_exe()?)
+            .arg("--sandboxed-scope-exec-cleared-env");
         for (key, value) in &env {
             if let Some(value) = value {
-                let mut assignment = key.clone();
-                assignment.push("=");
-                assignment.push(value);
-                scoped.arg(assignment);
+                scoped.arg(key).env(key, value);
             }
         }
+        scoped.arg("--");
     }
     scoped.arg(program).args(args);
     if let Some(cwd) = cwd {
@@ -535,7 +538,48 @@ fn systemd_scope_command(
             }
         }
     }
-    scoped
+    Ok(scoped)
+}
+
+/// Replace the node process with a scope payload whose environment contains
+/// only the named variables. Values stay in the inherited environment until
+/// `exec`, never in argv. Returns `Ok(false)` for a normal node invocation.
+pub fn maybe_exec_cleared_scope_payload() -> std::io::Result<bool> {
+    let mut args = std::env::args_os().skip(1);
+    if args.next().as_deref() != Some(std::ffi::OsStr::new("--sandboxed-scope-exec-cleared-env")) {
+        return Ok(false);
+    }
+
+    let mut keys = Vec::new();
+    loop {
+        let arg = args.next().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing scope payload")
+        })?;
+        if arg == "--" {
+            break;
+        }
+        keys.push(arg);
+    }
+    let program = args.next().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "missing scope payload program",
+        )
+    })?;
+    let env = keys
+        .into_iter()
+        .filter_map(|key| std::env::var_os(&key).map(|value| (key, value)))
+        .collect::<Vec<_>>();
+    let mut command = std::process::Command::new(program);
+    command.args(args).env_clear().envs(env);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        return Err(command.exec());
+    }
+    #[cfg(not(unix))]
+    Ok(true)
 }
 
 async fn kill_contained_process(
@@ -847,7 +891,8 @@ mod tests {
                 unit: "sandboxed-node-job-test.scope".to_string(),
                 mode: SystemdScopeMode::User,
             },
-        );
+        )
+        .unwrap();
         let argv = scoped
             .as_std()
             .get_args()
@@ -878,7 +923,8 @@ mod tests {
                 unit: "sandboxed-node-job-test.scope".to_string(),
                 mode: SystemdScopeMode::User,
             },
-        );
+        )
+        .unwrap();
         let argv = scoped
             .as_std()
             .get_args()
@@ -890,9 +936,11 @@ mod tests {
             .position(|arg| arg == "--")
             .map(|index| &argv[index + 1..])
             .expect("systemd-run payload separator");
-        assert_eq!(payload.first().map(String::as_str), Some("env"));
-        assert!(payload.iter().any(|arg| arg == "-i"));
-        assert!(payload.iter().any(|arg| arg == "EXPLICIT_JOB_ENV=present"));
+        assert!(payload
+            .iter()
+            .any(|arg| arg == "--sandboxed-scope-exec-cleared-env"));
+        assert!(payload.iter().any(|arg| arg == "EXPLICIT_JOB_ENV"));
+        assert!(!payload.iter().any(|arg| arg.contains("present")));
         assert!(!payload
             .iter()
             .any(|arg| arg.starts_with("SANDBOXED_NODE_TOKEN=")));

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -827,6 +827,38 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn user_scope_wrapper_preserves_cleared_payload_environment() {
+        let mut cmd = tokio::process::Command::new("/usr/bin/env");
+        cmd.env_clear().env("EXPLICIT_JOB_ENV", "present");
+
+        let scoped = systemd_scope_command(
+            cmd,
+            &SystemdScope {
+                unit: "sandboxed-node-job-test.scope".to_string(),
+                mode: SystemdScopeMode::User,
+            },
+        );
+        let argv = scoped
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        let payload = argv
+            .iter()
+            .position(|arg| arg == "--")
+            .map(|index| &argv[index + 1..])
+            .expect("systemd-run payload separator");
+        assert_eq!(payload.first().map(String::as_str), Some("env"));
+        assert!(payload.iter().any(|arg| arg == "-i"));
+        assert!(payload.iter().any(|arg| arg == "EXPLICIT_JOB_ENV=present"));
+        assert!(!payload
+            .iter()
+            .any(|arg| arg.starts_with("SANDBOXED_NODE_TOKEN=")));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn user_scope_probe_requires_an_accessible_bus_socket() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("bus"), b"not a socket").unwrap();

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -425,11 +425,21 @@ fn contain_command(
     cmd: tokio::process::Command,
     environment: CommandEnvironment,
 ) -> std::io::Result<(tokio::process::Command, Option<SystemdScope>)> {
-    // A libtest executable does not have sandboxed-node's hidden trampoline
-    // entrypoint. Construction is covered directly below; execution tests
-    // retain the process-group fallback for clear-env commands.
-    #[cfg(test)]
-    if environment == CommandEnvironment::Clear {
+    // Cargo's lib and binary test harnesses do not run sandboxed-node's main,
+    // so they cannot service the hidden trampoline entrypoint. Construction
+    // is covered directly below; execution tests retain the process-group
+    // fallback for clear-env commands.
+    if environment == CommandEnvironment::Clear
+        && std::env::current_exe()
+            .ok()
+            .and_then(|path| {
+                path.parent()
+                    .and_then(Path::file_name)
+                    .map(ToOwned::to_owned)
+            })
+            .as_deref()
+            == Some(std::ffi::OsStr::new("deps"))
+    {
         return Ok((cmd, None));
     }
     #[cfg(target_os = "linux")]

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -576,7 +576,7 @@ pub fn maybe_exec_cleared_scope_payload() -> std::io::Result<bool> {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        return Err(command.exec());
+        Err(command.exec())
     }
     #[cfg(not(unix))]
     Ok(true)

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -425,6 +425,13 @@ fn contain_command(
     cmd: tokio::process::Command,
     environment: CommandEnvironment,
 ) -> std::io::Result<(tokio::process::Command, Option<SystemdScope>)> {
+    // A libtest executable does not have sandboxed-node's hidden trampoline
+    // entrypoint. Construction is covered directly below; execution tests
+    // retain the process-group fallback for clear-env commands.
+    #[cfg(test)]
+    if environment == CommandEnvironment::Clear {
+        return Ok((cmd, None));
+    }
     #[cfg(target_os = "linux")]
     {
         if let Some(mode) = systemd_scope_mode() {


### PR DESCRIPTION
## Summary

- carry the intended payload environment policy explicitly through `run_logged_command` and the systemd scope wrapper
- for raw and Lean jobs that use `env_clear()`, route the scoped payload through a small node exec trampoline that reconstructs a clean environment from explicitly named variables
- preserve the existing wrapper behavior for commands that inherit their environment

## Why an exec trampoline

With `systemd-run --scope`, `systemd-run` executes the payload itself, so the payload otherwise inherits the client process environment. Clearing the environment on the outer `systemd-run` command is not viable for user scopes because the client still needs `XDG_RUNTIME_DIR` and/or `DBUS_SESSION_BUS_ADDRESS` to connect to the user manager. `--setenv` does not create a separate exec environment at the payload boundary in scope mode.

An initial `env -i KEY=VALUE...` implementation fixed runner-secret inheritance but placed explicit job env values in argv. The final implementation invokes the current node binary in a hidden trampoline mode. Only the allowed env **key names** are arguments; values stay in the outer environment. The trampoline reads those named values, constructs the real payload with `env_clear()` plus exactly those entries, then `exec`s it. Thus systemd-run keeps its bus/runtime variables, neither runner secrets nor job env values appear in argv, and the payload sees only its explicit environment.

## Regression evidence

The regression test was committed first as `a74e0591`. Against the pre-fix wrapper it fails because there is no clean-environment boundary. The final construction assertion verifies that the clear-env trampoline is present, explicit env keys are passed, explicit values are absent from argv, and `SANDBOXED_NODE_TOKEN` is not forwarded. With the fix it passes:

```text
test node::runner::tests::user_scope_wrapper_preserves_cleared_payload_environment ... ok
```

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace -- -D clippy::all`
- `cargo test --locked` — 1284 library tests passed, 1 ignored; all binary and doc-test suites passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how sandboxed job processes are spawned under systemd and how environment isolation is enforced at the payload boundary—security-critical for remote build workloads.
> 
> **Overview**
> Fixes a regression where **`systemd-run --scope`** ran cleared-env job payloads (raw commands and Lean builds) with the **runner service environment**, so secrets like `SANDBOXED_NODE_TOKEN` could reach untrusted code.
> 
> Job execution now threads an explicit **`CommandEnvironment`** (`Inherit` vs `Clear`) through `run_logged_command` and the systemd scope wrapper. **Clear** jobs on Linux route the scope payload through a hidden **`--sandboxed-scope-exec-cleared-env`** trampoline on the node binary: only env **key names** appear in argv; values are read from the outer env, then the real program runs under `env_clear()` plus those entries. **`sandboxed_node` main** handles that mode via `maybe_exec_cleared_scope_payload()` and exits before starting the HTTP server.
> 
> Git steps keep **`Inherit`**; raw and Lean build steps use **`Clear`**. Cargo test harnesses skip the trampoline when the exe lives under `deps/`. A Linux unit test asserts the clear-env scope argv shape and that runner tokens are not forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00a83c0d01a56a67285b09f9a334c28946cee71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->