### PR TITLE
fix: preserve Hermes MCPs during shutdown drain

### DIFF
--- a/docs/examples/hermes-assistant-dev.service.example
+++ b/docs/examples/hermes-assistant-dev.service.example
@@ -16,8 +16,14 @@ ExecStart=/usr/local/bin/hermes gateway --accept-hooks run
 Restart=always
 RestartSec=5
 TimeoutStopSec=240
+# Keep MCP/tool children alive while the gateway drains active turns. systemd
+# still SIGKILLs the complete cgroup if the stop timeout expires.
+KillMode=mixed
 NoNewPrivileges=true
 PrivateTmp=true
+
+# Existing installations are migrated by sandboxed.sh at startup through
+# hermes-assistant*.service.d/60-sandboxed-drain.conf; no re-adoption is needed.
 
 [Install]
 WantedBy=multi-user.target

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1375,6 +1375,7 @@ pub async fn reconcile_hermes_service_drain_policy(
     config: &crate::config::Config,
 ) -> Result<bool, String> {
     let mut changed = false;
+    let mut needs_reload = false;
     for runtime_name in assistant_runtime_candidates(config) {
         let service_name = format!("{runtime_name}.service");
         let service_path = format!("/etc/systemd/system/{service_name}");
@@ -1387,25 +1388,35 @@ pub async fn reconcile_hermes_service_drain_policy(
 
         let drop_in_dir = format!("/etc/systemd/system/{service_name}.d");
         let drop_in_path = format!("{drop_in_dir}/60-sandboxed-drain.conf");
-        if tokio::fs::read_to_string(&drop_in_path)
+        let drop_in_is_current = tokio::fs::read_to_string(&drop_in_path)
             .await
             .ok()
             .as_deref()
-            == Some(HERMES_SERVICE_DRAIN_DROP_IN)
-        {
-            continue;
+            == Some(HERMES_SERVICE_DRAIN_DROP_IN);
+
+        if !drop_in_is_current {
+            tokio::fs::create_dir_all(&drop_in_dir)
+                .await
+                .map_err(|e| format!("failed to create {drop_in_dir}: {e}"))?;
+            write_private_file(&drop_in_path, HERMES_SERVICE_DRAIN_DROP_IN).await?;
+            changed = true;
         }
 
-        tokio::fs::create_dir_all(&drop_in_dir)
-            .await
-            .map_err(|e| format!("failed to create {drop_in_dir}: {e}"))?;
-        write_private_file(&drop_in_path, HERMES_SERVICE_DRAIN_DROP_IN).await?;
-        changed = true;
+        // Checking systemd's effective value makes a failed daemon-reload
+        // self-healing. The drop-in may already be on disk from a previous
+        // attempt, but an old manager configuration still reports the default
+        // control-group policy and therefore triggers another reload.
+        let effective_kill_mode = run_host_command(
+            "systemctl",
+            &["show", "--property=KillMode", "--value", &service_name],
+        )
+        .await?;
+        needs_reload |= effective_kill_mode.trim() != "mixed";
     }
-    if changed {
+    if changed || needs_reload {
         run_host_command("systemctl", &["daemon-reload"]).await?;
     }
-    Ok(changed)
+    Ok(changed || needs_reload)
 }
 
 async fn run_host_command(program: &str, args: &[&str]) -> Result<String, String> {

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1410,8 +1410,21 @@ pub async fn reconcile_hermes_service_drain_policy(
             "systemctl",
             &["show", "--property=KillMode", "--value", &service_name],
         )
-        .await?;
-        needs_reload |= effective_kill_mode.trim() != "mixed";
+        .await;
+        match effective_kill_mode {
+            Ok(mode) => needs_reload |= mode.trim() != "mixed",
+            Err(err) => {
+                // An installed unit may not be known to the manager yet. A
+                // daemon-reload is the recovery path, so do not fail before
+                // giving it a chance to discover the unit and drop-in.
+                tracing::warn!(
+                    service = %service_name,
+                    %err,
+                    "Could not inspect Hermes drain policy; forcing daemon-reload"
+                );
+                needs_reload = true;
+            }
+        }
     }
     if changed || needs_reload {
         run_host_command("systemctl", &["daemon-reload"]).await?;

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -792,15 +792,9 @@ async fn get_assistant_mcp_info() -> ComponentInfo {
 }
 
 async fn get_hermes_assistant_info(config: &crate::config::Config) -> ComponentInfo {
-    let expected_service = format!("{}.service", assistant_runtime_name(config));
-    let fallback_service = if expected_service == "hermes-assistant-dev.service" {
-        "hermes-assistant.service"
-    } else {
-        "hermes-assistant-dev.service"
-    };
-
-    for service_name in [expected_service.as_str(), fallback_service] {
-        if let Some(info) = get_systemd_service_component("hermes_assistant", service_name).await {
+    for runtime_name in assistant_runtime_candidates(config) {
+        let service_name = format!("{runtime_name}.service");
+        if let Some(info) = get_systemd_service_component("hermes_assistant", &service_name).await {
             return info;
         }
     }
@@ -1111,6 +1105,16 @@ fn assistant_runtime_name(config: &crate::config::Config) -> &'static str {
     }
 }
 
+fn assistant_runtime_candidates(config: &crate::config::Config) -> [&'static str; 2] {
+    let expected = assistant_runtime_name(config);
+    let fallback = if expected == "hermes-assistant-dev" {
+        "hermes-assistant"
+    } else {
+        "hermes-assistant-dev"
+    };
+    [expected, fallback]
+}
+
 fn local_api_url(config: &crate::config::Config) -> String {
     format!("http://127.0.0.1:{}", config.port)
 }
@@ -1344,6 +1348,9 @@ ExecStart=/usr/local/bin/hermes gateway --accept-hooks run
 Restart=always
 RestartSec=5
 TimeoutStopSec=240
+# Signal only the gateway during its graceful drain. Its MCP/tool children must
+# remain available until Hermes finishes or the timeout escalates to SIGKILL.
+KillMode=mixed
 NoNewPrivileges=true
 PrivateTmp=true
 
@@ -1351,6 +1358,54 @@ PrivateTmp=true
 WantedBy=multi-user.target
 "#
     )
+}
+
+const HERMES_SERVICE_DRAIN_DROP_IN: &str = "[Service]\nKillMode=mixed\n";
+
+/// Migrate an already-installed Hermes service to the same drain-safe process
+/// policy used by newly generated units.
+///
+/// A regular systemd stop signals every process in the service cgroup when the
+/// default `KillMode=control-group` is in effect. That kills `assistant-mcp`
+/// while the Hermes gateway is still draining an in-flight controller turn.
+/// Installing a drop-in is deliberately narrower than re-running adoption: it
+/// preserves the existing Hermes environment, plugins, credentials, and unit
+/// customizations.
+pub async fn reconcile_hermes_service_drain_policy(
+    config: &crate::config::Config,
+) -> Result<bool, String> {
+    let mut changed = false;
+    for runtime_name in assistant_runtime_candidates(config) {
+        let service_name = format!("{runtime_name}.service");
+        let service_path = format!("/etc/systemd/system/{service_name}");
+        if !tokio::fs::try_exists(&service_path)
+            .await
+            .map_err(|e| format!("failed to inspect {service_path}: {e}"))?
+        {
+            continue;
+        }
+
+        let drop_in_dir = format!("/etc/systemd/system/{service_name}.d");
+        let drop_in_path = format!("{drop_in_dir}/60-sandboxed-drain.conf");
+        if tokio::fs::read_to_string(&drop_in_path)
+            .await
+            .ok()
+            .as_deref()
+            == Some(HERMES_SERVICE_DRAIN_DROP_IN)
+        {
+            continue;
+        }
+
+        tokio::fs::create_dir_all(&drop_in_dir)
+            .await
+            .map_err(|e| format!("failed to create {drop_in_dir}: {e}"))?;
+        write_private_file(&drop_in_path, HERMES_SERVICE_DRAIN_DROP_IN).await?;
+        changed = true;
+    }
+    if changed {
+        run_host_command("systemctl", &["daemon-reload"]).await?;
+    }
+    Ok(changed)
 }
 
 async fn run_host_command(program: &str, args: &[&str]) -> Result<String, String> {
@@ -4756,10 +4811,11 @@ fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::conve
 mod tests {
     use super::{
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
-        hermes_config_base_url, hermes_config_model_label, hermes_config_yaml,
+        hermes_config_base_url, hermes_config_model_label, hermes_config_yaml, hermes_service_unit,
         hermes_uses_native_codex, is_safe_repo_path, normalize_repo_path, prune_deploy_backups,
         sandboxed_service_name_from_path, select_repo_path, systemd_service_component_from_states,
         ComponentStatus, DebounceDecision, DeployRefusal, DEPLOY_DEBOUNCE_SECS,
+        HERMES_SERVICE_DRAIN_DROP_IN,
     };
 
     #[test]
@@ -4796,6 +4852,20 @@ mod tests {
                 "generated Hermes config missing {tool}"
             );
         }
+    }
+
+    #[test]
+    fn generated_hermes_service_keeps_mcp_children_alive_during_drain() {
+        let unit = hermes_service_unit(
+            "hermes-assistant",
+            "/etc/sandboxed-sh/hermes-assistant.env",
+            "sandboxed-sh-prod.service",
+        );
+
+        assert!(unit.contains("TimeoutStopSec=240\n"));
+        assert!(unit.contains("KillMode=mixed\n"));
+        assert!(!unit.contains("KillMode=control-group"));
+        assert_eq!(HERMES_SERVICE_DRAIN_DROP_IN, "[Service]\nKillMode=mixed\n");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,14 @@ async fn async_main() -> anyhow::Result<()> {
             .as_deref()
             .unwrap_or("(opencode default)")
     );
+    match api::system::reconcile_hermes_service_drain_policy(&config).await {
+        Ok(true) => info!("Migrated Hermes service to drain-safe mixed kill mode"),
+        Ok(false) => {}
+        Err(error) => warn!(
+            "Could not reconcile Hermes service drain policy: {}. Existing Hermes configuration was left unchanged.",
+            error
+        ),
+    }
     let context_root = config
         .context
         .context_dir(&config.working_dir.to_string_lossy());


### PR DESCRIPTION
## Summary

- generate Hermes systemd units with `KillMode=mixed`
- keep MCP/tool children alive while the gateway drains active cron/chat turns
- retain `TimeoutStopSec=240` so systemd still kills the whole cgroup if graceful shutdown stalls
- document the service behavior and cover the generated unit with a regression test

## Production failure reproduced

A normal `systemctl restart hermes-assistant` sent SIGTERM to both the gateway and `assistant-mcp`. Hermes correctly kept an in-flight controller turn alive during its drain window, but that turn then failed with `ClosedResourceError` because the MCP child had already exited. `KillMode=mixed` sends SIGTERM only to the main gateway process and reserves cgroup-wide SIGKILL for the stop timeout.

## Validation

- `cargo fmt --all --check`
- `cargo test --lib generated_hermes_service_keeps_mcp_children_alive_during_drain`
- `cargo clippy --lib -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production Hermes systemd stop semantics and runs host `systemctl`/filesystem writes at API startup; scope is limited to a drop-in and startup reconciliation is non-fatal on error.
> 
> **Overview**
> Fixes Hermes restarts killing `assistant-mcp` while the gateway is still draining in-flight turns (e.g. `ClosedResourceError` on `systemctl restart`).
> 
> **Systemd policy:** New and generated Hermes units set **`KillMode=mixed`** so stop/restart signals only the main gateway; MCP/tool children stay up until drain finishes or **`TimeoutStopSec=240`** escalates to cgroup SIGKILL. The example service file documents the same behavior.
> 
> **Existing installs:** On **sandboxed-sh** startup, **`reconcile_hermes_service_drain_policy`** writes **`hermes-assistant*.service.d/60-sandboxed-drain.conf`** when needed, verifies effective `KillMode` via `systemctl show`, and runs **`daemon-reload`**—without re-adoption. Failures log a warning and leave the current Hermes config untouched.
> 
> **Refactor:** Hermes runtime discovery uses shared **`assistant_runtime_candidates`** (expected + dev/prod fallback). A unit test asserts the generated service includes mixed kill mode and the drop-in contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb74941f261500627f94d63ab3a37305a13b669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->