### PR TITLE
Fix controller OAuth telemetry and mission ACKs

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -466,10 +466,24 @@ fn parse_grok_device_auth_line(line: &str) -> (Option<String>, Option<String>) {
 #[cfg(test)]
 mod oauth_deadletter_tests {
     use super::{
-        oauth_refresh_clear_dead, oauth_refresh_mark_token_dead, oauth_refresh_token_is_dead,
-        should_adopt_anthropic_tier, OAuthTokenEntry,
+        newer_matching_openai_tier_credentials, oauth_refresh_clear_dead,
+        oauth_refresh_mark_token_dead, oauth_refresh_token_is_dead, should_adopt_anthropic_tier,
+        OAuthTokenEntry,
     };
     use crate::ai_providers::OAuthCredentials;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    fn openai_access_token(account_id: &str) -> String {
+        let claims = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id
+            }
+        });
+        format!(
+            "header.{}.signature",
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap())
+        )
+    }
 
     #[test]
     fn deadletter_blocks_same_token_until_rotated_or_cleared() {
@@ -525,6 +539,38 @@ mod oauth_deadletter_tests {
             expires_at: now - 1,
         };
         assert!(!should_adopt_anthropic_tier(&store, &expired, true));
+    }
+
+    #[test]
+    fn openai_tier_adoption_requires_same_account_and_newer_live_token() {
+        let now = chrono::Utc::now().timestamp_millis();
+        let store = OAuthCredentials {
+            access_token: openai_access_token("acct-a"),
+            refresh_token: "refresh-old".into(),
+            expires_at: now - 1,
+        };
+        let matching = OAuthTokenEntry {
+            access_token: openai_access_token("acct-a"),
+            refresh_token: "refresh-new".into(),
+            expires_at: now + 20 * 60_000,
+        };
+
+        let adopted = newer_matching_openai_tier_credentials(&store, &matching).unwrap();
+        assert_eq!(adopted.access_token, matching.access_token);
+        assert_eq!(adopted.refresh_token, matching.refresh_token);
+        assert_eq!(adopted.expires_at, matching.expires_at);
+
+        let other_account = OAuthTokenEntry {
+            access_token: openai_access_token("acct-b"),
+            ..matching.clone()
+        };
+        assert!(newer_matching_openai_tier_credentials(&store, &other_account).is_none());
+
+        let older = OAuthTokenEntry {
+            expires_at: store.expires_at,
+            ..matching
+        };
+        assert!(newer_matching_openai_tier_credentials(&store, &older).is_none());
     }
 }
 
@@ -6700,7 +6746,7 @@ async fn get_provider_usage(
     let (
         provider_type,
         api_key_opt,
-        oauth,
+        mut oauth,
         account_email,
         provider_name,
         provider_uuid,
@@ -6815,6 +6861,35 @@ async fn get_provider_usage(
             format!("Invalid provider ID: {}", id),
         ));
     };
