### PR TITLE
Share node CPU budget across concurrent Lean builds

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -96,7 +96,11 @@ export SANDBOXED_NODE_LABELS=lean,docker
 node-wide execution budget: synchronous `/execute` leases and asynchronous
 jobs consume the same permits. A full node rejects a new `/execute` request
 with HTTP 429; queued jobs wait for a shared permit. This prevents the two API
-paths from each consuming the configured capacity independently.
+paths from each consuming the configured capacity independently. Lean jobs
+also divide the process's usable CPU affinity by this capacity before deriving
+their default Lake/Lean fan-out, so two admitted jobs do not each claim the
+whole node. Set capacity to the number of builds the host can sustain; explicit
+payload concurrency overrides remain an operator escape hatch.
 
 A node configured with the `lean` label must have an executable `lake` proxy
 either at `$SANDBOXED_NODE_WORK_DIR/caches/elan/bin/lake` or on the service's
@@ -289,13 +293,14 @@ Validation (node-side, before anything runs):
   `lake build ...` and `lean ...`. The service environment is cleared before
   execution so node bearer/signing secrets are not inherited by build code.
 - `env` keys must be within `SANDBOXED_NODE_ENV_ALLOWLIST`.
-- When the payload omits `LEAN_NUM_THREADS` or `LAKE_JOBS`, the node divides
-  its usable logical-CPU budget (`available_parallelism`, including OS
-  affinity/cgroup caps) across both levels. Lake defaults to at most four jobs
-  and Lean receives the remaining per-job thread budget. When only one key is
-  supplied, the other is derived from the remaining CPU budget. Explicit
-  allowlisted payload values still take precedence. Direct `lean ...` jobs do
-  not have Lake fan-out, so they receive the full thread budget and default
+- When the payload omits `LEAN_NUM_THREADS` or `LAKE_JOBS`, the node first
+  divides its usable logical-CPU budget (`available_parallelism`, including OS
+  affinity/cgroup caps) by `SANDBOXED_NODE_CAPACITY`, then divides that per-job
+  share across both levels. Lake defaults to at most four jobs and Lean
+  receives the remaining per-job thread budget. When only one key is supplied,
+  the other is derived from the remaining CPU budget. Explicit allowlisted
+  payload values still take precedence. Direct `lean ...` jobs do not have Lake
+  fan-out, so they receive the full per-job thread share and default
   `LAKE_JOBS` to one.
 - `timeout_secs` is clamped to `SANDBOXED_NODE_MAX_JOB_SECS`.
 

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -328,6 +328,18 @@ fn lean_concurrency_env(
     effective
 }
 
+/// Divide the node's usable CPU affinity among the number of jobs that its
+/// admission controller can run concurrently. The node may be idle when a
+/// single job starts, but budgeting for the configured worst case prevents a
+/// second job from multiplying Lean/Lake fan-out beyond the host capacity.
+fn per_job_parallelism(available_parallelism: usize, capacity: u32) -> usize {
+    available_parallelism
+        .max(1)
+        .checked_div(capacity.max(1) as usize)
+        .unwrap_or(1)
+        .max(1)
+}
+
 /// Derive the default lake cache key from the build cwd: sha256 over the
 /// contents of `lean-toolchain` and `lake-manifest.json` (whichever exist).
 /// `None` when neither file is present (no cache slot is used then).
@@ -724,6 +736,7 @@ pub async fn execute_lean_build(
     work_root: &Path,
     log_path: &Path,
     payload: &JobPayload,
+    node_capacity: u32,
     max_job_secs: u64,
     token: &CancellationToken,
 ) -> anyhow::Result<LeanBuildResult> {
@@ -808,7 +821,7 @@ pub async fn execute_lean_build(
         .unwrap_or(1);
     for (key, value) in lean_concurrency_env(
         env,
-        available_parallelism,
+        per_job_parallelism(available_parallelism, node_capacity),
         command.first().is_some_and(|c| c == "lake"),
     ) {
         cmd.env(key, value);
@@ -1088,6 +1101,26 @@ mod tests {
             Some("20")
         );
         assert_eq!(direct_lean.get("LAKE_JOBS").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn per_job_parallelism_respects_node_admission_capacity() {
+        assert_eq!(per_job_parallelism(8, 1), 8);
+        assert_eq!(per_job_parallelism(8, 2), 4);
+        assert_eq!(per_job_parallelism(20, 3), 6);
+        assert_eq!(per_job_parallelism(2, 8), 1);
+        assert_eq!(per_job_parallelism(0, 0), 1);
+
+        let two_job_defaults =
+            lean_concurrency_env(&HashMap::new(), per_job_parallelism(8, 2), true);
+        assert_eq!(
+            two_job_defaults.get("LEAN_NUM_THREADS").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            two_job_defaults.get("LAKE_JOBS").map(String::as_str),
+            Some("4")
+        );
     }
 
     #[test]

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -59,6 +59,7 @@ struct QueuedJob {
 pub struct JobRunner {
     store: JobStore,
     work_root: PathBuf,
+    capacity: u32,
     max_job_secs: u64,
     tx: mpsc::UnboundedSender<QueuedJob>,
     max_queued: u32,
@@ -104,6 +105,7 @@ impl JobRunner {
         let runner = Arc::new(Self {
             store,
             work_root,
+            capacity: capacity.max(1),
             max_job_secs: max_job_secs.max(1),
             tx,
             max_queued: u32::try_from(max_queued).unwrap_or(u32::MAX),
@@ -317,6 +319,7 @@ impl JobRunner {
                     &self.work_root,
                     &log_path,
                     &job.payload,
+                    self.capacity,
                     self.max_job_secs,
                     token,
                 )


### PR DESCRIPTION
## Summary
- carry the node admission capacity into every asynchronous Lean job
- derive default Lake/Lean fan-out from a safe per-job CPU share
- document the capacity interaction and cover single/multi-capacity nodes

## Why
A node with capacity 2 could admit two jobs while each derived its defaults from the full host CPU affinity, recreating oversubscription under fleet pressure.

## Validation
- cargo fmt --all --check
- cargo test per_job_parallelism_respects_node_admission_capacity
- cargo test concurrency_env_uses_capability_defaults_and_preserves_explicit_values
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to omitted default concurrency env vars on lean_build jobs; explicit overrides and admission semantics are unchanged.
> 
> **Overview**
> **Lean builds on remote nodes now size default `LEAN_NUM_THREADS` / `LAKE_JOBS` for the worst case where `SANDBOXED_NODE_CAPACITY` jobs run at once**, instead of each job assuming the full host CPU budget.
> 
> `JobRunner` keeps the configured capacity and passes it into `execute_lean_build`. A new `per_job_parallelism` helper divides `available_parallelism` by that capacity before `lean_concurrency_env` derives defaults, so two admitted builds on a capacity-2 node no longer each default to the whole machine. Explicit allowlisted env values in the payload are unchanged.
> 
> `docs/REMOTE_NODES.md` documents the capacity interaction for operators. Unit tests cover `per_job_parallelism` and the two-job default concurrency case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0203940310d1d09b876781a69f475e78ccf4aa4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->