### PR TITLE
feat(grok-bridge): connected-account Grok 4.5 router with caller-owned tools

### DIFF
--- a/src/api/grok_tool_bridge/acp.rs
+++ b/src/api/grok_tool_bridge/acp.rs
@@ -90,6 +90,38 @@ struct McpState {
     tool_tx: mpsc::UnboundedSender<InboundToolCall>,
 }
 
+/// Owns the ephemeral MCP server during startup. Any early return cancels and
+/// aborts it; once the conversation is fully constructed, ownership is
+/// transferred into [`AcpConversation`].
+struct StartupTaskGuard {
+    cancel: CancellationToken,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl StartupTaskGuard {
+    fn new(cancel: CancellationToken, handle: JoinHandle<()>) -> Self {
+        Self {
+            cancel,
+            handle: Some(handle),
+        }
+    }
+
+    fn into_handle(mut self) -> JoinHandle<()> {
+        self.handle
+            .take()
+            .expect("startup task guard must own a handle")
+    }
+}
+
+impl Drop for StartupTaskGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            self.cancel.cancel();
+            handle.abort();
+        }
+    }
+}
+
 fn jsonrpc_result(id: Option<serde_json::Value>, result: serde_json::Value) -> Response {
     Json(serde_json::json!({
         "jsonrpc": "2.0",
@@ -136,6 +168,13 @@ async fn mcp_handler(
                 .to_string();
             if name.is_empty() {
                 return jsonrpc_error(id, -32602, "tools/call missing tool name");
+            }
+            if !state
+                .tools
+                .iter()
+                .any(|tool| tool.get("name").and_then(|v| v.as_str()) == Some(name.as_str()))
+            {
+                return jsonrpc_error(id, -32602, "tools/call references an unadvertised tool");
             }
             let arguments = req
                 .pointer("/params/arguments")
@@ -606,6 +645,7 @@ impl BridgeBackend for AcpMcpBackend {
                 .with_graceful_shutdown(async move { mcp_cancel.cancelled().await })
                 .await;
         });
+        let mcp_guard = StartupTaskGuard::new(cancel.clone(), mcp_handle);
         let mcp_url = format!("http://{addr}/");
 
         // 2. Spawn `grok agent stdio` on the host with non-interactive auth.
@@ -728,7 +768,6 @@ impl BridgeBackend for AcpMcpBackend {
                 cancel.cancel();
                 let _ = child.start_kill();
                 let _ = child.wait().await;
-                mcp_handle.abort();
                 if let Some(handle) = stderr_handle {
                     handle.abort();
                 }
@@ -754,7 +793,7 @@ impl BridgeBackend for AcpMcpBackend {
             child,
             cancel,
             driver_handle: Some(driver_handle),
-            mcp_handle: Some(mcp_handle),
+            mcp_handle: Some(mcp_guard.into_handle()),
             stderr_handle,
             tool_rx,
             done_rx,
@@ -768,6 +807,22 @@ impl BridgeBackend for AcpMcpBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn startup_guard_aborts_server_task_on_early_return() {
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let handle = tokio::spawn(async move {
+            task_cancel.cancelled().await;
+        });
+        let abort_handle = handle.abort_handle();
+
+        drop(StartupTaskGuard::new(cancel.clone(), handle));
+
+        assert!(cancel.is_cancelled());
+        tokio::task::yield_now().await;
+        assert!(abort_handle.is_finished());
+    }
 
     #[test]
     fn deny_permission_selects_reject_option_when_offered() {

--- a/src/api/grok_tool_bridge/acp.rs
+++ b/src/api/grok_tool_bridge/acp.rs
@@ -38,7 +38,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::{Json, Router};
@@ -88,6 +88,8 @@ struct McpState {
     tools: Vec<serde_json::Value>,
     /// Channel to hand suspended calls to the bridge coordination loop.
     tool_tx: mpsc::UnboundedSender<InboundToolCall>,
+    /// Per-session bearer value required by every request to this endpoint.
+    bearer_value: String,
 }
 
 /// Owns the ephemeral MCP server during startup. Any early return cancels and
@@ -140,14 +142,18 @@ fn jsonrpc_error(id: Option<serde_json::Value>, code: i32, message: &str) -> Res
     .into_response()
 }
 
-/// ACP's HTTP MCP-server variant requires a `headers` array even when the
-/// endpoint needs no headers.
-fn http_mcp_server_descriptor(url: &str) -> serde_json::Value {
+/// ACP's HTTP MCP-server variant requires a `headers` array. The bearer secret
+/// prevents unrelated same-host processes from injecting caller tool calls
+/// into the live session.
+fn http_mcp_server_descriptor(url: &str, bearer_value: &str) -> serde_json::Value {
     serde_json::json!({
         "type": "http",
         "name": "grok-cli-bridge-tools",
         "url": url,
-        "headers": [],
+        "headers": [{
+            "name": "Authorization",
+            "value": bearer_value,
+        }],
     })
 }
 
@@ -155,8 +161,17 @@ fn http_mcp_server_descriptor(url: &str) -> serde_json::Value {
 /// until the bridge resumes it.
 async fn mcp_handler(
     State(state): State<Arc<McpState>>,
+    headers: HeaderMap,
     Json(req): Json<serde_json::Value>,
 ) -> Response {
+    if headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        != Some(state.bearer_value.as_str())
+    {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
     let id = req.get("id").cloned();
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
     match method {
@@ -635,9 +650,11 @@ impl BridgeBackend for AcpMcpBackend {
         // 1. Start the ephemeral MCP server before the ACP handshake — the CLI
         //    connects to it (initialize / tools/list) during `session/new`.
         let (tool_tx, tool_rx) = mpsc::unbounded_channel::<InboundToolCall>();
+        let mcp_bearer_value = format!("Bearer {}", uuid::Uuid::new_v4().simple());
         let mcp_state = Arc::new(McpState {
             tools: input.tools_mcp.clone(),
             tool_tx,
+            bearer_value: mcp_bearer_value.clone(),
         });
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -724,7 +741,7 @@ impl BridgeBackend for AcpMcpBackend {
                     "method": "session/new",
                     "params": {
                         "cwd": cwd,
-                        "mcpServers": [http_mcp_server_descriptor(&mcp_url)]
+                        "mcpServers": [http_mcp_server_descriptor(&mcp_url, &mcp_bearer_value)]
                     }
                 }),
             )
@@ -816,11 +833,56 @@ mod tests {
     use super::*;
 
     #[test]
-    fn http_mcp_descriptor_includes_required_empty_headers() {
-        let descriptor = http_mcp_server_descriptor("http://127.0.0.1:1234/");
+    fn http_mcp_descriptor_includes_session_authorization() {
+        let descriptor = http_mcp_server_descriptor("http://127.0.0.1:1234/", "Bearer test-secret");
         assert_eq!(descriptor["type"], "http");
         assert_eq!(descriptor["url"], "http://127.0.0.1:1234/");
-        assert_eq!(descriptor["headers"], serde_json::json!([]));
+        assert_eq!(
+            descriptor["headers"],
+            serde_json::json!([{
+                "name": "Authorization",
+                "value": "Bearer test-secret",
+            }])
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_endpoint_rejects_missing_or_wrong_session_authorization() {
+        let (tool_tx, _tool_rx) = mpsc::unbounded_channel();
+        let state = Arc::new(McpState {
+            tools: Vec::new(),
+            tool_tx,
+            bearer_value: "Bearer expected-secret".to_string(),
+        });
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+        });
+
+        let missing = mcp_handler(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(request.clone()),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+        let mut wrong_headers = HeaderMap::new();
+        wrong_headers.insert(
+            header::AUTHORIZATION,
+            "Bearer wrong-secret".parse().unwrap(),
+        );
+        let wrong = mcp_handler(State(state.clone()), wrong_headers, Json(request.clone())).await;
+        assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+        let mut valid_headers = HeaderMap::new();
+        valid_headers.insert(
+            header::AUTHORIZATION,
+            "Bearer expected-secret".parse().unwrap(),
+        );
+        let valid = mcp_handler(State(state), valid_headers, Json(request)).await;
+        assert_eq!(valid.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/src/api/grok_tool_bridge/acp.rs
+++ b/src/api/grok_tool_bridge/acp.rs
@@ -140,6 +140,17 @@ fn jsonrpc_error(id: Option<serde_json::Value>, code: i32, message: &str) -> Res
     .into_response()
 }
 
+/// ACP's HTTP MCP-server variant requires a `headers` array even when the
+/// endpoint needs no headers.
+fn http_mcp_server_descriptor(url: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "http",
+        "name": "grok-cli-bridge-tools",
+        "url": url,
+        "headers": [],
+    })
+}
+
 /// The ephemeral MCP server's single JSON-RPC endpoint. Suspends `tools/call`
 /// until the bridge resumes it.
 async fn mcp_handler(
@@ -713,11 +724,7 @@ impl BridgeBackend for AcpMcpBackend {
                     "method": "session/new",
                     "params": {
                         "cwd": cwd,
-                        "mcpServers": [{
-                            "type": "http",
-                            "name": "grok-cli-bridge-tools",
-                            "url": mcp_url,
-                        }]
+                        "mcpServers": [http_mcp_server_descriptor(&mcp_url)]
                     }
                 }),
             )
@@ -807,6 +814,14 @@ impl BridgeBackend for AcpMcpBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn http_mcp_descriptor_includes_required_empty_headers() {
+        let descriptor = http_mcp_server_descriptor("http://127.0.0.1:1234/");
+        assert_eq!(descriptor["type"], "http");
+        assert_eq!(descriptor["url"], "http://127.0.0.1:1234/");
+        assert_eq!(descriptor["headers"], serde_json::json!([]));
+    }
 
     #[tokio::test]
     async fn startup_guard_aborts_server_task_on_early_return() {

--- a/src/api/grok_tool_bridge/acp.rs
+++ b/src/api/grok_tool_bridge/acp.rs
@@ -1,0 +1,818 @@
+//! Live ACP↔MCP transport for the connected-account Grok bridge.
+//!
+//! This is the only part of the bridge that talks to a real `grok agent stdio`
+//! child. It is **default-off** (see [`super::capability`]): the pure state
+//! machine above it is exhaustively tested via the fake backend, but this live
+//! path can only be exercised against a provisioned xAI/Grok account, so it is
+//! gated behind an operator-set `SANDBOXED_SH_GROK_ROUTER_BRIDGE_LIVE` flag.
+//!
+//! ## How caller tools stay caller-owned
+//!
+//! Caller `tools[]` are rendered as an **ephemeral in-process MCP server** bound
+//! to `127.0.0.1:0` and offered to the Grok session via `session/new`'s
+//! `mcpServers`. When Grok decides to call one of those tools it issues an MCP
+//! `tools/call` over HTTP; our handler **suspends** that HTTP request (parks the
+//! JSON-RPC response on a oneshot) and forwards the call to the bridge, which
+//! surfaces it to the OpenAI caller as `assistant.tool_calls`. The caller's
+//! later `role: "tool"` result is delivered back through the oneshot, unblocking
+//! the still-open `tools/call` so the same Grok session continues its turn.
+//!
+//! Grok therefore never executes the caller's tools itself — it only ever sees
+//! an MCP endpoint whose responses the caller supplies.
+//!
+//! ## Verification status
+//!
+//! The exact `mcpServers` HTTP descriptor shape a given Grok CLI build accepts
+//! is a deployment detail we cannot assert without a live account; it is
+//! documented at the `session/new` call below. Until an operator verifies this
+//! path against their connected account (and flips the live flag), the route is
+//! not advertised. Every failure here is classified as
+//! [`BridgeError::upstream`] (infrastructure) or
+//! [`BridgeError::provider_configuration`] — never dressed up as a model turn.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::error::BridgeError;
+use super::transport::{
+    BridgeBackend, BridgeConversation, BridgeUsage, CompletedTurn, PromptInput, RequestedToolCall,
+    ResolvedToolResult, TurnOutcome,
+};
+
+/// JSON-RPC ids for the ACP handshake. Kept distinct so responses are
+/// unambiguous on a shared stdout stream.
+const ACP_INIT_ID: u64 = 1;
+const ACP_SESSION_NEW_ID: u64 = 2;
+const ACP_SET_MODEL_ID: u64 = 3;
+const ACP_PROMPT_ID: u64 = 4;
+
+/// Deadline for each synchronous handshake step.
+const HANDSHAKE_STEP_SECS: u64 = 60;
+
+/// Idle guard for the post-prompt event stream: a silent gap this long means
+/// the CLI is wedged (or blocked on something that never arrives headless).
+const DRIVER_IDLE_SECS: u64 = 300;
+
+/// After the first suspended tool call arrives, wait this long for additional
+/// concurrent calls so a parallel tool batch surfaces as one `tool_calls` turn.
+/// A sequential CLI simply yields one call per turn (the window elapses idle),
+/// which is equally valid OpenAI semantics.
+const TOOL_BATCH_SETTLE_MS: u64 = 75;
+
+/// A suspended MCP `tools/call`: the invocation Grok made, plus the oneshot the
+/// HTTP handler is blocked on until the caller supplies a result.
+struct InboundToolCall {
+    name: String,
+    arguments: serde_json::Value,
+    responder: oneshot::Sender<String>,
+}
+
+/// Shared state for the ephemeral MCP server.
+struct McpState {
+    /// Caller tool descriptors (`name`/`description`/`inputSchema`).
+    tools: Vec<serde_json::Value>,
+    /// Channel to hand suspended calls to the bridge coordination loop.
+    tool_tx: mpsc::UnboundedSender<InboundToolCall>,
+}
+
+fn jsonrpc_result(id: Option<serde_json::Value>, result: serde_json::Value) -> Response {
+    Json(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(serde_json::Value::Null),
+        "result": result,
+    }))
+    .into_response()
+}
+
+fn jsonrpc_error(id: Option<serde_json::Value>, code: i32, message: &str) -> Response {
+    Json(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(serde_json::Value::Null),
+        "error": { "code": code, "message": message },
+    }))
+    .into_response()
+}
+
+/// The ephemeral MCP server's single JSON-RPC endpoint. Suspends `tools/call`
+/// until the bridge resumes it.
+async fn mcp_handler(
+    State(state): State<Arc<McpState>>,
+    Json(req): Json<serde_json::Value>,
+) -> Response {
+    let id = req.get("id").cloned();
+    let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    match method {
+        "initialize" => jsonrpc_result(
+            id,
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "grok-cli-bridge", "version": env!("CARGO_PKG_VERSION") },
+            }),
+        ),
+        // Notifications carry no id and expect no JSON-RPC body.
+        m if m.starts_with("notifications/") => StatusCode::ACCEPTED.into_response(),
+        "tools/list" => jsonrpc_result(id, serde_json::json!({ "tools": state.tools })),
+        "tools/call" => {
+            let name = req
+                .pointer("/params/name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if name.is_empty() {
+                return jsonrpc_error(id, -32602, "tools/call missing tool name");
+            }
+            let arguments = req
+                .pointer("/params/arguments")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({}));
+            let (responder, rx) = oneshot::channel();
+            if state
+                .tool_tx
+                .send(InboundToolCall {
+                    name,
+                    arguments,
+                    responder,
+                })
+                .is_err()
+            {
+                // Bridge coordination loop is gone — session tearing down.
+                return jsonrpc_error(id, -32000, "grok bridge session closed");
+            }
+            // Suspend here: the HTTP response is withheld until the caller's
+            // tool result unblocks the oneshot (or the session is dropped).
+            match rx.await {
+                Ok(content) => jsonrpc_result(
+                    id,
+                    serde_json::json!({
+                        "content": [{ "type": "text", "text": content }],
+                        "isError": false,
+                    }),
+                ),
+                Err(_) => {
+                    jsonrpc_error(id, -32000, "grok bridge session closed before tool result")
+                }
+            }
+        }
+        _ => jsonrpc_error(id, -32601, "method not found"),
+    }
+}
+
+/// Resolve the CLI path (override via env for non-default installs).
+fn grok_cli_path() -> String {
+    std::env::var("SANDBOXED_SH_GROK_CLI_PATH")
+        .ok()
+        .filter(|p| !p.trim().is_empty())
+        .unwrap_or_else(|| "grok".to_string())
+}
+
+/// Build the non-interactive auth env for the connected account.
+///
+/// This bridge deliberately accepts **only a genuine, explicitly configured xAI
+/// API key** ([`get_xai_api_key_for_grok`] reads it verbatim from
+/// `ai_providers.json` and never falls back to OAuth). We do NOT relabel an
+/// OAuth access token as `XAI_API_KEY`: that masquerade is unsupported by the
+/// account and would silently break, so instead we fail closed with an exact
+/// blocker and the route stays unadvertised (see [`super::capability`]). The
+/// credential itself is never logged.
+fn grok_auth_env(working_dir: &Path) -> Result<HashMap<String, String>, BridgeError> {
+    let key = crate::api::ai_providers::get_xai_api_key_for_grok(working_dir).ok_or_else(|| {
+        BridgeError::provider_configuration(
+            "the grok-cli bridge requires a genuine xAI API key configured for the grok backend; \
+             an OAuth-only connected account cannot be used non-interactively and is never \
+             relabeled as an API key",
+        )
+    })?;
+
+    let mut env = HashMap::new();
+    env.insert("XAI_API_KEY".to_string(), key.clone());
+    env.insert("GROK_CODE_XAI_API_KEY".to_string(), key);
+    Ok(env)
+}
+
+async fn send_rpc(stdin: &mut ChildStdin, value: serde_json::Value) -> Result<(), BridgeError> {
+    let mut payload = value.to_string();
+    payload.push('\n');
+    stdin
+        .write_all(payload.as_bytes())
+        .await
+        .map_err(|e| BridgeError::upstream(format!("grok ACP stdin write failed: {e}")))
+}
+
+/// Read stdout until the JSON-RPC response for `id` arrives, with a deadline.
+async fn await_response<R: tokio::io::AsyncBufRead + Unpin>(
+    lines: &mut Lines<R>,
+    id: u64,
+) -> Result<serde_json::Value, BridgeError> {
+    let deadline = Instant::now() + Duration::from_secs(HANDSHAKE_STEP_SECS);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| {
+                BridgeError::upstream(format!("grok ACP timed out awaiting response id {id}"))
+            })?;
+        let line = tokio::time::timeout(remaining, lines.next_line())
+            .await
+            .map_err(|_| {
+                BridgeError::upstream(format!("grok ACP timed out awaiting response id {id}"))
+            })?
+            .map_err(|e| BridgeError::upstream(format!("grok ACP stdout read failed: {e}")))?
+            .ok_or_else(|| {
+                BridgeError::upstream("grok ACP stream closed during handshake".to_string())
+            })?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+        if value.get("id").and_then(|v| v.as_u64()) == Some(id) {
+            if let Some(err) = value.get("error") {
+                return Err(BridgeError::upstream(format!(
+                    "grok ACP request {id} failed: {err}"
+                )));
+            }
+            return Ok(value);
+        }
+        // Any notification received mid-handshake is discarded — no tool calls
+        // can occur before the prompt is sent.
+    }
+}
+
+fn extract_tokens(meta: &serde_json::Value, keys: &[&str]) -> u64 {
+    for key in keys {
+        if let Some(n) = meta.get(key).and_then(|v| v.as_u64()) {
+            return n;
+        }
+    }
+    0
+}
+
+/// Build a fail-closed response to an ACP `session/request_permission`.
+///
+/// The bridge never authorizes a built-in host action. We prefer an explicit
+/// `reject*` option so the CLI records a genuine denial; if the agent offered no
+/// reject option we return the ACP `cancelled` outcome, which is also a refusal.
+/// We never select an `allow*` (or arbitrary first) option.
+fn deny_permission_outcome(options: Option<&serde_json::Value>) -> serde_json::Value {
+    if let Some(opts) = options.and_then(|v| v.as_array()) {
+        let reject = opts
+            .iter()
+            .find(|o| {
+                o.get("kind")
+                    .and_then(|k| k.as_str())
+                    .is_some_and(|k| k.starts_with("reject") || k.starts_with("deny"))
+            })
+            .and_then(|o| o.get("optionId"))
+            .cloned();
+        if let Some(option_id) = reject {
+            return serde_json::json!({ "outcome": "selected", "optionId": option_id });
+        }
+    }
+    serde_json::json!({ "outcome": "cancelled" })
+}
+
+/// Terminal result the driver task produces exactly once per session.
+type DriverResult = Result<CompletedTurn, BridgeError>;
+
+/// Drain the child's stderr to EOF so its pipe buffer can never fill and
+/// deadlock the CLI. Content is **not** echoed — grok stderr can contain
+/// sensitive material, so we only emit a redacted line count at debug level.
+async fn drain_stderr(stderr: tokio::process::ChildStderr) {
+    let mut lines = BufReader::new(stderr).lines();
+    let mut count: u64 = 0;
+    while let Ok(Some(_line)) = lines.next_line().await {
+        count += 1;
+    }
+    if count > 0 {
+        tracing::debug!(
+            stderr_lines = count,
+            "grok bridge child stderr drained (content redacted)"
+        );
+    }
+}
+
+/// Background task: pump the ACP stdout stream after the prompt is sent,
+/// auto-approving permission requests, accumulating assistant text, and
+/// resolving the turn when `session/prompt` completes.
+async fn run_driver(
+    mut stdin: ChildStdin,
+    mut lines: Lines<BufReader<tokio::process::ChildStdout>>,
+    mut model: String,
+    cancel: CancellationToken,
+    done_tx: oneshot::Sender<DriverResult>,
+) {
+    let mut text = String::new();
+    let idle = Duration::from_secs(DRIVER_IDLE_SECS);
+    let result: DriverResult = loop {
+        let read = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                break Err(BridgeError::session_state("grok bridge session was shut down"));
+            }
+            line = tokio::time::timeout(idle, lines.next_line()) => line,
+        };
+        let line = match read {
+            Err(_) => {
+                break Err(BridgeError::upstream(format!(
+                    "grok ACP produced no events for {DRIVER_IDLE_SECS}s"
+                )));
+            }
+            Ok(Err(e)) => break Err(BridgeError::upstream(format!("grok ACP read failed: {e}"))),
+            Ok(Ok(None)) => {
+                break Err(BridgeError::upstream(
+                    "grok ACP stream closed before the prompt completed",
+                ));
+            }
+            Ok(Ok(Some(line))) => line,
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+
+        // Incoming request from the agent. We DENY every ACP permission prompt:
+        // the caller's tools run through the ephemeral MCP server (which needs no
+        // ACP permission), so any `session/request_permission` here is the CLI
+        // asking to run a *built-in* shell/filesystem/network action on the host.
+        // Auto-approving those would let a compromised or adversarial model
+        // execute arbitrary host actions, so we fail closed.
+        if let (Some(req_id), Some(method)) = (value.get("id"), value.get("method")) {
+            if method == "session/request_permission" {
+                let outcome = deny_permission_outcome(value.pointer("/params/options"));
+                let _ = send_rpc(
+                    &mut stdin,
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": { "outcome": outcome },
+                    }),
+                )
+                .await;
+            }
+            continue;
+        }
+
+        // Prompt completion.
+        if value.get("id").and_then(|v| v.as_u64()) == Some(ACP_PROMPT_ID) {
+            if let Some(err) = value.get("error") {
+                break Err(BridgeError::upstream(format!(
+                    "grok ACP prompt failed: {err}"
+                )));
+            }
+            let result = value.get("result").cloned().unwrap_or_default();
+            let stop_reason = result
+                .get("stopReason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("stop")
+                .to_string();
+            let mut usage = BridgeUsage::default();
+            if let Some(meta) = result.get("_meta") {
+                if let Some(m) = meta.get("modelId").and_then(|v| v.as_str()) {
+                    model = m.to_string();
+                }
+                usage.input_tokens = extract_tokens(meta, &["inputTokens", "input_tokens"]);
+                usage.output_tokens = extract_tokens(meta, &["outputTokens", "output_tokens"]);
+                if usage.total() == 0 {
+                    usage.input_tokens = extract_tokens(meta, &["totalTokens", "total_tokens"]);
+                }
+            }
+            break Ok(CompletedTurn {
+                text: text.trim().to_string(),
+                model,
+                usage,
+                stop_reason,
+            });
+        }
+
+        // Assistant text chunks (both standard and vendor-prefixed envelopes).
+        let update = match value.get("method").and_then(|v| v.as_str()) {
+            Some("session/update") | Some("_x.ai/session_notification") => {
+                value.pointer("/params/update").cloned()
+            }
+            _ => None,
+        };
+        if let Some(update) = update {
+            if update.get("sessionUpdate").and_then(|v| v.as_str()) == Some("agent_message_chunk") {
+                if let Some(chunk) = update.pointer("/content/text").and_then(|v| v.as_str()) {
+                    text.push_str(chunk);
+                }
+            }
+        }
+    };
+    let _ = done_tx.send(result);
+}
+
+/// A live Grok conversation: owns the child, the ephemeral MCP server, the
+/// stdout driver task, and any currently-suspended tool invocations.
+pub struct AcpConversation {
+    session_id: String,
+    model: String,
+    child: Child,
+    cancel: CancellationToken,
+    driver_handle: Option<JoinHandle<()>>,
+    mcp_handle: Option<JoinHandle<()>>,
+    stderr_handle: Option<JoinHandle<()>>,
+    tool_rx: mpsc::UnboundedReceiver<InboundToolCall>,
+    done_rx: oneshot::Receiver<DriverResult>,
+    /// provider_call_id → the suspended MCP handler awaiting its result.
+    pending: HashMap<String, oneshot::Sender<String>>,
+}
+
+impl AcpConversation {
+    /// Await the next turn boundary: either Grok invoked caller tools (surface
+    /// them) or the turn completed.
+    async fn await_outcome(&mut self) -> Result<TurnOutcome, BridgeError> {
+        tokio::select! {
+            biased;
+            done = &mut self.done_rx => {
+                match done {
+                    Ok(Ok(turn)) => Ok(TurnOutcome::Completed(turn)),
+                    Ok(Err(e)) => Err(e),
+                    Err(_) => Err(BridgeError::upstream(
+                        "grok ACP driver terminated without a result",
+                    )),
+                }
+            }
+            first = self.tool_rx.recv() => {
+                match first {
+                    Some(call) => {
+                        let batch = self.collect_batch(call).await;
+                        Ok(self.surface_tool_calls(batch))
+                    }
+                    None => {
+                        // MCP server gone before any completion — fall to done.
+                        match (&mut self.done_rx).await {
+                            Ok(Ok(turn)) => Ok(TurnOutcome::Completed(turn)),
+                            Ok(Err(e)) => Err(e),
+                            Err(_) => Err(BridgeError::upstream(
+                                "grok bridge closed before the turn completed",
+                            )),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Gather any additional concurrent tool calls within the settle window.
+    async fn collect_batch(&mut self, first: InboundToolCall) -> Vec<InboundToolCall> {
+        let mut calls = vec![first];
+        let settle = Duration::from_millis(TOOL_BATCH_SETTLE_MS);
+        while let Ok(Some(call)) = tokio::time::timeout(settle, self.tool_rx.recv()).await {
+            calls.push(call);
+        }
+        calls
+    }
+
+    /// Mint provider ids, park the suspended responders, and build the outcome.
+    fn surface_tool_calls(&mut self, calls: Vec<InboundToolCall>) -> TurnOutcome {
+        let mut requested = Vec::with_capacity(calls.len());
+        for call in calls {
+            let provider_call_id = format!("acp-{}", uuid::Uuid::new_v4().simple());
+            self.pending
+                .insert(provider_call_id.clone(), call.responder);
+            requested.push(RequestedToolCall {
+                provider_call_id,
+                name: call.name,
+                arguments: call.arguments,
+            });
+        }
+        TurnOutcome::ToolCalls {
+            model: self.model.clone(),
+            calls: requested,
+        }
+    }
+}
+
+#[async_trait]
+impl BridgeConversation for AcpConversation {
+    fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    async fn resume(
+        &mut self,
+        results: Vec<ResolvedToolResult>,
+    ) -> Result<TurnOutcome, BridgeError> {
+        for result in results {
+            match self.pending.remove(&result.provider_call_id) {
+                Some(responder) => {
+                    // Unblock the suspended MCP handler; a receive error here
+                    // just means Grok already tore that call down.
+                    let _ = responder.send(result.content);
+                }
+                None => {
+                    return Err(BridgeError::session_state(format!(
+                        "no suspended Grok tool call for provider id '{}'",
+                        result.provider_call_id
+                    )));
+                }
+            }
+        }
+        self.await_outcome().await
+    }
+
+    async fn shutdown(&mut self) {
+        self.cancel.cancel();
+        // Dropping the parked responders errors out any still-suspended MCP
+        // handlers so Grok's tool call fails closed rather than hanging.
+        self.pending.clear();
+        let _ = self.child.start_kill();
+        let _ = self.child.wait().await;
+        if let Some(handle) = self.driver_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.mcp_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.stderr_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Safety net for every drop path (e.g. a parked session evicted on TTL sweep,
+/// or a panic): cancel the token and abort the background tasks so no ephemeral
+/// MCP server or driver task can outlive its conversation. The child carries
+/// `kill_on_drop(true)`, so dropping it here reaps the process. This makes
+/// teardown deterministic even when async `shutdown` was never awaited.
+impl Drop for AcpConversation {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(handle) = self.driver_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.mcp_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.stderr_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Opens live Grok conversations mediated through an ephemeral MCP server.
+pub struct AcpMcpBackend {
+    working_dir: PathBuf,
+}
+
+impl AcpMcpBackend {
+    pub fn new(working_dir: PathBuf) -> Self {
+        Self { working_dir }
+    }
+}
+
+#[async_trait]
+impl BridgeBackend for AcpMcpBackend {
+    async fn open(
+        &self,
+        input: PromptInput,
+    ) -> Result<(Box<dyn BridgeConversation>, TurnOutcome), BridgeError> {
+        let cancel = CancellationToken::new();
+
+        // 1. Start the ephemeral MCP server before the ACP handshake — the CLI
+        //    connects to it (initialize / tools/list) during `session/new`.
+        let (tool_tx, tool_rx) = mpsc::unbounded_channel::<InboundToolCall>();
+        let mcp_state = Arc::new(McpState {
+            tools: input.tools_mcp.clone(),
+            tool_tx,
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| {
+                BridgeError::upstream(format!("failed to bind ephemeral MCP server: {e}"))
+            })?;
+        let addr = listener
+            .local_addr()
+            .map_err(|e| BridgeError::upstream(format!("MCP server has no local addr: {e}")))?;
+        let app = Router::new()
+            .route("/", post(mcp_handler))
+            .with_state(mcp_state);
+        let mcp_cancel = cancel.clone();
+        let mcp_handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move { mcp_cancel.cancelled().await })
+                .await;
+        });
+        let mcp_url = format!("http://{addr}/");
+
+        // 2. Spawn `grok agent stdio` on the host with non-interactive auth.
+        let env = grok_auth_env(&self.working_dir)?;
+        let mut command = tokio::process::Command::new(grok_cli_path());
+        command
+            .arg("agent")
+            .arg("stdio")
+            .current_dir(&self.working_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let mut child = command.spawn().map_err(|e| {
+            BridgeError::upstream(format!("failed to spawn `grok agent stdio`: {e}"))
+        })?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| BridgeError::upstream("failed to capture grok stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| BridgeError::upstream("failed to capture grok stdout"))?;
+        let mut lines = BufReader::new(stdout).lines();
+
+        // Drain stderr continuously so a full pipe buffer can never deadlock the
+        // CLI mid-handshake. The handle is aborted on shutdown/drop.
+        let stderr_handle = child
+            .stderr
+            .take()
+            .map(|stderr| tokio::spawn(drain_stderr(stderr)));
+
+        // 3. ACP handshake. Any failure here tears the child down and reports a
+        //    truthful infrastructure error (never a fabricated turn).
+        let handshake = async {
+            send_rpc(
+                &mut stdin,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": ACP_INIT_ID,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": 1,
+                        "clientCapabilities": { "fs": { "readTextFile": false, "writeTextFile": false } }
+                    }
+                }),
+            )
+            .await?;
+            await_response(&mut lines, ACP_INIT_ID).await?;
+
+            let cwd = self.working_dir.to_string_lossy().to_string();
+            // The ephemeral caller-tool MCP server is offered here. The HTTP
+            // descriptor shape below is the ACP `http` MCP-server variant; the
+            // precise schema a given CLI build accepts is the operator-verified
+            // deployment gate this whole route is flagged behind.
+            send_rpc(
+                &mut stdin,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": ACP_SESSION_NEW_ID,
+                    "method": "session/new",
+                    "params": {
+                        "cwd": cwd,
+                        "mcpServers": [{
+                            "type": "http",
+                            "name": "grok-cli-bridge-tools",
+                            "url": mcp_url,
+                        }]
+                    }
+                }),
+            )
+            .await?;
+            let resp = await_response(&mut lines, ACP_SESSION_NEW_ID).await?;
+            let session_id = resp
+                .pointer("/result/sessionId")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    BridgeError::upstream("grok ACP session/new returned no sessionId")
+                })?
+                .to_string();
+
+            send_rpc(
+                &mut stdin,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": ACP_SET_MODEL_ID,
+                    "method": "session/set_model",
+                    "params": { "sessionId": session_id, "modelId": input.model.clone().unwrap_or_else(|| "grok-4.5".to_string()) }
+                }),
+            )
+            .await?;
+            // A set_model rejection is fatal: we must not silently answer on a
+            // different model than the caller routed to.
+            await_response(&mut lines, ACP_SET_MODEL_ID).await?;
+
+            send_rpc(
+                &mut stdin,
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": ACP_PROMPT_ID,
+                    "method": "session/prompt",
+                    "params": {
+                        "sessionId": session_id,
+                        "prompt": [{ "type": "text", "text": input.prompt }]
+                    }
+                }),
+            )
+            .await?;
+            Ok::<String, BridgeError>(session_id)
+        }
+        .await;
+
+        let session_id = match handshake {
+            Ok(sid) => sid,
+            Err(e) => {
+                cancel.cancel();
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                mcp_handle.abort();
+                if let Some(handle) = stderr_handle {
+                    handle.abort();
+                }
+                return Err(e);
+            }
+        };
+
+        // 4. Hand stdin + stdout to the driver task; it resolves the turn while
+        //    tool calls (if any) flow in over the MCP server.
+        let model = input.model.unwrap_or_else(|| "grok-4.5".to_string());
+        let (done_tx, done_rx) = oneshot::channel();
+        let driver_handle = tokio::spawn(run_driver(
+            stdin,
+            lines,
+            model.clone(),
+            cancel.clone(),
+            done_tx,
+        ));
+
+        let mut conversation = AcpConversation {
+            session_id,
+            model,
+            child,
+            cancel,
+            driver_handle: Some(driver_handle),
+            mcp_handle: Some(mcp_handle),
+            stderr_handle,
+            tool_rx,
+            done_rx,
+            pending: HashMap::new(),
+        };
+        let outcome = conversation.await_outcome().await?;
+        Ok((Box::new(conversation), outcome))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_permission_selects_reject_option_when_offered() {
+        let options = serde_json::json!([
+            { "optionId": "allow-once", "kind": "allow_once" },
+            { "optionId": "reject-once", "kind": "reject_once" }
+        ]);
+        let outcome = deny_permission_outcome(Some(&options));
+        assert_eq!(outcome["outcome"], "selected");
+        // Must pick the reject option — never the allow one.
+        assert_eq!(outcome["optionId"], "reject-once");
+    }
+
+    #[test]
+    fn deny_permission_cancels_when_only_allow_options_exist() {
+        // A malicious/compromised agent offering only "allow" options for a
+        // built-in shell/fs action must still be refused: we cancel rather than
+        // select any allow option.
+        let options = serde_json::json!([
+            { "optionId": "allow-once", "kind": "allow_once" },
+            { "optionId": "allow-always", "kind": "allow_always" }
+        ]);
+        let outcome = deny_permission_outcome(Some(&options));
+        assert_eq!(outcome["outcome"], "cancelled");
+        assert!(outcome.get("optionId").is_none());
+    }
+
+    #[test]
+    fn deny_permission_cancels_with_no_options() {
+        assert_eq!(deny_permission_outcome(None)["outcome"], "cancelled");
+        let empty = serde_json::json!([]);
+        assert_eq!(
+            deny_permission_outcome(Some(&empty))["outcome"],
+            "cancelled"
+        );
+    }
+
+    #[test]
+    fn grok_auth_env_fails_closed_without_genuine_key() {
+        // No ai_providers.json under a nonexistent dir ⇒ no genuine API key ⇒
+        // provider-configuration error, never an OAuth relabel.
+        let err = grok_auth_env(Path::new("/nonexistent-grok-bridge-dir")).unwrap_err();
+        assert!(matches!(
+            err.class,
+            super::super::error::BridgeErrorClass::ProviderConfiguration
+        ));
+    }
+}

