### PR TITLE
Budget Lean and Lake concurrency together

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -289,10 +289,12 @@ Validation (node-side, before anything runs):
   `lake build ...` and `lean ...`. The service environment is cleared before
   execution so node bearer/signing secrets are not inherited by build code.
 - `env` keys must be within `SANDBOXED_NODE_ENV_ALLOWLIST`.
-- When the payload omits `LEAN_NUM_THREADS` or `LAKE_JOBS`, the node defaults
-  each missing key to its usable logical-CPU count (`available_parallelism`,
-  including OS affinity/cgroup caps). Explicit allowlisted payload values take
-  precedence independently for each key.
+- When the payload omits `LEAN_NUM_THREADS` or `LAKE_JOBS`, the node divides
+  its usable logical-CPU budget (`available_parallelism`, including OS
+  affinity/cgroup caps) across both levels. Lake defaults to at most four jobs
+  and Lean receives the remaining per-job thread budget. When only one key is
+  supplied, the other is derived from the remaining CPU budget. Explicit
+  allowlisted payload values still take precedence.
 - `timeout_secs` is clamped to `SANDBOXED_NODE_MAX_JOB_SECS`.
 
 Execution model:

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -294,7 +294,9 @@ Validation (node-side, before anything runs):
   affinity/cgroup caps) across both levels. Lake defaults to at most four jobs
   and Lean receives the remaining per-job thread budget. When only one key is
   supplied, the other is derived from the remaining CPU budget. Explicit
-  allowlisted payload values still take precedence.
+  allowlisted payload values still take precedence. Direct `lean ...` jobs do
+  not have Lake fan-out, so they receive the full thread budget and default
+  `LAKE_JOBS` to one.
 - `timeout_secs` is clamped to `SANDBOXED_NODE_MAX_JOB_SECS`.
 
 Execution model:

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -280,19 +280,41 @@ pub fn lean_runtime_ready(work_root: &Path) -> bool {
 }
 
 /// Add Lean/Lake concurrency defaults derived from the node process's usable
-/// parallelism. `available_parallelism` accounts for OS affinity and cgroup
-/// limits, so operator-imposed CPU caps remain authoritative. Payload values
-/// are copied last and therefore always win, including independently setting
-/// only one of the two knobs.
+/// parallelism. Lake starts several Lean processes and each Lean process may
+/// use several threads, so assigning the full CPU count to both knobs would
+/// multiply rather than divide the node's CPU budget.
+///
+/// `available_parallelism` accounts for OS affinity and cgroup limits. A
+/// payload may still override either or both values; when it supplies only one
+/// knob, the missing one is derived from the remaining CPU budget.
 fn lean_concurrency_env(
     payload_env: &HashMap<String, String>,
     available_parallelism: usize,
 ) -> HashMap<String, String> {
-    let default = available_parallelism.max(1).to_string();
-    let mut effective = HashMap::from([
-        ("LEAN_NUM_THREADS".to_string(), default.clone()),
-        ("LAKE_JOBS".to_string(), default),
-    ]);
+    const MAX_DEFAULT_LAKE_JOBS: usize = 4;
+
+    fn positive_value(env: &HashMap<String, String>, key: &str) -> Option<usize> {
+        env.get(key)
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+    }
+
+    let budget = available_parallelism.max(1);
+    let explicit_threads = payload_env.contains_key("LEAN_NUM_THREADS");
+    let explicit_lake_jobs = payload_env.contains_key("LAKE_JOBS");
+    let mut effective = HashMap::new();
+
+    if !explicit_lake_jobs {
+        let thread_cost = positive_value(payload_env, "LEAN_NUM_THREADS").unwrap_or(1);
+        let jobs = (budget / thread_cost).clamp(1, MAX_DEFAULT_LAKE_JOBS);
+        effective.insert("LAKE_JOBS".to_string(), jobs.to_string());
+    }
+    if !explicit_threads {
+        let lake_cost = positive_value(payload_env, "LAKE_JOBS")
+            .unwrap_or_else(|| budget.min(MAX_DEFAULT_LAKE_JOBS));
+        let threads = (budget / lake_cost).max(1);
+        effective.insert("LEAN_NUM_THREADS".to_string(), threads.to_string());
+    }
     effective.extend(payload_env.clone());
     effective
 }
