### PR TITLE
fix(oauth): adopt fresher tier tokens instead of refreshing stale store copies

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -10085,7 +10085,9 @@ pub async fn refresh_due_store_oauth(
     let now_ms = chrono::Utc::now().timestamp_millis();
     let mut found = 0u32;
     let mut refreshed = 0u32;
-    for account in ai_providers.get_all_by_type(provider_type).await {
+    let accounts = ai_providers.get_all_by_type(provider_type).await;
+    let single_account = accounts.len() == 1;
+    for account in accounts {
         let Some(oauth) = account.oauth.as_ref() else {
             continue;
         };
@@ -10093,6 +10095,52 @@ pub async fn refresh_due_store_oauth(
             continue;
         }
         found += 1;
+
+        // Adopt-before-refresh (Anthropic): mission harnesses rotate the shared
+        // credential tiers mid-run, making the tier token the ONLY live member
+        // of the rotating family — refreshing our (older) copy would revoke it,
+        // the recurring split-brain of 2026-07-16/17. When the freshest tier
+        // entry differs and is strictly fresher, adopt it into this record
+        // instead of refreshing, and lift any cached invalid_grant. Guarded to
+        // the unambiguous cases: a single store account of this type, or a
+        // record whose own token is already recorded dead (that record IS the
+        // tier owner that lost the rotation race; a secondary account's token
+        // is not part of the tier family and refreshes independently).
+        if provider_type == ProviderType::Anthropic {
+            if let Some(tier) = read_oauth_token_entry(provider_type) {
+                let record_dead = oauth_refresh_token_is_dead(account.id, &oauth.refresh_token)
+                    || account.rejected_oauth_refresh_fingerprint.is_some();
+                if !tier.refresh_token.trim().is_empty()
+                    && tier.refresh_token != oauth.refresh_token
+                    && tier.expires_at > oauth.expires_at
+                    && (single_account || record_dead)
+                {
+                    let adopted = crate::api::oauth_reconcile::apply_rotation(
+                        ai_providers,
+                        provider_type,
+                        &crate::api::oauth_reconcile::PendingRotation {
+                            provider: "anthropic".to_string(),
+                            old_refresh_token: oauth.refresh_token.clone(),
+                            new_refresh_token: tier.refresh_token.clone(),
+                            new_access_token: tier.access_token.clone(),
+                            expires_at: tier.expires_at,
+                        },
+                    )
+                    .await;
+                    if adopted.is_some() {
+                        refreshed += 1;
+                        tracing::info!(
+                            provider = ?provider_type,
+                            account_id = %account.id,
+                            new_expires_at = tier.expires_at,
+                            "Adopted fresher tier OAuth token into store record (skipping refresh)"
+                        );
+                        continue;
+                    }
+                }
+            }
+        }
+
         if oauth.expires_at - now_ms > refresh_threshold_ms {
             continue;
         }


### PR DESCRIPTION
Root fix for the recurring Anthropic invalid_grant split-brain (3 incidents 2026-07-16/17, each healed manually via the rotation sidecar).

**Problem:** the token family has two writers — the store record (proactive loop) and the shared credential tiers (rotated by Claude Code harnesses mid-run). A mission rotation leaves the store stale; the store's next refresh with the dead token revokes the family. `apply_rotation` only heals when the rotation was queued and the store is exactly one generation behind.

**Fix:** `refresh_due_store_oauth` adopts before refreshing: if the freshest tier entry differs and is strictly fresher, it's written into the record via `apply_rotation` (lifting any cached invalid_grant) and the refresh is skipped. Guarded to unambiguous cases (single store account, or a record already marked dead = the tier owner that lost the race) so secondary accounts can never capture the primary's tier tokens. Runs before the due-threshold check so dead records heal on the next cycle.

`cargo test --lib oauth`: 20 passed; cargo check clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proactive OAuth refresh for Anthropic credentials—a security-sensitive path—but scope is narrow (guarded adopt-before-refresh) and reuses existing rotation reconciliation.
> 
> **Overview**
> **Proactive store OAuth refresh** for Anthropic now **adopts fresher shared tier credentials** instead of blindly refreshing a stale store copy that can revoke the live token family.
> 
> Before the due-expiry refresh runs, each account compares its stored OAuth to `read_oauth_token_entry`. When the tier has a different refresh token with a **later** `expires_at`, and the case is unambiguous (**only one** store account of that type, or this record is already marked dead via invalid_grant / rejected fingerprint), it calls **`apply_rotation`** to write the tier tokens into the store (clearing cached invalid_grant), counts that as refreshed, and **skips** `refresh_store_account_oauth_locked`. Secondary accounts with healthy tokens still refresh on their own.
> 
> This runs **ahead of** the refresh-threshold check so dead records can heal on the next loop without issuing a refresh that would split-brain against mission harness rotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7054a7d5085cc23173de8a355ebd4d232a567c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->