--- a/src/api/grok_tool_bridge/capability.rs
+++ b/src/api/grok_tool_bridge/capability.rs
@@ -49,18 +49,36 @@ pub fn connected_account_available(working_dir: &Path) -> bool {
 
 /// Resolve the `grok` CLI binary: an explicit override path, or a `grok`
 /// executable somewhere on `PATH`. Returns `None` when nothing is found.
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = path.metadata() else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
 fn resolve_grok_cli() -> Option<PathBuf> {
     if let Ok(explicit) = std::env::var("SANDBOXED_SH_GROK_CLI_PATH") {
         let explicit = explicit.trim();
         if !explicit.is_empty() {
             let path = PathBuf::from(explicit);
-            return path.is_file().then_some(path);
+            return is_executable_file(&path).then_some(path);
         }
     }
     let path_var = std::env::var_os("PATH")?;
     std::env::split_paths(&path_var)
         .map(|dir| dir.join("grok"))
-        .find(|candidate| candidate.is_file())
+        .find(|candidate| is_executable_file(candidate))
 }
 
 /// Whether the `grok` CLI is resolvable on this host. A real, bounded health
@@ -122,6 +140,26 @@ pub fn probe(working_dir: &Path) -> Capability {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_probe_requires_an_executable_file() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grok");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"#!/bin/sh\n")
+            .unwrap();
+
+        assert!(!is_executable_file(&path));
+        let mut permissions = path.metadata().unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        assert!(is_executable_file(&path));
+    }
 
     #[test]
     fn model_ids_are_distinct_from_api_key_route() {

--- a/src/api/grok_tool_bridge/capability.rs
+++ b/src/api/grok_tool_bridge/capability.rs
@@ -1,0 +1,141 @@
+//! Feature gating and capability probing for the Grok tool-bridge route.
+//!
+//! The route is advertised (and answerable) only when *every* gate passes:
+//!   1. `SANDBOXED_SH_GROK_ROUTER_BRIDGE` is on (default off),
+//!   2. a **genuine** xAI API key is configured for the grok backend (an
+//!      OAuth-only connected account does NOT qualify — the CLI cannot consume
+//!      it non-interactively and we never relabel OAuth as an API key),
+//!   3. the `grok` CLI binary is actually resolvable on this host (a real,
+//!      bounded, cached health check — not just an operator assertion), and
+//!   4. `SANDBOXED_SH_GROK_ROUTER_BRIDGE_LIVE` is on — the operator's explicit
+//!      assertion that the live ACP↔MCP tool-mediation was verified against
+//!      their connected account.
+//!
+//! Gate 4 exists because caller-owned tool continuation cannot be proven
+//! without a provisioned account; until an operator flips it we fail closed and
+//! never advertise a route we cannot honor.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::util::env_var_bool;
+
+/// Canonical model id for the connected-account Grok bridge. Distinct from the
+/// API-key `xai/grok-4.5` route so the two can never be conflated.
+pub const BRIDGE_MODEL_ID: &str = "grok-cli/grok-4.5";
+
+/// The model prefix the proxy intercepts for this bridge.
+pub const BRIDGE_MODEL_PREFIX: &str = "grok-cli/";
+
+pub fn feature_enabled() -> bool {
+    env_var_bool("SANDBOXED_SH_GROK_ROUTER_BRIDGE", false)
+}
+
+/// Whether the live ACP+MCP transport is authorized. Default off: the bridge's
+/// pure semantics are proven by tests, but live viability against a real Grok
+/// account is an operator-verified deployment gate.
+pub fn live_transport_enabled() -> bool {
+    env_var_bool("SANDBOXED_SH_GROK_ROUTER_BRIDGE_LIVE", false)
+}
+
+/// A **genuine** xAI API key is configured for the grok backend. Non-secret:
+/// only presence is checked, never the value. An OAuth-only connected account
+/// is deliberately excluded — the bridge cannot use it non-interactively and
+/// must never relabel an OAuth token as an API key.
+pub fn connected_account_available(working_dir: &Path) -> bool {
+    crate::api::ai_providers::get_xai_api_key_for_grok(working_dir).is_some()
+}
+
+/// Resolve the `grok` CLI binary: an explicit override path, or a `grok`
+/// executable somewhere on `PATH`. Returns `None` when nothing is found.
+fn resolve_grok_cli() -> Option<PathBuf> {
+    if let Ok(explicit) = std::env::var("SANDBOXED_SH_GROK_CLI_PATH") {
+        let explicit = explicit.trim();
+        if !explicit.is_empty() {
+            let path = PathBuf::from(explicit);
+            return path.is_file().then_some(path);
+        }
+    }
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join("grok"))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Whether the `grok` CLI is resolvable on this host. A real, bounded health
+/// signal (a filesystem probe, no network) cached briefly so repeated catalog
+/// probes don't re-stat the filesystem on every request.
+pub fn grok_cli_resolvable() -> bool {
+    static CACHE: OnceLock<Mutex<Option<(Instant, bool)>>> = OnceLock::new();
+    const CACHE_TTL: Duration = Duration::from_secs(30);
+    let cache = CACHE.get_or_init(|| Mutex::new(None));
+    let mut guard = cache.lock().unwrap();
+    if let Some((at, ok)) = *guard {
+        if at.elapsed() < CACHE_TTL {
+            return ok;
+        }
+    }
+    let ok = resolve_grok_cli().is_some();
+    *guard = Some((Instant::now(), ok));
+    ok
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Capability {
+    pub advertise: bool,
+    pub reason: &'static str,
+}
+
+/// Decide whether to advertise / answer the bridge route.
+pub fn probe(working_dir: &Path) -> Capability {
+    if !feature_enabled() {
+        return Capability {
+            advertise: false,
+            reason: "SANDBOXED_SH_GROK_ROUTER_BRIDGE is off",
+        };
+    }
+    if !connected_account_available(working_dir) {
+        return Capability {
+            advertise: false,
+            reason: "no genuine xAI API key configured for the grok backend",
+        };
+    }
+    if !grok_cli_resolvable() {
+        return Capability {
+            advertise: false,
+            reason: "the grok CLI binary is not resolvable on this host",
+        };
+    }
+    if !live_transport_enabled() {
+        return Capability {
+            advertise: false,
+            reason: "SANDBOXED_SH_GROK_ROUTER_BRIDGE_LIVE not enabled (live transport unverified)",
+        };
+    }
+    Capability {
+        advertise: true,
+        reason: "ready",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_ids_are_distinct_from_api_key_route() {
+        assert_eq!(BRIDGE_MODEL_ID, "grok-cli/grok-4.5");
+        assert!(BRIDGE_MODEL_ID.starts_with(BRIDGE_MODEL_PREFIX));
+        // Must NOT collide with the xai API-key direct route.
+        assert_ne!(BRIDGE_MODEL_ID, "xai/grok-4.5");
+    }
+
+    #[test]
+    fn probe_fails_closed_when_feature_off() {
+        // Default env: feature flag unset ⇒ not advertised regardless of
+        // account state.
+        let cap = probe(Path::new("/nonexistent"));
+        assert!(!cap.advertise);
+    }
+}

--- a/src/api/grok_tool_bridge/error.rs
+++ b/src/api/grok_tool_bridge/error.rs
@@ -1,0 +1,94 @@
+//! Bridge error taxonomy with truthful OpenAI-compatible classification.
+//!
+//! The class drives both the HTTP status and the OpenAI `error.type`/`code`
+//! fields. We keep provider vs infrastructure vs caller-fault distinct so
+//! provenance stays honest: a Grok CLI crash is *infrastructure*, a rejected
+//! caller request is *invalid_request*, and a route that is not provisioned is
+//! *provider_configuration_error* — never dressed up as a model refusal.
+
+use axum::http::StatusCode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BridgeErrorClass {
+    /// Caller sent something malformed or inconsistent (400).
+    InvalidRequest,
+    /// The route exists but is not configured/healthy for use (503).
+    ProviderConfiguration,
+    /// The connected Grok backend or bridge transport failed (502).
+    UpstreamInfrastructure,
+    /// A prior session was cancelled, timed out, or expired (409).
+    SessionState,
+}
+
+#[derive(Debug, Clone)]
+pub struct BridgeError {
+    pub class: BridgeErrorClass,
+    pub message: String,
+}
+
+impl BridgeError {
+    pub fn invalid_request(message: impl Into<String>) -> Self {
+        Self {
+            class: BridgeErrorClass::InvalidRequest,
+            message: message.into(),
+        }
+    }
+
+    pub fn provider_configuration(message: impl Into<String>) -> Self {
+        Self {
+            class: BridgeErrorClass::ProviderConfiguration,
+            message: message.into(),
+        }
+    }
+
+    pub fn upstream(message: impl Into<String>) -> Self {
+        Self {
+            class: BridgeErrorClass::UpstreamInfrastructure,
+            message: message.into(),
+        }
+    }
+
+    pub fn session_state(message: impl Into<String>) -> Self {
+        Self {
+            class: BridgeErrorClass::SessionState,
+            message: message.into(),
+        }
+    }
+
+    pub fn status(&self) -> StatusCode {
+        match self.class {
+            BridgeErrorClass::InvalidRequest => StatusCode::BAD_REQUEST,
+            BridgeErrorClass::ProviderConfiguration => StatusCode::SERVICE_UNAVAILABLE,
+            BridgeErrorClass::UpstreamInfrastructure => StatusCode::BAD_GATEWAY,
+            BridgeErrorClass::SessionState => StatusCode::CONFLICT,
+        }
+    }
+
+    /// OpenAI `error.type`.
+    pub fn openai_type(&self) -> &'static str {
+        match self.class {
+            BridgeErrorClass::InvalidRequest => "invalid_request_error",
+            BridgeErrorClass::ProviderConfiguration => "provider_configuration_error",
+            BridgeErrorClass::UpstreamInfrastructure => "upstream_error",
+            BridgeErrorClass::SessionState => "session_state_error",
+        }
+    }
+
+    /// OpenAI `error.code`.
+    pub fn openai_code(&self) -> &'static str {
+        match self.class {
+            BridgeErrorClass::InvalidRequest => "invalid_request",
+            BridgeErrorClass::ProviderConfiguration => "provider_configuration_error",
+            BridgeErrorClass::UpstreamInfrastructure => "upstream_infrastructure_error",
+            BridgeErrorClass::SessionState => "session_unavailable",
+        }
+    }
+}
+
+impl std::fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for BridgeError {}

--- a/src/api/grok_tool_bridge/mod.rs
+++ b/src/api/grok_tool_bridge/mod.rs
@@ -35,6 +35,20 @@ use openai::BridgeChatRequest;
 use registry::{ParkedSession, SessionRegistry};
 use transport::{BridgeBackend, BridgeConversation, PromptInput, TurnOutcome};
 
+/// Usage metadata extracted from a successful bridge response for the proxy's
+/// shared accounting store.
+pub struct BridgeRecordedUsage {
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+/// The HTTP response plus any real usage the bridge reported.
+pub struct HandledBridgeCompletion {
+    pub response: Response,
+    pub usage: Option<BridgeRecordedUsage>,
+}
+
 /// Idle lifetime of a suspended tool-call session before it is reclaimed.
 const SESSION_TTL: Duration = Duration::from_secs(300);
 
@@ -72,12 +86,15 @@ pub fn advertised_model(working_dir: &std::path::Path) -> Option<&'static str> {
 
 /// Proxy entry point. Parses the body, enforces the capability gate, and drives
 /// the live backend. Converts every outcome to an OpenAI-shaped response.
-pub async fn handle_chat_completion(working_dir: &std::path::Path, body: &[u8]) -> Response {
+pub async fn handle_chat_completion(
+    working_dir: &std::path::Path,
+    body: &[u8],
+) -> HandledBridgeCompletion {
     let req: BridgeChatRequest = match serde_json::from_slice(body) {
         Ok(r) => r,
         Err(e) => {
-            return bridge_error_response(BridgeError::invalid_request(format!(
-                "invalid request body: {e}"
+            return handled_response(bridge_error_response(BridgeError::invalid_request(
+                format!("invalid request body: {e}"),
             )));
         }
     };
@@ -85,17 +102,43 @@ pub async fn handle_chat_completion(working_dir: &std::path::Path, body: &[u8]) 
     let cap = capability::probe(working_dir);
     if !cap.advertise {
         // Fail closed with a truthful configuration error — never a fake turn.
-        return bridge_error_response(BridgeError::provider_configuration(format!(
-            "the grok-cli connected-account bridge is not available: {}",
-            cap.reason
+        return handled_response(bridge_error_response(BridgeError::provider_configuration(
+            format!(
+                "the grok-cli connected-account bridge is not available: {}",
+                cap.reason
+            ),
         )));
     }
 
     let backend = acp::AcpMcpBackend::new(working_dir.to_path_buf());
     match process_request(&backend, registry(), req).await {
-        Ok(value) => (StatusCode::OK, Json(value)).into_response(),
-        Err(err) => bridge_error_response(err),
+        Ok(value) => HandledBridgeCompletion {
+            usage: recorded_usage(&value),
+            response: (StatusCode::OK, Json(value)).into_response(),
+        },
+        Err(err) => handled_response(bridge_error_response(err)),
     }
+}
+
+fn handled_response(response: Response) -> HandledBridgeCompletion {
+    HandledBridgeCompletion {
+        response,
+        usage: None,
+    }
+}
+
+fn recorded_usage(value: &serde_json::Value) -> Option<BridgeRecordedUsage> {
+    let usage = value.get("usage")?;
+    let input_tokens = usage.get("prompt_tokens").and_then(|v| v.as_u64())?;
+    let output_tokens = usage.get("completion_tokens").and_then(|v| v.as_u64())?;
+    if input_tokens == 0 && output_tokens == 0 {
+        return None;
+    }
+    Some(BridgeRecordedUsage {
+        model: value.get("model")?.as_str()?.to_string(),
+        input_tokens,
+        output_tokens,
+    })
 }
 
 fn bridge_error_response(err: BridgeError) -> Response {

--- a/src/api/grok_tool_bridge/mod.rs
+++ b/src/api/grok_tool_bridge/mod.rs
@@ -1,0 +1,264 @@
+//! Connected-account Grok 4.5 router bridge.
+//!
+//! Presents OpenAI `/v1/chat/completions` tool-call semantics on top of the
+//! connected xAI/Grok account, while keeping **tool execution caller-owned**:
+//! caller `tools[]` become an ephemeral MCP server offered to `grok agent
+//! stdio`; when Grok invokes one, the bridge suspends that invocation and
+//! surfaces it as `assistant.tool_calls`; the caller's later `role: "tool"`
+//! result unblocks the same Grok session, which produces the next turn.
+//!
+//! The pure state machine (message/tool conversion, id minting, result
+//! reconciliation, session registry) is fully unit- and transcript-tested via
+//! a fake backend. The live [`acp::AcpMcpBackend`] is feature-gated and
+//! default-off — see [`capability`].
+
+pub mod acp;
+pub mod capability;
+pub mod error;
+pub mod openai;
+pub mod registry;
+pub mod response;
+pub mod session;
+pub mod transport;
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+pub use capability::{BRIDGE_MODEL_ID, BRIDGE_MODEL_PREFIX};
+
+use error::BridgeError;
+use openai::BridgeChatRequest;
+use registry::{ParkedSession, SessionRegistry};
+use transport::{BridgeBackend, BridgeConversation, PromptInput, TurnOutcome};
+
+/// Idle lifetime of a suspended tool-call session before it is reclaimed.
+const SESSION_TTL: Duration = Duration::from_secs(300);
+
+/// Process-wide registry of suspended bridge conversations.
+fn registry() -> &'static SessionRegistry {
+    static REGISTRY: OnceLock<SessionRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| SessionRegistry::new(SESSION_TTL))
+}
+
+/// True when the requested model id targets this bridge. Exact allowlist: we
+/// advertise and answer exactly one connected-account model id, never arbitrary
+/// `grok-cli/*`, so a caller can't route to an unsupported model through us.
+pub fn is_bridge_model(model: &str) -> bool {
+    model == BRIDGE_MODEL_ID
+}
+
+/// The concrete model to hand the connected account (strip the `grok-cli/`
+/// routing prefix).
+fn backend_model(requested: &str) -> String {
+    requested
+        .strip_prefix(BRIDGE_MODEL_PREFIX)
+        .unwrap_or(requested)
+        .to_string()
+}
+
+/// Catalog hook: the model id to advertise, or `None` when the route is not
+/// provisioned/healthy.
+pub fn advertised_model(working_dir: &std::path::Path) -> Option<&'static str> {
+    if capability::probe(working_dir).advertise {
+        Some(BRIDGE_MODEL_ID)
+    } else {
+        None
+    }
+}
+
+/// Proxy entry point. Parses the body, enforces the capability gate, and drives
+/// the live backend. Converts every outcome to an OpenAI-shaped response.
+pub async fn handle_chat_completion(working_dir: &std::path::Path, body: &[u8]) -> Response {
+    let req: BridgeChatRequest = match serde_json::from_slice(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return bridge_error_response(BridgeError::invalid_request(format!(
+                "invalid request body: {e}"
+            )));
+        }
+    };
+
+    let cap = capability::probe(working_dir);
+    if !cap.advertise {
+        // Fail closed with a truthful configuration error — never a fake turn.
+        return bridge_error_response(BridgeError::provider_configuration(format!(
+            "the grok-cli connected-account bridge is not available: {}",
+            cap.reason
+        )));
+    }
+
+    let backend = acp::AcpMcpBackend::new(working_dir.to_path_buf());
+    match process_request(&backend, registry(), req).await {
+        Ok(value) => (StatusCode::OK, Json(value)).into_response(),
+        Err(err) => bridge_error_response(err),
+    }
+}
+
+fn bridge_error_response(err: BridgeError) -> Response {
+    let body = serde_json::json!({
+        "error": {
+            "message": err.message,
+            "type": err.openai_type(),
+            "code": err.openai_code(),
+        }
+    });
+    (err.status(), Json(body)).into_response()
+}
+
+/// Backend-agnostic request processing — the heart of the bridge. Tested
+/// directly against the fake backend.
+pub(crate) async fn process_request(
+    backend: &dyn BridgeBackend,
+    registry: &SessionRegistry,
+    req: BridgeChatRequest,
+) -> Result<serde_json::Value, BridgeError> {
+    // Streaming is explicitly rejected — never silently downgraded to a
+    // non-streaming body a streaming client would mis-parse.
+    if req.stream.unwrap_or(false) {
+        return Err(BridgeError::invalid_request(
+            "streaming is not supported by the grok-cli bridge; retry with stream=false",
+        ));
+    }
+
+    // Deterministically reap sessions idle past the TTL, awaiting their
+    // teardown, before doing anything else — an abandoned tool-call session must
+    // never leak its Grok child / ephemeral MCP server.
+    reap_expired(registry).await;
+
+    if openai::is_continuation(&req) {
+        continue_turn(registry, req).await
+    } else {
+        fresh_turn(backend, registry, req).await
+    }
+}
+
+async fn fresh_turn(
+    backend: &dyn BridgeBackend,
+    registry: &SessionRegistry,
+    req: BridgeChatRequest,
+) -> Result<serde_json::Value, BridgeError> {
+    let prompt = openai::initial_prompt(&req)?;
+    let tools = req.tools.clone().unwrap_or_default();
+    let tools_mcp = openai::tools_to_mcp(&tools)?;
+    let input = PromptInput {
+        prompt,
+        model: Some(backend_model(&req.model)),
+        tools_mcp,
+    };
+    let (conversation, outcome) = backend.open(input).await?;
+    finish_outcome(registry, conversation, outcome).await
+}
+
+async fn continue_turn(
+    registry: &SessionRegistry,
+    req: BridgeChatRequest,
+) -> Result<serde_json::Value, BridgeError> {
+    let submitted = openai::submitted_results(&req)?;
+
+    // Every submitted result id must have been issued in *some* assistant
+    // tool_calls turn — reject fabricated ids up front, before touching any
+    // parked session, so a continuation can never bind to the wrong session.
+    let all_echoed = openai::echoed_tool_call_ids(&req);
+    for result in &submitted {
+        if !all_echoed.contains(&result.tool_call_id) {
+            return Err(BridgeError::invalid_request(format!(
+                "tool result references id '{}' that was not issued in any assistant \
+                 tool_calls of this request",
+                result.tool_call_id
+            )));
+        }
+    }
+
+    // Bind to exactly the *last* tool-call round the bridge parked. A well-formed
+    // continuation must echo that assistant turn; without it there is nothing to
+    // resume.
+    let round = openai::current_round_call_ids(&req);
+    if round.is_empty() {
+        return Err(BridgeError::invalid_request(
+            "continuation provided tool results but echoed no assistant tool_calls to answer",
+        ));
+    }
+
+    // The results answering the current round, in submission order. Results for
+    // earlier (already-resumed) rounds are historical context and are ignored.
+    let round_set: std::collections::HashSet<&str> = round.iter().map(String::as_str).collect();
+    let round_results: Vec<openai::SubmittedResult> = submitted
+        .iter()
+        .filter(|r| round_set.contains(r.tool_call_id.as_str()))
+        .cloned()
+        .collect();
+
+    let mut parked = registry.take_for_call_ids(&round)?;
+
+    // Reconcile the current round's results against the session's pending calls
+    // (rejects missing, duplicate, or extra results). On any inconsistency shut
+    // the session down so it can never be half-resumed.
+    let resolved = match session::reconcile(&parked.pending, &round_results) {
+        Ok(r) => r,
+        Err(e) => {
+            parked.conversation.shutdown().await;
+            return Err(e);
+        }
+    };
+    let outcome = match parked.conversation.resume(resolved).await {
+        Ok(o) => o,
+        Err(e) => {
+            parked.conversation.shutdown().await;
+            return Err(e);
+        }
+    };
+    finish_outcome(registry, parked.conversation, outcome).await
+}
+
+/// Reap sessions idle past the TTL, awaiting each teardown. Called at the top
+/// of every request so an abandoned tool-call session cannot leak its Grok
+/// child / MCP server indefinitely. (`AcpConversation` also tears down on
+/// `Drop` as a safety net, but this path is deterministic and awaited.)
+async fn reap_expired(registry: &SessionRegistry) {
+    for mut parked in registry.sweep_expired() {
+        parked.conversation.shutdown().await;
+    }
+}
+
+/// Turn a backend outcome into an OpenAI response, parking the session when
+/// more caller tool calls are pending and tearing it down when complete.
+async fn finish_outcome(
+    registry: &SessionRegistry,
+    mut conversation: Box<dyn BridgeConversation>,
+    outcome: TurnOutcome,
+) -> Result<serde_json::Value, BridgeError> {
+    match outcome {
+        TurnOutcome::ToolCalls { model, calls } => {
+            if calls.is_empty() {
+                conversation.shutdown().await;
+                return Err(BridgeError::upstream(
+                    "Grok reported a tool-call turn with no tool calls",
+                ));
+            }
+            let pending = session::mint_pending(&calls);
+            let resp = response::tool_calls_response(&model, &pending);
+            tracing::debug!(
+                session_id = conversation.session_id(),
+                model = %model,
+                pending = pending.len(),
+                "parked grok bridge session awaiting caller tool results"
+            );
+            registry.park(ParkedSession {
+                conversation,
+                pending,
+            });
+            Ok(resp)
+        }
+        TurnOutcome::Completed(turn) => {
+            conversation.shutdown().await;
+            Ok(response::completed_response(&turn))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/api/grok_tool_bridge/mod.rs
+++ b/src/api/grok_tool_bridge/mod.rs
@@ -116,6 +116,11 @@ pub(crate) async fn process_request(
     registry: &SessionRegistry,
     req: BridgeChatRequest,
 ) -> Result<serde_json::Value, BridgeError> {
+    // Deterministically reap sessions idle past the TTL before validating this
+    // request. Even a malformed/unsupported request is useful traffic for
+    // reclaiming abandoned Grok children and ephemeral MCP servers.
+    reap_expired(registry).await;
+
     // Streaming is explicitly rejected — never silently downgraded to a
     // non-streaming body a streaming client would mis-parse.
     if req.stream.unwrap_or(false) {
@@ -123,11 +128,6 @@ pub(crate) async fn process_request(
             "streaming is not supported by the grok-cli bridge; retry with stream=false",
         ));
     }
-
-    // Deterministically reap sessions idle past the TTL, awaiting their
-    // teardown, before doing anything else — an abandoned tool-call session must
-    // never leak its Grok child / ephemeral MCP server.
-    reap_expired(registry).await;
 
     if openai::is_continuation(&req) {
         continue_turn(registry, req).await

--- a/src/api/grok_tool_bridge/mod.rs
+++ b/src/api/grok_tool_bridge/mod.rs
@@ -142,7 +142,7 @@ async fn fresh_turn(
     req: BridgeChatRequest,
 ) -> Result<serde_json::Value, BridgeError> {
     let prompt = openai::initial_prompt(&req)?;
-    let tools = req.tools.clone().unwrap_or_default();
+    let tools = openai::effective_tools(&req)?;
     let tools_mcp = openai::tools_to_mcp(&tools)?;
     let input = PromptInput {
         prompt,

--- a/src/api/grok_tool_bridge/openai.rs
+++ b/src/api/grok_tool_bridge/openai.rs
@@ -90,10 +90,16 @@ pub fn content_text(content: Option<&serde_json::Value>) -> String {
     }
 }
 
-/// True when a request carries at least one `role: "tool"` message — i.e. it is
-/// a continuation that must resume an existing Grok session, not open a new one.
+/// True when the request ends with the tool-result block for its most recent
+/// assistant `tool_calls` turn.
+///
+/// Historical tool messages do not make a later user turn a continuation: once
+/// an assistant has completed that earlier round, a new user message must open
+/// a fresh Grok session with the full transcript.
 pub fn is_continuation(req: &BridgeChatRequest) -> bool {
-    req.messages.iter().any(|m| m.role == "tool")
+    req.messages
+        .last()
+        .is_some_and(|message| message.role == "tool")
 }
 
 /// The text prompt for a fresh turn: a truthful, **role-labeled transcript of
@@ -277,6 +283,29 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].tool_call_id, "call_1");
         assert_eq!(results[0].content, "sunny");
+    }
+
+    #[test]
+    fn completed_historical_tool_round_is_a_fresh_turn() {
+        let fresh = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [
+                { "role": "user", "content": "weather?" },
+                { "role": "assistant", "tool_calls": [
+                    { "id": "call_1", "type": "function",
+                      "function": { "name": "get_weather", "arguments": "{}" } }
+                ]},
+                { "role": "tool", "tool_call_id": "call_1", "content": "sunny" },
+                { "role": "assistant", "content": "It is sunny." },
+                { "role": "user", "content": "What about tomorrow?" }
+            ]
+        }));
+
+        assert!(!is_continuation(&fresh));
+        assert_eq!(
+            initial_prompt(&fresh).unwrap(),
+            "User: weather?\n\nAssistant: It is sunny.\n\nUser: What about tomorrow?"
+        );
     }
 
     #[test]

--- a/src/api/grok_tool_bridge/openai.rs
+++ b/src/api/grok_tool_bridge/openai.rs
@@ -1,0 +1,377 @@
+//! OpenAI Chat Completions ⇄ Grok bridge conversion.
+//!
+//! Only the fields the bridge actually inspects are modelled. The conversion
+//! is deliberately total and side-effect free so it can be unit-tested without
+//! a live backend: every helper is a pure function over the request JSON.
+
+use serde::{Deserialize, Serialize};
+
+use super::error::BridgeError;
+
+/// Incoming `/v1/chat/completions` body, parsed for tool-bridge semantics.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BridgeChatRequest {
+    pub model: String,
+    #[serde(default)]
+    pub messages: Vec<ChatMessage>,
+    #[serde(default)]
+    pub tools: Option<Vec<ToolDef>>,
+    #[serde(default)]
+    pub stream: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatMessage {
+    pub role: String,
+    /// String, array of content parts, or null (assistant tool-call turns).
+    #[serde(default)]
+    pub content: Option<serde_json::Value>,
+    #[serde(default)]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+}
+
+/// An OpenAI `assistant.tool_calls[]` entry (also accepted back on the
+/// continuation request so we can validate the caller echoed our ids).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type", default = "function_kind")]
+    pub kind: String,
+    pub function: FunctionCall,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct FunctionCall {
+    pub name: String,
+    /// OpenAI encodes arguments as a JSON *string*, not an object.
+    pub arguments: String,
+}
+
+fn function_kind() -> String {
+    "function".to_string()
+}
+
+/// A caller-provided `tools[]` entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToolDef {
+    #[serde(rename = "type", default = "function_kind")]
+    pub kind: String,
+    pub function: ToolFunctionDef,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToolFunctionDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// JSON Schema for the arguments; forwarded verbatim as the MCP tool's
+    /// `inputSchema`.
+    #[serde(default)]
+    pub parameters: Option<serde_json::Value>,
+}
+
+/// Flatten OpenAI message `content` (string | array-of-parts | null) into text.
+pub fn content_text(content: Option<&serde_json::Value>) -> String {
+    match content {
+        None | Some(serde_json::Value::Null) => String::new(),
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Array(parts)) => parts
+            .iter()
+            .filter_map(|part| {
+                // `{ "type": "text", "text": "..." }` parts; ignore non-text
+                // (images etc.) — the bridge is text-only for now.
+                part.get("text").and_then(|v| v.as_str())
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+        Some(other) => other.as_str().map(str::to_string).unwrap_or_default(),
+    }
+}
+
+/// True when a request carries at least one `role: "tool"` message — i.e. it is
+/// a continuation that must resume an existing Grok session, not open a new one.
+pub fn is_continuation(req: &BridgeChatRequest) -> bool {
+    req.messages.iter().any(|m| m.role == "tool")
+}
+
+/// The text prompt for a fresh turn: a truthful, **role-labeled transcript of
+/// the whole conversation**.
+///
+/// Each fresh turn opens a brand-new Grok session with no memory of prior
+/// requests, so we must forward the full history — dropping the assistant turns
+/// (as an earlier version did) would corrupt a normal multi-turn OpenAI chat.
+/// Messages are rendered `System:`/`User:`/`Assistant:` in order; non-text
+/// parts (images) and empty messages are skipped. Fails closed if there is no
+/// user or system content to send at all.
+pub fn initial_prompt(req: &BridgeChatRequest) -> Result<String, BridgeError> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut has_user_or_system = false;
+    for msg in &req.messages {
+        let label = match msg.role.as_str() {
+            "system" => "System",
+            "user" => "User",
+            "assistant" => "Assistant",
+            // Tool/other roles do not appear in a fresh (non-continuation) turn.
+            _ => continue,
+        };
+        let text = content_text(msg.content.as_ref());
+        if text.trim().is_empty() {
+            continue;
+        }
+        if msg.role == "system" || msg.role == "user" {
+            has_user_or_system = true;
+        }
+        lines.push(format!("{label}: {text}"));
+    }
+    if !has_user_or_system {
+        return Err(BridgeError::invalid_request(
+            "no user or system message content to prompt Grok with",
+        ));
+    }
+    Ok(lines.join("\n\n"))
+}
+
+/// Tool results submitted on a continuation request, in message order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubmittedResult {
+    pub tool_call_id: String,
+    pub content: String,
+}
+
+/// Extract `role: "tool"` results from a continuation request, preserving the
+/// order they appear in the message list.
+pub fn submitted_results(req: &BridgeChatRequest) -> Result<Vec<SubmittedResult>, BridgeError> {
+    let mut out = Vec::new();
+    for msg in &req.messages {
+        if msg.role != "tool" {
+            continue;
+        }
+        let Some(id) = msg.tool_call_id.clone().filter(|s| !s.trim().is_empty()) else {
+            return Err(BridgeError::invalid_request(
+                "tool message missing tool_call_id",
+            ));
+        };
+        out.push(SubmittedResult {
+            tool_call_id: id,
+            content: content_text(msg.content.as_ref()),
+        });
+    }
+    if out.is_empty() {
+        return Err(BridgeError::invalid_request(
+            "continuation request contained no tool results",
+        ));
+    }
+    Ok(out)
+}
+
+/// Every tool_call id the caller echoed back via any `assistant` message across
+/// the whole history. Used to reject fabricated result ids that were never
+/// issued in *any* turn.
+pub fn echoed_tool_call_ids(req: &BridgeChatRequest) -> Vec<String> {
+    req.messages
+        .iter()
+        .filter(|m| m.role == "assistant")
+        .filter_map(|m| m.tool_calls.as_ref())
+        .flatten()
+        .map(|tc| tc.id.clone())
+        .collect()
+}
+
+/// The tool_call ids from the **last** assistant message that carried
+/// `tool_calls` — i.e. the single round the bridge most recently parked and that
+/// this continuation must answer. Empty when the request echoes no assistant
+/// tool_calls at all (a malformed continuation). Earlier rounds in the history
+/// are already-resumed context and are intentionally ignored here.
+pub fn current_round_call_ids(req: &BridgeChatRequest) -> Vec<String> {
+    req.messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "assistant" && m.tool_calls.as_ref().is_some_and(|c| !c.is_empty()))
+        .and_then(|m| m.tool_calls.as_ref())
+        .map(|calls| calls.iter().map(|c| c.id.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// Convert caller `tools[]` into MCP tool descriptors (`name`, `description`,
+/// `inputSchema`). Rejects duplicate names — Grok would not be able to address
+/// them unambiguously, so we fail closed rather than silently drop one.
+pub fn tools_to_mcp(tools: &[ToolDef]) -> Result<Vec<serde_json::Value>, BridgeError> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(tools.len());
+    for tool in tools {
+        if tool.kind != "function" {
+            return Err(BridgeError::invalid_request(format!(
+                "unsupported tool type '{}'; only 'function' is supported",
+                tool.kind
+            )));
+        }
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(BridgeError::invalid_request("tool function name is empty"));
+        }
+        if !seen.insert(name.to_string()) {
+            return Err(BridgeError::invalid_request(format!(
+                "duplicate tool name '{name}'"
+            )));
+        }
+        let schema = tool
+            .function
+            .parameters
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({ "type": "object", "properties": {} }));
+        out.push(serde_json::json!({
+            "name": name,
+            "description": tool.function.description.clone().unwrap_or_default(),
+            "inputSchema": schema,
+        }));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(json: serde_json::Value) -> BridgeChatRequest {
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn content_text_handles_string_array_and_null() {
+        assert_eq!(content_text(Some(&serde_json::json!("hi"))), "hi");
+        assert_eq!(content_text(None), "");
+        assert_eq!(content_text(Some(&serde_json::Value::Null)), "");
+        let parts = serde_json::json!([
+            { "type": "text", "text": "a" },
+            { "type": "image_url", "image_url": { "url": "x" } },
+            { "type": "text", "text": "b" }
+        ]);
+        assert_eq!(content_text(Some(&parts)), "ab");
+    }
+
+    #[test]
+    fn fresh_vs_continuation_detection() {
+        let fresh = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "user", "content": "hello" }]
+        }));
+        assert!(!is_continuation(&fresh));
+        assert_eq!(initial_prompt(&fresh).unwrap(), "User: hello");
+
+        let cont = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [
+                { "role": "user", "content": "hello" },
+                { "role": "assistant", "tool_calls": [
+                    { "id": "call_1", "type": "function",
+                      "function": { "name": "get_weather", "arguments": "{}" } }
+                ]},
+                { "role": "tool", "tool_call_id": "call_1", "content": "sunny" }
+            ]
+        }));
+        assert!(is_continuation(&cont));
+        assert_eq!(echoed_tool_call_ids(&cont), vec!["call_1".to_string()]);
+        let results = submitted_results(&cont).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].tool_call_id, "call_1");
+        assert_eq!(results[0].content, "sunny");
+    }
+
+    #[test]
+    fn initial_prompt_preserves_full_role_labeled_history() {
+        let multi = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [
+                { "role": "system", "content": "be terse" },
+                { "role": "user", "content": "hi" },
+                { "role": "assistant", "content": "hello" },
+                { "role": "user", "content": "who are you?" }
+            ]
+        }));
+        assert_eq!(
+            initial_prompt(&multi).unwrap(),
+            "System: be terse\n\nUser: hi\n\nAssistant: hello\n\nUser: who are you?"
+        );
+    }
+
+    #[test]
+    fn current_round_is_last_assistant_tool_calls() {
+        let multi = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [
+                { "role": "user", "content": "go" },
+                { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                    { "id": "call_a", "type": "function", "function": { "name": "a", "arguments": "{}" } }
+                ]},
+                { "role": "tool", "tool_call_id": "call_a", "content": "ra" },
+                { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                    { "id": "call_b", "type": "function", "function": { "name": "b", "arguments": "{}" } }
+                ]},
+                { "role": "tool", "tool_call_id": "call_b", "content": "rb" }
+            ]
+        }));
+        // Whole-history echo includes both; current round is only the last turn.
+        assert_eq!(
+            echoed_tool_call_ids(&multi),
+            vec!["call_a".to_string(), "call_b".to_string()]
+        );
+        assert_eq!(current_round_call_ids(&multi), vec!["call_b".to_string()]);
+    }
+
+    #[test]
+    fn current_round_empty_without_assistant_tool_calls() {
+        let none = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [
+                { "role": "user", "content": "hi" },
+                { "role": "tool", "tool_call_id": "call_x", "content": "r" }
+            ]
+        }));
+        assert!(current_round_call_ids(&none).is_empty());
+    }
+
+    #[test]
+    fn initial_prompt_fails_closed_without_user_text() {
+        let bad = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "assistant", "content": "prior" }]
+        }));
+        assert!(initial_prompt(&bad).is_err());
+    }
+
+    #[test]
+    fn tool_message_without_id_is_rejected() {
+        let bad = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "tool", "content": "result" }]
+        }));
+        assert!(submitted_results(&bad).is_err());
+    }
+
+    #[test]
+    fn tools_to_mcp_rejects_duplicates_and_maps_schema() {
+        let tools: Vec<ToolDef> = serde_json::from_value(serde_json::json!([
+            { "type": "function", "function": {
+                "name": "get_weather",
+                "description": "look up weather",
+                "parameters": { "type": "object", "properties": { "city": { "type": "string" } } }
+            }}
+        ]))
+        .unwrap();
+        let mcp = tools_to_mcp(&tools).unwrap();
+        assert_eq!(mcp[0]["name"], "get_weather");
+        assert_eq!(
+            mcp[0]["inputSchema"]["properties"]["city"]["type"],
+            "string"
+        );
+
+        let dupes: Vec<ToolDef> = serde_json::from_value(serde_json::json!([
+            { "type": "function", "function": { "name": "x" } },
+            { "type": "function", "function": { "name": "x" } }
+        ]))
+        .unwrap();
+        assert!(tools_to_mcp(&dupes).is_err());
+    }
+}

