### PR TITLE
Route xAI OAuth through CLIProxyAPI

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -532,10 +532,10 @@ mod oauth_deadletter_tests {
 mod grok_oauth_tests {
     use super::{
         build_response_from_store, get_xai_api_key_for_grok, grok_auth_expires_at_millis,
-        grok_cli_reconcile_due, oauth_refresh_clear_dead, oauth_refresh_mark_token_dead,
-        oauth_refresh_token_fingerprint, parse_grok_device_auth_line,
-        remove_legacy_grok_oauth_entry, ProviderStatusResponse, GROK_CLI_RECONCILE_INTERVAL,
-        GROK_OAUTH_CLIENT_KEY,
+        grok_cli_reconcile_due, has_refreshable_cli_proxy_account_in_dirs,
+        oauth_refresh_clear_dead, oauth_refresh_mark_token_dead, oauth_refresh_token_fingerprint,
+        parse_grok_device_auth_line, remove_legacy_grok_oauth_entry, ProviderStatusResponse,
+        GROK_CLI_RECONCILE_INTERVAL, GROK_OAUTH_CLIENT_KEY,
     };
     use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
     use std::time::{Duration as StdDuration, Instant};
@@ -678,6 +678,47 @@ mod grok_oauth_tests {
         .expect("write providers");
 
         assert_eq!(get_xai_api_key_for_grok(temp.path()), None);
+    }
+
+    #[test]
+    fn cli_proxy_xai_account_requires_both_oauth_tokens() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let auth_dir = temp.path().join("auth");
+        std::fs::create_dir_all(&auth_dir).expect("auth dir");
+
+        std::fs::write(
+            auth_dir.join("xai-thomas.json"),
+            serde_json::json!({
+                "type": "xai",
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "expired": "2020-01-01T00:00:00Z"
+            })
+            .to_string(),
+        )
+        .expect("write xai auth");
+
+        assert!(has_refreshable_cli_proxy_account_in_dirs(
+            std::slice::from_ref(&auth_dir),
+            "xai-",
+            "xai"
+        ));
+
+        std::fs::write(
+            auth_dir.join("xai-thomas.json"),
+            serde_json::json!({
+                "type": "xai",
+                "access_token": "access"
+            })
+            .to_string(),
+        )
+        .expect("rewrite xai auth");
+
+        assert!(!has_refreshable_cli_proxy_account_in_dirs(
+            std::slice::from_ref(&auth_dir),
+            "xai-",
+            "xai"
+        ));
     }
 
     #[test]
@@ -1163,6 +1204,28 @@ pub fn read_standard_accounts(working_dir: &Path) -> Vec<crate::provider_health:
         });
     }
 
+    // xAI subscription OAuth is likewise owned by CLI Proxy API. The OAuth
+    // access token is valid for Grok Build's Responses transport, not for the
+    // public API-key chat endpoint Sandboxed.sh would otherwise call. Expose a
+    // synthetic account only when CLIProxyAPI has a refreshable xAI credential
+    // on disk; the proxy then owns token refresh and protocol translation.
+    let xai_disabled = get_provider_config_entry(&opencode_config, ProviderType::Xai)
+        .and_then(|e| e.enabled)
+        == Some(false);
+    if !seen_types.contains(&ProviderType::Xai)
+        && !xai_disabled
+        && xai_cli_proxy_account_available()
+    {
+        accounts.push(crate::provider_health::StandardAccount {
+            account_id: crate::provider_health::stable_provider_uuid("xai-cli-proxy"),
+            provider_type: ProviderType::Xai,
+            api_key: None,
+            has_oauth: true,
+            base_url: None,
+            oauth_expires_at: Some(i64::MAX),
+        });
+    }
+
     accounts
 }
 
