### PR TITLE
fix: keep Hermes mission reads compact

### DIFF
--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -66,6 +66,11 @@ Tools:
 - `get_mission`
 - `get_mission_digest`
 - `get_mission_events`
+
+`get_mission` and `get_mission_digest` both return the compact mission digest.
+Use bounded `get_mission_events` pages when transcript or trace details are
+actually required; full histories are not injected by the status tools.
+
 - `get_mission_health` — diagnose stalls/loops/errors + a one-line recommendation
 - `get_mission_diagnostics` — tool-call timeline, repeated calls, error events
 - `start_mission`

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -136,10 +136,13 @@ you tried last so you don't repeat a failed intervention.
 
 ## Tools
 
-- `list_active_missions`, `list_missions`, `get_mission` — find and inspect missions
+- `list_active_missions`, `list_missions` — find missions with bounded filters
+- `get_mission`, `get_mission_digest` — compact mission status aliases; neither
+  returns the full transcript
 - `get_mission_health` — **start here**: diagnosis + recommendation
 - `get_mission_diagnostics` — deep tool/error timeline when health flags trouble
-- `get_mission_events` — raw transcript/trace when you need exact wording
+- `get_mission_events` — bounded/paginated transcript or trace when you need
+  exact wording
 - `send_message_to_mission` — send a hint / nudge to a mission
 - `update_mission_settings` — switch backend/model/effort/agent (between turns)
 - `resume_mission` — restart interrupted/blocked/failed, optionally with a hint

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -760,7 +760,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "get_mission".to_string(),
-                description: "Get one mission by UUID (full record incl. history — heavy; prefer get_mission_digest for status checks).".to_string(),
+                description: "Compatibility alias for the compact ~2KB mission digest. It never returns the full history; use get_mission_events with a bounded limit for transcript or trace details.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -1145,15 +1145,11 @@ impl AssistantMcp {
     }
 
     async fn get_mission(&self, params: MissionIdParams) -> Result<Value, String> {
-        let id = parse_uuid(&params.mission_id)?;
-        let response = self.api_get(&format!("/api/control/missions/{id}")).await?;
-        if !response.status().is_success() {
-            return Err(format!("Mission not found: {}", response.status()));
-        }
-        response
-            .json()
-            .await
-            .map_err(|error| format!("Failed to parse mission: {error}"))
+        // Keep the legacy tool name safe for autonomous controllers. Models
+        // routinely chose `get_mission` despite its former "heavy" warning,
+        // pulling entire transcripts into every reconciliation tick. Detailed
+        // history remains available through the bounded/paginated events tool.
+        self.get_mission_digest(params).await
     }
 
     async fn get_mission_digest(&self, params: MissionIdParams) -> Result<Value, String> {


### PR DESCRIPTION
## Summary
- make the legacy get_mission MCP tool a compact digest alias
- keep detailed history behind bounded, paginated get_mission_events
- document the safe controller-facing contract

This prevents recurring Hermes controllers from injecting full multi-KB mission transcripts when they only need ownership/status/last-message facts.

## Validation
- cargo fmt --all --check
- cargo test --bin assistant-mcp (21 passed)
- cargo clippy --bin assistant-mcp -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime contract of a legacy MCP tool name—anything that depended on full mission JSON from `get_mission` must switch to `get_mission_events`—but the change is intentional and documented for autonomous controllers.
> 
> **Overview**
> Stops Hermes controllers from bloating context by treating the legacy **`get_mission`** MCP tool as a **compact digest alias** (same payload as **`get_mission_digest`**, ~2KB) instead of fetching the full mission record from `/api/control/missions/{id}`.
> 
> The **`get_mission`** tool description is updated to state it never returns full history; **`get_mission_events`** remains the path for bounded, paginated transcript/trace details. **`docs/HERMES_ASSISTANT_MIGRATION.md`** and **`skills/hermes-mission-control/SKILL.md`** document that both status tools are digest-only and events are opt-in when exact wording is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b829b41d2837522908aa980bb16d3c067a59d18c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->