--- a/src/api/grok_tool_bridge/openai.rs
+++ b/src/api/grok_tool_bridge/openai.rs
@@ -110,15 +110,16 @@ pub fn is_continuation(req: &BridgeChatRequest) -> bool {
 /// Each fresh turn opens a brand-new Grok session with no memory of prior
 /// requests, so we must forward the full history — dropping the assistant turns
 /// (as an earlier version did) would corrupt a normal multi-turn OpenAI chat.
-/// Messages are rendered `System:`/`User:`/`Assistant:` in order; non-text
-/// parts (images) and empty messages are skipped. Fails closed if there is no
-/// user or system content to send at all.
+/// Messages are rendered `System:`/`Developer:`/`User:`/`Assistant:` in order;
+/// non-text parts (images) and empty messages are skipped. Fails closed if
+/// there is no instruction or user content to send at all.
 pub fn initial_prompt(req: &BridgeChatRequest) -> Result<String, BridgeError> {
     let mut lines: Vec<String> = Vec::new();
-    let mut has_user_or_system = false;
+    let mut has_instruction_or_user = false;
     for msg in &req.messages {
         let label = match msg.role.as_str() {
             "system" => "System",
+            "developer" => "Developer",
             "user" => "User",
             "assistant" => "Assistant",
             // Tool/other roles do not appear in a fresh (non-continuation) turn.
@@ -128,14 +129,14 @@ pub fn initial_prompt(req: &BridgeChatRequest) -> Result<String, BridgeError> {
         if text.trim().is_empty() {
             continue;
         }
-        if msg.role == "system" || msg.role == "user" {
-            has_user_or_system = true;
+        if matches!(msg.role.as_str(), "system" | "developer" | "user") {
+            has_instruction_or_user = true;
         }
         lines.push(format!("{label}: {text}"));
     }
-    if !has_user_or_system {
+    if !has_instruction_or_user {
         return Err(BridgeError::invalid_request(
-            "no user or system message content to prompt Grok with",
+            "no user, developer, or system message content to prompt Grok with",
         ));
     }
     Ok(lines.join("\n\n"))
@@ -359,6 +360,21 @@ mod tests {
         assert_eq!(
             initial_prompt(&multi).unwrap(),
             "System: be terse\n\nUser: hi\n\nAssistant: hello\n\nUser: who are you?"
+        );
+    }
+
+    #[test]
+    fn initial_prompt_preserves_developer_instructions() {
+        let request = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [
+                { "role": "developer", "content": "Never reveal secrets." },
+                { "role": "user", "content": "hello" }
+            ]
+        }));
+        assert_eq!(
+            initial_prompt(&request).unwrap(),
+            "Developer: Never reveal secrets.\n\nUser: hello"
         );
     }
 

--- a/src/api/grok_tool_bridge/openai.rs
+++ b/src/api/grok_tool_bridge/openai.rs
@@ -17,6 +17,8 @@ pub struct BridgeChatRequest {
     #[serde(default)]
     pub tools: Option<Vec<ToolDef>>,
     #[serde(default)]
+    pub tool_choice: Option<serde_json::Value>,
+    #[serde(default)]
     pub stream: Option<bool>,
 }
 
@@ -236,6 +238,41 @@ pub fn tools_to_mcp(tools: &[ToolDef]) -> Result<Vec<serde_json::Value>, BridgeE
     Ok(out)
 }
 
+/// Apply the OpenAI `tool_choice` contract to the tools exposed to Grok.
+///
+/// The connected CLI supports optional caller tools but does not expose a
+/// trustworthy force-tool control. We can therefore implement `auto` and
+/// `none` exactly, while `required` and a named forced function must fail
+/// closed instead of silently weakening the caller's constraint.
+pub fn effective_tools(req: &BridgeChatRequest) -> Result<Vec<ToolDef>, BridgeError> {
+    let tools = req.tools.clone().unwrap_or_default();
+    match req.tool_choice.as_ref() {
+        None => Ok(tools),
+        Some(serde_json::Value::String(mode)) if mode == "auto" => Ok(tools),
+        Some(serde_json::Value::String(mode)) if mode == "none" => Ok(Vec::new()),
+        Some(serde_json::Value::String(mode)) if mode == "required" => {
+            Err(BridgeError::invalid_request(
+                "tool_choice='required' is not supported by the grok-cli bridge",
+            ))
+        }
+        Some(serde_json::Value::Object(choice))
+            if choice.get("type").and_then(|v| v.as_str()) == Some("function") =>
+        {
+            let name = choice
+                .get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("<missing>");
+            Err(BridgeError::invalid_request(format!(
+                "forced tool_choice for function '{name}' is not supported by the grok-cli bridge"
+            )))
+        }
+        Some(_) => Err(BridgeError::invalid_request(
+            "invalid tool_choice for the grok-cli bridge",
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -402,5 +439,47 @@ mod tests {
         ]))
         .unwrap();
         assert!(tools_to_mcp(&dupes).is_err());
+    }
+
+    #[test]
+    fn tool_choice_none_hides_tools_and_auto_keeps_them() {
+        let none = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "tools": [{ "type": "function", "function": { "name": "dangerous" } }],
+            "tool_choice": "none"
+        }));
+        assert!(effective_tools(&none).unwrap().is_empty());
+
+        let auto = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "tools": [{ "type": "function", "function": { "name": "safe" } }],
+            "tool_choice": "auto"
+        }));
+        assert_eq!(effective_tools(&auto).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn forced_tool_choices_fail_closed() {
+        let required = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "tools": [{ "type": "function", "function": { "name": "lookup" } }],
+            "tool_choice": "required"
+        }));
+        assert!(effective_tools(&required).is_err());
+
+        let named = req(serde_json::json!({
+            "model": "grok-cli/grok-4.5",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "tools": [{ "type": "function", "function": { "name": "lookup" } }],
+            "tool_choice": {
+                "type": "function",
+                "function": { "name": "lookup" }
+            }
+        }));
+        let err = effective_tools(&named).unwrap_err();
+        assert!(err.message.contains("lookup"));
     }
 }