+
+    // Codex can refresh its shared OAuth credential tier independently from
+    // ai_providers.json. Reconcile the selected OpenAI provider before probing
+    // usage so an expired store copy cannot hide a live Codex account behind a
+    // false `needs_reauth` status.
+    if provider_type == ProviderType::OpenAI {
+        if let (Some(uuid), Some(store_oauth), Some(tier)) = (
+            provider_uuid,
+            oauth.as_ref(),
+            read_oauth_token_entry(ProviderType::OpenAI),
+        ) {
+            if let Some(reconciled) = newer_matching_openai_tier_credentials(store_oauth, &tier) {
+                if state
+                    .ai_providers
+                    .set_oauth_credentials(uuid, reconciled.clone())
+                    .await
+                    .is_some()
+                {
+                    tracing::info!(
+                        provider_id = %uuid,
+                        old_expires_at = store_oauth.expires_at,
+                        new_expires_at = reconciled.expires_at,
+                        "Adopted live shared-tier OpenAI OAuth token into provider store"
+                    );
+                    oauth = Some(reconciled);
+                }
+            }
+        }
+    }
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
@@ -10297,6 +10372,36 @@ fn should_adopt_anthropic_tier(
         && tier.refresh_token != store.refresh_token
         && !oauth_token_expired(tier.expires_at)
         && (tier.expires_at > store.expires_at || store_token_rejected)
+}
+
+/// Return a newer shared-tier OpenAI credential only when both JWTs belong to
+/// the same ChatGPT account.
+///
+/// The shared Codex tier represents one selected account while the provider
+/// store may contain several logins. Account identity must therefore match
+/// before adopting a token; expiry alone is not sufficient.
+fn newer_matching_openai_tier_credentials(
+    store: &crate::ai_providers::OAuthCredentials,
+    tier: &OAuthTokenEntry,
+) -> Option<crate::ai_providers::OAuthCredentials> {
+    if tier.refresh_token.trim().is_empty()
+        || oauth_token_expired(tier.expires_at)
+        || tier.expires_at <= store.expires_at
+    {
+        return None;
+    }
+
+    let store_account_id = extract_chatgpt_account_id(&store.access_token)?;
+    let tier_account_id = extract_chatgpt_account_id(&tier.access_token)?;
+    if store_account_id != tier_account_id {
+        return None;
+    }
+
+    Some(crate::ai_providers::OAuthCredentials {
+        access_token: tier.access_token.clone(),
+        refresh_token: tier.refresh_token.clone(),
+        expires_at: tier.expires_at,
+    })
 }
 
 /// Adopt the live shared-tier Anthropic token into the store when ownership is

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -902,6 +902,15 @@ impl AssistantMcp {
                 }),
             },
             ToolDefinition {
+                name: "acknowledge_mission".to_string(),
+                description: "Acknowledge a mission only after independently verifying its terminal result. This is the safe host-authenticated replacement for asking a workspace container to use the service JWT. It accepts only awaiting_user missions whose awaiting_kind is ack; decision waits and live missions are refused.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id"],
+                    "properties": {"mission_id": {"type": "string"}}
+                }),
+            },
+            ToolDefinition {
                 name: "get_compute_fleet".to_string(),
                 description: "Get a compact live view of sandboxed.sh compute capacity: remote node health, labels, Lean readiness/toolchains, available slots, active/queued jobs, and recent placement receipts. Use this before dispatching parallel compute or choosing a remote validation node. Ordinary CPU/Lean work should prefer non-GPU nodes while they have immediate capacity; request the gpu label only for GPU work.".to_string(),
                 input_schema: json!({"type": "object", "properties": {}}),
@@ -1437,6 +1446,49 @@ impl AssistantMcp {
             return Err(format!("Failed to cancel mission: {text}"));
         }
         Ok(json!({ "success": true, "cancelled": id.to_string() }))
+    }
+
+    async fn acknowledge_mission(&self, params: MissionIdParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.mission_id)?;
+        let response = self
+            .api_get(&format!("/api/control/missions/{id}/digest"))
+            .await?;
+        let digest = Self::response_value(response, "Read mission before ACK").await?;
+        if !mission_requires_acknowledgement(&digest)? {
+            return Ok(json!({
+                "success": true,
+                "acknowledged": id.to_string(),
+                "already_acknowledged": true,
+            }));
+        }
+
+        let response = self
+            .api_post(
+                &format!("/api/control/missions/{id}/status"),
+                json!({"status": "acknowledged"}),
+            )
+            .await?;
+        Self::response_value(response, "Acknowledge mission").await?;
+
+        // The status mutation response is only an operation envelope. Re-read
+        // the mission so controllers never mistake a successful HTTP response
+        // for a confirmed state transition.
+        let response = self
+            .api_get(&format!("/api/control/missions/{id}/digest"))
+            .await?;
+        let digest = Self::response_value(response, "Verify mission ACK").await?;
+        let mission = digest.get("mission").unwrap_or(&digest);
+        if mission.get("status").and_then(Value::as_str) != Some("acknowledged") {
+            return Err(
+                "Mission ACK mutation succeeded but readback is not acknowledged".to_string(),
+            );
+        }
+
+        Ok(json!({
+            "success": true,
+            "acknowledged": id.to_string(),
+            "already_acknowledged": false,
+        }))
     }
 
     async fn get_compute_fleet(&self) -> Result<Value, String> {
@@ -1986,6 +2038,11 @@ impl AssistantMcp {
                 let params: MissionIdParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
                 self.cancel_mission(params).await
+            }
+            "acknowledge_mission" => {
+                let params: MissionIdParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.acknowledge_mission(params).await
             }
             "get_compute_fleet" => self.get_compute_fleet().await,
             "list_workspaces" => self.list_workspaces().await,
@@ -2598,6 +2655,30 @@ async fn main() {
     }
 }
 