@@ -1204,7 +1267,7 @@ fn has_fresh_cli_proxy_account_of_type(file_prefix: &str, type_tag: &str) -> boo
 
     let now = chrono::Utc::now();
     for dir in dirs {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
+        let Ok(entries) = std::fs::read_dir(dir) else {
             continue;
         };
         for entry in entries.flatten() {
@@ -1277,6 +1340,80 @@ pub(crate) fn openai_cli_proxy_account_available() -> bool {
     }
 
     has_fresh_cli_proxy_codex_account()
+}
+
+/// True when CLI Proxy API has an xAI OAuth credential it can use or refresh.
+///
+/// Unlike direct xAI routing, this never forwards the OAuth access token as an
+/// API key. Sandboxed.sh authenticates only to the loopback proxy; CLIProxyAPI
+/// owns the xAI credential and refreshes it with the official Grok CLI client.
+pub(crate) fn xai_cli_proxy_account_available() -> bool {
+    if env_var_bool("CLAUDE_CODE_DISABLE_CLI_PROXY", false) {
+        return false;
+    }
+
+    has_refreshable_cli_proxy_account_of_type("xai-", "xai")
+}
+
+fn has_refreshable_cli_proxy_account_of_type(file_prefix: &str, type_tag: &str) -> bool {
+    let mut dirs = Vec::new();
+    if let Ok(dir) = std::env::var("CLI_PROXY_AUTH_DIR") {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            dirs.push(std::path::PathBuf::from(trimmed));
+        }
+    }
+    dirs.push(std::path::PathBuf::from("/root/.cli-proxy-api"));
+
+    has_refreshable_cli_proxy_account_in_dirs(&dirs, file_prefix, type_tag)
+}
+
+fn has_refreshable_cli_proxy_account_in_dirs(
+    dirs: &[std::path::PathBuf],
+    file_prefix: &str,
+    type_tag: &str,
+) -> bool {
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !(name.starts_with(file_prefix) && name.ends_with(".json")) {
+                continue;
+            }
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
+                continue;
+            };
+            if value
+                .get("disabled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+                || value.get("type").and_then(|v| v.as_str()) != Some(type_tag)
+            {
+                continue;
+            }
+            let has_access = value
+                .get("access_token")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.trim().is_empty());
+            let has_refresh = value
+                .get("refresh_token")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.trim().is_empty());
+            if has_access && has_refresh {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Create AI provider routes.

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -226,6 +226,13 @@ pub(crate) fn has_routable_proxy_credentials(
             has_api_key
                 || (has_oauth && crate::api::ai_providers::openai_cli_proxy_account_available())
         }
+        // Grok Build OAuth is not a public xAI API key. It is routable only
+        // through CLIProxyAPI, which owns the credential and translates the
+        // OpenAI-compatible request to xAI's Responses transport.
+        ProviderType::Xai => {
+            has_api_key
+                || (has_oauth && crate::api::ai_providers::xai_cli_proxy_account_available())
+        }
         ProviderType::Google => has_api_key || has_oauth,
         _ => has_api_key,
     }
