### PR TITLE
feat: add autonomous compute placement

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -176,6 +176,11 @@ Gotchas:
 
 - **No central OpenCode server needed**: Missions spawn per-workspace CLI
   processes.
+- **Compute placement is observable**: Hermes/controllers should call
+  `get_compute_fleet` before parallel dispatch. Auto placement preserves idle
+  GPU nodes for inference while ordinary CPU/Lean nodes have immediate slots,
+  then balances by normalized utilization. Only terminal node/job/head receipts
+  prove that work was actually distributed.
 - Agents are loaded from OpenCode built-ins and native `.opencode/agents/*.md` files.
 - Per-workspace execution eliminates host-to-container network issues.
 - For remote workspaces, SSH execution keeps bash/tooling on the remote host.

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -350,12 +350,23 @@ A node is eligible when all of the following hold:
 - `mem_available` ≥ `REMOTE_NODE_MIN_MEM_GB` (default 8)
 - `active_jobs + queued_jobs + active_leases + core reservations < 2 * capacity_total`
 
-Eligible nodes are ranked least-loaded first (ties broken by most available
-memory). When no node qualifies the request **fails closed** with every
+Eligible nodes are ranked by immediate capacity, specialization, and normalized
+utilization. Ordinary CPU/Lean jobs prefer non-GPU nodes while those nodes have
+an immediate slot, preserving GPU runners for inference. A free GPU node is
+still selected before queueing behind a saturated CPU node, and an explicit
+`"gpu"` requirement selects only GPU-capable nodes. Within a tier, lower
+`(active + queued + leases + reservations) / capacity_total` wins, with
+available memory and stable node id as tie-breakers. When no node qualifies the
+request **fails closed** with every
 configured node listed alongside its exclusion reason (offline / missing
 label X / low disk / low memory / busy), e.g.
 `no eligible remote node (babylon: low disk (12 GiB available, 20 GiB
 required); nippur: missing label 'lean')`.
+
+Hermes receives the same live capacity through the assistant MCP
+`get_compute_fleet` tool. Controllers should call it before parallel dispatch,
+then independently verify actual distribution from the returned remote job
+receipts; declared capacity is not placement evidence.
 
 ## POST /api/remote-build
 

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1221,6 +1221,7 @@ mcp_servers:
         - get_mission_events
         - get_mission_health
         - get_mission_diagnostics
