### PR TITLE
Fix Codex workspace project directory

### DIFF
--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -973,10 +973,16 @@ pub async fn run_codex_turn(
     // Create Codex backend
     let backend = CodexBackend::with_config_and_workspace(codex_config, workspace_exec);
 
+    // Keep generated config and Codex state in the mission directory, but run
+    // the agent from an explicitly configured project checkout when present.
+    // Verity's lean-lsp MCP uses the same LEAN_PROJECT_PATH, so this keeps
+    // Codex file tools and Lean requests on one mounted project tree.
+    let codex_work_dir = crate::workspace::configured_project_dir(workspace, mission_work_dir);
+
     // Create session
     let session = match backend
         .create_session(SessionConfig {
-            directory: mission_work_dir.to_string_lossy().to_string(),
+            directory: codex_work_dir.to_string_lossy().to_string(),
             title: Some(format!("Mission {}", mission_id)),
             model: resolved_model.clone(),
             agent: agent.map(|s| s.to_string()),

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -1356,11 +1356,19 @@ mod tests {
             Vec::new(),
             HashMap::new(),
         );
-        mcp.workspace_env_allowlist = vec!["PATH".to_string(), "ELAN_HOME".to_string()];
+        mcp.workspace_env_allowlist = vec![
+            "PATH".to_string(),
+            "ELAN_HOME".to_string(),
+            "LEAN_PROJECT_PATH".to_string(),
+        ];
 
         let workspace_env = HashMap::from([
             ("PATH".to_string(), "/root/.elan/bin:/usr/bin".to_string()),
             ("ELAN_HOME".to_string(), "/root/.elan".to_string()),
+            (
+                "LEAN_PROJECT_PATH".to_string(),
+                "/workspace/verity/base".to_string(),
+            ),
             ("GH_TOKEN".to_string(), "github-secret".to_string()),
             ("SSH_PRIVATE_KEY_B64".to_string(), "ssh-secret".to_string()),
             ("GPG_PRIVATE_KEY_B64".to_string(), "gpg-secret".to_string()),
@@ -1393,6 +1401,7 @@ mod tests {
         let launcher_contents = std::fs::read_to_string(&launcher).unwrap();
         assert!(launcher_contents.contains("PATH='/root/.elan/bin:/usr/bin'"));
         assert!(launcher_contents.contains("ELAN_HOME='/root/.elan'"));
+        assert!(launcher_contents.contains("LEAN_PROJECT_PATH='/workspace/verity/base'"));
         assert!(!launcher_contents.contains("github-secret"));
         assert!(!launcher_contents.contains("ssh-secret"));
         assert!(!launcher_contents.contains("gpg-secret"));

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -824,6 +824,20 @@ fn configured_project_dir_with_nspawn(
     fallback: &Path,
     uses_nspawn: bool,
 ) -> PathBuf {
+    // An explicit mission working directory (most importantly an
+    // orchestrator-owned git worktree) is authoritative. Only replace the
+    // generated per-mission state directory; otherwise every worker would be
+    // redirected back to the shared LEAN_PROJECT_PATH checkout.
+    let generated_workspaces = workspaces_root_for(&workspace.path);
+    let is_generated_mission_dir = fallback.parent() == Some(generated_workspaces.as_path())
+        && fallback
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("mission-"));
+    if !is_generated_mission_dir {
+        return fallback.to_path_buf();
+    }
+
     let Some(project) = workspace
         .env_vars
         .get("LEAN_PROJECT_PATH")
@@ -834,6 +848,19 @@ fn configured_project_dir_with_nspawn(
     };
 
     let configured = Path::new(project);
+    if configured.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::ParentDir | std::path::Component::CurDir
+        )
+    }) {
+        tracing::warn!(
+            workspace = %workspace.name,
+            project_path = %project,
+            "Ignoring project path containing relative traversal components"
+        );
+        return fallback.to_path_buf();
+    }
     let candidate = if workspace.workspace_type == WorkspaceType::Container && uses_nspawn {
         workspace
             .path
@@ -842,17 +869,21 @@ fn configured_project_dir_with_nspawn(
         configured.to_path_buf()
     };
 
-    if candidate.starts_with(&workspace.path) {
-        candidate
-    } else {
-        tracing::warn!(
-            workspace = %workspace.name,
-            project_path = %project,
-            workspace_root = %workspace.path.display(),
-            "Ignoring project path outside selected workspace"
-        );
-        fallback.to_path_buf()
+    let canonical_root = std::fs::canonicalize(&workspace.path);
+    let canonical_candidate = std::fs::canonicalize(&candidate);
+    if let (Ok(root), Ok(candidate)) = (canonical_root, canonical_candidate) {
+        if candidate.starts_with(&root) {
+            return candidate;
+        }
     }
+
+    tracing::warn!(
+        workspace = %workspace.name,
+        project_path = %project,
+        workspace_root = %workspace.path.display(),
+        "Ignoring missing project path or path outside selected workspace"
+    );
+    fallback.to_path_buf()
 }
 
 /// Workspace directory for a task under a specific workspace root.
@@ -3686,10 +3717,67 @@ mod tests {
             "/workspace/verity/base".to_string(),
         );
         let mission_dir = root.path().join("workspaces/mission-deadbeef");
+        std::fs::create_dir_all(root.path().join("workspace/verity/base")).unwrap();
 
         assert_eq!(
             configured_project_dir_with_nspawn(&workspace, &mission_dir, true),
-            root.path().join("workspace/verity/base")
+            std::fs::canonicalize(root.path().join("workspace/verity/base")).unwrap()
+        );
+    }
+
+    #[test]
+    fn configured_project_path_preserves_explicit_worker_worktree() {
+        let root = tempfile::tempdir().unwrap();
+        let mut workspace =
+            Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+        workspace.env_vars.insert(
+            "LEAN_PROJECT_PATH".to_string(),
+            "/workspace/verity/base".to_string(),
+        );
+        let worker = root.path().join("workspace/verity/worktrees/proof-2164");
+
+        assert_eq!(
+            configured_project_dir_with_nspawn(&workspace, &worker, true),
+            worker
+        );
+    }
+
+    #[test]
+    fn configured_project_path_rejects_parent_traversal() {
+        let root = tempfile::tempdir().unwrap();
+        let mut workspace =
+            Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+        workspace
+            .env_vars
+            .insert("LEAN_PROJECT_PATH".to_string(), "/../tmp".to_string());
+        let mission_dir = root.path().join("workspaces/mission-deadbeef");
+
+        assert_eq!(
+            configured_project_dir_with_nspawn(&workspace, &mission_dir, true),
+            mission_dir
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_project_path_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let mut workspace =
+            Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+        workspace.env_vars.insert(
+            "LEAN_PROJECT_PATH".to_string(),
+            "/workspace/verity/base".to_string(),
+        );
+        std::fs::create_dir_all(root.path().join("workspace/verity")).unwrap();
+        symlink(outside.path(), root.path().join("workspace/verity/base")).unwrap();
+        let mission_dir = root.path().join("workspaces/mission-deadbeef");
+
+        assert_eq!(
+            configured_project_dir_with_nspawn(&workspace, &mission_dir, true),
+            mission_dir
         );
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -807,6 +807,54 @@ pub fn mission_workspace_dir_for_root(root: &Path, mission_id: Uuid) -> PathBuf 
     workspaces_root_for(root).join(format!("mission-{}", short_id))
 }
 
+/// Resolve a configured project directory to its host-visible path.
+///
+/// Mission state (harness config, HOME and XDG data) deliberately lives in a
+/// per-mission directory, but a workspace can also expose a durable project
+/// checkout.  In an nspawn container, workspace environment paths name guest
+/// paths, so translate an absolute guest path through the container root
+/// before handing it to [`crate::workspace_exec::WorkspaceExec`].  Never
+/// accept a project path outside the selected workspace root.
+pub fn configured_project_dir(workspace: &Workspace, fallback: &Path) -> PathBuf {
+    configured_project_dir_with_nspawn(workspace, fallback, use_nspawn_for_workspace(workspace))
+}
+
+fn configured_project_dir_with_nspawn(
+    workspace: &Workspace,
+    fallback: &Path,
+    uses_nspawn: bool,
+) -> PathBuf {
+    let Some(project) = workspace
+        .env_vars
+        .get("LEAN_PROJECT_PATH")
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    else {
+        return fallback.to_path_buf();
+    };
+
+    let configured = Path::new(project);
+    let candidate = if workspace.workspace_type == WorkspaceType::Container && uses_nspawn {
+        workspace
+            .path
+            .join(configured.strip_prefix("/").unwrap_or(configured))
+    } else {
+        configured.to_path_buf()
+    };
+
+    if candidate.starts_with(&workspace.path) {
+        candidate
+    } else {
+        tracing::warn!(
+            workspace = %workspace.name,
+            project_path = %project,
+            workspace_root = %workspace.path.display(),
+            "Ignoring project path outside selected workspace"
+        );
+        fallback.to_path_buf()
+    }
+}
+
 /// Workspace directory for a task under a specific workspace root.
 pub fn task_workspace_dir_for_root(root: &Path, task_id: Uuid) -> PathBuf {
     let short_id = &task_id.to_string()[..8];
@@ -3627,6 +3675,23 @@ pub async fn read_sandboxed_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn verity_project_path_maps_to_container_checkout() {
+        let root = tempfile::tempdir().unwrap();
+        let mut workspace =
+            Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+        workspace.env_vars.insert(
+            "LEAN_PROJECT_PATH".to_string(),
+            "/workspace/verity/base".to_string(),
+        );
+        let mission_dir = root.path().join("workspaces/mission-deadbeef");
+
+        assert_eq!(
+            configured_project_dir_with_nspawn(&workspace, &mission_dir, true),
+            root.path().join("workspace/verity/base")
+        );
+    }
 
     #[tokio::test]
     async fn remote_build_wrapper_is_mission_scoped_and_executable_for_host_workspaces() {


### PR DESCRIPTION
## Summary
- start Codex sessions from the selected workspace checkout when `LEAN_PROJECT_PATH` is configured
- translate nspawn guest project paths to their selected workspace-root host paths and reject paths outside that root
- carry `LEAN_PROJECT_PATH` through the allowlisted lean-lsp MCP launcher environment

## Validation
- `cargo test --locked --lib workspace::config::tests::third_party_mcp_only_receives_allowlisted_workspace_env -- --exact`
- `cargo test --locked --lib workspace::tests::verity_project_path_maps_to_container_checkout -- --exact`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace -- -D clippy::all`
- `git diff --check`

No deployment was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission working-directory selection for Codex and container path translation; mitigated by canonicalization, workspace-root checks, and new unit tests, but wrong config could still point agents at an unexpected tree.
> 
> **Overview**
> Codex missions now open their session working directory from the workspace’s **`LEAN_PROJECT_PATH`** checkout when that env var is set, instead of always using the generated per-mission state folder. Per-mission **HOME**, harness config, and Codex SQLite state still live under `workspaces/mission-*`; only the agent’s file-tool cwd moves to the shared project tree so it matches **lean-lsp** MCP.
> 
> New **`configured_project_dir`** resolves the path: for nspawn containers it maps guest absolute paths (e.g. `/workspace/verity/base`) onto paths under the workspace root on the host; it rejects `..` traversal, paths outside the workspace, and symlink escapes; and it **does not** override an explicit orchestrator worktree when the fallback is not a generated mission directory.
> 
> The lean-lsp MCP **`workspace_env_allowlist`** and tests now include **`LEAN_PROJECT_PATH`** so the MCP launcher receives the same project path as Codex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3ab42ba72c7583e7d65bc68903605261b512a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->