### PR TITLE
fix(env-crypto): leave doc/fixture encrypted blocks untouched in content scans

### DIFF
--- a/src/library/env_crypto.rs
+++ b/src/library/env_crypto.rs
@@ -468,6 +468,20 @@ pub fn decrypt_content_tags(key: &[u8; KEY_LENGTH], content: &str) -> Result<Str
         // Reconstruct the full encrypted value for decryption
         let encrypted_value = full_match.as_str();
 
+        // A payload that is not even base64 is not a real secret: library
+        // content legitimately contains literal `<encrypted v="N">…</encrypted>`
+        // examples (the env-crypto Python utils' own docstrings, fixtures, and
+        // source regex). Rewriting those to <encrypted-failed> corrupted the
+        // synced files and warned twice per mission spawn. Leave such blocks
+        // untouched; only a well-formed ciphertext that fails AES decryption
+        // is a genuine broken secret worth flagging.
+        if BASE64.decode(ciphertext_b64).is_err() {
+            tracing::debug!(
+                "Skipping encrypted-looking block with non-base64 payload (doc/fixture)"
+            );
+            continue;
+        }
+
         // Try to decrypt, but handle failure gracefully
         let display_tag = match decrypt_value(key, encrypted_value) {
             Ok(plaintext) => {
@@ -908,5 +922,26 @@ export API_KEY=another-secret
         // Step 3->4: Strip for deployment
         let deployed = strip_encrypted_tags(&displayed);
         assert_eq!(deployed, "Key: my-secret-api-key");
+    }
+    #[test]
+    fn content_scan_leaves_non_base64_fixture_blocks_untouched() {
+        let key = [7u8; KEY_LENGTH];
+        let content = r#"docs: <encrypted v="1">BASE64(nonce||ciphertext)</encrypted> and fixture <encrypted v="1">abc123</encrypted>"#;
+        let out = decrypt_content_tags(&key, content).expect("scan succeeds");
+        assert_eq!(out, content);
+    }
+
+    #[test]
+    fn content_scan_still_flags_valid_b64_with_wrong_key() {
+        let key_a = [1u8; KEY_LENGTH];
+        let key_b = [2u8; KEY_LENGTH];
+        let secret = encrypt_value(&key_a, "s3cret").expect("encrypt");
+        let content = format!("KEY={}", secret);
+        let out = decrypt_content_tags(&key_b, &content).expect("scan succeeds");
+        assert!(
+            out.contains("<encrypted-failed"),
+            "wrong-key block must be flagged: {}",
+            out
+        );
     }
 }


### PR DESCRIPTION
The content-tag scanner treated every `<encrypted v=N>…</encrypted>` match as a real secret. Library content legitimately contains literal examples — the env-crypto Python utils' own docstrings, test fixtures (`abc123`, `secret-value`), even its source regex — so **every mission spawn warned twice and rewrote those blocks to `<encrypted-failed>`**, corrupting the synced files (recurring since 2026-07-15, ~26 warns/2h).

A payload that is not even base64 cannot be a produced secret: skip it with a debug log, keep content byte-identical. Well-formed ciphertext failing AES decryption still warns and flags as before (test covers both paths).

`cargo test --lib env_crypto`: 28 passed (2 new).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to content-tag scanning heuristics in env-crypto; no auth or data-model changes, with regression tests.
> 
> **Overview**
> **Fixes mission-spawn content scans** that matched every versioned `<encrypted v="N">…</encrypted>` block and rewrote failed decrypts to `<encrypted-failed>`, which corrupted library files full of literal examples (docstrings, fixtures like `abc123`).
> 
> `decrypt_content_tags` now **skips** blocks whose inner payload is not valid base64 (debug log only, output unchanged). **Well-formed ciphertext** that still fails AES decryption continues to warn and become `<encrypted-failed>`.
> 
> Two unit tests cover the skip path and the wrong-key failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11544ec8aec31e8bec5d0cfd39aacb4f3bfaa9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->