### PR TITLE
Fail closed when remote Lean runtime is unavailable

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -98,6 +98,14 @@ jobs consume the same permits. A full node rejects a new `/execute` request
 with HTTP 429; queued jobs wait for a shared permit. This prevents the two API
 paths from each consuming the configured capacity independently.
 
+A node configured with the `lean` label must have an executable `lake` proxy
+either at `$SANDBOXED_NODE_WORK_DIR/caches/elan/bin/lake` or on the service's
+absolute `PATH`. Install Elan under the `sandboxed-node` account and prewarm the
+project toolchains (for example `leanprover/lean4:v4.24.0`) before adding the
+label. The heartbeat reports `lean_runtime_ready`; when the proxy is missing,
+the node withholds `lean` and core rejects it for Lean placement instead of
+accepting jobs that will fail with `ENOENT`.
+
 Nippur and Ashur are configured identically with their own
 `SANDBOXED_NODE_ID` and token.
 
@@ -126,6 +134,8 @@ To rotate a node token with zero downtime:
 - `active_jobs` / `queued_jobs` (async job API)
 - `cached_toolchains` (Lean toolchain dirs under the node's shared elan
   cache; empty until the first `lean_build` job warms it)
+- `lean_runtime_ready` (`true` when the Lake proxy used by declarative builds
+  is executable; older nodes deserialize this as unknown)
 
 `capacity_available` is a snapshot of the shared semaphore, so it already
 accounts for work admitted through either `/execute` or `/jobs`.

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -187,6 +187,55 @@ fn default_node_id() -> String {
     "auto".to_string()
 }
 
+async fn probe_explicit_lean_node(
+    state: &AppState,
+    node_id: &str,
+    requirements: &[String],
+) -> Result<(), (StatusCode, String)> {
+    if node_id.eq_ignore_ascii_case("auto")
+        || !requirements.iter().any(|requirement| requirement == "lean")
+    {
+        return Ok(());
+    }
+    let settings = &state.config.remote_nodes;
+    if !settings.enabled || settings.nodes.is_empty() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "remote build nodes are not configured".to_string(),
+        ));
+    }
+    let node = settings.node(node_id).ok_or((
+        StatusCode::BAD_REQUEST,
+        format!("remote node '{node_id}' is not configured"),
+    ))?;
+
+    // This network I/O deliberately happens before the process-wide placement
+    // mutex is acquired. A slow explicit node must not block unrelated auto
+    // placement to healthy runners.
+    let client = RemoteNodeClient::default();
+    crate::remote_node::probe_node(&state.fleet, &client, node).await;
+    let cached = state.fleet.get(node_id);
+    if cached.as_ref().is_none_or(|cached| {
+        cached.status != RemoteNodeStatus::Online || cached.last_heartbeat.is_none()
+    }) {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("remote node '{node_id}' readiness probe failed"),
+        ));
+    }
+    if cached
+        .and_then(|cached| cached.last_heartbeat)
+        .and_then(|heartbeat| heartbeat.lean_runtime_ready)
+        == Some(false)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("remote node '{node_id}' has no executable Lake runtime"),
+        ));
+    }
+    Ok(())
+}
+
 fn default_wait() -> bool {
     true
 }
@@ -370,33 +419,6 @@ async fn resolve_node(
         StatusCode::BAD_REQUEST,
         format!("remote node '{node_id}' is not configured"),
     ))?;
