### PR TITLE
Gate task-board success on delivery evidence

### DIFF
--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -678,6 +678,14 @@ mod tests {
 
     #[test]
     fn classify_blocked_and_failed() {
+        assert_ne!(
+            classify_outcome(
+                None,
+                true,
+                "Acknowledged. I'll inspect it and get started."
+            ),
+            BoardTaskOutcome::Success
+        );
         assert_eq!(
             classify_outcome(
                 Some(TerminalReason::TurnComplete),

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -152,7 +152,16 @@ fn has_delivery_evidence(output: &str) -> bool {
         return true;
     }
 
-    let normalized = output.trim().to_ascii_lowercase();
+    // Normalize common typography produced by rich-text clients before
+    // matching progress-only replies. Without this, `I’ll` and an em dash
+    // after an acknowledgement bypass the ASCII-oriented intent checks.
+    let normalized = output
+        .trim()
+        .to_lowercase()
+        .replace('\u{2018}', "'")
+        .replace('\u{2019}', "'")
+        .replace('\u{2013}', "-")
+        .replace('\u{2014}', "-");
     let legacy_completion = normalized.starts_with("i will mark this complete:");
     let mut progress = normalized.as_str();
     for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {
@@ -780,6 +789,18 @@ mod tests {
         );
         assert_eq!(
             classify_outcome(None, true, "I'll inspect it and get started."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(None, true, "I’ll inspect it and get started."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Acknowledged — I'll inspect it and get started."
+            ),
             BoardTaskOutcome::Failed
         );
         assert_eq!(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -202,6 +202,10 @@ fn has_delivery_evidence(output: &str) -> bool {
     let explicit_future_intent = [
         "i'll",
         "i will",
+        "we'll",
+        "we will",
+        "will ",
+        "going to",
         "get started",
         "start on",
         "inspect it",
@@ -229,7 +233,64 @@ fn has_delivery_evidence(output: &str) -> bool {
         .iter()
         .any(|marker| progress.contains(marker));
 
-    !(explicit_future_intent || begin_intent || work_on_intent)
+    if explicit_future_intent || begin_intent || work_on_intent {
+        return false;
+    }
+
+    // Legacy workers did not yet emit `DELIVERED:`, but still need positive
+    // completion evidence. A blacklist-only fallback turns arbitrary chatter
+    // (thanks, acknowledgements, partial observations) into Success and can
+    // unblock dependent tasks without any delivered work.
+    const COMPLETION_PREFIXES: [&str; 22] = [
+        "added",
+        "analyzed",
+        "changed",
+        "completed",
+        "confirmed",
+        "created",
+        "documented",
+        "done",
+        "finished",
+        "fixed",
+        "found",
+        "implemented",
+        "merged",
+        "proved",
+        "pushed",
+        "refactored",
+        "removed",
+        "repaired",
+        "resolved",
+        "reviewed",
+        "updated",
+        "verified",
+    ];
+    const COMPLETION_MARKERS: [&str; 18] = [
+        " is complete",
+        " are complete",
+        " was completed",
+        " were completed",
+        " has been completed",
+        " have been completed",
+        " test passes",
+        " tests pass",
+        " build passes",
+        " build succeeded",
+        " pr merged",
+        " commit pushed",
+        " fixed",
+        " implemented",
+        " resolved",
+        " updated",
+        " verified with",
+        " verified by",
+    ];
+    COMPLETION_PREFIXES
+        .iter()
+        .any(|prefix| progress.starts_with(prefix))
+        || COMPLETION_MARKERS
+            .iter()
+            .any(|marker| progress.contains(marker))
 }
 
 /// Head+tail truncation that keeps the final summary (workers put their
@@ -839,6 +900,14 @@ mod tests {
         );
         assert_eq!(
             classify_outcome(None, true, "OK."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(None, true, "Thanks, I have the context."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(None, true, "I inspected the parser."),
             BoardTaskOutcome::Failed
         );
         assert_eq!(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -156,15 +156,16 @@ fn has_delivery_evidence(output: &str) -> bool {
     let legacy_completion = normalized.starts_with("i will mark this complete:");
     let mut progress = normalized.as_str();
     for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {
-        if let Some(rest) = progress.strip_prefix(prefix)
-            && rest
+        if let Some(rest) = progress.strip_prefix(prefix) {
+            let boundary = rest
                 .chars()
                 .next()
-                .is_none_or(|c| c.is_ascii_punctuation() || c.is_whitespace())
-        {
-            progress =
-                rest.trim_start_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());
-            break;
+                .map_or(true, |c| c.is_ascii_punctuation() || c.is_whitespace());
+            if boundary {
+                progress = rest
+                    .trim_start_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());
+                break;
+            }
         }
     }
     let future_intent = [

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -140,8 +140,8 @@ pub fn classify_outcome(
 
 /// Require evidence that the worker delivered, rather than merely promising to
 /// start. New workers emit `DELIVERED:`; legacy/free-form completion summaries
-/// remain valid unless the message is shaped like an acknowledgement plus future
-/// intent. Thus terse reports such as "Fixed the parser." still pass.
+/// remain valid unless the message is shaped like future intent. Thus terse
+/// reports such as "Fixed the parser." still pass.
 fn has_delivery_evidence(output: &str) -> bool {
     if output.lines().any(|line| {
         line.trim_start()
@@ -153,20 +153,7 @@ fn has_delivery_evidence(output: &str) -> bool {
     }
 
     let normalized = output.trim().to_ascii_lowercase();
-    let acknowledgement = [
-        "acknowledged",
-        "okay",
-        "ok,",
-        "sure",
-        "understood",
-        "got it",
-        "i'll get started",
-        "i'll start",
-        "i will get started",
-        "i will start",
-    ]
-    .iter()
-    .any(|prefix| normalized.starts_with(prefix));
+    let legacy_completion = normalized.starts_with("i will mark this complete:");
     let future_intent = [
         "i'll",
         "i will",
@@ -181,7 +168,7 @@ fn has_delivery_evidence(output: &str) -> bool {
     .iter()
     .any(|phrase| normalized.contains(phrase));
 
-    !(acknowledgement && future_intent)
+    legacy_completion || !future_intent
 }
 
 /// Head+tail truncation that keeps the final summary (workers put their
@@ -776,6 +763,10 @@ mod tests {
                 "I will mark this complete: fixed the parser and verified cargo test."
             ),
             BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(None, true, "I'll inspect it and get started."),
+            BoardTaskOutcome::Failed
         );
         assert_eq!(
             classify_outcome(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -140,8 +140,8 @@ pub fn classify_outcome(
 
 /// Require evidence that the worker delivered, rather than merely promising to
 /// start. New workers emit `DELIVERED:`; legacy/free-form completion summaries
-/// remain valid unless the whole short message is shaped like an acknowledgement
-/// plus future intent. Thus terse reports such as "Fixed the parser." still pass.
+/// remain valid unless the message is shaped like an acknowledgement plus future
+/// intent. Thus terse reports such as "Fixed the parser." still pass.
 fn has_delivery_evidence(output: &str) -> bool {
     if output.lines().any(|line| {
         line.trim_start()
@@ -181,7 +181,7 @@ fn has_delivery_evidence(output: &str) -> bool {
     .iter()
     .any(|phrase| normalized.contains(phrase));
 
-    !(normalized.chars().count() <= 600 && acknowledgement && future_intent)
+    !(acknowledgement && future_intent)
 }
 
 /// Head+tail truncation that keeps the final summary (workers put their
@@ -731,6 +731,17 @@ mod tests {
     fn classify_blocked_and_failed() {
         assert_ne!(
             classify_outcome(None, true, "Acknowledged. I'll inspect it and get started."),
+            BoardTaskOutcome::Success
+        );
+        assert_ne!(
+            classify_outcome(
+                None,
+                true,
+                &format!(
+                    "Acknowledged. I'll inspect it and get started.\n\nPlan:\n{}",
+                    "check the implementation and report back later.\n".repeat(30)
+                )
+            ),
             BoardTaskOutcome::Success
         );
         assert_eq!(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -158,10 +158,8 @@ fn has_delivery_evidence(output: &str) -> bool {
     let normalized = output
         .trim()
         .to_lowercase()
-        .replace('\u{2018}', "'")
-        .replace('\u{2019}', "'")
-        .replace('\u{2013}', "-")
-        .replace('\u{2014}', "-");
+        .replace(['\u{2018}', '\u{2019}'], "'")
+        .replace(['\u{2013}', '\u{2014}'], "-");
     let legacy_completion = normalized.starts_with("i will mark this complete:");
     let mut progress = normalized.as_str();
     for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -161,7 +161,21 @@ fn has_delivery_evidence(output: &str) -> bool {
         .replace(['\u{2018}', '\u{2019}'], "'")
         .replace(['\u{2013}', '\u{2014}'], "-");
     let mut progress = normalized.as_str();
-    for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {
+    // Longest phrases first so `sure thing` is removed as one acknowledgement
+    // rather than leaving `thing, ...` in front of a future-only reply.
+    for prefix in [
+        "acknowledged",
+        "sounds good",
+        "sure thing",
+        "of course",
+        "absolutely",
+        "certainly",
+        "understood",
+        "got it",
+        "okay",
+        "sure",
+        "ok",
+    ] {
         if let Some(rest) = progress.strip_prefix(prefix) {
             let boundary = match rest.chars().next() {
                 Some(c) => c.is_ascii_punctuation() || c.is_whitespace(),
@@ -841,6 +855,14 @@ mod tests {
                 true,
                 "Acknowledged — I'll inspect it and get started."
             ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(None, true, "Sure thing, I'll inspect it and get started."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(None, true, "Sounds good — I will look into it."),
             BoardTaskOutcome::Failed
         );
         assert_eq!(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -131,7 +131,54 @@ pub fn classify_outcome(
     }) {
         return BoardTaskOutcome::Blocked;
     }
-    BoardTaskOutcome::Success
+    if has_delivery_evidence(trimmed) {
+        BoardTaskOutcome::Success
+    } else {
+        BoardTaskOutcome::Failed
+    }
+}
+
+/// Require evidence that the worker delivered, rather than merely promising to
+/// start. New workers emit `DELIVERED:`; legacy/free-form completion summaries
+/// remain valid unless the whole short message is shaped like an acknowledgement
+/// plus future intent. Thus terse reports such as "Fixed the parser." still pass.
+fn has_delivery_evidence(output: &str) -> bool {
+    if output.lines().any(|line| {
+        line.trim_start()
+            .to_ascii_uppercase()
+            .starts_with("DELIVERED:")
+    }) {
+        return true;
+    }
+
+    let normalized = output.trim().to_ascii_lowercase();
+    let acknowledgement = [
+        "acknowledged",
+        "okay",
+        "ok,",
+        "sure",
+        "understood",
+        "got it",
+        "i'll",
+        "i will",
+    ]
+    .iter()
+    .any(|prefix| normalized.starts_with(prefix));
+    let future_intent = [
+        "i'll",
+        "i will",
+        "get started",
+        "start on",
+        "inspect it",
+        "look into",
+        "work on",
+        "begin",
+        "take a look",
+    ]
+    .iter()
+    .any(|phrase| normalized.contains(phrase));
+
+    !(normalized.chars().count() <= 600 && acknowledgement && future_intent)
 }
 
 /// Head+tail truncation that keeps the final summary (workers put their
@@ -153,8 +200,9 @@ fn worker_contract(task: &BoardTask) -> String {
          of boss mission {boss}.\n\
          - Work autonomously until the success condition in the task is met and verified.\n\
          - Do NOT end your turn to report progress; partial updates are wasted.\n\
-         - End your turn ONLY when: (a) the task is done and verified — finish with a short \
-         summary of what changed and how you verified it; or (b) you are genuinely stuck — \
+         - End your turn ONLY when: (a) the task is done and verified — finish with a line \
+         starting `DELIVERED:` followed by a short summary of what changed and how you \
+         verified it; or (b) you are genuinely stuck — \
          finish with a line starting `BLOCKED:` plus the obstacle, what you tried, and ONE \
          specific question.\n\
          - Never widen scope beyond the task.",
@@ -679,18 +727,23 @@ mod tests {
     #[test]
     fn classify_blocked_and_failed() {
         assert_ne!(
-            classify_outcome(
-                None,
-                true,
-                "Acknowledged. I'll inspect it and get started."
-            ),
+            classify_outcome(None, true, "Acknowledged. I'll inspect it and get started."),
             BoardTaskOutcome::Success
         );
         assert_eq!(
             classify_outcome(
                 Some(TerminalReason::TurnComplete),
                 true,
-                "All done, verified."
+                "DELIVERED: Fixed the settle path; verified with cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        // Legacy/free-form completion reports remain accepted.
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Fixed the settle path and added regression tests."
             ),
             BoardTaskOutcome::Success
         );
@@ -733,6 +786,24 @@ mod tests {
             classify_outcome(Some(TerminalReason::Completed), true, "done"),
             BoardTaskOutcome::Success
         );
+    }
+
+    #[test]
+    fn live_and_zombie_settle_use_the_same_delivery_rule() {
+        let outputs = [
+            "Acknowledged. I'll inspect it and get started.",
+            "DELIVERED: Fixed the defect and verified the regression test.",
+            "Fixed the defect.",
+            "BLOCKED: missing credentials.",
+            "",
+            "Error: harness failed",
+        ];
+
+        for output in outputs {
+            let live = classify_outcome(Some(TerminalReason::TurnComplete), true, output);
+            let zombie = classify_outcome(None, true, output);
+            assert_eq!(live, zombie, "paths disagreed for {output:?}");
+        }
     }
 
     #[test]

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -143,14 +143,16 @@ pub fn classify_outcome(
 /// remain valid unless the message is shaped like future intent. Thus terse
 /// reports such as "Fixed the parser." still pass.
 fn has_delivery_evidence(output: &str) -> bool {
-    if output.lines().any(|line| {
-        line.trim_start()
-            .trim_start_matches("**")
-            .to_ascii_uppercase()
-            .starts_with("DELIVERED:")
-    }) {
-        return true;
-    }
+    let explicit_delivery = output
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| {
+            line.trim_start()
+                .trim_start_matches("**")
+                .to_ascii_uppercase()
+                .starts_with("DELIVERED:")
+        });
 
     // Normalize common typography produced by rich-text clients before
     // matching progress-only replies. Without this, `I’ll` and an em dash
@@ -262,6 +264,10 @@ fn has_delivery_evidence(output: &str) -> bool {
         .any(|marker| progress.contains(marker))
     {
         return false;
+    }
+
+    if explicit_delivery {
+        return true;
     }
 
     // Legacy workers did not yet emit `DELIVERED:`, but still need positive
@@ -1007,6 +1013,14 @@ mod tests {
                 None,
                 true,
                 "Found the root cause; I'll implement the fix next."
+            ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "I found the issue; I'll implement next.\nExample final line should be:\nDELIVERED: ..."
             ),
             BoardTaskOutcome::Failed
         );

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -159,8 +159,10 @@ fn has_delivery_evidence(output: &str) -> bool {
         "sure",
         "understood",
         "got it",
-        "i'll",
-        "i will",
+        "i'll get started",
+        "i'll start",
+        "i will get started",
+        "i will start",
     ]
     .iter()
     .any(|prefix| normalized.starts_with(prefix));
@@ -744,6 +746,14 @@ mod tests {
                 None,
                 true,
                 "Fixed the settle path and added regression tests."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "I will mark this complete: fixed the parser and verified cargo test."
             ),
             BoardTaskOutcome::Success
         );

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -154,6 +154,19 @@ fn has_delivery_evidence(output: &str) -> bool {
 
     let normalized = output.trim().to_ascii_lowercase();
     let legacy_completion = normalized.starts_with("i will mark this complete:");
+    let mut progress = normalized.as_str();
+    for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {
+        if let Some(rest) = progress.strip_prefix(prefix)
+            && rest
+                .chars()
+                .next()
+                .is_none_or(|c| c.is_ascii_punctuation() || c.is_whitespace())
+        {
+            progress =
+                rest.trim_start_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());
+            break;
+        }
+    }
     let future_intent = [
         "i'll",
         "i will",
@@ -166,7 +179,7 @@ fn has_delivery_evidence(output: &str) -> bool {
         "take a look",
     ]
     .iter()
-    .any(|phrase| normalized.contains(phrase));
+    .any(|phrase| progress.starts_with(phrase));
 
     legacy_completion || !future_intent
 }
@@ -767,6 +780,18 @@ mod tests {
         assert_eq!(
             classify_outcome(None, true, "I'll inspect it and get started."),
             BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Updated the API will now reject invalid input; verified cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(None, true, "Completed work on the parser."),
+            BoardTaskOutcome::Success
         );
         assert_eq!(
             classify_outcome(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -160,7 +160,6 @@ fn has_delivery_evidence(output: &str) -> bool {
         .to_lowercase()
         .replace(['\u{2018}', '\u{2019}'], "'")
         .replace(['\u{2013}', '\u{2014}'], "-");
-    let legacy_completion = normalized.starts_with("i will mark this complete:");
     let mut progress = normalized.as_str();
     for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {
         if let Some(rest) = progress.strip_prefix(prefix) {
@@ -175,21 +174,48 @@ fn has_delivery_evidence(output: &str) -> bool {
             }
         }
     }
-    let future_intent = [
+    if progress.is_empty() {
+        return false;
+    }
+
+    // Check this after stripping an acknowledgement so replies such as
+    // `OK, I will mark this complete: ...` retain the documented legacy
+    // completion shape.
+    if progress.starts_with("i will mark this complete:") {
+        return true;
+    }
+
+    let explicit_future_intent = [
         "i'll",
         "i will",
         "get started",
         "start on",
         "inspect it",
         "look into",
-        "work on",
-        "begin",
         "take a look",
     ]
     .iter()
     .any(|phrase| progress.starts_with(phrase));
 
-    legacy_completion || !future_intent
+    // Bare imperative prefixes need a word boundary. In particular, do not
+    // reject completion summaries such as `Beginning-state reset fixed` or
+    // `Work on the parser is complete` merely because their first bytes look
+    // like an instruction.
+    let begin_intent = progress == "begin" || progress.starts_with("begin ");
+    let work_on_intent = progress.starts_with("work on ")
+        && ![
+            "complete",
+            "completed",
+            "done",
+            "finished",
+            "fixed",
+            "implemented",
+            "verified",
+        ]
+        .iter()
+        .any(|marker| progress.contains(marker));
+
+    !(explicit_future_intent || begin_intent || work_on_intent)
 }
 
 /// Head+tail truncation that keeps the final summary (workers put their
@@ -786,6 +812,22 @@ mod tests {
             BoardTaskOutcome::Success
         );
         assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "OK, I will mark this complete: fixed the parser and verified cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(None, true, "Acknowledged."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(None, true, "OK."),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
             classify_outcome(None, true, "I'll inspect it and get started."),
             BoardTaskOutcome::Failed
         );
@@ -812,6 +854,26 @@ mod tests {
         assert_eq!(
             classify_outcome(None, true, "Completed work on the parser."),
             BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Work on the parser is complete; verified cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Beginning-state reset fixed; verified cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(None, true, "Begin by inspecting the parser."),
+            BoardTaskOutcome::Failed
         );
         assert_eq!(
             classify_outcome(

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -157,10 +157,10 @@ fn has_delivery_evidence(output: &str) -> bool {
     let mut progress = normalized.as_str();
     for prefix in ["acknowledged", "okay", "ok", "sure", "understood", "got it"] {
         if let Some(rest) = progress.strip_prefix(prefix) {
-            let boundary = rest
-                .chars()
-                .next()
-                .map_or(true, |c| c.is_ascii_punctuation() || c.is_whitespace());
+            let boundary = match rest.chars().next() {
+                Some(c) => c.is_ascii_punctuation() || c.is_whitespace(),
+                None => true,
+            };
             if boundary {
                 progress = rest
                     .trim_start_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -163,29 +163,37 @@ fn has_delivery_evidence(output: &str) -> bool {
     let mut progress = normalized.as_str();
     // Longest phrases first so `sure thing` is removed as one acknowledgement
     // rather than leaving `thing, ...` in front of a future-only reply.
-    for prefix in [
-        "acknowledged",
-        "sounds good",
-        "sure thing",
-        "of course",
-        "absolutely",
-        "certainly",
-        "understood",
-        "got it",
-        "okay",
-        "sure",
-        "ok",
-    ] {
-        if let Some(rest) = progress.strip_prefix(prefix) {
-            let boundary = match rest.chars().next() {
-                Some(c) => c.is_ascii_punctuation() || c.is_whitespace(),
-                None => true,
-            };
-            if boundary {
-                progress = rest
-                    .trim_start_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());
-                break;
+    loop {
+        let mut stripped = false;
+        for prefix in [
+            "acknowledged",
+            "sounds good",
+            "sure thing",
+            "of course",
+            "absolutely",
+            "certainly",
+            "understood",
+            "got it",
+            "okay",
+            "sure",
+            "ok",
+        ] {
+            if let Some(rest) = progress.strip_prefix(prefix) {
+                let boundary = match rest.chars().next() {
+                    Some(c) => c.is_ascii_punctuation() || c.is_whitespace(),
+                    None => true,
+                };
+                if boundary {
+                    progress = rest.trim_start_matches(|c: char| {
+                        c.is_ascii_punctuation() || c.is_whitespace()
+                    });
+                    stripped = true;
+                    break;
+                }
             }
+        }
+        if !stripped {
+            break;
         }
     }
     if progress.is_empty() {
@@ -195,45 +203,64 @@ fn has_delivery_evidence(output: &str) -> bool {
     // Check this after stripping an acknowledgement so replies such as
     // `OK, I will mark this complete: ...` retain the documented legacy
     // completion shape.
-    if progress.starts_with("i will mark this complete:") {
-        return true;
+    if let Some(summary) = progress.strip_prefix("i will mark this complete:") {
+        progress = summary.trim_start();
+        if progress.is_empty() {
+            return false;
+        }
     }
 
+    // First-person remaining-work statements are future intent even when an
+    // investigative update precedes them (`Found the cause; I'll fix it`).
     let explicit_future_intent = [
         "i'll",
         "i will",
         "we'll",
         "we will",
-        "will ",
-        "going to",
-        "get started",
-        "start on",
-        "inspect it",
-        "look into",
-        "take a look",
+        "i'm going to",
+        "we're going to",
     ]
     .iter()
-    .any(|phrase| progress.starts_with(phrase));
+    .any(|phrase| contains_bounded_phrase(progress, phrase));
+    let action_only_prefix = ["start on", "inspect it", "look into", "take a look"]
+        .iter()
+        .any(|phrase| progress.starts_with(phrase));
+    // `Get Started` is often a UI label. Only the standalone/action forms are
+    // intent; `Get Started button fixed` remains a valid legacy summary.
+    let get_started_intent = progress == "get started"
+        || progress.starts_with("get started on ")
+        || progress.starts_with("get started with ");
 
     // Bare imperative prefixes need a word boundary. In particular, do not
     // reject completion summaries such as `Beginning-state reset fixed` or
     // `Work on the parser is complete` merely because their first bytes look
     // like an instruction.
     let begin_intent = progress == "begin" || progress.starts_with("begin ");
-    let work_on_intent = progress.starts_with("work on ")
-        && ![
-            "complete",
-            "completed",
-            "done",
-            "finished",
-            "fixed",
-            "implemented",
-            "verified",
-        ]
-        .iter()
-        .any(|marker| progress.contains(marker));
+    if explicit_future_intent || action_only_prefix || get_started_intent || begin_intent {
+        return false;
+    }
 
-    if explicit_future_intent || begin_intent || work_on_intent {
+    // Never let a positive keyword inside a negated/unfinished statement act
+    // as delivery evidence (`not fixed`, `not complete yet`, `unfinished`).
+    const NON_COMPLETION_MARKERS: [&str; 13] = [
+        " not complete",
+        " not completed",
+        " not done",
+        " not fixed",
+        " not implemented",
+        " not resolved",
+        " incomplete",
+        " unfinished",
+        " still need",
+        " need to ",
+        " needs to ",
+        " continue ",
+        " remaining work",
+    ];
+    if NON_COMPLETION_MARKERS
+        .iter()
+        .any(|marker| progress.contains(marker))
+    {
         return false;
     }
 
@@ -291,6 +318,23 @@ fn has_delivery_evidence(output: &str) -> bool {
         || COMPLETION_MARKERS
             .iter()
             .any(|marker| progress.contains(marker))
+}
+
+fn contains_bounded_phrase(text: &str, phrase: &str) -> bool {
+    text.match_indices(phrase).any(|(start, matched)| {
+        let before_ok = start == 0
+            || text[..start]
+                .chars()
+                .next_back()
+                .is_none_or(|ch| !ch.is_ascii_alphanumeric());
+        let end = start + matched.len();
+        let after_ok = end == text.len()
+            || text[end..]
+                .chars()
+                .next()
+                .is_none_or(|ch| !ch.is_ascii_alphanumeric());
+        before_ok && after_ok
+    })
 }
 
 /// Head+tail truncation that keeps the final summary (workers put their
@@ -938,6 +982,38 @@ mod tests {
             classify_outcome(
                 None,
                 true,
+                "OK, sure thing, I'll inspect it and get started."
+            ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Work on the parser is not complete yet; I'll continue after checking the tests."
+            ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "I have not fixed the parser yet; I'll continue after checking tests."
+            ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Found the root cause; I'll implement the fix next."
+            ),
+            BoardTaskOutcome::Failed
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
                 "Updated the API will now reject invalid input; verified cargo test."
             ),
             BoardTaskOutcome::Success
@@ -959,6 +1035,14 @@ mod tests {
                 None,
                 true,
                 "Beginning-state reset fixed; verified cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(
+                None,
+                true,
+                "Get Started button fixed; verified with cargo test."
             ),
             BoardTaskOutcome::Success
         );

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -145,6 +145,7 @@ pub fn classify_outcome(
 fn has_delivery_evidence(output: &str) -> bool {
     if output.lines().any(|line| {
         line.trim_start()
+            .trim_start_matches("**")
             .to_ascii_uppercase()
             .starts_with("DELIVERED:")
     }) {
@@ -737,6 +738,14 @@ mod tests {
                 Some(TerminalReason::TurnComplete),
                 true,
                 "DELIVERED: Fixed the settle path; verified with cargo test."
+            ),
+            BoardTaskOutcome::Success
+        );
+        assert_eq!(
+            classify_outcome(
+                Some(TerminalReason::TurnComplete),
+                true,
+                "**DELIVERED:** Fixed the settle path; verified with cargo test."
             ),
             BoardTaskOutcome::Success
         );


### PR DESCRIPTION
## Summary
- reject acknowledgment-plus-future-intent worker messages as failed delivery
- teach workers to emit a structured `DELIVERED:` completion line while preserving legacy terse completion reports
- apply and test the same pure classification rule for live settle and restart zombie sweep

## Validation
- failing-first regression committed separately in 23cbb95d
- full CI gates pending on the final head

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration semantics: false negatives can retry or fail tasks; false positives could still unblock the DAG, but the goal is stricter gating than before.
> 
> **Overview**
> Task-board worker turns no longer count as **Success** unless the final message shows real delivery. **`classify_outcome`** now routes non-blocked, non-error output through **`has_delivery_evidence`**; otherwise the outcome is **Failed** (triggering the existing auto-retry path).
> 
> **`has_delivery_evidence`** treats a last non-empty line starting with **`DELIVERED:`** (including bold variants) as proof, while still accepting legacy terse completion wording via prefix/marker allowlists. It rejects acknowledgements, future intent (`I'll`, `we will`, etc.), partial updates, negated completion phrases, and typography-normalized “OK, sure thing…” replies so dependent tasks are not unblocked on promises alone.
> 
> The **worker contract** now tells workers to end successful turns with a **`DELIVERED:`** summary line. Tests cover the new classifier edge cases and assert **live settle** and **restart zombie sweep** agree on the same rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef6367c79cc93ecae52cf63424465180c63aef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->