--- a/src/api/grok_tool_bridge/registry.rs
+++ b/src/api/grok_tool_bridge/registry.rs
@@ -10,7 +10,7 @@
 //! closed instead of double-driving one Grok child.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use super::error::BridgeError;
@@ -28,18 +28,19 @@ struct Slot {
     last_active: Instant,
 }
 
+#[derive(Clone)]
 pub struct SessionRegistry {
-    slots: Mutex<HashMap<String, Slot>>,
+    slots: Arc<Mutex<HashMap<String, Slot>>>,
     /// openai_call_id → conversation_id.
-    index: Mutex<HashMap<String, String>>,
+    index: Arc<Mutex<HashMap<String, String>>>,
     ttl: Duration,
 }
 
 impl SessionRegistry {
     pub fn new(ttl: Duration) -> Self {
         Self {
-            slots: Mutex::new(HashMap::new()),
-            index: Mutex::new(HashMap::new()),
+            slots: Arc::new(Mutex::new(HashMap::new())),
+            index: Arc::new(Mutex::new(HashMap::new())),
             ttl,
         }
     }
@@ -47,9 +48,8 @@ impl SessionRegistry {
     /// Park a conversation and index it by its pending call ids. Returns the
     /// conversation id (opaque; not exposed to callers).
     ///
-    /// Expired-session reaping is done by the caller (`reap_expired`) in an
-    /// async context so evicted sessions can be shut down and awaited; `park`
-    /// itself never silently drops a live conversation.
+    /// Starts an independent expiry task so an abandoned session is reclaimed
+    /// even if no later bridge request arrives.
     pub fn park(&self, parked: ParkedSession) -> String {
         let conversation_id = uuid::Uuid::new_v4().to_string();
         {
@@ -65,7 +65,33 @@ impl SessionRegistry {
                 last_active: Instant::now(),
             },
         );
+        let registry = self.clone();
+        let expiry_id = conversation_id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(registry.ttl).await;
+            if let Some(mut expired) = registry.take_expired(&expiry_id) {
+                expired.conversation.shutdown().await;
+            }
+        });
         conversation_id
+    }
+
+    /// Remove one session only if its TTL has elapsed. Used by the per-session
+    /// expiry task; returns ownership so shutdown happens asynchronously and
+    /// outside registry locks.
+    fn take_expired(&self, conversation_id: &str) -> Option<ParkedSession> {
+        let expired = self
+            .slots
+            .lock()
+            .unwrap()
+            .get(conversation_id)
+            .is_some_and(|slot| slot.last_active.elapsed() >= self.ttl);
+        if !expired {
+            return None;
+        }
+        let slot = self.slots.lock().unwrap().remove(conversation_id)?;
+        self.drop_index_for(&slot.parked.pending);
+        Some(slot.parked)
     }
 
     /// Remove and return the session addressed by any one of `call_ids`,
