### PR TITLE
fix: reconcile app-server tool calls after transport loss

### DIFF
--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -1,5 +1,6 @@
 pub mod app_server;
 pub mod client;
+mod tool_call_journal;
 
 use anyhow::Error;
 use async_trait::async_trait;
@@ -12,6 +13,7 @@ use crate::backend::events::ExecutionEvent;
 use crate::backend::{AgentInfo, Backend, Session, SessionConfig};
 
 use client::CodexConfig;
+use tool_call_journal::{PendingToolCall, ToolCallJournal};
 
 /// Codex backend that spawns the Codex CLI for mission execution.
 pub struct CodexBackend {
@@ -376,6 +378,11 @@ async fn send_message_streaming_app_server(
     let reconnect_cwd = session.directory.clone();
     let reconnect_workspace_exec = workspace_exec.cloned();
     let reconnect_thread_id = thread.id.clone();
+    let tool_call_journal = ToolCallJournal::new(
+        std::path::Path::new(&session.directory),
+        &session.id,
+        &thread.id,
+    );
 
     let handle = tokio::spawn(async move {
         // Seed the cached objective so the first GoalIteration event has
@@ -386,6 +393,7 @@ async fn send_message_streaming_app_server(
             ..Default::default()
         };
         let mut terminal = false;
+        let mut transport_failed = false;
         let mut stream_closed_unexpectedly = false;
 
         // Mutable so we can swap in a fresh session after a reconnect.
@@ -458,29 +466,14 @@ async fn send_message_streaming_app_server(
                         let (_, interrupted_ids) = pending_tool_reconciliation
                             .take()
                             .expect("reconciliation timer fired without pending state");
-                        let interrupted =
-                            translator.reconcile_interrupted_tools(&interrupted_ids);
+                        let interrupted = translator.transport_failures(&interrupted_ids);
                         if interrupted.is_empty() {
                             continue;
                         }
-                        let names = interrupted
-                            .iter()
-                            .filter_map(|event| match event {
-                                ExecutionEvent::ToolResult { name, .. } => Some(name.as_str()),
-                                _ => None,
-                            })
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        let _ = tx
-                            .send(ExecutionEvent::Error {
-                                message: format!(
-                                    "codex app-server transport interrupted while pending tool calls ({names}) could not be reconciled after thread/resume; synthetic infra_transport_interrupted results were emitted and commands were not replayed"
-                                ),
-                            })
-                            .await;
                         for event in interrupted {
                             let _ = tx.send(event).await;
                         }
+                        transport_failed = true;
                         break 'outer;
                     }
                 };
@@ -490,6 +483,27 @@ async fn send_message_streaming_app_server(
                         let outcome =
                             translator.handle_notification(&method, &params, is_goal_mission);
                         for ev in outcome.events {
+                            match &ev {
+                                ExecutionEvent::ToolCall { id, .. } => {
+                                    if let Some(descriptor) = translator.pending_tool_calls.get(id)
+                                    {
+                                        if let Err(err) =
+                                            tool_call_journal.started(descriptor.clone()).await
+                                        {
+                                            tracing::error!(?err, tool_call_id = %id, "failed to persist codex tool-call start");
+                                            let _ = tx.send(ExecutionEvent::Error { message: format!("codex app-server could not durably journal pending tool call {id}: {err}") }).await;
+                                            terminal = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                                ExecutionEvent::ToolResult { id, .. } => {
+                                    if let Err(err) = tool_call_journal.completed(id).await {
+                                        tracing::error!(?err, tool_call_id = %id, "failed to persist codex tool-call completion");
+                                    }
+                                }
+                                _ => {}
+                            }
                             if tx.send(ev).await.is_err() {
                                 terminal = true;
                                 break;
@@ -501,12 +515,7 @@ async fn send_message_streaming_app_server(
                                 &mut pending_tool_reconciliation,
                             );
                             if !interrupted.is_empty() {
-                                let _ = tx
-                                    .send(ExecutionEvent::Error {
-                                        message: "codex app-server resumed with pending tool calls but emitted a terminal turn before replaying their completion; synthetic infra_transport_interrupted results were emitted"
-                                            .to_string(),
-                                    })
-                                    .await;
+                                transport_failed = true;
                                 for event in interrupted {
                                     let _ = tx.send(event).await;
                                 }
@@ -636,12 +645,24 @@ async fn send_message_streaming_app_server(
             };
             session_arc = new_session;
             inbound = new_inbound;
+            match tool_call_journal.pending().await {
+                Ok(descriptors) => translator.restore_pending(descriptors),
+                Err(err) => {
+                    tracing::error!(
+                        ?err,
+                        "failed to reload codex tool-call journal after resume"
+                    );
+                    let _ = tx.send(ExecutionEvent::Error { message: format!("codex app-server transport reconciliation failed to load its durable tool-call journal: {err}") }).await;
+                    transport_failed = true;
+                    break 'outer;
+                }
+            }
             let interrupted_ids = translator.pending_tool_ids();
             if !interrupted_ids.is_empty() {
                 tracing::warn!(
                     pending_tool_count = interrupted_ids.len(),
                     grace_seconds = PENDING_TOOL_RECONCILE_GRACE.as_secs(),
-                    "codex app-server resumed with in-flight tool calls; waiting for completion replay before synthetic terminalization"
+                    "codex app-server resumed with journaled in-flight tool calls; waiting for completion replay"
                 );
                 pending_tool_reconciliation = Some((
                     tokio::time::Instant::now() + PENDING_TOOL_RECONCILE_GRACE,
@@ -652,14 +673,10 @@ async fn send_message_streaming_app_server(
         }
 
         if stream_closed_unexpectedly {
+            transport_failed = true;
             let interrupted_ids = translator.pending_tool_ids();
-            let interrupted = translator.reconcile_interrupted_tools(&interrupted_ids);
+            let interrupted = translator.transport_failures(&interrupted_ids);
             if !interrupted.is_empty() {
-                let _ = tx
-                    .send(ExecutionEvent::Error {
-                        message: "codex app-server stream closed while tool calls were pending; synthetic infra_transport_interrupted results were emitted and commands were not replayed".to_string(),
-                    })
-                    .await;
                 for event in interrupted {
                     let _ = tx.send(event).await;
                 }
@@ -676,6 +693,12 @@ async fn send_message_streaming_app_server(
                 session_id: session_id.clone(),
             })
             .await;
+
+        if terminal && !transport_failed {
+            if let Err(err) = tool_call_journal.clear().await {
+                tracing::warn!(?err, "failed to clean completed codex tool-call journal");
+            }
+        }
 
         let _ = session_arc.shutdown().await;
     });
@@ -734,7 +757,7 @@ struct AppServerEventTranslator {
     /// Tool calls emitted to consumers but not yet paired with a terminal
     /// result. Persisted across an app-server reconnect within this driver so
     /// a resumed stream can replay completion or be terminalized exactly once.
-    pending_tool_calls: std::collections::HashMap<String, String>,
+    pending_tool_calls: std::collections::HashMap<String, PendingToolCall>,
     emitted_tool_call_ids: std::collections::HashSet<String>,
     emitted_tool_result_ids: std::collections::HashSet<String>,
 }
@@ -751,7 +774,7 @@ fn reconcile_pending_before_terminal(
     let Some((_, interrupted_ids)) = pending.take() else {
         return Vec::new();
     };
-    translator.reconcile_interrupted_tools(&interrupted_ids)
+    translator.transport_failures(&interrupted_ids)
 }
 
 fn usage_tokens(usage: &serde_json::Value, keys: &[&str]) -> u64 {
@@ -797,7 +820,16 @@ impl AppServerEventTranslator {
         self.pending_tool_calls.keys().cloned().collect()
     }
 
-    fn reconcile_interrupted_tools(
+    fn restore_pending(&mut self, descriptors: Vec<PendingToolCall>) {
+        for descriptor in descriptors {
+            if !self.emitted_tool_result_ids.contains(&descriptor.id) {
+                self.pending_tool_calls
+                    .insert(descriptor.id.clone(), descriptor);
+            }
+        }
+    }
+
+    fn transport_failures(
         &mut self,
         interrupted_ids: &std::collections::HashSet<String>,
     ) -> Vec<ExecutionEvent> {
@@ -805,21 +837,15 @@ impl AppServerEventTranslator {
         ids.sort();
         let mut events = Vec::new();
         for id in ids {
-            let Some(name) = self.pending_tool_calls.remove(&id) else {
+            let Some(descriptor) = self.pending_tool_calls.remove(&id) else {
                 continue;
             };
-            if self.emitted_tool_result_ids.insert(id.clone()) {
-                events.push(ExecutionEvent::ToolResult {
-                    id,
-                    name,
-                    result: serde_json::json!({
-                        "status": "infra_transport_interrupted",
-                        "synthetic": true,
-                        "command_replayed": false,
-                        "message": "app-server stream closed before the tool result was observed",
-                    }),
+            events.push(ExecutionEvent::Error {
+                    message: format!(
+                        "codex app-server transport failure: pending tool call {} ({}) remained unresolved after thread/resume; the command was not replayed",
+                        descriptor.id, descriptor.name
+                    ),
                 });
-            }
         }
         events
     }
@@ -909,7 +935,14 @@ impl AppServerEventTranslator {
                                     .cloned()
                                     .unwrap_or(serde_json::Value::Null);
                                 if !self.emitted_tool_result_ids.contains(&id) {
-                                    self.pending_tool_calls.insert(id.clone(), name.clone());
+                                    self.pending_tool_calls.insert(
+                                        id.clone(),
+                                        PendingToolCall {
+                                            id: id.clone(),
+                                            name: name.clone(),
+                                            start_payload: item.clone(),
+                                        },
+                                    );
                                 }
                                 if !self.emitted_tool_result_ids.contains(&id)
                                     && self.emitted_tool_call_ids.insert(id.clone())
@@ -948,7 +981,14 @@ impl AppServerEventTranslator {
                                     .cloned()
                                     .unwrap_or(serde_json::Value::Null);
                                 if !self.emitted_tool_result_ids.contains(&id) {
-                                    self.pending_tool_calls.insert(id.clone(), name.clone());
+                                    self.pending_tool_calls.insert(
+                                        id.clone(),
+                                        PendingToolCall {
+                                            id: id.clone(),
+                                            name: name.clone(),
+                                            start_payload: item.clone(),
+                                        },
+                                    );
                                 }
                                 if !self.emitted_tool_result_ids.contains(&id)
                                     && self.emitted_tool_call_ids.insert(id.clone())
@@ -983,8 +1023,14 @@ impl AppServerEventTranslator {
                                 .unwrap_or(serde_json::Value::Null);
                             if method == "item/started" {
                                 if !self.emitted_tool_result_ids.contains(&id) {
-                                    self.pending_tool_calls
-                                        .insert(id.clone(), "bash".to_string());
+                                    self.pending_tool_calls.insert(
+                                        id.clone(),
+                                        PendingToolCall {
+                                            id: id.clone(),
+                                            name: "bash".to_string(),
+                                            start_payload: item.clone(),
+                                        },
+                                    );
                                 }
                                 if !self.emitted_tool_result_ids.contains(&id)
                                     && self.emitted_tool_call_ids.insert(id.clone())
@@ -1508,7 +1554,7 @@ mod tests {
         ));
 
         let interrupted = translator.pending_tool_ids();
-        let reconciled = translator.reconcile_interrupted_tools(&interrupted);
+        let reconciled = translator.transport_failures(&interrupted);
         assert!(reconciled
             .iter()
             .all(|event| !matches!(event, ExecutionEvent::ToolResult { .. })));
@@ -1520,9 +1566,7 @@ mod tests {
                     && message.contains("write_file")
         ));
         assert!(translator.pending_tool_ids().is_empty());
-        assert!(translator
-            .reconcile_interrupted_tools(&interrupted)
-            .is_empty());
+        assert!(translator.transport_failures(&interrupted).is_empty());
     }
 
     #[test]
@@ -1549,8 +1593,8 @@ mod tests {
         assert!(translator.pending_tool_ids().is_empty());
         assert!(matches!(
             events.as_slice(),
-            [ExecutionEvent::ToolResult { id, name, .. }]
-                if id == "tool-terminal" && name == "bash"
+            [ExecutionEvent::Error { message }]
+                if message.contains("tool-terminal") && message.contains("bash")
         ));
     }
 
@@ -1580,9 +1624,7 @@ mod tests {
             [ExecutionEvent::ToolResult { id, name, result }]
                 if id == "cmd-1" && name == "bash" && result == "ok"
         ));
-        assert!(translator
-            .reconcile_interrupted_tools(&interrupted)
-            .is_empty());
+        assert!(translator.transport_failures(&interrupted).is_empty());
         let duplicate = translator.handle_notification("item/completed", &params, false);
         assert!(duplicate.events.is_empty());
     }

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -836,12 +836,25 @@ impl AppServerEventTranslator {
             let Some(descriptor) = self.pending_tool_calls.remove(&id) else {
                 continue;
             };
-            events.push(ExecutionEvent::Error {
-                    message: format!(
-                        "codex app-server transport failure: pending tool call {} ({}) remained unresolved after thread/resume; the command was not replayed",
-                        descriptor.id, descriptor.name
-                    ),
-                });
+            let message = format!(
+                "codex app-server transport failure: pending tool call {} ({}) remained unresolved after thread/resume; the command was not replayed",
+                descriptor.id, descriptor.name
+            );
+            // Close the lifecycle for downstream accounting without claiming
+            // that the tool succeeded or failed remotely. The execution
+            // outcome is explicitly unknown and the turn still receives a
+            // fatal Error event immediately afterwards.
+            events.push(ExecutionEvent::ToolResult {
+                id: descriptor.id.clone(),
+                name: descriptor.name.clone(),
+                result: serde_json::json!({
+                    "status": "transport_interrupted",
+                    "execution_outcome": "unknown",
+                    "replayed": false,
+                    "error": message,
+                }),
+            });
+            events.push(ExecutionEvent::Error { message });
         }
         events
     }
@@ -1551,13 +1564,18 @@ mod tests {
 
         let interrupted = translator.pending_tool_ids();
         let reconciled = translator.transport_failures(&interrupted);
-        assert!(reconciled
-            .iter()
-            .all(|event| !matches!(event, ExecutionEvent::ToolResult { .. })));
         assert!(matches!(
             reconciled.as_slice(),
-            [ExecutionEvent::Error { message }]
-                if message.contains("transport")
+            [
+                ExecutionEvent::ToolResult { id, name, result },
+                ExecutionEvent::Error { message }
+            ]
+                if id == "tool-1"
+                    && name == "write_file"
+                    && result["status"] == "transport_interrupted"
+                    && result["execution_outcome"] == "unknown"
+                    && result["replayed"] == false
+                    && message.contains("transport")
                     && message.contains("tool-1")
                     && message.contains("write_file")
         ));
@@ -1589,8 +1607,15 @@ mod tests {
         assert!(translator.pending_tool_ids().is_empty());
         assert!(matches!(
             events.as_slice(),
-            [ExecutionEvent::Error { message }]
-                if message.contains("tool-terminal") && message.contains("bash")
+            [
+                ExecutionEvent::ToolResult { id, name, result },
+                ExecutionEvent::Error { message }
+            ]
+                if id == "tool-terminal"
+                    && name == "bash"
+                    && result["execution_outcome"] == "unknown"
+                    && message.contains("tool-terminal")
+                    && message.contains("bash")
         ));
     }
 

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -389,7 +389,6 @@ async fn send_message_streaming_app_server(
             ..Default::default()
         };
         let mut terminal = false;
-        let mut transport_failed = false;
         let mut stream_closed_unexpectedly = false;
 
         // Mutable so we can swap in a fresh session after a reconnect.
@@ -446,11 +445,9 @@ async fn send_message_streaming_app_server(
                             );
                         }
                         let _ = tx.send(ExecutionEvent::Cancelled).await;
-                        // Cancellation is terminal for this driver/session.
-                        // Mark it explicitly so the durable tool-call journal
-                        // is removed below instead of retaining command
-                        // arguments for a turn that will never be resumed.
-                        terminal = true;
+                        // Cancellation is terminal for this driver/session;
+                        // the unconditional terminal cleanup below removes the
+                        // durable journal for this non-resumable handle.
                         break 'outer;
                     }
                     msg = inbound.recv() => match msg {
@@ -474,7 +471,6 @@ async fn send_message_streaming_app_server(
                         for event in interrupted {
                             let _ = tx.send(event).await;
                         }
-                        transport_failed = true;
                         break 'outer;
                     }
                 };
@@ -483,6 +479,7 @@ async fn send_message_streaming_app_server(
                     InboundMessage::Notification { method, params } => {
                         let outcome =
                             translator.handle_notification(&method, &params, is_goal_mission);
+                        let mut journal_failed = false;
                         for ev in outcome.events {
                             match &ev {
                                 ExecutionEvent::ToolCall { id, .. } => {
@@ -492,8 +489,14 @@ async fn send_message_streaming_app_server(
                                             tool_call_journal.started(descriptor.clone()).await
                                         {
                                             tracing::error!(?err, tool_call_id = %id, "failed to persist codex tool-call start");
+                                            // Forward the real lifecycle event
+                                            // first so the downstream runner
+                                            // keeps this tool pending and
+                                            // cannot suppress the fatal error
+                                            // after prior assistant text.
+                                            let _ = tx.send(ev.clone()).await;
                                             let _ = tx.send(ExecutionEvent::Error { message: format!("codex app-server could not durably journal pending tool call {id}: {err}") }).await;
-                                            terminal = true;
+                                            journal_failed = true;
                                             break;
                                         }
                                     }
@@ -510,13 +513,15 @@ async fn send_message_streaming_app_server(
                                 break;
                             }
                         }
+                        if journal_failed {
+                            break 'outer;
+                        }
                         if outcome.terminal {
                             let interrupted = reconcile_pending_before_terminal(
                                 &mut translator,
                                 &mut pending_tool_reconciliation,
                             );
                             if !interrupted.is_empty() {
-                                transport_failed = true;
                                 for event in interrupted {
                                     let _ = tx.send(event).await;
                                 }
@@ -654,7 +659,6 @@ async fn send_message_streaming_app_server(
                         "failed to reload codex tool-call journal after resume"
                     );
                     let _ = tx.send(ExecutionEvent::Error { message: format!("codex app-server transport reconciliation failed to load its durable tool-call journal: {err}") }).await;
-                    transport_failed = true;
                     break 'outer;
                 }
             }
@@ -674,7 +678,6 @@ async fn send_message_streaming_app_server(
         }
 
         if stream_closed_unexpectedly {
-            transport_failed = true;
             let interrupted_ids = translator.pending_tool_ids();
             let interrupted = translator.transport_failures(&interrupted_ids);
             if !interrupted.is_empty() {
@@ -695,10 +698,12 @@ async fn send_message_streaming_app_server(
             })
             .await;
 
-        if terminal && !transport_failed {
-            if let Err(err) = tool_call_journal.clear().await {
-                tracing::warn!(?err, "failed to clean completed codex tool-call journal");
-            }
+        // This driver will never resume its local session/thread after the
+        // handle exits. Clear the journal after clean completion,
+        // cancellation, and terminalized transport failure alike so command
+        // arguments are not retained indefinitely in /tmp.
+        if let Err(err) = tool_call_journal.clear().await {
+            tracing::warn!(?err, "failed to clean terminal codex tool-call journal");
         }
 
         let _ = session_arc.shutdown().await;

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -1487,7 +1487,7 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_tool_is_reconciled_exactly_once_without_replay() {
+    fn unresolved_tool_after_resume_is_an_explicit_transport_failure() {
         let mut translator = AppServerEventTranslator::default();
         let started = translator.handle_notification(
             "item/started",
@@ -1509,14 +1509,15 @@ mod tests {
 
         let interrupted = translator.pending_tool_ids();
         let reconciled = translator.reconcile_interrupted_tools(&interrupted);
+        assert!(reconciled
+            .iter()
+            .all(|event| !matches!(event, ExecutionEvent::ToolResult { .. })));
         assert!(matches!(
             reconciled.as_slice(),
-            [ExecutionEvent::ToolResult { id, name, result }]
-                if id == "tool-1"
-                    && name == "write_file"
-                    && result.get("status").and_then(|v| v.as_str())
-                        == Some("infra_transport_interrupted")
-                    && result.get("command_replayed").and_then(|v| v.as_bool()) == Some(false)
+            [ExecutionEvent::Error { message }]
+                if message.contains("transport")
+                    && message.contains("tool-1")
+                    && message.contains("write_file")
         ));
         assert!(translator.pending_tool_ids().is_empty());
         assert!(translator
@@ -1554,7 +1555,7 @@ mod tests {
     }
 
     #[test]
-    fn resumed_real_completion_wins_over_synthetic_reconciliation() {
+    fn resumed_real_completion_closes_pending_tool_exactly_once() {
         let mut translator = AppServerEventTranslator::default();
         let params = json!({
             "item": {
@@ -1582,6 +1583,8 @@ mod tests {
         assert!(translator
             .reconcile_interrupted_tools(&interrupted)
             .is_empty());
+        let duplicate = translator.handle_notification("item/completed", &params, false);
+        assert!(duplicate.events.is_empty());
     }
 
     #[test]

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -840,10 +840,15 @@ impl AppServerEventTranslator {
                 "codex app-server transport failure: pending tool call {} ({}) remained unresolved after thread/resume; the command was not replayed",
                 descriptor.id, descriptor.name
             );
-            // Close the lifecycle for downstream accounting without claiming
-            // that the tool succeeded or failed remotely. The execution
-            // outcome is explicitly unknown and the turn still receives a
-            // fatal Error event immediately afterwards.
+            // Surface the fatal error while the downstream runner still sees
+            // the tool as pending. Otherwise an existing assistant text can
+            // suppress the error after ToolResult clears `pending_tools` and
+            // incorrectly turn an unknown execution outcome into success.
+            events.push(ExecutionEvent::Error {
+                message: message.clone(),
+            });
+            // Then close the lifecycle for downstream accounting without
+            // claiming that the tool succeeded or failed remotely.
             events.push(ExecutionEvent::ToolResult {
                 id: descriptor.id.clone(),
                 name: descriptor.name.clone(),
@@ -854,7 +859,6 @@ impl AppServerEventTranslator {
                     "error": message,
                 }),
             });
-            events.push(ExecutionEvent::Error { message });
         }
         events
     }
@@ -1567,8 +1571,8 @@ mod tests {
         assert!(matches!(
             reconciled.as_slice(),
             [
-                ExecutionEvent::ToolResult { id, name, result },
-                ExecutionEvent::Error { message }
+                ExecutionEvent::Error { message },
+                ExecutionEvent::ToolResult { id, name, result }
             ]
                 if id == "tool-1"
                     && name == "write_file"
@@ -1608,8 +1612,8 @@ mod tests {
         assert!(matches!(
             events.as_slice(),
             [
-                ExecutionEvent::ToolResult { id, name, result },
-                ExecutionEvent::Error { message }
+                ExecutionEvent::Error { message },
+                ExecutionEvent::ToolResult { id, name, result }
             ]
                 if id == "tool-terminal"
                     && name == "bash"

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -378,11 +378,7 @@ async fn send_message_streaming_app_server(
     let reconnect_cwd = session.directory.clone();
     let reconnect_workspace_exec = workspace_exec.cloned();
     let reconnect_thread_id = thread.id.clone();
-    let tool_call_journal = ToolCallJournal::new(
-        std::path::Path::new(&session.directory),
-        &session.id,
-        &thread.id,
-    );
+    let tool_call_journal = ToolCallJournal::new(&session.id, &thread.id);
 
     let handle = tokio::spawn(async move {
         // Seed the cached objective so the first GoalIteration event has

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -446,6 +446,11 @@ async fn send_message_streaming_app_server(
                             );
                         }
                         let _ = tx.send(ExecutionEvent::Cancelled).await;
+                        // Cancellation is terminal for this driver/session.
+                        // Mark it explicitly so the durable tool-call journal
+                        // is removed below instead of retaining command
+                        // arguments for a turn that will never be resumed.
+                        terminal = true;
                         break 'outer;
                     }
                     msg = inbound.recv() => match msg {

--- a/src/backend/codex/tool_call_journal.rs
+++ b/src/backend/codex/tool_call_journal.rs
@@ -1,0 +1,146 @@
+//! Durable app-server tool-call lifecycle journal.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PendingToolCall {
+    pub id: String,
+    pub name: String,
+    pub start_payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum Entry {
+    Started { descriptor: PendingToolCall },
+    Completed { descriptor: PendingToolCall },
+}
+
+pub struct ToolCallJournal {
+    path: PathBuf,
+}
+
+fn lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+impl ToolCallJournal {
+    pub fn new(working_dir: &Path, session_id: &str, thread_id: &str) -> Self {
+        let safe = |value: &str| {
+            value
+                .chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect::<String>()
+        };
+        Self {
+            path: working_dir
+                .join(".sandboxed-sh")
+                .join("codex-tool-calls")
+                .join(format!("{}-{}.json", safe(session_id), safe(thread_id))),
+        }
+    }
+
+    async fn load_entries(&self) -> anyhow::Result<Vec<Entry>> {
+        match tokio::fs::read(&self.path).await {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map_err(|err| anyhow::anyhow!("parse {}: {err}", self.path.display())),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(err) => Err(anyhow::anyhow!("read {}: {err}", self.path.display())),
+        }
+    }
+
+    async fn store(&self, entries: &[Entry]) -> anyhow::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let bytes = serde_json::to_vec_pretty(entries)?;
+        let tmp = self.path.with_extension("json.tmp");
+        tokio::fs::write(&tmp, bytes).await?;
+        tokio::fs::rename(tmp, &self.path).await?;
+        Ok(())
+    }
+
+    pub async fn started(&self, descriptor: PendingToolCall) -> anyhow::Result<()> {
+        let _guard = lock().lock().await;
+        let mut entries = self.load_entries().await?;
+        entries.retain(|entry| match entry {
+            Entry::Started { descriptor: old } | Entry::Completed { descriptor: old } => {
+                old.id != descriptor.id
+            }
+        });
+        entries.push(Entry::Started { descriptor });
+        self.store(&entries).await
+    }
+
+    pub async fn completed(&self, id: &str) -> anyhow::Result<()> {
+        let _guard = lock().lock().await;
+        let mut entries = self.load_entries().await?;
+        for entry in &mut entries {
+            if let Entry::Started { descriptor } = entry {
+                if descriptor.id == id {
+                    *entry = Entry::Completed {
+                        descriptor: descriptor.clone(),
+                    };
+                    self.store(&entries).await?;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn pending(&self) -> anyhow::Result<Vec<PendingToolCall>> {
+        Ok(self
+            .load_entries()
+            .await?
+            .into_iter()
+            .filter_map(|entry| match entry {
+                Entry::Started { descriptor } => Some(descriptor),
+                Entry::Completed { .. } => None,
+            })
+            .collect())
+    }
+
+    pub async fn clear(&self) -> anyhow::Result<()> {
+        let _guard = lock().lock().await;
+        match tokio::fs::remove_file(&self.path).await {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn lifecycle_is_atomic_idempotent_and_clearable() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = ToolCallJournal::new(dir.path(), "session", "thread");
+        let descriptor = PendingToolCall {
+            id: "call-1".into(),
+            name: "bash".into(),
+            start_payload: serde_json::json!({"command": "do-once"}),
+        };
+        journal.started(descriptor.clone()).await.unwrap();
+        journal.started(descriptor.clone()).await.unwrap();
+        assert_eq!(journal.pending().await.unwrap(), vec![descriptor]);
+        journal.completed("call-1").await.unwrap();
+        journal.completed("call-1").await.unwrap();
+        assert!(journal.pending().await.unwrap().is_empty());
+        journal.clear().await.unwrap();
+        assert!(!journal.path.exists());
+    }
+}

--- a/src/backend/codex/tool_call_journal.rs
+++ b/src/backend/codex/tool_call_journal.rs
@@ -1,6 +1,6 @@
 //! Durable app-server tool-call lifecycle journal.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,7 @@ fn lock() -> &'static tokio::sync::Mutex<()> {
 }
 
 impl ToolCallJournal {
-    pub fn new(working_dir: &Path, session_id: &str, thread_id: &str) -> Self {
+    pub fn new(session_id: &str, thread_id: &str) -> Self {
         let safe = |value: &str| {
             value
                 .chars()
@@ -43,8 +43,8 @@ impl ToolCallJournal {
                 .collect::<String>()
         };
         Self {
-            path: working_dir
-                .join(".sandboxed-sh")
+            path: std::env::temp_dir()
+                .join("sandboxed-sh")
                 .join("codex-tool-calls")
                 .join(format!("{}-{}.json", safe(session_id), safe(thread_id))),
         }
@@ -128,7 +128,8 @@ mod tests {
     #[tokio::test]
     async fn lifecycle_is_atomic_idempotent_and_clearable() {
         let dir = tempfile::tempdir().unwrap();
-        let journal = ToolCallJournal::new(dir.path(), "session", "thread");
+        let journal = ToolCallJournal::new(&uuid::Uuid::new_v4().to_string(), "thread");
+        assert!(!journal.path.starts_with(dir.path()));
         let descriptor = PendingToolCall {
             id: "call-1".into(),
             name: "bash".into(),

--- a/src/backend/codex/tool_call_journal.rs
+++ b/src/backend/codex/tool_call_journal.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PendingToolCall {
@@ -62,10 +63,29 @@ impl ToolCallJournal {
     async fn store(&self, entries: &[Entry]) -> anyhow::Result<()> {
         if let Some(parent) = self.path.parent() {
             tokio::fs::create_dir_all(parent).await?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).await?;
+            }
         }
         let bytes = serde_json::to_vec_pretty(entries)?;
         let tmp = self.path.with_extension("json.tmp");
-        tokio::fs::write(&tmp, bytes).await?;
+        let mut options = tokio::fs::OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            options.mode(0o600);
+        }
+        let mut file = options.open(&tmp).await?;
+        file.write_all(&bytes).await?;
+        file.sync_all().await?;
+        drop(file);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await?;
+        }
         tokio::fs::rename(tmp, &self.path).await?;
         Ok(())
     }
@@ -136,6 +156,26 @@ mod tests {
             start_payload: serde_json::json!({"command": "do-once"}),
         };
         journal.started(descriptor.clone()).await.unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(journal.path.parent().unwrap())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                std::fs::metadata(&journal.path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
         journal.started(descriptor.clone()).await.unwrap();
         assert_eq!(journal.pending().await.unwrap(), vec![descriptor]);
         journal.completed("call-1").await.unwrap();


### PR DESCRIPTION
## Summary
- durably journal complete Codex app-server tool-call start payloads and completion transitions
- reload unresolved calls after `thread/resume` and deduplicate real completions by item ID
- terminate unresolved resumed calls with explicit transport errors, never fabricated `ToolResult` values or command replay
- clean the per-session/thread journal after clean turn completion

## Failing-first
Commit `bc964d4e` adds the regression contract before the implementation in `739d524d`.

## Scope
Only `src/backend/codex/mod.rs` and a small journal module beside it are changed. No deploy or restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission failure semantics and persists tool command payloads to disk during runs; scope is limited to the Codex app-server driver.
> 
> **Overview**
> Adds a **durable on-disk journal** (`ToolCallJournal`) for Codex app-server tool starts and completions under `/tmp`, wired into the mission driver so starts are persisted before events are forwarded and completions update the journal.
> 
> After **`thread/resume`**, unresolved calls are **reloaded** into the translator (`restore_pending` with full `PendingToolCall` descriptors, not just names). A grace window still waits for real completion replay; if tools stay unresolved, **`reconcile_interrupted_tools` is replaced by `transport_failures`**, which emits **`ExecutionEvent::Error` before `ToolResult`** with `execution_outcome: unknown` and **no command replay**—dropping the extra blanket error messages that duplicated synthetic reconciliation.
> 
> **Journal write failures** on tool start are fatal (tool call forwarded first, then error, driver exits). **Reload failures** after resume also terminate the driver. The journal is **cleared** when the driver exits (success, cancel, or transport failure) so command args are not left in `/tmp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9c90200b95b658eaa7710cd7778e8735998a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->