+        - get_compute_fleet
         - start_mission
         - send_message_to_mission
         - ask_mission

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -902,6 +902,11 @@ impl AssistantMcp {
                 }),
             },
             ToolDefinition {
+                name: "get_compute_fleet".to_string(),
+                description: "Get a compact live view of sandboxed.sh compute capacity: remote node health, labels, Lean readiness/toolchains, available slots, active/queued jobs, and recent placement receipts. Use this before dispatching parallel compute or choosing a remote validation node. Ordinary CPU/Lean work should prefer non-GPU nodes while they have immediate capacity; request the gpu label only for GPU work.".to_string(),
+                input_schema: json!({"type": "object", "properties": {}}),
+            },
+            ToolDefinition {
                 name: "list_workspaces".to_string(),
                 description: "List sandboxed.sh workspaces so new missions can target the right environment.".to_string(),
                 input_schema: json!({"type": "object", "properties": {}}),
@@ -1432,6 +1437,20 @@ impl AssistantMcp {
             return Err(format!("Failed to cancel mission: {text}"));
         }
         Ok(json!({ "success": true, "cancelled": id.to_string() }))
+    }
+
+    async fn get_compute_fleet(&self) -> Result<Value, String> {
+        let response = self.api_get("/api/remote-nodes").await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("Failed to get compute fleet ({status}): {text}"));
+        }
+        let fleet: Value = response
+            .json()
+            .await
+            .map_err(|error| format!("Failed to parse compute fleet: {error}"))?;
+        Ok(compact_compute_fleet(&fleet))
     }
 
     async fn list_workspaces(&self) -> Result<Value, String> {
@@ -1968,6 +1987,7 @@ impl AssistantMcp {
                     .map_err(|error| format!("Invalid params: {error}"))?;
                 self.cancel_mission(params).await
             }
+            "get_compute_fleet" => self.get_compute_fleet().await,
             "list_workspaces" => self.list_workspaces().await,
             "get_workspace" => {
                 let params: WorkspaceIdParams = serde_json::from_value(arguments)
@@ -2091,6 +2111,78 @@ fn resolve_default_workspace_id(explicit_workspace_id: Option<String>) -> Option
         .or_else(|| std::env::var("HERMES_DEFAULT_WORKSPACE_ID").ok())
         .or_else(|| std::env::var("ASSISTANT_DEFAULT_WORKSPACE_ID").ok())
         .filter(|value| !value.trim().is_empty())
+}
+
+fn compact_compute_fleet(fleet: &Value) -> Value {
+    let nodes = fleet
+        .get("nodes")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let compact_nodes: Vec<Value> = nodes
+        .iter()
+        .map(|node| {
+            json!({
+                "id": node.get("id").cloned().unwrap_or(Value::Null),
+                "status": node.get("status").cloned().unwrap_or(Value::Null),
+                "labels": node.get("labels").cloned().unwrap_or_else(|| json!([])),
+                "capacity_total": node.get("capacity_total").cloned().unwrap_or(Value::Null),
+                "capacity_available": node.get("capacity_available").cloned().unwrap_or(Value::Null),
+                "active_jobs": node.get("active_jobs").cloned().unwrap_or(Value::Null),
+                "queued_jobs": node.get("queued_jobs").cloned().unwrap_or(Value::Null),
+                "cpu_total": node.get("cpu_total").cloned().unwrap_or(Value::Null),
+                "mem_available_bytes": node.get("mem_available_bytes").cloned().unwrap_or(Value::Null),
+                "disk_available_bytes": node.get("disk_available_bytes").cloned().unwrap_or(Value::Null),
+                "cached_toolchains": node.get("cached_toolchains").cloned().unwrap_or_else(|| json!([])),
+                "lean_runtime_ready": node.get("lean_runtime_ready").cloned().unwrap_or(Value::Null),
+                "last_error": node.get("last_error").cloned().unwrap_or(Value::Null),
+            })
+        })
+        .collect();
+
+    let online = nodes
+        .iter()
+        .filter(|node| node.get("status").and_then(Value::as_str) == Some("online"));
+    let online_nodes = online.clone().count();
+    let lean_nodes: Vec<&Value> = online
+        .filter(|node| node.get("lean_runtime_ready").and_then(Value::as_bool) == Some(true))
+        .collect();
+    let lean_slots_total = lean_nodes
+        .iter()
+        .filter_map(|node| node.get("capacity_total").and_then(Value::as_u64))
+        .sum::<u64>();
+    let lean_slots_available = lean_nodes
+        .iter()
+        .filter_map(|node| node.get("capacity_available").and_then(Value::as_u64))
+        .sum::<u64>();
+    let active_jobs = nodes
+        .iter()
+        .filter_map(|node| node.get("active_jobs").and_then(Value::as_u64))
+        .sum::<u64>();
+    let queued_jobs = nodes
+        .iter()
+        .filter_map(|node| node.get("queued_jobs").and_then(Value::as_u64))
+        .sum::<u64>();
+
+    json!({
+        "enabled": fleet.get("enabled").cloned().unwrap_or(Value::Bool(false)),
+        "summary": {
+            "nodes_total": nodes.len(),
+            "nodes_online": online_nodes,
+            "lean_nodes_online": lean_nodes.len(),
+            "lean_slots_total": lean_slots_total,
+            "lean_slots_available": lean_slots_available,
+            "active_remote_jobs": active_jobs,
+            "queued_remote_jobs": queued_jobs,
+        },
+        "placement_policy": {
+            "ordinary_cpu_work": "prefer online non-GPU nodes with immediate capacity, then lowest normalized utilization",
+            "gpu_work": "request the gpu label explicitly",
+            "parallel_clean_builds": "use distinct missions and verify distinct node/job/head receipts",
+        },
+        "nodes": compact_nodes,
+        "recent_jobs": fleet.get("recent_jobs").cloned().unwrap_or_else(|| json!([])),
+    })
 }
 
 fn compact_mission_summary(mission: Value) -> Value {
@@ -2830,6 +2922,7 @@ mod tests {
     fn workspace_management_tools_are_exposed_with_destructive_confirmations() {
         let tools = AssistantMcp::tools();
         let names: Vec<_> = tools.iter().map(|tool| tool.name.as_str()).collect();
+        assert!(names.contains(&"get_compute_fleet"));
         for expected in [
             "get_workspace",
             "create_workspace",
@@ -2859,6 +2952,50 @@ mod tests {
                 .unwrap()
                 .contains(&json!("confirm")));
         }
+    }
+
+    #[test]
+    fn compute_fleet_summary_is_compact_and_capacity_aware() {
+        let raw = json!({
+            "enabled": true,
+            "nodes": [
+                {
+                    "id": "cpu",
+                    "status": "online",
+                    "labels": ["lean"],
+                    "capacity_total": 2,
+                    "capacity_available": 1,
+                    "active_jobs": 1,
+                    "queued_jobs": 0,
+                    "cpu_total": 8,
+                    "mem_available_bytes": 32_u64 << 30,
+                    "disk_available_bytes": 100_u64 << 30,
+                    "cached_toolchains": ["leanprover--lean4---v4.24.0"],
+                    "lean_runtime_ready": true,
+                    "base_url": "must-not-leak"
+                },
+                {
+                    "id": "general",
+                    "status": "online",
+                    "labels": ["general"],
+                    "capacity_total": 1,
+                    "capacity_available": 1,
+                    "active_jobs": 0,
+                    "queued_jobs": 0,
+                    "lean_runtime_ready": false
+                }
+            ],
+            "recent_jobs": [{"job_id": "job", "node_id": "cpu", "state": "succeeded"}]
+        });
+
+        let compact = compact_compute_fleet(&raw);
+        assert_eq!(compact["summary"]["nodes_online"], 2);
+        assert_eq!(compact["summary"]["lean_nodes_online"], 1);
+        assert_eq!(compact["summary"]["lean_slots_total"], 2);
+        assert_eq!(compact["summary"]["lean_slots_available"], 1);
+        assert_eq!(compact["summary"]["active_remote_jobs"], 1);
+        assert!(compact["nodes"][0].get("base_url").is_none());
+        assert_eq!(compact["recent_jobs"][0]["node_id"], "cpu");
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -2135,7 +2135,7 @@ fn compact_compute_fleet(fleet: &Value) -> Value {
                 "disk_available_bytes": node.get("disk_available_bytes").cloned().unwrap_or(Value::Null),
                 "cached_toolchains": node.get("cached_toolchains").cloned().unwrap_or_else(|| json!([])),
                 "lean_runtime_ready": node.get("lean_runtime_ready").cloned().unwrap_or(Value::Null),
-                "last_error": node.get("last_error").cloned().unwrap_or(Value::Null),
+                "error": node.get("error").cloned().unwrap_or(Value::Null),
             })
         })
         .collect();
@@ -2145,7 +2145,13 @@ fn compact_compute_fleet(fleet: &Value) -> Value {
         .filter(|node| node.get("status").and_then(Value::as_str) == Some("online"));
     let online_nodes = online.clone().count();
     let lean_nodes: Vec<&Value> = online
-        .filter(|node| node.get("lean_runtime_ready").and_then(Value::as_bool) == Some(true))
+        .filter(|node| {
+            node.get("lean_runtime_ready").and_then(Value::as_bool) == Some(true)
+                && node
+                    .get("labels")
+                    .and_then(Value::as_array)
+                    .is_some_and(|labels| labels.iter().any(|label| label.as_str() == Some("lean")))
+        })
         .collect();
     let lean_slots_total = lean_nodes
         .iter()
@@ -2983,18 +2989,30 @@ mod tests {
                     "active_jobs": 0,
                     "queued_jobs": 0,
                     "lean_runtime_ready": false
+                },
+                {
+                    "id": "gpu-only",
+                    "status": "online",
+                    "labels": ["gpu"],
+                    "capacity_total": 4,
+                    "capacity_available": 4,
+                    "active_jobs": 0,
+                    "queued_jobs": 0,
+                    "lean_runtime_ready": true,
+                    "error": "probe degraded"
                 }
             ],
             "recent_jobs": [{"job_id": "job", "node_id": "cpu", "state": "succeeded"}]
         });
 
         let compact = compact_compute_fleet(&raw);
