### PR TITLE
Resume interrupted remote Lean builds

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -409,10 +409,11 @@ uncommitted changes would be silently ignored), submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
 persists the returned job/node receipt under
 `${XDG_STATE_HOME:-$HOME/.local/state}/sandboxed-sh/remote-builds/`, then polls
-the mission-authenticated status endpoint. Running the same immutable command
-after a client/tool interruption resumes the recorded job instead of
-submitting a duplicate. It prints the remote log tail and exits with the remote
-build's exit code. On
+the mission-authenticated status endpoint. Receipts are scoped to the remote
+endpoint as well as the immutable request. Running the same command after a
+client/tool interruption resumes the recorded job instead of submitting a
+duplicate. It prints the remote log tail and exits with the remote build's exit
+code. On
 HTTP 503 (placement failure, fleet down, feature off) it prints the reason
 and exits 75 (`EX_TEMPFAIL`) so scripts can fall back to a local build:
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -412,8 +412,11 @@ persists the returned job/node receipt under
 the mission-authenticated status endpoint. Receipts are scoped to the remote
 endpoint as well as the immutable request. Running the same command after a
 client/tool interruption resumes the recorded job instead of submitting a
-duplicate. It prints the remote log tail and exits with the remote build's exit
-code. On
+duplicate; if the terminal status was already persisted, it replays that
+evidence without polling or resubmitting. It prints the remote log tail and
+exits with the remote build's exit code. Once a job has been accepted, polling
+errors and client timeouts never request local fallback: rerun the identical
+command to resume it. On
 HTTP 503 (placement failure, fleet down, feature off) it prints the reason
 and exits 75 (`EX_TEMPFAIL`) so scripts can fall back to a local build:
 

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -422,9 +422,13 @@ remote-lean-build || { [ $? -eq 75 ] && lake build; }
 ```
 
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
-node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_STATE_DIR` overrides the
-receipt directory. `REMOTE_BUILD_FORCE_NEW=1` deliberately bypasses a live
-matching receipt and should be reserved for operator-directed retries.
+node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`
+controls the pre-receipt HTTP budget (default 90 seconds, long enough for a
+fresh probe plus node submission). A submit timeout is treated as an ambiguous
+outcome and never triggers local fallback. `REMOTE_BUILD_STATE_DIR` overrides
+the receipt directory. Receipts never contain the capability token or the Git
+remote URL. `REMOTE_BUILD_FORCE_NEW=1` deliberately bypasses a live matching
+receipt and should be reserved for operator-directed retries.
 
 Workspace configuration can pin the placement policy without exposing node
 credentials:

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -425,9 +425,11 @@ and exits 75 (`EX_TEMPFAIL`) so scripts can fall back to a local build:
 remote-lean-build || { [ $? -eq 75 ] && lake build; }
 ```
 
