### PR TITLE
fix(control): research-intent carve-out for the Fable admission guard

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5290,6 +5290,24 @@ fn fable_mandate_requests_integration(intent: Option<&str>, prompt: Option<&str>
         "commit",
         "committing",
     ];
+    // Declared research scope: controllers that explicitly tag the mission as
+    // hypothesis/brainstorm work (proposal-only by construction) get a
+    // narrower guard. Research prompts unavoidably contain "commit" as a noun
+    // ("baseline commit <sha>") and "push" as an idiom ("axes to push"), which
+    // kept rejecting authorized Beal focus-brainstorms even after the verb
+    // rework (2026-07-17). Blatant integration verbs (merge/rebase) still
+    // reject regardless of the declared intent.
+    const RESEARCH_INTENT_MARKERS: [&str; 3] = ["hypothesis", "brainstorm", "research"];
+    const HARD_VERBS: [&str; 4] = ["merge", "merging", "rebase", "rebasing"];
+    let intent_norm = intent.unwrap_or_default().to_ascii_lowercase();
+    let declared_research = RESEARCH_INTENT_MARKERS
+        .iter()
+        .any(|marker| intent_norm.contains(marker));
+    let verbs: &[&str] = if declared_research {
+        &HARD_VERBS
+    } else {
+        &MUTATION_VERBS
+    };
     const NEGATORS_BEFORE: [&str; 9] = [
         "not", "never", "no", "without", "dont", "cannot", "cant", "forbid", "before",
     ];
@@ -5306,7 +5324,7 @@ fn fable_mandate_requests_integration(intent: Option<&str>, prompt: Option<&str>
         .filter(|token| !token.is_empty())
         .collect();
     words.iter().enumerate().any(|(i, word)| {
-        if !MUTATION_VERBS.contains(word) {
+        if !verbs.contains(word) {
             return false;
         }
         let negated_before = words[i.saturating_sub(3)..i]
@@ -23259,6 +23277,28 @@ And the report:
                 "Produce a prioritized focus plan as proposals only; do not \
                  commit or push anything; merging is forbidden; stop before commit"
             )
+        ));
+    }
+
+    #[test]
+    fn fable_research_intent_tolerates_commit_nouns_and_push_idioms() {
+        // Declared hypothesis/brainstorm scope: baseline-commit references and
+        // "axes to push" idioms must not reject (the 2026-07-17 regression).
+        assert!(!fable_mandate_requests_integration(
+            Some("hypothesis_generation"),
+            Some(
+                "Baseline is main at commit d83704e0; decide which frontier axes to push or pause"
+            )
+        ));
+        // ...but blatant integration verbs still reject even with the intent.
+        assert!(fable_mandate_requests_integration(
+            Some("hypothesis_generation"),
+            Some("Then merge the branch into main")
+        ));
+        // Without a research intent, commit/push mandates keep rejecting.
+        assert!(fable_mandate_requests_integration(
+            Some("repair"),
+            Some("Fix the lemma, then commit and push")
         ));
     }
 


### PR DESCRIPTION
Follow-up to #630: the verb rework still rejected authorized Beal focus-brainstorms because research prompts unavoidably contain `commit` as a noun (`baseline commit <sha>`) and `push` as an idiom (`axes to push`) — confirmed live at the 09:22 Beal controller tick (two progressively-reduced pure-math prompts rejected).

Missions declaring a hypothesis/brainstorm/research **intent** are proposal-only by construction, so the guard narrows to blatant integration verbs (merge/rebase) for them — those still reject regardless of intent. Undeclared intents keep the full verb list, so the original incident class (a review+merge mandate routed to Fable) stays blocked.

Paired with a controller-prompt update (already live) that sets `intent=hypothesis_generation` on brainstorm missions. `cargo test --lib fable`: 5 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guard logic in Fable admission with explicit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Fable admission guard** now treats missions whose `intent` mentions hypothesis, brainstorm, or research as proposal-only: it only flags **merge/rebase** verbs, not **commit/push**, so prompts like “baseline commit \<sha\>” or “axes to push” no longer false-reject authorized brainstorms.
> 
> All other intents still use the full mutation-verb list (merge, rebase, push, commit, etc.), so undeclared repair/integration mandates remain blocked. Tests cover the carve-out, hard-verb rejection under research intent, and unchanged behavior without research intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9850a21029920c4c9fcb5e14f24176bd7ed0ac90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->