-        assert_eq!(compact["summary"]["nodes_online"], 2);
+        assert_eq!(compact["summary"]["nodes_online"], 3);
         assert_eq!(compact["summary"]["lean_nodes_online"], 1);
         assert_eq!(compact["summary"]["lean_slots_total"], 2);
         assert_eq!(compact["summary"]["lean_slots_available"], 1);
         assert_eq!(compact["summary"]["active_remote_jobs"], 1);
         assert!(compact["nodes"][0].get("base_url").is_none());
+        assert_eq!(compact["nodes"][2]["error"], "probe degraded");
         assert_eq!(compact["recent_jobs"][0]["node_id"], "cpu");
     }
 

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -2146,7 +2146,7 @@ fn compact_compute_fleet(fleet: &Value) -> Value {
     let online_nodes = online.clone().count();
     let lean_nodes: Vec<&Value> = online
         .filter(|node| {
-            node.get("lean_runtime_ready").and_then(Value::as_bool) == Some(true)
+            node.get("lean_runtime_ready").and_then(Value::as_bool) != Some(false)
                 && node
                     .get("labels")
                     .and_then(Value::as_array)
@@ -3000,16 +3000,25 @@ mod tests {
                     "queued_jobs": 0,
                     "lean_runtime_ready": true,
                     "error": "probe degraded"
+                },
+                {
+                    "id": "legacy-lean",
+                    "status": "online",
+                    "labels": ["lean"],
+                    "capacity_total": 1,
+                    "capacity_available": 1,
+                    "active_jobs": 0,
+                    "queued_jobs": 0
                 }
             ],
             "recent_jobs": [{"job_id": "job", "node_id": "cpu", "state": "succeeded"}]
         });
 
         let compact = compact_compute_fleet(&raw);