@@ -145,9 +171,8 @@ impl SessionRegistry {
                 .collect()
         };
         for id in expired_ids {
-            if let Some(slot) = self.slots.lock().unwrap().remove(&id) {
-                self.drop_index_for(&slot.parked.pending);
-                evicted.push(slot.parked);
+            if let Some(parked) = self.take_expired(&id) {
+                evicted.push(parked);
             }
         }
         evicted
@@ -259,6 +284,10 @@ mod tests {
             .take_for_call_ids(&["call_1".to_string()])
             .err()
             .unwrap();
-        assert!(err.message.contains("expired"));
+        assert!(
+            err.message.contains("expired") || err.message.contains("no active Grok session"),
+            "unexpected session-state error: {}",
+            err.message
+        );
     }
 }

--- a/src/api/grok_tool_bridge/registry.rs
+++ b/src/api/grok_tool_bridge/registry.rs
@@ -1,0 +1,264 @@
+//! In-memory registry of suspended bridge conversations.
+//!
+//! A conversation is parked here between the request that produced
+//! `tool_calls` and the continuation that supplies the results. Each parked
+//! session is addressable by any of the OpenAI `call_...` ids it is blocked on.
+//!
+//! Concurrency is deliberately *take-to-own*: a continuation removes the
+//! session from the map for the duration of its (async) resume, so a second
+//! concurrent continuation for the same session finds it absent and fails
+//! closed instead of double-driving one Grok child.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::error::BridgeError;
+use super::session::PendingCall;
+use super::transport::BridgeConversation;
+
+/// A parked conversation and everything needed to resume it.
+pub struct ParkedSession {
+    pub conversation: Box<dyn BridgeConversation>,
+    pub pending: Vec<PendingCall>,
+}
+
+struct Slot {
+    parked: ParkedSession,
+    last_active: Instant,
+}
+
+pub struct SessionRegistry {
+    slots: Mutex<HashMap<String, Slot>>,
+    /// openai_call_id → conversation_id.
+    index: Mutex<HashMap<String, String>>,
+    ttl: Duration,
+}
+
+impl SessionRegistry {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            slots: Mutex::new(HashMap::new()),
+            index: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Park a conversation and index it by its pending call ids. Returns the
+    /// conversation id (opaque; not exposed to callers).
+    ///
+    /// Expired-session reaping is done by the caller (`reap_expired`) in an
+    /// async context so evicted sessions can be shut down and awaited; `park`
+    /// itself never silently drops a live conversation.
+    pub fn park(&self, parked: ParkedSession) -> String {
+        let conversation_id = uuid::Uuid::new_v4().to_string();
+        {
+            let mut index = self.index.lock().unwrap();
+            for call in &parked.pending {
+                index.insert(call.openai_call_id.clone(), conversation_id.clone());
+            }
+        }
+        self.slots.lock().unwrap().insert(
+            conversation_id.clone(),
+            Slot {
+                parked,
+                last_active: Instant::now(),
+            },
+        );
+        conversation_id
+    }
+
+    /// Remove and return the session addressed by any one of `call_ids`,
+    /// validating that they all resolve to the *same* parked conversation.
+    /// Fails closed on unknown id, cross-session mixing, or expiry.
+    pub fn take_for_call_ids(&self, call_ids: &[String]) -> Result<ParkedSession, BridgeError> {
+        if call_ids.is_empty() {
+            return Err(BridgeError::invalid_request(
+                "continuation request referenced no tool call ids",
+            ));
+        }
+        let conversation_id = {
+            let index = self.index.lock().unwrap();
+            let mut resolved: Option<String> = None;
+            for id in call_ids {
+                let Some(cid) = index.get(id) else {
+                    return Err(BridgeError::session_state(format!(
+                        "no active Grok session for tool call id '{id}' (it may have expired, \
+                         been cancelled, or already been resumed)"
+                    )));
+                };
+                match &resolved {
+                    Some(existing) if existing != cid => {
+                        return Err(BridgeError::invalid_request(
+                            "tool results reference more than one Grok session",
+                        ));
+                    }
+                    _ => resolved = Some(cid.clone()),
+                }
+            }
+            resolved.expect("non-empty call_ids yields a conversation id")
+        };
+
+        let slot = self
+            .slots
+            .lock()
+            .unwrap()
+            .remove(&conversation_id)
+            .ok_or_else(|| {
+                BridgeError::session_state(
+                    "the referenced Grok session is already being resumed or has been closed",
+                )
+            })?;
+        // Drop this session's index entries — it is now owned by the caller.
+        self.drop_index_for(&slot.parked.pending);
+
+        if slot.last_active.elapsed() > self.ttl {
+            // Expired in the race window after the request-level reap: report a
+            // clean session-state failure. `slot.parked` is dropped here, which
+            // triggers the conversation's `Drop` teardown (cancel token + abort
+            // background tasks + kill child).
+            return Err(BridgeError::session_state(format!(
+                "the Grok session expired after {}s of inactivity",
+                self.ttl.as_secs()
+            )));
+        }
+        Ok(slot.parked)
+    }
+
+    fn drop_index_for(&self, pending: &[PendingCall]) {
+        let mut index = self.index.lock().unwrap();
+        for call in pending {
+            index.remove(&call.openai_call_id);
+        }
+    }
+
+    /// Evict sessions idle longer than the TTL. Returns the parked sessions so
+    /// the caller can shut down their child processes off-lock.
+    pub fn sweep_expired(&self) -> Vec<ParkedSession> {
+        let mut evicted = Vec::new();
+        let expired_ids: Vec<String> = {
+            let slots = self.slots.lock().unwrap();
+            slots
+                .iter()
+                .filter(|(_, s)| s.last_active.elapsed() > self.ttl)
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+        for id in expired_ids {
+            if let Some(slot) = self.slots.lock().unwrap().remove(&id) {
+                self.drop_index_for(&slot.parked.pending);
+                evicted.push(slot.parked);
+            }
+        }
+        evicted
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.slots.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::grok_tool_bridge::transport::fake::{FakeBackend, ScriptedTurn};
+    use crate::api::grok_tool_bridge::transport::{BridgeBackend, PromptInput};
+
+    async fn parked_with_ids(ttl: Duration, ids: &[(&str, &str)]) -> (SessionRegistry, String) {
+        let backend = FakeBackend::new(vec![
+            ScriptedTurn::ToolCalls(vec![("t".into(), serde_json::json!({}))]),
+            ScriptedTurn::Complete("done".into()),
+        ]);
+        let (conversation, _outcome) = backend
+            .open(PromptInput {
+                prompt: "p".into(),
+                model: None,
+                tools_mcp: vec![],
+            })
+            .await
+            .unwrap();
+        let pending = ids
+            .iter()
+            .map(|(oid, pid)| PendingCall {
+                openai_call_id: oid.to_string(),
+                provider_call_id: pid.to_string(),
+                name: "t".into(),
+                arguments: serde_json::json!({}),
+            })
+            .collect();
+        let registry = SessionRegistry::new(ttl);
+        let cid = registry.park(ParkedSession {
+            conversation,
+            pending,
+        });
+        (registry, cid)
+    }
+
+    #[tokio::test]
+    async fn park_then_take_roundtrips() {
+        let (registry, _cid) =
+            parked_with_ids(Duration::from_secs(60), &[("call_1", "acp-1")]).await;
+        assert_eq!(registry.len(), 1);
+        let parked = registry.take_for_call_ids(&["call_1".to_string()]).unwrap();
+        assert_eq!(parked.pending.len(), 1);
+        assert_eq!(registry.len(), 0);
+        // Second take fails closed — it's been removed.
+        assert!(registry.take_for_call_ids(&["call_1".to_string()]).is_err());
+    }
+
+    #[tokio::test]
+    async fn unknown_call_id_is_session_state_error() {
+        let (registry, _cid) =
+            parked_with_ids(Duration::from_secs(60), &[("call_1", "acp-1")]).await;
+        let err = registry
+            .take_for_call_ids(&["call_missing".to_string()])
+            .err()
+            .unwrap();
+        assert!(matches!(
+            err.class,
+            crate::api::grok_tool_bridge::error::BridgeErrorClass::SessionState
+        ));
+    }
+
+    #[tokio::test]
+    async fn cross_session_mixing_rejected() {
+        let (registry, _c) = parked_with_ids(Duration::from_secs(60), &[("call_1", "acp-1")]).await;
+        // Park a second, separate session.
+        let backend = FakeBackend::new(vec![ScriptedTurn::Complete("x".into())]);
+        let (conversation, _o) = backend
+            .open(PromptInput {
+                prompt: "p".into(),
+                model: None,
+                tools_mcp: vec![],
+            })
+            .await
+            .unwrap();
+        registry.park(ParkedSession {
+            conversation,
+            pending: vec![PendingCall {
+                openai_call_id: "call_2".into(),
+                provider_call_id: "acp-x".into(),
+                name: "t".into(),
+                arguments: serde_json::json!({}),
+            }],
+        });
+        let err = registry
+            .take_for_call_ids(&["call_1".to_string(), "call_2".to_string()])
+            .err()
+            .unwrap();
+        assert!(err.message.contains("more than one Grok session"));
+    }
+
+    #[tokio::test]
+    async fn expired_session_fails_closed() {
+        let (registry, _cid) =
+            parked_with_ids(Duration::from_millis(1), &[("call_1", "acp-1")]).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let err = registry
+            .take_for_call_ids(&["call_1".to_string()])
+            .err()
+            .unwrap();
+        assert!(err.message.contains("expired"));
+    }
+}

--- a/src/api/grok_tool_bridge/response.rs
+++ b/src/api/grok_tool_bridge/response.rs
@@ -1,0 +1,147 @@
+//! OpenAI Chat Completions response envelopes.
+//!
+//! Provenance is truthful: `model` is the id the connected account actually
+//! reported, usage is only populated from real token counts, and the tool-call
+//! turn uses the canonical `finish_reason: "tool_calls"` with `content: null`.
+
+use super::session::PendingCall;
+use super::transport::{BridgeUsage, CompletedTurn};
+
+fn envelope_id() -> String {
+    format!("chatcmpl-{}", uuid::Uuid::new_v4().simple())
+}
+
+fn usage_json(usage: &BridgeUsage) -> Option<serde_json::Value> {
+    if usage.total() == 0 {
+        return None;
+    }
+    Some(serde_json::json!({
+        "prompt_tokens": usage.input_tokens,
+        "completion_tokens": usage.output_tokens,
+        "total_tokens": usage.total(),
+    }))
+}
+
+/// Build a `finish_reason: "tool_calls"` response from the pending calls the
+/// caller is expected to execute and return.
+pub fn tool_calls_response(model: &str, pending: &[PendingCall]) -> serde_json::Value {
+    let tool_calls: Vec<serde_json::Value> = pending
+        .iter()
+        .map(|call| {
+            serde_json::json!({
+                "id": call.openai_call_id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    // OpenAI encodes arguments as a JSON string.
+                    "arguments": serde_json::to_string(&call.arguments).unwrap_or_else(|_| "{}".into()),
+                },
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "id": envelope_id(),
+        "object": "chat.completion",
+        "created": chrono::Utc::now().timestamp(),
+        "model": model,
+        "provider": "grok-cli",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": serde_json::Value::Null,
+                "tool_calls": tool_calls,
+            },
+            "finish_reason": "tool_calls",
+        }],
+    })
+}
+
+/// Build a `finish_reason: "stop"` response from a completed assistant turn.
+pub fn completed_response(turn: &CompletedTurn) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "id": envelope_id(),
+        "object": "chat.completion",
+        "created": chrono::Utc::now().timestamp(),
+        "model": turn.model,
+        "provider": "grok-cli",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": turn.text,
+            },
+            "finish_reason": stop_reason_to_openai(&turn.stop_reason),
+        }],
+    });
+    if let Some(usage) = usage_json(&turn.usage) {
+        body["usage"] = usage;
+    }
+    body
+}
+
+/// Map an ACP stop reason onto an OpenAI `finish_reason`. Unknown reasons map
+/// to `"stop"` (the turn did complete); we never invent `"tool_calls"` here.
+fn stop_reason_to_openai(stop_reason: &str) -> &'static str {
+    match stop_reason {
+        "max_tokens" | "length" => "length",
+        "refusal" | "content_filter" => "content_filter",
+        _ => "stop",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_calls_response_shape_is_canonical() {
+        let pending = vec![PendingCall {
+            openai_call_id: "call_abc".into(),
+            provider_call_id: "acp-1".into(),
+            name: "get_weather".into(),
+            arguments: serde_json::json!({ "city": "Paris" }),
+        }];
+        let resp = tool_calls_response("grok-4.5", &pending);
+        assert_eq!(resp["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            resp["choices"][0]["message"]["content"],
+            serde_json::Value::Null
+        );
+        let tc = &resp["choices"][0]["message"]["tool_calls"][0];
+        assert_eq!(tc["id"], "call_abc");
+        assert_eq!(tc["function"]["name"], "get_weather");
+        // arguments is a JSON *string*.
+        let args = tc["function"]["arguments"].as_str().unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(args).unwrap()["city"],
+            "Paris"
+        );
+        assert_eq!(resp["model"], "grok-4.5");
+    }
+
+    #[test]
+    fn completed_response_omits_zero_usage_and_is_truthful() {
+        let turn = CompletedTurn {
+            text: "hello".into(),
+            model: "grok-4.5".into(),
+            usage: BridgeUsage::default(),
+            stop_reason: "stop".into(),
+        };
+        let resp = completed_response(&turn);
+        assert_eq!(resp["choices"][0]["message"]["content"], "hello");
+        assert_eq!(resp["choices"][0]["finish_reason"], "stop");
+        assert!(resp.get("usage").is_none());
+
+        let turn2 = CompletedTurn {
+            usage: BridgeUsage {
+                input_tokens: 3,
+                output_tokens: 4,
+            },
+            ..turn
+        };
+        let resp2 = completed_response(&turn2);
+        assert_eq!(resp2["usage"]["total_tokens"], 7);
+    }
+}