-    if requirements.iter().any(|requirement| requirement == "lean") {
-        // Explicit placement must not bypass the fail-closed readiness gate
-        // when the monitor is disabled or has not completed its first tick.
-        // Probe synchronously so the decision covers the runner's current
-        // identity and PATH rather than an absent or stale cache entry.
-        let client = RemoteNodeClient::default();
-        crate::remote_node::probe_node(&state.fleet, &client, &node).await;
-        let cached = state.fleet.get(node_id);
-        if cached.as_ref().is_none_or(|cached| {
-            cached.status != RemoteNodeStatus::Online || cached.last_heartbeat.is_none()
-        }) {
-            return Err((
-                StatusCode::SERVICE_UNAVAILABLE,
-                format!("remote node '{node_id}' readiness probe failed"),
-            ));
-        }
-        if cached
-            .and_then(|cached| cached.last_heartbeat)
-            .and_then(|heartbeat| heartbeat.lean_runtime_ready)
-            == Some(false)
-        {
-            return Err((
-                StatusCode::SERVICE_UNAVAILABLE,
-                format!("remote node '{node_id}' has no executable Lake runtime"),
-            ));
-        }
-    }
     Ok(node)
 }
 
@@ -507,6 +529,11 @@ async fn submit_remote_build(
     // placement labels, but may not remove the runtime readiness gate by
     // sending an empty or unrelated requirements list.
     let requirements = normalized_lean_requirements(&req.requirements);
+    if let Err((status, message)) =
+        probe_explicit_lean_node(&state, &req.node_id, &requirements).await
+    {
+        return (status, message).into_response();
+    }
 
     // Serialize placement through tentative-handle persistence. Otherwise a
     // burst can select the same idle node before its next heartbeat.

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -370,18 +370,32 @@ async fn resolve_node(
         StatusCode::BAD_REQUEST,
         format!("remote node '{node_id}' is not configured"),
     ))?;
-    if requirements.iter().any(|requirement| requirement == "lean")
-        && state
-            .fleet
-            .get(node_id)
+    if requirements.iter().any(|requirement| requirement == "lean") {
+        // Explicit placement must not bypass the fail-closed readiness gate
+        // when the monitor is disabled or has not completed its first tick.
+        // Probe synchronously so the decision covers the runner's current
+        // identity and PATH rather than an absent or stale cache entry.
+        let client = RemoteNodeClient::default();
+        crate::remote_node::probe_node(&state.fleet, &client, &node).await;
+        let cached = state.fleet.get(node_id);
+        if cached.as_ref().is_none_or(|cached| {
+            cached.status != RemoteNodeStatus::Online || cached.last_heartbeat.is_none()
+        }) {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("remote node '{node_id}' readiness probe failed"),
+            ));
+        }
+        if cached
             .and_then(|cached| cached.last_heartbeat)
             .and_then(|heartbeat| heartbeat.lean_runtime_ready)
             == Some(false)
-    {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("remote node '{node_id}' has no executable Lake runtime"),
-        ));
+        {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("remote node '{node_id}' has no executable Lake runtime"),
+            ));
+        }
     }
     Ok(node)
 }

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -175,6 +175,14 @@ fn default_requirements() -> Vec<String> {
     vec!["lean".to_string()]
 }
 
+fn normalized_lean_requirements(requirements: &[String]) -> Vec<String> {
+    let mut normalized = requirements.to_vec();
+    if !normalized.iter().any(|requirement| requirement == "lean") {
+        normalized.push("lean".to_string());
+    }
+    normalized
+}
+
 fn default_node_id() -> String {
     "auto".to_string()
 }
@@ -358,10 +366,24 @@ async fn resolve_node(
             format!("placed node '{picked}' vanished from configuration"),
         ));
     }
-    settings.node(node_id).cloned().ok_or((
+    let node = settings.node(node_id).cloned().ok_or((
         StatusCode::BAD_REQUEST,
         format!("remote node '{node_id}' is not configured"),
-    ))
+    ))?;
+    if requirements.iter().any(|requirement| requirement == "lean")
+        && state
+            .fleet
+            .get(node_id)
+            .and_then(|cached| cached.last_heartbeat)
+            .and_then(|heartbeat| heartbeat.lean_runtime_ready)
+            == Some(false)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("remote node '{node_id}' has no executable Lake runtime"),
+        ));
+    }
+    Ok(node)
 }
 
 fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
@@ -467,11 +489,15 @@ async fn submit_remote_build(
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
     }
