### PR TITLE
fix(board): guard retry respawns with branch and PR state

### DIFF
--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -38,6 +38,7 @@ use super::{ControlCommand, MissionStatus};
 /// One slot is always reserved for the boss itself so digest delivery can
 /// never be starved by board workers occupying every parallel slot.
 const RESERVED_BOSS_SLOTS: usize = 1;
+const RETRY_PREFLIGHT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
 
 /// Max attempts per task (1 original + 1 automatic retry).
 const MAX_ATTEMPTS: u32 = 2;
@@ -130,16 +131,23 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
     };
     let working_directory = task.working_directory.clone();
     let task_key = task.task_key.clone();
-    tokio::task::spawn_blocking(move || {
+    let preflight = tokio::task::spawn_blocking(move || {
         let local_repo = if Path::new(&repository).exists() {
             Some(repository.as_str())
         } else {
-            working_directory.as_deref().filter(|path| Path::new(path).exists())
+            working_directory
+                .as_deref()
+                .filter(|path| Path::new(path).exists())
         };
         let local_exists = local_repo.is_some_and(|repo| {
             Command::new("git")
                 .current_dir(repo)
-                .args(["show-ref", "--verify", "--quiet", &format!("refs/heads/{branch}")])
+                .args([
+                    "show-ref",
+                    "--verify",
+                    "--quiet",
+                    &format!("refs/heads/{branch}"),
+                ])
                 .status()
                 .is_ok_and(|status| status.success())
         });
@@ -161,13 +169,25 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
         if let Some(identity) = repository_identity(&repository) {
             match Command::new("gh")
                 .args([
-                    "pr", "list", "--repo", &identity, "--head", &branch, "--state", "all",
-                    "--limit", "20", "--json", "number,state,mergedAt",
+                    "pr",
+                    "list",
+                    "--repo",
+                    &identity,
+                    "--head",
+                    &branch,
+                    "--state",
+                    "all",
+                    "--limit",
+                    "20",
+                    "--json",
+                    "number,state,mergedAt",
                 ])
                 .output()
             {
                 Ok(output) if output.status.success() => {
-                    if let Ok(rows) = serde_json::from_slice::<Vec<serde_json::Value>>(&output.stdout) {
+                    if let Ok(rows) =
+                        serde_json::from_slice::<Vec<serde_json::Value>>(&output.stdout)
+                    {
                         for row in rows {
                             let number = row["number"].as_u64().unwrap_or_default();
                             if row["mergedAt"].is_string() {
@@ -199,12 +219,22 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
         } else {
             RetryPreflight::NothingFound
         }
-    })
-    .await
-    .unwrap_or_else(|error| {
-        tracing::warn!(task = %task.task_key, "board: retry preflight failed: {error}");
-        RetryPreflight::NothingFound
-    })
+    });
+    match tokio::time::timeout(RETRY_PREFLIGHT_TIMEOUT, preflight).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => {
+            tracing::warn!(task = %task.task_key, "board: retry preflight failed: {error}");
+            RetryPreflight::NothingFound
+        }
+        Err(_) => {
+            tracing::warn!(
+                task = %task.task_key,
+                timeout_secs = RETRY_PREFLIGHT_TIMEOUT.as_secs(),
+                "board: retry preflight timed out; continuing best-effort"
+            );
+            RetryPreflight::NothingFound
+        }
+    }
 }
 
 /// Snapshot of runner occupancy, computed by the actor loop each pass.

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -89,7 +89,9 @@ fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
         // retain the same conservative branch guard for every declared retry
         // rather than falling back to the original unguarded prompt.
         RetryPreflight::NothingFound
-            if task.prior_worker_mission_id.is_some() && task.branch.is_some() =>
+            if task.attempts > 1
+                && task.prior_worker_mission_id.is_some()
+                && task.branch.is_some() =>
         {
             ("declared retry branch; re-check before editing", None)
         }
@@ -896,6 +898,20 @@ mod tests {
         assert!(prompt.contains("checkout the existing branch"));
         assert!(prompt.contains("never recreate from master"));
         assert!(prompt.contains("never force-push"));
+    }
+
+    #[test]
+    fn post_rejection_fresh_spawn_does_not_reuse_retry_guard() {
+        let mut task = mk("fresh-after-reject", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 1;
+        task.branch = Some("agent/already-merged".into());
+        task.prior_worker_mission_id = Some(Uuid::new_v4());
+        task.prior_outcome = Some(BoardTaskOutcome::Failed);
+
+        assert_eq!(
+            retry_prompt(&task, &RetryPreflight::NothingFound),
+            task.prompt
+        );
     }
 
     #[test]

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -79,12 +79,21 @@ fn retry_disposition(task: &BoardTask, preflight: &RetryPreflight) -> RetryDispo
 }
 
 fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
-    let RetryPreflight::Surviving {
-        branch_state,
-        pr_number,
-    } = preflight
-    else {
-        return task.prompt.clone();
+    let (branch_state, pr_number) = match preflight {
+        RetryPreflight::Surviving {
+            branch_state,
+            pr_number,
+        } => (branch_state.as_str(), *pr_number),
+        // A spawn message can be dropped after the live preflight result was
+        // computed. The zombie re-kick only has persisted task metadata, so
+        // retain the same conservative branch guard for every declared retry
+        // rather than falling back to the original unguarded prompt.
+        RetryPreflight::NothingFound
+            if task.prior_worker_mission_id.is_some() && task.branch.is_some() =>
+        {
+            ("declared retry branch; re-check before editing", None)
+        }
+        _ => return task.prompt.clone(),
     };
     let pr = pr_number
         .map(|number| format!("#{number}"))
@@ -541,7 +550,11 @@ pub async fn scheduler_pass(
                     if seconds_since(&task.updated_at) > STUCK_PENDING_SECS {
                         tracing::info!(task = %task.task_key, worker = %worker_id,
                             "board: re-kicking stuck pending worker");
-                        let prompt = format!("{}{}", task.prompt, worker_contract(task));
+                        let prompt = format!(
+                            "{}{}",
+                            retry_prompt(task, &RetryPreflight::NothingFound),
+                            worker_contract(task)
+                        );
                         if self_send_message(cmd_tx, worker_id, prompt) {
                             let mut t = task.clone();
                             t.notes = append_note(&t.notes, "re-kicked stuck pending worker");
@@ -829,6 +842,22 @@ mod tests {
         let prompt = retry_prompt(&task, &preflight);
 
         assert_ne!(prompt, task.prompt);
+        assert!(prompt.contains("Prior-attempt digest"));
+        assert!(prompt.contains("checkout the existing branch"));
+        assert!(prompt.contains("never recreate from master"));
+        assert!(prompt.contains("never force-push"));
+    }
+
+    #[test]
+    fn retry_rekick_retains_branch_guard_from_persisted_metadata() {
+        let mut task = mk("retry-rekick", &[], BoardTaskStatus::Running, None);
+        task.attempts = 2;
+        task.branch = Some("agent/already-pushed".into());
+        task.prior_worker_mission_id = Some(Uuid::new_v4());
+        task.prior_outcome = Some(BoardTaskOutcome::Failed);
+
+        let prompt = retry_prompt(&task, &RetryPreflight::NothingFound);
+
         assert!(prompt.contains("Prior-attempt digest"));
         assert!(prompt.contains("checkout the existing branch"));
         assert!(prompt.contains("never recreate from master"));

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -131,6 +131,35 @@ fn repository_identity(repository: &str) -> Option<String> {
     Some(slug.trim_start_matches('/').to_string())
 }
 
+fn retry_pr_state(
+    rows: &[serde_json::Value],
+    current_branch_sha: Option<&str>,
+) -> (Option<u64>, Option<u64>) {
+    let mut open_pr = None;
+    let mut matching_merged_pr = None;
+    let mut any_merged_pr = None;
+    for row in rows {
+        let number = row["number"].as_u64().unwrap_or_default();
+        if row["state"].as_str() == Some("OPEN") {
+            open_pr.get_or_insert(number);
+        }
+        if row["mergedAt"].is_string() {
+            any_merged_pr.get_or_insert(number);
+            if current_branch_sha.is_some_and(|sha| row["headRefOid"].as_str() == Some(sha)) {
+                matching_merged_pr.get_or_insert(number);
+            }
+        }
+    }
+    let merged_pr = if open_pr.is_some() {
+        None
+    } else if current_branch_sha.is_some() {
+        matching_merged_pr
+    } else {
+        any_merged_pr
+    };
+    (open_pr, merged_pr)
+}
+
 async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
     let Some(repository) = task.repository.clone() else {
         return RetryPreflight::NothingFound;
@@ -148,33 +177,40 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
                 .as_deref()
                 .filter(|path| Path::new(path).exists())
         };
-        let local_exists = local_repo.is_some_and(|repo| {
-            Command::new("git")
+        let local_sha = local_repo.and_then(|repo| {
+            let output = Command::new("git")
                 .current_dir(repo)
-                .args([
-                    "show-ref",
-                    "--verify",
-                    "--quiet",
-                    &format!("refs/heads/{branch}"),
-                ])
-                .status()
-                .is_ok_and(|status| status.success())
+                .args(["rev-parse", "--verify", &format!("refs/heads/{branch}")])
+                .output()
+                .ok()?;
+            output
+                .status
+                .success()
+                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
         });
-        let remote_exists = local_repo.is_some_and(|repo| {
+        let remote_sha = local_repo.and_then(|repo| {
             match Command::new("git")
                 .current_dir(repo)
                 .args(["ls-remote", "--exit-code", "origin", &format!("refs/heads/{branch}")])
                 .output()
             {
-                Ok(output) => output.status.success(),
+                Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+                    .split_whitespace()
+                    .next()
+                    .map(str::to_string),
+                Ok(_) => None,
                 Err(error) => {
                     tracing::warn!(task = %task_key, "board: retry remote branch lookup failed: {error}");
-                    false
+                    None
                 }
             }
         });
+        let local_exists = local_sha.is_some();
+        let remote_exists = remote_sha.is_some();
+        let current_branch_sha = remote_sha.as_deref().or(local_sha.as_deref());
 
         let mut open_pr = None;
+        let mut merged_pr = None;
         if let Some(identity) = repository_identity(&repository) {
             match Command::new("gh")
                 .args([
@@ -189,7 +225,7 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
                     "--limit",
                     "20",
                     "--json",
-                    "number,state,mergedAt",
+                    "number,state,mergedAt,headRefOid",
                 ])
                 .output()
             {
@@ -197,15 +233,7 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
                     if let Ok(rows) =
                         serde_json::from_slice::<Vec<serde_json::Value>>(&output.stdout)
                     {
-                        for row in rows {
-                            let number = row["number"].as_u64().unwrap_or_default();
-                            if row["mergedAt"].is_string() {
-                                return RetryPreflight::Merged { pr_number: number };
-                            }
-                            if row["state"].as_str() == Some("OPEN") {
-                                open_pr = Some(number);
-                            }
-                        }
+                        (open_pr, merged_pr) = retry_pr_state(&rows, current_branch_sha);
                     }
                 }
                 Ok(output) => tracing::warn!(task = %task_key, status = %output.status,
@@ -213,6 +241,12 @@ async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
                 Err(error) => tracing::warn!(task = %task_key,
                     "board: retry PR lookup unavailable; continuing best-effort: {error}"),
             }
+        }
+        // An open PR always represents the current continuation. A historical
+        // merged PR for a reused deterministic branch only parks the retry
+        // when its reviewed head matches the branch we can currently observe.
+        if let Some(pr_number) = merged_pr {
+            return RetryPreflight::Merged { pr_number };
         }
         if local_exists || remote_exists || open_pr.is_some() {
             let state = match (local_exists, remote_exists) {
@@ -874,6 +908,31 @@ mod tests {
         assert_eq!(
             retry_disposition(&task, &RetryPreflight::Merged { pr_number: 99 }),
             RetryDisposition::ParkForBossReview
+        );
+    }
+
+    #[test]
+    fn retry_pr_state_ignores_stale_merge_when_branch_head_changed() {
+        let rows = vec![
+            serde_json::json!({
+                "number": 12,
+                "state": "MERGED",
+                "mergedAt": "2026-07-01T00:00:00Z",
+                "headRefOid": "old-head"
+            }),
+            serde_json::json!({
+                "number": 13,
+                "state": "OPEN",
+                "mergedAt": null,
+                "headRefOid": "new-head"
+            }),
+        ];
+
+        assert_eq!(retry_pr_state(&rows, Some("new-head")), (Some(13), None));
+        assert_eq!(retry_pr_state(&rows[..1], Some("new-head")), (None, None));
+        assert_eq!(
+            retry_pr_state(&rows[..1], Some("old-head")),
+            (None, Some(12))
         );
     }
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -23,6 +23,8 @@
 //! `try_send` (never awaited — the scheduler runs on the consuming task).
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::process::Command;
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
@@ -48,6 +50,162 @@ const STUCK_PENDING_SECS: i64 = 90;
 /// Digest truncation: keep the head and tail of the worker's final message.
 const DIGEST_HEAD_CHARS: usize = 400;
 const DIGEST_TAIL_CHARS: usize = 1200;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RetryPreflight {
+    NothingFound,
+    Surviving {
+        branch_state: String,
+        pr_number: Option<u64>,
+    },
+    Merged {
+        pr_number: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryDisposition {
+    Spawn,
+    ParkForBossReview,
+}
+
+fn retry_disposition(task: &BoardTask, preflight: &RetryPreflight) -> RetryDisposition {
+    if task.attempts > 0 && matches!(preflight, RetryPreflight::Merged { .. }) {
+        RetryDisposition::ParkForBossReview
+    } else {
+        RetryDisposition::Spawn
+    }
+}
+
+fn retry_prompt(task: &BoardTask, preflight: &RetryPreflight) -> String {
+    let RetryPreflight::Surviving {
+        branch_state,
+        pr_number,
+    } = preflight
+    else {
+        return task.prompt.clone();
+    };
+    let pr = pr_number
+        .map(|number| format!("#{number}"))
+        .unwrap_or_else(|| "none".to_string());
+    format!(
+        "[Prior-attempt digest]\nPrior worker: {}\nPrior outcome: {}\nPrior result: {}\nBranch: {} ({branch_state})\nPR: {pr}\n\
+         Continue the prior attempt: checkout the existing branch, never recreate from master, never force-push.\n\n{}",
+        task.prior_worker_mission_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "unknown".into()),
+        task.prior_outcome
+            .map(|outcome| outcome.to_string())
+            .unwrap_or_else(|| "unknown".into()),
+        task.prior_result_digest.as_deref().unwrap_or("unavailable"),
+        task.branch.as_deref().unwrap_or("unknown"),
+        task.prompt,
+    )
+}
+
+fn repository_identity(repository: &str) -> Option<String> {
+    if !Path::new(repository).exists() {
+        return repository.contains('/').then(|| repository.to_string());
+    }
+    let output = Command::new("git")
+        .current_dir(repository)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let trimmed = url.trim_end_matches(".git");
+    let slug = trimmed
+        .split("github.com/")
+        .nth(1)
+        .or_else(|| trimmed.rsplit_once(':').map(|(_, tail)| tail))?;
+    Some(slug.trim_start_matches('/').to_string())
+}
+
+async fn retry_preflight(task: &BoardTask) -> RetryPreflight {
+    let Some(repository) = task.repository.clone() else {
+        return RetryPreflight::NothingFound;
+    };
+    let Some(branch) = task.branch.clone() else {
+        return RetryPreflight::NothingFound;
+    };
+    let working_directory = task.working_directory.clone();
+    let task_key = task.task_key.clone();
+    tokio::task::spawn_blocking(move || {
+        let local_repo = if Path::new(&repository).exists() {
+            Some(repository.as_str())
+        } else {
+            working_directory.as_deref().filter(|path| Path::new(path).exists())
+        };
+        let local_exists = local_repo.is_some_and(|repo| {
+            Command::new("git")
+                .current_dir(repo)
+                .args(["show-ref", "--verify", "--quiet", &format!("refs/heads/{branch}")])
+                .status()
+                .is_ok_and(|status| status.success())
+        });
+        let remote_exists = local_repo.is_some_and(|repo| {
+            match Command::new("git")
+                .current_dir(repo)
+                .args(["ls-remote", "--exit-code", "origin", &format!("refs/heads/{branch}")])
+                .output()
+            {
+                Ok(output) => output.status.success(),
+                Err(error) => {
+                    tracing::warn!(task = %task_key, "board: retry remote branch lookup failed: {error}");
+                    false
+                }
+            }
+        });
+
+        let mut open_pr = None;
+        if let Some(identity) = repository_identity(&repository) {
+            match Command::new("gh")
+                .args([
+                    "pr", "list", "--repo", &identity, "--head", &branch, "--state", "all",
+                    "--limit", "20", "--json", "number,state,mergedAt",
+                ])
+                .output()
+            {
+                Ok(output) if output.status.success() => {
+                    if let Ok(rows) = serde_json::from_slice::<Vec<serde_json::Value>>(&output.stdout) {
+                        for row in rows {
+                            let number = row["number"].as_u64().unwrap_or_default();
+                            if row["mergedAt"].is_string() {
+                                return RetryPreflight::Merged { pr_number: number };
+                            }
+                            if row["state"].as_str() == Some("OPEN") {
+                                open_pr = Some(number);
+                            }
+                        }
+                    }
+                }
+                Ok(output) => tracing::warn!(task = %task_key, status = %output.status,
+                    "board: retry PR lookup failed; continuing best-effort"),
+                Err(error) => tracing::warn!(task = %task_key,
+                    "board: retry PR lookup unavailable; continuing best-effort: {error}"),
+            }
+        }
+        if local_exists || remote_exists || open_pr.is_some() {
+            let state = match (local_exists, remote_exists) {
+                (true, true) => "local and remote branch exist",
+                (true, false) => "local branch exists",
+                (false, true) => "remote branch exists",
+                (false, false) => "open PR exists",
+            };
+            RetryPreflight::Surviving {
+                branch_state: state.into(),
+                pr_number: open_pr,
+            }
+        } else {
+            RetryPreflight::NothingFound
+        }
+    })
+    .await
+    .unwrap_or_else(|error| {
+        tracing::warn!(task = %task.task_key, "board: retry preflight failed: {error}");
+        RetryPreflight::NothingFound
+    })
+}
 
 /// Snapshot of runner occupancy, computed by the actor loop each pass.
 pub struct RunnerSnapshot {
@@ -416,7 +574,40 @@ pub async fn scheduler_pass(
                     if available == 0 {
                         break;
                     }
-                    match spawn_task_worker(mission_store, cmd_tx, &task, boss.workspace_id).await {
+                    let preflight = if task.attempts > 0 {
+                        retry_preflight(&task).await
+                    } else {
+                        RetryPreflight::NothingFound
+                    };
+                    if retry_disposition(&task, &preflight) == RetryDisposition::ParkForBossReview {
+                        let RetryPreflight::Merged { pr_number } = preflight else {
+                            unreachable!();
+                        };
+                        let mut parked = task.clone();
+                        parked.status = BoardTaskStatus::Settled;
+                        parked.outcome = Some(BoardTaskOutcome::Blocked);
+                        parked.result_digest = Some(format!(
+                            "Retry suppressed: declared branch was already merged in PR #{pr_number}; boss review required."
+                        ));
+                        parked.notes = append_note(
+                            &parked.notes,
+                            &format!("auto-respawn parked: PR #{pr_number} is merged"),
+                        );
+                        if let Err(error) = mission_store.save_board_task(&parked).await {
+                            tracing::warn!(task = %task.task_key,
+                                "board: failed to park merged retry: {error}");
+                        }
+                        continue;
+                    }
+                    match spawn_task_worker(
+                        mission_store,
+                        cmd_tx,
+                        &task,
+                        boss.workspace_id,
+                        &preflight,
+                    )
+                    .await
+                    {
                         Ok(worker_id) => {
                             available -= 1;
                             tracing::info!(task = %task.task_key, worker = %worker_id, boss = %boss_id,
@@ -471,6 +662,7 @@ async fn spawn_task_worker(
     cmd_tx: &mpsc::Sender<ControlCommand>,
     task: &BoardTask,
     workspace_id: Uuid,
+    preflight: &RetryPreflight,
 ) -> Result<Uuid, String> {
     // Board tasks bypass the public create-mission handler, so apply the same
     // backend-aware normalization here as a defensive migration for tasks that
@@ -503,7 +695,7 @@ async fn spawn_task_worker(
     }
     mission_store.save_board_task(&t).await?;
 
-    let prompt = format!("{}{}", t.prompt, worker_contract(&t));
+    let prompt = format!("{}{}", retry_prompt(&t, preflight), worker_contract(&t));
     if !self_send_message(cmd_tx, mission.id, prompt) {
         // Channel full: leave the task running; the zombie sweep re-kicks the
         // pending worker mission after the grace period.
@@ -535,6 +727,9 @@ async fn settle_task(
                     .unwrap_or_default()
             ),
         );
+        task.prior_worker_mission_id = task.worker_mission_id;
+        task.prior_outcome = Some(outcome);
+        task.prior_result_digest = Some(digest_excerpt(output));
         task.worker_mission_id = None;
         if let Err(e) = mission_store.save_board_task(&task).await {
             tracing::warn!(task = %task.task_key, "board: failed to persist retry: {}", e);
@@ -654,10 +849,15 @@ mod tests {
             model_override: None,
             model_effort: None,
             working_directory: None,
+            repository: None,
+            branch: None,
             depends_on: deps.iter().map(|s| s.to_string()).collect(),
             status,
             outcome,
             worker_mission_id: None,
+            prior_worker_mission_id: None,
+            prior_outcome: None,
+            prior_result_digest: None,
             attempts: 0,
             result_digest: None,
             notes: None,
@@ -839,6 +1039,8 @@ mod tests {
                         model_override: Some("gpt-5.6-sol".into()),
                         model_effort: None,
                         working_directory: None,
+                        repository: None,
+                        branch: None,
                         depends_on: vec![],
                     },
                     NewBoardTask {
@@ -849,6 +1051,8 @@ mod tests {
                         model_override: None,
                         model_effort: None,
                         working_directory: None,
+                        repository: None,
+                        branch: None,
                         depends_on: vec!["t1".into()],
                     },
                 ],
@@ -888,6 +1092,8 @@ mod tests {
                     model_override: None,
                     model_effort: None,
                     working_directory: None,
+                    repository: None,
+                    branch: None,
                     depends_on: vec![],
                 }],
             )
@@ -958,6 +1164,8 @@ mod tests {
                         model_override: None,
                         model_effort: None,
                         working_directory: None,
+                        repository: None,
+                        branch: None,
                         depends_on: vec![],
                     },
                     NewBoardTask {
@@ -968,6 +1176,8 @@ mod tests {
                         model_override: None,
                         model_effort: None,
                         working_directory: None,
+                        repository: None,
+                        branch: None,
                         depends_on: vec![],
                     },
                 ],

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -588,6 +588,56 @@ mod tests {
     use super::*;
     use crate::api::mission_store::NewBoardTask;
 
+    #[test]
+    fn retry_with_surviving_branch_includes_prior_attempt_digest() {
+        let mut task = mk("retry", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 1;
+        task.repository = Some("Th0rgal/sandboxed.sh".into());
+        task.branch = Some("agent/already-pushed".into());
+        task.prior_worker_mission_id = Some(Uuid::new_v4());
+        task.prior_outcome = Some(BoardTaskOutcome::Failed);
+
+        let preflight = RetryPreflight::Surviving {
+            branch_state: "remote branch exists".into(),
+            pr_number: Some(42),
+        };
+        let prompt = retry_prompt(&task, &preflight);
+
+        assert_ne!(prompt, task.prompt);
+        assert!(prompt.contains("Prior-attempt digest"));
+        assert!(prompt.contains("checkout the existing branch"));
+        assert!(prompt.contains("never recreate from master"));
+        assert!(prompt.contains("never force-push"));
+    }
+
+    #[test]
+    fn retry_with_merged_pr_is_parked_for_boss_review() {
+        let mut task = mk("merged", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 1;
+        task.repository = Some("Th0rgal/sandboxed.sh".into());
+        task.branch = Some("agent/already-merged".into());
+
+        assert_eq!(
+            retry_disposition(&task, &RetryPreflight::Merged { pr_number: 99 }),
+            RetryDisposition::ParkForBossReview
+        );
+    }
+
+    #[test]
+    fn retry_without_repository_metadata_keeps_original_prompt() {
+        let mut task = mk("legacy", &[], BoardTaskStatus::Pending, None);
+        task.attempts = 1;
+
+        assert_eq!(
+            retry_prompt(&task, &RetryPreflight::NothingFound),
+            task.prompt
+        );
+        assert_eq!(
+            retry_disposition(&task, &RetryPreflight::NothingFound),
+            RetryDisposition::Spawn
+        );
+    }
+
     fn mk(
         key: &str,
         deps: &[&str],

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -23140,6 +23140,8 @@ And the report:
             model_override: Some(model.to_string()),
             model_effort: None,
             working_directory: None,
+            repository: None,
+            branch: None,
             depends_on: Vec::new(),
         }
     }

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -610,6 +610,8 @@ impl MissionStore for InMemoryMissionStore {
                         bt.model_override = t.model_override;
                         bt.model_effort = t.model_effort;
                         bt.working_directory = t.working_directory;
+                        bt.repository = t.repository;
+                        bt.branch = t.branch;
                         bt.depends_on = t.depends_on;
                         bt.updated_at = now.clone();
                     }
@@ -626,10 +628,15 @@ impl MissionStore for InMemoryMissionStore {
                         model_override: t.model_override,
                         model_effort: t.model_effort,
                         working_directory: t.working_directory,
+                        repository: t.repository,
+                        branch: t.branch,
                         depends_on: t.depends_on,
                         status: BoardTaskStatus::Pending,
                         outcome: None,
                         worker_mission_id: None,
+                        prior_worker_mission_id: None,
+                        prior_outcome: None,
+                        prior_result_digest: None,
                         attempts: 0,
                         result_digest: None,
                         notes: None,

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -1352,6 +1352,12 @@ pub struct BoardTask {
     /// Working directory for the worker (usually an isolated git worktree).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_directory: Option<String>,
+    /// Declared repository (path or OWNER/REPO identity) for retry artifact checks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    /// Declared git branch created for this task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     /// Task keys (same board) that must settle successfully or be accepted
     /// before this task may start.
     pub depends_on: Vec<String>,
@@ -1360,6 +1366,12 @@ pub struct BoardTask {
     pub outcome: Option<BoardTaskOutcome>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_mission_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prior_worker_mission_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prior_outcome: Option<BoardTaskOutcome>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prior_result_digest: Option<String>,
     /// Number of worker spawns so far (1 = first attempt).
     pub attempts: u32,
     /// Truncated tail of the worker's final message, set on settle.
@@ -1385,6 +1397,10 @@ pub struct NewBoardTask {
     pub model_effort: Option<String>,
     #[serde(default)]
     pub working_directory: Option<String>,
+    #[serde(default)]
+    pub repository: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
     #[serde(default)]
     pub depends_on: Vec<String>,
 }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -1253,11 +1253,21 @@ impl SqliteMissionStore {
                 .map_err(|e| format!("Failed to query board_tasks schema: {e}"))?;
             if !exists {
                 tracing::info!(column, "Running migration: adding board task column");
-                conn.execute(
+                match conn.execute(
                     &format!("ALTER TABLE board_tasks ADD COLUMN {column} {ty}"),
                     [],
-                )
-                .map_err(|e| format!("Failed to add board_tasks.{column}: {e}"))?;
+                ) {
+                    Ok(_) => {}
+                    Err(error) if error.to_string().contains("duplicate column") => {
+                        tracing::debug!(
+                            column,
+                            "board task column already exists after concurrent migration"
+                        );
+                    }
+                    Err(error) => {
+                        return Err(format!("Failed to add board_tasks.{column}: {error}"));
+                    }
+                }
             }
         }
 
@@ -11941,6 +11951,16 @@ mod tests {
                 .ok();
             conn.execute("ALTER TABLE missions DROP COLUMN next_check_at", [])
                 .ok();
+            for column in [
+                "repository",
+                "branch",
+                "prior_worker_mission_id",
+                "prior_outcome",
+                "prior_result_digest",
+            ] {
+                conn.execute(&format!("ALTER TABLE board_tasks DROP COLUMN {column}"), [])
+                    .expect("drop board task column for migration race");
+            }
         }
 
         // Two concurrent initializations on the SAME db file — both must succeed.
@@ -11983,6 +12003,23 @@ mod tests {
                 exists,
                 "{} column must exist after concurrent migration",
                 col
+            );
+        }
+        for col in [
+            "repository",
+            "branch",
+            "prior_worker_mission_id",
+            "prior_outcome",
+            "prior_result_digest",
+        ] {
+            let exists: bool = conn
+                .prepare("SELECT 1 FROM pragma_table_info('board_tasks') WHERE name = ?1")
+                .unwrap()
+                .exists([col])
+                .unwrap();
+            assert!(
+                exists,
+                "{col} board_tasks column must survive concurrent migration"
             );
         }
     }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -14707,6 +14707,8 @@ mod tests {
         assert_eq!(tasks.len(), 2);
         assert_eq!(tasks[0].status, BoardTaskStatus::Pending);
         assert_eq!(tasks[1].depends_on, vec!["t1".to_string()]);
+        assert_eq!(tasks[0].repository.as_deref(), Some("Th0rgal/sandboxed.sh"));
+        assert_eq!(tasks[0].branch.as_deref(), Some("agent/test"));
 
         // Active boards includes our boss.
         let active = store.list_active_board_missions().await.expect("active");

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -657,10 +657,15 @@ CREATE TABLE IF NOT EXISTS board_tasks (
     model_override TEXT,
     model_effort TEXT,
     working_directory TEXT,
+    repository TEXT,
+    branch TEXT,
     depends_on TEXT NOT NULL DEFAULT '[]',
     status TEXT NOT NULL DEFAULT 'pending',
     outcome TEXT,
     worker_mission_id TEXT,
+    prior_worker_mission_id TEXT,
+    prior_outcome TEXT,
+    prior_result_digest TEXT,
     attempts INTEGER NOT NULL DEFAULT 0,
     result_digest TEXT,
     notes TEXT,
@@ -1232,6 +1237,30 @@ impl SqliteMissionStore {
     /// CREATE TABLE IF NOT EXISTS doesn't add columns to existing tables,
     /// so we need to handle schema changes manually.
     fn run_migrations(conn: &Connection) -> Result<(), String> {
+        for (column, ty) in [
+            ("repository", "TEXT"),
+            ("branch", "TEXT"),
+            ("prior_worker_mission_id", "TEXT"),
+            ("prior_outcome", "TEXT"),
+            ("prior_result_digest", "TEXT"),
+        ] {
+            let exists = conn
+                .prepare(&format!(
+                    "SELECT 1 FROM pragma_table_info('board_tasks') WHERE name = '{column}'"
+                ))
+                .map_err(|e| format!("Failed to check board_tasks.{column}: {e}"))?
+                .exists([])
+                .map_err(|e| format!("Failed to query board_tasks schema: {e}"))?;
+            if !exists {
+                tracing::info!(column, "Running migration: adding board task column");
+                conn.execute(
+                    &format!("ALTER TABLE board_tasks ADD COLUMN {column} {ty}"),
+                    [],
+                )
+                .map_err(|e| format!("Failed to add board_tasks.{column}: {e}"))?;
+            }
+        }
+
         // Check if 'backend' column exists in missions table
         let has_backend_column: bool = conn
             .prepare("SELECT 1 FROM pragma_table_info('missions') WHERE name = 'backend'")
@@ -10021,7 +10050,7 @@ impl MissionStore for SqliteMissionStore {
                         conn.execute(
                             "UPDATE board_tasks SET title = ?1, prompt = ?2, backend = ?3, \
                              model_override = ?4, model_effort = ?5, working_directory = ?6, \
-                             depends_on = ?7, updated_at = ?8 WHERE id = ?9",
+                             repository = ?7, branch = ?8, depends_on = ?9, updated_at = ?10 WHERE id = ?11",
                             params![
                                 t.title,
                                 t.prompt,
@@ -10029,6 +10058,8 @@ impl MissionStore for SqliteMissionStore {
                                 t.model_override,
                                 t.model_effort,
                                 t.working_directory,
+                                t.repository,
+                                t.branch,
                                 depends_on_json,
                                 now,
                                 id,
@@ -10042,9 +10073,9 @@ impl MissionStore for SqliteMissionStore {
                         let id = Uuid::new_v4().to_string();
                         conn.execute(
                             "INSERT INTO board_tasks (id, boss_mission_id, task_key, title, prompt, \
-                             backend, model_override, model_effort, working_directory, depends_on, \
+                             backend, model_override, model_effort, working_directory, repository, branch, depends_on, \
                              status, attempts, created_at, updated_at) \
-                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', 0, ?11, ?11)",
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 'pending', 0, ?13, ?13)",
                             params![
                                 id,
                                 boss_mission_id.to_string(),
@@ -10055,6 +10086,8 @@ impl MissionStore for SqliteMissionStore {
                                 t.model_override,
                                 t.model_effort,
                                 t.working_directory,
+                                t.repository,
+                                t.branch,
                                 depends_on_json,
                                 now,
                             ],
@@ -10173,9 +10206,10 @@ impl MissionStore for SqliteMissionStore {
             let updated = conn
                 .execute(
                     "UPDATE board_tasks SET task_key = ?1, title = ?2, prompt = ?3, backend = ?4, \
-                     model_override = ?5, model_effort = ?6, working_directory = ?7, depends_on = ?8, \
-                     status = ?9, outcome = ?10, worker_mission_id = ?11, attempts = ?12, \
-                     result_digest = ?13, notes = ?14, updated_at = ?15 WHERE id = ?16",
+                     model_override = ?5, model_effort = ?6, working_directory = ?7, repository = ?8, \
+                     branch = ?9, depends_on = ?10, status = ?11, outcome = ?12, worker_mission_id = ?13, \
+                     prior_worker_mission_id = ?14, prior_outcome = ?15, prior_result_digest = ?16, \
+                     attempts = ?17, result_digest = ?18, notes = ?19, updated_at = ?20 WHERE id = ?21",
                     params![
                         t.task_key,
                         t.title,
@@ -10184,10 +10218,15 @@ impl MissionStore for SqliteMissionStore {
                         t.model_override,
                         t.model_effort,
                         t.working_directory,
+                        t.repository,
+                        t.branch,
                         depends_on_json,
                         t.status.to_string(),
                         t.outcome.map(|o| o.to_string()),
                         t.worker_mission_id.map(|id| id.to_string()),
+                        t.prior_worker_mission_id.map(|id| id.to_string()),
+                        t.prior_outcome.map(|o| o.to_string()),
+                        t.prior_result_digest,
                         t.attempts as i64,
                         t.result_digest,
                         t.notes,
@@ -10209,17 +10248,20 @@ impl MissionStore for SqliteMissionStore {
 /// Column list shared by every board task SELECT so `parse_board_task_row`
 /// indices stay in sync.
 const BOARD_TASK_COLUMNS: &str = "id, boss_mission_id, task_key, title, prompt, backend, \
-    model_override, model_effort, working_directory, depends_on, status, outcome, \
-    worker_mission_id, attempts, result_digest, notes, created_at, updated_at";
+    model_override, model_effort, working_directory, repository, branch, depends_on, status, outcome, \
+    worker_mission_id, prior_worker_mission_id, prior_outcome, prior_result_digest, attempts, \
+    result_digest, notes, created_at, updated_at";
 
 fn parse_board_task_row(row: &rusqlite::Row<'_>) -> Result<BoardTask, rusqlite::Error> {
     let id: String = row.get(0)?;
     let boss_mission_id: String = row.get(1)?;
-    let depends_on_json: String = row.get(9)?;
-    let status_str: String = row.get(10)?;
-    let outcome_str: Option<String> = row.get(11)?;
-    let worker_mission_id: Option<String> = row.get(12)?;
-    let attempts: i64 = row.get(13)?;
+    let depends_on_json: String = row.get(11)?;
+    let status_str: String = row.get(12)?;
+    let outcome_str: Option<String> = row.get(13)?;
+    let worker_mission_id: Option<String> = row.get(14)?;
+    let prior_worker_mission_id: Option<String> = row.get(15)?;
+    let prior_outcome: Option<String> = row.get(16)?;
+    let attempts: i64 = row.get(18)?;
     Ok(BoardTask {
         id: Uuid::parse_str(&id)
             .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
@@ -10232,15 +10274,20 @@ fn parse_board_task_row(row: &rusqlite::Row<'_>) -> Result<BoardTask, rusqlite::
         model_override: row.get(6)?,
         model_effort: row.get(7)?,
         working_directory: row.get(8)?,
+        repository: row.get(9)?,
+        branch: row.get(10)?,
         depends_on: serde_json::from_str(&depends_on_json).unwrap_or_default(),
         status: BoardTaskStatus::parse(&status_str).unwrap_or(BoardTaskStatus::Pending),
         outcome: outcome_str.as_deref().and_then(BoardTaskOutcome::parse),
         worker_mission_id: worker_mission_id.and_then(|s| Uuid::parse_str(&s).ok()),
+        prior_worker_mission_id: prior_worker_mission_id.and_then(|s| Uuid::parse_str(&s).ok()),
+        prior_outcome: prior_outcome.as_deref().and_then(BoardTaskOutcome::parse),
+        prior_result_digest: row.get(17)?,
         attempts: attempts as u32,
-        result_digest: row.get(14)?,
-        notes: row.get(15)?,
-        created_at: row.get(16)?,
-        updated_at: row.get(17)?,
+        result_digest: row.get(19)?,
+        notes: row.get(20)?,
+        created_at: row.get(21)?,
+        updated_at: row.get(22)?,
     })
 }
 
@@ -14648,6 +14695,8 @@ mod tests {
             model_override: Some("gpt-5.5".to_string()),
             model_effort: Some("high".to_string()),
             working_directory: Some("/workspaces/x/wt-1".to_string()),
+            repository: Some("Th0rgal/sandboxed.sh".to_string()),
+            branch: Some("agent/test".to_string()),
             depends_on: deps.into_iter().map(String::from).collect(),
         };
 

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1776,6 +1776,20 @@ impl OrchestratorMcp {
             } else {
                 spec.working_directory.clone()
             };
+            let (repository, branch) = spec
+                .worktree
+                .as_ref()
+                .map(|wt| {
+                    (
+                        Some(
+                            resolve_repo_path(wt.repo_path.as_deref())
+                                .to_string_lossy()
+                                .into_owned(),
+                        ),
+                        Some(wt.branch.clone()),
+                    )
+                })
+                .unwrap_or((None, None));
             if let Some(wd) = working_directory.as_deref() {
                 validate_working_directory_visible_to_worker(wd)?;
             }
@@ -1788,6 +1802,8 @@ impl OrchestratorMcp {
                 "model_override": spec.model_override,
                 "model_effort": spec.model_effort,
                 "working_directory": working_directory,
+                "repository": repository,
+                "branch": branch,
                 "depends_on": spec.depends_on,
             }));
         }

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1780,8 +1780,9 @@ impl OrchestratorMcp {
                 .worktree
                 .as_ref()
                 .map(|wt| {
+                    let repo_path = resolve_repo_path(wt.repo_path.as_deref());
                     (
-                        Some(resolve_repo_path(wt.repo_path.as_deref())),
+                        Some(repository_identity_for_scheduler(&repo_path)),
                         Some(wt.branch.clone()),
                     )
                 })
@@ -2697,6 +2698,37 @@ fn resolve_repo_path(explicit: Option<&str>) -> String {
     workspace_root
 }
 
+/// Persist a repository identifier the API/control process can use after this
+/// container-scoped MCP exits. Container guest paths are not necessarily
+/// visible on the host, while an OWNER/REPO identity works with `gh --repo`.
+fn repository_identity_for_scheduler(repo_path: &str) -> String {
+    if !std::path::Path::new(repo_path).exists() {
+        return repo_path.to_string();
+    }
+    let remote = Command::new("git")
+        .current_dir(repo_path)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string());
+
+    remote
+        .as_deref()
+        .and_then(github_repository_identity)
+        .unwrap_or_else(|| repo_path.to_string())
+}
+
+fn github_repository_identity(remote: &str) -> Option<String> {
+    let trimmed = remote.trim().trim_end_matches(".git");
+    let slug = trimmed
+        .split("github.com/")
+        .nth(1)
+        .or_else(|| trimmed.rsplit_once("github.com:").map(|(_, tail)| tail))?;
+    let slug = slug.trim_start_matches('/');
+    (slug.split('/').count() == 2).then(|| slug.to_string())
+}
+
 // =============================================================================
 // Container resource estimation
 // =============================================================================
@@ -3365,7 +3397,9 @@ async fn main() {
 
 #[cfg(test)]
 mod working_directory_tests {
-    use super::{path_is_within, validate_working_directory_visible_to_worker};
+    use super::{
+        github_repository_identity, path_is_within, validate_working_directory_visible_to_worker,
+    };
 
     fn with_env<F: FnOnce()>(workspace_type: Option<&str>, workspace: Option<&str>, f: F) {
         // SAFETY: tests in this module are run serially via `#[test]` with
@@ -3471,6 +3505,22 @@ mod working_directory_tests {
                 .expect_err("sibling path with prefix match should be rejected");
             assert!(err.contains("not be visible to the worker"));
         });
+    }
+
+    #[test]
+    fn github_repository_identity_parses_https_and_ssh_remotes() {
+        assert_eq!(
+            github_repository_identity("https://github.com/lfglabs-dev/verity.git").as_deref(),
+            Some("lfglabs-dev/verity")
+        );
+        assert_eq!(
+            github_repository_identity("git@github.com:lfglabs-dev/verity.git").as_deref(),
+            Some("lfglabs-dev/verity")
+        );
+        assert_eq!(
+            github_repository_identity("https://example.com/repo.git"),
+            None
+        );
     }
 }
 

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1781,11 +1781,7 @@ impl OrchestratorMcp {
                 .as_ref()
                 .map(|wt| {
                     (
-                        Some(
-                            resolve_repo_path(wt.repo_path.as_deref())
-                                .to_string_lossy()
-                                .into_owned(),
-                        ),
+                        Some(resolve_repo_path(wt.repo_path.as_deref())),
                         Some(wt.branch.clone()),
                     )
                 })

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1759,12 +1759,19 @@ impl OrchestratorMcp {
                 ));
             }
 
+            // Resolve an implicit repository before adding the worktree. Once the
+            // worktree exists, auto-detection may see both checkouts and fall back
+            // to the workspace root, which is not useful to the host scheduler.
+            let resolved_worktree_repo = spec
+                .worktree
+                .as_ref()
+                .map(|wt| resolve_repo_path(wt.repo_path.as_deref()));
             let working_directory = if let Some(wt) = &spec.worktree {
                 self.create_worktree(CreateWorktreeParams {
                     path: wt.path.clone(),
                     branch: wt.branch.clone(),
                     base: wt.base.clone(),
-                    repo_path: wt.repo_path.clone(),
+                    repo_path: resolved_worktree_repo.clone(),
                 })
                 .map_err(|e| format!("task `{}`: worktree failed: {}", spec.task_key, e))?;
                 worktrees_created.push(json!({
@@ -1780,9 +1787,11 @@ impl OrchestratorMcp {
                 .worktree
                 .as_ref()
                 .map(|wt| {
-                    let repo_path = resolve_repo_path(wt.repo_path.as_deref());
+                    let repo_path = resolved_worktree_repo
+                        .as_deref()
+                        .expect("worktree repository was resolved before creation");
                     (
-                        Some(repository_identity_for_scheduler(&repo_path)),
+                        Some(repository_identity_for_scheduler(repo_path)),
                         Some(wt.branch.clone()),
                     )
                 })

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -1740,6 +1740,20 @@ impl OrchestratorMcp {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
+        // Auto-detect once for the whole batch. Creating the first worktree
+        // adds another `.git` entry under the workspace, so resolving again
+        // for a later task would make an originally unambiguous checkout look
+        // ambiguous and fall back to the workspace root.
+        let implicit_worktree_repo = params
+            .tasks
+            .iter()
+            .any(|spec| {
+                spec.worktree
+                    .as_ref()
+                    .is_some_and(|worktree| worktree.repo_path.is_none())
+            })
+            .then(|| resolve_repo_path(None));
+
         let mut registered = Vec::with_capacity(params.tasks.len());
         let mut worktrees_created = Vec::new();
         for spec in params.tasks {
@@ -1762,10 +1776,13 @@ impl OrchestratorMcp {
             // Resolve an implicit repository before adding the worktree. Once the
             // worktree exists, auto-detection may see both checkouts and fall back
             // to the workspace root, which is not useful to the host scheduler.
-            let resolved_worktree_repo = spec
-                .worktree
-                .as_ref()
-                .map(|wt| resolve_repo_path(wt.repo_path.as_deref()));
+            let resolved_worktree_repo = spec.worktree.as_ref().map(|wt| {
+                wt.repo_path.clone().unwrap_or_else(|| {
+                    implicit_worktree_repo
+                        .clone()
+                        .expect("implicit worktree repository was resolved before the batch")
+                })
+            });
             let working_directory = if let Some(wt) = &spec.worktree {
                 self.create_worktree(CreateWorktreeParams {
                     path: wt.path.clone(),

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -816,7 +816,9 @@ mod tests {
                 ) && matches!(
                     store.get(queued).await.unwrap().map(|record| record.state),
                     Some(JobState::Queued)
-                ) {
+                ) && runner.active_count() == 1
+                    && runner.queued_count() == 1
+                {
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(20)).await;


### PR DESCRIPTION
## Summary
- persist optional repository/branch metadata and prior-attempt provenance on board tasks
- run a best-effort local/remote branch and GitHub PR preflight before automatic retries
- continue surviving artifacts with an explicit digest, while parking merged PRs for boss review

## Design
Retries without repository metadata or without surviving artifacts retain the existing prompt and scheduling behavior. Lookup errors only emit warnings and degrade to that same legacy behavior. A merged PR is stored as the existing settled/blocked state because it is the least invasive board mechanism that both prevents another do-the-work spawn and wakes the boss for an explicit verdict; no new status or UI behavior is introduced.

## Failing first
Commit 8833d547 adds the three regression expectations before implementation. Running cargo test --locked retry_ at that commit fails to compile because BoardTask has no repository/branch/prior-attempt fields and the retry preflight/prompt API does not exist (for example: no field repository on BoardTask).

## Base
Fetched origin/master: 70012ebcee30085be60a1a4e016ee17f2f484b5d.

## Validation
- cargo check --locked
- focused regression and full CI gates in progress

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scheduler now shells out to git/gh on the control path during retries; failures degrade to legacy behavior but timeouts and mis-detection could still spawn wrong workers or park tasks incorrectly.
> 
> **Overview**
> Adds **repository/branch** and **prior-attempt** fields on board tasks (memory + SQLite migrations) so automatic retries can reason about git/GitHub state instead of blindly re-spawning workers.
> 
> Before respawning a task with `attempts > 0`, the scheduler runs a **12s best-effort preflight** (`git` branch local/remote, `gh pr list`) and classifies **nothing found**, **surviving artifacts**, or **merged PR**. Merged retries are **parked** as settled/blocked with a digest (boss wake) instead of spawning; surviving branches get a **prior-attempt digest** prompt (checkout existing branch, no recreate/force-push). Failed auto-retries now persist `prior_worker_mission_id`, outcome, and result digest; stuck-pending re-kicks keep the same branch guard from stored metadata when preflight isn’t available.
> 
> **`plan_tasks`** in orchestrator MCP records `repository`/`branch` from worktrees (OWNER/REPO when possible) and resolves implicit repo **once per batch** so later worktrees don’t confuse auto-detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71727cde037c90039cc230a9760794ea60fb5cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->