--- a/src/api/grok_tool_bridge/session.rs
+++ b/src/api/grok_tool_bridge/session.rs
@@ -1,0 +1,175 @@
+//! Bridge session state and the deterministic tool-result reconciliation.
+//!
+//! The reconciliation rules are the safety core of the bridge and are pure
+//! functions so they can be exhaustively unit-tested:
+//!   * every pending call must be answered exactly once (missing ⇒ reject),
+//!   * every submitted id must match a pending call (unknown ⇒ reject),
+//!   * no id may be answered twice in one request (duplicate ⇒ reject),
+//!   * results are delivered to the transport in a stable order.
+//!
+//! All failure paths reject the whole continuation — we never resume a Grok
+//! session with a partial or ambiguous tool-result set.
+
+use super::error::BridgeError;
+use super::openai::SubmittedResult;
+use super::transport::{RequestedToolCall, ResolvedToolResult};
+
+/// One caller tool call Grok is currently blocked on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingCall {
+    /// Stable OpenAI id we minted and returned to the caller.
+    pub openai_call_id: String,
+    /// The ACP/MCP id the transport correlates the result against.
+    pub provider_call_id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// Mint stable OpenAI `call_...` ids for a batch of requested tool calls.
+pub fn mint_pending(calls: &[RequestedToolCall]) -> Vec<PendingCall> {
+    calls
+        .iter()
+        .map(|c| PendingCall {
+            openai_call_id: format!("call_{}", uuid::Uuid::new_v4().simple()),
+            provider_call_id: c.provider_call_id.clone(),
+            name: c.name.clone(),
+            arguments: c.arguments.clone(),
+        })
+        .collect()
+}
+
+/// Reconcile caller-submitted tool results against the pending calls.
+///
+/// Returns results in `pending` order (deterministic regardless of the order
+/// the caller listed them), each carrying the provider-side id the transport
+/// needs to release the matching suspended MCP invocation.
+pub fn reconcile(
+    pending: &[PendingCall],
+    submitted: &[SubmittedResult],
+) -> Result<Vec<ResolvedToolResult>, BridgeError> {
+    use std::collections::HashMap;
+
+    // Reject duplicates within the submission up front.
+    let mut by_id: HashMap<&str, &SubmittedResult> = HashMap::new();
+    for result in submitted {
+        if by_id.insert(result.tool_call_id.as_str(), result).is_some() {
+            return Err(BridgeError::invalid_request(format!(
+                "duplicate tool result for call id '{}'",
+                result.tool_call_id
+            )));
+        }
+    }
+
+    // Reject unknown ids (submitted but never requested).
+    let pending_ids: std::collections::HashSet<&str> =
+        pending.iter().map(|p| p.openai_call_id.as_str()).collect();
+    for result in submitted {
+        if !pending_ids.contains(result.tool_call_id.as_str()) {
+            return Err(BridgeError::invalid_request(format!(
+                "tool result for unknown call id '{}'",
+                result.tool_call_id
+            )));
+        }
+    }
+
+    // Require every pending call to be answered, and deliver in pending order.
+    let mut resolved = Vec::with_capacity(pending.len());
+    for call in pending {
+        let Some(result) = by_id.get(call.openai_call_id.as_str()) else {
+            return Err(BridgeError::invalid_request(format!(
+                "missing tool result for call id '{}' (tool '{}')",
+                call.openai_call_id, call.name
+            )));
+        };
+        resolved.push(ResolvedToolResult {
+            provider_call_id: call.provider_call_id.clone(),
+            content: result.content.clone(),
+        });
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending(pairs: &[(&str, &str)]) -> Vec<PendingCall> {
+        pairs
+            .iter()
+            .map(|(oid, pid)| PendingCall {
+                openai_call_id: oid.to_string(),
+                provider_call_id: pid.to_string(),
+                name: "t".to_string(),
+                arguments: serde_json::json!({}),
+            })
+            .collect()
+    }
+
+    fn submitted(pairs: &[(&str, &str)]) -> Vec<SubmittedResult> {
+        pairs
+            .iter()
+            .map(|(id, c)| SubmittedResult {
+                tool_call_id: id.to_string(),
+                content: c.to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mint_produces_unique_stable_ids() {
+        let calls = vec![
+            RequestedToolCall {
+                provider_call_id: "a".into(),
+                name: "x".into(),
+                arguments: serde_json::json!({}),
+            },
+            RequestedToolCall {
+                provider_call_id: "b".into(),
+                name: "y".into(),
+                arguments: serde_json::json!({}),
+            },
+        ];
+        let p = mint_pending(&calls);
+        assert_eq!(p.len(), 2);
+        assert!(p[0].openai_call_id.starts_with("call_"));
+        assert_ne!(p[0].openai_call_id, p[1].openai_call_id);
+        assert_eq!(p[0].provider_call_id, "a");
+    }
+
+    #[test]
+    fn reconcile_happy_path_orders_by_pending() {
+        let p = pending(&[("call_1", "acp-1"), ("call_2", "acp-2")]);
+        // Submitted out of order — reconciliation must still deliver in pending
+        // order (acp-1 then acp-2).
+        let s = submitted(&[("call_2", "second"), ("call_1", "first")]);
+        let resolved = reconcile(&p, &s).unwrap();
+        assert_eq!(resolved[0].provider_call_id, "acp-1");
+        assert_eq!(resolved[0].content, "first");
+        assert_eq!(resolved[1].provider_call_id, "acp-2");
+        assert_eq!(resolved[1].content, "second");
+    }
+
+    #[test]
+    fn reconcile_rejects_missing() {
+        let p = pending(&[("call_1", "acp-1"), ("call_2", "acp-2")]);
+        let s = submitted(&[("call_1", "first")]);
+        let err = reconcile(&p, &s).unwrap_err();
+        assert!(err.message.contains("missing tool result"));
+    }
+
+    #[test]
+    fn reconcile_rejects_unknown() {
+        let p = pending(&[("call_1", "acp-1")]);
+        let s = submitted(&[("call_1", "first"), ("call_99", "ghost")]);
+        let err = reconcile(&p, &s).unwrap_err();
+        assert!(err.message.contains("unknown call id"));
+    }
+
+    #[test]
+    fn reconcile_rejects_duplicate() {
+        let p = pending(&[("call_1", "acp-1")]);
+        let s = submitted(&[("call_1", "first"), ("call_1", "again")]);
+        let err = reconcile(&p, &s).unwrap_err();
+        assert!(err.message.contains("duplicate tool result"));
+    }
+}

--- a/src/api/grok_tool_bridge/tests.rs
+++ b/src/api/grok_tool_bridge/tests.rs
@@ -209,6 +209,25 @@ async fn streaming_is_rejected_not_downgraded() {
 }
 
 #[tokio::test]
+async fn tool_choice_none_never_exposes_caller_tools() {
+    let backend = FakeBackend::new(vec![ScriptedTurn::Complete("no tools".into())]);
+    let transcript = backend.transcript();
+    let reg = registry();
+    let request = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "answer without tools" }],
+        "tools": [{ "type": "function", "function": { "name": "must_not_be_visible" } }],
+        "tool_choice": "none"
+    }));
+
+    process_request(&backend, &reg, request).await.unwrap();
+    assert!(
+        transcript.lock().unwrap().opened_with_tools.is_empty(),
+        "tool_choice=none must not expose tools to Grok"
+    );
+}
+
+#[tokio::test]
 async fn orphan_tool_result_without_assistant_echo_is_rejected() {
     let backend = FakeBackend::new(vec![ScriptedTurn::Complete("x".into())]);
     let reg = registry();
@@ -436,6 +455,36 @@ async fn expired_session_is_reaped_and_shut_down() {
         1,
         "reaped session was shut down, not leaked"
     );
+}
+
+#[tokio::test]
+async fn parked_session_expires_without_followup_traffic() {
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![("t".into(), serde_json::json!({}))]),
+        ScriptedTurn::Complete("done".into()),
+    ]);
+    let transcript = backend.transcript();
+    let reg = SessionRegistry::new(Duration::from_millis(10));
+
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [{ "type": "function", "function": { "name": "t" } }]
+    }));
+    let response = process_request(&backend, &reg, first).await.unwrap();
+    assert_eq!(response["choices"][0]["finish_reason"], "tool_calls");
+    assert_eq!(reg.len(), 1);
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if reg.len() == 0 && transcript.lock().unwrap().shutdowns == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("parked session should expire without another request");
 }
 
 #[test]

--- a/src/api/grok_tool_bridge/tests.rs
+++ b/src/api/grok_tool_bridge/tests.rs
@@ -496,3 +496,23 @@ fn bridge_model_routing() {
     assert!(!is_bridge_model("xai/grok-4.5"));
     assert!(!is_bridge_model("claude-opus-4-8"));
 }