+    // Every endpoint payload is a declarative Lean build. Callers may add
+    // placement labels, but may not remove the runtime readiness gate by
+    // sending an empty or unrelated requirements list.
+    let requirements = normalized_lean_requirements(&req.requirements);
 
     // Serialize placement through tentative-handle persistence. Otherwise a
     // burst can select the same idle node before its next heartbeat.
     let placement_guard = placement_lock().lock().await;
-    let node = match resolve_node(&state, &req.node_id, &req.requirements).await {
+    let node = match resolve_node(&state, &req.node_id, &requirements).await {
         Ok(node) => node,
         Err((status, message)) => return (status, message).into_response(),
     };
@@ -985,6 +1011,19 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert_eq!(req.cwd_rel.as_deref(), Some("verity"));
         assert_eq!(req.timeout_secs, Some(1200));
         assert_eq!(req.artifacts, vec![".lake/build/lib/*"]);
+    }
+
+    #[test]
+    fn lean_requirement_cannot_be_removed_by_request_overrides() {
+        assert_eq!(normalized_lean_requirements(&[]), vec!["lean".to_string()]);
+        assert_eq!(
+            normalized_lean_requirements(&["high-memory".to_string()]),
+            vec!["high-memory".to_string(), "lean".to_string()]
+        );
+        assert_eq!(
+            normalized_lean_requirements(&["lean".to_string(), "gpu".to_string()]),
+            vec!["lean".to_string(), "gpu".to_string()]
+        );
     }
 
     #[test]

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -617,7 +617,7 @@ mod tests {
             mission_id,
             node_id: state.node_id.clone(),
             lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
-            command: "sleep 0.2".to_string(),
+            command: "sleep 1".to_string(),
         };
 
         let running = tokio::spawn(execute(
@@ -625,7 +625,7 @@ mod tests {
             headers.clone(),
             Json(request()),
         ));
-        for _ in 0..20 {
+        for _ in 0..100 {
             if state.active_leases.load(Ordering::Acquire) == 1 {
                 break;
             }

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -214,6 +214,8 @@ async fn heartbeat(
     check_auth(&headers, &state)?;
     let active_leases = state.active_leases.load(Ordering::Acquire);
     let resources = host_resources(&state.work_root);
+    let lean_runtime_ready = sandboxed_sh::node::lean_runtime_ready(&state.work_root);
+    let labels = advertised_labels(&state.labels, lean_runtime_ready);
     Ok(Json(NodeHeartbeat {
         node_id: state.node_id.clone(),
         online: true,
@@ -224,7 +226,7 @@ async fn heartbeat(
         active_leases,
         version: env!("CARGO_PKG_VERSION").to_string(),
         protocol_version: NODE_PROTOCOL_VERSION,
-        labels: state.labels.clone(),
+        labels,
         cpu_total: resources.cpu_total,
         mem_total_bytes: resources.mem_total_bytes,
         mem_available_bytes: resources.mem_available_bytes,
@@ -233,7 +235,16 @@ async fn heartbeat(
         active_jobs: state.runner.active_count(),
         queued_jobs: state.runner.queued_count(),
         cached_toolchains: sandboxed_sh::node::cached_toolchains(&state.work_root),
+        lean_runtime_ready: Some(lean_runtime_ready),
     }))
+}
+
+fn advertised_labels(configured: &[String], lean_runtime_ready: bool) -> Vec<String> {
+    let mut labels = configured.to_vec();
+    if !lean_runtime_ready {
+        labels.retain(|label| label != "lean");
+    }
+    labels
 }
 
 /// Signing secrets accepted for lease validation: the current token plus,
@@ -577,6 +588,16 @@ mod tests {
         let idle = heartbeat(State(state), headers).await.expect("heartbeat").0;
         assert_eq!(idle.active_leases, 0);
         assert_eq!(idle.capacity_available, 2);
+    }
+
+    #[test]
+    fn heartbeat_withholds_lean_label_without_a_lake_proxy() {
+        let labels = vec!["lean".to_string(), "high-memory".to_string()];
+        assert_eq!(
+            advertised_labels(&labels, false),
+            vec!["high-memory".to_string()]
+        );
+        assert_eq!(advertised_labels(&labels, true), labels);
     }
 
     #[tokio::test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -15,6 +15,7 @@
 //!   `<build cwd>/.lake` before a build and refreshed after a successful one.
 
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -232,6 +233,43 @@ fn cache_env(work_root: &Path) -> Vec<(String, String)> {
         ),
         ("PATH".to_string(), path),
     ]
+}
+
+fn executable_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn lean_runtime_ready_with_path(work_root: &Path, service_path: Option<&OsStr>) -> bool {
+    let cached_lake = caches_dir(work_root).join("elan/bin/lake");
+    executable_file(&cached_lake)
+        || service_path
+            .into_iter()
+            .flat_map(std::env::split_paths)
+            // Repository-controlled relative PATH entries must never make a
+            // node advertise itself as a trustworthy Lean runner.
+            .filter(|dir| dir.is_absolute())
+            .any(|dir| executable_file(&dir.join("lake")))
+}
+
+/// Whether a `lean`-labelled node can actually start the Lake proxy used by
+/// declarative builds. Toolchains may be downloaded lazily by Elan, but a
+/// missing proxy would make every accepted Lean job fail with `ENOENT`.
+pub fn lean_runtime_ready(work_root: &Path) -> bool {
+    lean_runtime_ready_with_path(work_root, std::env::var_os("PATH").as_deref())
 }
 
 /// Add Lean/Lake concurrency defaults derived from the node process's usable
@@ -1420,6 +1458,43 @@ mod tests {
                 "leanprover--lean4---v4.16.0".to_string(),
             ]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lean_runtime_readiness_requires_an_executable_lake_proxy() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("caches/elan/bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let lake = bin.join("lake");
+        std::fs::write(&lake, b"#!/bin/sh\n").unwrap();
+
+        assert!(!lean_runtime_ready_with_path(dir.path(), None));
+        std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(lean_runtime_ready_with_path(dir.path(), None));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lean_runtime_readiness_accepts_an_absolute_service_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let service_bin = tempfile::tempdir().unwrap();
+        let lake = service_bin.path().join("lake");
+        std::fs::write(&lake, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(lean_runtime_ready_with_path(
+            dir.path(),
+            Some(service_bin.path().as_os_str())
+        ));
+        assert!(!lean_runtime_ready_with_path(
+            dir.path(),
+            Some(OsStr::new("relative/bin"))
+        ));
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -244,8 +244,15 @@ fn executable_file(path: &Path) -> bool {
     }
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        metadata.permissions().mode() & 0o111 != 0
+        use std::os::unix::ffi::OsStrExt;
+
+        let Ok(path) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
+            return false;
+        };
+        // SAFETY: `path` is a live, NUL-terminated C string. `access` has no
+        // additional pointer or lifetime requirements and only probes access
+        // for the current process identity (the sandboxed-node service user).
+        unsafe { libc::access(path.as_ptr(), libc::X_OK) == 0 }
     }
     #[cfg(not(unix))]
     {
@@ -1471,6 +1478,8 @@ mod tests {
         let lake = bin.join("lake");
         std::fs::write(&lake, b"#!/bin/sh\n").unwrap();
 
+        assert!(!lean_runtime_ready_with_path(dir.path(), None));
+        std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o001)).unwrap();
         assert!(!lean_runtime_ready_with_path(dir.path(), None));
         std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert!(lean_runtime_ready_with_path(dir.path(), None));

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1478,8 +1478,7 @@ mod tests {
         let lake = bin.join("lake");
         std::fs::write(&lake, b"#!/bin/sh\n").unwrap();
 
-        assert!(!lean_runtime_ready_with_path(dir.path(), None));
-        std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o001)).unwrap();
+        std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o600)).unwrap();
         assert!(!lean_runtime_ready_with_path(dir.path(), None));
         std::fs::set_permissions(&lake, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert!(lean_runtime_ready_with_path(dir.path(), None));

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -8,7 +8,7 @@ pub mod lean;
 pub mod runner;
 
 pub use job_store::{JobRecord, JobState, JobStore};
-pub use lean::{cached_toolchains, spawn_cache_gc};
+pub use lean::{cached_toolchains, lean_runtime_ready, spawn_cache_gc};
 pub use runner::{
     maybe_exec_cleared_scope_payload, read_log_tail, JobRunner, NodeQueueFull,
     DEFAULT_MAX_JOB_SECS, LOG_TAIL_MAX_BYTES,

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -215,6 +215,7 @@ mod tests {
                 active_jobs: 0,
                 queued_jobs: 0,
                 cached_toolchains: vec![],
+                lean_runtime_ready: Some(true),
             })
         }
         let app = Router::new().route("/heartbeat", get(heartbeat));
