### PR TITLE
Stop idle workspace containers from spinning CPUs

### DIFF
--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -575,7 +575,13 @@ fn persistent_nspawn_command(scope_args: Option<&[String]>) -> Command {
         Command::new("systemd-nspawn")
     };
     nspawn::scrub_systemd_service_environment(&mut command);
-    command.arg("--console=pipe");
+    // This leader outlives the API process and has no interactive console.
+    // `--console=pipe` continuously wakes on the closed/null stdin after the
+    // launcher is restarted, making each otherwise-idle workspace consume a
+    // large fraction of one CPU. A passive PTY keeps the container detached
+    // without forwarding or polling console file descriptors. One-shot
+    // nspawn commands continue to use pipe mode so their output is captured.
+    command.arg("--console=passive");
     command
 }
 
@@ -735,13 +741,17 @@ mod tests {
     }
 
     #[test]
-    fn persistent_nspawn_boot_scrubs_service_environment() {
+    fn persistent_nspawn_boot_uses_passive_console_and_scrubs_service_environment() {
         let command = persistent_nspawn_command(Some(&["--scope".to_string()]));
         assert!(command
             .as_std()
             .get_args()
             .any(|arg| arg == OsStr::new("systemd-nspawn")));
         assert!(command
+            .as_std()
+            .get_args()
+            .any(|arg| arg == OsStr::new("--console=passive")));
+        assert!(!command
             .as_std()
             .get_args()
             .any(|arg| arg == OsStr::new("--console=pipe")));


### PR DESCRIPTION
## Summary

- use a passive PTY for persistent, headless systemd-nspawn workspace leaders
- keep pipe consoles for one-shot executions whose output must be captured
- cover the persistent command contract with a regression test

## Production diagnosis

After core restarts, nine detached keepalive containers were each consuming roughly 40-80% of one CPU. strace showed the pipe console waking continuously on its closed stdin. A production probe of console=passive consumed 0 CPU ticks over two seconds. Stopping eight unused keepalives raised host idle CPU from about 5% to about 52% without deleting workspace data.

## Validation

- cargo fmt --all --check
- cargo test workspace_exec --lib
- cargo clippy --locked --lib -- -D clippy::all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to console mode for persistent nspawn boot only; one-shot exec paths unchanged and behavior is covered by a unit test.
> 
> **Overview**
> Fixes **high idle CPU** on detached workspace keepalive containers after core/API restarts.
> 
> `persistent_nspawn_command` (the long-lived `systemd-nspawn` leader used for container workspaces) now passes **`--console=passive`** instead of **`--console=pipe`**. Pipe mode was continuously waking on closed/null stdin when the launcher had no interactive console, so each idle workspace could sit at a large fraction of one CPU. Passive PTY keeps the container detached without polling console fds; **one-shot** nspawn paths (e.g. in `nspawn.rs`) still use **pipe** so captured output behavior is unchanged.
> 
> The regression test **`persistent_nspawn_boot_uses_passive_console_and_scrubs_service_environment`** now asserts `--console=passive` and that `--console=pipe` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eab15006a52e70b52e5c8b2e75713c245b7e3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->