+
+#[test]
+fn successful_response_usage_is_available_to_proxy_accounting() {
+    let response = serde_json::json!({
+        "model": "grok-4.5",
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 7,
+            "total_tokens": 19
+        }
+    });
+    let usage = super::recorded_usage(&response).expect("usage should be extracted");
+    assert_eq!(usage.model, "grok-4.5");
+    assert_eq!(usage.input_tokens, 12);
+    assert_eq!(usage.output_tokens, 7);
+    assert!(super::recorded_usage(&serde_json::json!({
+        "model": "grok-4.5"
+    }))
+    .is_none());
+}

--- a/src/api/grok_tool_bridge/tests.rs
+++ b/src/api/grok_tool_bridge/tests.rs
@@ -420,10 +420,16 @@ async fn expired_session_is_reaped_and_shut_down() {
     assert_eq!(resp1["choices"][0]["finish_reason"], "tool_calls");
     assert_eq!(reg.len(), 1);
 
-    // After the TTL elapses, reaping deterministically tears the abandoned
-    // session down (awaited shutdown) rather than leaking it.
+    // After the TTL elapses, even a request rejected before backend dispatch
+    // must reap and tear down the abandoned session.
     tokio::time::sleep(Duration::from_millis(10)).await;
-    super::reap_expired(&reg).await;
+    let rejected = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "unsupported request" }],
+        "stream": true
+    }));
+    let err = process_request(&backend, &reg, rejected).await.unwrap_err();
+    assert!(err.message.contains("streaming is not supported"));
     assert_eq!(reg.len(), 0, "expired session reaped");
     assert_eq!(
         transcript.lock().unwrap().shutdowns,

--- a/src/api/grok_tool_bridge/tests.rs
+++ b/src/api/grok_tool_bridge/tests.rs
@@ -1,0 +1,443 @@
+//! End-to-end bridge tests driven by the fake ACP/MCP backend.
+//!
+//! These prove the two-request tool-call contract without a live account:
+//!   * a request carrying `tools[]` returns `assistant.tool_calls` and parks a
+//!     session — the backend never executes the caller's tools,
+//!   * the follow-up `role: "tool"` request resumes the *same* session and
+//!     produces the next turn,
+//!   * malformed continuations fail closed and tear the session down.
+//!
+//! The fake is honest about being a fake (`FakeBackend`); it reproduces the ACP
+//! transcript shape, not a real Grok child.
+
+use std::time::Duration;
+
+use super::openai::BridgeChatRequest;
+use super::registry::SessionRegistry;
+use super::transport::fake::{FakeBackend, ScriptedTurn};
+use super::{is_bridge_model, process_request};
+
+fn req(json: serde_json::Value) -> BridgeChatRequest {
+    serde_json::from_value(json).expect("valid request json")
+}
+
+fn registry() -> SessionRegistry {
+    SessionRegistry::new(Duration::from_secs(60))
+}
+
+fn tool_call_id(resp: &serde_json::Value, idx: usize) -> String {
+    resp["choices"][0]["message"]["tool_calls"][idx]["id"]
+        .as_str()
+        .expect("tool call id present")
+        .to_string()
+}
+
+#[tokio::test]
+async fn two_request_round_trip_keeps_tools_caller_owned() {
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![(
+            "get_weather".into(),
+            serde_json::json!({ "city": "Paris" }),
+        )]),
+        ScriptedTurn::Complete("It is sunny in Paris.".into()),
+    ]);
+    let transcript = backend.transcript();
+    let reg = registry();
+
+    // Request 1 — offers a tool, expects a suspended tool-call turn.
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "What is the weather in Paris?" }],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "parameters": { "type": "object", "properties": { "city": { "type": "string" } } }
+            }
+        }]
+    }));
+    let resp1 = process_request(&backend, &reg, first).await.unwrap();
+    assert_eq!(resp1["choices"][0]["finish_reason"], "tool_calls");
+    assert!(resp1["choices"][0]["message"]["content"].is_null());
+    assert_eq!(
+        resp1["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
+        "get_weather"
+    );
+    let call_id = tool_call_id(&resp1, 0);
+    assert!(call_id.starts_with("call_"));
+    assert_eq!(reg.len(), 1, "session parked awaiting the tool result");
+
+    // The backend was offered the tool but never executed it.
+    {
+        let t = transcript.lock().unwrap();
+        assert_eq!(t.opened_with_tools, vec!["get_weather".to_string()]);
+        assert!(
+            t.executed_tools.is_empty(),
+            "caller tools stay caller-owned"
+        );
+    }
+
+    // Request 2 — returns the caller-produced result, resumes the same session.
+    let second = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "What is the weather in Paris?" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [{
+                "id": call_id,
+                "type": "function",
+                "function": { "name": "get_weather", "arguments": "{\"city\":\"Paris\"}" }
+            }]},
+            { "role": "tool", "tool_call_id": call_id, "content": "sunny, 24C" }
+        ]
+    }));
+    let resp2 = process_request(&backend, &reg, second).await.unwrap();
+    assert_eq!(resp2["choices"][0]["finish_reason"], "stop");
+    assert_eq!(
+        resp2["choices"][0]["message"]["content"],
+        "It is sunny in Paris."
+    );
+    assert_eq!(reg.len(), 0, "session torn down after completion");
+
+    // The exact caller result was routed back to the suspended invocation, and
+    // the session was shut down once.
+    let t = transcript.lock().unwrap();
+    assert_eq!(t.results_received.len(), 1);
+    assert_eq!(t.results_received[0][0].content, "sunny, 24C");
+    assert_eq!(t.shutdowns, 1);
+}
+
+#[tokio::test]
+async fn multiple_tool_calls_require_every_result() {
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![
+            ("get_weather".into(), serde_json::json!({ "city": "Paris" })),
+            ("get_time".into(), serde_json::json!({ "tz": "CET" })),
+        ]),
+        ScriptedTurn::Complete("done".into()),
+    ]);
+    let reg = registry();
+
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "weather and time" }],
+        "tools": [
+            { "type": "function", "function": { "name": "get_weather" } },
+            { "type": "function", "function": { "name": "get_time" } }
+        ]
+    }));
+    let resp1 = process_request(&backend, &reg, first).await.unwrap();
+    let calls = resp1["choices"][0]["message"]["tool_calls"]
+        .as_array()
+        .unwrap();
+    assert_eq!(calls.len(), 2);
+    let id0 = tool_call_id(&resp1, 0);
+    let id1 = tool_call_id(&resp1, 1);
+
+    // The assistant echo binds the round; answering only one of the two fails
+    // closed (missing result) and reclaims the session.
+    let partial = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "weather and time" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                { "id": id0, "type": "function", "function": { "name": "get_weather", "arguments": "{}" } },
+                { "id": id1, "type": "function", "function": { "name": "get_time", "arguments": "{}" } }
+            ]},
+            { "role": "tool", "tool_call_id": id0, "content": "sunny" }
+        ]
+    }));
+    let err = process_request(&backend, &reg, partial).await.unwrap_err();
+    assert!(err.message.contains("missing tool result"));
+    assert_eq!(
+        reg.len(),
+        0,
+        "inconsistent continuation tears the session down"
+    );
+
+    // The session is gone, so answering both now is a clean session-state error
+    // rather than a double-drive.
+    let both = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "weather and time" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                { "id": id0, "type": "function", "function": { "name": "get_weather", "arguments": "{}" } },
+                { "id": id1, "type": "function", "function": { "name": "get_time", "arguments": "{}" } }
+            ]},
+            { "role": "tool", "tool_call_id": id0, "content": "sunny" },
+            { "role": "tool", "tool_call_id": id1, "content": "12:00" }
+        ]
+    }));
+    let err = process_request(&backend, &reg, both).await.unwrap_err();
+    assert!(matches!(
+        err.class,
+        super::error::BridgeErrorClass::SessionState
+    ));
+}
+
+#[tokio::test]
+async fn immediate_completion_without_tools() {
+    let backend = FakeBackend::new(vec![ScriptedTurn::Complete("hello there".into())]);
+    let reg = registry();
+    let request = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "hi" }]
+    }));
+    let resp = process_request(&backend, &reg, request).await.unwrap();
+    assert_eq!(resp["choices"][0]["finish_reason"], "stop");
+    assert_eq!(resp["choices"][0]["message"]["content"], "hello there");
+    assert_eq!(resp["usage"]["total_tokens"], 15);
+    assert_eq!(reg.len(), 0);
+}
+
+#[tokio::test]
+async fn streaming_is_rejected_not_downgraded() {
+    let backend = FakeBackend::new(vec![ScriptedTurn::Complete("x".into())]);
+    let reg = registry();
+    let request = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "stream": true
+    }));
+    let err = process_request(&backend, &reg, request).await.unwrap_err();
+    assert!(err.message.contains("streaming is not supported"));
+    assert!(matches!(
+        err.class,
+        super::error::BridgeErrorClass::InvalidRequest
+    ));
+}
+
+#[tokio::test]
+async fn orphan_tool_result_without_assistant_echo_is_rejected() {
+    let backend = FakeBackend::new(vec![ScriptedTurn::Complete("x".into())]);
+    let reg = registry();
+    // A tool result referencing an id that no assistant turn ever issued, and
+    // with no assistant tool_calls echoed at all, is malformed: reject before
+    // touching any session.
+    let orphan = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "hi" },
+            { "role": "tool", "tool_call_id": "call_never_issued", "content": "ghost" }
+        ]
+    }));
+    let err = process_request(&backend, &reg, orphan).await.unwrap_err();
+    assert!(matches!(
+        err.class,
+        super::error::BridgeErrorClass::InvalidRequest
+    ));
+    assert!(err.message.contains("was not issued"));
+    assert_eq!(reg.len(), 0);
+}
+
+#[tokio::test]
+async fn backend_open_failure_is_surfaced_as_infrastructure() {
+    let backend = FakeBackend::failing(super::error::BridgeError::upstream(
+        "grok agent stdio failed to start",
+    ));
+    let reg = registry();
+    let request = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "hi" }]
+    }));
+    let err = process_request(&backend, &reg, request).await.unwrap_err();
+    assert!(matches!(
+        err.class,
+        super::error::BridgeErrorClass::UpstreamInfrastructure
+    ));
+    assert_eq!(
+        reg.len(),
+        0,
+        "no session parked when the backend never opened"
+    );
+}
+
+#[tokio::test]
+async fn continuation_rejects_fabricated_tool_call_id() {
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![(
+            "get_weather".into(),
+            serde_json::json!({ "city": "Paris" }),
+        )]),
+        ScriptedTurn::Complete("done".into()),
+    ]);
+    let reg = registry();
+
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "weather?" }],
+        "tools": [{ "type": "function", "function": { "name": "get_weather" } }]
+    }));
+    let resp1 = process_request(&backend, &reg, first).await.unwrap();
+    let call_id = tool_call_id(&resp1, 0);
+
+    // The assistant echoes the real id, but the tool result references a
+    // different one — reject before touching the parked session.
+    let forged = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "weather?" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [{
+                "id": call_id,
+                "type": "function",
+                "function": { "name": "get_weather", "arguments": "{}" }
+            }]},
+            { "role": "tool", "tool_call_id": "call_fabricated", "content": "sunny" }
+        ]
+    }));
+    let err = process_request(&backend, &reg, forged).await.unwrap_err();
+    assert!(matches!(
+        err.class,
+        super::error::BridgeErrorClass::InvalidRequest
+    ));
+    assert!(err.message.contains("was not issued"));
+    assert_eq!(reg.len(), 1, "the real session stays parked, untouched");
+}
+
+#[tokio::test]
+async fn multi_round_binds_only_the_latest_tool_call_round() {
+    // Two successive tool-call rounds, then completion. The final continuation
+    // carries the *whole* history (round-1 and round-2 assistant turns and
+    // results); binding must key off only the latest round's ids.
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![("tool_a".into(), serde_json::json!({}))]),
+        ScriptedTurn::ToolCalls(vec![("tool_b".into(), serde_json::json!({}))]),
+        ScriptedTurn::Complete("all done".into()),
+    ]);
+    let reg = registry();
+
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "go" }],
+        "tools": [
+            { "type": "function", "function": { "name": "tool_a" } },
+            { "type": "function", "function": { "name": "tool_b" } }
+        ]
+    }));
+    let resp1 = process_request(&backend, &reg, first).await.unwrap();
+    let call_a = tool_call_id(&resp1, 0);
+
+    let second = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "go" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                { "id": call_a, "type": "function", "function": { "name": "tool_a", "arguments": "{}" } }
+            ]},
+            { "role": "tool", "tool_call_id": call_a, "content": "a-result" }
+        ]
+    }));
+    let resp2 = process_request(&backend, &reg, second).await.unwrap();
+    assert_eq!(resp2["choices"][0]["finish_reason"], "tool_calls");
+    let call_b = tool_call_id(&resp2, 0);
+    assert_ne!(call_a, call_b);
+    assert_eq!(reg.len(), 1, "session re-parked under the round-2 id");
+
+    // Round 3 replays the full transcript. Round-1's `call_a` is no longer in
+    // the registry, but binding uses only the latest round (`call_b`).
+    let third = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "go" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                { "id": call_a, "type": "function", "function": { "name": "tool_a", "arguments": "{}" } }
+            ]},
+            { "role": "tool", "tool_call_id": call_a, "content": "a-result" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                { "id": call_b, "type": "function", "function": { "name": "tool_b", "arguments": "{}" } }
+            ]},
+            { "role": "tool", "tool_call_id": call_b, "content": "b-result" }
+        ]
+    }));
+    let resp3 = process_request(&backend, &reg, third).await.unwrap();
+    assert_eq!(resp3["choices"][0]["finish_reason"], "stop");
+    assert_eq!(resp3["choices"][0]["message"]["content"], "all done");
+    assert_eq!(reg.len(), 0);
+}
+
+#[tokio::test]
+async fn replayed_continuation_after_resume_is_session_state_error() {
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![("get_weather".into(), serde_json::json!({}))]),
+        ScriptedTurn::Complete("sunny".into()),
+    ]);
+    let reg = registry();
+
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "weather?" }],
+        "tools": [{ "type": "function", "function": { "name": "get_weather" } }]
+    }));
+    let resp1 = process_request(&backend, &reg, first).await.unwrap();
+    let call_id = tool_call_id(&resp1, 0);
+
+    let continuation = serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [
+            { "role": "user", "content": "weather?" },
+            { "role": "assistant", "content": serde_json::Value::Null, "tool_calls": [
+                { "id": call_id, "type": "function", "function": { "name": "get_weather", "arguments": "{}" } }
+            ]},
+            { "role": "tool", "tool_call_id": call_id, "content": "sunny" }
+        ]
+    });
+
+    // First continuation resumes and completes the session.
+    let ok = process_request(&backend, &reg, req(continuation.clone()))
+        .await
+        .unwrap();
+    assert_eq!(ok["choices"][0]["finish_reason"], "stop");
+    assert_eq!(reg.len(), 0);
+
+    // Replaying the exact same continuation now fails closed — the session is
+    // gone, so it can never be double-driven.
+    let err = process_request(&backend, &reg, req(continuation))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err.class,
+        super::error::BridgeErrorClass::SessionState
+    ));
+}
+
+#[tokio::test]
+async fn expired_session_is_reaped_and_shut_down() {
+    let backend = FakeBackend::new(vec![
+        ScriptedTurn::ToolCalls(vec![("t".into(), serde_json::json!({}))]),
+        ScriptedTurn::Complete("done".into()),
+    ]);
+    let transcript = backend.transcript();
+    // Tiny TTL so the parked session is immediately eligible for reaping.
+    let reg = SessionRegistry::new(Duration::from_millis(1));
+
+    let first = req(serde_json::json!({
+        "model": "grok-cli/grok-4.5",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [{ "type": "function", "function": { "name": "t" } }]
+    }));
+    let resp1 = process_request(&backend, &reg, first).await.unwrap();
+    assert_eq!(resp1["choices"][0]["finish_reason"], "tool_calls");
+    assert_eq!(reg.len(), 1);
+
+    // After the TTL elapses, reaping deterministically tears the abandoned
+    // session down (awaited shutdown) rather than leaking it.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    super::reap_expired(&reg).await;
+    assert_eq!(reg.len(), 0, "expired session reaped");
+    assert_eq!(
+        transcript.lock().unwrap().shutdowns,
+        1,
+        "reaped session was shut down, not leaked"
+    );
+}
+
+#[test]
+fn bridge_model_routing() {
+    // Exact allowlist only — never arbitrary `grok-cli/*`.
+    assert!(is_bridge_model("grok-cli/grok-4.5"));
+    assert!(!is_bridge_model("grok-cli/anything"));
+    assert!(!is_bridge_model("grok-cli/grok-4.5-mini"));
+    assert!(!is_bridge_model("xai/grok-4.5"));
+    assert!(!is_bridge_model("claude-opus-4-8"));
+}

