### PR TITLE
fix: surface revoked OAuth credentials

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -33,6 +33,7 @@ import { cn } from '@/lib/utils';
 import { AddProviderModal } from '@/components/ui/add-provider-modal';
 import {
   ReconnectProviderModal,
+  providerShouldShowReconnect,
   providerSupportsOAuthReconnect,
 } from '@/components/ui/reconnect-provider-modal';
 import { AsyncButton } from '@/components/ui/async-button';
@@ -780,7 +781,7 @@ export default function ProvidersPage() {
                   : provider.status.type;
                 const statusColor = effectiveStatus === 'connected'
                   ? 'bg-emerald-400'
-                  : effectiveStatus === 'needs_auth'
+                  : effectiveStatus === 'needs_auth' || effectiveStatus === 'needs_reauth'
                   ? 'bg-amber-400'
                   : 'bg-red-400';
                 const statusTitle = usageIndicatesDisconnected
@@ -943,7 +944,7 @@ export default function ProvidersPage() {
                                 )}
                               </button>
                             )}
-                            {(effectiveStatus === 'needs_auth' || effectiveStatus === 'needs_reauth' || effectiveStatus === 'error') && (
+                            {providerShouldShowReconnect(provider, effectiveStatus) && (
                               <button
                                 onClick={() => handleAuthenticate(provider)}
                                 disabled={authenticatingProviderId === provider.id}
@@ -954,7 +955,9 @@ export default function ProvidersPage() {
                                     : 'text-red-400 hover:text-red-300'
                                 )}
                                 title={
-                                  effectiveStatus === 'needs_auth'
+                                  providerSupportsOAuthReconnect(provider) && effectiveStatus === 'connected'
+                                    ? 'Reconnect OAuth account'
+                                    : effectiveStatus === 'needs_auth'
                                     ? 'Connect'
                                     : effectiveStatus === 'needs_reauth'
                                     ? 'Reconnect'

--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -776,9 +776,13 @@ export default function ProvidersPage() {
                   !!cachedUsage?.error ||
                   (typeof cachedUsage?.status === 'string' &&
                     !['connected', 'ok'].includes(cachedUsage.status));
-                const effectiveStatus = usageIndicatesDisconnected
-                  ? 'error'
-                  : provider.status.type;
+                const cachedAuthStatus =
+                  cachedUsage?.status === 'needs_auth' || cachedUsage?.status === 'needs_reauth'
+                    ? cachedUsage.status
+                    : null;
+                const effectiveStatus = cachedAuthStatus ?? (
+                  usageIndicatesDisconnected ? 'error' : provider.status.type
+                );
                 const statusColor = effectiveStatus === 'connected'
                   ? 'bg-emerald-400'
                   : effectiveStatus === 'needs_auth' || effectiveStatus === 'needs_reauth'

--- a/dashboard/src/components/ui/reconnect-provider-modal.test.ts
+++ b/dashboard/src/components/ui/reconnect-provider-modal.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { AIProvider } from '@/lib/api';
+import {
+  providerShouldShowReconnect,
+  providerSupportsOAuthReconnect,
+} from './reconnect-provider-modal';
+
+function xaiProvider(status: AIProvider['status']['type']): AIProvider {
+  return {
+    id: 'xai-account',
+    provider_type: 'xai',
+    provider_type_name: 'xAI',
+    name: 'xAI',
+    has_api_key: false,
+    has_oauth: true,
+    base_url: null,
+    enabled: true,
+    is_default: false,
+    uses_oauth: true,
+    auth_methods: [],
+    status: { type: status },
+    use_for_backends: ['opencode', 'grok'],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('OAuth reconnect availability', () => {
+  it('keeps reconnect available while a provider is reported connected', () => {
+    const provider = xaiProvider('connected');
+
+    expect(providerSupportsOAuthReconnect(provider)).toBe(true);
+    expect(providerShouldShowReconnect(provider, 'connected')).toBe(true);
+  });
+
+  it('keeps reconnect available when xAI requires reauthorization', () => {
+    expect(providerShouldShowReconnect(xaiProvider('needs_reauth'), 'needs_reauth')).toBe(true);
+  });
+});

--- a/dashboard/src/components/ui/reconnect-provider-modal.tsx
+++ b/dashboard/src/components/ui/reconnect-provider-modal.tsx
@@ -46,6 +46,18 @@ export function providerSupportsOAuthReconnect(provider: AIProvider): boolean {
   );
 }
 
+export function providerShouldShowReconnect(
+  provider: AIProvider,
+  effectiveStatus: AIProvider['status']['type']
+): boolean {
+  return (
+    providerSupportsOAuthReconnect(provider) ||
+    effectiveStatus === 'needs_auth' ||
+    effectiveStatus === 'needs_reauth' ||
+    effectiveStatus === 'error'
+  );
+}
+
 interface ReconnectProviderModalProps {
   provider: AIProvider | null;
   open: boolean;

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -582,30 +582,27 @@ impl AIProviderStore {
 
         {
             let mut providers = self.providers.write().await;
-            if let Some(existing) = providers.get(&id) {
-                let existing_refresh = existing
-                    .oauth
-                    .as_ref()
-                    .map(|oauth| oauth.refresh_token.as_str());
-                let replacement_refresh = provider
-                    .oauth
-                    .as_ref()
-                    .map(|oauth| oauth.refresh_token.as_str());
-                if existing_refresh != replacement_refresh {
-                    provider.rejected_oauth_refresh_fingerprint = None;
-                }
-                // If setting as default, unset others
-                if provider.is_default {
-                    for p in providers.values_mut() {
-                        if p.id != id {
-                            p.is_default = false;
-                        }
+            let existing = providers.get(&id)?;
+            let existing_refresh = existing
+                .oauth
+                .as_ref()
+                .map(|oauth| oauth.refresh_token.as_str());
+            let replacement_refresh = provider
+                .oauth
+                .as_ref()
+                .map(|oauth| oauth.refresh_token.as_str());
+            if existing_refresh != replacement_refresh {
+                provider.rejected_oauth_refresh_fingerprint = None;
+            }
+            // If setting as default, unset others
+            if provider.is_default {
+                for p in providers.values_mut() {
+                    if p.id != id {
+                        p.is_default = false;
                     }
                 }
-                providers.insert(id, provider.clone());
-            } else {
-                return None;
             }
+            providers.insert(id, provider.clone());
         }
 
         if let Err(e) = self.save_to_disk().await {

--- a/src/ai_providers.rs
+++ b/src/ai_providers.rs
@@ -369,6 +369,12 @@ pub struct AIProvider {
     /// and apply shared cooldowns across them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization_id: Option<String>,
+    /// SHA-256 fingerprint of an OAuth refresh token that the provider has
+    /// permanently rejected. Persisted so a service restart cannot briefly
+    /// present a revoked account as connected again. This is deliberately a
+    /// one-way fingerprint rather than another copy of the credential.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejected_oauth_refresh_fingerprint: Option<String>,
     /// Connection status (populated at runtime)
     #[serde(skip)]
     pub status: ProviderStatus,
@@ -414,6 +420,7 @@ impl AIProvider {
             is_default: false,
             account_email: None,
             organization_id: None,
+            rejected_oauth_refresh_fingerprint: None,
             status: ProviderStatus::Unknown,
             created_at: now,
             updated_at: now,
@@ -575,7 +582,18 @@ impl AIProviderStore {
 
         {
             let mut providers = self.providers.write().await;
-            if providers.contains_key(&id) {
+            if let Some(existing) = providers.get(&id) {
+                let existing_refresh = existing
+                    .oauth
+                    .as_ref()
+                    .map(|oauth| oauth.refresh_token.as_str());
+                let replacement_refresh = provider
+                    .oauth
+                    .as_ref()
+                    .map(|oauth| oauth.refresh_token.as_str());
+                if existing_refresh != replacement_refresh {
+                    provider.rejected_oauth_refresh_fingerprint = None;
+                }
                 // If setting as default, unset others
                 if provider.is_default {
                     for p in providers.values_mut() {
@@ -655,6 +673,7 @@ impl AIProviderStore {
 
         if let Some(provider) = providers.get_mut(&id) {
             provider.oauth = Some(credentials);
+            provider.rejected_oauth_refresh_fingerprint = None;
             provider.status = ProviderStatus::Connected;
             provider.updated_at = chrono::Utc::now();
             let updated = provider.clone();
@@ -668,6 +687,27 @@ impl AIProviderStore {
         } else {
             None
         }
+    }
+
+    /// Persist or clear the fingerprint of a permanently rejected OAuth
+    /// refresh token without retaining an additional plaintext credential.
+    pub async fn set_rejected_oauth_refresh_fingerprint(
+        &self,
+        id: Uuid,
+        fingerprint: Option<String>,
+    ) -> Option<AIProvider> {
+        let mut providers = self.providers.write().await;
+        let provider = providers.get_mut(&id)?;
+        provider.rejected_oauth_refresh_fingerprint = fingerprint;
+        provider.updated_at = chrono::Utc::now();
+        let updated = provider.clone();
+        drop(providers);
+
+        if let Err(e) = self.save_to_disk().await {
+            tracing::error!("Failed to save AI providers to disk: {}", e);
+        }
+
+        Some(updated)
     }
 
     /// Update the provider's recorded organization ID (no-op when unchanged).

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -467,8 +467,9 @@ mod oauth_deadletter_tests {
 #[cfg(test)]
 mod grok_oauth_tests {
     use super::{
-        get_xai_api_key_for_grok, grok_auth_expires_at_millis, grok_cli_reconcile_due,
-        parse_grok_device_auth_line, GROK_CLI_RECONCILE_INTERVAL,
+        build_response_from_store, get_xai_api_key_for_grok, grok_auth_expires_at_millis,
+        grok_cli_reconcile_due, oauth_refresh_clear_dead, oauth_refresh_mark_token_dead,
+        parse_grok_device_auth_line, ProviderStatusResponse, GROK_CLI_RECONCILE_INTERVAL,
     };
     use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
     use std::time::{Duration as StdDuration, Instant};
@@ -566,6 +567,39 @@ mod grok_oauth_tests {
         .expect("write providers");
 
         assert_eq!(get_xai_api_key_for_grok(temp.path()), None);
+    }
+
+    #[test]
+    fn rejected_grok_refresh_token_requires_reconnect_even_before_access_expiry() {
+        let mut provider = AIProvider::new(ProviderType::Xai, "xAI OAuth".to_string());
+        provider.oauth = Some(OAuthCredentials {
+            access_token: "access-token".to_string(),
+            refresh_token: "revoked-refresh-token".to_string(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60 * 60 * 1000,
+        });
+        oauth_refresh_mark_token_dead(provider.id, "revoked-refresh-token");
+
+        let response = build_response_from_store(&provider);
+
+        assert!(matches!(
+            response.status,
+            ProviderStatusResponse::NeedsReauth { .. }
+        ));
+        oauth_refresh_clear_dead(provider.id);
+    }
+
+    #[test]
+    fn fresh_grok_oauth_token_remains_connected() {
+        let mut provider = AIProvider::new(ProviderType::Xai, "xAI OAuth".to_string());
+        provider.oauth = Some(OAuthCredentials {
+            access_token: "access-token".to_string(),
+            refresh_token: "fresh-refresh-token".to_string(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60 * 60 * 1000,
+        });
+
+        let response = build_response_from_store(&provider);
+
+        assert!(matches!(response.status, ProviderStatusResponse::Connected));
     }
 }
 
@@ -3236,7 +3270,19 @@ fn build_response_from_store(provider: &crate::ai_providers::AIProvider) -> Prov
         .oauth
         .as_ref()
         .is_some_and(|oauth| oauth_token_expired(oauth.expires_at));
-    let status = if pt == ProviderType::Xai && has_oauth && !has_api_key && oauth_expired {
+    let oauth_refresh_rejected = provider
+        .oauth
+        .as_ref()
+        .is_some_and(|oauth| oauth_refresh_token_is_dead(provider.id, &oauth.refresh_token));
+    let status = if has_oauth && !has_api_key && oauth_refresh_rejected {
+        ProviderStatusResponse::NeedsReauth {
+            reason: format!(
+                "{} OAuth refresh token was rejected; reconnect the provider",
+                pt.display_name()
+            ),
+            auth_url: None,
+        }
+    } else if pt == ProviderType::Xai && has_oauth && !has_api_key && oauth_expired {
         ProviderStatusResponse::NeedsReauth {
             reason: "xAI OAuth token expired; reconnect Grok Build".to_string(),
             auth_url: None,
@@ -7366,13 +7412,19 @@ async fn get_provider_usage(
                     .unwrap()
                     .insert("status".to_string(), serde_json::json!("connected"));
             } else if let Some(ref o) = oauth {
-                if oauth_token_expired(o.expires_at) {
+                let refresh_rejected = provider_uuid
+                    .is_some_and(|uuid| oauth_refresh_token_is_dead(uuid, &o.refresh_token));
+                if refresh_rejected || oauth_token_expired(o.expires_at) {
                     info.as_object_mut()
                         .unwrap()
                         .insert("status".to_string(), serde_json::json!("needs_reauth"));
                     info.as_object_mut().unwrap().insert(
                         "error".to_string(),
-                        serde_json::json!("xAI OAuth token expired; reconnect Grok Build"),
+                        serde_json::json!(if refresh_rejected {
+                            "xAI OAuth refresh token was rejected; reconnect Grok Build"
+                        } else {
+                            "xAI OAuth token expired; reconnect Grok Build"
+                        }),
                     );
                 } else {
                     info.as_object_mut()

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -68,6 +68,24 @@ fn oauth_refresh_mark_token_dead(account_id: uuid::Uuid, token: &str) {
     }
 }
 
+fn oauth_refresh_token_fingerprint(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn provider_refresh_token_is_rejected(provider: &crate::ai_providers::AIProvider) -> bool {
+    match (
+        provider.rejected_oauth_refresh_fingerprint.as_deref(),
+        provider.oauth.as_ref(),
+    ) {
+        (Some(rejected), Some(oauth)) => {
+            rejected == oauth_refresh_token_fingerprint(&oauth.refresh_token)
+        }
+        _ => false,
+    }
+}
+
 pub(crate) fn oauth_refresh_clear_dead(account_id: uuid::Uuid) {
     if let Ok(mut m) = OAUTH_REFRESH_DEADLETTER.lock() {
         m.remove(&account_id);
@@ -469,7 +487,8 @@ mod grok_oauth_tests {
     use super::{
         build_response_from_store, get_xai_api_key_for_grok, grok_auth_expires_at_millis,
         grok_cli_reconcile_due, oauth_refresh_clear_dead, oauth_refresh_mark_token_dead,
-        parse_grok_device_auth_line, ProviderStatusResponse, GROK_CLI_RECONCILE_INTERVAL,
+        oauth_refresh_token_fingerprint, parse_grok_device_auth_line, ProviderStatusResponse,
+        GROK_CLI_RECONCILE_INTERVAL,
     };
     use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
     use std::time::{Duration as StdDuration, Instant};
@@ -600,6 +619,28 @@ mod grok_oauth_tests {
         let response = build_response_from_store(&provider);
 
         assert!(matches!(response.status, ProviderStatusResponse::Connected));
+    }
+
+    #[test]
+    fn rejected_grok_refresh_fingerprint_survives_store_serialization() {
+        let mut provider = AIProvider::new(ProviderType::Xai, "xAI OAuth".to_string());
+        provider.oauth = Some(OAuthCredentials {
+            access_token: "access-token".to_string(),
+            refresh_token: "revoked-refresh-token".to_string(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60 * 60 * 1000,
+        });
+        provider.rejected_oauth_refresh_fingerprint =
+            Some(oauth_refresh_token_fingerprint("revoked-refresh-token"));
+        let serialized = serde_json::to_string(&provider).expect("serialize provider");
+        assert_eq!(serialized.matches("revoked-refresh-token").count(), 1);
+        let restored: AIProvider = serde_json::from_str(&serialized).expect("restore provider");
+
+        let response = build_response_from_store(&restored);
+
+        assert!(matches!(
+            response.status,
+            ProviderStatusResponse::NeedsReauth { .. }
+        ));
     }
 }
 
@@ -3270,10 +3311,11 @@ fn build_response_from_store(provider: &crate::ai_providers::AIProvider) -> Prov
         .oauth
         .as_ref()
         .is_some_and(|oauth| oauth_token_expired(oauth.expires_at));
-    let oauth_refresh_rejected = provider
-        .oauth
-        .as_ref()
-        .is_some_and(|oauth| oauth_refresh_token_is_dead(provider.id, &oauth.refresh_token));
+    let oauth_refresh_rejected = provider_refresh_token_is_rejected(provider)
+        || provider
+            .oauth
+            .as_ref()
+            .is_some_and(|oauth| oauth_refresh_token_is_dead(provider.id, &oauth.refresh_token));
     let status = if has_oauth && !has_api_key && oauth_refresh_rejected {
         ProviderStatusResponse::NeedsReauth {
             reason: format!(
@@ -6437,113 +6479,124 @@ async fn get_provider_usage(
     // Resolve provider credentials: check AIProviderStore first, then OpenCode auth.
     // `provider_uuid` is `Some` when the credentials live in AIProviderStore and we
     // can persist a refreshed OAuth back into that specific record.
-    let (provider_type, api_key_opt, oauth, account_email, provider_name, provider_uuid) =
-        if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
-            // UUID lookup for custom providers
-            let provider = state
-                .ai_providers
-                .get(uuid)
-                .await
-                .ok_or((StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+    let (
+        provider_type,
+        api_key_opt,
+        oauth,
+        account_email,
+        provider_name,
+        provider_uuid,
+        provider_refresh_rejected,
+    ) = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        // UUID lookup for custom providers
+        let provider = state
+            .ai_providers
+            .get(uuid)
+            .await
+            .ok_or((StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
+        let refresh_rejected = provider_refresh_token_is_rejected(&provider);
+        (
+            provider.provider_type,
+            provider.api_key.clone(),
+            provider.oauth.clone(),
+            provider.account_email.clone(),
+            provider.name.clone(),
+            Some(uuid),
+            refresh_rejected,
+        )
+    } else if let Some(pt) = ProviderType::from_id(&id) {
+        // Try AIProviderStore first
+        if let Some(provider) = state.ai_providers.get_by_type(pt).await {
+            let refresh_rejected = provider_refresh_token_is_rejected(&provider);
             (
                 provider.provider_type,
                 provider.api_key.clone(),
                 provider.oauth.clone(),
                 provider.account_email.clone(),
                 provider.name.clone(),
-                Some(uuid),
+                Some(provider.id),
+                refresh_rejected,
             )
-        } else if let Some(pt) = ProviderType::from_id(&id) {
-            // Try AIProviderStore first
-            if let Some(provider) = state.ai_providers.get_by_type(pt).await {
-                (
-                    provider.provider_type,
-                    provider.api_key.clone(),
-                    provider.oauth.clone(),
-                    provider.account_email.clone(),
-                    provider.name.clone(),
-                    Some(provider.id),
-                )
-            } else {
-                // Fall back to OpenCode auth: check both central auth.json
-                // and per-provider auth files (~/.opencode/auth/{provider}.json)
-                let auth = read_opencode_auth().map_err(internal_error)?;
-                let accounts_state = read_provider_accounts_state(&state.config.working_dir);
-                let account_email = accounts_state.get(pt.id()).cloned();
-
-                // Collect all auth entries: central + per-provider file
-                let mut auth_entries: Vec<&serde_json::Value> = opencode_auth_keys(pt)
-                    .into_iter()
-                    .filter_map(|key| auth.get(key))
-                    .collect();
-                // Also read per-provider auth file
-                let provider_auth_path = get_opencode_provider_auth_path(pt);
-                let provider_auth_value: Option<serde_json::Value> = if provider_auth_path.exists()
-                {
-                    std::fs::read_to_string(&provider_auth_path)
-                        .ok()
-                        .and_then(|c| serde_json::from_str(&c).ok())
-                } else {
-                    None
-                };
-                if let Some(ref pav) = provider_auth_value {
-                    auth_entries.push(pav);
-                }
-
-                let api_key = auth_entries.iter().find_map(|v| {
-                    v.get("key")
-                        .or_else(|| v.get("api_key"))
-                        .or_else(|| v.get("apiKey"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                });
-
-                let oauth_creds = auth_entries.iter().find_map(|entry| {
-                    let access = entry
-                        .get("access")
-                        .or_else(|| entry.get("access_token"))
-                        .and_then(|v| v.as_str())?;
-                    let refresh = entry
-                        .get("refresh")
-                        .or_else(|| entry.get("refresh_token"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let expires_at = entry
-                        .get("expires")
-                        .or_else(|| entry.get("expires_at"))
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-                    Some(crate::ai_providers::OAuthCredentials {
-                        access_token: access.to_string(),
-                        refresh_token: refresh,
-                        expires_at,
-                    })
-                });
-
-                if api_key.is_none() && oauth_creds.is_none() {
-                    return Ok(Json(serde_json::json!({
-                        "provider_type": pt.id(),
-                        "provider_name": pt.display_name(),
-                        "error": "No credentials found"
-                    })));
-                }
-
-                (
-                    pt,
-                    api_key,
-                    oauth_creds,
-                    account_email,
-                    pt.display_name().to_string(),
-                    None,
-                )
-            }
         } else {
-            return Err((
-                StatusCode::NOT_FOUND,
-                format!("Invalid provider ID: {}", id),
-            ));
-        };
+            // Fall back to OpenCode auth: check both central auth.json
+            // and per-provider auth files (~/.opencode/auth/{provider}.json)
+            let auth = read_opencode_auth().map_err(internal_error)?;
+            let accounts_state = read_provider_accounts_state(&state.config.working_dir);
+            let account_email = accounts_state.get(pt.id()).cloned();
+
+            // Collect all auth entries: central + per-provider file
+            let mut auth_entries: Vec<&serde_json::Value> = opencode_auth_keys(pt)
+                .into_iter()
+                .filter_map(|key| auth.get(key))
+                .collect();
+            // Also read per-provider auth file
+            let provider_auth_path = get_opencode_provider_auth_path(pt);
+            let provider_auth_value: Option<serde_json::Value> = if provider_auth_path.exists() {
+                std::fs::read_to_string(&provider_auth_path)
+                    .ok()
+                    .and_then(|c| serde_json::from_str(&c).ok())
+            } else {
+                None
+            };
+            if let Some(ref pav) = provider_auth_value {
+                auth_entries.push(pav);
+            }
+
+            let api_key = auth_entries.iter().find_map(|v| {
+                v.get("key")
+                    .or_else(|| v.get("api_key"))
+                    .or_else(|| v.get("apiKey"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            });
+
+            let oauth_creds = auth_entries.iter().find_map(|entry| {
+                let access = entry
+                    .get("access")
+                    .or_else(|| entry.get("access_token"))
+                    .and_then(|v| v.as_str())?;
+                let refresh = entry
+                    .get("refresh")
+                    .or_else(|| entry.get("refresh_token"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let expires_at = entry
+                    .get("expires")
+                    .or_else(|| entry.get("expires_at"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                Some(crate::ai_providers::OAuthCredentials {
+                    access_token: access.to_string(),
+                    refresh_token: refresh,
+                    expires_at,
+                })
+            });
+
+            if api_key.is_none() && oauth_creds.is_none() {
+                return Ok(Json(serde_json::json!({
+                    "provider_type": pt.id(),
+                    "provider_name": pt.display_name(),
+                    "error": "No credentials found"
+                })));
+            }
+
+            (
+                pt,
+                api_key,
+                oauth_creds,
+                account_email,
+                pt.display_name().to_string(),
+                None,
+                false,
+            )
+        }
+    } else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Invalid provider ID: {}", id),
+        ));
+    };
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
@@ -7412,8 +7465,9 @@ async fn get_provider_usage(
                     .unwrap()
                     .insert("status".to_string(), serde_json::json!("connected"));
             } else if let Some(ref o) = oauth {
-                let refresh_rejected = provider_uuid
-                    .is_some_and(|uuid| oauth_refresh_token_is_dead(uuid, &o.refresh_token));
+                let refresh_rejected = provider_refresh_rejected
+                    || provider_uuid
+                        .is_some_and(|uuid| oauth_refresh_token_is_dead(uuid, &o.refresh_token));
                 if refresh_rejected || oauth_token_expired(o.expires_at) {
                     info.as_object_mut()
                         .unwrap()
@@ -10106,7 +10160,18 @@ pub async fn refresh_store_account_oauth_locked(
 
     // Re-read the freshest credentials now that we're serialized — a concurrent
     // refresh may have just rotated the token while we waited on the gate.
-    let current_oauth = ai_providers.get(account_id).await.and_then(|p| p.oauth);
+    let current_provider = ai_providers.get(account_id).await;
+    let persistent_rejection = current_provider
+        .as_ref()
+        .is_some_and(provider_refresh_token_is_rejected);
+    let current_oauth = current_provider.and_then(|p| p.oauth);
+
+    if persistent_rejection {
+        return Err(OAuthRefreshError::InvalidGrant(
+            "invalid_grant (persisted): refresh token previously rejected; re-auth required"
+                .to_string(),
+        ));
+    }
 
     // Double-checked: if a concurrent refresh already produced a still-valid
     // access token, reuse it instead of consuming the (now-rotated) refresh
@@ -10132,6 +10197,12 @@ pub async fn refresh_store_account_oauth_locked(
     // (the re-read value above differs from the dead one) or any refresh
     // succeeds. Surface a permanent-looking error so callers log at debug.
     if oauth_refresh_token_is_dead(account_id, &refresh_token) {
+        let _ = ai_providers
+            .set_rejected_oauth_refresh_fingerprint(
+                account_id,
+                Some(oauth_refresh_token_fingerprint(&refresh_token)),
+            )
+            .await;
         return Err(OAuthRefreshError::InvalidGrant(
             "invalid_grant (cached): refresh token previously rejected; re-auth required"
                 .to_string(),
@@ -10157,6 +10228,12 @@ pub async fn refresh_store_account_oauth_locked(
                 // ~2-min cycle skips the doomed retry until re-auth.
                 if matches!(e, OAuthRefreshError::InvalidGrant(_)) {
                     oauth_refresh_mark_token_dead(account_id, &refresh_token);
+                    let _ = ai_providers
+                        .set_rejected_oauth_refresh_fingerprint(
+                            account_id,
+                            Some(oauth_refresh_token_fingerprint(&refresh_token)),
+                        )
+                        .await;
                 }
                 return Err(e);
             }


### PR DESCRIPTION
## Summary
- report OAuth refresh tokens rejected with invalid_grant as needs_reauth
- make xAI usage health reflect the dead refresh-token circuit breaker
- keep OAuth reconnect available from the provider row even while status is stale/connected
- render needs_reauth as amber and add regression coverage

## Validation
- cargo fmt --all --check
- cargo test rejected_grok_refresh_token_requires_reconnect_even_before_access_expiry
- cargo test fresh_grok_oauth_token_remains_connected
- eslint provider page/reconnect modal/tests
- vitest reconnect-provider-modal.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth refresh, persisted credentials, and provider status used for inference routing; incorrect fingerprint logic could block valid accounts or miss revoked ones.
> 
> **Overview**
> **Revoked OAuth refresh tokens** are now treated as **needs reauth** across the API and dashboard, including when the access token is still unexpired.
> 
> The backend persists a **SHA-256 fingerprint** of permanently rejected refresh tokens on `AIProvider` (cleared on successful re-auth or refresh rotation). That state survives restarts and complements the in-memory dead-letter circuit breaker; refresh attempts short-circuit when the fingerprint matches.
> 
> **Provider list API** and **xAI usage health** report `needs_reauth` with explicit errors when refresh is rejected, not only on access-token expiry.
> 
> **Dashboard** prefers cached usage `needs_auth` / `needs_reauth` for status dots (amber for reauth), and **`providerShouldShowReconnect`** keeps the OAuth reconnect action visible for supported providers even when status still shows connected, with Vitest coverage for xAI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612e3a26c3591bf573eedc13dab1ce3cf7b85c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->