### PR TITLE
fix: isolate remote Lean project outputs

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -319,11 +319,12 @@ Execution model:
 - Lake dependency cache: `cache_key` defaults to a digest of the build cwd's
   `lean-toolchain` + `lake-manifest.json`, then is namespaced by repository,
   build cwd, and command. Before a cold build only
-  `<workdir>/caches/lake/<key>/packages/` is copied without hardlinks into
-  `<cwd>/.lake/packages`; after a successful build only that dependency tree is
+  `<workdir>/caches/lake/<key>/packages/` is copied without hardlinks into the
+  manifest's configured `packagesDir` (which must be a clean relative path
+  below `lakeDir`); after a successful build only that dependency tree is
   refreshed through a temp dir and atomic rename under a per-key flock. No
-  other top-level `.lake` entry is shared, so default or custom root-project
-  build directories are rebuilt per commit while dependencies stay warm.
+  other entry under `lakeDir` is shared, so default or custom root-project build
+  directories are rebuilt per commit while dependencies stay warm.
 - `artifacts` patterns are resolved relative to the checkout root after a
   successful build: exact relative paths, or `*` within a single path
   segment (never across `/`); `..` and absolute paths are rejected. Each

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -321,10 +321,11 @@ Execution model:
   build cwd, and command. Before a cold build only
   `<workdir>/caches/lake/<key>/packages/` is copied without hardlinks into the
   manifest's configured `packagesDir` (which must be a clean relative path
-  below `lakeDir`); after a successful build only that dependency tree is
-  refreshed through a temp dir and atomic rename under a per-key flock. No
-  other entry under `lakeDir` is shared, so default or custom root-project build
-  directories are rebuilt per commit while dependencies stay warm.
+  below `lakeDir` and must not overlap the root `buildDir`); after a successful
+  build only that dependency tree is refreshed through a temp dir and atomic
+  rename under a per-key flock. No other entry under `lakeDir` is shared, so
+  default or custom root-project build directories are rebuilt per commit while
+  dependencies stay warm.
 - `artifacts` patterns are resolved relative to the checkout root after a
   successful build: exact relative paths, or `*` within a single path
   segment (never across `/`); `..` and absolute paths are rejected. Each

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -323,9 +323,11 @@ Execution model:
   manifest's configured `packagesDir` (which must be a clean relative path
   below `lakeDir` and must not overlap the root `buildDir`); after a successful
   build only that dependency tree is refreshed through a temp dir and atomic
-  rename under a per-key flock. No other entry under `lakeDir` is shared, so
-  default or custom root-project build directories are rebuilt per commit while
-  dependencies stay warm.
+  rename under a per-key flock. Because Lake 4.24 does not normally persist the
+  evaluated root `buildDir` in `lake-manifest.json`, dependency restore/sync is
+  conservatively skipped unless the manifest explicitly contains `buildDir`.
+  This keeps dynamic lakefile layouts cold rather than risking cross-commit
+  root outputs. No other entry under `lakeDir` is shared.
 - `artifacts` patterns are resolved relative to the checkout root after a
   successful build: exact relative paths, or `*` within a single path
   segment (never across `/`); `..` and absolute paths are rejected. Each

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -318,12 +318,12 @@ Execution model:
   `<workdir>/caches/elan/bin` prepended to `PATH`.
 - Lake dependency cache: `cache_key` defaults to a digest of the build cwd's
   `lean-toolchain` + `lake-manifest.json`, then is namespaced by repository,
-  build cwd, and command. Before a cold build the slot
-  `<workdir>/caches/lake/<key>/` is copied without hardlinks into
-  `<cwd>/.lake`; after a successful build it is refreshed through a temp dir
-  and atomic rename under a per-key flock. Root-project `.lake/build` outputs
-  are removed both on restore and before persistence, so every commit rebuilds
-  its own sources while dependency outputs under `.lake/packages` stay warm.
+  build cwd, and command. Before a cold build only
+  `<workdir>/caches/lake/<key>/packages/` is copied without hardlinks into
+  `<cwd>/.lake/packages`; after a successful build only that dependency tree is
+  refreshed through a temp dir and atomic rename under a per-key flock. No
+  other top-level `.lake` entry is shared, so default or custom root-project
+  build directories are rebuilt per commit while dependencies stay warm.
 - `artifacts` patterns are resolved relative to the checkout root after a
   successful build: exact relative paths, or `*` within a single path
   segment (never across `/`); `..` and absolute paths are rejected. Each

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -316,18 +316,15 @@ Execution model:
 - Builds run with shared caches: `ELAN_HOME=<workdir>/caches/elan`,
   `XDG_CACHE_HOME=<workdir>/caches/xdg`, `HOME=<workdir>/caches/home`, and
   `<workdir>/caches/elan/bin` prepended to `PATH`.
-- Lake dependency cache: `cache_key` defaults to a digest of the build cwd's
-  `lean-toolchain` + `lake-manifest.json`, then is namespaced by repository,
-  build cwd, and command. Before a cold build only
-  `<workdir>/caches/lake/<key>/packages/` is copied without hardlinks into the
-  manifest's configured `packagesDir` (which must be a clean relative path
-  below `lakeDir` and must not overlap the root `buildDir`); after a successful
-  build only that dependency tree is refreshed through a temp dir and atomic
-  rename under a per-key flock. Because Lake 4.24 does not normally persist the
-  evaluated root `buildDir` in `lake-manifest.json`, dependency restore/sync is
-  conservatively skipped unless the manifest explicitly contains `buildDir`.
-  This keeps dynamic lakefile layouts cold rather than risking cross-commit
-  root outputs. No other entry under `lakeDir` is shared.
+- Lake dependency cache: the copy/sync machinery is isolated, namespaced, and
+  lock-protected, but restore and sync currently fail closed. Lake 4.24 does
+  not persist an authoritative evaluated root `buildDir` in
+  `lake-manifest.json`; checked-in manifest fields can also be stale or disagree
+  with a dynamic lakefile. The node therefore never trusts manifest-only layout
+  assertions and keeps repository `.lake` trees cold until a trusted Lake
+  configuration query is implemented. Shared Elan/XDG/Home caches remain
+  enabled, so toolchains and downloads are still reused without sharing root
+  build artifacts across commits.
 - `artifacts` patterns are resolved relative to the checkout root after a
   successful build: exact relative paths, or `*` within a single path
   segment (never across `/`); `..` and absolute paths are rejected. Each

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -316,12 +316,14 @@ Execution model:
 - Builds run with shared caches: `ELAN_HOME=<workdir>/caches/elan`,
   `XDG_CACHE_HOME=<workdir>/caches/xdg`, `HOME=<workdir>/caches/home`, and
   `<workdir>/caches/elan/bin` prepended to `PATH`.
-- Lake cache: `cache_key` defaults to a digest of the build cwd's
-  `lean-toolchain` + `lake-manifest.json`. Before a cold build the slot
-  `<workdir>/caches/lake/<key>/` is hardlink-copied (`cp -al`) into
-  `<cwd>/.lake`; after a successful build the slot is refreshed the same way
-  (tmp dir + atomic rename, under a per-key flock). Accepted caveat: mtime
-  drift may cause partial rebuilds, never wrong artifacts.
+- Lake dependency cache: `cache_key` defaults to a digest of the build cwd's
+  `lean-toolchain` + `lake-manifest.json`, then is namespaced by repository,
+  build cwd, and command. Before a cold build the slot
+  `<workdir>/caches/lake/<key>/` is copied without hardlinks into
+  `<cwd>/.lake`; after a successful build it is refreshed through a temp dir
+  and atomic rename under a per-key flock. Root-project `.lake/build` outputs
+  are removed both on restore and before persistence, so every commit rebuilds
+  its own sources while dependency outputs under `.lake/packages` stay warm.
 - `artifacts` patterns are resolved relative to the checkout root after a
   successful build: exact relative paths, or `*` within a single path
   segment (never across `/`); `..` and absolute paths are rejected. Each

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1181,7 +1181,7 @@ async fn cancel_working_agent(turn: &AskTurn) -> Result<(), String> {
         .await
         .map_err(|_| "the control session is unavailable".to_string())?;
     match tokio::time::timeout(std::time::Duration::from_secs(15), rx).await {
-        Ok(Ok(result)) => result,
+        Ok(Ok(result)) => result.map(|_| ()),
         Ok(Err(_)) => Err("the control session dropped the request".to_string()),
         Err(_) => Err("timed out waiting for the cancellation to be acknowledged".to_string()),
     }

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -458,7 +458,7 @@ pub enum ControlCommand {
         /// the caller's "stalled" observation and the actor processing
         /// this command. User-initiated cancels pass `None`.
         min_idle: Option<std::time::Duration>,
-        respond: oneshot::Sender<Result<(), String>>,
+        respond: oneshot::Sender<Result<CancelMissionOutcome, String>>,
     },
     /// Pause a mission (FLEET-004). Stops any in-flight runner (main or
     /// parallel) for the mission, then sets its status to `Paused`. Unlike
@@ -504,6 +504,15 @@ pub enum ControlCommand {
         mission_id: Option<Uuid>,
         respond: oneshot::Sender<usize>, // number of messages cleared
     },
+}
+
+/// Whether a conditional cancellation actually reached the runner. Background
+/// watchdogs must not overwrite mission state when the actor declined a stale
+/// cancellation because activity resumed in the meantime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelMissionOutcome {
+    Cancelled,
+    SkippedRecentlyActive,
 }
 
 // ==================== Mission Types ====================

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -14393,7 +14393,7 @@ async fn control_actor_loop(
                                 } else {
                                     super::mission_runner::MissionRunState::Running
                                 };
