### PR TITLE
fix(opencode): fall back after copied CLI probe failure

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,10 @@ Notes:
 - Use `--skip-proxy` to run harness streaming smoke only.
 - Use `--skip-mission` to run proxy smoke only.
 - Use `--help` to see all options.
+- For an OpenCode container bootstrap change, include a direct-output canary
+  using the intended `provider/model` override. Confirm both the persisted
+  mission event past CLI bootstrap and the returned model text; do not use a
+  native provider backend as a substitute.
 
 ## Optional: Deferred Queue Mode for Proxy Routing
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7254,27 +7254,6 @@ fn copy_host_executable_into_container(
     Ok(format!("/usr/local/bin/{}", name))
 }
 
-fn remove_container_usr_local_bin(
-    workspace: &crate::workspace::Workspace,
-    name: &str,
-) -> Result<(), String> {
-    let path = workspace
-        .path
-        .join("usr")
-        .join("local")
-        .join("bin")
-        .join(name);
-    match std::fs::remove_file(&path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(format!(
-            "Failed to remove rejected container executable {}: {}",
-            path.display(),
-            e
-        )),
-    }
-}
-
 fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
     output.split_whitespace().find_map(|word| {
         let candidate = word.trim_start_matches(['v', 'V']);
@@ -7312,7 +7291,7 @@ fn classify_copied_opencode_probe(
 enum ContainerOpenCodeSync {
     NotNeeded,
     Copied,
-    NeedsContainerInstall,
+    NeedsContainerInstall { host_version: (u64, u64, u64) },
 }
 
 async fn host_cli_version(program: &std::path::Path) -> Option<(u64, u64, u64)> {
@@ -7407,8 +7386,7 @@ async fn sync_container_opencode_from_host(
             copied_version = ?installed_version,
             "Copied OpenCode did not pass the explicit container version probe; using container installer fallback"
         );
-        remove_container_usr_local_bin(&workspace_exec.workspace, "opencode")?;
-        return Ok(ContainerOpenCodeSync::NeedsContainerInstall);
+        return Ok(ContainerOpenCodeSync::NeedsContainerInstall { host_version });
     }
 
     tracing::info!(
@@ -7494,10 +7472,12 @@ pub(crate) async fn ensure_opencode_cli_available(
     // stale container CLIs that could not load plugins installed from `latest`.
     // Synchronize from the managed host installation before accepting the
     // container binary.
-    let force_container_install = matches!(
-        sync_container_opencode_from_host(workspace_exec, cwd).await?,
-        ContainerOpenCodeSync::NeedsContainerInstall
-    );
+    let sync_result = sync_container_opencode_from_host(workspace_exec, cwd).await?;
+    let fallback_host_version = match sync_result {
+        ContainerOpenCodeSync::NeedsContainerInstall { host_version } => Some(host_version),
+        ContainerOpenCodeSync::NotNeeded | ContainerOpenCodeSync::Copied => None,
+    };
+    let force_container_install = fallback_host_version.is_some();
 
     if !force_container_install && opencode_binary_available(workspace_exec, cwd).await {
         return Ok(());
@@ -7520,13 +7500,18 @@ pub(crate) async fn ensure_opencode_cli_available(
     args.push("-lc".to_string());
     // Use explicit /root path for container workspaces since $HOME may not be set in nspawn
     // Try both /root and $HOME to cover both container and host workspaces
+    let installer_flags = if let Some((major, minor, patch)) = fallback_host_version {
+        format!("--version {major}.{minor}.{patch} --no-modify-path")
+    } else {
+        "--no-modify-path".to_string()
+    };
     args.push(
         format!(
-            "{} | bash -s -- --no-modify-path \
+            "{} | bash -s -- {} \
         && for bindir in /root/.opencode/bin \"$HOME/.opencode/bin\"; do \
             if [ -x \"$bindir/opencode\" ]; then install -m 0755 \"$bindir/opencode\" /usr/local/bin/opencode && break; fi; \
         done"
-            , fetcher
+            , fetcher, installer_flags
         ),
     );
     let output = workspace_exec
@@ -7553,15 +7538,14 @@ pub(crate) async fn ensure_opencode_cli_available(
         return Err(format!("OpenCode install failed: {}", message));
     }
 
-    if force_container_install {
-        if workspace_cli_version(workspace_exec, cwd, "/usr/local/bin/opencode")
-            .await
-            .is_none()
-        {
-            return Err(
-                "OpenCode install completed but '/usr/local/bin/opencode --version' did not succeed."
-                    .to_string(),
-            );
+    if let Some(host_version) = fallback_host_version {
+        let installed_version =
+            workspace_cli_version(workspace_exec, cwd, "/usr/local/bin/opencode").await;
+        if installed_version != Some(host_version) {
+            return Err(format!(
+                "OpenCode install completed but '/usr/local/bin/opencode --version' returned {:?}, expected {:?}.",
+                installed_version, host_version
+            ));
         }
     } else if !opencode_binary_available(workspace_exec, cwd).await {
         return Err(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7265,6 +7265,35 @@ fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CopiedOpenCodeProbe {
+    MatchesHost,
+    Unavailable,
+    DifferentVersion,
+}
+
+/// Classify a copied OpenCode binary using only the version output collected
+/// from its explicit path.  In particular, do not treat an executable bit (or
+/// a PATH lookup) as proof that a host-native binary can run in an nspawn
+/// rootfs.
+fn classify_copied_opencode_probe(
+    host_version: (u64, u64, u64),
+    copied_version: Option<(u64, u64, u64)>,
+) -> CopiedOpenCodeProbe {
+    match copied_version {
+        Some(version) if version == host_version => CopiedOpenCodeProbe::MatchesHost,
+        Some(_) => CopiedOpenCodeProbe::DifferentVersion,
+        None => CopiedOpenCodeProbe::Unavailable,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContainerOpenCodeSync {
+    NotNeeded,
+    Copied,
+    NeedsContainerInstall,
+}
+
 async fn host_cli_version(program: &std::path::Path) -> Option<(u64, u64, u64)> {
     let output = tokio::process::Command::new(program)
         .arg("--version")
@@ -7313,23 +7342,23 @@ async fn workspace_cli_version(
 async fn sync_container_opencode_from_host(
     workspace_exec: &WorkspaceExec,
     cwd: &std::path::Path,
-) -> Result<Option<String>, String> {
+) -> Result<ContainerOpenCodeSync, String> {
     if !should_sync_container_opencode(
         workspace_exec.workspace.workspace_type == WorkspaceType::Container,
         workspace::use_nspawn_for_workspace(&workspace_exec.workspace),
     ) {
-        return Ok(None);
+        return Ok(ContainerOpenCodeSync::NotNeeded);
     }
 
     let Some(host_opencode) = resolve_host_executable("opencode") else {
-        return Ok(None);
+        return Ok(ContainerOpenCodeSync::NotNeeded);
     };
     let Some(host_version) = host_cli_version(&host_opencode).await else {
         tracing::warn!(
             host_path = %host_opencode.display(),
             "Could not determine host OpenCode version; leaving container CLI unchanged"
         );
-        return Ok(None);
+        return Ok(ContainerOpenCodeSync::NotNeeded);
     };
 
     let container_program = "/usr/local/bin/opencode";
@@ -7340,16 +7369,24 @@ async fn sync_container_opencode_from_host(
     };
 
     if container_version == Some(host_version) {
-        return Ok(None);
+        return Ok(ContainerOpenCodeSync::NotNeeded);
     }
 
     let installed = copy_host_executable_into_container(&workspace_exec.workspace, &host_opencode)?;
     let installed_version = workspace_cli_version(workspace_exec, cwd, &installed).await;
-    if installed_version != Some(host_version) {
-        return Err(format!(
-            "Copied host OpenCode {:?} into container, but version probe returned {:?}",
-            host_version, installed_version
-        ));
+    if classify_copied_opencode_probe(host_version, installed_version)
+        != CopiedOpenCodeProbe::MatchesHost
+    {
+        // A host-native OpenCode can be dynamically linked against libraries
+        // unavailable in an older container rootfs.  It is not safe to accept
+        // that copied file merely because it exists, but failing here also
+        // prevents the container-native installer fallback below.
+        tracing::warn!(
+            host_version = ?host_version,
+            copied_version = ?installed_version,
+            "Copied OpenCode did not pass the explicit container version probe; using container installer fallback"
+        );
+        return Ok(ContainerOpenCodeSync::NeedsContainerInstall);
     }
 
     tracing::info!(
@@ -7359,7 +7396,7 @@ async fn sync_container_opencode_from_host(
         new_version = ?host_version,
         "Synchronized host OpenCode CLI into container"
     );
-    Ok(Some(installed))
+    Ok(ContainerOpenCodeSync::Copied)
 }
 
 async fn resolve_opencode_installer_fetcher(
@@ -7435,9 +7472,12 @@ pub(crate) async fn ensure_opencode_cli_available(
     // stale container CLIs that could not load plugins installed from `latest`.
     // Synchronize from the managed host installation before accepting the
     // container binary.
-    sync_container_opencode_from_host(workspace_exec, cwd).await?;
+    let force_container_install = matches!(
+        sync_container_opencode_from_host(workspace_exec, cwd).await?,
+        ContainerOpenCodeSync::NeedsContainerInstall
+    );
 
-    if opencode_binary_available(workspace_exec, cwd).await {
+    if !force_container_install && opencode_binary_available(workspace_exec, cwd).await {
         return Ok(());
     }
 
@@ -8421,10 +8461,11 @@ fn cleanup_old_debug_files(
 mod tests {
     use super::{
         actual_cost_cents_from_total_cost_usd, apply_terminal_result_text, bind_command_params,
-        claudecode_idle_timeout_for_state, claudecode_incomplete_turn_message,
-        claudecode_malformed_startup_message, claudecode_pre_turn_transport_message,
-        claudecode_resume_current_session_message, claudecode_transport_failure_data,
-        claudecode_transport_failure_stage, claudecode_transport_failure_stage_for_incomplete_turn,
+        classify_copied_opencode_probe, claudecode_idle_timeout_for_state,
+        claudecode_incomplete_turn_message, claudecode_malformed_startup_message,
+        claudecode_pre_turn_transport_message, claudecode_resume_current_session_message,
+        claudecode_transport_failure_data, claudecode_transport_failure_stage,
+        claudecode_transport_failure_stage_for_incomplete_turn,
         claudecode_transport_recovery_strategy, clear_codex_account_cooldown,
         codex_account_cooldown_remaining, codex_chatgpt_fallback_for_result,
         codex_chatgpt_fallback_model, codex_cooldown_for_reason, codex_error_message_to_surface,
@@ -8453,8 +8494,8 @@ mod tests {
         text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
         truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
-        ClaudeTurnWaitState, MissionHealth, MissionRunState, MissionStallSeverity,
-        OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
+        ClaudeTurnWaitState, CopiedOpenCodeProbe, MissionHealth, MissionRunState,
+        MissionStallSeverity, OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
         CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS, TOOL_CALL_STALL_GRACE_SECS,
     };
     use super::{
@@ -11442,6 +11483,33 @@ mod tests {
     fn parse_cli_semver_rejects_incomplete_or_unrelated_output() {
         assert_eq!(parse_cli_semver("opencode 1.17"), None);
         assert_eq!(parse_cli_semver("version unknown"), None);
+    }
+
+    #[test]
+    fn copied_opencode_probe_accepts_current_native_cli_output() {
+        // Captured from the backend host's native OpenCode CLI. A bare semver
+        // is the normal output shape, not an installer error.
+        let host = parse_cli_semver("1.17.18\n").expect("host OpenCode semver");
+        assert_eq!(
+            classify_copied_opencode_probe(host, parse_cli_semver("1.17.18\n")),
+            CopiedOpenCodeProbe::MatchesHost
+        );
+    }
+
+    #[test]
+    fn copied_opencode_probe_requires_container_install_for_mismatch_or_failure() {
+        let host = (1, 17, 18);
+        assert_eq!(
+            classify_copied_opencode_probe(
+                host,
+                parse_cli_semver("opencode version v1.16.9-beta.1"),
+            ),
+            CopiedOpenCodeProbe::DifferentVersion
+        );
+        assert_eq!(
+            classify_copied_opencode_probe(host, parse_cli_semver("not found")),
+            CopiedOpenCodeProbe::Unavailable
+        );
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7254,6 +7254,27 @@ fn copy_host_executable_into_container(
     Ok(format!("/usr/local/bin/{}", name))
 }
 
+fn remove_container_usr_local_bin(
+    workspace: &crate::workspace::Workspace,
+    name: &str,
+) -> Result<(), String> {
+    let path = workspace
+        .path
+        .join("usr")
+        .join("local")
+        .join("bin")
+        .join(name);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!(
+            "Failed to remove rejected container executable {}: {}",
+            path.display(),
+            e
+        )),
+    }
+}
+
 fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
     output.split_whitespace().find_map(|word| {
         let candidate = word.trim_start_matches(['v', 'V']);
@@ -7386,6 +7407,7 @@ async fn sync_container_opencode_from_host(
             copied_version = ?installed_version,
             "Copied OpenCode did not pass the explicit container version probe; using container installer fallback"
         );
+        remove_container_usr_local_bin(&workspace_exec.workspace, "opencode")?;
         return Ok(ContainerOpenCodeSync::NeedsContainerInstall);
     }
 
@@ -7531,7 +7553,17 @@ pub(crate) async fn ensure_opencode_cli_available(
         return Err(format!("OpenCode install failed: {}", message));
     }
 
-    if !opencode_binary_available(workspace_exec, cwd).await {
+    if force_container_install {
+        if workspace_cli_version(workspace_exec, cwd, "/usr/local/bin/opencode")
+            .await
+            .is_none()
+        {
+            return Err(
+                "OpenCode install completed but '/usr/local/bin/opencode --version' did not succeed."
+                    .to_string(),
+            );
+        }
+    } else if !opencode_binary_available(workspace_exec, cwd).await {
         return Err(
             "OpenCode install completed but 'opencode' is still not available in workspace PATH."
                 .to_string(),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7255,13 +7255,32 @@ fn copy_host_executable_into_container(
 }
 
 fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
+    parse_cli_version(output).map(|version| version.semver)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedCliVersion {
+    semver: (u64, u64, u64),
+    install_version: String,
+}
+
+fn parse_cli_version(output: &str) -> Option<ParsedCliVersion> {
     output.split_whitespace().find_map(|word| {
         let candidate = word.trim_start_matches(['v', 'V']);
+        if !candidate
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'+'))
+        {
+            return None;
+        }
         let mut parts = candidate.split(['.', '-', '+']);
         let major = parts.next()?.parse().ok()?;
         let minor = parts.next()?.parse().ok()?;
         let patch = parts.next()?.parse().ok()?;
-        Some((major, minor, patch))
+        Some(ParsedCliVersion {
+            semver: (major, minor, patch),
+            install_version: candidate.to_string(),
+        })
     })
 }
 
@@ -7277,8 +7296,8 @@ enum CopiedOpenCodeProbe {
 /// a PATH lookup) as proof that a host-native binary can run in an nspawn
 /// rootfs.
 fn classify_copied_opencode_probe(
-    host_version: (u64, u64, u64),
-    copied_version: Option<(u64, u64, u64)>,
+    host_version: &ParsedCliVersion,
+    copied_version: Option<&ParsedCliVersion>,
 ) -> CopiedOpenCodeProbe {
     match copied_version {
         Some(version) if version == host_version => CopiedOpenCodeProbe::MatchesHost,
@@ -7287,14 +7306,14 @@ fn classify_copied_opencode_probe(
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ContainerOpenCodeSync {
     NotNeeded,
     Copied,
-    NeedsContainerInstall { host_version: (u64, u64, u64) },
+    NeedsContainerInstall { host_version: ParsedCliVersion },
 }
 
-async fn host_cli_version(program: &std::path::Path) -> Option<(u64, u64, u64)> {
+async fn host_cli_version(program: &std::path::Path) -> Option<ParsedCliVersion> {
     let output = tokio::process::Command::new(program)
         .arg("--version")
         .output()
@@ -7308,14 +7327,14 @@ async fn host_cli_version(program: &std::path::Path) -> Option<(u64, u64, u64)> 
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    parse_cli_semver(&combined)
+    parse_cli_version(&combined)
 }
 
 async fn workspace_cli_version(
     workspace_exec: &WorkspaceExec,
     cwd: &std::path::Path,
     program: &str,
-) -> Option<(u64, u64, u64)> {
+) -> Option<ParsedCliVersion> {
     let output = workspace_exec
         .output(cwd, program, &["--version".to_string()], HashMap::new())
         .await
@@ -7328,7 +7347,7 @@ async fn workspace_cli_version(
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    parse_cli_semver(&combined)
+    parse_cli_version(&combined)
 }
 
 /// Keep a container's managed OpenCode CLI identical to the backend host CLI.
@@ -7368,13 +7387,13 @@ async fn sync_container_opencode_from_host(
         None
     };
 
-    if container_version == Some(host_version) {
+    if container_version.as_ref() == Some(&host_version) {
         return Ok(ContainerOpenCodeSync::NotNeeded);
     }
 
     let installed = copy_host_executable_into_container(&workspace_exec.workspace, &host_opencode)?;
     let installed_version = workspace_cli_version(workspace_exec, cwd, &installed).await;
-    if classify_copied_opencode_probe(host_version, installed_version)
+    if classify_copied_opencode_probe(&host_version, installed_version.as_ref())
         != CopiedOpenCodeProbe::MatchesHost
     {
         // A host-native OpenCode can be dynamically linked against libraries
@@ -7500,8 +7519,8 @@ pub(crate) async fn ensure_opencode_cli_available(
     args.push("-lc".to_string());
     // Use explicit /root path for container workspaces since $HOME may not be set in nspawn
     // Try both /root and $HOME to cover both container and host workspaces
-    let installer_flags = if let Some((major, minor, patch)) = fallback_host_version {
-        format!("--version {major}.{minor}.{patch} --no-modify-path")
+    let installer_flags = if let Some(version) = &fallback_host_version {
+        format!("--version {} --no-modify-path", version.install_version)
     } else {
         "--no-modify-path".to_string()
     };
@@ -7541,7 +7560,7 @@ pub(crate) async fn ensure_opencode_cli_available(
     if let Some(host_version) = fallback_host_version {
         let installed_version =
             workspace_cli_version(workspace_exec, cwd, "/usr/local/bin/opencode").await;
-        if installed_version != Some(host_version) {
+        if installed_version.as_ref() != Some(&host_version) {
             return Err(format!(
                 "OpenCode install completed but '/usr/local/bin/opencode --version' returned {:?}, expected {:?}.",
                 installed_version, host_version
@@ -8498,7 +8517,7 @@ mod tests {
         is_tool_call_only_output, opencode_goal_terminal_status,
         opencode_idle_timeout_result_message, opencode_output_needs_fallback,
         opencode_session_exists_in_data_home, opencode_session_token_from_line,
-        overlay_opencode_auth, parse_cli_semver, parse_opencode_goal_objective,
+        overlay_opencode_auth, parse_cli_semver, parse_cli_version, parse_opencode_goal_objective,
         parse_opencode_session_token, parse_opencode_sse_event, parse_opencode_stderr_text_part,
         preferred_model_for_cost, preferred_opencode_bin_dir, prepend_unique_path_entry,
         record_codex_error_message, replace_filepath_artifact_with_tool_output,
@@ -11493,12 +11512,19 @@ mod tests {
             parse_cli_semver("opencode version v1.17.18-beta.2"),
             Some((1, 17, 18))
         );
+        assert_eq!(
+            parse_cli_version("opencode version v1.17.18-beta.2")
+                .expect("parsed version")
+                .install_version,
+            "1.17.18-beta.2"
+        );
     }
 
     #[test]
     fn parse_cli_semver_rejects_incomplete_or_unrelated_output() {
         assert_eq!(parse_cli_semver("opencode 1.17"), None);
         assert_eq!(parse_cli_semver("version unknown"), None);
+        assert_eq!(parse_cli_semver("1.17.18-beta;echo"), None);
     }
 
     #[test]
@@ -11506,24 +11532,30 @@ mod tests {
         // Captured from the backend host's native OpenCode CLI. A bare semver
         // is the normal output shape, not an installer error.
         let host = parse_cli_semver("1.17.18\n").expect("host OpenCode semver");
+        let host_version = parse_cli_version("1.17.18\n").expect("host OpenCode version");
+        let copied_version = parse_cli_version("1.17.18\n").expect("copied OpenCode version");
+        assert_eq!(host, host_version.semver,);
         assert_eq!(
-            classify_copied_opencode_probe(host, parse_cli_semver("1.17.18\n")),
+            classify_copied_opencode_probe(&host_version, Some(&copied_version)),
             CopiedOpenCodeProbe::MatchesHost
         );
     }
 
     #[test]
     fn copied_opencode_probe_requires_container_install_for_mismatch_or_failure() {
-        let host = (1, 17, 18);
+        let host = parse_cli_version("1.17.18-beta.2").expect("host OpenCode version");
+        let stable = parse_cli_version("opencode version v1.17.18").expect("stable version");
+        let older = parse_cli_version("opencode version v1.16.9-beta.1").expect("older version");
         assert_eq!(
-            classify_copied_opencode_probe(
-                host,
-                parse_cli_semver("opencode version v1.16.9-beta.1"),
-            ),
+            classify_copied_opencode_probe(&host, Some(&stable)),
             CopiedOpenCodeProbe::DifferentVersion
         );
         assert_eq!(
-            classify_copied_opencode_probe(host, parse_cli_semver("not found")),
+            classify_copied_opencode_probe(&host, Some(&older)),
+            CopiedOpenCodeProbe::DifferentVersion
+        );
+        assert_eq!(
+            classify_copied_opencode_probe(&host, parse_cli_version("not found").as_ref()),
             CopiedOpenCodeProbe::Unavailable
         );
     }


### PR DESCRIPTION
## Summary
- keep OpenCode host-copy version validation fail-closed at the explicit copied path
- route an unavailable or mismatched copied CLI probe through the existing container-native installer fallback instead of terminating bootstrap
- cover current bare-semver OpenCode output, a normal semantic-version mismatch, and unavailable/malformed probe output
- document the required direct-output OpenCode acceptance canary

## Evidence
- Dev-only guarded deployment: `4098b576b810` to `sandboxed-sh-dev.service`
- Post-deploy direct-output canary: mission `27ef0b4a-73da-476d-a7dc-0caf283d488b`, backend `opencode`, model `xai/grok-4.5`, output `GROK_CANARY_OK`
- `cargo fmt --check` passed locally.
- Local Cargo 1.75 cannot parse the repository's v4 lockfile (`-Znext-lockfile-bump` required), so focused/full tests and Clippy were attempted but blocked before compilation. The guarded development deploy completed its debug Cargo build successfully.

## Scope
Development deployment only; no production restart or deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission bootstrap and CLI installation paths for container workspaces; incorrect fallback logic could leave wrong OpenCode versions or block OpenCode missions, but behavior is scoped to container sync and includes explicit post-install version checks.
> 
> **Overview**
> When syncing the host **OpenCode** binary into nspawn containers, bootstrap no longer **fails hard** if the copied binary cannot be verified at the explicit container path (common when a host-native binary is incompatible with the container rootfs). It now **classifies** the probe outcome and, on mismatch or probe failure, **falls through** to the existing in-container installer with **`--version`** pinned to the host’s install string, then **re-checks** `/usr/local/bin/opencode --version` before continuing.
> 
> Version parsing was tightened to capture full **install version** strings (including pre-release suffixes) and reject unsafe tokens in `--version` output. **Unit tests** cover probe classification and semver parsing; **getting-started** notes a direct-output OpenCode canary for validating container bootstrap changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d7096d0833114caa504b23a2b49e18eb43b75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->