+/// Return true when a mission is an ACK-only wait that may transition to
+/// `acknowledged`, false when it is already acknowledged, and reject every
+/// live or decision-bearing state.
+fn mission_requires_acknowledgement(digest: &Value) -> Result<bool, String> {
+    let mission = digest.get("mission").unwrap_or(digest);
+    let status = mission
+        .get("status")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "Mission digest did not include a status".to_string())?;
+    if status == "acknowledged" {
+        return Ok(false);
+    }
+
+    let awaiting_kind = mission.get("awaiting_kind").and_then(Value::as_str);
+    if status == "awaiting_user" && awaiting_kind == Some("ack") {
+        return Ok(true);
+    }
+
+    Err(format!(
+        "Mission cannot be ACKed from status={status}, awaiting_kind={}",
+        awaiting_kind.unwrap_or("none")
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3038,6 +3119,38 @@ mod tests {
         let backwards = mission_events_path(id, 40, "all", Some(99), Some(17));
         assert!(backwards.ends_with("&before_seq=99"));
         assert!(!backwards.contains("since_seq"));
+    }
+
+    #[test]
+    fn mission_acknowledgement_accepts_only_ack_waits_and_is_idempotent() {
+        assert_eq!(
+            mission_requires_acknowledgement(&json!({
+                "status": "awaiting_user",
+                "awaiting_kind": "ack"
+            }))
+            .unwrap(),
+            true
+        );
+        assert_eq!(
+            mission_requires_acknowledgement(&json!({
+                "mission": {
+                    "status": "acknowledged",
+                    "awaiting_kind": null
+                }
+            }))
+            .unwrap(),
+            false
+        );
+        assert!(mission_requires_acknowledgement(&json!({
+            "status": "awaiting_user",
+            "awaiting_kind": "decision"
+        }))
+        .is_err());
+        assert!(mission_requires_acknowledgement(&json!({
+            "status": "active",
+            "awaiting_kind": null
+        }))
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Reconcile a newer canonical Codex OAuth token into the matching OpenAI provider row before probing usage.
- Match on ChatGPT account ID, preventing cross-account credential adoption.
- Add a host-authenticated acknowledge_mission tool for Hermes controllers.
- Permit ACK only for awaiting_user/ack missions, refuse decisions and live work, and verify status by readback.

## Root causes

Codex refreshed the canonical credential store while ai_providers.json retained an expired copy. The usage endpoint therefore reported needs_reauth even while Codex missions were healthy, leaving Ready work idle.

Separately, controllers had no safe MCP ACK operation. Workers then tried REST from isolated containers, where the host JWT is intentionally absent, and deferred routine housekeeping to Thomas.

## Validation

- cargo fmt --all --check
- git diff --check
- cargo test --lib (1392 passed, 1 ignored)
- cargo test --bin assistant-mcp (24 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OpenAI OAuth reconciliation touches credential persistence and usage/auth telemetry; mission ACK adds a new control-plane path that must not ACK live or decision-wait missions.
> 
> **Overview**
> Fixes **false `needs_reauth`** on OpenAI usage when Codex has refreshed the shared OAuth tier but `ai_providers.json` still holds an older copy. **`get_provider_usage`** now reconciles store credentials against the live tier via **`newer_matching_openai_tier_credentials`**, which only adopts a newer non-expired token when JWT **`chatgpt_account_id`** matches—so multi-account installs cannot pick up another login’s tokens.
> 
> Adds a host-authenticated MCP tool **`acknowledge_mission`** for Hermes controllers: it reads the mission digest, allows ACK only for **`awaiting_user`** with **`awaiting_kind: ack`** (idempotent if already acknowledged), posts status **`acknowledged`**, then re-reads the digest to confirm the transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910562418658fa018628d59dda656b884d3419c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->