### PR TITLE
feat: ship lean-slot and spark-build wrappers with the repo

### DIFF
--- a/scripts/lean-slot
+++ b/scripts/lean-slot
@@ -42,6 +42,15 @@ _spark_eligible() {
   # live in the boss mission's dir, e.g. mission-<boss>/wk-NNNN). spark-build
   # re-derives the real workspace root + rel from cwd; the endpoint authorizes a
   # worker's token for an ancestor mission's dir.
+  #
+  # Deliberately NOT eligible: builds from a configured project checkout
+  # (LEAN_PROJECT_PATH, e.g. /workspace/verity/base) that lives outside the
+  # mission dirs. The offload endpoint rsyncs artifacts BACK into host_dir, so
+  # its write-back authorization is scoped to <root>/workspaces/mission-* on
+  # purpose; widening it to shared checkouts would let one mission's token
+  # write into a tree other missions build from. Those builds keep the local
+  # flock gate below — per compute-placement policy they are the bounded dirty
+  # lane anyway, and clean validation goes through remote-lean-build instead.
   _guest_root="$(dirname "${SPARK_WORKSPACE_GUEST_DIR%/}")"
   case "$(pwd -P)/" in
     "${_guest_root}"/mission-*/)  return 0 ;;

--- a/scripts/lean-slot
+++ b/scripts/lean-slot
@@ -1,0 +1,71 @@
+#!/bin/sh
+# lean-slot — host-wide gate for heavy Lean work (lake build, REPL start),
+# with optional transparent offload to the DGX Spark.
+# Usage: lean-slot lake build Verity ...   (waits up to 45 min for a local slot)
+#
+# If the workspace has spark_offload enabled (SPARK_OFFLOAD_* injected) and the
+# mission is allowlisted (see SPARK_OFFLOAD_ALLOW), the build is shipped to the
+# Spark via `spark-build` and consumes NO local slot. If offload isn't
+# configured/allowed, or the offload infrastructure is unreachable, we fall back
+# to the original local flock gate below (identical to pre-offload behavior).
+#
+# SPARK_OFFLOAD_ALLOW: comma-separated mission-id (full or 8-char prefix)
+# allowlist. Empty/unset here defaults to a single mission for the initial
+# controlled rollout. Set SPARK_OFFLOAD_ALLOW="" in the environment to allow
+# every offload-enabled mission (full fleet).
+set -u
+
+# --- rollout gate ---
+# Defaults to a single mission for a controlled rollout. To arm a mission, set
+# this to its id (or set SPARK_OFFLOAD_ALLOW="" in the env to arm the whole
+# fleet — safe now that the offload rsync is rel-scoped to the build subtree and
+# the endpoint authorizes each mission's token only for its own / an ancestor's
+# workspace dir).
+SPARK_OFFLOAD_ALLOW="${SPARK_OFFLOAD_ALLOW-}"
+
+_spark_eligible() {
+  [ -n "${SPARK_OFFLOAD_URL:-}" ]          || return 1
+  [ -n "${SPARK_OFFLOAD_MISSION_ID:-}" ]   || return 1
+  [ -n "${SPARK_WORKSPACE_GUEST_DIR:-}" ]  || return 1
+  # Allowlist (empty = allow all offload-enabled missions).
+  if [ -n "${SPARK_OFFLOAD_ALLOW}" ]; then
+    _mid="${SPARK_OFFLOAD_MISSION_ID}"
+    _short="$(printf %s "$_mid" | cut -c1-8)"
+    case ",${SPARK_OFFLOAD_ALLOW}," in
+      *",${_mid},"*)   : ;;
+      *",${_short},"*) : ;;
+      *) return 1 ;;
+    esac
+  fi
+  # Offload builds invoked from inside ANY workspace tree under the workspaces
+  # root: the mission's own dir, OR a shared fleet dir (orchestrator worktrees
+  # live in the boss mission's dir, e.g. mission-<boss>/wk-NNNN). spark-build
+  # re-derives the real workspace root + rel from cwd; the endpoint authorizes a
+  # worker's token for an ancestor mission's dir.
+  _guest_root="$(dirname "${SPARK_WORKSPACE_GUEST_DIR%/}")"
+  case "$(pwd -P)/" in
+    "${_guest_root}"/mission-*/)  return 0 ;;
+    "${_guest_root}"/mission-*/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if _spark_eligible; then
+  spark-build "$@"
+  rc=$?
+  # 90/91 = offload not available -> fall through to the local gate.
+  if [ "$rc" -ne 90 ] && [ "$rc" -ne 91 ]; then
+    exit "$rc"
+  fi
+  echo "lean-slot: spark offload unavailable (rc=$rc); building locally" >&2
+fi
+
+# --- original local concurrency gate: heavy Lean concurrency kept at 2 ---
+for i in 0 1; do
+  exec 9>"/tmp/lean-slot-$i.lock"
+  if flock -n 9; then exec "$@"; fi
+  exec 9>&-
+done
+exec 9>"/tmp/lean-slot-0.lock"
+flock -w 2700 9 || { echo "lean-slot: no slot after 45min" >&2; exit 75; }
+exec "$@"