-                                let tool_subprocess_alive = main_runner_active_tool_calls
+                                let tool_call_in_flight = main_runner_active_tool_calls
                                     .load(std::sync::atomic::Ordering::Relaxed)
                                     > 0;
                                 running_list.push(super::mission_runner::RunningMissionInfo {
@@ -14402,11 +14402,11 @@ async fn control_actor_loop(
                                     queue_len: queue.len(),
                                     history_len: history.len(),
                                     seconds_since_activity,
-                                    tool_subprocess_alive,
+                                    tool_call_in_flight,
                                     health: super::mission_runner::running_health(
                                         mission_state,
                                         seconds_since_activity,
-                                        tool_subprocess_alive,
+                                        tool_call_in_flight,
                                     ),
                                     expected_deliverables: 0,
                                     current_activity: main_runner_activity.clone(),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -14117,7 +14117,9 @@ async fn control_actor_loop(
                                         threshold_secs = min_idle.as_secs(),
                                         "Skipping watchdog/cleanup cancel: mission resumed activity before cancel was processed"
                                     );
-                                    let _ = respond.send(Ok(()));
+                                    let _ = respond.send(Ok(
+                                        CancelMissionOutcome::SkippedRecentlyActive,
+                                    ));
                                     continue;
                                 }
                             }
@@ -14202,7 +14204,7 @@ async fn control_actor_loop(
                             .await;
                             // Cascade cancel child missions
                             cancel_child_missions(mission_id, &mission_store, &mut parallel_runners, &events_tx, &config.working_dir).await;
-                            let _ = respond.send(Ok(()));
+                            let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
                         } else {
                             // Check if this is the currently executing mission
                             // Use running_mission_id (the actual mission being executed)
@@ -14233,7 +14235,7 @@ async fn control_actor_loop(
                                     // Sending both causes duplicate UI messages.
                                     // Cascade cancel child missions
                                     cancel_child_missions(mission_id, &mission_store, &mut parallel_runners, &events_tx, &config.working_dir).await;
-                                    let _ = respond.send(Ok(()));
+                                    let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
                                 } else {
                                     let _ = respond.send(Err("Mission not currently executing".to_string()));
                                 }
@@ -14251,7 +14253,7 @@ async fn control_actor_loop(
                                         || mission.status.is_terminal()
                                         || mission.status == MissionStatus::Acknowledged =>
                                     {
-                                        let _ = respond.send(Ok(()));
+                                        let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
                                     }
                                     Ok(Some(_)) => {
                                         let update = mission_store
@@ -14288,7 +14290,7 @@ async fn control_actor_loop(
                                             &config.working_dir,
                                         )
                                         .await;
-                                        let _ = respond.send(Ok(()));
+                                        let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
                                     }
                                     Ok(None) => {
                                         let _ = respond.send(Err(format!(

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13656,6 +13656,8 @@ async fn control_actor_loop(
                                 main_runner_last_activity = std::time::Instant::now();
                                 main_runner_activity = None;
                                 main_runner_subtasks.clear();
+                                main_runner_active_tool_calls
+                                    .store(0, std::sync::atomic::Ordering::Relaxed);
                                 let user_id_for_turn = session_user_id.clone();
                                 running = Some(tokio::spawn(async move {
                                     let result = run_single_control_turn(
@@ -14713,6 +14715,8 @@ async fn control_actor_loop(
                                         main_runner_last_activity = std::time::Instant::now();
                                         main_runner_activity = None;
                                         main_runner_subtasks.clear();
+                                        main_runner_active_tool_calls
+                                            .store(0, std::sync::atomic::Ordering::Relaxed);
                                         let user_id_for_turn = session_user_id.clone();
                                         running = Some(tokio::spawn(async move {
                                             let result = run_single_control_turn(
@@ -15126,6 +15130,8 @@ async fn control_actor_loop(
                     running_cancel = None;
                     running_mission_id = None;
                     main_runner_activity = None;
+                    main_runner_active_tool_calls
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
                     // Runner cleared itself; cancel the force-clear watchdog.
                     runner_force_clear_deadline = None;
                     let mut completed_terminal_reason = None;
@@ -15515,6 +15521,8 @@ async fn control_actor_loop(
                     main_runner_last_activity = std::time::Instant::now();
                     main_runner_activity = None;
                     main_runner_subtasks.clear();
+                    main_runner_active_tool_calls
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
                     let user_id_for_turn = session_user_id.clone();
                     running = Some(tokio::spawn(async move {
                         let result = run_single_control_turn(
@@ -15983,6 +15991,8 @@ async fn control_actor_loop(
                 running_cancel = None;
                 running_mission_id = None;
                 main_runner_activity = None;
+                main_runner_active_tool_calls
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
                 runner_force_clear_deadline = None;
                 if let Some(mid) = stuck_mid {
                     // Mark mission as Interrupted so it stays resumable.

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -14391,18 +14391,20 @@ async fn control_actor_loop(
                                 } else {
                                     super::mission_runner::MissionRunState::Running
                                 };
+                                let tool_subprocess_alive = main_runner_active_tool_calls
+                                    .load(std::sync::atomic::Ordering::Relaxed)
+                                    > 0;
                                 running_list.push(super::mission_runner::RunningMissionInfo {
                                     mission_id,
                                     state: state_label.to_string(),
                                     queue_len: queue.len(),
                                     history_len: history.len(),
                                     seconds_since_activity,
+                                    tool_subprocess_alive,
                                     health: super::mission_runner::running_health(
                                         mission_state,
                                         seconds_since_activity,
-                                        main_runner_active_tool_calls
-                                            .load(std::sync::atomic::Ordering::Relaxed)
-                                            > 0,
+                                        tool_subprocess_alive,
                                     ),
                                     expected_deliverables: 0,
                                     current_activity: main_runner_activity.clone(),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2724,6 +2724,14 @@ impl MissionRunner {
         self.last_activity = Instant::now();
     }
 
+    /// Clear turn-scoped tool hints before a runner is reused. Some harnesses
+    /// can omit a terminal ToolResult, so the counter must not survive into a
+    /// later queued turn and incorrectly extend its watchdog grace period.
+    fn reset_turn_tool_calls(&self) {
+        self.active_tool_calls
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Check the health of this mission.
     pub async fn check_health(&self) -> MissionHealth {
         let seconds_since = self.last_activity.elapsed().as_secs();
@@ -2844,6 +2852,7 @@ impl MissionRunner {
             None => return false,
         };
 
+        self.reset_turn_tool_calls();
         self.state = MissionRunState::Running;
 
         let cancel = CancellationToken::new();
@@ -2932,6 +2941,10 @@ impl MissionRunner {
 
         // Check if handle is finished
         if handle.is_finished() {
+            // A completed or panicked turn can leave an unmatched ToolCall in
+            // harnesses that omit ToolResult events. Never expose that stale
+            // hint while queued or carry it into the next turn.
+            self.reset_turn_tool_calls();
             match handle.await {
                 Ok(result) => {
                     self.touch(); // Update last activity

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -8218,6 +8218,9 @@ pub struct RunningMissionInfo {
     pub queue_len: usize,
     pub history_len: usize,
     pub seconds_since_activity: u64,
+    /// A harness tool call is still in flight. Long-running builds can be
+    /// silent at the model-event layer while their subprocess is healthy.
+    pub tool_subprocess_alive: bool,
     pub health: MissionHealth,
     pub expected_deliverables: usize,
     /// Current activity label (e.g., "Reading: main.rs")
@@ -8232,6 +8235,10 @@ pub struct RunningMissionInfo {
 impl From<&MissionRunner> for RunningMissionInfo {
     fn from(runner: &MissionRunner) -> Self {
         let seconds_since_activity = runner.last_activity.elapsed().as_secs();
+        let tool_subprocess_alive = runner
+            .active_tool_calls
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 0;
         Self {
             mission_id: runner.mission_id,
             state: match runner.state {
@@ -8243,14 +8250,8 @@ impl From<&MissionRunner> for RunningMissionInfo {
             queue_len: runner.queue.len(),
             history_len: runner.history.len(),
             seconds_since_activity,
-            health: running_health(
-                runner.state,
-                seconds_since_activity,
-                runner
-                    .active_tool_calls
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                    > 0,
-            ),
+            tool_subprocess_alive,
+            health: running_health(runner.state, seconds_since_activity, tool_subprocess_alive),
             expected_deliverables: runner.deliverables.deliverables.len(),
             current_activity: runner.current_activity.clone(),
             subtask_total: runner.subtasks.len(),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2431,6 +2431,11 @@ pub enum MissionRunState {
 
 const STALL_WARN_SECS: u64 = 120;
 const STALL_SEVERE_SECS: u64 = 300;
+/// An unmatched ToolCall is only evidence that a tool *may* still be running.
+/// Some harnesses omit ToolResult events, so this hint must not suppress
+/// severe-stall handling forever. One hour accommodates large local builds
+/// while bounding stale counter damage.
+pub(crate) const TOOL_CALL_STALL_GRACE_SECS: u64 = 3600;
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -2459,26 +2464,24 @@ pub enum MissionHealth {
 
 /// Classify how long a turn has been quiet.
 ///
-/// `tool_subprocess_alive` reports whether the worker is currently inside a
-/// tool call (e.g. `Bash` running `lake build` / `make check`).  Long tool
-/// subprocesses are expected to produce ~zero model tokens for many minutes;
-/// without this signal the watchdog would mark them as Severe-stalled at
-/// 5 minutes and terminate the mission mid-build (issue: workers tripped
-/// killed during honest subprocess work).
+/// `tool_call_in_flight` reports an unmatched harness ToolCall (e.g. `Bash`
+/// running `lake build` / `make check`). Long calls can produce ~zero model
+/// tokens for many minutes. It is a hint rather than OS-process proof because
+/// some harnesses omit ToolResult events, so its protection is time-bounded.
 ///
 /// Rule:
 ///   Severe ⇔ (seconds_since_activity > STALL_SEVERE_SECS)
-///              AND no live tool subprocess.
+///              AND no recent in-flight tool hint.
 ///
 /// When a tool is in flight we degrade Severe to Warning so the operator
 /// still sees the mission is quiet, but the auto-terminate watchdog
 /// (which only fires on Severe) does not interrupt the build.
 fn stall_severity(
     seconds_since_activity: u64,
-    tool_subprocess_alive: bool,
+    tool_call_in_flight: bool,
 ) -> Option<MissionStallSeverity> {
     if seconds_since_activity > STALL_SEVERE_SECS {
-        if tool_subprocess_alive {
+        if tool_call_in_flight && seconds_since_activity < TOOL_CALL_STALL_GRACE_SECS {
             // Long-running tool: keep the user informed via Warning, but
             // do not escalate to Severe (which would trip the watchdog).
             Some(MissionStallSeverity::Warning)
@@ -2495,13 +2498,13 @@ fn stall_severity(
 pub fn running_health(
     state: MissionRunState,
     seconds_since_activity: u64,
-    tool_subprocess_alive: bool,
+    tool_call_in_flight: bool,
 ) -> MissionHealth {
     if matches!(
         state,
         MissionRunState::Running | MissionRunState::WaitingForTool
     ) {
-        if let Some(severity) = stall_severity(seconds_since_activity, tool_subprocess_alive) {
+        if let Some(severity) = stall_severity(seconds_since_activity, tool_call_in_flight) {
             return MissionHealth::Stalled {
                 seconds_since_activity,
                 last_state: format!("{:?}", state),
@@ -8218,9 +8221,9 @@ pub struct RunningMissionInfo {
     pub queue_len: usize,
     pub history_len: usize,
     pub seconds_since_activity: u64,
-    /// A harness tool call is still in flight. Long-running builds can be
-    /// silent at the model-event layer while their subprocess is healthy.
-    pub tool_subprocess_alive: bool,
+    /// The harness emitted a ToolCall without a matching ToolResult yet. This
+    /// is time-bounded stall evidence, not proof that an OS process is alive.
+    pub tool_call_in_flight: bool,
     pub health: MissionHealth,
     pub expected_deliverables: usize,
     /// Current activity label (e.g., "Reading: main.rs")
@@ -8235,7 +8238,7 @@ pub struct RunningMissionInfo {
 impl From<&MissionRunner> for RunningMissionInfo {
     fn from(runner: &MissionRunner) -> Self {
         let seconds_since_activity = runner.last_activity.elapsed().as_secs();
-        let tool_subprocess_alive = runner
+        let tool_call_in_flight = runner
             .active_tool_calls
             .load(std::sync::atomic::Ordering::Relaxed)
             > 0;
@@ -8250,8 +8253,8 @@ impl From<&MissionRunner> for RunningMissionInfo {
             queue_len: runner.queue.len(),
             history_len: runner.history.len(),
             seconds_since_activity,
-            tool_subprocess_alive,
-            health: running_health(runner.state, seconds_since_activity, tool_subprocess_alive),
+            tool_call_in_flight,
+            health: running_health(runner.state, seconds_since_activity, tool_call_in_flight),
             expected_deliverables: runner.deliverables.deliverables.len(),
             current_activity: runner.current_activity.clone(),
             subtask_total: runner.subtasks.len(),
@@ -8439,7 +8442,7 @@ mod tests {
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
         ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
         OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
-        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS, TOOL_CALL_STALL_GRACE_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -10427,11 +10430,17 @@ mod tests {
     }
 
     #[test]
-    fn stall_severity_no_severe_when_tool_alive_even_at_extreme_quiet() {
-        // 30 minutes of silence with a live subprocess (e.g. a long
-        // `make check`) is still classified as Warning, never Severe.
+    fn stall_severity_grants_long_tool_call_a_bounded_warning_window() {
+        // 30 minutes of silence after a ToolCall (e.g. a long `make check`)
+        // remains Warning and does not interrupt a healthy large build.
         let result = stall_severity(STALL_SEVERE_SECS * 6, true).unwrap();
         assert!(matches!(result, MissionStallSeverity::Warning));
+    }
+
+    #[test]
+    fn stall_severity_does_not_trust_unmatched_tool_call_forever() {
+        let result = stall_severity(TOOL_CALL_STALL_GRACE_SECS, true).unwrap();
+        assert!(matches!(result, MissionStallSeverity::Severe));
     }
 
     #[test]

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 use super::control::MissionStatus;
 #[allow(unused_imports)]
 use super::control::*;
+use super::mission_runner::TOOL_CALL_STALL_GRACE_SECS;
 use super::mission_store::MissionStore;
 
 mod bg_autoresume;
@@ -313,8 +314,9 @@ pub(crate) async fn ack_promotion_loop(
     }
 }
 
-fn inactivity_is_cancellable(seconds_since_activity: u64, tool_subprocess_alive: bool) -> bool {
-    seconds_since_activity >= STUCK_SECONDS && !tool_subprocess_alive
+fn inactivity_is_cancellable(seconds_since_activity: u64, tool_call_in_flight: bool) -> bool {
+    seconds_since_activity >= STUCK_SECONDS
+        && (!tool_call_in_flight || seconds_since_activity >= TOOL_CALL_STALL_GRACE_SECS)
 }
 
 pub(crate) async fn stuck_mission_watchdog_loop(
@@ -398,16 +400,14 @@ pub(crate) async fn stuck_mission_watchdog_loop(
             if info.seconds_since_activity < STUCK_SECONDS {
                 continue;
             }
-            if !inactivity_is_cancellable(info.seconds_since_activity, info.tool_subprocess_alive) {
-                // Model events are quiet while a harness tool executes. The
-                // runner tracks the ToolCall/ToolResult pair explicitly, so a
-                // live `lake build` (or any other long command) is progress,
-                // not an idle agent. Command/tool timeouts remain responsible
-                // for genuinely hung subprocesses.
+            if !inactivity_is_cancellable(info.seconds_since_activity, info.tool_call_in_flight) {
+                // Model events are quiet while a harness tool executes. An
+                // unmatched ToolCall protects normal long builds, but only for
+                // a bounded grace because some harnesses omit ToolResult.
                 tracing::debug!(
                     mission_id = %info.mission_id,
                     seconds_since_activity = info.seconds_since_activity,
-                    "Stuck-mission watchdog: skipping mission with a live tool subprocess"
+                    "Stuck-mission watchdog: applying bounded in-flight tool grace"
                 );
                 continue;
             }
@@ -705,5 +705,10 @@ mod tests {
     #[test]
     fn inactivity_watchdog_preserves_live_tool_past_threshold() {
         assert!(!inactivity_is_cancellable(STUCK_SECONDS * 4, true));
+    }
+
+    #[test]
+    fn inactivity_watchdog_eventually_cancels_stale_tool_hint() {
+        assert!(inactivity_is_cancellable(TOOL_CALL_STALL_GRACE_SECS, true));
     }
 }

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -209,6 +209,7 @@ pub(crate) async fn cleanup_stale_active_missions_once(
                 // which is the common case for stale missions, and we
                 // ignore that error.
                 let (tx, rx) = oneshot::channel();
+                let mut cancellation_skipped = false;
                 if cmd_tx
                     .send(ControlCommand::CancelMission {
                         mission_id: mission.id,
@@ -218,7 +219,17 @@ pub(crate) async fn cleanup_stale_active_missions_once(
                     .await
                     .is_ok()
                 {
-                    let _ = rx.await;
+                    cancellation_skipped = matches!(
+                        rx.await,
+                        Ok(Ok(CancelMissionOutcome::SkippedRecentlyActive))
+                    );
+                }
+                if cancellation_skipped {
+                    tracing::info!(
+                        mission_id = %mission.id,
+                        "Stale cleanup: mission resumed activity; leaving it active"
+                    );
+                    continue;
                 }
 
                 if let Err(e) = mission_store
@@ -420,7 +431,7 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 info.seconds_since_activity
             );
             let (cancel_tx, cancel_rx) = oneshot::channel();
-            if cmd_tx
+            let cancelled = if cmd_tx
                 .send(ControlCommand::CancelMission {
                     mission_id: info.mission_id,
                     min_idle: Some(std::time::Duration::from_secs(STUCK_SECONDS)),
@@ -429,7 +440,16 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                 .await
                 .is_ok()
             {
-                let _ = cancel_rx.await;
+                matches!(cancel_rx.await, Ok(Ok(CancelMissionOutcome::Cancelled)))
+            } else {
+                false
+            };
+            if !cancelled {
+                tracing::info!(
+                    mission_id = %info.mission_id,
+                    "Stuck-mission watchdog: cancellation was skipped or not acknowledged"
+                );
+                continue;
             }
             if let Err(e) = mission_store
                 .update_mission_status_with_reason(

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -302,6 +302,10 @@ pub(crate) async fn ack_promotion_loop(
     }
 }
 
+fn inactivity_is_cancellable(seconds_since_activity: u64, tool_subprocess_alive: bool) -> bool {
+    seconds_since_activity >= STUCK_SECONDS && !tool_subprocess_alive
+}
+
 pub(crate) async fn stuck_mission_watchdog_loop(
     mission_store: Arc<dyn MissionStore>,
     cmd_tx: mpsc::Sender<ControlCommand>,
@@ -380,62 +384,76 @@ pub(crate) async fn stuck_mission_watchdog_loop(
         // threshold. Cancel via the actor (clean shutdown) and mark
         // the row Interrupted.
         for info in &running_list {
-            if info.seconds_since_activity >= STUCK_SECONDS {
-                // A mission parked on a frontend tool (e.g. AskUserQuestion) is
-                // intentionally silent: its harness is killed while it awaits a
-                // human answer, so it emits no activity. Do not count that as a
-                // stall — humans routinely take longer than the threshold to
-                // reply. The wait is cleared the moment the answer arrives (or
-                // the mission is cancelled), so this can't pin a dead mission.
-                if tool_hub.is_waiting_for_input(info.mission_id) {
-                    tracing::debug!(
-                        mission_id = %info.mission_id,
-                        seconds_since_activity = info.seconds_since_activity,
-                        "Stuck-mission watchdog: skipping mission blocked on user input"
-                    );
-                    continue;
-                }
-                tracing::warn!(
-                    "Stuck-mission watchdog: cancelling {} after {}s of inactivity",
-                    info.mission_id,
-                    info.seconds_since_activity
-                );
-                let (cancel_tx, cancel_rx) = oneshot::channel();
-                if cmd_tx
-                    .send(ControlCommand::CancelMission {
-                        mission_id: info.mission_id,
-                        min_idle: Some(std::time::Duration::from_secs(STUCK_SECONDS)),
-                        respond: cancel_tx,
-                    })
-                    .await
-                    .is_ok()
-                {
-                    let _ = cancel_rx.await;
-                }
-                if let Err(e) = mission_store
-                    .update_mission_status_with_reason(
-                        info.mission_id,
-                        MissionStatus::Interrupted,
-                        Some("watchdog_stalled"),
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        "Stuck-mission watchdog: status update failed for {}: {}",
-                        info.mission_id,
-                        e
-                    );
-                    continue;
-                }
-                let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                    mission_id: info.mission_id,
-                    status: MissionStatus::Interrupted,
-                    summary: Some(format!(
-                        "Interrupted: no agent activity for {}s (>{}s threshold)",
-                        info.seconds_since_activity, STUCK_SECONDS
-                    )),
-                });
+            if info.seconds_since_activity < STUCK_SECONDS {
+                continue;
             }
+            if !inactivity_is_cancellable(info.seconds_since_activity, info.tool_subprocess_alive) {
+                // Model events are quiet while a harness tool executes. The
+                // runner tracks the ToolCall/ToolResult pair explicitly, so a
+                // live `lake build` (or any other long command) is progress,
+                // not an idle agent. Command/tool timeouts remain responsible
+                // for genuinely hung subprocesses.
+                tracing::debug!(
+                    mission_id = %info.mission_id,
+                    seconds_since_activity = info.seconds_since_activity,
+                    "Stuck-mission watchdog: skipping mission with a live tool subprocess"
+                );
+                continue;
+            }
+            // A mission parked on a frontend tool (e.g. AskUserQuestion) is
+            // intentionally silent: its harness is killed while it awaits a
+            // human answer, so it emits no activity. Do not count that as a
+            // stall — humans routinely take longer than the threshold to
+            // reply. The wait is cleared the moment the answer arrives (or
+            // the mission is cancelled), so this can't pin a dead mission.
+            if tool_hub.is_waiting_for_input(info.mission_id) {
+                tracing::debug!(
+                    mission_id = %info.mission_id,
+                    seconds_since_activity = info.seconds_since_activity,
+                    "Stuck-mission watchdog: skipping mission blocked on user input"
+                );
+                continue;
+            }
+            tracing::warn!(
+                "Stuck-mission watchdog: cancelling {} after {}s of inactivity",
+                info.mission_id,
+                info.seconds_since_activity
+            );
+            let (cancel_tx, cancel_rx) = oneshot::channel();
+            if cmd_tx
+                .send(ControlCommand::CancelMission {
+                    mission_id: info.mission_id,
+                    min_idle: Some(std::time::Duration::from_secs(STUCK_SECONDS)),
+                    respond: cancel_tx,
+                })
+                .await
+                .is_ok()
+            {
+                let _ = cancel_rx.await;
+            }
+            if let Err(e) = mission_store
+                .update_mission_status_with_reason(
+                    info.mission_id,
+                    MissionStatus::Interrupted,
+                    Some("watchdog_stalled"),
+                )
+                .await
+            {
+                tracing::warn!(
+                    "Stuck-mission watchdog: status update failed for {}: {}",
+                    info.mission_id,
+                    e
+                );
+                continue;
+            }
+            let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                mission_id: info.mission_id,
+                status: MissionStatus::Interrupted,
+                summary: Some(format!(
+                    "Interrupted: no agent activity for {}s (>{}s threshold)",
+                    info.seconds_since_activity, STUCK_SECONDS
+                )),
+            });
         }
 
         // Case 2 — Active in DB, not in actor's running list at all.
@@ -652,5 +670,20 @@ pub(crate) async fn stale_mission_cleanup_loop(
     loop {
         tokio::time::sleep(check_interval).await;
         cleanup_stale_active_missions_once(&mission_store, stale_hours, &events_tx, &cmd_tx).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inactivity_watchdog_cancels_idle_runner_at_threshold() {
+        assert!(inactivity_is_cancellable(STUCK_SECONDS, false));
+    }
+
+    #[test]
+    fn inactivity_watchdog_preserves_live_tool_past_threshold() {
+        assert!(!inactivity_is_cancellable(STUCK_SECONDS * 4, true));
     }
 }

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn inactivity_watchdog_preserves_live_tool_past_threshold() {
-        assert!(!inactivity_is_cancellable(STUCK_SECONDS * 4, true));
+        assert!(!inactivity_is_cancellable(STUCK_SECONDS * 2, true));
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -11,8 +11,9 @@
 //! - `checkouts/<sha256(repo)[..16]>/<commit>/` — immutable-ish checkouts
 //! - `caches/elan/` (`ELAN_HOME`), `caches/xdg/` (`XDG_CACHE_HOME`),
 //!   `caches/home/` (`HOME`) — shared toolchain caches
-//! - `caches/lake/<cache_key>/` — lake build cache slots, copied into
-//!   `<build cwd>/.lake` before a build and refreshed after a successful one.
+//! - `caches/lake/<cache_key>/` — dependency-only Lake cache slots, copied into
+//!   `<build cwd>/.lake` before a build and refreshed after a successful one;
+//!   root-project `.lake/build` outputs are never restored across commits.
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -725,6 +726,32 @@ async fn isolated_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Remove a path without following a final symlink. Lake caches are populated
+/// by repository builds, so a malicious or corrupt cache must not make cleanup
+/// escape the cache tree.
+async fn remove_path_if_exists(path: &Path) -> anyhow::Result<()> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        tokio::fs::remove_dir_all(path).await?;
+    } else {
+        tokio::fs::remove_file(path).await?;
+    }
+    Ok(())
+}
+
+/// Restore shared Lake dependencies while discarding root-project outputs.
+/// Root `.lake/build` artifacts are commit-specific; restoring them across
+/// commits can make Lake trust a future-dated stale `.olean` and skip changed
+/// source. Dependency builds under `.lake/packages` remain warm.
+async fn restore_lake_dependency_cache(slot: &Path, lake_dir: &Path) -> anyhow::Result<()> {
+    isolated_copy(slot, lake_dir).await?;
+    remove_path_if_exists(&lake_dir.join("build")).await
+}
+
 // ---------------------------------------------------------------------------
 // Build execution
 // ---------------------------------------------------------------------------
@@ -787,9 +814,10 @@ pub async fn execute_lean_build(
         anyhow::bail!("cwd_rel '{rel_clean}' does not exist in the checkout");
     }
 
-    // Lake cache restore: isolate the slot into `<cwd>/.lake` when the
-    // checkout has no .lake yet. Slot mutation is guarded by a per-key flock
-    // (shared across commits with the same toolchain+manifest).
+    // Lake dependency-cache restore: isolate the slot into `<cwd>/.lake` when
+    // the checkout has no .lake yet, then discard root-project build outputs.
+    // Slot mutation is guarded by a per-key flock (shared across commits with
+    // the same toolchain+manifest).
     let effective_cache_key = cache_key
         .clone()
         .filter(|key| !key.trim().is_empty())
@@ -800,7 +828,7 @@ pub async fn execute_lean_build(
         let lake_dir = build_cwd.join(".lake");
         if !lake_dir.exists() && slot.is_dir() {
             let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
-            if let Err(err) = isolated_copy(&slot, &lake_dir).await {
+            if let Err(err) = restore_lake_dependency_cache(&slot, &lake_dir).await {
                 tracing::warn!("lake cache restore failed (continuing cold): {err}");
                 let _ = tokio::fs::remove_dir_all(&lake_dir).await;
             }
@@ -870,6 +898,10 @@ async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> a
     let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
     if let Err(err) = isolated_copy(lake_dir, &tmp).await {
+        let _ = tokio::fs::remove_dir_all(&tmp).await;
+        return Err(err);
+    }
+    if let Err(err) = remove_path_if_exists(&tmp.join("build")).await {
         let _ = tokio::fs::remove_dir_all(&tmp).await;
         return Err(err);
     }
@@ -1535,6 +1567,83 @@ mod tests {
         assert_eq!(
             tokio::fs::read(slot.join("cache.bin")).await.unwrap(),
             b"shared"
+        );
+    }
+
+    #[tokio::test]
+    async fn lake_cache_restore_keeps_dependencies_but_drops_root_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("slot");
+        let restored = dir.path().join("restored");
+        std::fs::create_dir_all(slot.join("build/lib/lean")).unwrap();
+        std::fs::create_dir_all(slot.join("packages/mathlib/.lake/build/lib/lean")).unwrap();
+        std::fs::write(slot.join("build/lib/lean/Root.olean"), b"stale").unwrap();
+        std::fs::write(
+            slot.join("packages/mathlib/.lake/build/lib/lean/Mathlib.olean"),
+            b"dependency",
+        )
+        .unwrap();
+
+        restore_lake_dependency_cache(&slot, &restored)
+            .await
+            .unwrap();
+
+        assert!(!restored.join("build").exists());
+        assert_eq!(
+            tokio::fs::read(restored.join("packages/mathlib/.lake/build/lib/lean/Mathlib.olean"))
+                .await
+                .unwrap(),
+            b"dependency"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn lake_cache_restore_unlinks_root_build_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let slot = dir.path().join("slot");
+        let restored = dir.path().join("restored");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&slot).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("keep"), b"safe").unwrap();
+        symlink(&outside, slot.join("build")).unwrap();
+
+        restore_lake_dependency_cache(&slot, &restored)
+            .await
+            .unwrap();
+
+        assert!(!restored.join("build").exists());
+        assert_eq!(std::fs::read(outside.join("keep")).unwrap(), b"safe");
+    }
+
+    #[tokio::test]
+    async fn lake_cache_sync_does_not_persist_root_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let work_root = dir.path().join("work");
+        let lake_dir = dir.path().join("lake");
+        std::fs::create_dir_all(lake_dir.join("build/lib/lean")).unwrap();
+        std::fs::create_dir_all(lake_dir.join("packages/mathlib/.lake/build/lib/lean")).unwrap();
+        std::fs::write(lake_dir.join("build/lib/lean/Root.olean"), b"root").unwrap();
+        std::fs::write(
+            lake_dir.join("packages/mathlib/.lake/build/lib/lean/Mathlib.olean"),
+            b"dependency",
+        )
+        .unwrap();
+
+        sync_lake_cache_back(&work_root, "test-key", &lake_dir)
+            .await
+            .unwrap();
+
+        let slot = lake_cache_slot(&work_root, "test-key");
+        assert!(!slot.join("build").exists());
+        assert_eq!(
+            tokio::fs::read(slot.join("packages/mathlib/.lake/build/lib/lean/Mathlib.olean"))
+                .await
+                .unwrap(),
+            b"dependency"
         );
     }
 

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -385,11 +385,17 @@ fn configured_lake_cache_paths(build_cwd: &Path) -> Option<(PathBuf, PathBuf)> {
             .and_then(serde_json::Value::as_str)
             .unwrap_or(".lake/packages"),
     );
+    // Lake 4.24's manifest normally records lakeDir/packagesDir but does not
+    // record the root package's buildDir.  Falling back to `.lake/build` is
+    // unsafe: a dynamic lakefile can put root outputs below packagesDir, and
+    // sync-back would then persist those outputs across commits.  Cache only
+    // when a producer has explicitly recorded buildDir in the manifest.  This
+    // deliberately turns an unknown layout into a cold build until the node
+    // can query Lake's evaluated package configuration safely.
     let build_rel = Path::new(
         manifest
             .get("buildDir")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or(".lake/build"),
+            .and_then(serde_json::Value::as_str)?,
     );
     let is_clean_relative = |path: &Path| {
         !path.as_os_str().is_empty()
@@ -1747,7 +1753,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("lake-manifest.json"),
-            br#"{"lakeDir":".lake","packagesDir":".lake/deps"}"#,
+            br#"{"lakeDir":".lake","packagesDir":".lake/deps","buildDir":".lake/build"}"#,
         )
         .unwrap();
 
@@ -1756,6 +1762,7 @@ mod tests {
         assert_eq!(packages_dir, dir.path().join(".lake/deps"));
 
         for manifest in [
+            br#"{"lakeDir":".lake","packagesDir":".lake/deps"}"#.as_slice(),
             br#"{"lakeDir":".lake","packagesDir":"../deps"}"#.as_slice(),
             br#"{"lakeDir":".lake","packagesDir":"deps"}"#.as_slice(),
             br#"{"lakeDir":".lake","packagesDir":".lake"}"#.as_slice(),

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -784,6 +784,36 @@ async fn require_real_directory(path: &Path, label: &str) -> anyhow::Result<bool
     Ok(true)
 }
 
+/// Validate every component of a directory path below a trusted lexical root.
+/// Checking only the final path follows symlinked parents such as
+/// `.lake/nested -> /outside`, which would let cache sync read outside Lake.
+async fn require_real_directory_tree(
+    root: &Path,
+    path: &Path,
+    label: &str,
+) -> anyhow::Result<bool> {
+    if path == root || !path.starts_with(root) {
+        anyhow::bail!("{label} must be below {}", root.display());
+    }
+    if !require_real_directory(root, label).await? {
+        return Ok(false);
+    }
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|_| anyhow::anyhow!("{label} must be below {}", root.display()))?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(part) = component else {
+            anyhow::bail!("{label} contains an invalid path component");
+        };
+        current.push(part);
+        if !require_real_directory(&current, label).await? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 /// Restore only shared Lake dependencies. Every other top-level `.lake` entry
 /// belongs to the root project and is commit-specific (including custom Lake
 /// `buildDir` values), so copying the whole directory can make Lake trust a
@@ -975,13 +1005,7 @@ async fn sync_lake_cache_back(
     lake_dir: &Path,
     packages_dir: &Path,
 ) -> anyhow::Result<()> {
-    if !require_real_directory(lake_dir, "project .lake").await? {
-        return Ok(());
-    }
-    if packages_dir == lake_dir || !packages_dir.starts_with(lake_dir) {
-        anyhow::bail!("configured packages directory must be below lake directory");
-    }
-    if !require_real_directory(packages_dir, "project Lake packages").await? {
+    if !require_real_directory_tree(lake_dir, packages_dir, "project Lake packages").await? {
         return Ok(());
     }
     let slot = lake_cache_slot(work_root, key);
@@ -1787,6 +1811,30 @@ mod tests {
 
         assert!(error.to_string().contains("must not be a symlink"));
         assert_eq!(std::fs::read(outside.join("build/keep")).unwrap(), b"safe");
+        assert!(!lake_cache_slot(&work_root, "test-key").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn lake_cache_sync_rejects_symlinked_packages_parent() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let work_root = dir.path().join("work");
+        let lake_dir = dir.path().join("lake");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&lake_dir).unwrap();
+        std::fs::create_dir_all(outside.join("deps")).unwrap();
+        std::fs::write(outside.join("deps/keep"), b"safe").unwrap();
+        symlink(&outside, lake_dir.join("nested")).unwrap();
+        let packages_dir = lake_dir.join("nested/deps");
+
+        let error = sync_lake_cache_back(&work_root, "test-key", &lake_dir, &packages_dir)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("must not be a symlink"));
+        assert_eq!(std::fs::read(outside.join("deps/keep")).unwrap(), b"safe");
         assert!(!lake_cache_slot(&work_root, "test-key").exists());
     }
 

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -11,9 +11,9 @@
 //! - `checkouts/<sha256(repo)[..16]>/<commit>/` — immutable-ish checkouts
 //! - `caches/elan/` (`ELAN_HOME`), `caches/xdg/` (`XDG_CACHE_HOME`),
 //!   `caches/home/` (`HOME`) — shared toolchain caches
-//! - `caches/lake/<cache_key>/` — dependency-only Lake cache slots, copied into
-//!   `<build cwd>/.lake` before a build and refreshed after a successful one;
-//!   root-project `.lake/build` outputs are never restored across commits.
+//! - `caches/lake/<cache_key>/packages/` — dependency-only Lake cache slots,
+//!   copied into `<build cwd>/.lake/packages` before a build and refreshed
+//!   after a successful one; root-project `.lake` outputs are never shared.
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -726,23 +726,6 @@ async fn isolated_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Remove a path without following a final symlink. Lake caches are populated
-/// by repository builds, so a malicious or corrupt cache must not make cleanup
-/// escape the cache tree.
-async fn remove_path_if_exists(path: &Path) -> anyhow::Result<()> {
-    let metadata = match tokio::fs::symlink_metadata(path).await {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error.into()),
-    };
-    if metadata.is_dir() && !metadata.file_type().is_symlink() {
-        tokio::fs::remove_dir_all(path).await?;
-    } else {
-        tokio::fs::remove_file(path).await?;
-    }
-    Ok(())
-}
-
 /// Require a cache root to be a real directory, not a symlink. Checking only
 /// `Path::is_dir` follows symlinks; a repository-controlled `.lake` symlink
 /// would then let later cleanup resolve `build` outside the checkout/cache.
@@ -761,16 +744,32 @@ async fn require_real_directory(path: &Path, label: &str) -> anyhow::Result<bool
     Ok(true)
 }
 
-/// Restore shared Lake dependencies while discarding root-project outputs.
-/// Root `.lake/build` artifacts are commit-specific; restoring them across
-/// commits can make Lake trust a future-dated stale `.olean` and skip changed
-/// source. Dependency builds under `.lake/packages` remain warm.
+/// Restore only shared Lake dependencies. Every other top-level `.lake` entry
+/// belongs to the root project and is commit-specific (including custom Lake
+/// `buildDir` values), so copying the whole directory can make Lake trust a
+/// stale `.olean` and skip changed source.
 async fn restore_lake_dependency_cache(slot: &Path, lake_dir: &Path) -> anyhow::Result<()> {
     if !require_real_directory(slot, "lake cache slot").await? {
         return Ok(());
     }
-    isolated_copy(slot, lake_dir).await?;
-    remove_path_if_exists(&lake_dir.join("build")).await
+    let packages = slot.join("packages");
+    if !require_real_directory(&packages, "lake cache packages").await? {
+        return Ok(());
+    }
+    match tokio::fs::symlink_metadata(lake_dir).await {
+        Ok(_) => anyhow::bail!(
+            "lake cache restore destination already exists: {}",
+            lake_dir.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    tokio::fs::create_dir_all(lake_dir).await?;
+    if let Err(error) = isolated_copy(&packages, &lake_dir.join("packages")).await {
+        let _ = tokio::fs::remove_dir_all(lake_dir).await;
+        return Err(error);
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -835,8 +834,8 @@ pub async fn execute_lean_build(
         anyhow::bail!("cwd_rel '{rel_clean}' does not exist in the checkout");
     }
 
-    // Lake dependency-cache restore: isolate the slot into `<cwd>/.lake` when
-    // the checkout has no .lake yet, then discard root-project build outputs.
+    // Lake dependency-cache restore: copy only the slot's packages into
+    // `<cwd>/.lake/packages` when the checkout has no .lake yet.
     // Slot mutation is guarded by a per-key flock (shared across commits with
     // the same toolchain+manifest).
     let effective_cache_key = cache_key
@@ -847,11 +846,13 @@ pub async fn execute_lean_build(
     if let Some(key) = effective_cache_key.as_deref() {
         let slot = lake_cache_slot(work_root, key);
         let lake_dir = build_cwd.join(".lake");
-        if !lake_dir.exists() && slot.is_dir() {
+        let lake_dir_is_absent = tokio::fs::symlink_metadata(&lake_dir)
+            .await
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound);
+        if lake_dir_is_absent && slot.is_dir() {
             let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
             if let Err(err) = restore_lake_dependency_cache(&slot, &lake_dir).await {
                 tracing::warn!("lake cache restore failed (continuing cold): {err}");
-                let _ = tokio::fs::remove_dir_all(&lake_dir).await;
             }
         }
     }
@@ -906,9 +907,13 @@ pub async fn execute_lean_build(
     })
 }
 
-/// Replace the lake cache slot for `key` with the contents of `lake_dir`.
+/// Replace the Lake cache slot for `key` with dependency packages only.
 async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> anyhow::Result<()> {
     if !require_real_directory(lake_dir, "project .lake").await? {
+        return Ok(());
+    }
+    let packages = lake_dir.join("packages");
+    if !require_real_directory(&packages, "project .lake/packages").await? {
         return Ok(());
     }
     let slot = lake_cache_slot(work_root, key);
@@ -918,11 +923,8 @@ async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> a
     tokio::fs::create_dir_all(parent).await?;
     let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
-    if let Err(err) = isolated_copy(lake_dir, &tmp).await {
-        let _ = tokio::fs::remove_dir_all(&tmp).await;
-        return Err(err);
-    }
-    if let Err(err) = remove_path_if_exists(&tmp.join("build")).await {
+    tokio::fs::create_dir_all(&tmp).await?;
+    if let Err(err) = isolated_copy(&packages, &tmp.join("packages")).await {
         let _ = tokio::fs::remove_dir_all(&tmp).await;
         return Err(err);
     }
@@ -1620,7 +1622,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn lake_cache_restore_unlinks_root_build_symlink_without_following_it() {
+    async fn lake_cache_restore_ignores_root_build_symlink_without_following_it() {
         use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().unwrap();
@@ -1668,8 +1670,14 @@ mod tests {
         let work_root = dir.path().join("work");
         let lake_dir = dir.path().join("lake");
         std::fs::create_dir_all(lake_dir.join("build/lib/lean")).unwrap();
+        std::fs::create_dir_all(lake_dir.join("custom-root/lib/lean")).unwrap();
         std::fs::create_dir_all(lake_dir.join("packages/mathlib/.lake/build/lib/lean")).unwrap();
         std::fs::write(lake_dir.join("build/lib/lean/Root.olean"), b"root").unwrap();
+        std::fs::write(
+            lake_dir.join("custom-root/lib/lean/CustomRoot.olean"),
+            b"custom-root",
+        )
+        .unwrap();
         std::fs::write(
             lake_dir.join("packages/mathlib/.lake/build/lib/lean/Mathlib.olean"),
             b"dependency",
@@ -1682,6 +1690,7 @@ mod tests {
 
         let slot = lake_cache_slot(&work_root, "test-key");
         assert!(!slot.join("build").exists());
+        assert!(!slot.join("custom-root").exists());
         assert_eq!(
             tokio::fs::read(slot.join("packages/mathlib/.lake/build/lib/lean/Mathlib.olean"))
                 .await

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -385,6 +385,12 @@ fn configured_lake_cache_paths(build_cwd: &Path) -> Option<(PathBuf, PathBuf)> {
             .and_then(serde_json::Value::as_str)
             .unwrap_or(".lake/packages"),
     );
+    let build_rel = Path::new(
+        manifest
+            .get("buildDir")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(".lake/build"),
+    );
     let is_clean_relative = |path: &Path| {
         !path.as_os_str().is_empty()
             && !path.is_absolute()
@@ -392,11 +398,20 @@ fn configured_lake_cache_paths(build_cwd: &Path) -> Option<(PathBuf, PathBuf)> {
                 .components()
                 .all(|component| matches!(component, Component::Normal(_)))
     };
-    if !is_clean_relative(lake_rel) || !is_clean_relative(packages_rel) {
+    if !is_clean_relative(lake_rel)
+        || !is_clean_relative(packages_rel)
+        || !is_clean_relative(build_rel)
+    {
         return None;
     }
     let package_suffix = packages_rel.strip_prefix(lake_rel).ok()?;
     if package_suffix.as_os_str().is_empty() {
+        return None;
+    }
+    // Lake's root build directory is commit-specific. If a manifest (or a
+    // future manifest version) points the dependency tree at the same path or
+    // an ancestor/descendant, caching it would persist root `.olean` files.
+    if packages_rel.starts_with(build_rel) || build_rel.starts_with(packages_rel) {
         return None;
     }
     Some((build_cwd.join(lake_rel), build_cwd.join(packages_rel)))
@@ -1745,6 +1760,10 @@ mod tests {
             br#"{"lakeDir":".lake","packagesDir":"deps"}"#.as_slice(),
             br#"{"lakeDir":".lake","packagesDir":".lake"}"#.as_slice(),
             br#"{"lakeDir":"/tmp/lake","packagesDir":"/tmp/lake/deps"}"#.as_slice(),
+            br#"{"lakeDir":".lake","packagesDir":".lake/build"}"#.as_slice(),
+            br#"{"lakeDir":".lake","packagesDir":".lake/build/deps"}"#.as_slice(),
+            br#"{"lakeDir":".lake","packagesDir":".lake/deps","buildDir":".lake/deps/root"}"#
+                .as_slice(),
         ] {
             std::fs::write(dir.path().join("lake-manifest.json"), manifest).unwrap();
             assert!(configured_lake_cache_paths(dir.path()).is_none());

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -743,11 +743,32 @@ async fn remove_path_if_exists(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Require a cache root to be a real directory, not a symlink. Checking only
+/// `Path::is_dir` follows symlinks; a repository-controlled `.lake` symlink
+/// would then let later cleanup resolve `build` outside the checkout/cache.
+async fn require_real_directory(path: &Path, label: &str) -> anyhow::Result<bool> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        anyhow::bail!("{label} must not be a symlink: {}", path.display());
+    }
+    if !metadata.is_dir() {
+        anyhow::bail!("{label} is not a directory: {}", path.display());
+    }
+    Ok(true)
+}
+
 /// Restore shared Lake dependencies while discarding root-project outputs.
 /// Root `.lake/build` artifacts are commit-specific; restoring them across
 /// commits can make Lake trust a future-dated stale `.olean` and skip changed
 /// source. Dependency builds under `.lake/packages` remain warm.
 async fn restore_lake_dependency_cache(slot: &Path, lake_dir: &Path) -> anyhow::Result<()> {
+    if !require_real_directory(slot, "lake cache slot").await? {
+        return Ok(());
+    }
     isolated_copy(slot, lake_dir).await?;
     remove_path_if_exists(&lake_dir.join("build")).await
 }
@@ -887,7 +908,7 @@ pub async fn execute_lean_build(
 
 /// Replace the lake cache slot for `key` with the contents of `lake_dir`.
 async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> anyhow::Result<()> {
-    if !lake_dir.is_dir() {
+    if !require_real_directory(lake_dir, "project .lake").await? {
         return Ok(());
     }
     let slot = lake_cache_slot(work_root, key);
@@ -1617,6 +1638,28 @@ mod tests {
 
         assert!(!restored.join("build").exists());
         assert_eq!(std::fs::read(outside.join("keep")).unwrap(), b"safe");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn lake_cache_sync_rejects_symlinked_lake_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let work_root = dir.path().join("work");
+        let lake_dir = dir.path().join("lake-link");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(outside.join("build")).unwrap();
+        std::fs::write(outside.join("build/keep"), b"safe").unwrap();
+        symlink(&outside, &lake_dir).unwrap();
+
+        let error = sync_lake_cache_back(&work_root, "test-key", &lake_dir)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("must not be a symlink"));
+        assert_eq!(std::fs::read(outside.join("build/keep")).unwrap(), b"safe");
+        assert!(!lake_cache_slot(&work_root, "test-key").exists());
     }
 
     #[tokio::test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -11,13 +11,13 @@
 //! - `checkouts/<sha256(repo)[..16]>/<commit>/` — immutable-ish checkouts
 //! - `caches/elan/` (`ELAN_HOME`), `caches/xdg/` (`XDG_CACHE_HOME`),
 //!   `caches/home/` (`HOME`) — shared toolchain caches
-//! - `caches/lake/<cache_key>/packages/` — dependency-only Lake cache slots,
-//!   copied into `<build cwd>/.lake/packages` before a build and refreshed
-//!   after a successful one; root-project `.lake` outputs are never shared.
+//! - `caches/lake/<cache_key>/packages/` — normalized dependency-only Lake
+//!   cache slots, copied into the manifest's configured `packagesDir` before a
+//!   build and refreshed after success; root-project outputs are never shared.
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use fs2::FileExt;
@@ -360,6 +360,46 @@ pub fn derive_cache_key(build_cwd: &Path) -> Option<String> {
         hasher.update(bytes);
     }
     Some(hex::encode(hasher.finalize()))
+}
+
+/// Resolve Lake's configured dependency directory from the manifest without
+/// executing repository code. Both paths must be clean, relative, and the
+/// packages directory must remain below Lake's own directory so cache I/O
+/// cannot escape into root-project or host paths.
+fn configured_lake_cache_paths(build_cwd: &Path) -> Option<(PathBuf, PathBuf)> {
+    let manifest_path = build_cwd.join("lake-manifest.json");
+    let manifest = match std::fs::read(&manifest_path) {
+        Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes).ok()?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::Value::Null,
+        Err(_) => return None,
+    };
+    let lake_rel = Path::new(
+        manifest
+            .get("lakeDir")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(".lake"),
+    );
+    let packages_rel = Path::new(
+        manifest
+            .get("packagesDir")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(".lake/packages"),
+    );
+    let is_clean_relative = |path: &Path| {
+        !path.as_os_str().is_empty()
+            && !path.is_absolute()
+            && path
+                .components()
+                .all(|component| matches!(component, Component::Normal(_)))
+    };
+    if !is_clean_relative(lake_rel) || !is_clean_relative(packages_rel) {
+        return None;
+    }
+    let package_suffix = packages_rel.strip_prefix(lake_rel).ok()?;
+    if package_suffix.as_os_str().is_empty() {
+        return None;
+    }
+    Some((build_cwd.join(lake_rel), build_cwd.join(packages_rel)))
 }
 
 /// Namespace a dependency cache key by the project and requested build. A
@@ -748,7 +788,11 @@ async fn require_real_directory(path: &Path, label: &str) -> anyhow::Result<bool
 /// belongs to the root project and is commit-specific (including custom Lake
 /// `buildDir` values), so copying the whole directory can make Lake trust a
 /// stale `.olean` and skip changed source.
-async fn restore_lake_dependency_cache(slot: &Path, lake_dir: &Path) -> anyhow::Result<()> {
+async fn restore_lake_dependency_cache(
+    slot: &Path,
+    lake_dir: &Path,
+    packages_dir: &Path,
+) -> anyhow::Result<()> {
     if !require_real_directory(slot, "lake cache slot").await? {
         return Ok(());
     }
@@ -764,8 +808,14 @@ async fn restore_lake_dependency_cache(slot: &Path, lake_dir: &Path) -> anyhow::
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),
     }
-    tokio::fs::create_dir_all(lake_dir).await?;
-    if let Err(error) = isolated_copy(&packages, &lake_dir.join("packages")).await {
+    let Some(packages_parent) = packages_dir.parent() else {
+        anyhow::bail!("configured packages directory has no parent");
+    };
+    if packages_dir == lake_dir || !packages_dir.starts_with(lake_dir) {
+        anyhow::bail!("configured packages directory must be below lake directory");
+    }
+    tokio::fs::create_dir_all(packages_parent).await?;
+    if let Err(error) = isolated_copy(&packages, packages_dir).await {
         let _ = tokio::fs::remove_dir_all(lake_dir).await;
         return Err(error);
     }
@@ -834,8 +884,8 @@ pub async fn execute_lean_build(
         anyhow::bail!("cwd_rel '{rel_clean}' does not exist in the checkout");
     }
 
-    // Lake dependency-cache restore: copy only the slot's packages into
-    // `<cwd>/.lake/packages` when the checkout has no .lake yet.
+    // Lake dependency-cache restore: copy only the slot's packages into the
+    // manifest's configured packagesDir when the checkout has no lakeDir yet.
     // Slot mutation is guarded by a per-key flock (shared across commits with
     // the same toolchain+manifest).
     let effective_cache_key = cache_key
@@ -845,15 +895,20 @@ pub async fn execute_lean_build(
         .map(|key| project_cache_key(&key, source, rel_clean, command));
     if let Some(key) = effective_cache_key.as_deref() {
         let slot = lake_cache_slot(work_root, key);
-        let lake_dir = build_cwd.join(".lake");
-        let lake_dir_is_absent = tokio::fs::symlink_metadata(&lake_dir)
-            .await
-            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound);
-        if lake_dir_is_absent && slot.is_dir() {
-            let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
-            if let Err(err) = restore_lake_dependency_cache(&slot, &lake_dir).await {
-                tracing::warn!("lake cache restore failed (continuing cold): {err}");
+        if let Some((lake_dir, packages_dir)) = configured_lake_cache_paths(&build_cwd) {
+            let lake_dir_is_absent = tokio::fs::symlink_metadata(&lake_dir)
+                .await
+                .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound);
+            if lake_dir_is_absent && slot.is_dir() {
+                let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
+                if let Err(err) =
+                    restore_lake_dependency_cache(&slot, &lake_dir, &packages_dir).await
+                {
+                    tracing::warn!("lake cache restore failed (continuing cold): {err}");
+                }
             }
+        } else {
+            tracing::warn!("lake cache restore skipped: invalid lakeDir/packagesDir");
         }
     }
 
@@ -886,8 +941,14 @@ pub async fn execute_lean_build(
         // Sync the lake cache back: copy into a tmp slot, then swap
         // it in under the per-key flock so readers never see a partial slot.
         if let Some(key) = effective_cache_key.as_deref() {
-            if let Err(err) = sync_lake_cache_back(work_root, key, &build_cwd.join(".lake")).await {
-                tracing::warn!("lake cache sync-back failed: {err}");
+            if let Some((lake_dir, packages_dir)) = configured_lake_cache_paths(&build_cwd) {
+                if let Err(err) =
+                    sync_lake_cache_back(work_root, key, &lake_dir, &packages_dir).await
+                {
+                    tracing::warn!("lake cache sync-back failed: {err}");
+                }
+            } else {
+                tracing::warn!("lake cache sync-back skipped: invalid lakeDir/packagesDir");
             }
         }
         if !artifacts.is_empty() {
@@ -908,12 +969,19 @@ pub async fn execute_lean_build(
 }
 
 /// Replace the Lake cache slot for `key` with dependency packages only.
-async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> anyhow::Result<()> {
+async fn sync_lake_cache_back(
+    work_root: &Path,
+    key: &str,
+    lake_dir: &Path,
+    packages_dir: &Path,
+) -> anyhow::Result<()> {
     if !require_real_directory(lake_dir, "project .lake").await? {
         return Ok(());
     }
-    let packages = lake_dir.join("packages");
-    if !require_real_directory(&packages, "project .lake/packages").await? {
+    if packages_dir == lake_dir || !packages_dir.starts_with(lake_dir) {
+        anyhow::bail!("configured packages directory must be below lake directory");
+    }
+    if !require_real_directory(packages_dir, "project Lake packages").await? {
         return Ok(());
     }
     let slot = lake_cache_slot(work_root, key);
@@ -924,7 +992,7 @@ async fn sync_lake_cache_back(work_root: &Path, key: &str, lake_dir: &Path) -> a
     let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&tmp).await?;
-    if let Err(err) = isolated_copy(&packages, &tmp.join("packages")).await {
+    if let Err(err) = isolated_copy(packages_dir, &tmp.join("packages")).await {
         let _ = tokio::fs::remove_dir_all(&tmp).await;
         return Err(err);
     }
@@ -1593,6 +1661,59 @@ mod tests {
         );
     }
 
+    #[test]
+    fn lake_cache_paths_follow_manifest_packages_dir_and_reject_escapes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("lake-manifest.json"),
+            br#"{"lakeDir":".lake","packagesDir":".lake/deps"}"#,
+        )
+        .unwrap();
+
+        let (lake_dir, packages_dir) = configured_lake_cache_paths(dir.path()).unwrap();
+        assert_eq!(lake_dir, dir.path().join(".lake"));
+        assert_eq!(packages_dir, dir.path().join(".lake/deps"));
+
+        for manifest in [
+            br#"{"lakeDir":".lake","packagesDir":"../deps"}"#.as_slice(),
+            br#"{"lakeDir":".lake","packagesDir":"deps"}"#.as_slice(),
+            br#"{"lakeDir":".lake","packagesDir":".lake"}"#.as_slice(),
+            br#"{"lakeDir":"/tmp/lake","packagesDir":"/tmp/lake/deps"}"#.as_slice(),
+        ] {
+            std::fs::write(dir.path().join("lake-manifest.json"), manifest).unwrap();
+            assert!(configured_lake_cache_paths(dir.path()).is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn lake_cache_round_trip_supports_custom_packages_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let work_root = dir.path().join("work");
+        let source_lake = dir.path().join("source/.lake");
+        let source_packages = source_lake.join("deps");
+        std::fs::create_dir_all(source_packages.join("mathlib")).unwrap();
+        std::fs::write(source_packages.join("mathlib/cache.bin"), b"dependency").unwrap();
+
+        sync_lake_cache_back(&work_root, "custom-key", &source_lake, &source_packages)
+            .await
+            .unwrap();
+
+        let restored_lake = dir.path().join("restored/.lake");
+        let restored_packages = restored_lake.join("deps");
+        restore_lake_dependency_cache(
+            &lake_cache_slot(&work_root, "custom-key"),
+            &restored_lake,
+            &restored_packages,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            std::fs::read(restored_packages.join("mathlib/cache.bin")).unwrap(),
+            b"dependency"
+        );
+        assert!(!restored_lake.join("packages").exists());
+    }
+
     #[tokio::test]
     async fn lake_cache_restore_keeps_dependencies_but_drops_root_outputs() {
         let dir = tempfile::tempdir().unwrap();
@@ -1607,7 +1728,7 @@ mod tests {
         )
         .unwrap();
 
-        restore_lake_dependency_cache(&slot, &restored)
+        restore_lake_dependency_cache(&slot, &restored, &restored.join("packages"))
             .await
             .unwrap();
 
@@ -1634,7 +1755,7 @@ mod tests {
         std::fs::write(outside.join("keep"), b"safe").unwrap();
         symlink(&outside, slot.join("build")).unwrap();
 
-        restore_lake_dependency_cache(&slot, &restored)
+        restore_lake_dependency_cache(&slot, &restored, &restored.join("packages"))
             .await
             .unwrap();
 
@@ -1655,9 +1776,14 @@ mod tests {
         std::fs::write(outside.join("build/keep"), b"safe").unwrap();
         symlink(&outside, &lake_dir).unwrap();
 
-        let error = sync_lake_cache_back(&work_root, "test-key", &lake_dir)
-            .await
-            .unwrap_err();
+        let error = sync_lake_cache_back(
+            &work_root,
+            "test-key",
+            &lake_dir,
+            &lake_dir.join("packages"),
+        )
+        .await
+        .unwrap_err();
 
         assert!(error.to_string().contains("must not be a symlink"));
         assert_eq!(std::fs::read(outside.join("build/keep")).unwrap(), b"safe");
@@ -1684,9 +1810,14 @@ mod tests {
         )
         .unwrap();
 
-        sync_lake_cache_back(&work_root, "test-key", &lake_dir)
-            .await
-            .unwrap();
+        sync_lake_cache_back(
+            &work_root,
+            "test-key",
+            &lake_dir,
+            &lake_dir.join("packages"),
+        )
+        .await
+        .unwrap();
 
         let slot = lake_cache_slot(&work_root, "test-key");
         assert!(!slot.join("build").exists());

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -814,12 +814,49 @@ async fn require_real_directory_tree(
     Ok(true)
 }
 
+/// Before creating a cache destination, require every existing ancestor below
+/// the checkout root to be a real directory. Once a component is absent, all
+/// deeper components are necessarily absent too and may be created safely.
+async fn require_safe_directory_creation_path(
+    root: &Path,
+    path: &Path,
+    label: &str,
+) -> anyhow::Result<()> {
+    if path == root || !path.starts_with(root) {
+        anyhow::bail!("{label} must be below {}", root.display());
+    }
+    if !require_real_directory(root, label).await? {
+        anyhow::bail!("{label} root does not exist: {}", root.display());
+    }
+    let relative = path
+        .strip_prefix(root)
+        .map_err(|_| anyhow::anyhow!("{label} must be below {}", root.display()))?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(part) = component else {
+            anyhow::bail!("{label} contains an invalid path component");
+        };
+        current.push(part);
+        match tokio::fs::symlink_metadata(&current).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!("{label} must not contain a symlink: {}", current.display());
+            }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => anyhow::bail!("{label} is not a directory: {}", current.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
 /// Restore only shared Lake dependencies. Every other top-level `.lake` entry
 /// belongs to the root project and is commit-specific (including custom Lake
 /// `buildDir` values), so copying the whole directory can make Lake trust a
 /// stale `.olean` and skip changed source.
 async fn restore_lake_dependency_cache(
     slot: &Path,
+    build_cwd: &Path,
     lake_dir: &Path,
     packages_dir: &Path,
 ) -> anyhow::Result<()> {
@@ -844,6 +881,7 @@ async fn restore_lake_dependency_cache(
     if packages_dir == lake_dir || !packages_dir.starts_with(lake_dir) {
         anyhow::bail!("configured packages directory must be below lake directory");
     }
+    require_safe_directory_creation_path(build_cwd, packages_dir, "Lake cache destination").await?;
     tokio::fs::create_dir_all(packages_parent).await?;
     if let Err(error) = isolated_copy(&packages, packages_dir).await {
         let _ = tokio::fs::remove_dir_all(lake_dir).await;
@@ -932,7 +970,7 @@ pub async fn execute_lean_build(
             if lake_dir_is_absent && slot.is_dir() {
                 let _cache_lock = FileLock::acquire(slot.with_extension("lock")).await?;
                 if let Err(err) =
-                    restore_lake_dependency_cache(&slot, &lake_dir, &packages_dir).await
+                    restore_lake_dependency_cache(&slot, &build_cwd, &lake_dir, &packages_dir).await
                 {
                     tracing::warn!("lake cache restore failed (continuing cold): {err}");
                 }
@@ -973,7 +1011,7 @@ pub async fn execute_lean_build(
         if let Some(key) = effective_cache_key.as_deref() {
             if let Some((lake_dir, packages_dir)) = configured_lake_cache_paths(&build_cwd) {
                 if let Err(err) =
-                    sync_lake_cache_back(work_root, key, &lake_dir, &packages_dir).await
+                    sync_lake_cache_back(work_root, key, &build_cwd, &lake_dir, &packages_dir).await
                 {
                     tracing::warn!("lake cache sync-back failed: {err}");
                 }
@@ -1002,10 +1040,14 @@ pub async fn execute_lean_build(
 async fn sync_lake_cache_back(
     work_root: &Path,
     key: &str,
+    build_cwd: &Path,
     lake_dir: &Path,
     packages_dir: &Path,
 ) -> anyhow::Result<()> {
-    if !require_real_directory_tree(lake_dir, packages_dir, "project Lake packages").await? {
+    if packages_dir == lake_dir || !packages_dir.starts_with(lake_dir) {
+        anyhow::bail!("configured packages directory must be below lake directory");
+    }
+    if !require_real_directory_tree(build_cwd, packages_dir, "project Lake packages").await? {
         return Ok(());
     }
     let slot = lake_cache_slot(work_root, key);
@@ -1718,14 +1760,23 @@ mod tests {
         std::fs::create_dir_all(source_packages.join("mathlib")).unwrap();
         std::fs::write(source_packages.join("mathlib/cache.bin"), b"dependency").unwrap();
 
-        sync_lake_cache_back(&work_root, "custom-key", &source_lake, &source_packages)
-            .await
-            .unwrap();
+        sync_lake_cache_back(
+            &work_root,
+            "custom-key",
+            &dir.path().join("source"),
+            &source_lake,
+            &source_packages,
+        )
+        .await
+        .unwrap();
 
-        let restored_lake = dir.path().join("restored/.lake");
+        let restored_root = dir.path().join("restored");
+        std::fs::create_dir_all(&restored_root).unwrap();
+        let restored_lake = restored_root.join(".lake");
         let restored_packages = restored_lake.join("deps");
         restore_lake_dependency_cache(
             &lake_cache_slot(&work_root, "custom-key"),
+            &restored_root,
             &restored_lake,
             &restored_packages,
         )
@@ -1752,7 +1803,7 @@ mod tests {
         )
         .unwrap();
 
-        restore_lake_dependency_cache(&slot, &restored, &restored.join("packages"))
+        restore_lake_dependency_cache(&slot, dir.path(), &restored, &restored.join("packages"))
             .await
             .unwrap();
 
@@ -1779,12 +1830,38 @@ mod tests {
         std::fs::write(outside.join("keep"), b"safe").unwrap();
         symlink(&outside, slot.join("build")).unwrap();
 
-        restore_lake_dependency_cache(&slot, &restored, &restored.join("packages"))
+        restore_lake_dependency_cache(&slot, dir.path(), &restored, &restored.join("packages"))
             .await
             .unwrap();
 
         assert!(!restored.join("build").exists());
         assert_eq!(std::fs::read(outside.join("keep")).unwrap(), b"safe");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn lake_cache_restore_rejects_symlinked_lake_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let checkout = dir.path().join("checkout");
+        let slot = dir.path().join("slot");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&checkout).unwrap();
+        std::fs::create_dir_all(slot.join("packages/mathlib")).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("keep"), b"safe").unwrap();
+        symlink(&outside, checkout.join("link")).unwrap();
+        let lake_dir = checkout.join("link/.lake");
+        let packages_dir = lake_dir.join("deps");
+
+        let error = restore_lake_dependency_cache(&slot, &checkout, &lake_dir, &packages_dir)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("must not contain a symlink"));
+        assert_eq!(std::fs::read(outside.join("keep")).unwrap(), b"safe");
+        assert!(!outside.join(".lake").exists());
     }
 
     #[cfg(unix)]
@@ -1803,6 +1880,7 @@ mod tests {
         let error = sync_lake_cache_back(
             &work_root,
             "test-key",
+            dir.path(),
             &lake_dir,
             &lake_dir.join("packages"),
         )
@@ -1829,9 +1907,10 @@ mod tests {
         symlink(&outside, lake_dir.join("nested")).unwrap();
         let packages_dir = lake_dir.join("nested/deps");
 
-        let error = sync_lake_cache_back(&work_root, "test-key", &lake_dir, &packages_dir)
-            .await
-            .unwrap_err();
+        let error =
+            sync_lake_cache_back(&work_root, "test-key", dir.path(), &lake_dir, &packages_dir)
+                .await
+                .unwrap_err();
 
         assert!(error.to_string().contains("must not be a symlink"));
         assert_eq!(std::fs::read(outside.join("deps/keep")).unwrap(), b"safe");
@@ -1861,6 +1940,7 @@ mod tests {
         sync_lake_cache_back(
             &work_root,
             "test-key",
+            dir.path(),
             &lake_dir,
             &lake_dir.join("packages"),
         )

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -2,18 +2,17 @@
 //!
 //! A lean-build job carries only a git source (repo + pinned commit), a
 //! constrained argv (`lake build`/`lean`), and artifact patterns. The node
-//! materializes a content-addressed checkout, restores shared elan/lake
-//! caches, runs the build, syncs the lake cache back on success, and records
-//! artifact digests. No workspace sync with core, no shell interpretation of
-//! the payload.
+//! materializes a content-addressed checkout, restores trusted shared runtime
+//! caches, runs the build, and records artifact digests. Lake dependency-cache
+//! plumbing fails closed until the evaluated package layout can be attested.
+//! No workspace sync with core, no shell interpretation of the payload.
 //!
 //! Layout under `SANDBOXED_NODE_WORK_DIR`:
 //! - `checkouts/<sha256(repo)[..16]>/<commit>/` — immutable-ish checkouts
 //! - `caches/elan/` (`ELAN_HOME`), `caches/xdg/` (`XDG_CACHE_HOME`),
 //!   `caches/home/` (`HOME`) — shared toolchain caches
-//! - `caches/lake/<cache_key>/packages/` — normalized dependency-only Lake
-//!   cache slots, copied into the manifest's configured `packagesDir` before a
-//!   build and refreshed after success; root-project outputs are never shared.
+//! - `caches/lake/<cache_key>/packages/` — reserved dependency-only Lake cache
+//!   slots; restore/sync is disabled while package layout is unverified.
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -362,65 +361,17 @@ pub fn derive_cache_key(build_cwd: &Path) -> Option<String> {
     Some(hex::encode(hasher.finalize()))
 }
 
-/// Resolve Lake's configured dependency directory from the manifest without
-/// executing repository code. Both paths must be clean, relative, and the
-/// packages directory must remain below Lake's own directory so cache I/O
-/// cannot escape into root-project or host paths.
-fn configured_lake_cache_paths(build_cwd: &Path) -> Option<(PathBuf, PathBuf)> {
-    let manifest_path = build_cwd.join("lake-manifest.json");
-    let manifest = match std::fs::read(&manifest_path) {
-        Ok(bytes) => serde_json::from_slice::<serde_json::Value>(&bytes).ok()?,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::Value::Null,
-        Err(_) => return None,
-    };
-    let lake_rel = Path::new(
-        manifest
-            .get("lakeDir")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or(".lake"),
-    );
-    let packages_rel = Path::new(
-        manifest
-            .get("packagesDir")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or(".lake/packages"),
-    );
-    // Lake 4.24's manifest normally records lakeDir/packagesDir but does not
-    // record the root package's buildDir.  Falling back to `.lake/build` is
-    // unsafe: a dynamic lakefile can put root outputs below packagesDir, and
-    // sync-back would then persist those outputs across commits.  Cache only
-    // when a producer has explicitly recorded buildDir in the manifest.  This
-    // deliberately turns an unknown layout into a cold build until the node
-    // can query Lake's evaluated package configuration safely.
-    let build_rel = Path::new(
-        manifest
-            .get("buildDir")
-            .and_then(serde_json::Value::as_str)?,
-    );
-    let is_clean_relative = |path: &Path| {
-        !path.as_os_str().is_empty()
-            && !path.is_absolute()
-            && path
-                .components()
-                .all(|component| matches!(component, Component::Normal(_)))
-    };
-    if !is_clean_relative(lake_rel)
-        || !is_clean_relative(packages_rel)
-        || !is_clean_relative(build_rel)
-    {
-        return None;
-    }
-    let package_suffix = packages_rel.strip_prefix(lake_rel).ok()?;
-    if package_suffix.as_os_str().is_empty() {
-        return None;
-    }
-    // Lake's root build directory is commit-specific. If a manifest (or a
-    // future manifest version) points the dependency tree at the same path or
-    // an ancestor/descendant, caching it would persist root `.olean` files.
-    if packages_rel.starts_with(build_rel) || build_rel.starts_with(packages_rel) {
-        return None;
-    }
-    Some((build_cwd.join(lake_rel), build_cwd.join(packages_rel)))
+/// Return dependency-cache paths only after Lake's *evaluated* root package
+/// layout has been attested by the node.
+///
+/// `lake-manifest.json` is repository content and does not authoritatively
+/// describe `buildDir`: a checked-in or stale field can disagree with a
+/// dynamic lakefile. Trusting it could copy root `.olean` files through a
+/// directory presented as `packagesDir`, making a later commit falsely pass.
+/// Until the node has a trusted Lake configuration query, fail closed and keep
+/// these builds cold. Shared Elan/XDG/Home caches remain enabled.
+fn configured_lake_cache_paths(_build_cwd: &Path) -> Option<(PathBuf, PathBuf)> {
+    None
 }
 
 /// Namespace a dependency cache key by the project and requested build. A
@@ -1749,19 +1700,11 @@ mod tests {
     }
 
     #[test]
-    fn lake_cache_paths_follow_manifest_packages_dir_and_reject_escapes() {
+    fn lake_dependency_cache_rejects_unverified_manifest_layouts() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("lake-manifest.json"),
-            br#"{"lakeDir":".lake","packagesDir":".lake/deps","buildDir":".lake/build"}"#,
-        )
-        .unwrap();
-
-        let (lake_dir, packages_dir) = configured_lake_cache_paths(dir.path()).unwrap();
-        assert_eq!(lake_dir, dir.path().join(".lake"));
-        assert_eq!(packages_dir, dir.path().join(".lake/deps"));
-
         for manifest in [
+            br#"{"lakeDir":".lake","packagesDir":".lake/deps","buildDir":".lake/build"}"#
+                .as_slice(),
             br#"{"lakeDir":".lake","packagesDir":".lake/deps"}"#.as_slice(),
             br#"{"lakeDir":".lake","packagesDir":"../deps"}"#.as_slice(),
             br#"{"lakeDir":".lake","packagesDir":"deps"}"#.as_slice(),


### PR DESCRIPTION
## Summary

- prevent remote Lean false-greens by never restoring or persisting root-project Lake outputs across commits
- cache only dependency packages when the manifest explicitly records a clean, non-overlapping root `buildDir`; otherwise prefer a cold exact build
- reject symlinked Lake path components and unsafe/custom path overlaps
- preserve long-running harness tools from the 15-minute mission watchdog, with a bounded one-hour grace for unmatched `ToolCall` events
- make conditional cancellation report whether it actually landed, so watchdog/cleanup races cannot overwrite a mission that resumed
- document the exact remote cache contract

This closes the Verity #2164 incident where direct elaboration failed but a remote build reused stale root `.olean` files and incorrectly exited 0. It also closes the observed watchdog interruption of a healthy `lake build PrintAxioms` after exactly 900 seconds.

## Validation

- `cargo fmt --all --check`
- `cargo test node::lean::tests` (29 tests)
- `cargo test inactivity_watchdog` (3 tests)
- `cargo test stall_severity` (9 tests)
- `cargo clippy --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches remote build correctness (stale `.olean` false greens) and mission watchdog/cancellation logic that can interrupt or mis-label long-running agent work.
> 
> **Overview**
> Remote **Lean** builds no longer restore or persist whole `.lake` trees across commits. Lake dependency-cache copy/sync is refactored toward **packages-only** slots with symlink and path-tree validation, but **restore and sync stay disabled** (`configured_lake_cache_paths` fails closed) until Lake layout can be attested without trusting `lake-manifest.json`. **Elan/XDG/Home** shared caches are unchanged; docs describe this contract.
> 
> Mission **stall detection** treats an unmatched harness **ToolCall** (not OS subprocess proof) as a bounded hint: severe auto-cancel is deferred up to **`TOOL_CALL_STALL_GRACE_SECS` (1h)**, counters reset per turn, and **`tool_call_in_flight`** is exposed on running-mission info. The stuck-mission watchdog and stale cleanup use the same grace and only mark missions **Interrupted** when **`CancelMission` returns `Cancelled`**, not when the actor returns **`SkippedRecentlyActive`** after activity resumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee123564dea0a2e9d6428478dc68f74498ed488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->