### PR TITLE
fix: isolate dev and prod companion binaries

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -41,6 +41,11 @@ Hermes gotchas:
 
 - After a prod deploy, `systemctl restart hermes-assistant` so the gateway
   respawns the freshly installed `/usr/local/bin/assistant-mcp`.
+- Companion binaries are environment-scoped: production owns the historical
+  unsuffixed paths (`assistant-mcp`, `orchestrator-mcp`, `palomactl`), while
+  `sandboxed-sh-dev` installs `*-dev`. Never copy a dev MCP over an unsuffixed
+  production path; doing so changes Hermes production tooling without a prod
+  deploy.
 - When testing the WS handshake with curl, force `--http1.1` — ALPN negotiates
   h2, which has no `Upgrade` header, and the resulting 401 is a red herring.
 - When rotating the `hsk_` key, update `API_SERVER_KEY`,

--- a/agents.md
+++ b/agents.md
@@ -181,6 +181,10 @@ Gotchas:
   GPU nodes for inference while ordinary CPU/Lean nodes have immediate slots,
   then balances by normalized utilization. Only terminal node/job/head receipts
   prove that work was actually distributed.
+- **Dev/prod companion binaries are isolated**: production uses unsuffixed MCP
+  and palomactl paths; non-production services use a service suffix (for
+  example `assistant-mcp-dev`). A dev deploy must never replace Hermes's
+  production connector.
 - Agents are loaded from OpenCode built-ins and native `.opencode/agents/*.md` files.
 - Per-workspace execution eliminates host-to-container network issues.
 - For remote workspaces, SSH execution keeps bash/tooling on the remote host.

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7254,6 +7254,7 @@ fn copy_host_executable_into_container(
     Ok(format!("/usr/local/bin/{}", name))
 }
 
+#[cfg(test)]
 fn parse_cli_semver(output: &str) -> Option<(u64, u64, u64)> {
     parse_cli_version(output).map(|version| version.semver)
 }

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1620,25 +1620,44 @@ async fn migrate_hermes_assistant_mcp_command(
     runtime_name: &str,
     command: &str,
 ) -> Result<bool, String> {
-    let mut touched = false;
     let updates = [("HERMES_ASSISTANT_MCP_COMMAND", command)];
+    let mut planned_writes = Vec::new();
     for env_path in hermes_env_paths(runtime_name) {
         let Ok(contents) = tokio::fs::read_to_string(&env_path).await else {
             continue;
         };
-        write_private_file(&env_path, &upsert_env_lines(&contents, &updates)).await?;
-        touched = true;
+        let updated = upsert_env_lines(&contents, &updates);
+        if updated != contents {
+            planned_writes.push((env_path, contents, updated));
+        }
     }
 
     let config_path = format!("/var/lib/{runtime_name}/config.yaml");
     if let Ok(contents) = tokio::fs::read_to_string(&config_path).await {
         let updated = upsert_hermes_mcp_command(&contents, command);
         if updated != contents {
-            write_private_file(&config_path, &updated).await?;
-            touched = true;
+            planned_writes.push((config_path, contents, updated));
         }
     }
-    Ok(touched)
+
+    for (committed, (path, _, updated)) in planned_writes.iter().enumerate() {
+        if let Err(error) = write_private_file(path, updated).await {
+            let mut restore_errors = Vec::new();
+            for (restore_path, original, _) in planned_writes.iter().take(committed) {
+                if let Err(restore_error) = write_private_file(restore_path, original).await {
+                    restore_errors.push(restore_error);
+                }
+            }
+            let restore_suffix = if restore_errors.is_empty() {
+                String::new()
+            } else {
+                format!("; rollback errors: {}", restore_errors.join("; "))
+            };
+            return Err(format!("{error}{restore_suffix}"));
+        }
+    }
+
+    Ok(!planned_writes.is_empty())
 }
 
 fn generate_hermes_remote_key() -> String {
@@ -3533,23 +3552,50 @@ fn current_sandboxed_service_name() -> Result<String, String> {
     })
 }
 
-async fn prepare_deploy_backup(destination: &str, backup: &str) -> Result<bool, String> {
-    if !std::path::Path::new(destination).exists() {
-        return Ok(false);
+#[derive(Debug)]
+enum DeployRollback {
+    Missing,
+    Backup,
+    Symlink(std::path::PathBuf),
+}
+
+async fn prepare_deploy_backup(destination: &str, backup: &str) -> Result<DeployRollback, String> {
+    let metadata = match tokio::fs::symlink_metadata(destination).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(DeployRollback::Missing);
+        }
+        Err(error) => return Err(format!("failed to inspect {destination}: {error}")),
+    };
+    if metadata.file_type().is_symlink() {
+        return tokio::fs::read_link(destination)
+            .await
+            .map(DeployRollback::Symlink)
+            .map_err(|error| format!("failed to read symlink {destination}: {error}"));
     }
     tokio::fs::copy(destination, backup)
         .await
         .map_err(|error| format!("failed to back up {destination} to {backup}: {error}"))?;
-    Ok(true)
+    Ok(DeployRollback::Backup)
 }
 