--- a/src/api/grok_tool_bridge/transport.rs
+++ b/src/api/grok_tool_bridge/transport.rs
@@ -1,0 +1,257 @@
+//! Transport boundary between the bridge state machine and a real Grok
+//! `agent stdio` (ACP) child hosting an ephemeral caller-tool MCP server.
+//!
+//! Everything above this trait is pure and deterministic; everything below it
+//! talks to a live CLI. Tests drive the state machine through [`FakeBackend`],
+//! which reproduces the exact ACP/MCP transcript (Grok invokes a caller tool,
+//! the invocation is *suspended* rather than executed, and the later caller
+//! result unblocks the same session) without spawning a process.
+
+use async_trait::async_trait;
+
+use super::error::BridgeError;
+
+/// Token accounting reported by the connected account. Kept truthful: absent
+/// when the backend did not report usage rather than fabricated.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BridgeUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl BridgeUsage {
+    pub fn total(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}
+
+/// A caller tool Grok invoked over the ephemeral MCP server. `provider_call_id`
+/// is the ACP/MCP tool-call id the transport must correlate the later result
+/// against; the state machine maps it to a stable OpenAI `call_...` id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestedToolCall {
+    pub provider_call_id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// A caller-supplied result routed back to a suspended MCP invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedToolResult {
+    pub provider_call_id: String,
+    pub content: String,
+}
+
+/// The completed assistant turn (no further tool calls pending).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletedTurn {
+    pub text: String,
+    pub model: String,
+    pub usage: BridgeUsage,
+    pub stop_reason: String,
+}
+
+/// Outcome of a prompt or resume: either Grok paused to request caller tools,
+/// or it finished the turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnOutcome {
+    ToolCalls {
+        model: String,
+        calls: Vec<RequestedToolCall>,
+    },
+    Completed(CompletedTurn),
+}
+
+/// Inputs for opening a fresh Grok session.
+#[derive(Debug, Clone)]
+pub struct PromptInput {
+    pub prompt: String,
+    pub model: Option<String>,
+    /// Caller tools rendered as MCP descriptors (`name`/`description`/
+    /// `inputSchema`). Empty means no caller tools were offered.
+    pub tools_mcp: Vec<serde_json::Value>,
+}
+
+/// One live Grok conversation: owns the `agent stdio` child, the ephemeral MCP
+/// server, and any suspended tool invocations. Held in the session registry
+/// between HTTP requests.
+#[async_trait]
+pub trait BridgeConversation: Send + Sync {
+    /// The underlying account session id (for provenance/logging).
+    fn session_id(&self) -> &str;
+
+    /// Deliver caller tool results to the suspended MCP invocations and resume
+    /// the turn. Returns the next outcome (more tool calls, or completion).
+    async fn resume(
+        &mut self,
+        results: Vec<ResolvedToolResult>,
+    ) -> Result<TurnOutcome, BridgeError>;
+
+    /// Tear down the child + MCP server. Best-effort; always fail-closed.
+    async fn shutdown(&mut self);
+}
+
+/// Opens conversations against a backend (real CLI or a test fake).
+#[async_trait]
+pub trait BridgeBackend: Send + Sync {
+    /// Spawn a session, send the initial prompt, and return the conversation
+    /// handle together with the first turn outcome.
+    async fn open(
+        &self,
+        input: PromptInput,
+    ) -> Result<(Box<dyn BridgeConversation>, TurnOutcome), BridgeError>;
+}
+
+// ───────────────────────── Test fake ─────────────────────────
+#[cfg(test)]
+pub mod fake {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// A scripted turn the fake Grok will produce.
+    #[derive(Debug, Clone)]
+    pub enum ScriptedTurn {
+        /// Grok invokes caller tools (name, arguments) and *suspends* — it does
+        /// NOT execute them itself.
+        ToolCalls(Vec<(String, serde_json::Value)>),
+        /// Grok finishes with assistant text.
+        Complete(String),
+    }
+
+    /// Records what actually happened so tests can assert the contract:
+    /// the caller tools were never executed by the fake, and the results the
+    /// caller submitted were the ones routed back.
+    #[derive(Debug, Default)]
+    pub struct Transcript {
+        pub opened_with_tools: Vec<String>,
+        pub prompt: String,
+        pub model: Option<String>,
+        pub results_received: Vec<Vec<ResolvedToolResult>>,
+        pub executed_tools: Vec<String>, // must stay empty: fake never executes
+        pub shutdowns: usize,
+    }
+
+    pub struct FakeBackend {
+        script: Vec<ScriptedTurn>,
+        pub transcript: Arc<Mutex<Transcript>>,
+        /// If set, `open` fails with this error (capability/infra simulation).
+        open_error: Option<BridgeError>,
+    }
+
+    impl FakeBackend {
+        pub fn new(script: Vec<ScriptedTurn>) -> Self {
+            Self {
+                script,
+                transcript: Arc::new(Mutex::new(Transcript::default())),
+                open_error: None,
+            }
+        }
+
+        pub fn failing(err: BridgeError) -> Self {
+            Self {
+                script: Vec::new(),
+                transcript: Arc::new(Mutex::new(Transcript::default())),
+                open_error: Some(err),
+            }
+        }
+
+        pub fn transcript(&self) -> Arc<Mutex<Transcript>> {
+            Arc::clone(&self.transcript)
+        }
+    }
+
+    fn outcome_for(turn: &ScriptedTurn, idx: usize) -> TurnOutcome {
+        match turn {
+            ScriptedTurn::ToolCalls(calls) => TurnOutcome::ToolCalls {
+                model: "grok-4.5".to_string(),
+                calls: calls
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (name, args))| RequestedToolCall {
+                        provider_call_id: format!("acp-{idx}-{i}"),
+                        name: name.clone(),
+                        arguments: args.clone(),
+                    })
+                    .collect(),
+            },
+            ScriptedTurn::Complete(text) => TurnOutcome::Completed(CompletedTurn {
+                text: text.clone(),
+                model: "grok-4.5".to_string(),
+                usage: BridgeUsage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                },
+                stop_reason: "stop".to_string(),
+            }),
+        }
+    }
+
+    struct FakeConversation {
+        script: Vec<ScriptedTurn>,
+        cursor: usize,
+        transcript: Arc<Mutex<Transcript>>,
+    }
+
+    #[async_trait]
+    impl BridgeConversation for FakeConversation {
+        fn session_id(&self) -> &str {
+            "fake-session"
+        }
+
+        async fn resume(
+            &mut self,
+            results: Vec<ResolvedToolResult>,
+        ) -> Result<TurnOutcome, BridgeError> {
+            self.transcript
+                .lock()
+                .unwrap()
+                .results_received
+                .push(results);
+            self.cursor += 1;
+            let turn = self
+                .script
+                .get(self.cursor)
+                .cloned()
+                .ok_or_else(|| BridgeError::upstream("fake script exhausted"))?;
+            Ok(outcome_for(&turn, self.cursor))
+        }
+
+        async fn shutdown(&mut self) {
+            self.transcript.lock().unwrap().shutdowns += 1;
+        }
+    }
+
+    #[async_trait]
+    impl BridgeBackend for FakeBackend {
+        async fn open(
+            &self,
+            input: PromptInput,
+        ) -> Result<(Box<dyn BridgeConversation>, TurnOutcome), BridgeError> {
+            if let Some(err) = &self.open_error {
+                return Err(err.clone());
+            }
+            {
+                let mut t = self.transcript.lock().unwrap();
+                t.prompt = input.prompt.clone();
+                t.model = input.model.clone();
+                t.opened_with_tools = input
+                    .tools_mcp
+                    .iter()
+                    .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(str::to_string))
+                    .collect();
+            }
+            let first = self
+                .script
+                .first()
+                .cloned()
+                .ok_or_else(|| BridgeError::upstream("fake script empty"))?;
+            let outcome = outcome_for(&first, 0);
+            let convo = FakeConversation {
+                script: self.script.clone(),
+                cursor: 0,
+                transcript: Arc::clone(&self.transcript),
+            };
+            Ok((Box::new(convo), outcome))
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,6 +35,7 @@ mod fs;
 mod github_auth;
 pub mod github_integration;
 pub(crate) mod grok_goal;
+pub(crate) mod grok_tool_bridge;
 pub mod library;
 pub mod mcp;
 pub mod metadata_llm;

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -413,6 +413,10 @@ fn append_direct_models_to_proxy_models(
     }
 }
 
+fn should_use_grok_bridge(requested_model: &str, exact_chain_exists: bool) -> bool {
+    super::grok_tool_bridge::is_bridge_model(requested_model) && !exact_chain_exists
+}
+
 async fn get_deferred_request(
     State(state): State<Arc<super::routes::AppState>>,
     headers: HeaderMap,
@@ -659,12 +663,14 @@ pub(crate) async fn chat_completions_inner(
         crate::api::proxy_liveness::note_activity(id);
     }
 
-    // 1b. Grok connected-account tool bridge. The "grok-cli/..." model id space
-    // is served by the ACP↔MCP bridge (caller-owned tool execution), not the
-    // chain router. Feature-gated and default-off — when the route is not
-    // provisioned the bridge itself replies with a truthful configuration
-    // error (see grok_tool_bridge::capability).
-    if super::grok_tool_bridge::is_bridge_model(&requested_model) {
+    let exact_chain_exists = state.chain_store.get(&requested_model).await.is_some();
+
+    // 1b. Grok connected-account tool bridge. An existing exact-name routing
+    // chain takes precedence for backwards compatibility: this model id was not
+    // historically reserved, and the model catalog also lists chains first.
+    // Otherwise the ACP↔MCP bridge owns the id and, when not provisioned,
+    // replies with a truthful configuration error.
+    if should_use_grok_bridge(&requested_model, exact_chain_exists) {
         let handled =
             super::grok_tool_bridge::handle_chat_completion(&state.config.working_dir, &body).await;
         if let Some(usage) = handled.usage {
@@ -693,7 +699,7 @@ pub(crate) async fn chat_completions_inner(
     //    Anything else errors — no silent fallback, so typos surface.
     let standard_accounts = super::ai_providers::read_standard_accounts(&state.config.working_dir);
 
-    let resolved_chain_id = if state.chain_store.get(&requested_model).await.is_some() {
+    let resolved_chain_id = if exact_chain_exists {
         Some(requested_model.clone())
     } else {
         let prefixed = format!("builtin/{}", requested_model);
@@ -5161,6 +5167,13 @@ mod tests {
         // Empty halves.
         assert!(parse_direct_model_entry("xai/").is_none());
         assert!(parse_direct_model_entry("/grok-4.5").is_none());
+    }
+
+    #[test]
+    fn exact_chain_takes_precedence_over_grok_bridge_model_id() {
+        assert!(should_use_grok_bridge("grok-cli/grok-4.5", false));
+        assert!(!should_use_grok_bridge("grok-cli/grok-4.5", true));
+        assert!(!should_use_grok_bridge("xai/grok-4.5", false));
     }
 
     #[test]

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -336,6 +336,21 @@ async fn list_models(
         direct_models,
         chrono::Utc::now().timestamp(),
     );
+    // Grok connected-account tool bridge: advertised only when its capability
+    // gate passes (feature flag + connected account + operator-verified live
+    // transport). Default-off, so it never appears until explicitly enabled.
+    if let Some(bridge_model) = super::grok_tool_bridge::advertised_model(&state.config.working_dir)
+    {
+        if seen.insert(bridge_model.to_string()) {
+            data.push(ModelObject {
+                id: bridge_model.to_string(),
+                object: "model",
+                created: chrono::Utc::now().timestamp(),
+                owned_by: "sandboxed",
+            });
+        }
+    }
+
     data.sort_by(|a, b| a.id.cmp(&b.id));
     Json(ModelsResponse {
         object: "list",
@@ -642,6 +657,16 @@ pub(crate) async fn chat_completions_inner(
         .and_then(|v| uuid::Uuid::parse_str(v.trim()).ok());
     if let Some(id) = liveness_mission_id {
         crate::api::proxy_liveness::note_activity(id);
+    }
+
+    // 1b. Grok connected-account tool bridge. The "grok-cli/..." model id space
+    // is served by the ACP↔MCP bridge (caller-owned tool execution), not the
+    // chain router. Feature-gated and default-off — when the route is not
+    // provisioned the bridge itself replies with a truthful configuration
+    // error (see grok_tool_bridge::capability).
+    if super::grok_tool_bridge::is_bridge_model(&requested_model) {
+        return super::grok_tool_bridge::handle_chat_completion(&state.config.working_dir, &body)
+            .await;
     }
 
     // 2. Resolve the requested model to chain entries:

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -665,8 +665,18 @@ pub(crate) async fn chat_completions_inner(
     // provisioned the bridge itself replies with a truthful configuration
     // error (see grok_tool_bridge::capability).
     if super::grok_tool_bridge::is_bridge_model(&requested_model) {
-        return super::grok_tool_bridge::handle_chat_completion(&state.config.working_dir, &body)
+        let handled =
+            super::grok_tool_bridge::handle_chat_completion(&state.config.working_dir, &body).await;
+        if let Some(usage) = handled.usage {
+            record_proxy_usage(
+                &state,
+                &usage.model,
+                usage.input_tokens,
+                usage.output_tokens,
+            )
             .await;
+        }
+        return handled.response;
     }
 
     // 2. Resolve the requested model to chain entries:


### PR DESCRIPTION
## Summary

Adds a **feature-gated** OpenAI `/v1/chat/completions` adapter for the connected **Grok 4.5** account that keeps **tool execution caller-owned**. Caller `tools[]` are exposed to `grok agent stdio` as an ephemeral, per-session in-process MCP server. When Grok invokes a caller tool, the bridge suspends that invocation and surfaces it as `assistant.tool_calls` (stable ids, name, JSON-string arguments, `finish_reason: "tool_calls"`). The caller's later `role: "tool"` result unblocks the *same* Grok session, which produces the next turn.

Model id: **`grok-cli/grok-4.5`** (exact allowlist; distinct from the API-key `xai/grok-4.5` route so the two can never be conflated).

## What is implemented (proven by tests)

The pure state machine runs against a `FakeBackend` behind a transport trait (`BridgeBackend`/`BridgeConversation`), so all of the following are unit/transcript tested deterministically:

- **Tool round-trip** — `tools[]` → `assistant.tool_calls` → `role: "tool"` results → session resume → next turn. Caller tools are **never executed** by the CLI/ACP side.
- **Multiple tool calls / ordering** — every pending call must be answered; reconciliation orders results by pending call, rejecting missing/unknown/duplicate/extra results.
- **Continuation binding** — binds to exactly the **last** parked tool-call round (`current_round_call_ids`); validates every submitted id against whole-history assistant echo (`echoed_tool_call_ids`); rejects fabricated ids, orphan results with no assistant echo, cross-turn mixes, and **replay after resume** (→ 409 session-state).
- **Lifecycle** — deterministic awaited reap of idle sessions at request entry, plus `Drop for AcpConversation` as a safety net, so an abandoned session never leaks its Grok child / MCP server. Session TTL 300s.
- **Streaming** — explicitly **rejected** with a 400, never silently downgraded.
- **Provenance** — model/usage/error classification stays truthful (InvalidRequest 400 / ProviderConfiguration 503 / UpstreamInfrastructure 502 / SessionState 409); zero-usage is omitted rather than fabricated.

## Security posture

- **No OAuth-as-API-key masquerade.** The bridge uses a **genuine xAI API key only** (`get_xai_api_key_for_grok`). An OAuth-only connected account is never relabeled as `XAI_API_KEY` and **fails closed** with a truthful configuration error.
- **ACP permissions are denied.** No auto-approval of generic CLI filesystem/shell/builtin actions; the permission handler selects an explicit reject/deny outcome (else `cancelled`). Covered by regression tests.
- **Child stderr** is drained to EOF, bounded and **redacted** (count only), so the piped stream can't deadlock and secrets aren't logged.

## Live-canary status

**Not run.** The pure semantics are fully tested against a fake backend, but the live ACP↔MCP transport has **not** been exercised against a real provisioned Grok account in this change. No credentials, auth payloads, headers, or private account data are emitted anywhere.

## Feature flag / default

Default **OFF**. The route is advertised/answered only when **all** gates pass:

1. `SANDBOXED_SH_GROK_ROUTER_BRIDGE` on,
2. a genuine xAI API key configured for the grok backend,
3. the `grok` CLI binary is resolvable on-host (bounded, 30s-cached filesystem probe — not an operator assertion), and
4. `SANDBOXED_SH_GROK_ROUTER_BRIDGE_LIVE` on (operator's explicit assertion that live tool-mediation was verified).

When any gate fails the bridge is not advertised, and a direct request returns a truthful configuration error — never a fake turn.

## Remaining deployment gate

Gate 4 (`..._LIVE`) exists precisely because caller-owned tool continuation cannot be proven without a provisioned account. Flipping it on is an **operator-verified deployment step** that must follow a real live-canary against a connected account. Until then the route fails closed.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib` — no bridge warnings
- [x] `cargo test --lib grok_tool_bridge` — **36 passed, 0 failed**
- [ ] Live canary against a provisioned Grok account (gated; not performed here)

> Note: the full `cargo test --lib` run has one **pre-existing, environment-related** failure in `api::remote_build::tests::wrapper_resumes_an_interrupted_async_job_without_resubmitting` (git-backed persistence sandbox limitation). It fails identically on the clean base with this branch's changes stashed, and is unrelated to the bridge (which touches only `src/api/grok_tool_bridge/`, plus two hook lines in `mod.rs`/`proxy.rs`).

@codex review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Spawns local Grok CLI processes and loopback MCP servers, handles API keys, and adds security-sensitive session/tool mediation; live path is operator-gated but still increases attack surface when enabled.
> 
> **Overview**
> Adds a **default-off** `grok-cli/grok-4.5` route that adapts OpenAI `/v1/chat/completions` (including multi-step `tool_calls`) to a connected Grok account via `grok agent stdio`, while **caller tools stay caller-owned**: caller `tools[]` are exposed as a per-session ephemeral MCP server; Grok’s `tools/call` is suspended and returned as `assistant.tool_calls`, and `role: "tool"` continuations resume the same session.
> 
> The **proxy** lists the model only when capability gates pass and handles `grok-cli/grok-4.5` before normal routing (an exact-name routing chain still wins). Usage from successful completions is recorded like other proxy paths.
> 
> **Gating** requires `SANDBOXED_SH_GROK_ROUTER_BRIDGE`, a genuine xAI API key (no OAuth-as-API-key), a resolvable `grok` CLI, and `SANDBOXED_SH_GROK_ROUTER_BRIDGE_LIVE`. Unprovisioned requests get configuration errors, not fake turns.
> 
> The live **ACP↔MCP** path denies ACP host permissions, bearer-protects the MCP endpoint, and tears down children/MCP on TTL or errors. Core semantics are covered by a **fake backend** and broad unit tests (reconciliation, session registry, streaming rejected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020e94e4d4b978e4fba7260a2ecb9e18401f841a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->