@@ -996,9 +1018,9 @@ mod tests {
         let defaults = lean_concurrency_env(&HashMap::new(), 12);
         assert_eq!(
             defaults.get("LEAN_NUM_THREADS").map(String::as_str),
-            Some("12")
+            Some("3")
         );
-        assert_eq!(defaults.get("LAKE_JOBS").map(String::as_str), Some("12"));
+        assert_eq!(defaults.get("LAKE_JOBS").map(String::as_str), Some("4"));
 
         let explicit = HashMap::from([
             ("LEAN_NUM_THREADS".to_string(), "3".to_string()),
@@ -1019,10 +1041,7 @@ mod tests {
             only_threads.get("LEAN_NUM_THREADS").map(String::as_str),
             Some("7")
         );
-        assert_eq!(
-            only_threads.get("LAKE_JOBS").map(String::as_str),
-            Some("12")
-        );
+        assert_eq!(only_threads.get("LAKE_JOBS").map(String::as_str), Some("1"));
 
         let only_lake = lean_concurrency_env(
             &HashMap::from([("LAKE_JOBS".to_string(), "9".to_string())]),
@@ -1030,9 +1049,23 @@ mod tests {
         );
         assert_eq!(
             only_lake.get("LEAN_NUM_THREADS").map(String::as_str),
-            Some("12")
+            Some("1")
         );
         assert_eq!(only_lake.get("LAKE_JOBS").map(String::as_str), Some("9"));
+
+        let dgx_defaults = lean_concurrency_env(&HashMap::new(), 20);
+        assert_eq!(
+            dgx_defaults.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("5")
+        );
+        assert_eq!(dgx_defaults.get("LAKE_JOBS").map(String::as_str), Some("4"));
+
+        let single_core = lean_concurrency_env(&HashMap::new(), 1);
+        assert_eq!(
+            single_core.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(single_core.get("LAKE_JOBS").map(String::as_str), Some("1"));
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -290,6 +290,7 @@ pub fn lean_runtime_ready(work_root: &Path) -> bool {
 fn lean_concurrency_env(
     payload_env: &HashMap<String, String>,
     available_parallelism: usize,
+    uses_lake_fanout: bool,
 ) -> HashMap<String, String> {
     const MAX_DEFAULT_LAKE_JOBS: usize = 4;
 
@@ -305,13 +306,21 @@ fn lean_concurrency_env(
     let mut effective = HashMap::new();
 
     if !explicit_lake_jobs {
-        let thread_cost = positive_value(payload_env, "LEAN_NUM_THREADS").unwrap_or(1);
-        let jobs = (budget / thread_cost).clamp(1, MAX_DEFAULT_LAKE_JOBS);
+        let jobs = if uses_lake_fanout {
+            let thread_cost = positive_value(payload_env, "LEAN_NUM_THREADS").unwrap_or(1);
+            (budget / thread_cost).clamp(1, MAX_DEFAULT_LAKE_JOBS)
+        } else {
+            1
+        };
         effective.insert("LAKE_JOBS".to_string(), jobs.to_string());
     }
     if !explicit_threads {
-        let lake_cost = positive_value(payload_env, "LAKE_JOBS")
-            .unwrap_or_else(|| budget.min(MAX_DEFAULT_LAKE_JOBS));
+        let lake_cost = if uses_lake_fanout {
+            positive_value(payload_env, "LAKE_JOBS")
+                .unwrap_or_else(|| budget.min(MAX_DEFAULT_LAKE_JOBS))
+        } else {
+            1
+        };
         let threads = (budget / lake_cost).max(1);
         effective.insert("LEAN_NUM_THREADS".to_string(), threads.to_string());
     }
@@ -797,7 +806,11 @@ pub async fn execute_lean_build(
     let available_parallelism = std::thread::available_parallelism()
         .map(|parallelism| parallelism.get())
         .unwrap_or(1);
-    for (key, value) in lean_concurrency_env(env, available_parallelism) {
+    for (key, value) in lean_concurrency_env(
+        env,
+        available_parallelism,
+        command.first().is_some_and(|c| c == "lake"),
+    ) {
         cmd.env(key, value);
     }
     let limit_secs = clamp_timeout(*timeout_secs, max_job_secs);
@@ -1015,7 +1028,7 @@ mod tests {
 
     #[test]
     fn concurrency_env_uses_capability_defaults_and_preserves_explicit_values() {
-        let defaults = lean_concurrency_env(&HashMap::new(), 12);
+        let defaults = lean_concurrency_env(&HashMap::new(), 12, true);
         assert_eq!(
             defaults.get("LEAN_NUM_THREADS").map(String::as_str),
             Some("3")
@@ -1026,7 +1039,7 @@ mod tests {
             ("LEAN_NUM_THREADS".to_string(), "3".to_string()),
             ("LAKE_JOBS".to_string(), "5".to_string()),
         ]);
-        let overridden = lean_concurrency_env(&explicit, 12);
+        let overridden = lean_concurrency_env(&explicit, 12, true);
         assert_eq!(
             overridden.get("LEAN_NUM_THREADS").map(String::as_str),
             Some("3")
@@ -1036,6 +1049,7 @@ mod tests {
         let only_threads = lean_concurrency_env(
             &HashMap::from([("LEAN_NUM_THREADS".to_string(), "7".to_string())]),
             12,
+            true,
         );
         assert_eq!(
             only_threads.get("LEAN_NUM_THREADS").map(String::as_str),
@@ -1046,6 +1060,7 @@ mod tests {
         let only_lake = lean_concurrency_env(
             &HashMap::from([("LAKE_JOBS".to_string(), "9".to_string())]),
             12,
+            true,
         );
         assert_eq!(
             only_lake.get("LEAN_NUM_THREADS").map(String::as_str),
@@ -1053,19 +1068,26 @@ mod tests {
         );
         assert_eq!(only_lake.get("LAKE_JOBS").map(String::as_str), Some("9"));
 
-        let dgx_defaults = lean_concurrency_env(&HashMap::new(), 20);
+        let dgx_defaults = lean_concurrency_env(&HashMap::new(), 20, true);
         assert_eq!(
             dgx_defaults.get("LEAN_NUM_THREADS").map(String::as_str),
             Some("5")
         );
         assert_eq!(dgx_defaults.get("LAKE_JOBS").map(String::as_str), Some("4"));
 
-        let single_core = lean_concurrency_env(&HashMap::new(), 1);
+        let single_core = lean_concurrency_env(&HashMap::new(), 1, true);
         assert_eq!(
             single_core.get("LEAN_NUM_THREADS").map(String::as_str),
             Some("1")
         );
         assert_eq!(single_core.get("LAKE_JOBS").map(String::as_str), Some("1"));
+
+        let direct_lean = lean_concurrency_env(&HashMap::new(), 20, false);
+        assert_eq!(
+            direct_lean.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("20")
+        );
+        assert_eq!(direct_lean.get("LAKE_JOBS").map(String::as_str), Some("1"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed
- derive default `LAKE_JOBS` and `LEAN_NUM_THREADS` from one node CPU budget instead of assigning the full core count to both layers
- keep explicit operator overrides, deriving only the missing layer from remaining capacity
- document the bounded fan-out model and examples

## Why
A 20-core DGX was receiving `LAKE_JOBS=20` and `LEAN_NUM_THREADS=20`, multiplying process fan-out and pushing load above the physical CPU budget. Defaults now use at most four Lake jobs and divide Lean threads across them (for example 20 CPUs -> 4 Lake jobs x 5 Lean threads).

## Validation
- `cargo fmt --all --check`
- `cargo test node::lean --lib`
- `cargo test --bin sandboxed-node`
- `cargo clippy --locked --lib -- -D clippy::all`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default concurrency for all lean_build jobs on remote nodes, which can affect build time and host load but not security; explicit env overrides are unchanged.
> 
> **Overview**
> Remote **lean_build** jobs no longer default `LAKE_JOBS` and `LEAN_NUM_THREADS` to the full logical CPU count independently. Defaults now come from a single **usable parallelism** budget (affinity/cgroup-aware), with **at most four** Lake jobs for `lake build` and Lean threads sized from what remains—e.g. 20 CPUs → 4 Lake jobs × 5 threads.
> 
> **`lean ...`** commands skip Lake fan-out: they get the full thread budget and `LAKE_JOBS=1`. If the payload sets only one knob, the other is derived from leftover capacity; explicit allowlisted values still win.
> 
> `docs/REMOTE_NODES.md` describes the model; unit tests cover the new defaults and partial overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9ddcb7b7d643cac08b2a362a34ae128967cabd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->