@@ -234,5 +235,6 @@ mod tests {
         let heartbeat = client.heartbeat(&node, "unused").await.unwrap();
         assert_eq!(heartbeat.capacity_available, 1);
         assert_eq!(heartbeat.labels, vec!["lean".to_string()]);
+        assert_eq!(heartbeat.lean_runtime_ready, Some(true));
     }
 }

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -293,6 +293,15 @@ pub fn select_node_auto_with_reservations(
             reasons.push((node.id.clone(), "no heartbeat data".to_string()));
             continue;
         };
+        if requirements.iter().any(|requirement| requirement == "lean")
+            && heartbeat.lean_runtime_ready == Some(false)
+        {
+            reasons.push((
+                node.id.clone(),
+                "Lean runtime unavailable (Lake proxy missing)".to_string(),
+            ));
+            continue;
+        }
         // Labels come from the heartbeat, falling back to static config for
         // nodes that don't report any (mirrors RemoteNodeView).
         let labels: &[String] = if heartbeat.labels.is_empty() {
@@ -420,6 +429,7 @@ pub struct RemoteNodeView {
     pub disk_total_bytes: Option<u64>,
     pub disk_available_bytes: Option<u64>,
     pub cached_toolchains: Vec<String>,
+    pub lean_runtime_ready: Option<bool>,
     pub last_seen: Option<DateTime<Utc>>,
     pub error: Option<String>,
 }
@@ -454,6 +464,7 @@ impl RemoteNodeView {
             cached_toolchains: heartbeat
                 .map(|h| h.cached_toolchains.clone())
                 .unwrap_or_default(),
+            lean_runtime_ready: heartbeat.and_then(|h| h.lean_runtime_ready),
             last_seen: cached.and_then(|c| c.last_seen),
             error: cached.and_then(|c| c.last_error.clone()),
         }
@@ -766,6 +777,36 @@ mod tests {
         let picked =
             select_node_auto(&[node_config("e")], &statuses, &[], 20 * GIB, 8 * GIB).unwrap();
         assert_eq!(picked, "e");
+    }
+
+    #[test]
+    fn place_auto_rejects_a_lean_label_when_runtime_is_not_ready() {
+        let node = node_config("missing-lake");
+        let mut status = cached_online("missing-lake", &["lean"], 100, 32, 2, 0, 0);
+        status
+            .last_heartbeat
+            .as_mut()
+            .expect("heartbeat")
+            .lean_runtime_ready = Some(false);
+        let statuses = HashMap::from([("missing-lake".to_string(), status)]);
+
+        let error = select_node_auto(&[node], &statuses, &["lean".to_string()], 20 * GIB, 8 * GIB)
+            .unwrap_err();
+        assert!(error.reasons[0].1.contains("Lake proxy missing"));
+
+        // Compatibility: the readiness field is irrelevant to jobs that do
+        // not request the Lean capability.
+        assert_eq!(
+            select_node_auto(
+                &[node_config("missing-lake")],
+                &statuses,
+                &[],
+                20 * GIB,
+                8 * GIB,
+            )
+            .unwrap(),
+            "missing-lake"
+        );
     }
 
     #[test]

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -441,6 +441,9 @@ impl RemoteNodeView {
         if labels.is_empty() {
             labels = config.labels.clone().unwrap_or_default();
         }
+        if heartbeat.and_then(|h| h.lean_runtime_ready) == Some(false) {
+            labels.retain(|label| label != "lean");
+        }
         Self {
             id: config.id.clone(),
             base_url: config.base_url.clone(),
@@ -807,6 +810,22 @@ mod tests {
             .unwrap(),
             "missing-lake"
         );
+    }
+
+    #[test]
+    fn node_view_does_not_restore_a_withheld_lean_label() {
+        let mut config = node_config("missing-lake");
+        config.labels = Some(vec!["lean".to_string(), "cpu".to_string()]);
+        let mut status = cached_online("missing-lake", &[], 100, 32, 2, 0, 0);
+        status
+            .last_heartbeat
+            .as_mut()
+            .expect("heartbeat")
+            .lean_runtime_ready = Some(false);
+
+        let view = RemoteNodeView::from_cache(&config, Some(&status));
+        assert_eq!(view.labels, vec!["cpu".to_string()]);
+        assert_eq!(view.lean_runtime_ready, Some(false));
     }
 
     #[test]

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -68,6 +68,10 @@ pub struct NodeHeartbeat {
     /// Prewarmed toolchains cached on the node (empty until S3).
     #[serde(default)]
     pub cached_toolchains: Vec<String>,
+    /// Whether the node can resolve an executable Lake proxy. `None` means an
+    /// older node that predates readiness reporting.
+    #[serde(default)]
+    pub lean_runtime_ready: Option<bool>,
 }
 
 /// Legacy per-node status shape (kept for API compatibility).
@@ -586,6 +590,7 @@ mod tests {
             active_jobs: 1,
             queued_jobs: 2,
             cached_toolchains: vec![],
+            lean_runtime_ready: Some(true),
         };
         let json = serde_json::to_string(&heartbeat).unwrap();
         let parsed: NodeHeartbeat = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary
- report whether the node can actually execute the Lake proxy used by declarative builds
- withhold the lean label and reject Lean placement when runtime readiness is explicitly false
- expose readiness in the fleet API while remaining compatible with older nodes
- document the Elan/Lake prerequisite and stabilize the atomic-admission concurrency test

## Validation
- cargo fmt --all --check
- cargo test node::lean --lib
- cargo test remote_node::monitor --lib
- cargo test node::runner --lib
- cargo test --bin sandboxed-node (three consecutive runs)
- cargo clippy --locked --bin sandboxed-node --lib -- -D clippy::all

Operationally, Lean 4.24 and 4.31 were prewarmed on ashur, babylon, nippur, and federation before opening this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote build placement and heartbeat semantics across core and nodes; behavior is fail-closed with backward-compatible optional fields, but misconfigured nodes may see more 503s until Lake is installed.
> 
> **Overview**
> Adds **Lean runtime readiness** so remote nodes and core stop placing `lean_build` work on runners that cannot execute `lake`.
> 
> Nodes now probe for an executable Lake proxy under `$WORK_DIR/caches/elan/bin/lake` or on an **absolute** service `PATH`, expose `lean_runtime_ready` on heartbeat v2, and **strip the `lean` label** from advertised labels when readiness is false. Core auto-placement and fleet views treat `lean_runtime_ready == false` as ineligible for Lean jobs (with serde defaults so older nodes stay compatible).
> 
> **`POST /api/remote-build`** always normalizes requirements to include `lean`, probes explicitly named nodes **before** the placement mutex (so a slow bad node does not block auto placement), and returns **503** when the node is offline or Lake is missing.
> 
> Docs describe the Elan/Lake prerequisite; a concurrency test timing tweak stabilizes capacity tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbb55876b2850aab96c1862fe6cf809b00a79c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->