@@ -829,6 +836,10 @@ pub(crate) async fn chat_completions_inner(
             && entry.has_oauth
             && entry.api_key.is_none()
             && crate::api::ai_providers::openai_cli_proxy_account_available();
+        let use_xai_oauth_cli_proxy_adapter = provider_type == ProviderType::Xai
+            && entry.has_oauth
+            && entry.api_key.is_none()
+            && crate::api::ai_providers::xai_cli_proxy_account_available();
         let use_google_oauth_adapter = provider_type == ProviderType::Google && entry.has_oauth;
         let (url, upstream_body, extra_headers) = if use_anthropic_oauth_cli_proxy_adapter {
             let upstream_body = match rewrite_model_for_anthropic_cli_proxy(&body, &entry.model_id)
@@ -846,6 +857,20 @@ pub(crate) async fn chat_completions_inner(
                 build_cli_proxy_headers(),
             )
         } else if use_openai_oauth_cli_proxy_adapter {
+            let upstream_body = match rewrite_model(&body, &entry.model_id) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::error!("Failed to rewrite model in request body: {}", e);
+                    server_error_count += 1;
+                    continue;
+                }
+            };
+            (
+                cli_proxy_chat_completions_url(),
+                upstream_body,
+                build_cli_proxy_headers(),
+            )
+        } else if use_xai_oauth_cli_proxy_adapter {
             let upstream_body = match rewrite_model(&body, &entry.model_id) {
                 Ok(b) => b,
                 Err(e) => {
@@ -980,6 +1005,7 @@ pub(crate) async fn chat_completions_inner(
             && !use_anthropic_adapter
             && !use_anthropic_oauth_cli_proxy_adapter
             && !use_openai_oauth_cli_proxy_adapter
+            && !use_xai_oauth_cli_proxy_adapter
         {
             if let Some(api_key) = &entry.api_key {
                 upstream_req = upstream_req.header("Authorization", format!("Bearer {}", api_key));

--- a/src/provider_health.rs
+++ b/src/provider_health.rs
@@ -1391,7 +1391,14 @@ impl ModelChainStore {
                 );
                 let credential_is_oauth_token =
                     account.api_key.is_none() && oauth_is_fresh && provider_oauth_is_proxy_routable;
-                let entry_has_oauth = credential_is_oauth_token || google_oauth_routable;
+                let xai_oauth_cli_proxy_routable =
+                    matches!(provider_type, crate::ai_providers::ProviderType::Xai)
+                        && account.api_key.is_none()
+                        && oauth_is_fresh
+                        && crate::api::ai_providers::xai_cli_proxy_account_available();
+                let entry_has_oauth = credential_is_oauth_token
+                    || google_oauth_routable
+                    || xai_oauth_cli_proxy_routable;
                 let entry_has_api_key = routed_api_key.is_some();
                 resolved.push(ResolvedEntry {
                     provider_id: entry.provider_id.clone(),
@@ -1673,7 +1680,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_chain_does_not_treat_xai_oauth_as_proxy_api_key() {
+    async fn resolve_chain_never_treats_xai_oauth_as_api_key() {
         let mut xai = AIProvider::new(ProviderType::Xai, "xAI Grok OAuth".to_string());
         xai.oauth = Some(OAuthCredentials {
             access_token: "grok-oauth-token".to_string(),
@@ -1700,15 +1707,19 @@ mod tests {
             resolved[0].api_key.is_none(),
             "Grok Build OAuth must not be forwarded as XAI_API_KEY"
         );
-        assert!(
-            !resolved[0].has_oauth,
-            "xAI OAuth is CLI-only for this router path"
+        let cli_proxy_available = crate::api::ai_providers::xai_cli_proxy_account_available();
+        assert_eq!(
+            resolved[0].has_oauth, cli_proxy_available,
+            "xAI OAuth must be marked routable only through CLIProxyAPI"
         );
-        assert!(!crate::api::proxy::has_routable_proxy_credentials(
-            ProviderType::Xai,
-            resolved[0].api_key.is_some(),
-            resolved[0].has_oauth
-        ));
+        assert_eq!(
+            crate::api::proxy::has_routable_proxy_credentials(
+                ProviderType::Xai,
+                resolved[0].api_key.is_some(),
+                resolved[0].has_oauth
+            ),
+            cli_proxy_available
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- detect refreshable xAI OAuth credentials in CLIProxyAPI's auth directory
- synthesize an xAI OAuth routing account without exposing the provider token
- route OAuth-only xAI model-chain entries through the loopback CLIProxyAPI OpenAI-compatible endpoint
- keep direct `XAI_API_KEY` routing and the existing ACP bridge behavior unchanged

## Why

The production xAI account is OAuth-only. Sandboxed.sh previously treated that credential as unroutable in the OpenAI-compatible proxy because it correctly refused to relabel the OAuth access token as an xAI API key. CLIProxyAPI natively owns xAI OAuth refresh and translates OpenAI chat/tool requests to Grok's Responses transport, so it is the appropriate credential boundary.

## Impact

An exact chain such as `grok-cli/grok-4.5 -> xai/grok-4.5` can now use the connected Grok account through CLIProxyAPI. The route remains unavailable when no xAI CLIProxyAPI credential is present.

## Validation

- `cargo fmt --all --check`
- `cargo test grok_oauth_tests --lib`
- `cargo test grok_tool_bridge --lib` (47 passed)
- `cargo test api::proxy::tests --lib` (58 passed)
- `cargo clippy --lib -- -D warnings`
- production CLIProxyAPI 7.2.88 canaries: basic completion, forced function tool call, and tool-result continuation all passed on `grok-4.5`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM proxy authentication and provider chain resolution for xAI, but follows the existing OpenAI CLI-proxy boundary and avoids exposing OAuth tokens as API keys.
> 
> **Overview**
> **OAuth-only Grok/xAI accounts can now be used in model chains** when CLIProxyAPI has a refreshable on-disk `xai-*.json` credential (access + refresh tokens). The app no longer treats that OAuth token as unroutable or as a public `XAI_API_KEY`.
> 
> Detection scans `CLI_PROXY_AUTH_DIR` and `/root/.cli-proxy-api` for enabled `type: xai` auth files. When present, a **synthetic `xai-cli-proxy` standard account** is added (OAuth flagged, no API key, far-future expiry sentinel). Chain resolution marks xAI OAuth as routable only if that CLI-proxy credential exists.
> 
> The OpenAI-compatible **proxy sends OAuth-only xAI entries to the loopback CLIProxyAPI** chat-completions URL (model rewrite + proxy headers), mirroring the existing OpenAI Codex CLI-proxy path and **skipping Bearer forwarding** of the provider OAuth token. `has_routable_proxy_credentials` for `ProviderType::Xai` now requires `xai_cli_proxy_account_available()` for OAuth, same pattern as OpenAI.
> 
> Direct `XAI_API_KEY` routing is unchanged. Tests cover refreshable credential detection and updated expectations that Grok OAuth is never forwarded as an API key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd1a95e066f0ca69d53c49b0cd8414a0b051c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->