### PR TITLE
Preserve Grok CLI proxy model IDs in OpenCode missions

### DIFF
--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -352,12 +352,12 @@ pub async fn run_opencode_turn(
         escaped
     };
 
-    let opencode_model = resolved_model.as_deref().unwrap_or("builtin/fast");
+    let opencode_model = opencode_model_argument(resolved_model.as_deref());
     if opencode_model.starts_with("builtin/") {
         ensure_opencode_provider_for_model(
             &opencode_config_dir_host,
             app_working_dir,
-            opencode_model,
+            opencode_model.as_ref(),
             &workspace_host_ip,
             Some(&mission_id.to_string()),
         );
@@ -367,7 +367,7 @@ pub async fn run_opencode_turn(
     inner_cmd.push_str("#!/bin/sh\n");
     inner_cmd.push_str(&shell_escape(&cli_runner));
     inner_cmd.push_str(" run --format json --model ");
-    inner_cmd.push_str(&shell_escape(opencode_model));
+    inner_cmd.push_str(&shell_escape(opencode_model.as_ref()));
     if let Some(a) = agent {
         inner_cmd.push_str(" --agent ");
         inner_cmd.push_str(&shell_escape(a));
@@ -2083,6 +2083,19 @@ pub async fn run_opencode_turn(
     result
 }
 
+/// OpenCode treats the first path segment as its provider id and sends only
+/// the remainder as the upstream model. Route the exact Grok CLI bridge model
+/// through the existing `builtin` provider so the proxy receives the complete
+/// `grok-cli/grok-4.5` chain id instead of the ambiguous bare `grok-4.5`.
+fn opencode_model_argument(model: Option<&str>) -> Cow<'_, str> {
+    let model = model.unwrap_or("builtin/fast");
+    if crate::api::grok_tool_bridge::is_bridge_model(model) {
+        Cow::Owned(format!("builtin/{model}"))
+    } else {
+        Cow::Borrowed(model)
+    }
+}
+
 fn opencode_path(
     mission_path: Option<&str>,
     work_dir_arg: &str,
@@ -2104,7 +2117,24 @@ fn opencode_path(
 
 #[cfg(test)]
 mod path_tests {
-    use super::opencode_path;
+    use super::{opencode_model_argument, opencode_path};
+
+    #[test]
+    fn grok_cli_model_keeps_its_full_proxy_chain_id() {
+        assert_eq!(
+            opencode_model_argument(Some("grok-cli/grok-4.5")),
+            "builtin/grok-cli/grok-4.5"
+        );
+        assert_eq!(
+            opencode_model_argument(Some("builtin/smart")),
+            "builtin/smart"
+        );
+        assert_eq!(
+            opencode_model_argument(Some("xai/grok-4.5")),
+            "xai/grok-4.5"
+        );
+        assert_eq!(opencode_model_argument(None), "builtin/fast");
+    }
 
     #[test]
     fn opencode_path_preserves_mission_path_prepends() {


### PR DESCRIPTION
## What changed

OpenCode interprets the first path segment as its provider and forwards only the remaining model id. Map the exact `grok-cli/grok-4.5` route internally to `builtin/grok-cli/grok-4.5`, reusing the existing authenticated local proxy provider so Sandboxed.sh receives the complete chain id.

The external mission model remains `grok-cli/grok-4.5`; only the OpenCode CLI argument is rewritten.

## Why

Without this adapter, an OpenCode mission selected as `grok-cli/grok-4.5` would send the ambiguous bare model `grok-4.5` and miss the exact CLIProxyAPI-backed chain added in #637.

## Validation

- `cargo fmt --all --check`
- `cargo test grok_cli_model_keeps_its_full_proxy_chain_id --lib`
- `cargo test api::runners::opencode --lib`
- `cargo clippy --lib -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow adapter in the OpenCode runner for a single allowlisted bridge model id, with tests and no auth or data-path changes.
> 
> **Overview**
> OpenCode missions that select **`grok-cli/grok-4.5`** now rewrite only the **`opencode run --model`** argument to **`builtin/grok-cli/grok-4.5`**, because OpenCode treats the first path segment as the provider and would otherwise forward bare **`grok-4.5`** to the local proxy and miss the full CLIProxyAPI chain id.
> 
> The change is centralized in **`opencode_model_argument`**, which uses **`grok_tool_bridge::is_bridge_model`** for the allowlisted bridge id and leaves other models (including **`builtin/*`** and **`xai/*`**) unchanged. Builtin provider setup for rewritten ids still runs via the existing **`builtin/`** prefix check.
> 
> Unit tests cover the rewrite and default **`builtin/fast`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8782a1dd84739ebb22a3dc814b231b003319cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->