-async fn rollback_deployed_binary(destination: &str, backup: &str, had_backup: bool) {
-    if had_backup {
-        let _ = tokio::fs::rename(backup, destination).await;
-    } else {
-        // This deploy created the destination for the first time. Leaving it
-        // behind after rolling the service back would mix binary generations.
-        let _ = tokio::fs::remove_file(destination).await;
+async fn rollback_deployed_binary(destination: &str, backup: &str, rollback: &DeployRollback) {
+    match rollback {
+        DeployRollback::Backup => {
+            let _ = tokio::fs::rename(backup, destination).await;
+        }
+        DeployRollback::Symlink(target) => {
+            let _ = tokio::fs::remove_file(destination).await;
+            let _ = Command::new("ln")
+                .args(["-sfn", target.to_string_lossy().as_ref(), destination])
+                .output()
+                .await;
+        }
+        DeployRollback::Missing => {
+            // This deploy created the destination for the first time. Leaving
+            // it behind after rollback would mix binary generations.
+            let _ = tokio::fs::remove_file(destination).await;
+        }
     }
 }
 
@@ -3732,54 +3778,65 @@ fn stream_deploy(
             _ => "unknown".to_string(),
         };
 
-        // We do NOT use install_versioned_binary here because that helper
-        // assumes the source filename equals the deployed filename (e.g.
-        // src=target/debug/sandboxed-sh-prod, dest=/usr/local/bin/sandboxed-sh-prod).
-        // The cargo bin is always `sandboxed-sh`; the deployed name is
-        // service-specific. Doing a direct `install -m 0755 <src> <dest>`
-        // gives us the rename for free.
-        //
         // Backup the live binaries to `.pre-deploy-<sha>` so a one-line
-        // rollback is `mv backup live && systemctl restart`. No versioned
-        // dir scheme — the existing manual ops use the .backup-<ts>
-        // convention, so we match it.
+        // rollback is possible. If the service already uses the versioned
+        // symlink layout, preserve it and retarget the symlink atomically.
         yield sse("log", format!("Installing {} → {}", src_main.display(), install_dest_main), Some(75));
         let bkp_main = format!("{}.pre-deploy-{}", install_dest_main, sha);
-        let backed_main = match prepare_deploy_backup(&install_dest_main, &bkp_main).await {
-            Ok(backed) => backed,
+        let rollback_main = match prepare_deploy_backup(&install_dest_main, &bkp_main).await {
+            Ok(rollback) => rollback,
             Err(error) => {
                 yield sse("error", error, None);
                 return;
             }
         };
-        let install_main = Command::new("install")
-            .args([
-                "-m", "0755",
-                src_main.to_string_lossy().as_ref(),
+        let install_main = if matches!(&rollback_main, DeployRollback::Symlink(_)) {
+            let installed_name = current_exe
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(MAIN_CARGO_BIN);
+            install_versioned_binary_as(
+                repo_path,
+                MAIN_CARGO_BIN,
+                installed_name,
+                &sha,
                 &install_dest_main,
-            ])
-            .output()
-            .await;
+            )
+            .await
+        } else {
+            Command::new("install")
+                .args([
+                    "-m",
+                    "0755",
+                    src_main.to_string_lossy().as_ref(),
+                    &install_dest_main,
+                ])
+                .output()
+                .await
+                .map_err(|error| error.to_string())
+                .and_then(|output| {
+                    if output.status.success() {
+                        Ok(())
+                    } else {
+                        Err(String::from_utf8_lossy(&output.stderr).to_string())
+                    }
+                })
+        };
         match install_main {
-            Ok(o) if o.status.success() => {}
-            Ok(o) => {
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
-                yield sse("error", format!("Install of main binary failed: {}", String::from_utf8_lossy(&o.stderr)), None);
-                return;
-            }
-            Err(e) => {
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
-                yield sse("error", format!("install command error: {}", e), None);
+            Ok(()) => {}
+            Err(error) => {
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
+                yield sse("error", format!("Install of main binary failed: {}", error), None);
                 return;
             }
         }
 
         yield sse("log", format!("Installing {} → {}", src_mcp.display(), install_dest_mcp), Some(82));
         let bkp_mcp = format!("{}.pre-deploy-{}", install_dest_mcp, sha);
-        let backed_mcp = match prepare_deploy_backup(&install_dest_mcp, &bkp_mcp).await {
-            Ok(backed) => backed,
+        let rollback_mcp = match prepare_deploy_backup(&install_dest_mcp, &bkp_mcp).await {
+            Ok(rollback) => rollback,
             Err(error) => {
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", error, None);
                 return;
             }
@@ -3798,14 +3855,14 @@ fn stream_deploy(
                 // Roll back the main binary swap before bailing — leaving
                 // the main binary swapped without its matching MCP is the
                 // worst possible half-applied state.
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("Install of orchestrator-mcp failed (main binary rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("install command error (main rolled back): {}", e), None);
                 return;
             }
@@ -3813,12 +3870,12 @@ fn stream_deploy(
 
         yield sse("log", format!("Installing {} → {}", src_assistant_mcp.display(), install_dest_assistant_mcp), Some(85));
         let bkp_assistant_mcp = format!("{}.pre-deploy-{}", install_dest_assistant_mcp, sha);
-        let backed_assistant_mcp =
+        let rollback_assistant_mcp =
             match prepare_deploy_backup(&install_dest_assistant_mcp, &bkp_assistant_mcp).await {
-                Ok(backed) => backed,
+                Ok(rollback) => rollback,
                 Err(error) => {
-                    rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                    rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                    rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                    rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                     yield sse("error", error, None);
                     return;
                 }
@@ -3834,16 +3891,16 @@ fn stream_deploy(
         match install_assistant_mcp {
             Ok(o) if o.status.success() => {}
             Ok(o) => {
-                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("Install of assistant-mcp failed (main/orchestrator binaries rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
-                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("install command error for assistant-mcp (main/orchestrator rolled back): {}", e), None);
                 return;
             }
@@ -3851,12 +3908,12 @@ fn stream_deploy(
 
         yield sse("log", format!("Installing {} → {}", src_paloma.display(), install_dest_paloma), Some(87));
         let bkp_paloma = format!("{}.pre-deploy-{}", install_dest_paloma, sha);
-        let backed_paloma = match prepare_deploy_backup(&install_dest_paloma, &bkp_paloma).await {
-            Ok(backed) => backed,
+        let rollback_paloma = match prepare_deploy_backup(&install_dest_paloma, &bkp_paloma).await {
+            Ok(rollback) => rollback,
             Err(error) => {
-                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", error, None);
                 return;
             }
@@ -3872,18 +3929,18 @@ fn stream_deploy(
         match install_paloma {
             Ok(o) if o.status.success() => {}
             Ok(o) => {
-                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, backed_paloma).await;
-                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("Install of palomactl failed (service binaries rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
-                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, backed_paloma).await;
-                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("install command error for palomactl (service binaries rolled back): {}", e), None);
                 return;
             }
@@ -3896,10 +3953,10 @@ fn stream_deploy(
             }
             Ok(false) => {}
             Err(error) => {
-                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, backed_paloma).await;
-                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
-                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
-                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
                 yield sse("error", format!("Hermes MCP command migration failed; service binaries rolled back: {}", error), None);
                 return;
             }
@@ -4054,6 +4111,16 @@ async fn install_versioned_binary(
     tag: &str,
     install_dest: &str,
 ) -> Result<(), String> {
+    install_versioned_binary_as(repo_path, exe_name, exe_name, tag, install_dest).await
+}
+
+async fn install_versioned_binary_as(
+    repo_path: &std::path::Path,
+    source_name: &str,
+    installed_name: &str,
+    tag: &str,
+    install_dest: &str,
+) -> Result<(), String> {
     use std::path::PathBuf;
 
     let dest_path = PathBuf::from(install_dest);
@@ -4083,7 +4150,7 @@ async fn install_versioned_binary(
             tokio::fs::create_dir_all(&legacy_dir)
                 .await
                 .map_err(|e| format!("create_dir_all {}: {}", legacy_dir.display(), e))?;
-            let legacy_path = legacy_dir.join(exe_name);
+            let legacy_path = legacy_dir.join(installed_name);
             // Best-effort copy — we don't fail the deploy if the legacy
             // archive step fails; the new symlink swap below is what
             // actually has to work.
@@ -4092,8 +4159,8 @@ async fn install_versioned_binary(
     }
 
     // Install the freshly-built binary into the version dir.
-    let src = repo_path.join("target").join("debug").join(exe_name);
-    let target = version_dir.join(exe_name);
+    let src = repo_path.join("target").join("debug").join(source_name);
+    let target = version_dir.join(installed_name);
     let install_status = tokio::process::Command::new("install")
         .args([
             "-m",
@@ -4993,11 +5060,11 @@ mod tests {
     use super::{
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
         hermes_config_base_url, hermes_config_model_label, hermes_config_yaml, hermes_service_unit,
-        hermes_uses_native_codex, is_safe_repo_path, normalize_repo_path, prepare_deploy_backup,
-        prune_deploy_backups, rollback_deployed_binary, sandboxed_service_name_from_path,
-        select_repo_path, systemd_service_component_from_states, upsert_hermes_mcp_command,
-        ComponentStatus, DebounceDecision, DeployRefusal, DEPLOY_DEBOUNCE_SECS,
-        HERMES_SERVICE_DRAIN_DROP_IN,
+        hermes_uses_native_codex, install_versioned_binary_as, is_safe_repo_path,
+        normalize_repo_path, prepare_deploy_backup, prune_deploy_backups, rollback_deployed_binary,
+        sandboxed_service_name_from_path, select_repo_path, systemd_service_component_from_states,
+        upsert_hermes_mcp_command, ComponentStatus, DebounceDecision, DeployRefusal,
+        DeployRollback, DEPLOY_DEBOUNCE_SECS, HERMES_SERVICE_DRAIN_DROP_IN,
     };
 
     #[test]
@@ -5054,18 +5121,76 @@ mod tests {
         let destination = destination.to_string_lossy().to_string();
         let backup = backup.to_string_lossy().to_string();
 
-        let had_backup = prepare_deploy_backup(&destination, &backup).await.unwrap();
-        assert!(!had_backup);
+        let rollback = prepare_deploy_backup(&destination, &backup).await.unwrap();
+        assert!(matches!(rollback, DeployRollback::Missing));
         tokio::fs::write(&destination, b"new").await.unwrap();
-        rollback_deployed_binary(&destination, &backup, had_backup).await;
+        rollback_deployed_binary(&destination, &backup, &rollback).await;
         assert!(!std::path::Path::new(&destination).exists());
 
         tokio::fs::write(&destination, b"old").await.unwrap();
-        let had_backup = prepare_deploy_backup(&destination, &backup).await.unwrap();
-        assert!(had_backup);
+        let rollback = prepare_deploy_backup(&destination, &backup).await.unwrap();
+        assert!(matches!(rollback, DeployRollback::Backup));
         tokio::fs::write(&destination, b"new").await.unwrap();
-        rollback_deployed_binary(&destination, &backup, had_backup).await;
+        rollback_deployed_binary(&destination, &backup, &rollback).await;
         assert_eq!(tokio::fs::read(&destination).await.unwrap(), b"old");
+
+        let target = dir.path().join("versions/old/assistant-mcp-dev");
+        tokio::fs::create_dir_all(target.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&target, b"old-version").await.unwrap();
+        tokio::fs::remove_file(&destination).await.unwrap();
+        tokio::fs::symlink(&target, &destination).await.unwrap();
+        let rollback = prepare_deploy_backup(&destination, &backup).await.unwrap();
+        assert!(matches!(rollback, DeployRollback::Symlink(_)));
+        tokio::fs::remove_file(&destination).await.unwrap();
+        tokio::fs::write(&destination, b"plain-new").await.unwrap();
+        rollback_deployed_binary(&destination, &backup, &rollback).await;
+        assert!(tokio::fs::symlink_metadata(&destination)
+            .await
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(tokio::fs::read_link(&destination).await.unwrap(), target);
+    }
+
+    #[tokio::test]
+    async fn versioned_deploy_preserves_service_symlink_with_renamed_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let bin_dir = dir.path().join("bin");
+        tokio::fs::create_dir_all(repo.join("target/debug"))
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(&bin_dir).await.unwrap();
+        tokio::fs::write(repo.join("target/debug/sandboxed-sh"), b"new-version")
+            .await
+            .unwrap();
+        let destination = bin_dir.join("sandboxed-sh-dev");
+        tokio::fs::symlink("versions/old/sandboxed-sh-dev", &destination)
+            .await
+            .unwrap();
+
+        install_versioned_binary_as(
+            &repo,
+            "sandboxed-sh",
+            "sandboxed-sh-dev",
+            "new-head",
+            destination.to_string_lossy().as_ref(),
+        )
+        .await
+        .unwrap();
+
+        assert!(tokio::fs::symlink_metadata(&destination)
+            .await
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            tokio::fs::read_link(&destination).await.unwrap(),
+            bin_dir.join("versions/new-head/sandboxed-sh-dev")
+        );
+        assert_eq!(tokio::fs::read(&destination).await.unwrap(), b"new-version");
     }
 
     #[test]

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -27,7 +27,7 @@ use super::auth::AuthUser;
 use super::control::{self, MissionStatus};
 use super::mission_store::Mission;
 use super::routes::AppState;
-use crate::util::home_dir;
+use crate::util::{current_service_companion_binary_path, home_dir, service_companion_binary_path};
 use crate::workspace::{Workspace, WorkspaceStatus, WorkspaceType};
 
 /// Git remote used for sandboxed.sh self-updates
@@ -2056,6 +2056,11 @@ async fn adopt_hermes_assistant(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     let home_channel = choose_telegram_home_channel(&channel.allowed_chat_ids, &chat_mappings);
+    let assistant_mcp_command = current_service_companion_binary_path("assistant-mcp")
+        .filter(|path| path.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("/usr/local/bin/assistant-mcp"))
+        .to_string_lossy()
+        .to_string();
 
     run_host_command("install", &["-d", "-m", "0755", "/etc/sandboxed-sh"])
         .await
@@ -2103,7 +2108,10 @@ async fn adopt_hermes_assistant(
     if req.allow_all_users {
         env.push_str("GATEWAY_ALLOW_ALL_USERS=true\n");
     }
-    env.push_str("HERMES_ASSISTANT_MCP_COMMAND=/usr/local/bin/assistant-mcp\n");
+    env.push_str(&env_line(
+        "HERMES_ASSISTANT_MCP_COMMAND",
+        &assistant_mcp_command,
+    ));
 
     // Preserve remote access (desktop proxy mode) across adoptions: keep the
     // existing API_SERVER_KEY so connected desktop apps don't break.
@@ -2135,7 +2143,7 @@ async fn adopt_hermes_assistant(
             &model,
             &format!("{api_url}/v1"),
             &proxy_key,
-            "/usr/local/bin/assistant-mcp",
+            &assistant_mcp_command,
             &api_url,
             &jwt_secret,
             &user_id,
@@ -2550,6 +2558,11 @@ async fn which_grok() -> Option<String> {
 
 /// Find the path to the Hermes assistant MCP connector.
 async fn which_assistant_mcp() -> Option<String> {
+    if let Some(path) = current_service_companion_binary_path("assistant-mcp") {
+        if path.exists() {
+            return Some(path.to_string_lossy().to_string());
+        }
+    }
     which_binary("assistant-mcp", &["/usr/local/bin/assistant-mcp"]).await
 }
 
@@ -3130,7 +3143,9 @@ fn stream_sandboxed_update(
         // Also install MCP binaries if they were built
         for mcp_bin in ["workspace-mcp", "desktop-mcp", "assistant-mcp"] {
             let mcp_src = format!("{}/target/debug/{}", repo_path.display(), mcp_bin);
-            let mcp_dest = format!("/usr/local/bin/{}", mcp_bin);
+            let mcp_dest = service_companion_binary_path(&current_exe, mcp_bin)
+                .to_string_lossy()
+                .to_string();
             if std::path::Path::new(&mcp_src).exists() {
                 let _ = Command::new("install")
                     .args(["-m", "0755", &mcp_src, &mcp_dest])
@@ -3524,19 +3539,26 @@ fn stream_deploy(
         const ASSISTANT_MCP_CARGO_BIN: &str = "assistant-mcp";
         const PALOMA_CARGO_BIN: &str = "palomactl";
         let install_dest_main = current_exe.to_string_lossy().to_string();
-        // Match the MCP install location: same dir as the main binary, fixed name.
-        let install_dest_mcp = current_exe
-            .parent()
-            .map(|p| p.join(MCP_CARGO_BIN).to_string_lossy().to_string())
-            .unwrap_or_else(|| format!("/usr/local/bin/{}", MCP_CARGO_BIN));
-        let install_dest_assistant_mcp = current_exe
-            .parent()
-            .map(|p| p.join(ASSISTANT_MCP_CARGO_BIN).to_string_lossy().to_string())
-            .unwrap_or_else(|| format!("/usr/local/bin/{}", ASSISTANT_MCP_CARGO_BIN));
-        let install_dest_paloma = std::env::var("PALOMACTL_INSTALL_PATH")
-            .ok()
-            .filter(|path| !path.trim().is_empty())
-            .unwrap_or_else(|| {
+        // Production owns the historical unsuffixed companion paths consumed
+        // by Hermes. Dev/staging services install suffixed companions so their
+        // deploys cannot replace production MCP or palomactl binaries.
+        let install_dest_mcp = service_companion_binary_path(&current_exe, MCP_CARGO_BIN)
+            .to_string_lossy()
+            .to_string();
+        let install_dest_assistant_mcp =
+            service_companion_binary_path(&current_exe, ASSISTANT_MCP_CARGO_BIN)
+                .to_string_lossy()
+                .to_string();
+        let scoped_paloma = service_companion_binary_path(&current_exe, PALOMA_CARGO_BIN);
+        let install_dest_paloma = if scoped_paloma.file_name().and_then(|v| v.to_str())
+            != Some(PALOMA_CARGO_BIN)
+        {
+            scoped_paloma.to_string_lossy().to_string()
+        } else {
+            std::env::var("PALOMACTL_INSTALL_PATH")
+                .ok()
+                .filter(|path| !path.trim().is_empty())
+                .unwrap_or_else(|| {
                 let hermes_bin = std::path::Path::new("/var/lib/hermes-assistant/bin");
                 let wrapper = hermes_bin.join("palomactl-wrapper");
                 let real = hermes_bin.join("palomactl.real");
@@ -3551,7 +3573,8 @@ fn stream_deploy(
                 } else {
                     "/usr/local/bin/palomactl".to_string()
                 }
-            });
+            })
+        };
 
         if !req.skip_build {
             yield sse("log", format!("Building {} + {} + {} + {} (cargo build, debug)", MAIN_CARGO_BIN, MCP_CARGO_BIN, ASSISTANT_MCP_CARGO_BIN, PALOMA_CARGO_BIN), Some(25));

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2141,7 +2141,6 @@ async fn adopt_hermes_assistant(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     let home_channel = choose_telegram_home_channel(&channel.allowed_chat_ids, &chat_mappings);
     let assistant_mcp_command = current_service_companion_binary_path("assistant-mcp")
-        .filter(|path| path.exists())
         .unwrap_or_else(|| std::path::PathBuf::from("/usr/local/bin/assistant-mcp"))
         .to_string_lossy()
         .to_string();
@@ -3170,8 +3169,8 @@ fn stream_sandboxed_update(
                 return;
             }
         };
-        let exe_name = current_exe.file_name().unwrap_or_default().to_string_lossy().to_string();
-        let service_name = format!("{}.service", exe_name);
+        let installed_name = current_exe.file_name().unwrap_or_default().to_string_lossy().to_string();
+        let service_name = format!("{}.service", installed_name);
         let install_dest = current_exe.to_string_lossy().to_string();
 
         yield sse("log", format!("Installing binary to {} (service: {})...", install_dest, service_name), Some(75));
@@ -3196,10 +3195,18 @@ fn stream_sandboxed_update(
             .output()
             .await;
 
-        let src = format!("{}/target/debug/{}", repo_path.display(), exe_name);
+        const MAIN_CARGO_BIN: &str = "sandboxed-sh";
+        let src = format!("{}/target/debug/{}", repo_path.display(), MAIN_CARGO_BIN);
 
         let install_result = if versioned_install {
-            install_versioned_binary(repo_path, &exe_name, &latest_tag, &install_dest).await
+            install_versioned_binary_as(
+                repo_path,
+                MAIN_CARGO_BIN,
+                &installed_name,
+                &latest_tag,
+                &install_dest,
+            )
+            .await
         } else {
             // Legacy path: write straight to `install_dest`. Keep until the
             // operator opts into versioned installs.
@@ -4105,15 +4112,6 @@ async fn prune_deploy_backups(dest: &str, keep: usize) -> (Vec<String>, u64) {
 /// On first run against an existing real-file install, the live binary at
 /// `install_dest` is moved aside into `versions/legacy/<exe>` and the
 /// symlink is created. After that, every deploy is just step 3.
-async fn install_versioned_binary(
-    repo_path: &std::path::Path,
-    exe_name: &str,
-    tag: &str,
-    install_dest: &str,
-) -> Result<(), String> {
-    install_versioned_binary_as(repo_path, exe_name, exe_name, tag, install_dest).await
-}
-
 async fn install_versioned_binary_as(
     repo_path: &std::path::Path,
     source_name: &str,

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -27,7 +27,10 @@ use super::auth::AuthUser;
 use super::control::{self, MissionStatus};
 use super::mission_store::Mission;
 use super::routes::AppState;
-use crate::util::{current_service_companion_binary_path, home_dir, service_companion_binary_path};
+use crate::util::{
+    current_sandboxed_service_binary_path, current_service_companion_binary_path, home_dir,
+    service_binary_path_for_unit, service_companion_binary_path,
+};
 use crate::workspace::{Workspace, WorkspaceStatus, WorkspaceType};
 
 /// Git remote used for sandboxed.sh self-updates
@@ -1576,6 +1579,68 @@ fn upsert_env_lines(contents: &str, updates: &[(&str, &str)]) -> String {
     out
 }
 
+fn upsert_hermes_mcp_command(contents: &str, command: &str) -> String {
+    let mut output = String::new();
+    let mut in_sandboxed_assistant = false;
+    let mut replaced = false;
+
+    for line in contents.lines() {
+        if line == "  sandboxed_assistant:" {
+            in_sandboxed_assistant = true;
+        } else if in_sandboxed_assistant
+            && line.starts_with("  ")
+            && !line.starts_with("    ")
+            && !line.trim().is_empty()
+        {
+            in_sandboxed_assistant = false;
+        }
+
+        if in_sandboxed_assistant && line.starts_with("    command:") {
+            output.push_str("    command: ");
+            output.push_str(&yaml_squote(command));
+            output.push('\n');
+            replaced = true;
+        } else {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+
+    if replaced {
+        output
+    } else {
+        contents.to_string()
+    }
+}
+
+/// Keep already-adopted Hermes installations on the companion binary owned
+/// by this sandboxed.sh environment. This migration runs on every deploy so a
+/// dev service cannot keep spawning the historical production connector.
+async fn migrate_hermes_assistant_mcp_command(
+    runtime_name: &str,
+    command: &str,
+) -> Result<bool, String> {
+    let mut touched = false;
+    let updates = [("HERMES_ASSISTANT_MCP_COMMAND", command)];
+    for env_path in hermes_env_paths(runtime_name) {
+        let Ok(contents) = tokio::fs::read_to_string(&env_path).await else {
+            continue;
+        };
+        write_private_file(&env_path, &upsert_env_lines(&contents, &updates)).await?;
+        touched = true;
+    }
+
+    let config_path = format!("/var/lib/{runtime_name}/config.yaml");
+    if let Ok(contents) = tokio::fs::read_to_string(&config_path).await {
+        let updated = upsert_hermes_mcp_command(&contents, command);
+        if updated != contents {
+            write_private_file(&config_path, &updated).await?;
+            touched = true;
+        }
+    }
+    Ok(touched)
+}
+
 fn generate_hermes_remote_key() -> String {
     format!("hsk_{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
 }
@@ -3079,10 +3144,10 @@ fn stream_sandboxed_update(
 
         // Detect the current binary path and derive the service name from it.
         // e.g. /usr/local/bin/sandboxed-sh-prod → service sandboxed-sh-prod.service
-        let current_exe = match std::env::current_exe() {
-            Ok(p) => p,
-            Err(e) => {
-                yield sse("error", format!("Failed to detect current binary path: {}", e), None);
+        let current_exe = match current_sandboxed_service_binary_path() {
+            Some(path) => path,
+            None => {
+                yield sse("error", "Failed to detect current service binary path", None);
                 return;
             }
         };
@@ -3468,6 +3533,26 @@ fn current_sandboxed_service_name() -> Result<String, String> {
     })
 }
 
+async fn prepare_deploy_backup(destination: &str, backup: &str) -> Result<bool, String> {
+    if !std::path::Path::new(destination).exists() {
+        return Ok(false);
+    }
+    tokio::fs::copy(destination, backup)
+        .await
+        .map_err(|error| format!("failed to back up {destination} to {backup}: {error}"))?;
+    Ok(true)
+}
+
+async fn rollback_deployed_binary(destination: &str, backup: &str, had_backup: bool) {
+    if had_backup {
+        let _ = tokio::fs::rename(backup, destination).await;
+    } else {
+        // This deploy created the destination for the first time. Leaving it
+        // behind after rolling the service back would mix binary generations.
+        let _ = tokio::fs::remove_file(destination).await;
+    }
+}
+
 /// The actual deploy stream — git checkout (optional), build (optional),
 /// versioned install, then a detached `systemctl restart`. Mirrors
 /// `stream_sandboxed_update` but skips the "stop service first" step so the
@@ -3524,13 +3609,14 @@ fn stream_deploy(
             }
         }
 
-        let current_exe = match std::env::current_exe() {
+        let resolved_exe = match std::env::current_exe() {
             Ok(p) => p,
             Err(e) => {
                 yield sse("error", format!("Failed to detect current binary path: {}", e), None);
                 return;
             }
         };
+        let current_exe = service_binary_path_for_unit(&resolved_exe, &service_name);
         // The cargo bin name is always `sandboxed-sh` regardless of how we
         // rename it on install (e.g. `sandboxed-sh-prod` or `sandboxed-sh-dev`).
         // Same for MCP binaries.
@@ -3659,9 +3745,13 @@ fn stream_deploy(
         // convention, so we match it.
         yield sse("log", format!("Installing {} → {}", src_main.display(), install_dest_main), Some(75));
         let bkp_main = format!("{}.pre-deploy-{}", install_dest_main, sha);
-        if std::path::Path::new(&install_dest_main).exists() {
-            let _ = tokio::fs::copy(&install_dest_main, &bkp_main).await;
-        }
+        let backed_main = match prepare_deploy_backup(&install_dest_main, &bkp_main).await {
+            Ok(backed) => backed,
+            Err(error) => {
+                yield sse("error", error, None);
+                return;
+            }
+        };
         let install_main = Command::new("install")
             .args([
                 "-m", "0755",
@@ -3673,10 +3763,12 @@ fn stream_deploy(
         match install_main {
             Ok(o) if o.status.success() => {}
             Ok(o) => {
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("Install of main binary failed: {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("install command error: {}", e), None);
                 return;
             }
@@ -3684,9 +3776,14 @@ fn stream_deploy(
 
         yield sse("log", format!("Installing {} → {}", src_mcp.display(), install_dest_mcp), Some(82));
         let bkp_mcp = format!("{}.pre-deploy-{}", install_dest_mcp, sha);
-        if std::path::Path::new(&install_dest_mcp).exists() {
-            let _ = tokio::fs::copy(&install_dest_mcp, &bkp_mcp).await;
-        }
+        let backed_mcp = match prepare_deploy_backup(&install_dest_mcp, &bkp_mcp).await {
+            Ok(backed) => backed,
+            Err(error) => {
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                yield sse("error", error, None);
+                return;
+            }
+        };
         let install_mcp = Command::new("install")
             .args([
                 "-m", "0755",
@@ -3701,12 +3798,14 @@ fn stream_deploy(
                 // Roll back the main binary swap before bailing — leaving
                 // the main binary swapped without its matching MCP is the
                 // worst possible half-applied state.
-                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("Install of orchestrator-mcp failed (main binary rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
-                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("install command error (main rolled back): {}", e), None);
                 return;
             }
@@ -3714,9 +3813,16 @@ fn stream_deploy(
 
         yield sse("log", format!("Installing {} → {}", src_assistant_mcp.display(), install_dest_assistant_mcp), Some(85));
         let bkp_assistant_mcp = format!("{}.pre-deploy-{}", install_dest_assistant_mcp, sha);
-        if std::path::Path::new(&install_dest_assistant_mcp).exists() {
-            let _ = tokio::fs::copy(&install_dest_assistant_mcp, &bkp_assistant_mcp).await;
-        }
+        let backed_assistant_mcp =
+            match prepare_deploy_backup(&install_dest_assistant_mcp, &bkp_assistant_mcp).await {
+                Ok(backed) => backed,
+                Err(error) => {
+                    rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                    rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                    yield sse("error", error, None);
+                    return;
+                }
+            };
         let install_assistant_mcp = Command::new("install")
             .args([
                 "-m", "0755",
@@ -3728,14 +3834,16 @@ fn stream_deploy(
         match install_assistant_mcp {
             Ok(o) if o.status.success() => {}
             Ok(o) => {
-                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
-                let _ = tokio::fs::rename(&bkp_mcp, &install_dest_mcp).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("Install of assistant-mcp failed (main/orchestrator binaries rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
-                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
-                let _ = tokio::fs::rename(&bkp_mcp, &install_dest_mcp).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("install command error for assistant-mcp (main/orchestrator rolled back): {}", e), None);
                 return;
             }
@@ -3743,9 +3851,16 @@ fn stream_deploy(
 
         yield sse("log", format!("Installing {} → {}", src_paloma.display(), install_dest_paloma), Some(87));
         let bkp_paloma = format!("{}.pre-deploy-{}", install_dest_paloma, sha);
-        if std::path::Path::new(&install_dest_paloma).exists() {
-            let _ = tokio::fs::copy(&install_dest_paloma, &bkp_paloma).await;
-        }
+        let backed_paloma = match prepare_deploy_backup(&install_dest_paloma, &bkp_paloma).await {
+            Ok(backed) => backed,
+            Err(error) => {
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                yield sse("error", error, None);
+                return;
+            }
+        };
         let install_paloma = Command::new("install")
             .args([
                 "-m", "0755",
@@ -3757,17 +3872,35 @@ fn stream_deploy(
         match install_paloma {
             Ok(o) if o.status.success() => {}
             Ok(o) => {
-                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
-                let _ = tokio::fs::rename(&bkp_mcp, &install_dest_mcp).await;
-                let _ = tokio::fs::rename(&bkp_assistant_mcp, &install_dest_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, backed_paloma).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("Install of palomactl failed (service binaries rolled back): {}", String::from_utf8_lossy(&o.stderr)), None);
                 return;
             }
             Err(e) => {
-                let _ = tokio::fs::rename(&bkp_main, &install_dest_main).await;
-                let _ = tokio::fs::rename(&bkp_mcp, &install_dest_mcp).await;
-                let _ = tokio::fs::rename(&bkp_assistant_mcp, &install_dest_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, backed_paloma).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
                 yield sse("error", format!("install command error for palomactl (service binaries rolled back): {}", e), None);
+                return;
+            }
+        }
+
+        let hermes_runtime = assistant_runtime_name(&state.config);
+        match migrate_hermes_assistant_mcp_command(hermes_runtime, &install_dest_assistant_mcp).await {
+            Ok(true) => {
+                yield sse("log", format!("Migrated {} to {}", hermes_runtime, install_dest_assistant_mcp), Some(88));
+            }
+            Ok(false) => {}
+            Err(error) => {
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, backed_paloma).await;
+                rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, backed_assistant_mcp).await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, backed_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, backed_main).await;
+                yield sse("error", format!("Hermes MCP command migration failed; service binaries rolled back: {}", error), None);
                 return;
             }
         }
@@ -4860,8 +4993,9 @@ mod tests {
     use super::{
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
         hermes_config_base_url, hermes_config_model_label, hermes_config_yaml, hermes_service_unit,
-        hermes_uses_native_codex, is_safe_repo_path, normalize_repo_path, prune_deploy_backups,
-        sandboxed_service_name_from_path, select_repo_path, systemd_service_component_from_states,
+        hermes_uses_native_codex, is_safe_repo_path, normalize_repo_path, prepare_deploy_backup,
+        prune_deploy_backups, rollback_deployed_binary, sandboxed_service_name_from_path,
+        select_repo_path, systemd_service_component_from_states, upsert_hermes_mcp_command,
         ComponentStatus, DebounceDecision, DeployRefusal, DEPLOY_DEBOUNCE_SECS,
         HERMES_SERVICE_DRAIN_DROP_IN,
     };
@@ -4900,6 +5034,38 @@ mod tests {
                 "generated Hermes config missing {tool}"
             );
         }
+    }
+
+    #[test]
+    fn hermes_mcp_command_migration_only_updates_sandboxed_assistant() {
+        let yaml = "mcp_servers:\n  other:\n    command: '/usr/bin/other'\n  sandboxed_assistant:\n    command: '/usr/local/bin/assistant-mcp'\n    timeout: 600\nmodel:\n  default: test\n";
+        let updated = upsert_hermes_mcp_command(yaml, "/usr/local/bin/assistant-mcp-dev");
+        assert!(updated.contains("other:\n    command: '/usr/bin/other'"));
+        assert!(updated
+            .contains("sandboxed_assistant:\n    command: '/usr/local/bin/assistant-mcp-dev'"));
+        assert!(!updated.contains("command: '/usr/local/bin/assistant-mcp'\n"));
+    }
+
+    #[tokio::test]
+    async fn deploy_rollback_removes_first_install_and_restores_existing_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("assistant-mcp-dev");
+        let backup = dir.path().join("assistant-mcp-dev.pre-deploy-test");
+        let destination = destination.to_string_lossy().to_string();
+        let backup = backup.to_string_lossy().to_string();
+
+        let had_backup = prepare_deploy_backup(&destination, &backup).await.unwrap();
+        assert!(!had_backup);
+        tokio::fs::write(&destination, b"new").await.unwrap();
+        rollback_deployed_binary(&destination, &backup, had_backup).await;
+        assert!(!std::path::Path::new(&destination).exists());
+
+        tokio::fs::write(&destination, b"old").await.unwrap();
+        let had_backup = prepare_deploy_backup(&destination, &backup).await.unwrap();
+        assert!(had_backup);
+        tokio::fs::write(&destination, b"new").await.unwrap();
+        rollback_deployed_binary(&destination, &backup, had_backup).await;
+        assert_eq!(tokio::fs::read(&destination).await.unwrap(), b"old");
     }
 
     #[test]

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 
 use super::config::McpConfigStore;
 use super::types::*;
+use crate::util::current_service_companion_binary_path;
 
 /// MCP protocol version we support
 const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
@@ -78,8 +79,12 @@ fn is_builtin_workspace_mcp(config: &McpServerConfig, working_dir: &Path) -> boo
     }
 
     let command_path = Path::new(command);
+    let scoped_workspace_mcp = current_service_companion_binary_path("workspace-mcp");
     command == "workspace-mcp"
         || command_path == Path::new("/usr/local/bin/workspace-mcp")
+        || scoped_workspace_mcp
+            .as_deref()
+            .is_some_and(|path| command_path == path)
         || command_path == working_dir.join("target/release/workspace-mcp")
         || command_path == working_dir.join("target/debug/workspace-mcp")
 }
@@ -263,6 +268,10 @@ impl McpRegistry {
                 release.to_string_lossy().to_string()
             } else if debug.exists() {
                 debug.to_string_lossy().to_string()
+            } else if let Some(scoped) = current_service_companion_binary_path("orchestrator-mcp")
+                .filter(|path| path.exists())
+            {
+                scoped.to_string_lossy().to_string()
             } else {
                 "orchestrator-mcp".to_string()
             }
@@ -344,6 +353,11 @@ impl McpRegistry {
             let debug = working_dir.join("target").join("debug").join(name);
             if debug.exists() {
                 return Some(debug.to_string_lossy().to_string());
+            }
+            if let Some(scoped) =
+                current_service_companion_binary_path(name).filter(|path| path.exists())
+            {
+                return Some(scoped.to_string_lossy().to_string());
             }
             None
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,6 +55,40 @@ pub fn home_dir() -> String {
     std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())
 }
 
+/// Return the install path for a companion binary owned by one sandboxed.sh
+/// service environment.
+///
+/// Production keeps the historical unsuffixed paths (`assistant-mcp`,
+/// `orchestrator-mcp`, ...), because the production Hermes service consumes
+/// them directly. Non-production binaries such as `sandboxed-sh-dev` use
+/// suffixed companions (`assistant-mcp-dev`). This prevents a dev deployment
+/// from silently replacing the tools used by production.
+pub fn service_companion_binary_path(
+    current_exe: &std::path::Path,
+    binary: &str,
+) -> std::path::PathBuf {
+    let parent = current_exe
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("/usr/local/bin"));
+    let service_suffix = current_exe
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("sandboxed-sh-"))
+        .filter(|suffix| !suffix.is_empty() && *suffix != "prod");
+
+    match service_suffix {
+        Some(suffix) => parent.join(format!("{binary}-{suffix}")),
+        None => parent.join(binary),
+    }
+}
+
+/// Resolve a companion path for the currently running sandboxed.sh binary.
+pub fn current_service_companion_binary_path(binary: &str) -> Option<std::path::PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .map(|exe| service_companion_binary_path(&exe, binary))
+}
+
 /// Read an environment variable, returning `Some(trimmed)` only when the
 /// variable is set *and* non-empty after trimming whitespace. Callers that
 /// chain several aliases via `or_else` need this to skip templated blank
@@ -477,6 +511,38 @@ mod tests {
         let result = build_history_context(&history, 10000);
         assert!(result.contains("USER: hello"));
         assert!(result.contains("ASSISTANT: world"));
+    }
+
+    #[test]
+    fn companion_binaries_are_isolated_outside_production() {
+        assert_eq!(
+            service_companion_binary_path(
+                std::path::Path::new("/usr/local/bin/sandboxed-sh-prod"),
+                "assistant-mcp",
+            ),
+            std::path::PathBuf::from("/usr/local/bin/assistant-mcp")
+        );
+        assert_eq!(
+            service_companion_binary_path(
+                std::path::Path::new("/usr/local/bin/sandboxed-sh-dev"),
+                "assistant-mcp",
+            ),
+            std::path::PathBuf::from("/usr/local/bin/assistant-mcp-dev")
+        );
+        assert_eq!(
+            service_companion_binary_path(
+                std::path::Path::new("/opt/bin/sandboxed-sh-staging"),
+                "orchestrator-mcp",
+            ),
+            std::path::PathBuf::from("/opt/bin/orchestrator-mcp-staging")
+        );
+        assert_eq!(
+            service_companion_binary_path(
+                std::path::Path::new("/usr/local/bin/sandboxed-sh"),
+                "palomactl",
+            ),
+            std::path::PathBuf::from("/usr/local/bin/palomactl")
+        );
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,11 +82,70 @@ pub fn service_companion_binary_path(
     }
 }
 
+/// Return the directory that owns the live service symlink/binary.
+///
+/// `current_exe()` resolves symlinks. With versioned installs that produces a
+/// path such as `/usr/local/bin/versions/<sha>/sandboxed-sh`, while companions
+/// must remain beside the stable `/usr/local/bin/sandboxed-sh-dev` entrypoint.
+fn service_install_dir(current_exe: &std::path::Path) -> std::path::PathBuf {
+    for ancestor in current_exe.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("versions") {
+            if let Some(parent) = ancestor.parent() {
+                return parent.to_path_buf();
+            }
+        }
+    }
+    current_exe
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("/usr/local/bin"))
+        .to_path_buf()
+}
+
+/// Resolve the stable service entrypoint from a systemd unit name.
+pub fn service_binary_path_for_unit(
+    current_exe: &std::path::Path,
+    service_name: &str,
+) -> std::path::PathBuf {
+    let binary_name = service_name.trim_end_matches(".service");
+    service_install_dir(current_exe).join(binary_name)
+}
+
+/// Resolve the stable entrypoint of the currently running sandboxed.sh
+/// service without trusting `current_exe()` to preserve a symlink suffix.
+pub fn current_sandboxed_service_binary_path() -> Option<std::path::PathBuf> {
+    let current_exe = std::env::current_exe().ok()?;
+
+    if let Some(argv0) = std::env::args_os().next() {
+        let argv0 = std::path::PathBuf::from(argv0);
+        if argv0
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("sandboxed-sh"))
+        {
+            if argv0.is_absolute() {
+                return Some(argv0);
+            }
+            return Some(service_install_dir(&current_exe).join(argv0));
+        }
+    }
+
+    if let Ok(cgroup) = std::fs::read_to_string("/proc/self/cgroup") {
+        if let Some(service_name) = cgroup
+            .lines()
+            .flat_map(|line| line.rsplit('/'))
+            .find(|part| part.starts_with("sandboxed-sh") && part.ends_with(".service"))
+        {
+            return Some(service_binary_path_for_unit(&current_exe, service_name));
+        }
+    }
+
+    Some(current_exe)
+}
+
 /// Resolve a companion path for the currently running sandboxed.sh binary.
 pub fn current_service_companion_binary_path(binary: &str) -> Option<std::path::PathBuf> {
-    std::env::current_exe()
-        .ok()
-        .map(|exe| service_companion_binary_path(&exe, binary))
+    current_sandboxed_service_binary_path()
+        .map(|service_path| service_companion_binary_path(&service_path, binary))
 }
 
 /// Read an environment variable, returning `Some(trimmed)` only when the
@@ -542,6 +601,13 @@ mod tests {
                 "palomactl",
             ),
             std::path::PathBuf::from("/usr/local/bin/palomactl")
+        );
+        assert_eq!(
+            service_binary_path_for_unit(
+                std::path::Path::new("/usr/local/bin/versions/0123456789ab/sandboxed-sh",),
+                "sandboxed-sh-dev.service",
+            ),
+            std::path::PathBuf::from("/usr/local/bin/sandboxed-sh-dev")
         );
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -38,7 +38,10 @@ use crate::library::env_crypto::strip_encrypted_tags;
 use crate::library::LibraryStore;
 use crate::mcp::{McpRegistry, McpScope, McpServerConfig, McpTransport};
 use crate::nspawn::{self, NspawnDistro};
-use crate::util::{env_var_bool, home_dir, strip_jsonc_comments, AI_PROVIDERS_PATH};
+use crate::util::{
+    current_service_companion_binary_path, env_var_bool, home_dir, strip_jsonc_comments,
+    AI_PROVIDERS_PATH,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Workspace Types
@@ -2956,6 +2959,12 @@ fn find_host_binary(name: &str, working_dir: &Path) -> Option<PathBuf> {
         if candidate.exists() {
             return Some(candidate);
         }
+    }
+
+    if let Some(scoped) =
+        current_service_companion_binary_path(name).filter(|candidate| candidate.exists())
+    {
+        return Some(scoped);
     }
 
     if let Ok(path_var) = std::env::var("PATH") {


### PR DESCRIPTION
## Summary
- keep production MCP/palomactl paths unsuffixed for Hermes compatibility
- install and resolve service-suffixed companions for dev/staging deployments
- propagate the scoped assistant path into environment-specific Hermes adoption
- document the deployment isolation contract

## Incident
A dev deployment replaced /usr/local/bin/assistant-mcp immediately after a production install. The production API binary remained correct, but Hermes would have picked up the dev connector on restart. This removes that shared mutable path.

## Validation
- cargo fmt --all --check
- targeted util, MCP registry, and system tests
- cargo clippy --all-targets -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy and Hermes MCP wiring on every deploy; incorrect path logic could break assistant connectivity, but the change is narrowly aimed at preventing cross-environment binary overwrites.
> 
> **Overview**
> Prevents non-production sandboxed.sh deploys from overwriting shared `/usr/local/bin` MCP and `palomactl` paths that production Hermes still expects.
> 
> **Companion path scoping** adds helpers so production keeps unsuffixed names (`assistant-mcp`, `orchestrator-mcp`, …) while services like `sandboxed-sh-dev` install and resolve suffixed binaries (`assistant-mcp-dev`). Deploy, self-update, Hermes adoption, component discovery, MCP registry defaults, and workspace binary resolution all use these paths instead of hard-coded unsuffixed installs.
> 
> **Hermes alignment** writes the scoped `assistant-mcp` path into new adoptions and runs a deploy-time migration that updates `HERMES_ASSISTANT_MCP_COMMAND` and the `sandboxed_assistant` block in Hermes config so an environment cannot keep pointing at the wrong connector after a dev deploy.
> 
> **Deploy hardening** resolves the stable service entrypoint when `current_exe` points through versioned symlinks, generalizes versioned installs with `install_versioned_binary_as` (cargo `sandboxed-sh` → service-specific binary name), and adds symlink-aware backup/rollback so a failed multi-binary deploy does not leave a half-applied state.
> 
> Docs in `DEBUGGING.md` and `agents.md` document the dev/prod binary isolation contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ded2fa94d7029c90f1b92ccd42e6d6fe40157af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->