-        assert_eq!(compact["summary"]["nodes_online"], 3);
-        assert_eq!(compact["summary"]["lean_nodes_online"], 1);
-        assert_eq!(compact["summary"]["lean_slots_total"], 2);
-        assert_eq!(compact["summary"]["lean_slots_available"], 1);
+        assert_eq!(compact["summary"]["nodes_online"], 4);
+        assert_eq!(compact["summary"]["lean_nodes_online"], 2);
+        assert_eq!(compact["summary"]["lean_slots_total"], 3);
+        assert_eq!(compact["summary"]["lean_slots_available"], 2);
         assert_eq!(compact["summary"]["active_remote_jobs"], 1);
         assert!(compact["nodes"][0].get("base_url").is_none());
         assert_eq!(compact["nodes"][2]["error"], "probe degraded");

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -617,8 +617,12 @@ mod tests {
             mission_id,
             node_id: state.node_id.clone(),
             lease_token: create_lease_token(&claims, &state.shared_token).expect("lease token"),
-            command: "sleep 1".to_string(),
+            command: "while [ ! -e release ]; do sleep 0.01; done".to_string(),
         };
+        let mission_dir = work_root.path().join(mission_id.to_string());
+        tokio::fs::create_dir_all(&mission_dir)
+            .await
+            .expect("mission dir");
 
         let running = tokio::spawn(execute(
             State(Arc::clone(&state)),
@@ -635,6 +639,9 @@ mod tests {
 
         let rejected = execute(State(Arc::clone(&state)), headers, Json(request())).await;
         assert_eq!(rejected.unwrap_err().0, StatusCode::TOO_MANY_REQUESTS);
+        tokio::fs::write(mission_dir.join("release"), b"")
+            .await
+            .expect("release running command");
         let _ = running
             .await
             .expect("execute task")

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -278,7 +278,15 @@ pub fn select_node_auto_with_reservations(
     reservations: &HashMap<String, u32>,
 ) -> Result<String, PlacementError> {
     let mut reasons: Vec<(String, String)> = Vec::new();
-    let mut eligible: Vec<(u32, u64, String)> = Vec::new(); // (load, mem_avail, id)
+    // (queued, specialized, load, capacity, mem_avail, id)
+    //
+    // `specialized` keeps scarce GPU runners available for inference while a
+    // normal CPU runner still has an immediate slot. It is deliberately sorted
+    // after `queued`: an idle GPU runner is still better than queueing behind a
+    // saturated CPU-only node. Within the same tier, normalized utilization
+    // lets two-slot nodes consume their second slot before one-slot nodes are
+    // overloaded.
+    let mut eligible: Vec<(bool, bool, u32, u32, u64, String)> = Vec::new();
     for node in nodes {
         let cached = statuses.get(&node.id);
         let status = cached
@@ -351,13 +359,30 @@ pub fn select_node_auto_with_reservations(
             ));
             continue;
         }
-        eligible.push((load, heartbeat.mem_available_bytes, node.id.clone()));
+        let queued = load >= heartbeat.capacity_total;
+        let specialized = labels.iter().any(|label| label == "gpu")
+            && !requirements.iter().any(|requirement| requirement == "gpu");
+        eligible.push((
+            queued,
+            specialized,
+            load,
+            heartbeat.capacity_total.max(1),
+            heartbeat.mem_available_bytes,
+            node.id.clone(),
+        ));
     }
-    eligible.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+    eligible.sort_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then(a.1.cmp(&b.1))
+            // Compare load/capacity without floating point.
+            .then((a.2 as u64 * b.3 as u64).cmp(&(b.2 as u64 * a.3 as u64)))
+            .then(b.4.cmp(&a.4))
+            .then(a.5.cmp(&b.5))
+    });
     eligible
         .into_iter()
         .next()
