### PR TITLE
Fix legacy durable job authorization via owning mission

### DIFF
--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -203,18 +203,15 @@ async fn authorize_legacy_job(
             "legacy durable job has no caller ownership metadata",
         )
     })?;
-    let workspace_id = job.workspace_id.ok_or_else(|| {
-        err(
-            StatusCode::FORBIDDEN,
-            "legacy durable job has no workspace ownership metadata",
-        )
-    })?;
     let mission = mission_store
         .get_mission(mission_id)
         .await
         .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error))?
         .ok_or_else(|| err(StatusCode::FORBIDDEN, "durable job belongs to another user"))?;
-    if mission.workspace_id != workspace_id {
+    if job
+        .workspace_id
+        .is_some_and(|workspace_id| mission.workspace_id != workspace_id)
+    {
         return Err(err(
             StatusCode::FORBIDDEN,
             "durable job belongs to another user",

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -23,6 +23,7 @@ use tokio::process::{Child, Command};
 use uuid::Uuid;
 
 use super::{auth::AuthUser, control::control_for_user, routes::AppState};
+use crate::api::mission_store::MissionStore;
 use crate::workspace::WorkspaceType;
 use crate::workspace_exec::WorkspaceExec;
 
@@ -188,6 +189,14 @@ async fn authorize_job(
     }
 
     // Backward compatibility for jobs created before owner_user_id existed.
+    let control = control_for_user(state, user).await;
+    authorize_legacy_job(&control.mission_store, job).await
+}
+
+async fn authorize_legacy_job(
+    mission_store: &Arc<dyn MissionStore>,
+    job: &DurableJob,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     let mission_id = job.started_by_mission_id.ok_or_else(|| {
         err(
             StatusCode::FORBIDDEN,
@@ -200,9 +209,7 @@ async fn authorize_job(
             "legacy durable job has no workspace ownership metadata",
         )
     })?;
-    let control = control_for_user(state, user).await;
-    let mission = control
-        .mission_store
+    let mission = mission_store
         .get_mission(mission_id)
         .await
         .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error))?
@@ -838,6 +845,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::mission_store::SqliteMissionStore;
 
     fn test_job(status: DurableJobStatus) -> DurableJob {
         let now = Utc::now();
@@ -1024,6 +1032,44 @@ mod tests {
         assert!(terminal_for_mission(dir.path(), job.id, mission_id)
             .await
             .unwrap());
+    }
+
+    #[tokio::test]
+    async fn legacy_job_without_workspace_uses_owning_mission() {
+        let dir = tempfile::tempdir().unwrap();
+        let owner_store: Arc<dyn MissionStore> = Arc::new(
+            SqliteMissionStore::new(dir.path().to_path_buf(), "owner")
+                .await
+                .unwrap(),
+        );
+        let other_store: Arc<dyn MissionStore> = Arc::new(
+            SqliteMissionStore::new(dir.path().to_path_buf(), "other")
+                .await
+                .unwrap(),
+        );
+        let mission = owner_store
+            .create_mission(Some("legacy owner"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let mut job = test_job(DurableJobStatus::Running);
+        job.started_by_mission_id = Some(mission.id);
+        let registry_dir = dir
+            .path()
+            .join(".sandboxed-sh/durable-jobs")
+            .join(job.id.to_string());
+        std::fs::create_dir_all(&registry_dir).unwrap();
+        std::fs::write(
+            registry_dir.join("job.json"),
+            serde_json::to_vec(&job).unwrap(),
+        )
+        .unwrap();
+        let persisted: DurableJob =
+            serde_json::from_slice(&std::fs::read(registry_dir.join("job.json")).unwrap()).unwrap();
+
+        assert!(authorize_legacy_job(&owner_store, &persisted).await.is_ok());
+        assert!(authorize_legacy_job(&other_store, &persisted)
+            .await
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- authorize legacy durable jobs by resolving `started_by_mission_id` before consulting optional workspace metadata
- derive ownership from the caller-scoped mission when `workspace_id` is absent
- preserve workspace consistency rejection when legacy jobs carry `workspace_id`
- add a persisted legacy-job regression covering owner access and cross-user rejection

## Test evidence
- Red: `cargo test --locked api::durable_jobs::tests::legacy_job_without_workspace_uses_owning_mission -- --exact` failed at the owner authorization assertion before the fix
- Green: the same regression passed after the fix
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test --locked --lib api::durable_jobs::tests` (14 passed)
- `cargo clippy --locked --workspace -- -D clippy::all`
- `cargo test --locked` (workspace suite passed; 2 doc tests ignored)

Base fetched from `origin/master`: `236f64458c3d0eab96bda0403c26e62664a50a11`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable-job authorization for legacy records; behavior change could affect access boundaries, though cross-user rejection and workspace mismatch checks are preserved.
> 
> **Overview**
> Fixes **false 403s** for pre-`owner_user_id` durable jobs that have `started_by_mission_id` but no `workspace_id`.
> 
> Legacy authorization is moved into `authorize_legacy_job`, which loads the mission from the **caller’s** `MissionStore` and allows access when that mission exists. A stored `workspace_id` is only enforced when present—mismatch with the mission’s workspace still returns forbidden.
> 
> Adds `legacy_job_without_workspace_uses_owning_mission` to assert the owning user’s store authorizes the job and another user’s store does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80739ea7106c3ec1a1937b8beff73dc5d449f1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->