--- a/scripts/spark-build
+++ b/scripts/spark-build
@@ -1,0 +1,87 @@
+#!/bin/sh
+# spark-build CMD... — offload a build to the DGX Spark via the host
+# /api/spark/offload endpoint. Pure offloader: it does NOT fall back to a
+# local build. Exit codes:
+#   0..89, 92..255 = the remote build's own exit code (propagate to caller)
+#   90             = offload not configured / cwd outside workspace (caller may
+#                    fall back to a local build)
+#   91             = offload infrastructure error (HTTP/network; caller may
+#                    fall back to a local build)
+# Requires SPARK_OFFLOAD_{URL,TOKEN,MISSION_ID} and SPARK_WORKSPACE_{HOST,GUEST}_DIR
+# (injected by the backend when the workspace has spark_offload enabled).
+set -u
+
+if [ -z "${SPARK_OFFLOAD_URL:-}" ] || [ -z "${SPARK_OFFLOAD_TOKEN:-}" ] || \
+   [ -z "${SPARK_OFFLOAD_MISSION_ID:-}" ] || [ -z "${SPARK_WORKSPACE_HOST_DIR:-}" ] || \
+   [ -z "${SPARK_WORKSPACE_GUEST_DIR:-}" ]; then
+  echo "spark-build: offload not configured (missing SPARK_OFFLOAD_* env)" >&2
+  exit 90
+fi
+[ "$#" -ge 1 ] || { echo "spark-build: no command given" >&2; exit 2; }
+
+# Derive the build's workspace root + rel from the ACTUAL cwd, not from the
+# injected own *_DIR. Orchestrator fleets build in per-PR git worktrees under the
+# BOSS mission's dir (mission-<boss>/wk-NNNN), so a worker's cwd is under its
+# parent's workspace, not its own (vestigial) dir. We keep our own MISSION_ID +
+# TOKEN for auth; the offload endpoint authorizes a worker's token for an
+# ancestor mission's dir. The workspaces root is the parent of our injected
+# guest/host dirs (both are "<root>/mission-<own>").
+guest_root="$(dirname "${SPARK_WORKSPACE_GUEST_DIR%/}")"
+host_root="$(dirname "${SPARK_WORKSPACE_HOST_DIR%/}")"
+pwd_abs="$(pwd -P)"
+case "$pwd_abs/" in
+  "$guest_root"/mission-*/) : ;;
+  "$guest_root"/mission-*/*) : ;;
+  *)
+    echo "spark-build: cwd $pwd_abs is outside a workspace under $guest_root" >&2
+    exit 90
+    ;;
+esac
+sub="${pwd_abs#"$guest_root"/}"          # mission-<X>/wk-2019  OR  mission-<X>
+ws_name="${sub%%/*}"                      # mission-<X>
+case "$ws_name" in
+  mission-*) : ;;
+  *) echo "spark-build: cannot derive workspace from $pwd_abs" >&2; exit 90 ;;
+esac
+rel="${sub#"$ws_name"}"                   # /wk-2019  OR  (empty)
+rel="${rel#/}"                            # wk-2019   OR  (empty)
+host_dir="$host_root/$ws_name"           # <root>/mission-<X>
+
+SPARK_HOST_DIR="$host_dir" SPARK_REL="$rel" SPARK_CMD="$*" python3 - <<'PY'
+import json, os, sys, urllib.request, urllib.error
+url   = os.environ["SPARK_OFFLOAD_URL"]
+body  = json.dumps({
+    "mission_id": os.environ["SPARK_OFFLOAD_MISSION_ID"],
+    "host_dir":   os.environ["SPARK_HOST_DIR"],
+    "rel":        os.environ.get("SPARK_REL", ""),
+    "cmd":        os.environ["SPARK_CMD"],
+    "priority":   os.environ.get("SPARK_OFFLOAD_PRIORITY", "P0"),  # arbiter accepts P0|P1 only
+}).encode()
+req = urllib.request.Request(url, data=body, method="POST", headers={
+    "Authorization": "Bearer " + os.environ["SPARK_OFFLOAD_TOKEN"],
+    "Content-Type":  "application/json",
+})
+sys.stderr.write("spark-build: offloading to DGX Spark (host_dir=%r rel=%r cmd=%r)\n"
+                 % (os.environ["SPARK_HOST_DIR"], os.environ.get("SPARK_REL", ""), os.environ["SPARK_CMD"]))
+try:
+    # Covers rsync-up + remote build + rsync-back; host caps the build at ~60min.
+    with urllib.request.urlopen(req, timeout=7200) as r:
+        data = json.load(r)
+except urllib.error.HTTPError as e:
+    detail = e.read().decode("utf-8", "replace")[:800]
+    sys.stderr.write("spark-build: offload HTTP %s: %s\n" % (e.code, detail))
+    sys.exit(91)
+except Exception as e:
+    sys.stderr.write("spark-build: offload error: %s\n" % e)
+    sys.exit(91)
+log = data.get("log", "") or ""
+sys.stdout.write(log)
+if not log.endswith("\n"):
+    sys.stdout.write("\n")
+rc = int(data.get("exit_code", -1))
+sys.stderr.write("spark-build: remote build finished (exit=%d)\n" % rc)
+# Map remote exit code into the propagate range; never collide with 90/91.
+if rc in (90, 91) or rc < 0:
+    rc = 1
+sys.exit(rc & 0xff)
+PY

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2108,24 +2108,43 @@ async fn install_remote_build_wrapper(
     workspace: &Workspace,
     mission_id: Uuid,
 ) -> anyhow::Result<()> {
-    let destination = if workspace.workspace_type == WorkspaceType::Container
-        && !is_container_fallback(workspace)
-    {
-        workspace.path.join("usr/local/bin/remote-lean-build")
-    } else {
-        remote_build_wrapper_path(workspace, mission_id)
-    };
-    if let Some(parent) = destination.parent() {
-        tokio::fs::create_dir_all(parent).await?;
+    // All three build wrappers ship with the repo and are (re)installed at
+    // mission spawn: `remote-lean-build` (remote-node dispatch), `lean-slot`
+    // (host-wide Lean gate that transparently offloads to the Spark when the
+    // workspace opted in), and `spark-build` (the raw Spark offloader that
+    // `lean-slot` shells out to). Previously `lean-slot`/`spark-build` were
+    // hand-copied into container rootfs and drifted per workspace.
+    const WRAPPERS: [(&str, &[u8]); 3] = [
+        (
+            "remote-lean-build",
+            include_bytes!("../../scripts/remote-lean-build"),
+        ),
+        ("lean-slot", include_bytes!("../../scripts/lean-slot")),
+        ("spark-build", include_bytes!("../../scripts/spark-build")),
+    ];
+    for (name, contents) in WRAPPERS {
+        let destination = if workspace.workspace_type == WorkspaceType::Container
+            && !is_container_fallback(workspace)
+        {
+            workspace.path.join("usr/local/bin").join(name)
+        } else {
+            remote_build_wrapper_path(workspace, mission_id)
+                .parent()
+                .expect("wrapper path has a bin dir parent")
+                .join(name)
+        };
+        if let Some(parent) = destination.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let tmp = destination.with_extension(format!("tmp-{}-{mission_id}", std::process::id()));
+        tokio::fs::write(&tmp, contents).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)).await?;
+        }
+        tokio::fs::rename(&tmp, &destination).await?;
     }
-    let tmp = destination.with_extension(format!("tmp-{}-{mission_id}", std::process::id()));
-    tokio::fs::write(&tmp, include_bytes!("../../scripts/remote-lean-build")).await?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)).await?;
-    }
-    tokio::fs::rename(&tmp, &destination).await?;
     Ok(())
 }
 


### PR DESCRIPTION
lean-slot (host-wide Lean gate with transparent Spark offload) and spark-build (raw Spark offloader) were hand-copied into container rootfs and drifted per workspace — the verity container still ran a pre-offload lean-slot until it was hand-ported on 2026-07-16.

This absorbs the canonical versions (allow-all rollout gate + ancestry fix) under scripts/ and installs all three build wrappers at mission spawn alongside remote-lean-build (same atomic-write path, containers get /usr/local/bin, host workspaces get the mission .sandboxed-sh/bin dir already on PATH).

cargo check clean; the 13 remote_build wrapper tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Lean builds are gated and offloaded (Spark HTTP, mission allowlists, cwd-scoped write-back); misconfiguration could affect build placement or concurrency, but behavior is largely codifying existing offload logic with explicit safety boundaries.
> 
> **Overview**
> **Canonical Lean build wrappers** are added under `scripts/` and deployed at mission spawn together with `remote-lean-build`, replacing per-container hand copies that could drift.
> 
> `install_remote_build_wrapper` now loops over all three scripts (embedded via `include_bytes!`), writing each to `/usr/local/bin` in nspawn containers or the mission `.sandboxed-sh/bin` dir on the host, using the same atomic tmp+rename and `0755` permissions as before.
> 
> The new **`lean-slot`** gate optionally forwards heavy Lean commands to **`spark-build`** when Spark offload env is set and the mission passes `SPARK_OFFLOAD_ALLOW`, only from cwd under `mission-*` trees (including boss worktrees like `wk-NNNN`); shared `LEAN_PROJECT_PATH` checkouts stay on the local two-slot `flock` path. Offload failures with exit 90/91 fall back to that local gate unchanged.
> 
> **`spark-build`** POSTs to `/api/spark/offload` with workspace root and `rel` derived from actual cwd (not the worker’s own mission dir), using the mission’s scoped bearer token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbab7373a56693834f6624af5e4835a92221cf41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->