-        .map(|(_, _, id)| id)
+        .map(|(_, _, _, _, _, id)| id)
         .ok_or(PlacementError { reasons })
 }
 
@@ -779,6 +804,73 @@ mod tests {
         let picked =
             select_node_auto(&[node_config("e")], &statuses, &[], 20 * GIB, 8 * GIB).unwrap();
         assert_eq!(picked, "e");
+    }
+
+    #[test]
+    fn placement_reserves_idle_gpu_for_inference_when_cpu_capacity_exists() {
+        let nodes = vec![node_config("cpu"), node_config("gpu")];
+        let statuses = HashMap::from([
+            (
+                "cpu".to_string(),
+                cached_online("cpu", &["lean"], 100, 16, 1, 0, 0),
+            ),
+            (
+                "gpu".to_string(),
+                cached_online("gpu", &["lean", "gpu", "high-memory"], 100, 128, 1, 0, 0),
+            ),
+        ]);
+
+        let picked =
+            select_node_auto(&nodes, &statuses, &["lean".to_string()], 20 * GIB, 8 * GIB).unwrap();
+        assert_eq!(picked, "cpu");
+
+        let picked = select_node_auto(
+            &nodes,
+            &statuses,
+            &["lean".to_string(), "gpu".to_string()],
+            20 * GIB,
+            8 * GIB,
+        )
+        .unwrap();
+        assert_eq!(picked, "gpu");
+    }
+
+    #[test]
+    fn placement_uses_idle_gpu_before_queueing_on_saturated_cpu() {
+        let nodes = vec![node_config("cpu"), node_config("gpu")];
+        let statuses = HashMap::from([
+            (
+                "cpu".to_string(),
+                cached_online("cpu", &["lean"], 100, 16, 1, 1, 0),
+            ),
+            (
+                "gpu".to_string(),
+                cached_online("gpu", &["lean", "gpu"], 100, 128, 1, 0, 0),
+            ),
+        ]);
+
+        let picked =
+            select_node_auto(&nodes, &statuses, &["lean".to_string()], 20 * GIB, 8 * GIB).unwrap();
+        assert_eq!(picked, "gpu");
+    }
+
+    #[test]
+    fn placement_prefers_lower_normalized_utilization() {
+        let nodes = vec![node_config("single"), node_config("double")];
+        let statuses = HashMap::from([
+            (
+                "single".to_string(),
+                cached_online("single", &["lean"], 100, 64, 1, 1, 0),
+            ),
+            (
+                "double".to_string(),
+                cached_online("double", &["lean"], 100, 32, 2, 1, 0),
+            ),
+        ]);
+
+        let picked =
+            select_node_auto(&nodes, &statuses, &["lean".to_string()], 20 * GIB, 8 * GIB).unwrap();
+        assert_eq!(picked, "double");
     }
 
     #[test]

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -984,12 +984,17 @@ mod tests {
 
     #[test]
     fn nspawn_cmdline_directory_supports_short_and_long_forms() {
+        let assistant = nspawn_directory_from_cmdline(
+            b"/usr/bin/systemd-nspawn\0-D\0/var/lib/containers/assistant\0--quiet\0",
+        );
+        let assistant_benchmark = nspawn_directory_from_cmdline(
+            b"/usr/bin/systemd-nspawn\0-D\0/var/lib/containers/assistant-benchmark\0--quiet\0",
+        );
         assert_eq!(
-            nspawn_directory_from_cmdline(
-                b"/usr/bin/systemd-nspawn\0-D\0/var/lib/containers/assistant\0--quiet\0"
-            ),
+            assistant,
             Some(PathBuf::from("/var/lib/containers/assistant"))
         );
+        assert_ne!(assistant, assistant_benchmark);
         assert_eq!(
             nspawn_directory_from_cmdline(
                 b"systemd-nspawn\0--directory=/root/.sandboxed-sh/containers/assistant\0"
@@ -1490,45 +1495,12 @@ impl WorkspaceExec {
     }
 
     async fn running_container_leader(&self) -> Option<String> {
-        // Patched: discover the leader via pgrep instead of machinectl.
-        // Inside the docker entrypoint (Caddy as PID 1) machinectl refuses
-        // to operate, and machined cannot create cgroup scopes without
-        // systemd as PID 1, so we run nspawn with --register=no and locate
-        // the leader by scanning for `systemd-nspawn -D <workspace path>`.
-        let mut paths = vec![self.workspace.path.to_string_lossy().into_owned()];
-        if let Ok(canonical) = self.workspace.path.canonicalize() {
-            let canonical = canonical.to_string_lossy().into_owned();
-            if !paths.iter().any(|path| path == &canonical) {
-                paths.push(canonical);
-            }
-        }
-
-        let mut nspawn_pid = None;
-        for path in paths {
-            let output = Command::new("pgrep")
-                .args(["-f", &format!("systemd-nspawn.*-D {}", path)])
-                .output()
-                .await
-                .ok()?;
-            if output.status.success() {
-                nspawn_pid = String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .next()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty());
-                if nspawn_pid.is_some() {
-                    break;
-                }
-            }
-        }
-        // Multiple API services can refer to the same container through
-        // different symlinked roots (for example prod and dev). pgrep only
-        // sees the spelling used by the service that started nspawn, so fall
-        // back to canonicalizing every live nspawn `-D` argument before
-        // deciding that no durable leader exists. Starting a second nspawn on
-        // the same root otherwise waits and eventually fails as "tree busy".
-        let nspawn_pid =
-            nspawn_pid.or_else(|| find_nspawn_pid_by_canonical_root(&self.workspace.path))?;
+        // `pgrep -f "... -D <path>"` is unsafe here: a workspace named
+        // `verity` also matches a simultaneously booting `verity-benchmark`
+        // container. Parse the NUL-delimited argv of every live nspawn and
+        // compare its canonical `-D` directory exactly instead. This also
+        // handles prod/dev aliases that spell the same root through symlinks.
+        let nspawn_pid = find_nspawn_pid_by_canonical_root(&self.workspace.path)?;
         let child_pids = Command::new("pgrep")
             .args(["-P", &nspawn_pid])
             .output()


### PR DESCRIPTION
## Summary
- expose a compact `get_compute_fleet` assistant tool for Hermes controllers
- preserve GPU runners for inference while CPU/Lean capacity is available
- balance builds by immediate capacity and normalized utilization
- document autonomous placement and receipt requirements

## Validation
- `cargo fmt --all --check`
- `cargo test --locked remote_node::monitor::tests --lib`
- `cargo test --locked --bin assistant-mcp`
- `cargo test --locked --bin sandboxed-node`
- `cargo clippy --all-targets -- -D warnings`

One concurrency test flaked once in the first workspace-wide run, then passed both alone and in the complete `sandboxed-node` binary suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote job placement and container leader detection, which can shift production load across nodes or affect workspace exec when multiple nspawn roots share path prefixes; MCP exposure is read-only fleet data.
> 
> **Overview**
> Adds a **`get_compute_fleet`** assistant MCP tool (and Hermes tool allowlist entry) that returns a compact view of `/api/remote-nodes`: per-node capacity, Lean readiness, fleet summary, placement policy hints, and recent job receipts—without leaking sensitive fields like `base_url`.
> 
> **Auto placement** in `select_node_auto_with_reservations` no longer ranks only by raw load and memory. It now tiers candidates by whether they are already at capacity, deprioritizes GPU-labeled nodes for non-`gpu` work when CPU runners have immediate slots, still prefers an idle GPU runner over queueing on a saturated CPU node, and breaks ties with normalized utilization `(load / capacity_total)` before memory and node id.
> 
> **Container leader discovery** stops using broad `pgrep -f` on the `-D` path (which could match similarly named workspace roots) and relies on exact canonical `-D` directory matching via parsed nspawn argv.
> 
> Docs (`agents.md`, `REMOTE_NODES.md`) describe calling `get_compute_fleet` before parallel dispatch and verifying distribution via receipts. A **sandboxed-node** concurrency test uses a release file instead of `sleep 1` to reduce flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5cf5d9fa38ac2f5e647a097d9115eaee951c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->