-If submission to a selected node has an ambiguous response-side transport
-failure, core returns 502 while its tentative ledger reconciles/cancels the
-possible job. The wrapper exits 1 for that response and never falls back.
+If the core cannot connect to the selected node before sending the request, it
+returns 503 and local fallback remains safe. If submission instead has an
+ambiguous response-side transport failure, core returns 502 while its tentative
+ledger reconciles/cancels the possible job. The wrapper exits 1 for that
+response and never falls back.
 
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
 node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -425,6 +425,10 @@ and exits 75 (`EX_TEMPFAIL`) so scripts can fall back to a local build:
 remote-lean-build || { [ $? -eq 75 ] && lake build; }
 ```
 
+If submission to a selected node has an ambiguous response-side transport
+failure, core returns 502 while its tentative ledger reconciles/cancels the
+possible job. The wrapper exits 1 for that response and never falls back.
+
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
 node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`
 controls the pre-receipt HTTP budget (default 90 seconds, long enough for a

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -404,8 +404,8 @@ remote-lean-build lake build Verity
 
 It derives `repo` (`git remote get-url origin`), `commit`
 (`git rev-parse HEAD`) and `cwd_rel` (`git rev-parse --show-prefix`),
-refuses a dirty tree (exit 2 — the node builds a pinned commit, so
-uncommitted changes would be silently ignored), submits asynchronously to
+refuses a dirty tree for a new submission (exit 2 — the node builds a pinned
+commit, so uncommitted changes would be silently ignored), submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
 persists the returned job/node receipt under
 `${XDG_STATE_HOME:-$HOME/.local/state}/sandboxed-sh/remote-builds/`, then polls
@@ -413,7 +413,8 @@ the mission-authenticated status endpoint. Receipts are scoped to the remote
 endpoint as well as the immutable request. Running the same command after a
 client/tool interruption resumes the recorded job instead of submitting a
 duplicate; if the terminal status was already persisted, it replays that
-evidence without polling or resubmitting. It prints the remote log tail and
+evidence without polling or resubmitting. Existing receipts remain resumable
+when the checkout later becomes dirty. It prints the remote log tail and
 exits with the remote build's exit code. Once a job has been accepted, polling
 errors and client timeouts never request local fallback: rerun the identical
 command to resume it. On

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -427,11 +427,14 @@ remote-lean-build || { [ $? -eq 75 ] && lake build; }
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
 node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`
 controls the pre-receipt HTTP budget (default 90 seconds, long enough for a
-fresh probe plus node submission). A submit timeout is treated as an ambiguous
-outcome and never triggers local fallback. `REMOTE_BUILD_STATE_DIR` overrides
-the receipt directory. Receipts never contain the capability token or the Git
-remote URL. `REMOTE_BUILD_FORCE_NEW=1` deliberately bypasses a live matching
-receipt and should be reserved for operator-directed retries.
+fresh probe plus node submission). Submit timeouts and response-side transport
+failures are treated as ambiguous outcomes and never trigger local fallback;
+only failures that happen before connecting are fallback-safe. Failure to
+persist the receipt after a `202` is also fail-closed and reports the accepted
+job handle. `REMOTE_BUILD_STATE_DIR` overrides the receipt directory. Receipts
+never contain the capability token or the Git remote URL.
+`REMOTE_BUILD_FORCE_NEW=1` deliberately bypasses a live matching receipt and
+should be reserved for operator-directed retries.
 
 Workspace configuration can pin the placement policy without exposing node
 credentials:

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -39,8 +39,9 @@ Supported now:
   `remote_requirements` labels) picks the least-loaded eligible node from the
   fleet cache and fails closed with a per-node exclusion report
 - `POST /api/remote-build`: an in-workspace, capability-token-authenticated
-  endpoint that dispatches a `lean_build` job (auto-placed by default) and
-  waits for the result — used by the `remote-lean-build` wrapper
+  endpoint that dispatches a `lean_build` job (auto-placed by default). The
+  wrapper submits asynchronously and polls the mission-scoped status endpoint
+  so interrupted clients can resume the same immutable job.
 - dispatch failures fail closed: the mission is marked failed and the API
   returns an error
 - future `not_before` scheduling with `remote_node_id` is rejected for now so
@@ -402,9 +403,14 @@ remote-lean-build lake build Verity
 It derives `repo` (`git remote get-url origin`), `commit`
 (`git rev-parse HEAD`) and `cwd_rel` (`git rev-parse --show-prefix`),
 refuses a dirty tree (exit 2 — the node builds a pinned commit, so
-uncommitted changes would be silently ignored), POSTs to
+uncommitted changes would be silently ignored), submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
-prints the remote log tail, and exits with the remote build's exit code. On
+persists the returned job/node receipt under
+`${XDG_STATE_HOME:-$HOME/.local/state}/sandboxed-sh/remote-builds/`, then polls
+the mission-authenticated status endpoint. Running the same immutable command
+after a client/tool interruption resumes the recorded job instead of
+submitting a duplicate. It prints the remote log tail and exits with the remote
+build's exit code. On
 HTTP 503 (placement failure, fleet down, feature off) it prints the reason
 and exits 75 (`EX_TEMPFAIL`) so scripts can fall back to a local build:
 
@@ -413,7 +419,9 @@ remote-lean-build || { [ $? -eq 75 ] && lake build; }
 ```
 
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
-node's `SANDBOXED_NODE_MAX_JOB_SECS`).
+node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_STATE_DIR` overrides the
+receipt directory. `REMOTE_BUILD_FORCE_NEW=1` deliberately bypasses a live
+matching receipt and should be reserved for operator-directed retries.
 
 Workspace configuration can pin the placement policy without exposing node
 credentials:

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -429,7 +429,9 @@ If the core cannot connect to the selected node before sending the request, it
 returns 503 and local fallback remains safe. If submission instead has an
 ambiguous response-side transport failure, core returns 502 while its tentative
 ledger reconciles/cancels the possible job. The wrapper exits 1 for that
-response and never falls back.
+response and never falls back. It also persists a secret-free `ambiguous`
+receipt, so an identical retry cannot submit a second job before operators
+confirm reconciliation; `REMOTE_BUILD_FORCE_NEW=1` is an explicit override.
 
 Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
 node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -142,10 +142,14 @@ if [ -z "$job_id" ]; then
         -d "$body" "$REMOTE_BUILD_URL")"
     curl_status=$?
     if [ "$curl_status" -ne 0 ]; then
-        if [ "$curl_status" -eq 28 ]; then
-            die "submit timed out with an unknown outcome; do not fall back locally, retry the same command after checking the fleet" 1
-        fi
-        die "cannot reach $REMOTE_BUILD_URL" 75
+        case "$curl_status" in
+            5|6|7)
+                die "cannot reach $REMOTE_BUILD_URL" 75
+                ;;
+            *)
+                die "submit transport failed with an unknown outcome (curl $curl_status); do not fall back locally, check the fleet before retrying" 1
+                ;;
+        esac
     fi
 
     if [ "$http_code" = "401" ] || [ "$http_code" = "403" ] || [ "$http_code" = "503" ]; then
@@ -190,6 +194,10 @@ finally:
     if os.path.exists(tmp):
         os.unlink(tmp)
 PY
+    persist_status=$?
+    if [ "$persist_status" -ne 0 ]; then
+        die "accepted job $job_id on node '$node_id' but failed to persist its receipt; do not fall back locally or resubmit" 1
+    fi
     echo "remote-lean-build: submitted job $job_id on node '$node_id'; receipt $state_file" >&2
 fi
 

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -54,7 +54,7 @@ req = {
     "repo": repo,
     "commit": commit,
     "command": command,
-    "wait": True,
+    "wait": False,
 }
 if cwd_rel:
     req["cwd_rel"] = cwd_rel
@@ -78,33 +78,182 @@ print(json.dumps(req))
 PY
 )" || die "failed to encode request"
 
-echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
+request_key="$(python3 - "$body" <<'PY'
+import hashlib, json, sys
+request = json.loads(sys.argv[1])
+request.pop("token", None)
+request.pop("wait", None)
+canonical = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+print(hashlib.sha256(canonical).hexdigest())
+PY
+)" || die "failed to fingerprint request"
+
+home_state_root="${XDG_STATE_HOME:-${HOME:-/tmp}/.local/state}"
+state_root="${REMOTE_BUILD_STATE_DIR:-$home_state_root/sandboxed-sh/remote-builds}"
+umask 077
+mkdir -p "$state_root" || die "cannot create receipt directory $state_root" 75
+state_file="$state_root/$request_key.json"
+
 response_file="$(mktemp)"
 trap 'rm -f "$response_file"' EXIT
-http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
-    -H 'Content-Type: application/json' \
-    --max-time 7500 \
-    -d "$body" "$REMOTE_BUILD_URL")" || die "cannot reach $REMOTE_BUILD_URL" 75
 
-if [ "$http_code" = "401" ] || [ "$http_code" = "403" ] || [ "$http_code" = "503" ]; then
-    echo "remote-lean-build: remote build unavailable:" >&2
-    cat "$response_file" >&2; echo >&2
-    exit 75  # EX_TEMPFAIL: caller should fall back to a local build
-fi
-if [ "$http_code" != "200" ]; then
-    echo "remote-lean-build: HTTP $http_code from $REMOTE_BUILD_URL:" >&2
-    cat "$response_file" >&2; echo >&2
-    exit 1
+job_id=""
+node_id=""
+receipt_state=""
+if [ "${REMOTE_BUILD_FORCE_NEW:-0}" != "1" ] && [ -f "$state_file" ]; then
+    IFS=$'\t' read -r job_id node_id receipt_state < <(python3 - "$state_file" <<'PY'
+import json, re, sys
+try:
+    receipt = json.load(open(sys.argv[1]))
+except (OSError, ValueError):
+    raise SystemExit(0)
+job = str(receipt.get("job_id") or "")
+node = str(receipt.get("node_id") or "")
+state = str(receipt.get("state") or "")
+if re.fullmatch(r"[0-9a-fA-F-]{36}", job) and re.fullmatch(r"[A-Za-z0-9._-]+", node):
+    print(job, node, state, sep="\t")
+PY
+    )
+    case "$receipt_state" in
+        submitted|queued|running)
+            echo "remote-lean-build: resuming job $job_id on node '$node_id' for ${commit:0:12} ..." >&2
+            ;;
+        *)
+            job_id=""; node_id=""; receipt_state=""
+            ;;
+    esac
 fi
 
-python3 - "$response_file" <<'PY'
-import json, sys
+if [ -z "$job_id" ]; then
+    echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
+    http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        --max-time 45 \
+        -d "$body" "$REMOTE_BUILD_URL")" || die "cannot reach $REMOTE_BUILD_URL" 75
+
+    if [ "$http_code" = "401" ] || [ "$http_code" = "403" ] || [ "$http_code" = "503" ]; then
+        echo "remote-lean-build: remote build unavailable:" >&2
+        cat "$response_file" >&2; echo >&2
+        exit 75  # EX_TEMPFAIL: caller should fall back to a local build
+    fi
+    if [ "$http_code" != "202" ]; then
+        echo "remote-lean-build: HTTP $http_code from $REMOTE_BUILD_URL:" >&2
+        cat "$response_file" >&2; echo >&2
+        exit 1
+    fi
+
+    IFS=$'\t' read -r job_id node_id < <(python3 - "$response_file" <<'PY'
+import json, re, sys
+response = json.load(open(sys.argv[1]))
+job = str(response.get("job_id") or "")
+node = str(response.get("node_id") or "")
+if not re.fullmatch(r"[0-9a-fA-F-]{36}", job):
+    raise SystemExit("invalid job_id in submit response")
+if not re.fullmatch(r"[A-Za-z0-9._-]+", node):
+    raise SystemExit("invalid node_id in submit response")
+print(job, node, sep="\t")
+PY
+    ) || die "invalid remote-build submit response"
+
+    python3 - "$state_file" "$body" "$job_id" "$node_id" <<'PY'
+import json, os, sys, tempfile
+path, raw_request, job_id, node_id = sys.argv[1:]
+request = json.loads(raw_request)
+request.pop("token", None)
+request.update({"job_id": job_id, "node_id": node_id, "state": "submitted"})
+fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
+try:
+    with os.fdopen(fd, "w") as out:
+        json.dump(request, out, sort_keys=True)
+        out.write("\n")
+    os.replace(tmp, path)
+finally:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+PY
+    echo "remote-lean-build: submitted job $job_id on node '$node_id'; receipt $state_file" >&2
+fi
+
+encoded_node="$(python3 - "$node_id" <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+)"
+encoded_mission="$(python3 - "$REMOTE_BUILD_MISSION_ID" <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+)"
+poll_url="${REMOTE_BUILD_URL%/}/$job_id?mission_id=$encoded_mission&node_id=$encoded_node"
+poll_secs="${REMOTE_BUILD_POLL_SECS:-3}"
+client_timeout_secs="${REMOTE_BUILD_CLIENT_TIMEOUT_SECS:-7500}"
+case "$poll_secs" in
+    ''|*[!0-9]*) die "REMOTE_BUILD_POLL_SECS must be a positive integer" ;;
+esac
+case "$client_timeout_secs" in
+    ''|*[!0-9]*) die "REMOTE_BUILD_CLIENT_TIMEOUT_SECS must be a positive integer" ;;
+esac
+[ "$poll_secs" -gt 0 ] || die "REMOTE_BUILD_POLL_SECS must be greater than zero"
+[ "$client_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_CLIENT_TIMEOUT_SECS must be greater than zero"
+deadline=$(( $(date +%s) + client_timeout_secs ))
+
+while :; do
+    http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
+        -H "Authorization: Bearer $REMOTE_BUILD_TOKEN" \
+        --max-time 20 "$poll_url")" || http_code="000"
+
+    if [ "$http_code" = "200" ]; then
+        receipt_state="$(python3 - "$state_file" "$response_file" <<'PY'
+import json, os, sys, tempfile
+path, response_path = sys.argv[1:]
+receipt = json.load(open(path))
+status = json.load(open(response_path))
+receipt.update(status)
+fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
+try:
+    with os.fdopen(fd, "w") as out:
+        json.dump(receipt, out, sort_keys=True)
+        out.write("\n")
+    os.replace(tmp, path)
+finally:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+print(status.get("state") or "")
+PY
+        )" || die "invalid remote-build status response"
+        case "$receipt_state" in
+            succeeded|failed|cancelled|lost) break ;;
+        esac
+    elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+        echo "remote-lean-build: polling authorization failed" >&2
+        exit 75
+    elif [ "$http_code" = "400" ] || [ "$http_code" = "404" ]; then
+        echo "remote-lean-build: cannot recover job $job_id (HTTP $http_code):" >&2
+        cat "$response_file" >&2; echo >&2
+        exit 1
+    fi
+
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        die "timed out polling job $job_id; resume it by running the same command again" 75
+    fi
+    sleep "$poll_secs"
+done
+
+python3 - "$state_file" <<'PY'
+import datetime, json, sys
 with open(sys.argv[1]) as f:
     resp = json.load(f)
+duration = None
+try:
+    started = datetime.datetime.fromisoformat(resp["started_at"])
+    finished = datetime.datetime.fromisoformat(resp["finished_at"])
+    duration = max(0, int((finished - started).total_seconds()))
+except (KeyError, TypeError, ValueError):
+    pass
 sys.stderr.write(
     "remote-lean-build: job %s on node '%s' finished: %s (exit %s, %ss)\n"
     % (resp.get("job_id"), resp.get("node_id"), resp.get("state"),
-       resp.get("exit_code"), resp.get("duration_secs"))
+       resp.get("exit_code"), duration if duration is not None else "?")
 )
 log_tail = resp.get("log_tail") or ""
 if log_tail:

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -31,12 +31,6 @@ command -v curl >/dev/null 2>&1 || die "curl is required"
 
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git checkout"
 
-# The node fetches a pinned commit; uncommitted changes would silently not
-# be part of the remote build.
-if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    die "working tree is dirty; commit (and push) your changes first" 2
-fi
-
 repo="$(git remote get-url origin 2>/dev/null)" || die "no 'origin' remote"
 commit="$(git rev-parse HEAD)" || die "cannot resolve HEAD"
 cwd_rel="$(git rev-parse --show-prefix)"; cwd_rel="${cwd_rel%/}"
@@ -135,6 +129,12 @@ PY
 fi
 
 if [ -z "$job_id" ]; then
+    # The node fetches a pinned commit; uncommitted changes would silently not
+    # be part of a new remote build. An existing receipt remains resumable after
+    # the checkout changes because its immutable request was already accepted.
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+        die "working tree is dirty; commit (and push) your changes before submitting a new build" 2
+    fi
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -116,7 +116,8 @@ except (OSError, ValueError):
 job = str(receipt.get("job_id") or "")
 node = str(receipt.get("node_id") or "")
 state = str(receipt.get("state") or "")
-if re.fullmatch(r"[0-9a-fA-F-]{36}", job) and re.fullmatch(r"[A-Za-z0-9._-]+", node):
+node_is_safe_field = bool(node.strip()) and not any(ch in node for ch in "\t\r\n")
+if re.fullmatch(r"[0-9a-fA-F-]{36}", job) and node_is_safe_field:
     print(job, node, state, sep="\t")
 PY
     )
@@ -165,7 +166,7 @@ job = str(response.get("job_id") or "")
 node = str(response.get("node_id") or "")
 if not re.fullmatch(r"[0-9a-fA-F-]{36}", job):
     raise SystemExit("invalid job_id in submit response")
-if not re.fullmatch(r"[A-Za-z0-9._-]+", node):
+if not node.strip() or any(ch in node for ch in "\t\r\n"):
     raise SystemExit("invalid node_id in submit response")
 print(job, node, sep="\t")
 PY

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -103,9 +103,11 @@ response_file="$(mktemp)"
 submit_lock_held=0
 submit_lock_persistent=0
 submit_lock_dir="$state_file.lock"
+submit_recovery_blocker="$submit_lock_dir/recovery-blocker"
 release_submit_lock() {
     if [ "$submit_lock_held" = "1" ] && [ "$submit_lock_persistent" = "0" ]; then
         rm -f "$submit_lock_dir/owner"
+        rm -f "$submit_recovery_blocker"
         rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
         submit_lock_held=0
     fi
@@ -125,7 +127,38 @@ while ! mkdir "$submit_lock_dir" 2>/dev/null; do
     if [ -f "$submit_lock_dir/owner" ]; then
         read -r lock_owner < "$submit_lock_dir/owner" || lock_owner=""
     fi
+    if [ -f "$submit_recovery_blocker" ]; then
+        if [ "${REMOTE_BUILD_FORCE_NEW:-0}" = "1" ]; then
+            case "$lock_owner" in
+                ''|*[!0-9]*)
+                    rm -f "$submit_lock_dir/owner" "$submit_recovery_blocker"
+                    rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
+                    continue
+                    ;;
+                *)
+                    if ! kill -0 "$lock_owner" 2>/dev/null; then
+                        rm -f "$submit_lock_dir/owner" "$submit_recovery_blocker"
+                        rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
+                        continue
+                    fi
+                    ;;
+            esac
+        fi
+        case "$lock_owner" in
+            *[!0-9]*|'')
+                die "a previous submission stopped after its recovery blocker was armed; reconcile the remote fleet before forcing a new build" 1
+                ;;
+            *)
+                if ! kill -0 "$lock_owner" 2>/dev/null; then
+                    die "a previous submission stopped after its recovery blocker was armed; reconcile the remote fleet before forcing a new build" 1
+                fi
+                ;;
+        esac
+    fi
     case "$lock_owner" in
+        ambiguous)
+            die "a previous accepted submission could not persist its receipt; reconcile the remote fleet before forcing a new build" 1
+            ;;
         ''|*[!0-9]*)
             # Avoid racing the tiny mkdir -> owner-file window. An empty lock
             # older than two seconds belongs to a wrapper that died there.
@@ -225,6 +258,11 @@ if [ -z "$job_id" ]; then
     if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
         die "working tree is dirty; commit (and push) your changes before submitting a new build" 2
     fi
+    # Pre-create the durable blocker while no remote request has been made.
+    # Cleanup removes it on known pre-acceptance outcomes; ambiguous/accepted
+    # failures retain it so a dead owner PID can never permit a duplicate job.
+    printf '%s\n' "armed" > "$submit_recovery_blocker" \
+        || die "cannot arm the remote-build recovery blocker before submission" 75
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \
@@ -265,6 +303,10 @@ if [ -z "$job_id" ]; then
         exit 1
     fi
 
+    # From this point the node has accepted work. Keep the pre-created blocker
+    # unless a complete durable receipt is written below.
+    submit_lock_persistent=1
+
     IFS=$'\t' read -r job_id node_id < <(python3 - "$response_file" <<'PY'
 import json, re, sys
 response = json.load(open(sys.argv[1]))
@@ -300,6 +342,7 @@ PY
     if [ "$persist_status" -ne 0 ]; then
         die "accepted job $job_id on node '$node_id' but failed to persist its receipt; do not fall back locally or resubmit" 1
     fi
+    submit_lock_persistent=0
     echo "remote-lean-build: submitted job $job_id on node '$node_id'; receipt $state_file" >&2
 fi
 

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -78,12 +78,13 @@ print(json.dumps(req))
 PY
 )" || die "failed to encode request"
 
-request_key="$(python3 - "$body" <<'PY'
+request_key="$(python3 - "$body" "$REMOTE_BUILD_URL" <<'PY'
 import hashlib, json, sys
 request = json.loads(sys.argv[1])
 request.pop("token", None)
 request.pop("wait", None)
-canonical = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+fingerprint = {"endpoint": sys.argv[2], "request": request}
+canonical = json.dumps(fingerprint, sort_keys=True, separators=(",", ":")).encode()
 print(hashlib.sha256(canonical).hexdigest())
 PY
 )" || die "failed to fingerprint request"

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -124,6 +124,9 @@ PY
         submitted|queued|running)
             echo "remote-lean-build: resuming job $job_id on node '$node_id' for ${commit:0:12} ..." >&2
             ;;
+        succeeded|failed|cancelled|lost)
+            echo "remote-lean-build: replaying terminal job $job_id on node '$node_id' for ${commit:0:12} ..." >&2
+            ;;
         *)
             job_id=""; node_id=""; receipt_state=""
             ;;
@@ -210,15 +213,17 @@ case "$client_timeout_secs" in
 esac
 [ "$poll_secs" -gt 0 ] || die "REMOTE_BUILD_POLL_SECS must be greater than zero"
 [ "$client_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_CLIENT_TIMEOUT_SECS must be greater than zero"
-deadline=$(( $(date +%s) + client_timeout_secs ))
+if [ "$receipt_state" != "succeeded" ] && [ "$receipt_state" != "failed" ] \
+    && [ "$receipt_state" != "cancelled" ] && [ "$receipt_state" != "lost" ]; then
+    deadline=$(( $(date +%s) + client_timeout_secs ))
 
-while :; do
-    http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
-        -H "Authorization: Bearer $REMOTE_BUILD_TOKEN" \
-        --max-time 20 "$poll_url")" || http_code="000"
+    while :; do
+        http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
+            -H "Authorization: Bearer $REMOTE_BUILD_TOKEN" \
+            --max-time 20 "$poll_url")" || http_code="000"
 
-    if [ "$http_code" = "200" ]; then
-        receipt_state="$(python3 - "$state_file" "$response_file" <<'PY'
+        if [ "$http_code" = "200" ]; then
+            receipt_state="$(python3 - "$state_file" "$response_file" <<'PY'
 import json, os, sys, tempfile
 path, response_path = sys.argv[1:]
 receipt = json.load(open(path))
@@ -235,24 +240,25 @@ finally:
         os.unlink(tmp)
 print(status.get("state") or "")
 PY
-        )" || die "invalid remote-build status response"
-        case "$receipt_state" in
-            succeeded|failed|cancelled|lost) break ;;
-        esac
-    elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
-        echo "remote-lean-build: polling authorization failed" >&2
-        exit 75
-    elif [ "$http_code" = "400" ] || [ "$http_code" = "404" ]; then
-        echo "remote-lean-build: cannot recover job $job_id (HTTP $http_code):" >&2
-        cat "$response_file" >&2; echo >&2
-        exit 1
-    fi
+            )" || die "invalid remote-build status response"
+            case "$receipt_state" in
+                succeeded|failed|cancelled|lost) break ;;
+            esac
+        elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+            echo "remote-lean-build: polling authorization failed; the accepted job remains resumable" >&2
+            exit 1
+        elif [ "$http_code" = "400" ] || [ "$http_code" = "404" ]; then
+            echo "remote-lean-build: cannot recover job $job_id (HTTP $http_code):" >&2
+            cat "$response_file" >&2; echo >&2
+            exit 1
+        fi
 
-    if [ "$(date +%s)" -ge "$deadline" ]; then
-        die "timed out polling job $job_id; resume it by running the same command again" 75
-    fi
-    sleep "$poll_secs"
-done
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            die "timed out polling job $job_id; do not fall back locally, resume it by running the same command again" 1
+        fi
+        sleep "$poll_secs"
+    done
+fi
 
 python3 - "$state_file" <<'PY'
 import datetime, json, sys

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -89,13 +89,74 @@ umask 077
 mkdir -p "$state_root" || die "cannot create receipt directory $state_root" 75
 state_file="$state_root/$request_key.json"
 submit_timeout_secs="${REMOTE_BUILD_SUBMIT_TIMEOUT_SECS:-90}"
+lock_timeout_secs="${REMOTE_BUILD_LOCK_TIMEOUT_SECS:-120}"
 case "$submit_timeout_secs" in
     ''|*[!0-9]*) die "REMOTE_BUILD_SUBMIT_TIMEOUT_SECS must be a positive integer" ;;
 esac
+case "$lock_timeout_secs" in
+    ''|*[!0-9]*) die "REMOTE_BUILD_LOCK_TIMEOUT_SECS must be a positive integer" ;;
+esac
 [ "$submit_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_SUBMIT_TIMEOUT_SECS must be greater than zero"
+[ "$lock_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_LOCK_TIMEOUT_SECS must be greater than zero"
 
 response_file="$(mktemp)"
-trap 'rm -f "$response_file"' EXIT
+submit_lock_held=0
+submit_lock_dir="$state_file.lock"
+release_submit_lock() {
+    if [ "$submit_lock_held" = "1" ]; then
+        rm -f "$submit_lock_dir/owner"
+        rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
+        submit_lock_held=0
+    fi
+}
+cleanup() {
+    release_submit_lock
+    rm -f "$response_file"
+}
+trap cleanup EXIT
+
+# Serialize receipt discovery, first submission, and durable receipt creation
+# for this immutable request. `mkdir` is atomic on the workspace filesystem;
+# the owner PID lets a retry recover a lock left by an interrupted wrapper.
+lock_deadline=$(( $(date +%s) + lock_timeout_secs ))
+while ! mkdir "$submit_lock_dir" 2>/dev/null; do
+    lock_owner=""
+    if [ -f "$submit_lock_dir/owner" ]; then
+        read -r lock_owner < "$submit_lock_dir/owner" || lock_owner=""
+    fi
+    case "$lock_owner" in
+        ''|*[!0-9]*)
+            # Avoid racing the tiny mkdir -> owner-file window. An empty lock
+            # older than two seconds belongs to a wrapper that died there.
+            if python3 - "$submit_lock_dir" <<'PY'
+import os, sys, time
+try:
+    stale = time.time() - os.stat(sys.argv[1]).st_mtime > 2
+except OSError:
+    stale = False
+raise SystemExit(0 if stale else 1)
+PY
+            then
+                rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
+                continue
+            fi
+            ;;
+        *)
+            if ! kill -0 "$lock_owner" 2>/dev/null; then
+                rm -f "$submit_lock_dir/owner"
+                rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
+                continue
+            fi
+            ;;
+    esac
+    if [ "$(date +%s)" -ge "$lock_deadline" ]; then
+        die "timed out waiting for the existing submission of ${commit:0:12}; retry to resume it" 1
+    fi
+    sleep 1
+done
+submit_lock_held=1
+printf '%s\n' "$$" > "$submit_lock_dir/owner" \
+    || die "cannot record submission lock owner for $state_file" 75
 
 job_id=""
 node_id=""
@@ -200,6 +261,8 @@ PY
     fi
     echo "remote-lean-build: submitted job $job_id on node '$node_id'; receipt $state_file" >&2
 fi
+
+release_submit_lock
 
 encoded_node="$(python3 - "$node_id" <<'PY'
 import sys, urllib.parse

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -94,6 +94,11 @@ state_root="${REMOTE_BUILD_STATE_DIR:-$home_state_root/sandboxed-sh/remote-build
 umask 077
 mkdir -p "$state_root" || die "cannot create receipt directory $state_root" 75
 state_file="$state_root/$request_key.json"
+submit_timeout_secs="${REMOTE_BUILD_SUBMIT_TIMEOUT_SECS:-90}"
+case "$submit_timeout_secs" in
+    ''|*[!0-9]*) die "REMOTE_BUILD_SUBMIT_TIMEOUT_SECS must be a positive integer" ;;
+esac
+[ "$submit_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_SUBMIT_TIMEOUT_SECS must be greater than zero"
 
 response_file="$(mktemp)"
 trap 'rm -f "$response_file"' EXIT
@@ -129,8 +134,15 @@ if [ -z "$job_id" ]; then
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \
-        --max-time 45 \
-        -d "$body" "$REMOTE_BUILD_URL")" || die "cannot reach $REMOTE_BUILD_URL" 75
+        --max-time "$submit_timeout_secs" \
+        -d "$body" "$REMOTE_BUILD_URL")"
+    curl_status=$?
+    if [ "$curl_status" -ne 0 ]; then
+        if [ "$curl_status" -eq 28 ]; then
+            die "submit timed out with an unknown outcome; do not fall back locally, retry the same command after checking the fleet" 1
+        fi
+        die "cannot reach $REMOTE_BUILD_URL" 75
+    fi
 
     if [ "$http_code" = "401" ] || [ "$http_code" = "403" ] || [ "$http_code" = "503" ]; then
         echo "remote-lean-build: remote build unavailable:" >&2
@@ -161,6 +173,8 @@ import json, os, sys, tempfile
 path, raw_request, job_id, node_id = sys.argv[1:]
 request = json.loads(raw_request)
 request.pop("token", None)
+request.pop("repo", None)
+request.pop("wait", None)
 request.update({"job_id": job_id, "node_id": node_id, "state": "submitted"})
 fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
 try:

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -101,9 +101,10 @@ esac
 
 response_file="$(mktemp)"
 submit_lock_held=0
+submit_lock_persistent=0
 submit_lock_dir="$state_file.lock"
 release_submit_lock() {
-    if [ "$submit_lock_held" = "1" ]; then
+    if [ "$submit_lock_held" = "1" ] && [ "$submit_lock_persistent" = "0" ]; then
         rm -f "$submit_lock_dir/owner"
         rmdir "$submit_lock_dir" >/dev/null 2>&1 || true
         submit_lock_held=0
@@ -171,6 +172,9 @@ except (OSError, ValueError):
 job = str(receipt.get("job_id") or "")
 node = str(receipt.get("node_id") or "")
 state = str(receipt.get("state") or "")
+if state == "ambiguous":
+    print("ambiguous", "ambiguous", state, sep="\t")
+    raise SystemExit(0)
 node_is_safe_field = bool(node.strip()) and not any(ch in node for ch in "\t\r\n")
 if re.fullmatch(r"[0-9a-fA-F-]{36}", job) and node_is_safe_field:
     print(job, node, state, sep="\t")
@@ -183,11 +187,36 @@ PY
         succeeded|failed|cancelled|lost)
             echo "remote-lean-build: replaying terminal job $job_id on node '$node_id' for ${commit:0:12} ..." >&2
             ;;
+        ambiguous)
+            die "a previous submission for ${commit:0:12} has an ambiguous outcome; do not resubmit until core reconciliation is confirmed (set REMOTE_BUILD_FORCE_NEW=1 only after that check)" 1
+            ;;
         *)
             job_id=""; node_id=""; receipt_state=""
             ;;
     esac
 fi
+
+persist_ambiguous_receipt() {
+    reason="$1"
+    python3 - "$state_file" "$body" "$reason" <<'PY'
+import json, os, sys, tempfile
+path, raw_request, reason = sys.argv[1:]
+request = json.loads(raw_request)
+request.pop("token", None)
+request.pop("repo", None)
+request.pop("wait", None)
+request.update({"state": "ambiguous", "submit_outcome": reason})
+fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
+try:
+    with os.fdopen(fd, "w") as out:
+        json.dump(request, out, sort_keys=True)
+        out.write("\n")
+    os.replace(tmp, path)
+finally:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+PY
+}
 
 if [ -z "$job_id" ]; then
     # The node fetches a pinned commit; uncommitted changes would silently not
@@ -208,6 +237,10 @@ if [ -z "$job_id" ]; then
                 die "cannot reach $REMOTE_BUILD_URL" 75
                 ;;
             *)
+                if ! persist_ambiguous_receipt "curl-$curl_status"; then
+                    printf '%s\n' "ambiguous" > "$submit_lock_dir/owner" || true
+                    submit_lock_persistent=1
+                fi
                 die "submit transport failed with an unknown outcome (curl $curl_status); do not fall back locally, check the fleet before retrying" 1
                 ;;
         esac
@@ -219,6 +252,14 @@ if [ -z "$job_id" ]; then
         exit 75  # EX_TEMPFAIL: caller should fall back to a local build
     fi
     if [ "$http_code" != "202" ]; then
+        case "$http_code" in
+            5??)
+                if [ "$http_code" != "503" ] && ! persist_ambiguous_receipt "http-$http_code"; then
+                    printf '%s\n' "ambiguous" > "$submit_lock_dir/owner" || true
+                    submit_lock_persistent=1
+                fi
+                ;;
+        esac
         echo "remote-lean-build: HTTP $http_code from $REMOTE_BUILD_URL:" >&2
         cat "$response_file" >&2; echo >&2
         exit 1

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1124,6 +1124,135 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_resumes_an_interrupted_async_job_without_resubmitting() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("create wrapper test directory");
+        let repo = temp.path().join("repo");
+        let bin = temp.path().join("bin");
+        let state = temp.path().join("state");
+        let submit_count = temp.path().join("submit-count");
+        std::fs::create_dir_all(&repo).expect("create test repo");
+        std::fs::create_dir_all(&bin).expect("create fake bin directory");
+
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--quiet"]);
+        git(&["config", "user.name", "Remote Build Test"]);
+        git(&["config", "user.email", "remote-build@example.invalid"]);
+        std::fs::write(repo.join("README.md"), "test\n").expect("write tracked file");
+        git(&["add", "README.md"]);
+        git(&[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            "test",
+        ]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://example.invalid/repo.git",
+        ]);
+
+        let fake_curl = bin.join("curl");
+        std::fs::write(
+            &fake_curl,
+            r#"#!/bin/sh
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) shift; output="$1" ;;
+        http://*) url="$1" ;;
+    esac
+    shift
+done
+case "$url" in
+    */api/remote-build/*)
+        if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "fail" ]; then
+            exit 7
+        fi
+        printf '{"job_id":"11111111-1111-1111-1111-111111111111","mission_id":"%s","state":"succeeded","exit_code":0,"created_at":"2026-07-15T20:00:00Z","started_at":"2026-07-15T20:00:01Z","finished_at":"2026-07-15T20:00:03Z","error":null,"log_tail":"remote ok\\n","artifacts":[]}' "$REMOTE_BUILD_TEST_MISSION_ID" > "$output"
+        printf '200'
+        ;;
+    *)
+        count=0
+        [ ! -f "$REMOTE_BUILD_TEST_SUBMIT_COUNT" ] || count=$(cat "$REMOTE_BUILD_TEST_SUBMIT_COUNT")
+        count=$((count + 1))
+        printf '%s' "$count" > "$REMOTE_BUILD_TEST_SUBMIT_COUNT"
+        printf '{"job_id":"11111111-1111-1111-1111-111111111111","node_id":"test-node"}' > "$output"
+        printf '202'
+        ;;
+esac
+"#,
+        )
+        .expect("write fake curl");
+        let mut permissions = std::fs::metadata(&fake_curl)
+            .expect("stat fake curl")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_curl, permissions).expect("make fake curl executable");
+
+        let mission_id = Uuid::new_v4().to_string();
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let run = |poll_mode: &str| {
+            std::process::Command::new("bash")
+                .arg(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/scripts/remote-lean-build"
+                ))
+                .current_dir(&repo)
+                .env("PATH", &path)
+                .env(
+                    "REMOTE_BUILD_URL",
+                    "http://example.invalid/api/remote-build",
+                )
+                .env("REMOTE_BUILD_TOKEN", "test-token")
+                .env("REMOTE_BUILD_MISSION_ID", &mission_id)
+                .env("REMOTE_BUILD_STATE_DIR", &state)
+                .env("REMOTE_BUILD_POLL_SECS", "1")
+                .env("REMOTE_BUILD_CLIENT_TIMEOUT_SECS", "1")
+                .env("REMOTE_BUILD_TEST_POLL_MODE", poll_mode)
+                .env("REMOTE_BUILD_TEST_MISSION_ID", &mission_id)
+                .env("REMOTE_BUILD_TEST_SUBMIT_COUNT", &submit_count)
+                .output()
+                .expect("run remote-build wrapper")
+        };
+
+        let interrupted = run("fail");
+        assert_eq!(interrupted.status.code(), Some(75));
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
+
+        let resumed = run("success");
+        assert!(
+            resumed.status.success(),
+            "resume failed: {}",
+            String::from_utf8_lossy(&resumed.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
+        assert!(String::from_utf8_lossy(&resumed.stderr).contains("resuming job"));
+        assert_eq!(String::from_utf8_lossy(&resumed.stdout), "remote ok\n");
+    }
+
     #[test]
     fn failed_auto_placement_reprobes_every_cache_state() {
         assert!(should_reprobe_after_placement_failure(None));

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1201,7 +1201,7 @@ case "$url" in
         [ ! -f "$REMOTE_BUILD_TEST_SUBMIT_COUNT" ] || count=$(cat "$REMOTE_BUILD_TEST_SUBMIT_COUNT")
         count=$((count + 1))
         printf '%s' "$count" > "$REMOTE_BUILD_TEST_SUBMIT_COUNT"
-        printf '{"job_id":"11111111-1111-1111-1111-111111111111","node_id":"test-node"}' > "$output"
+        printf '{"job_id":"11111111-1111-1111-1111-111111111111","node_id":"lean:gpu"}' > "$output"
         printf '202'
         ;;
 esac

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -424,6 +424,9 @@ async fn resolve_node(
 
 fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
     match err {
+        // DNS/connect failures happen before an HTTP request reaches the node,
+        // so no remote job can have been accepted and local fallback is safe.
+        RemoteNodeError::Connect(_) => StatusCode::SERVICE_UNAVAILABLE,
         // A transport failure may happen after the node accepted the request.
         // The tentative ledger/observer will reconcile it, but the caller must
         // not start a duplicate local build in the meantime.
@@ -606,9 +609,9 @@ async fn submit_remote_build(
     let accepted = match client.submit_job(&node, &shared_token, &submit).await {
         Ok(accepted) => accepted,
         Err(err) => {
-            // Transport outages and queue saturation remain 503 so the wrapper
-            // can fall back locally. Node-side caller validation stays 4xx and
-            // must not be disguised as a fleet outage.
+            // Pre-connect outages and queue saturation remain 503 so the
+            // wrapper can fall back locally. Response-side transport failures
+            // are ambiguous and return 502 to prohibit duplicate local work.
             let status = submit_error_status(&err);
             if matches!(&err, RemoteNodeError::Request(_)) {
                 spawn_remote_build_observer(
@@ -1112,6 +1115,10 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             submit_error_status(&RemoteNodeError::Request("offline".to_string())),
             StatusCode::BAD_GATEWAY
         );
+        assert_eq!(
+            submit_error_status(&RemoteNodeError::Connect("offline".to_string())),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 
     #[cfg(unix)]
@@ -1242,8 +1249,9 @@ esac
             bin.display(),
             std::env::var("PATH").unwrap_or_default()
         );
-        let run = |poll_mode: &str| {
-            std::process::Command::new("bash")
+        let command = |poll_mode: &str| {
+            let mut command = std::process::Command::new("bash");
+            command
                 .arg(concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/scripts/remote-lean-build"
@@ -1262,20 +1270,43 @@ esac
                 .env("REMOTE_BUILD_CLIENT_TIMEOUT_SECS", "1")
                 .env("REMOTE_BUILD_TEST_POLL_MODE", poll_mode)
                 .env("REMOTE_BUILD_TEST_MISSION_ID", &mission_id)
-                .env("REMOTE_BUILD_TEST_SUBMIT_COUNT", &submit_count)
+                .env("REMOTE_BUILD_TEST_SUBMIT_COUNT", &submit_count);
+            command
+        };
+        let run = |poll_mode: &str| {
+            command(poll_mode)
                 .output()
                 .expect("run remote-build wrapper")
         };
 
-        let interrupted = run("fail");
-        assert_eq!(
-            interrupted.status.code(),
-            Some(1),
-            "an accepted remote job must never request local fallback"
-        );
+        let first = command("fail")
+            .spawn()
+            .expect("start first concurrent wrapper");
+        let second = command("fail")
+            .spawn()
+            .expect("start second concurrent wrapper");
+        for interrupted in [
+            first.wait_with_output().expect("wait for first wrapper"),
+            second.wait_with_output().expect("wait for second wrapper"),
+        ] {
+            assert_eq!(
+                interrupted.status.code(),
+                Some(1),
+                "an accepted remote job must never request local fallback: stdout={} stderr={}",
+                String::from_utf8_lossy(&interrupted.stdout),
+                String::from_utf8_lossy(&interrupted.stderr)
+            );
+        }
         assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
         let receipts = std::fs::read_dir(&state)
             .expect("read receipt directory")
+            .filter(|entry| {
+                entry
+                    .as_ref()
+                    .ok()
+                    .and_then(|entry| entry.path().extension().map(|ext| ext == "json"))
+                    .unwrap_or(false)
+            })
             .collect::<Result<Vec<_>, _>>()
             .expect("collect receipts");
         assert_eq!(receipts.len(), 1);

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1287,6 +1287,8 @@ esac
             Some("11111111-1111-1111-1111-111111111111")
         );
 
+        std::fs::write(repo.join("DIRTY-WORKTREE"), "changed after submit\n")
+            .expect("dirty checkout after accepted build");
         let resumed = run("success");
         assert!(
             resumed.status.success(),
@@ -1307,6 +1309,8 @@ esac
         assert!(String::from_utf8_lossy(&replayed.stderr).contains("replaying terminal job"));
         assert_eq!(String::from_utf8_lossy(&replayed.stdout), "remote ok\n");
 
+        std::fs::remove_file(repo.join("DIRTY-WORKTREE"))
+            .expect("restore clean checkout before new submission");
         for receipt in std::fs::read_dir(&state).expect("read receipts before persistence failure")
         {
             std::fs::remove_file(receipt.expect("read receipt entry").path())

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -424,6 +424,10 @@ async fn resolve_node(
 
 fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
     match err {
+        // A transport failure may happen after the node accepted the request.
+        // The tentative ledger/observer will reconcile it, but the caller must
+        // not start a duplicate local build in the meantime.
+        RemoteNodeError::Request(_) => StatusCode::BAD_GATEWAY,
         RemoteNodeError::Rejected { status, .. }
             if (400..500).contains(status) && !matches!(*status, 401 | 403 | 408 | 429) =>
         {
@@ -1106,7 +1110,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         }
         assert_eq!(
             submit_error_status(&RemoteNodeError::Request("offline".to_string())),
-            StatusCode::SERVICE_UNAVAILABLE
+            StatusCode::BAD_GATEWAY
         );
     }
 

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -440,6 +440,18 @@ fn submit_error_status(err: &RemoteNodeError) -> StatusCode {
     }
 }
 
+fn job_status_error_status(err: &RemoteNodeError) -> StatusCode {
+    match err {
+        // Preserve terminal lookup failures from the runner so a resumable
+        // client can stop polling a handle that no longer exists. Keep node
+        // authentication and transient/transport failures behind the core.
+        RemoteNodeError::Rejected { status, .. } if matches!(*status, 400 | 404) => {
+            StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_GATEWAY)
+        }
+        _ => StatusCode::BAD_GATEWAY,
+    }
+}
+
 fn node_shared_token(node: &RemoteNodeConfig) -> Result<String, (StatusCode, String)> {
     std::env::var(&node.token_env)
         .ok()
@@ -808,7 +820,7 @@ async fn get_remote_build(
     let status = RemoteNodeClient::default()
         .get_job(&node, &shared_token, job_id)
         .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+        .map_err(|e| (job_status_error_status(&e), e.to_string()))?;
     // The capability token is mission-scoped: never leak another mission's
     // job status through it.
     if status.mission_id != query.mission_id {
@@ -1118,6 +1130,36 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert_eq!(
             submit_error_status(&RemoteNodeError::Connect("offline".to_string())),
             StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn job_status_errors_preserve_unrecoverable_lookup_failures_only() {
+        for status in [400, 404] {
+            assert_eq!(
+                job_status_error_status(&RemoteNodeError::Rejected {
+                    status,
+                    body: "job not found".to_string(),
+                }),
+                StatusCode::from_u16(status).unwrap()
+            );
+        }
+        for status in [401, 403, 429, 500, 503] {
+            assert_eq!(
+                job_status_error_status(&RemoteNodeError::Rejected {
+                    status,
+                    body: "runner failure".to_string(),
+                }),
+                StatusCode::BAD_GATEWAY
+            );
+        }
+        assert_eq!(
+            job_status_error_status(&RemoteNodeError::Connect("offline".to_string())),
+            StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            job_status_error_status(&RemoteNodeError::Request("offline".to_string())),
+            StatusCode::BAD_GATEWAY
         );
     }
 

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -875,7 +875,10 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn run_remote_build_wrapper_with_http_status(status: u16) -> std::process::ExitStatus {
+    fn run_remote_build_wrapper_with_submit_result(
+        status: u16,
+        curl_exit: u8,
+    ) -> std::process::ExitStatus {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().expect("create wrapper test directory");
@@ -929,7 +932,7 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 printf '{}' > "$output"
-[ "$REMOTE_BUILD_TEST_HTTP_STATUS" != "0" ] || exit 28
+[ "$REMOTE_BUILD_TEST_CURL_EXIT" = "0" ] || exit "$REMOTE_BUILD_TEST_CURL_EXIT"
 printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
 "#,
         )
@@ -959,6 +962,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             .env("REMOTE_BUILD_TOKEN", "expired-test-token")
             .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
             .env("REMOTE_BUILD_TEST_HTTP_STATUS", status.to_string())
+            .env("REMOTE_BUILD_TEST_CURL_EXIT", curl_exit.to_string())
             .status()
             .expect("run remote-build wrapper")
     }
@@ -1111,22 +1115,32 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
     fn wrapper_treats_host_capability_auth_failures_as_temporary() {
         for status in [401, 403, 503] {
             assert_eq!(
-                run_remote_build_wrapper_with_http_status(status).code(),
+                run_remote_build_wrapper_with_submit_result(status, 0).code(),
                 Some(75),
                 "HTTP {status} should request local fallback"
             );
         }
         for status in [400, 422] {
             assert_eq!(
-                run_remote_build_wrapper_with_http_status(status).code(),
+                run_remote_build_wrapper_with_submit_result(status, 0).code(),
                 Some(1),
                 "HTTP {status} remains a caller error"
             );
         }
         assert_eq!(
-            run_remote_build_wrapper_with_http_status(0).code(),
+            run_remote_build_wrapper_with_submit_result(0, 28).code(),
             Some(1),
             "a submit timeout has an ambiguous outcome and must not request local fallback"
+        );
+        assert_eq!(
+            run_remote_build_wrapper_with_submit_result(0, 56).code(),
+            Some(1),
+            "a response-side transport failure may follow acceptance and must not request fallback"
+        );
+        assert_eq!(
+            run_remote_build_wrapper_with_submit_result(0, 7).code(),
+            Some(75),
+            "a pre-connect failure is safe for local fallback"
         );
     }
 
@@ -1197,6 +1211,10 @@ case "$url" in
         printf '200'
         ;;
     *)
+        if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "persist-fail" ]; then
+            rm -rf "$REMOTE_BUILD_TEST_STATE_DIR"
+            printf 'not-a-directory' > "$REMOTE_BUILD_TEST_STATE_DIR"
+        fi
         count=0
         [ ! -f "$REMOTE_BUILD_TEST_SUBMIT_COUNT" ] || count=$(cat "$REMOTE_BUILD_TEST_SUBMIT_COUNT")
         count=$((count + 1))
@@ -1235,6 +1253,7 @@ esac
                 .env("REMOTE_BUILD_TOKEN", "test-token")
                 .env("REMOTE_BUILD_MISSION_ID", &mission_id)
                 .env("REMOTE_BUILD_STATE_DIR", &state)
+                .env("REMOTE_BUILD_TEST_STATE_DIR", &state)
                 .env("REMOTE_BUILD_POLL_SECS", "1")
                 .env("REMOTE_BUILD_CLIENT_TIMEOUT_SECS", "1")
                 .env("REMOTE_BUILD_TEST_POLL_MODE", poll_mode)
@@ -1287,6 +1306,32 @@ esac
         assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
         assert!(String::from_utf8_lossy(&replayed.stderr).contains("replaying terminal job"));
         assert_eq!(String::from_utf8_lossy(&replayed.stdout), "remote ok\n");
+
+        for receipt in std::fs::read_dir(&state).expect("read receipts before persistence failure")
+        {
+            std::fs::remove_file(receipt.expect("read receipt entry").path())
+                .expect("remove prior receipt");
+        }
+        let persistence_failed = run("persist-fail");
+        if state.is_file() {
+            std::fs::remove_file(&state).expect("remove persistence-failure sentinel");
+            std::fs::create_dir(&state).expect("restore state directory");
+        }
+        let mut state_permissions = std::fs::metadata(&state)
+            .expect("stat state directory after persistence failure")
+            .permissions();
+        state_permissions.set_mode(0o700);
+        std::fs::set_permissions(&state, state_permissions)
+            .expect("restore state directory permissions");
+        assert_eq!(
+            persistence_failed.status.code(),
+            Some(1),
+            "unexpected persistence-failure result: stdout={} stderr={}",
+            String::from_utf8_lossy(&persistence_failed.stdout),
+            String::from_utf8_lossy(&persistence_failed.stderr)
+        );
+        assert!(String::from_utf8_lossy(&persistence_failed.stderr)
+            .contains("failed to persist its receipt"));
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1245,7 +1245,11 @@ esac
         };
 
         let interrupted = run("fail");
-        assert_eq!(interrupted.status.code(), Some(75));
+        assert_eq!(
+            interrupted.status.code(),
+            Some(1),
+            "an accepted remote job must never request local fallback"
+        );
         assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
         let receipts = std::fs::read_dir(&state)
             .expect("read receipt directory")
@@ -1273,6 +1277,16 @@ esac
         assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
         assert!(String::from_utf8_lossy(&resumed.stderr).contains("resuming job"));
         assert_eq!(String::from_utf8_lossy(&resumed.stdout), "remote ok\n");
+
+        let replayed = run("fail");
+        assert!(
+            replayed.status.success(),
+            "terminal receipt replay failed: {}",
+            String::from_utf8_lossy(&replayed.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
+        assert!(String::from_utf8_lossy(&replayed.stderr).contains("replaying terminal job"));
+        assert_eq!(String::from_utf8_lossy(&replayed.stdout), "remote ok\n");
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -929,6 +929,7 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 printf '{}' > "$output"
+[ "$REMOTE_BUILD_TEST_HTTP_STATUS" != "0" ] || exit 28
 printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
 "#,
         )
@@ -1122,6 +1123,11 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                 "HTTP {status} remains a caller error"
             );
         }
+        assert_eq!(
+            run_remote_build_wrapper_with_http_status(0).code(),
+            Some(1),
+            "a submit timeout has an ambiguous outcome and must not request local fallback"
+        );
     }
 
     #[cfg(unix)]
@@ -1241,6 +1247,22 @@ esac
         let interrupted = run("fail");
         assert_eq!(interrupted.status.code(), Some(75));
         assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
+        let receipts = std::fs::read_dir(&state)
+            .expect("read receipt directory")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect receipts");
+        assert_eq!(receipts.len(), 1);
+        let receipt: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(receipts[0].path()).expect("read persisted receipt"),
+        )
+        .expect("parse persisted receipt");
+        assert!(receipt.get("token").is_none());
+        assert!(receipt.get("repo").is_none());
+        assert!(receipt.get("wait").is_none());
+        assert_eq!(
+            receipt.get("job_id").and_then(serde_json::Value::as_str),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
 
         let resumed = run("success");
         assert!(

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1265,8 +1265,7 @@ case "$url" in
         ;;
     *)
         if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "persist-fail" ]; then
-            rm -rf "$REMOTE_BUILD_TEST_STATE_DIR"
-            printf 'not-a-directory' > "$REMOTE_BUILD_TEST_STATE_DIR"
+            chmod 500 "$REMOTE_BUILD_TEST_STATE_DIR"
         fi
         count=0
         [ ! -f "$REMOTE_BUILD_TEST_SUBMIT_COUNT" ] || count=$(cat "$REMOTE_BUILD_TEST_SUBMIT_COUNT")
@@ -1416,6 +1415,25 @@ esac
         );
         assert!(String::from_utf8_lossy(&persistence_failed.stderr)
             .contains("failed to persist its receipt"));
+        let persistence_retry = run("success");
+        assert_eq!(persistence_retry.status.code(), Some(1));
+        assert!(String::from_utf8_lossy(&persistence_retry.stderr)
+            .contains("previous submission stopped"));
+        assert_eq!(
+            std::fs::read_to_string(&submit_count).unwrap(),
+            "2",
+            "the accepted persistence-failure submission must block an identical retry"
+        );
+        let forced_after_reconciliation = command("success")
+            .env("REMOTE_BUILD_FORCE_NEW", "1")
+            .output()
+            .expect("force a new build after explicit reconciliation");
+        assert!(
+            forced_after_reconciliation.status.success(),
+            "explicitly forced build failed: {}",
+            String::from_utf8_lossy(&forced_after_reconciliation.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "3");
 
         for entry in std::fs::read_dir(&state).expect("read state before ambiguous submission") {
             let path = entry.expect("read state entry").path();

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1230,6 +1230,9 @@ case "$url" in
         [ ! -f "$REMOTE_BUILD_TEST_SUBMIT_COUNT" ] || count=$(cat "$REMOTE_BUILD_TEST_SUBMIT_COUNT")
         count=$((count + 1))
         printf '%s' "$count" > "$REMOTE_BUILD_TEST_SUBMIT_COUNT"
+        if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "ambiguous" ]; then
+            exit 28
+        fi
         printf '{"job_id":"11111111-1111-1111-1111-111111111111","node_id":"lean:gpu"}' > "$output"
         printf '202'
         ;;
@@ -1371,6 +1374,43 @@ esac
         );
         assert!(String::from_utf8_lossy(&persistence_failed.stderr)
             .contains("failed to persist its receipt"));
+
+        for entry in std::fs::read_dir(&state).expect("read state before ambiguous submission") {
+            let path = entry.expect("read state entry").path();
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).expect("remove stale test lock directory");
+            } else {
+                std::fs::remove_file(path).expect("remove prior test receipt");
+            }
+        }
+        std::fs::write(&submit_count, "0").expect("reset submit counter");
+        let ambiguous = run("ambiguous");
+        assert_eq!(ambiguous.status.code(), Some(1));
+        assert!(String::from_utf8_lossy(&ambiguous.stderr).contains("unknown outcome"));
+        let blocked_retry = run("success");
+        assert_eq!(blocked_retry.status.code(), Some(1));
+        assert!(String::from_utf8_lossy(&blocked_retry.stderr).contains("previous submission"));
+        assert_eq!(
+            std::fs::read_to_string(&submit_count).unwrap(),
+            "1",
+            "an ambiguous first submit must block an identical retry"
+        );
+        let ambiguous_receipt = std::fs::read_dir(&state)
+            .expect("read ambiguous receipt directory")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .expect("ambiguous receipt");
+        let receipt: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(ambiguous_receipt).expect("read ambiguous receipt"),
+        )
+        .expect("parse ambiguous receipt");
+        assert_eq!(
+            receipt.get("state").and_then(serde_json::Value::as_str),
+            Some("ambiguous")
+        );
+        assert!(receipt.get("token").is_none());
+        assert!(receipt.get("repo").is_none());
     }
 
     #[test]

--- a/src/remote_node/client.rs
+++ b/src/remote_node/client.rs
@@ -10,6 +10,14 @@ use super::protocol::{
 };
 use super::{RemoteNodeConfig, RemoteNodeError};
 
+fn transport_error(error: reqwest::Error) -> RemoteNodeError {
+    if error.is_connect() {
+        RemoteNodeError::Connect(error.to_string())
+    } else {
+        RemoteNodeError::Request(error.to_string())
+    }
+}
+
 /// Total request timeout for `/execute`, which blocks until the remote
 /// command completes.
 const EXECUTE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
@@ -50,7 +58,7 @@ impl RemoteNodeClient {
             .bearer_auth(token)
             .send()
             .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+            .map_err(transport_error)?;
         if !response.status().is_success() {
             return Err(RemoteNodeError::Request(format!(
                 "heartbeat returned {}",
@@ -81,7 +89,7 @@ impl RemoteNodeClient {
             .json(request)
             .send()
             .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+            .map_err(transport_error)?;
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
@@ -112,7 +120,7 @@ impl RemoteNodeClient {
             .json(request)
             .send()
             .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+            .map_err(transport_error)?;
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
@@ -142,7 +150,7 @@ impl RemoteNodeClient {
             .bearer_auth(shared_token)
             .send()
             .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+            .map_err(transport_error)?;
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
@@ -172,7 +180,7 @@ impl RemoteNodeClient {
             .bearer_auth(shared_token)
             .send()
             .await
-            .map_err(|e| RemoteNodeError::Request(e.to_string()))?;
+            .map_err(transport_error)?;
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
@@ -236,5 +244,36 @@ mod tests {
         assert_eq!(heartbeat.capacity_available, 1);
         assert_eq!(heartbeat.labels, vec!["lean".to_string()]);
         assert_eq!(heartbeat.lean_runtime_ready, Some(true));
+    }
+
+    #[tokio::test]
+    async fn submit_classifies_preconnect_failure_as_safe() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let client = RemoteNodeClient::default();
+        let node = RemoteNodeConfig {
+            id: "offline".to_string(),
+            base_url: format!("http://{addr}"),
+            token_env: "TOKEN".to_string(),
+            labels: None,
+        };
+        let request = SubmitJobRequest {
+            job_id: Uuid::new_v4(),
+            mission_id: Uuid::new_v4(),
+            lease_token: "unused".to_string(),
+            payload: crate::remote_node::protocol::JobPayload::RawCommand {
+                command: "true".to_string(),
+                timeout_secs: None,
+                env: None,
+            },
+        };
+
+        let error = client
+            .submit_job(&node, "unused", &request)
+            .await
+            .expect_err("a closed listening port must fail before submission");
+        assert!(matches!(error, RemoteNodeError::Connect(_)), "{error}");
     }
 }

--- a/src/remote_node/mod.rs
+++ b/src/remote_node/mod.rs
@@ -101,6 +101,8 @@ pub enum RemoteNodeError {
     MissingToken(String, String),
     #[error("invalid remote node config: {0}")]
     InvalidConfig(String),
+    #[error("remote node connection failed before the request was sent: {0}")]
+    Connect(String),
     #[error("remote node request failed: {0}")]
     Request(String),
     #[error("remote node rejected request with HTTP {status}: {body}")]


### PR DESCRIPTION
## What changed
- submit remote Lean builds asynchronously and persist the returned job/node receipt before polling
- fingerprint immutable mission/repo/head/command requests so rerunning after a tool or transport interruption resumes the live job instead of submitting a duplicate
- poll through the mission-scoped authenticated status endpoint and retain terminal log/artifact/exit evidence
- add explicit state-directory, polling timeout, and operator-only force-new controls
- document the recovery behavior

## Why
A lost Codex tool result caused the Verity controller to submit the same 9-minute `PrintAxioms` build twice because the synchronous wrapper did not reveal the job ID until completion. Durable receipts make the build handle available immediately and recoverable.

## Validation
- `cargo fmt --all --check`
- `bash -n scripts/remote-lean-build`
- `cargo test wrapper_resumes_an_interrupted_async_job_without_resubmitting --lib`
- `cargo test wrapper_treats_host_capability_auth_failures_as_temporary --lib`
- `cargo clippy --locked --lib -- -D clippy::all`
- `git diff --check`

The resumability regression deliberately interrupts polling after a successful submit, reruns the exact command, and asserts the submit count remains one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-build dispatch, exit codes, and duplicate-job prevention across the wrapper and API; mistakes could cause double builds or block legitimate local fallback, but behavior is heavily tested and documented.
> 
> **Overview**
> **Remote Lean builds are no longer one blocking HTTP call.** `remote-lean-build` submits with `wait: false`, writes a secret-free job receipt under state dir, then polls `GET /api/remote-build/:job_id`. Identical commands fingerprint the immutable request and **resume** the same job (or replay a terminal receipt) instead of dispatching again.
> 
> **Fallback rules are tightened.** Pre-connect failures stay **503 / exit 75** (local fallback OK). Response-side transport ambiguity returns **502** on core and **exit 1** in the wrapper—no local fallback after a job may have been accepted. Ambiguous submits persist an `ambiguous` receipt and block duplicate submission until reconciliation or `REMOTE_BUILD_FORCE_NEW=1`. Locks and recovery blockers serialize concurrent submits for the same fingerprint.
> 
> **Core/client plumbing:** `RemoteNodeError::Connect` vs `Request` distinguishes safe vs ambiguous node errors; job status polling forwards **400/404** so clients can stop on unrecoverable handles. Docs updated for the async/resume model and new env knobs (`REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`, state dir, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf99a76cb979b12c8c5016e1a9aee7681b2225b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->