### PR TITLE
fix(oauth): harden Anthropic and Grok credential recovery

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -385,6 +385,9 @@ fn read_grok_auth_entry() -> Option<serde_json::Value> {
             continue;
         };
         if let Some(entry) = auth.get(GROK_OAUTH_CLIENT_KEY) {
+            if entry.get("auth_mode").and_then(|value| value.as_str()) == Some("oauth") {
+                continue;
+            }
             return Some(entry.clone());
         }
     }
@@ -464,7 +467,9 @@ fn parse_grok_device_auth_line(line: &str) -> (Option<String>, Option<String>) {
 mod oauth_deadletter_tests {
     use super::{
         oauth_refresh_clear_dead, oauth_refresh_mark_token_dead, oauth_refresh_token_is_dead,
+        should_adopt_anthropic_tier, OAuthTokenEntry,
     };
+    use crate::ai_providers::OAuthCredentials;
 
     #[test]
     fn deadletter_blocks_same_token_until_rotated_or_cleared() {
@@ -480,6 +485,47 @@ mod oauth_deadletter_tests {
         oauth_refresh_clear_dead(acct);
         assert!(!oauth_refresh_token_is_dead(acct, "tok-A"));
     }
+
+    #[test]
+    fn tier_adoption_requires_a_different_live_generation() {
+        let now = chrono::Utc::now().timestamp_millis();
+        let store = OAuthCredentials {
+            access_token: "access-old".into(),
+            refresh_token: "refresh-old".into(),
+            expires_at: now + 10 * 60_000,
+        };
+        let newer = OAuthTokenEntry {
+            access_token: "access-new".into(),
+            refresh_token: "refresh-new".into(),
+            expires_at: now + 20 * 60_000,
+        };
+        assert!(should_adopt_anthropic_tier(&store, &newer, false));
+
+        let same_generation = OAuthTokenEntry {
+            access_token: "access-old".into(),
+            refresh_token: "refresh-old".into(),
+            expires_at: now + 20 * 60_000,
+        };
+        assert!(!should_adopt_anthropic_tier(&store, &same_generation, true));
+
+        let rejected_store_with_equal_expiry = OAuthTokenEntry {
+            access_token: "access-recovered".into(),
+            refresh_token: "refresh-recovered".into(),
+            expires_at: store.expires_at,
+        };
+        assert!(should_adopt_anthropic_tier(
+            &store,
+            &rejected_store_with_equal_expiry,
+            true
+        ));
+
+        let expired = OAuthTokenEntry {
+            access_token: "access-expired".into(),
+            refresh_token: "refresh-expired".into(),
+            expires_at: now - 1,
+        };
+        assert!(!should_adopt_anthropic_tier(&store, &expired, true));
+    }
 }
 
 #[cfg(test)]
@@ -487,8 +533,9 @@ mod grok_oauth_tests {
     use super::{
         build_response_from_store, get_xai_api_key_for_grok, grok_auth_expires_at_millis,
         grok_cli_reconcile_due, oauth_refresh_clear_dead, oauth_refresh_mark_token_dead,
-        oauth_refresh_token_fingerprint, parse_grok_device_auth_line, ProviderStatusResponse,
-        GROK_CLI_RECONCILE_INTERVAL,
+        oauth_refresh_token_fingerprint, parse_grok_device_auth_line,
+        remove_legacy_grok_oauth_entry, ProviderStatusResponse, GROK_CLI_RECONCILE_INTERVAL,
+        GROK_OAUTH_CLIENT_KEY,
     };
     use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
     use std::time::{Duration as StdDuration, Instant};
@@ -529,6 +576,51 @@ mod grok_oauth_tests {
         });
 
         assert_eq!(grok_auth_expires_at_millis(&entry), 1779172231759);
+    }
+
+    #[test]
+    fn removes_only_sandboxed_legacy_grok_auth_entry() {
+        let mut legacy = serde_json::json!({
+            GROK_OAUTH_CLIENT_KEY: {
+                "auth_mode": "oauth",
+                "key": "legacy-access",
+                "refresh_token": "legacy-refresh"
+            },
+            "unrelated": {
+                "auth_mode": "api_key",
+                "key": "preserve-me"
+            }
+        })
+        .as_object()
+        .cloned()
+        .expect("auth object");
+        assert!(remove_legacy_grok_oauth_entry(&mut legacy));
+        assert!(!legacy.contains_key(GROK_OAUTH_CLIENT_KEY));
+        assert_eq!(
+            legacy
+                .get("unrelated")
+                .and_then(|entry| entry.get("key"))
+                .and_then(|value| value.as_str()),
+            Some("preserve-me")
+        );
+
+        let mut current = serde_json::json!({
+            GROK_OAUTH_CLIENT_KEY: {
+                "auth_mode": "oidc",
+                "key": "native-token"
+            }
+        })
+        .as_object()
+        .cloned()
+        .expect("auth object");
+        assert!(!remove_legacy_grok_oauth_entry(&mut current));
+        assert_eq!(
+            current
+                .get(GROK_OAUTH_CLIENT_KEY)
+                .and_then(|entry| entry.get("key"))
+                .and_then(|value| value.as_str()),
+            Some("native-token")
+        );
     }
 
     #[test]
@@ -3731,8 +3823,8 @@ fn sync_to_opencode_auth(
     }
 
     if matches!(provider_type, ProviderType::Xai) {
-        if let Err(e) = write_grok_oauth_auth_file(refresh_token, access_token, expires_at) {
-            tracing::error!("Failed to write Grok OAuth auth file: {}", e);
+        if let Err(e) = remove_legacy_grok_oauth_auth_entries() {
+            tracing::warn!("Failed to remove obsolete Grok OAuth auth entry: {}", e);
         }
     }
 
@@ -3751,68 +3843,52 @@ fn sync_to_opencode_auth(
     Ok(())
 }
 
-pub(crate) fn write_grok_oauth_auth_file(
-    refresh_token: &str,
-    access_token: &str,
-    expires_at: i64,
-) -> Result<(), String> {
-    let expires_at = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(expires_at)
-        .map(|dt| dt.to_rfc3339())
-        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+fn remove_legacy_grok_oauth_entry(auth: &mut serde_json::Map<String, serde_json::Value>) -> bool {
+    let generated_legacy_entry = auth
+        .get(GROK_OAUTH_CLIENT_KEY)
+        .and_then(|value| value.as_object())
+        .and_then(|entry| entry.get("auth_mode"))
+        .and_then(|value| value.as_str())
+        == Some("oauth");
+    if generated_legacy_entry {
+        auth.remove(GROK_OAUTH_CLIENT_KEY);
+    }
+    generated_legacy_entry
+}
 
+/// Remove the legacy Grok credential entry written by older Sandboxed.sh
+/// releases.
+///
+/// Grok CLI 0.2.93 no longer accepts `auth_mode: "oauth"` (and rejects the
+/// token as a legacy WebLogin credential). Sandboxed missions authenticate
+/// non-interactively through the runner's `XAI_API_KEY` environment, so
+/// materializing this incompatible file only breaks native CLI state. Preserve
+/// every CLI-owned entry and remove only our uniquely identifiable old shape.
+pub(crate) fn remove_legacy_grok_oauth_auth_entries() -> Result<(), String> {
     let mut last_error = None;
     for auth_path in grok_auth_paths() {
-        let mut auth = if auth_path.exists() {
-            match std::fs::read_to_string(&auth_path)
-                .ok()
-                .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
-                .and_then(|value| value.as_object().cloned())
-            {
-                Some(auth) => auth,
-                None => serde_json::Map::new(),
-            }
-        } else {
-            serde_json::Map::new()
-        };
-
-        let mut entry = auth
-            .get(GROK_OAUTH_CLIENT_KEY)
+        if !auth_path.exists() {
+            continue;
+        }
+        let mut auth = match std::fs::read_to_string(&auth_path)
+            .ok()
+            .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
             .and_then(|value| value.as_object().cloned())
-            .unwrap_or_default();
-        entry.insert(
-            "auth_mode".to_string(),
-            serde_json::Value::String("oauth".to_string()),
-        );
-        entry.insert(
-            "oidc_client_id".to_string(),
-            serde_json::Value::String(GROK_OAUTH_CLIENT_ID.to_string()),
-        );
-        entry.insert(
-            "oidc_issuer".to_string(),
-            serde_json::Value::String("https://auth.x.ai".to_string()),
-        );
-        entry.insert(
-            "key".to_string(),
-            serde_json::Value::String(access_token.to_string()),
-        );
-        entry.insert(
-            "refresh_token".to_string(),
-            serde_json::Value::String(refresh_token.to_string()),
-        );
-        entry.insert(
-            "expires_at".to_string(),
-            serde_json::Value::String(expires_at.clone()),
-        );
-        auth.insert(
-            GROK_OAUTH_CLIENT_KEY.to_string(),
-            serde_json::Value::Object(entry),
-        );
+        {
+            Some(auth) => auth,
+            None => {
+                tracing::warn!(
+                    path = %auth_path.display(),
+                    "Leaving unreadable Grok auth file untouched"
+                );
+                continue;
+            }
+        };
+        if !remove_legacy_grok_oauth_entry(&mut auth) {
+            continue;
+        }
 
         let write_result = (|| -> Result<(), String> {
-            if let Some(parent) = auth_path.parent() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| format!("Failed to create Grok auth directory: {}", e))?;
-            }
             let contents = serde_json::to_string_pretty(&serde_json::Value::Object(auth))
                 .map_err(|e| format!("Failed to serialize Grok auth: {}", e))?;
             std::fs::write(&auth_path, contents)
@@ -6145,6 +6221,11 @@ async fn list_providers(
     // Keep the xAI provider's stored token in sync with the Grok CLI's own
     // refreshed auth file so it doesn't show a false "needs reauth".
     maybe_reconcile_xai_store_from_grok_cli(&state.ai_providers).await;
+
+    // Claude Code may have rotated Anthropic's single-use refresh token in the
+    // shared tiers since the last background cycle. Reconcile before deriving
+    // UI health so a live harness credential is never shown as disconnected.
+    reconcile_anthropic_store_from_tiers(&state.ai_providers).await;
 
     // All providers live in AIProviderStore now
     let store_providers = state.ai_providers.list().await;
@@ -10068,6 +10149,74 @@ pub async fn refresh_oauth_token_with_lock(
     // _lock is dropped here, releasing the file lock
 }
 
+/// Return whether the shared Anthropic tier is a safe recovery candidate for a
+/// stale store generation.
+fn should_adopt_anthropic_tier(
+    store: &crate::ai_providers::OAuthCredentials,
+    tier: &OAuthTokenEntry,
+    store_token_rejected: bool,
+) -> bool {
+    !tier.refresh_token.trim().is_empty()
+        && tier.refresh_token != store.refresh_token
+        && !oauth_token_expired(tier.expires_at)
+        && (tier.expires_at > store.expires_at || store_token_rejected)
+}
+
+/// Adopt the live shared-tier Anthropic token into the store when ownership is
+/// unambiguous.
+///
+/// Anthropic refresh tokens are single-use. Claude Code can rotate the shared
+/// credential tiers before the store-backed account observes the sidecar, so
+/// the dashboard and on-demand usage endpoint must not keep treating the stale
+/// store generation as authoritative. We only infer ownership when exactly one
+/// enabled OAuth account exists. Multi-account installations are reconciled by
+/// the old-token sidecar, which attributes a rotation without guessing.
+pub async fn reconcile_anthropic_store_from_tiers(
+    ai_providers: &crate::ai_providers::AIProviderStore,
+) -> u32 {
+    let accounts: Vec<_> = ai_providers
+        .get_all_by_type(ProviderType::Anthropic)
+        .await
+        .into_iter()
+        .filter(|account| account.enabled && account.oauth.is_some())
+        .collect();
+    let [account] = accounts.as_slice() else {
+        return 0;
+    };
+    let Some(store_oauth) = account.oauth.as_ref() else {
+        return 0;
+    };
+    let Some(tier) = read_oauth_token_entry(ProviderType::Anthropic) else {
+        return 0;
+    };
+    let store_token_rejected = provider_refresh_token_is_rejected(account);
+    if !should_adopt_anthropic_tier(store_oauth, &tier, store_token_rejected) {
+        return 0;
+    }
+
+    let rotation = crate::api::oauth_reconcile::PendingRotation {
+        provider: "anthropic".to_string(),
+        old_refresh_token: store_oauth.refresh_token.clone(),
+        new_refresh_token: tier.refresh_token.clone(),
+        new_access_token: tier.access_token.clone(),
+        expires_at: tier.expires_at,
+    };
+    if crate::api::oauth_reconcile::apply_rotation(ai_providers, ProviderType::Anthropic, &rotation)
+        .await
+        .is_some()
+    {
+        tracing::info!(
+            account_id = %account.id,
+            new_expires_at = tier.expires_at,
+            store_token_rejected,
+            "Adopted live shared-tier Anthropic OAuth token into store"
+        );
+        1
+    } else {
+        0
+    }
+}
+
 /// Refresh OAuth tokens for **store-backed** accounts (AIProviderStore) of
 /// `provider_type` that expire within `refresh_threshold_ms`, writing the new
 /// tokens back to the store (and credential tiers).
@@ -10084,9 +10233,12 @@ pub async fn refresh_due_store_oauth(
 ) -> (u32, u32) {
     let now_ms = chrono::Utc::now().timestamp_millis();
     let mut found = 0u32;
-    let mut refreshed = 0u32;
+    let mut refreshed = if provider_type == ProviderType::Anthropic {
+        reconcile_anthropic_store_from_tiers(ai_providers).await
+    } else {
+        0
+    };
     let accounts = ai_providers.get_all_by_type(provider_type).await;
-    let single_account = accounts.len() == 1;
     for account in accounts {
         let Some(oauth) = account.oauth.as_ref() else {
             continue;
@@ -10095,51 +10247,6 @@ pub async fn refresh_due_store_oauth(
             continue;
         }
         found += 1;
-
-        // Adopt-before-refresh (Anthropic): mission harnesses rotate the shared
-        // credential tiers mid-run, making the tier token the ONLY live member
-        // of the rotating family — refreshing our (older) copy would revoke it,
-        // the recurring split-brain of 2026-07-16/17. When the freshest tier
-        // entry differs and is strictly fresher, adopt it into this record
-        // instead of refreshing, and lift any cached invalid_grant. Guarded to
-        // the unambiguous cases: a single store account of this type, or a
-        // record whose own token is already recorded dead (that record IS the
-        // tier owner that lost the rotation race; a secondary account's token
-        // is not part of the tier family and refreshes independently).
-        if provider_type == ProviderType::Anthropic {
-            if let Some(tier) = read_oauth_token_entry(provider_type) {
-                let record_dead = oauth_refresh_token_is_dead(account.id, &oauth.refresh_token)
-                    || account.rejected_oauth_refresh_fingerprint.is_some();
-                if !tier.refresh_token.trim().is_empty()
-                    && tier.refresh_token != oauth.refresh_token
-                    && tier.expires_at > oauth.expires_at
-                    && (single_account || record_dead)
-                {
-                    let adopted = crate::api::oauth_reconcile::apply_rotation(
-                        ai_providers,
-                        provider_type,
-                        &crate::api::oauth_reconcile::PendingRotation {
-                            provider: "anthropic".to_string(),
-                            old_refresh_token: oauth.refresh_token.clone(),
-                            new_refresh_token: tier.refresh_token.clone(),
-                            new_access_token: tier.access_token.clone(),
-                            expires_at: tier.expires_at,
-                        },
-                    )
-                    .await;
-                    if adopted.is_some() {
-                        refreshed += 1;
-                        tracing::info!(
-                            provider = ?provider_type,
-                            account_id = %account.id,
-                            new_expires_at = tier.expires_at,
-                            "Adopted fresher tier OAuth token into store record (skipping refresh)"
-                        );
-                        continue;
-                    }
-                }
-            }
-        }
 
         if oauth.expires_at - now_ms > refresh_threshold_ms {
             continue;
@@ -10205,6 +10312,13 @@ pub async fn refresh_store_account_oauth_locked(
     let gate = oauth_refresh_gate(provider_type);
     let _gate = gate.lock().await;
     let _lock = acquire_oauth_refresh_lock(provider_type).ok();
+
+    // Heal an out-of-band Claude Code rotation before consulting a persisted
+    // invalid_grant. This makes the usage endpoint and other on-demand callers
+    // recover immediately instead of waiting for the periodic refresher.
+    if provider_type == ProviderType::Anthropic {
+        reconcile_anthropic_store_from_tiers(ai_providers).await;
+    }
 
     // Re-read the freshest credentials now that we're serialized — a concurrent
     // refresh may have just rotated the token while we waited on the gate.

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1492,6 +1492,37 @@ pub fn get_api_key_for_provider(
     None
 }
 
+/// Resolve an actual Anthropic API key for `/v1/models`.
+///
+/// Claude subscription OAuth access tokens are valid for Claude Code's bearer
+/// flow but Anthropic's model catalog expects `x-api-key`. Passing an OAuth
+/// access token there produces a harmless but noisy 401 every refresh cycle.
+/// Store/API-key credentials take precedence; file and environment lookup is
+/// retained, while OAuth-only store records are deliberately excluded.
+fn get_enabled_store_api_key(
+    provider_type: ProviderType,
+    ai_providers: &[crate::ai_providers::AIProvider],
+) -> Option<String> {
+    ai_providers
+        .iter()
+        .find(|provider| {
+            provider.provider_type == provider_type
+                && provider.enabled
+                && provider
+                    .api_key
+                    .as_ref()
+                    .is_some_and(|key| !key.trim().is_empty())
+        })
+        .and_then(|provider| provider.api_key.clone())
+}
+
+fn get_anthropic_models_api_key(
+    ai_providers: &[crate::ai_providers::AIProvider],
+) -> Option<String> {
+    get_enabled_store_api_key(ProviderType::Anthropic, ai_providers)
+        .or_else(|| get_api_key_for_provider(ProviderType::Anthropic, &[]))
+}
+
 /// Fetch model lists from all supported provider APIs concurrently.
 ///
 /// Returns a map of provider ID -> fetched models. Providers that fail
@@ -1665,7 +1696,7 @@ pub async fn fetch_model_catalog(
     ];
 
     // Resolve API keys for all targets + Anthropic
-    let anthropic_key = get_api_key_for_provider(ProviderType::Anthropic, &providers_list);
+    let anthropic_key = get_anthropic_models_api_key(&providers_list);
     let target_keys: Vec<(FetchTarget, Option<String>)> = targets
         .into_iter()
         .map(|t| {
@@ -2444,6 +2475,29 @@ mod tests {
             .models
             .iter()
             .any(|model| model.id == "claude-opus-4-7"));
+    }
+
+    #[test]
+    fn anthropic_catalog_key_ignores_oauth_only_store_accounts() {
+        let mut oauth =
+            crate::ai_providers::AIProvider::new(ProviderType::Anthropic, "OAuth".into());
+        oauth.oauth = Some(crate::ai_providers::OAuthCredentials {
+            access_token: "oauth-access-token".into(),
+            refresh_token: "oauth-refresh-token".into(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60_000,
+        });
+        assert_eq!(
+            get_enabled_store_api_key(ProviderType::Anthropic, &[oauth]),
+            None
+        );
+
+        let mut api =
+            crate::ai_providers::AIProvider::new(ProviderType::Anthropic, "API key".into());
+        api.api_key = Some("sk-ant-api-key".into());
+        assert_eq!(
+            get_enabled_store_api_key(ProviderType::Anthropic, &[api]).as_deref(),
+            Some("sk-ant-api-key")
+        );
     }
 
     #[test]

--- a/src/api/runners/grok.rs
+++ b/src/api/runners/grok.rs
@@ -89,117 +89,6 @@ async fn ensure_grok_cli_available(
     }
 }
 
-async fn sync_grok_oauth_auth_file(
-    workspace_exec: &WorkspaceExec,
-    cwd: &std::path::Path,
-) -> Result<bool, String> {
-    let auth_path = std::path::PathBuf::from(crate::util::home_dir())
-        .join(".grok")
-        .join("auth.json");
-    if !auth_path.is_file() {
-        return Ok(false);
-    }
-
-    let auth_json = tokio::fs::read_to_string(&auth_path)
-        .await
-        .map_err(|e| format!("Failed to read Grok auth file: {}", e))?;
-    if auth_json.trim().is_empty() {
-        return Ok(false);
-    }
-
-    let source_expires_at = grok_auth_file_expires_at(&auth_json);
-    if crate::api::ai_providers::oauth_token_expired(source_expires_at) {
-        return Err(
-            "Host Grok auth file is expired; reconnect xAI or refresh OAuth before syncing"
-                .to_string(),
-        );
-    }
-    let existing_output = workspace_exec
-        .output(
-            cwd,
-            "/bin/sh",
-            &[
-                "-lc".to_string(),
-                "test -s \"${HOME:-/root}/.grok/auth.json\" && cat \"${HOME:-/root}/.grok/auth.json\""
-                    .to_string(),
-            ],
-            HashMap::new(),
-        )
-        .await
-        .map_err(|e| format!("Failed to inspect workspace Grok auth file: {}", e))?;
-    if existing_output.status.success() {
-        let existing_json = String::from_utf8_lossy(&existing_output.stdout);
-        let existing_expires_at = grok_auth_file_expires_at(&existing_json);
-        if existing_expires_at >= source_expires_at {
-            tracing::debug!(
-                source_expires_at,
-                existing_expires_at,
-                "Skipping Grok auth sync because workspace auth is at least as fresh"
-            );
-            return Ok(false);
-        }
-    }
-
-    let encoded = {
-        use base64::Engine;
-        base64::engine::general_purpose::STANDARD.encode(auth_json.as_bytes())
-    };
-    let output = workspace_exec
-        .output(
-            cwd,
-            "/bin/sh",
-            &[
-                "-lc".to_string(),
-                format!(
-                    "mkdir -p \"${{HOME:-/root}}/.grok\" && printf %s '{}' | base64 -d > \"${{HOME:-/root}}/.grok/auth.json\" && chmod 600 \"${{HOME:-/root}}/.grok/auth.json\"",
-                    encoded
-                ),
-            ],
-            HashMap::new(),
-        )
-        .await
-        .map_err(|e| format!("Failed to sync Grok auth file: {}", e))?;
-    if output.status.success() {
-        Ok(true)
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        Err(format!(
-            "Failed to sync Grok auth file into workspace: {}{}{}",
-            stderr.trim(),
-            if stderr.trim().is_empty() || stdout.trim().is_empty() {
-                ""
-            } else {
-                " | "
-            },
-            stdout.trim()
-        ))
-    }
-}
-
-fn grok_auth_file_expires_at(contents: &str) -> i64 {
-    const GROK_OAUTH_CLIENT_KEY: &str = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828";
-
-    serde_json::from_str::<serde_json::Value>(contents)
-        .ok()
-        .and_then(|auth| auth.get(GROK_OAUTH_CLIENT_KEY).cloned())
-        .and_then(|entry| {
-            entry.get("expires_at").and_then(|value| {
-                if let Some(expires_at) = value.as_i64() {
-                    return Some(expires_at);
-                }
-                let text = value.as_str()?.trim();
-                if let Ok(expires_at) = text.parse::<i64>() {
-                    return Some(expires_at);
-                }
-                chrono::DateTime::parse_from_rfc3339(text)
-                    .ok()
-                    .map(|dt| dt.timestamp_millis())
-            })
-        })
-        .unwrap_or(0)
-}
-
 fn grok_event_is_reasoning_type(value: &serde_json::Value) -> bool {
     value.get("type").and_then(|v| v.as_str()).is_some_and(|t| {
         let lower = t.to_ascii_lowercase();
@@ -445,8 +334,6 @@ pub(crate) fn grok_stdout_line_requests_interactive_login(line: &str) -> bool {
 /// `XAI_API_KEY` (key > OAuth access token > ambient env). Shared by the
 /// streaming-json and ACP turn paths.
 async fn prepare_grok_auth_env(
-    workspace_exec: &WorkspaceExec,
-    work_dir: &std::path::Path,
     app_working_dir: &std::path::Path,
     mission_id: Uuid,
 ) -> Result<HashMap<String, String>, AgentResult> {
@@ -492,22 +379,19 @@ async fn prepare_grok_auth_env(
             }
         } else {
             oauth_access_token = Some(entry.access_token.clone());
-            if let Err(err) = crate::api::ai_providers::write_grok_oauth_auth_file(
-                &entry.refresh_token,
-                &entry.access_token,
-                entry.expires_at,
-            ) {
-                tracing::warn!(
-                    mission_id = %mission_id,
-                    error = %err,
-                    "Failed to materialize fresh xAI OAuth token into Grok auth file"
-                );
-            }
         }
     }
 
-    if let Err(err) = sync_grok_oauth_auth_file(workspace_exec, work_dir).await {
-        tracing::warn!(mission_id = %mission_id, error = %err, "Failed to sync Grok OAuth auth file");
+    // Grok CLI 0.2.93 rejects the legacy `auth_mode: "oauth"` shape older
+    // Sandboxed versions generated. The runner authenticates with an explicit
+    // environment key below, so never copy or overwrite the CLI's native auth
+    // file; just remove our obsolete entry when present.
+    if let Err(err) = crate::api::ai_providers::remove_legacy_grok_oauth_auth_entries() {
+        tracing::warn!(
+            mission_id = %mission_id,
+            error = %err,
+            "Failed to remove obsolete Grok OAuth auth entry"
+        );
     }
 
     // Authenticate the Grok CLI non-interactively via XAI_API_KEY. Priority:
@@ -727,11 +611,10 @@ async fn run_grok_streaming_json_turn(
     // capture the freshest one here and inject it below. Without it the CLI
     // falls back to an interactive browser sign-in that never completes in a
     // headless mission — the run then hangs forever ("Agent is working").
-    let env =
-        match prepare_grok_auth_env(&workspace_exec, work_dir, app_working_dir, mission_id).await {
-            Ok(env) => env,
-            Err(result) => return result,
-        };
+    let env = match prepare_grok_auth_env(app_working_dir, mission_id).await {
+        Ok(env) => env,
+        Err(result) => return result,
+    };
 
     let mut child = match workspace_exec
         .spawn_streaming(work_dir, &cli_path, &args, env)
@@ -1144,13 +1027,12 @@ async fn run_grok_acp_turn(
         .await
         .map_err(|e| format!("grok CLI unavailable: {e}"))?;
 
-    let env =
-        match prepare_grok_auth_env(&workspace_exec, work_dir, app_working_dir, mission_id).await {
-            Ok(env) => env,
-            // Auth failures are terminal for BOTH paths — surface them directly
-            // instead of falling back into the same failure.
-            Err(result) => return Ok(result),
-        };
+    let env = match prepare_grok_auth_env(app_working_dir, mission_id).await {
+        Ok(env) => env,
+        // Auth failures are terminal for BOTH paths — surface them directly
+        // instead of falling back into the same failure.
+        Err(result) => return Ok(result),
+    };
 
     // `grok agent stdio` accepts no further flags (verified: it rejects
     // --no-auto-update). cwd comes from spawn_streaming's working dir and


### PR DESCRIPTION
## Summary

- reconcile a live shared-tier Anthropic token before computing provider health or attempting an on-demand refresh, so Claude Code rotations heal the dashboard immediately
- restrict inferred Anthropic ownership to the unambiguous single-account case; multi-account rotations continue through the exact old-token sidecar matcher
- stop treating Claude OAuth bearer tokens as Anthropic `/v1/models` API keys, eliminating the recurring catalog 401 noise while retaining the built-in catalog
- stop generating and copying the Grok CLI-incompatible `auth_mode: "oauth"` file; preserve native CLI auth and authenticate isolated missions through the already-working `XAI_API_KEY` runner environment
- remove only the obsolete Sandboxed-generated Grok entry as a bounded migration

## Why

Anthropic refresh tokens rotate and revoke their previous generation. A mission can update Claude Code credential tiers before the store/UI observes it, which used to leave a false `needs_reauth` state or make an on-demand probe reject the stale store token before considering the live tier.

Grok CLI 0.2.93 rejects the legacy auth file shape (`unknown variant 'oauth'` / legacy WebLogin token). Sandboxed actual mission path already works through explicit environment injection, so copying that file into each workspace was both unnecessary and harmful.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace -- -D clippy::all`
- `cargo test --lib oauth --no-fail-fast` (23 passed)
- `cargo test --lib api::providers::tests:: --no-fail-fast` (15 passed, 1 ignored network test)
- `cargo test --lib api::runners::grok::tests:: --no-fail-fast` (2 passed)
- `cargo test --locked --workspace` (full workspace: 1339 lib tests passed plus all binary and doc-test targets)

Production canaries will verify the exact runner paths for Claude OAuth and Grok 4.5 after deployment of the reviewed commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth refresh, store reconciliation, and Grok runner auth paths where token rotation mistakes could cause false disconnects or auth failures, but changes are narrowly scoped with tests and bounded migrations.
> 
> **Overview**
> **Anthropic OAuth** now pulls live shared-tier tokens into the store via `reconcile_anthropic_store_from_tiers` before provider list health, background refresh, and on-demand refresh—using `should_adopt_anthropic_tier` only when exactly one enabled OAuth account exists (or the store token was rejected). The per-account adopt-before-refresh block inside `refresh_due_store_oauth` is removed in favor of this centralized path.
> 
> **Grok / xAI** stops writing or syncing the legacy `auth_mode: "oauth"` Grok `auth.json` entry and workspace copies; it only removes that Sandboxed-generated shape and skips reading it when reconciling from the CLI. Grok missions still authenticate through **`XAI_API_KEY`** in `prepare_grok_auth_env`.
> 
> **Model catalog** resolves Anthropic `/v1/models` keys from enabled store API keys or file/env only—OAuth bearer tokens are no longer used, avoiding recurring 401 noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648d19e870750f946324c14dc19fbfffe63bdc16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->