### PR TITLE
Fix storage-aware Lean failover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,6 +188,11 @@ JWT_TTL_DAYS=30
 # excluded from `remote_node_id: "auto"` / POST /api/remote-build placement.
 # REMOTE_NODE_MIN_DISK_GB=20
 # REMOTE_NODE_MIN_MEM_GB=8
+# Scratch-space admission for declarative Lean builds. Placement requires the
+# estimate plus the emergency floor and reserves the estimate until terminal.
+# REMOTE_BUILD_ESTIMATED_DISK_GB=12
+# REMOTE_BUILD_MAX_ESTIMATED_DISK_GB=512
+# REMOTE_NODE_DISK_EMERGENCY_GB=10
 # Per-mission remote-build capability lifetime (minimum 300s, default 6h).
 # REMOTE_BUILD_TOKEN_TTL_SECS=21600
 
@@ -204,6 +209,9 @@ JWT_TTL_DAYS=30
 # DISK_WARN_PCT=90
 # DISK_CRITICAL_PCT=95
 # DISK_ADMISSION_ENABLED=1
+# Local disk-heavy mission requests can declare `estimated_disk_gib`; they are
+# rejected before creation if this emergency floor would be crossed.
+# MISSION_DISK_EMERGENCY_RESERVE_GB=64
 # DISK_ALERT_REPEAT_HOURS=24
 #
 # Exec-scope lifecycle. Mission-end teardown stops a mission's

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -218,9 +218,13 @@ Node env vars for lean-build jobs:
   payload may set (default `LEAN_NUM_THREADS,LAKE_JOBS`); anything else is
   rejected before the build starts.
 - `SANDBOXED_NODE_MIN_FREE_GB` — free-space floor (default 10 GiB) for the
-  node's cache GC: every 30 minutes, when the work-dir filesystem drops below
-  it, checkout dirs then lake cache slots are LRU-deleted (by dir mtime)
-  until the threshold is met.
+  node's admission and cache GC. A build is rejected unless its declared
+  scratch estimate fits above this floor. Every 30 minutes, when the work-dir
+  filesystem drops below it, checkout dirs then lake cache slots are
+  LRU-deleted (by dir mtime) until the threshold is met.
+- `SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES` — maximum decoded size of a local
+  source overlay (default 1 MiB; at most 256 regular files). Paths, per-file
+  hashes and the manifest hash are verified before any file is applied.
 - `SANDBOXED_NODE_GIT_SSH_KEY` — path to an SSH key used for git fetches
   (`GIT_SSH_COMMAND="ssh -i <key> -o IdentitiesOnly=yes -o
   StrictHostKeyChecking=accept-new"`); unset = default git auth.
@@ -346,7 +350,9 @@ A node is eligible when all of the following hold:
 - cached status is `online`
 - its labels (heartbeat, falling back to static config) cover every
   requirement
-- `disk_available` ≥ `REMOTE_NODE_MIN_DISK_GB` (default 20)
+- effective disk after non-terminal reservations is at least the greater of
+  `REMOTE_NODE_MIN_DISK_GB` (default 20) and the request's scratch estimate
+  plus `REMOTE_NODE_DISK_EMERGENCY_GB` (default 10)
 - `mem_available` ≥ `REMOTE_NODE_MIN_MEM_GB` (default 8)
 - `active_jobs + queued_jobs + active_leases + core reservations < 2 * capacity_total`
 
@@ -359,9 +365,7 @@ still selected before queueing behind a saturated CPU node, and an explicit
 available memory and stable node id as tie-breakers. When no node qualifies the
 request **fails closed** with every
 configured node listed alongside its exclusion reason (offline / missing
-label X / low disk / low memory / busy), e.g.
-`no eligible remote node (babylon: low disk (12 GiB available, 20 GiB
-required); nippur: missing label 'lean')`.
+label X / low disk after reservations / low memory / busy).
 
 Hermes receives the same live capacity through the assistant MCP
 `get_compute_fleet` tool. Controllers should call it before parallel dispatch,

--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -9,7 +9,7 @@ It never receives a dashboard JWT or broad API token.
 
 Supported now:
 
-- core lists configured nodes and reports cached fleet status (heartbeat v2:
+- core lists configured nodes and reports cached fleet status (heartbeat v3:
   capacity, labels, CPU/memory/disk figures, job counts)
 - a background fleet monitor polls every node's `/heartbeat` on an interval
   (`REMOTE_NODE_MONITOR_SECS`, default 15s, `0` disables) and derives per-node
@@ -125,12 +125,14 @@ To rotate a node token with zero downtime:
    and restart/redeploy core.
 3. Remove `SANDBOXED_NODE_TOKEN_PREVIOUS` on the node and restart it.
 
-### Heartbeat v2
+### Heartbeat v3
 
 `GET /heartbeat` returns the v1 fields (`node_id`, `online`, `capacity_total`,
 `capacity_available`, `active_leases`, `version`) plus:
 
-- `protocol_version` (currently `2`; core treats a missing field as `1`)
+- `protocol_version` (currently `3`; core treats a missing field as `1`).
+  Version 3 is required for source-bundle jobs so a rolling deployment can
+  never silently drop a dirty overlay on an older node.
 - `labels` (from `SANDBOXED_NODE_LABELS`)
 - `cpu_total` (logical cores)
 - `mem_total_bytes` / `mem_available_bytes`
@@ -145,8 +147,9 @@ To rotate a node token with zero downtime:
 `capacity_available` is a snapshot of the shared semaphore, so it already
 accounts for work admitted through either `/execute` or `/jobs`.
 
-All new fields are serde-default-tolerant in both directions, so mixed-version
-core/node fleets keep working during upgrades.
+New fields are serde-default-tolerant in both directions. Features whose
+semantics an older node would silently ignore are additionally gated by the
+reported protocol version.
 
 Minimal systemd unit:
 

--- a/docs/STORAGE_LIFECYCLE.md
+++ b/docs/STORAGE_LIFECYCLE.md
@@ -43,3 +43,19 @@ been reviewed and backed up; it is deliberately off by default.
 Resource limits are separate from retention. Use `GET
 /api/workspaces/:id/resources` to inspect effective memory/swap/CPU limits and
 matching live scopes before changing a workspace shared by concurrent missions.
+
+## Admission and continuity
+
+Disk warning is not a portfolio-wide stop. Small/no-build controller, review,
+Fable and source-analysis lanes remain eligible at warn level. A local
+disk-heavy mission should set `estimated_disk_gib`; the API rejects only that
+mission when its estimate would cross `MISSION_DISK_EMERGENCY_RESERVE_GB`
+(default 64 GiB). Critical level still rejects all new local missions.
+
+Lean builds should use `remote-lean-build`. The wrapper can ship modified and
+untracked regular source files as a bounded, content-hashed overlay on top of a
+pinned commit; deletion, rename, symlink, `.git`, `.lake`, traversal and
+oversized overlays fail closed. Remote placement reserves the declared scratch
+estimate, while runners reuse content-addressed checkouts and dependency-only
+Lake cache slots. This lets a dirty proof lane continue on a roomy node without
+duplicating a fresh Mathlib tree on the production host.

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -16,7 +16,7 @@
 #
 # Exit codes:
 #   remote build's exit code on success/failure of the build itself
-#   2   dirty working tree (commit or stash first — the node builds a pinned commit)
+#   2   unsupported local deletion/symlink or oversized source overlay
 #   75  remote build unavailable (EX_TEMPFAIL: placement failed / nodes down /
 #       not configured) — fall back to a local build
 set -u
@@ -38,8 +38,9 @@ cwd_rel="$(git rev-parse --show-prefix)"; cwd_rel="${cwd_rel%/}"
 # Build argv: everything passed on the command line, default `lake build`.
 if [ "$#" -eq 0 ]; then set -- lake build; fi
 
-body="$(python3 - "$REMOTE_BUILD_MISSION_ID" "$REMOTE_BUILD_TOKEN" "$repo" "$commit" "$cwd_rel" "$@" <<'PY'
-import json, sys, os
+request_file="$(mktemp)" || die "cannot create temporary request file" 75
+python3 - "$REMOTE_BUILD_MISSION_ID" "$REMOTE_BUILD_TOKEN" "$repo" "$commit" "$cwd_rel" "$@" > "$request_file" <<'PY'
+import base64, hashlib, json, os, pathlib, subprocess, sys
 mission_id, token, repo, commit, cwd_rel = sys.argv[1:6]
 command = sys.argv[6:]
 req = {
@@ -50,11 +51,92 @@ req = {
     "command": command,
     "wait": False,
 }
+
+def git_paths(*args):
+    raw = subprocess.check_output(["git", *args])
+    return [item.decode("utf-8") for item in raw.split(b"\0") if item]
+
+deleted = git_paths("diff", "--name-only", "-z", "--diff-filter=DR", "HEAD")
+if deleted:
+    raise SystemExit(
+        "remote source bundles do not encode deletions or renames; commit/stash these paths first: "
+        + ", ".join(deleted[:8])
+    )
+tracked = git_paths("diff", "--name-only", "-z", "--diff-filter=ACMRTUXB", "HEAD")
+untracked = git_paths("ls-files", "--others", "--exclude-standard", "-z")
+untracked_source = [
+    path for path in untracked
+    if path.endswith(".lean")
+    or pathlib.PurePosixPath(path).name in {
+        "lakefile.toml", "lake-manifest.json", "lean-toolchain"
+    }
+]
+ignored_untracked = sorted(set(untracked) - set(untracked_source))
+if ignored_untracked:
+    print(
+        "remote-lean-build: ignoring untracked non-Lean files: "
+        + ", ".join(ignored_untracked[:8]),
+        file=sys.stderr,
+    )
+paths = sorted(set(tracked + untracked_source))
+max_files = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES", "256"))
+max_bytes = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES", str(1 << 20)))
+if max_files <= 0 or max_bytes <= 0:
+    raise SystemExit("remote source bundle limits must be positive integers")
+if len(paths) > max_files:
+    raise SystemExit(f"source bundle has {len(paths)} files; maximum is {max_files}")
+files = []
+total = 0
+manifest = hashlib.sha256(b"sandboxed-source-bundle-v1\n")
+for rel in paths:
+    components = rel.split("/")
+    if (
+        not rel
+        or any(
+            not component
+            or component == ".."
+            or component.startswith("-")
+            or component in {".git", ".lake"}
+            or any(not (ch.isascii() and (ch.isalnum() or ch in "_.-")) for ch in component)
+            for component in components
+        )
+    ):
+        raise SystemExit(f"unsafe source bundle path: {rel!r}")
+    path = pathlib.Path(rel)
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"source bundle path must be a regular file, not a symlink: {rel}")
+    data = path.read_bytes()
+    total += len(data)
+    if total > max_bytes:
+        raise SystemExit(f"source bundle is {total} bytes; maximum is {max_bytes}")
+    digest = hashlib.sha256(data).hexdigest()
+    manifest.update(rel.encode())
+    manifest.update(b"\0")
+    manifest.update(digest.encode())
+    manifest.update(b"\n")
+    files.append({
+        "path": rel,
+        "sha256": digest,
+        "data_base64": base64.b64encode(data).decode("ascii"),
+    })
+if files:
+    req["source_bundle"] = {
+        "manifest_sha256": manifest.hexdigest(),
+        "files": files,
+    }
 if cwd_rel:
     req["cwd_rel"] = cwd_rel
 timeout = os.environ.get("REMOTE_BUILD_TIMEOUT_SECS")
 if timeout:
     req["timeout_secs"] = int(timeout)
+estimate_bytes = os.environ.get("REMOTE_BUILD_ESTIMATED_DISK_BYTES")
+if estimate_bytes:
+    estimate = int(estimate_bytes)
+else:
+    estimate = int(os.environ.get("REMOTE_BUILD_ESTIMATED_DISK_GB", "12")) * (1 << 30)
+if estimate <= 0:
+    raise SystemExit("remote build disk estimate must be positive")
+req["estimated_disk_bytes"] = estimate
 node_id = os.environ.get("REMOTE_BUILD_NODE_ID", "auto").strip()
 if node_id:
     req["node_id"] = node_id
@@ -70,11 +152,15 @@ if not isinstance(requirements, list) or not all(
 req["requirements"] = requirements
 print(json.dumps(req))
 PY
-)" || die "failed to encode request"
+encode_status=$?
+if [ "$encode_status" -ne 0 ]; then
+    rm -f "$request_file"
+    die "failed to encode request" 2
+fi
 
-request_key="$(python3 - "$body" "$REMOTE_BUILD_URL" <<'PY'
+request_key="$(python3 - "$request_file" "$REMOTE_BUILD_URL" <<'PY'
 import hashlib, json, sys
-request = json.loads(sys.argv[1])
+request = json.load(open(sys.argv[1]))
 request.pop("token", None)
 request.pop("wait", None)
 fingerprint = {"endpoint": sys.argv[2], "request": request}
@@ -114,7 +200,7 @@ release_submit_lock() {
 }
 cleanup() {
     release_submit_lock
-    rm -f "$response_file"
+    rm -f "$response_file" "$request_file"
 }
 trap cleanup EXIT
 
@@ -231,13 +317,16 @@ fi
 
 persist_ambiguous_receipt() {
     reason="$1"
-    python3 - "$state_file" "$body" "$reason" <<'PY'
+    python3 - "$state_file" "$request_file" "$reason" <<'PY'
 import json, os, sys, tempfile
-path, raw_request, reason = sys.argv[1:]
-request = json.loads(raw_request)
+path, request_path, reason = sys.argv[1:]
+request = json.load(open(request_path))
 request.pop("token", None)
 request.pop("repo", None)
 request.pop("wait", None)
+bundle = request.pop("source_bundle", None)
+if bundle:
+    request["source_bundle_sha256"] = bundle.get("manifest_sha256")
 request.update({"state": "ambiguous", "submit_outcome": reason})
 fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
 try:
@@ -252,12 +341,6 @@ PY
 }
 
 if [ -z "$job_id" ]; then
-    # The node fetches a pinned commit; uncommitted changes would silently not
-    # be part of a new remote build. An existing receipt remains resumable after
-    # the checkout changes because its immutable request was already accepted.
-    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-        die "working tree is dirty; commit (and push) your changes before submitting a new build" 2
-    fi
     # Pre-create the durable blocker while no remote request has been made.
     # Cleanup removes it on known pre-acceptance outcomes; ambiguous/accepted
     # failures retain it so a dead owner PID can never permit a duplicate job.
@@ -267,7 +350,7 @@ if [ -z "$job_id" ]; then
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \
         --max-time "$submit_timeout_secs" \
-        -d "$body" "$REMOTE_BUILD_URL")"
+        --data-binary "@$request_file" "$REMOTE_BUILD_URL")"
     curl_status=$?
     if [ "$curl_status" -ne 0 ]; then
         case "$curl_status" in
@@ -320,13 +403,16 @@ print(job, node, sep="\t")
 PY
     ) || die "invalid remote-build submit response"
 
-    python3 - "$state_file" "$body" "$job_id" "$node_id" <<'PY'
+    python3 - "$state_file" "$request_file" "$job_id" "$node_id" <<'PY'
 import json, os, sys, tempfile
-path, raw_request, job_id, node_id = sys.argv[1:]
-request = json.loads(raw_request)
+path, request_path, job_id, node_id = sys.argv[1:]
+request = json.load(open(request_path))
 request.pop("token", None)
 request.pop("repo", None)
 request.pop("wait", None)
+bundle = request.pop("source_bundle", None)
+if bundle:
+    request["source_bundle_sha256"] = bundle.get("manifest_sha256")
 request.update({"job_id": job_id, "node_id": node_id, "state": "submitted"})
 fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
 try:

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -51,9 +51,12 @@ req = {
     "command": command,
     "wait": False,
 }
+repo_root = pathlib.Path(
+    subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
+).resolve()
 
 def git_paths(*args):
-    raw = subprocess.check_output(["git", *args])
+    raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
     return [item.decode("utf-8") for item in raw.split(b"\0") if item]
 
 deleted = git_paths("diff", "--name-only", "-z", "--diff-filter=DR", "HEAD")
@@ -63,7 +66,7 @@ if deleted:
         + ", ".join(deleted[:8])
     )
 tracked = git_paths("diff", "--name-only", "-z", "--diff-filter=ACMRTUXB", "HEAD")
-untracked = git_paths("ls-files", "--others", "--exclude-standard", "-z")
+untracked = git_paths("ls-files", "--full-name", "--others", "--exclude-standard", "-z")
 untracked_source = [
     path for path in untracked
     if path.endswith(".lean")
@@ -102,7 +105,7 @@ for rel in paths:
         )
     ):
         raise SystemExit(f"unsafe source bundle path: {rel!r}")
-    path = pathlib.Path(rel)
+    path = repo_root / rel
     if path.is_symlink() or not path.is_file():
         raise SystemExit(f"source bundle path must be a regular file, not a symlink: {rel}")
     data = path.read_bytes()

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4262,6 +4262,21 @@ fn disk_admission_refusal() -> Option<String> {
     }
 }
 
+fn disk_estimate_refusal(
+    available_bytes: u64,
+    estimated_gib: u64,
+    reserve_gib: u64,
+) -> Option<String> {
+    let required_gib = estimated_gib.saturating_add(reserve_gib);
+    (available_bytes < required_gib.saturating_mul(1 << 30)).then(|| {
+        format!(
+            "mission needs an estimated {estimated_gib} GiB scratch plus a {reserve_gib} GiB \
+             emergency floor, but only {} GiB is free; select a remote node or free space",
+            available_bytes / (1 << 30)
+        )
+    })
+}
+
 pub async fn fleet_health(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -5108,6 +5123,11 @@ pub struct CreateMissionRequest {
     /// background poll loop finalizes it when the job completes. Default
     /// false keeps the synchronous blocking `/execute` path unchanged.
     pub remote_async: Option<bool>,
+    /// Expected peak local scratch consumption in GiB. Small/no-build missions
+    /// may omit it; disk-heavy missions should set it so warn-level operation
+    /// can continue without admitting work that would cross the emergency
+    /// reserve.
+    pub estimated_disk_gib: Option<u64>,
     /// Catch-all for unrecognized request fields. Serde ignores unknown fields
     /// by default, which has repeatedly hidden client bugs (a `prompt` sent
     /// before the field existed, a mistyped `target_mission_id`). Captured
@@ -5905,6 +5925,7 @@ pub async fn create_mission(
         remote_requirements: None,
         remote_command: None,
         remote_async: None,
+        estimated_disk_gib: None,
         extra: Default::default(),
     });
 
@@ -6085,7 +6106,39 @@ pub async fn create_mission(
     // Writer creation is checked once before actor creation and again while
     // tagging the returned mission. Never hold this mutex while waiting on the
     // control actor: actor commands also acquire it when resuming writers.
-    let normalized_request_tags = normalize_mission_tags(req.tags.as_deref());
+    if let Some(estimated_gib) = req.estimated_disk_gib {
+        if estimated_gib == 0 || estimated_gib > 512 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "estimated_disk_gib must be between 1 and 512".to_string(),
+            ));
+        }
+        if req
+            .remote_node_id
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty)
+        {
+            let (used, total, _) = crate::api::monitoring::current_disk_usage();
+            let reserve_gib = std::env::var("MISSION_DISK_EMERGENCY_RESERVE_GB")
+                .ok()
+                .and_then(|raw| raw.trim().parse::<u64>().ok())
+                .unwrap_or(64);
+            if let Some(reason) =
+                disk_estimate_refusal(total.saturating_sub(used), estimated_gib, reserve_gib)
+            {
+                return Err((StatusCode::INSUFFICIENT_STORAGE, reason));
+            }
+        }
+    }
+    let mut normalized_request_tags = normalize_mission_tags(req.tags.as_deref());
+    if let Some(estimated_gib) = req.estimated_disk_gib {
+        let tag = format!("disk-estimate-gib:{estimated_gib}");
+        let tags = normalized_request_tags.get_or_insert_with(Vec::new);
+        if !tags.iter().any(|existing| existing == &tag) {
+            tags.push(tag);
+        }
+    }
     let request_is_writer = requested_pr_writer(
         req.writer,
         normalized_request_tags.as_deref(),
@@ -6643,6 +6696,7 @@ async fn dispatch_remote_job(
             job_id,
             started_at: submit_started_at,
             accepted_at: None,
+            disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
         },
     )
@@ -6687,6 +6741,7 @@ async fn dispatch_remote_job(
             job_id,
             started_at: submit_started_at,
             accepted_at: Some(chrono::Utc::now()),
+            disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::Mission,
         },
     )
@@ -9007,6 +9062,7 @@ pub async fn clone_mission(
         remote_requirements: None,
         remote_command: None,
         remote_async: None,
+        estimated_disk_gib: None,
         extra: Default::default(),
     };
 
@@ -19908,6 +19964,15 @@ mod tests {
         let guard = METADATA_REFRESH_TEST_LOCK.lock().await;
         reset_metadata_refresh_test_state();
         guard
+    }
+
+    #[test]
+    fn disk_estimate_preserves_emergency_free_space() {
+        assert!(disk_estimate_refusal(100 << 30, 20, 64).is_none());
+        let refusal = disk_estimate_refusal(80 << 30, 20, 64).unwrap();
+        assert!(refusal.contains("20 GiB scratch"));
+        assert!(refusal.contains("64 GiB"));
+        assert!(refusal.contains("80 GiB is free"));
     }
 
     fn reset_metadata_refresh_test_state() {

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -407,6 +407,7 @@ async fn resolve_node(
     node_id: &str,
     requirements: &[String],
     min_disk_bytes: u64,
+    min_protocol_version: u32,
 ) -> Result<RemoteNodeConfig, (StatusCode, String)> {
     let settings = &state.config.remote_nodes;
     if !settings.enabled || settings.nodes.is_empty() {
@@ -419,13 +420,16 @@ async fn resolve_node(
         let reservations = core_side_reservations(state)
             .await
             .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
-        let first = state.fleet.place_auto_with_resource_reservations(
-            settings,
-            requirements,
-            min_disk_bytes,
-            &reservations.jobs,
-            &reservations.disk_bytes,
-        );
+        let first = state
+            .fleet
+            .place_auto_with_protocol_and_resource_reservations(
+                settings,
+                requirements,
+                min_disk_bytes,
+                min_protocol_version,
+                &reservations.jobs,
+                &reservations.disk_bytes,
+            );
         let picked = match first {
             Ok(picked) => picked,
             Err(initial_err) => {
@@ -459,10 +463,11 @@ async fn resolve_node(
                     .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
                 state
                     .fleet
-                    .place_auto_with_resource_reservations(
+                    .place_auto_with_protocol_and_resource_reservations(
                         settings,
                         requirements,
                         min_disk_bytes,
+                        min_protocol_version,
                         &reservations.jobs,
                         &reservations.disk_bytes,
                     )
@@ -489,6 +494,15 @@ async fn resolve_node(
         StatusCode::SERVICE_UNAVAILABLE,
         format!("remote node '{}' has no heartbeat data", node.id),
     ))?;
+    if heartbeat.protocol_version < min_protocol_version {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "remote node '{}' reports protocol v{}; v{} is required",
+                node.id, heartbeat.protocol_version, min_protocol_version
+            ),
+        ));
+    }
     let reserved = reservations.disk_bytes.get(&node.id).copied().unwrap_or(0);
     let effective = heartbeat.disk_available_bytes.saturating_sub(reserved);
     if effective < min_disk_bytes {
@@ -688,6 +702,11 @@ async fn submit_remote_build(
             .into_response();
     }
     let min_disk_bytes = required_node_disk_bytes(req.estimated_disk_bytes);
+    let min_protocol_version = if req.source_bundle.is_some() {
+        crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+    } else {
+        1
+    };
     // Every endpoint payload is a declarative Lean build. Callers may add
     // placement labels, but may not remove the runtime readiness gate by
     // sending an empty or unrelated requirements list.
@@ -701,7 +720,15 @@ async fn submit_remote_build(
     // Serialize placement through tentative-handle persistence. Otherwise a
     // burst can select the same idle node before its next heartbeat.
     let placement_guard = placement_lock().lock().await;
-    let node = match resolve_node(&state, &req.node_id, &requirements, min_disk_bytes).await {
+    let node = match resolve_node(
+        &state,
+        &req.node_id,
+        &requirements,
+        min_disk_bytes,
+        min_protocol_version,
+    )
+    .await
+    {
         Ok(node) => node,
         Err((status, message)) => return (status, message).into_response(),
     };

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1408,6 +1408,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         let capture = temp.path().join("request.json");
         std::fs::create_dir_all(&repo).unwrap();
         std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(repo.join("Theory")).unwrap();
         let git = |args: &[&str]| {
             let output = std::process::Command::new("git")
                 .args(args)
@@ -1423,8 +1424,8 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         git(&["init", "--quiet"]);
         git(&["config", "user.name", "Remote Build Test"]);
         git(&["config", "user.email", "remote-build@example.invalid"]);
-        std::fs::write(repo.join("Proof.lean"), "old\n").unwrap();
-        git(&["add", "Proof.lean"]);
+        std::fs::write(repo.join("Theory/Proof.lean"), "old\n").unwrap();
+        git(&["add", "Theory/Proof.lean"]);
         git(&[
             "-c",
             "commit.gpgsign=false",
@@ -1439,8 +1440,8 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             "origin",
             "https://example.invalid/repo.git",
         ]);
-        std::fs::write(repo.join("Proof.lean"), "new proof\n").unwrap();
-        std::fs::write(repo.join("Witness.lean"), "new witness\n").unwrap();
+        std::fs::write(repo.join("Theory/Proof.lean"), "new proof\n").unwrap();
+        std::fs::write(repo.join("Theory/Witness.lean"), "new witness\n").unwrap();
 
         let fake_curl = bin.join("curl");
         std::fs::write(
@@ -1475,7 +1476,7 @@ printf '503'
                 env!("CARGO_MANIFEST_DIR"),
                 "/scripts/remote-lean-build"
             ))
-            .current_dir(&repo)
+            .current_dir(repo.join("Theory"))
             .env("PATH", path)
             .env(
                 "REMOTE_BUILD_URL",
@@ -1503,7 +1504,7 @@ printf '503'
                 .iter()
                 .map(|file| file.get("path").unwrap().as_str().unwrap())
                 .collect::<Vec<_>>(),
-            vec!["Proof.lean", "Witness.lean"]
+            vec!["Theory/Proof.lean", "Theory/Witness.lean"]
         );
         let manifest = files
             .iter()

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -342,7 +342,7 @@ struct CoreReservations {
     disk_bytes: HashMap<String, u64>,
 }
 
-async fn core_side_reservations(state: &AppState) -> CoreReservations {
+async fn core_side_reservations(state: &AppState) -> Result<CoreReservations, String> {
     match crate::remote_node::job_ledger::load(&state.config.working_dir).await {
         Ok(handles) => {
             let mut reservations = CoreReservations::default();
@@ -371,12 +371,11 @@ async fn core_side_reservations(state: &AppState) -> CoreReservations {
                     *reservations.jobs.entry(handle.node_id).or_insert(0) += 1;
                 }
             }
-            reservations
+            Ok(reservations)
         }
-        Err(error) => {
-            tracing::warn!(?error, "remote job reservations could not be loaded");
-            CoreReservations::default()
-        }
+        Err(error) => Err(format!(
+            "remote job reservations could not be loaded; disk-aware placement fails closed: {error}"
+        )),
     }
 }
 
@@ -417,7 +416,9 @@ async fn resolve_node(
         ));
     }
     if node_id.eq_ignore_ascii_case("auto") {
-        let reservations = core_side_reservations(state).await;
+        let reservations = core_side_reservations(state)
+            .await
+            .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
         let first = state.fleet.place_auto_with_resource_reservations(
             settings,
             requirements,
@@ -453,7 +454,9 @@ async fn resolve_node(
                         .map(|node| crate::remote_node::probe_node(&state.fleet, &client, node)),
                 )
                 .await;
-                let reservations = core_side_reservations(state).await;
+                let reservations = core_side_reservations(state)
+                    .await
+                    .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
                 state
                     .fleet
                     .place_auto_with_resource_reservations(
@@ -475,7 +478,9 @@ async fn resolve_node(
         StatusCode::BAD_REQUEST,
         format!("remote node '{node_id}' is not configured"),
     ))?;
-    let reservations = core_side_reservations(state).await;
+    let reservations = core_side_reservations(state)
+        .await
+        .map_err(|message| (StatusCode::SERVICE_UNAVAILABLE, message))?;
     let cached = state.fleet.get(&node.id).ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         format!("remote node '{}' has no heartbeat data", node.id),

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -30,8 +30,8 @@ use uuid::Uuid;
 use super::routes::AppState;
 use crate::remote_node::{
     ArtifactEntry, DispatchOutcome, JobPayload, JobSource, LeaseClaims, NodeJobStatus,
-    RemoteNodeClient, RemoteNodeConfig, RemoteNodeError, RemoteNodeStatus, SubmitJobRequest,
-    SCOPE_JOB_SUBMIT,
+    RemoteNodeClient, RemoteNodeConfig, RemoteNodeError, RemoteNodeStatus, SourceBundle,
+    SubmitJobRequest, SCOPE_JOB_SUBMIT,
 };
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -43,6 +43,32 @@ pub fn routes() -> Router<Arc<AppState>> {
 /// Client-side cap on a waited build: poll every 3s for at most 2 hours.
 const WAIT_POLL_INTERVAL: Duration = Duration::from_secs(3);
 const WAIT_MAX_POLLS: u32 = 2 * 60 * 60 / 3;
+const GIB: u64 = 1 << 30;
+const DEFAULT_ESTIMATED_DISK_GB: u64 = 12;
+const MAX_ESTIMATED_DISK_GB: u64 = 512;
+const DEFAULT_NODE_MIN_DISK_GB: u64 = 20;
+const DEFAULT_NODE_DISK_EMERGENCY_GB: u64 = 10;
+
+fn env_gib(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(default)
+        .saturating_mul(GIB)
+}
+
+fn default_estimated_disk_bytes() -> u64 {
+    env_gib("REMOTE_BUILD_ESTIMATED_DISK_GB", DEFAULT_ESTIMATED_DISK_GB)
+}
+
+fn required_node_disk_bytes(estimated_disk_bytes: u64) -> u64 {
+    env_gib("REMOTE_NODE_MIN_DISK_GB", DEFAULT_NODE_MIN_DISK_GB).max(
+        estimated_disk_bytes.saturating_add(env_gib(
+            "REMOTE_NODE_DISK_EMERGENCY_GB",
+            DEFAULT_NODE_DISK_EMERGENCY_GB,
+        )),
+    )
+}
 
 /// Secret used to sign the per-mission remote-build capability token. Same
 /// source as the spark-offload token (`src/api/spark.rs`).
@@ -250,6 +276,10 @@ pub struct RemoteBuildRequest {
     pub repo: String,
     /// Full 40-char lowercase hex commit SHA.
     pub commit: String,
+    /// Optional, bounded source overlay whose hashes are verified by the node
+    /// before it is applied over the pinned commit.
+    #[serde(default)]
+    pub source_bundle: Option<SourceBundle>,
     /// Build cwd relative to the checkout root.
     #[serde(default)]
     pub cwd_rel: Option<String>,
@@ -257,6 +287,10 @@ pub struct RemoteBuildRequest {
     pub command: Vec<String>,
     #[serde(default)]
     pub timeout_secs: Option<u64>,
+    /// Expected peak scratch use. Defaults to 12 GiB and is reserved during
+    /// placement so simultaneous cold builds cannot overcommit one node.
+    #[serde(default = "default_estimated_disk_bytes")]
+    pub estimated_disk_bytes: u64,
     /// Node label requirements for auto placement.
     #[serde(default = "default_requirements")]
     pub requirements: Vec<String>,
@@ -302,11 +336,22 @@ fn placement_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
+#[derive(Default)]
+struct CoreReservations {
+    jobs: HashMap<String, u32>,
+    disk_bytes: HashMap<String, u64>,
+}
+
+async fn core_side_reservations(state: &AppState) -> CoreReservations {
     match crate::remote_node::job_ledger::load(&state.config.working_dir).await {
         Ok(handles) => {
-            let mut reservations = HashMap::new();
+            let mut reservations = CoreReservations::default();
             for handle in handles {
+                let disk = reservations
+                    .disk_bytes
+                    .entry(handle.node_id.clone())
+                    .or_insert(0);
+                *disk = disk.saturating_add(handle.disk_reservation_bytes);
                 let cached = state.fleet.get(&handle.node_id);
                 let heartbeat_started_at = cached
                     .as_ref()
@@ -323,14 +368,14 @@ async fn core_side_reservations(state: &AppState) -> HashMap<String, u32> {
                     heartbeat_started_at,
                     heartbeat_has_job_counters,
                 ) {
-                    *reservations.entry(handle.node_id).or_insert(0) += 1;
+                    *reservations.jobs.entry(handle.node_id).or_insert(0) += 1;
                 }
             }
             reservations
         }
         Err(error) => {
             tracing::warn!(?error, "remote job reservations could not be loaded");
-            HashMap::new()
+            CoreReservations::default()
         }
     }
 }
@@ -362,6 +407,7 @@ async fn resolve_node(
     state: &AppState,
     node_id: &str,
     requirements: &[String],
+    min_disk_bytes: u64,
 ) -> Result<RemoteNodeConfig, (StatusCode, String)> {
     let settings = &state.config.remote_nodes;
     if !settings.enabled || settings.nodes.is_empty() {
@@ -372,9 +418,13 @@ async fn resolve_node(
     }
     if node_id.eq_ignore_ascii_case("auto") {
         let reservations = core_side_reservations(state).await;
-        let first = state
-            .fleet
-            .place_auto_with_reservations(settings, requirements, &reservations);
+        let first = state.fleet.place_auto_with_resource_reservations(
+            settings,
+            requirements,
+            min_disk_bytes,
+            &reservations.jobs,
+            &reservations.disk_bytes,
+        );
         let picked = match first {
             Ok(picked) => picked,
             Err(initial_err) => {
@@ -406,7 +456,13 @@ async fn resolve_node(
                 let reservations = core_side_reservations(state).await;
                 state
                     .fleet
-                    .place_auto_with_reservations(settings, requirements, &reservations)
+                    .place_auto_with_resource_reservations(
+                        settings,
+                        requirements,
+                        min_disk_bytes,
+                        &reservations.jobs,
+                        &reservations.disk_bytes,
+                    )
                     .map_err(|err| (StatusCode::SERVICE_UNAVAILABLE, err.to_string()))?
             }
         };
@@ -419,6 +475,29 @@ async fn resolve_node(
         StatusCode::BAD_REQUEST,
         format!("remote node '{node_id}' is not configured"),
     ))?;
+    let reservations = core_side_reservations(state).await;
+    let cached = state.fleet.get(&node.id).ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        format!("remote node '{}' has no heartbeat data", node.id),
+    ))?;
+    let heartbeat = cached.last_heartbeat.ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        format!("remote node '{}' has no heartbeat data", node.id),
+    ))?;
+    let reserved = reservations.disk_bytes.get(&node.id).copied().unwrap_or(0);
+    let effective = heartbeat.disk_available_bytes.saturating_sub(reserved);
+    if effective < min_disk_bytes {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "remote node '{}' has {} GiB effective free after {} GiB reserved; {} GiB required",
+                node.id,
+                effective / GIB,
+                reserved / GIB,
+                min_disk_bytes / GIB
+            ),
+        ));
+    }
     Ok(node)
 }
 
@@ -591,6 +670,19 @@ async fn submit_remote_build(
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
     }
+    let max_estimated_disk_bytes =
+        env_gib("REMOTE_BUILD_MAX_ESTIMATED_DISK_GB", MAX_ESTIMATED_DISK_GB);
+    if req.estimated_disk_bytes == 0 || req.estimated_disk_bytes > max_estimated_disk_bytes {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "estimated_disk_bytes must be between 1 and {} GiB",
+                max_estimated_disk_bytes / GIB
+            ),
+        )
+            .into_response();
+    }
+    let min_disk_bytes = required_node_disk_bytes(req.estimated_disk_bytes);
     // Every endpoint payload is a declarative Lean build. Callers may add
     // placement labels, but may not remove the runtime readiness gate by
     // sending an empty or unrelated requirements list.
@@ -604,7 +696,7 @@ async fn submit_remote_build(
     // Serialize placement through tentative-handle persistence. Otherwise a
     // burst can select the same idle node before its next heartbeat.
     let placement_guard = placement_lock().lock().await;
-    let node = match resolve_node(&state, &req.node_id, &requirements).await {
+    let node = match resolve_node(&state, &req.node_id, &requirements, min_disk_bytes).await {
         Ok(node) => node,
         Err((status, message)) => return (status, message).into_response(),
     };
@@ -633,10 +725,12 @@ async fn submit_remote_build(
             source: JobSource {
                 repo: req.repo.clone(),
                 commit: req.commit.clone(),
+                bundle: req.source_bundle.clone(),
             },
             cwd_rel: req.cwd_rel.clone(),
             command: req.command.clone(),
             timeout_secs: req.timeout_secs,
+            estimated_disk_bytes: Some(req.estimated_disk_bytes),
             cache_key: None,
             artifacts: req.artifacts.clone(),
             env: Default::default(),
@@ -653,6 +747,7 @@ async fn submit_remote_build(
             job_id,
             started_at,
             accepted_at: None,
+            disk_reservation_bytes: req.estimated_disk_bytes,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
         },
     )
@@ -726,6 +821,7 @@ async fn submit_remote_build(
             job_id,
             started_at,
             accepted_at: Some(chrono::Utc::now()),
+            disk_reservation_bytes: req.estimated_disk_bytes,
             kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
         },
     )
@@ -935,6 +1031,7 @@ mod tests {
             job_id: Uuid::new_v4(),
             started_at: now,
             accepted_at: None,
+            disk_reservation_bytes: 12 * GIB,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
         };
 
@@ -1123,6 +1220,8 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert_eq!(req.requirements, vec!["lean".to_string()]);
         assert_eq!(req.cwd_rel, None);
         assert_eq!(req.timeout_secs, None);
+        assert_eq!(req.estimated_disk_bytes, 12 * GIB);
+        assert!(req.source_bundle.is_none());
         assert!(req.artifacts.is_empty());
 
         let req: RemoteBuildRequest = serde_json::from_value(serde_json::json!({
@@ -1263,6 +1362,129 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             run_remote_build_wrapper_with_submit_result(0, 7).code(),
             Some(75),
             "a pre-connect failure is safe for local fallback"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_sends_dirty_sources_as_a_hashed_bounded_bundle() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        let bin = temp.path().join("bin");
+        let capture = temp.path().join("request.json");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&bin).unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--quiet"]);
+        git(&["config", "user.name", "Remote Build Test"]);
+        git(&["config", "user.email", "remote-build@example.invalid"]);
+        std::fs::write(repo.join("Proof.lean"), "old\n").unwrap();
+        git(&["add", "Proof.lean"]);
+        git(&[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            "baseline",
+        ]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://example.invalid/repo.git",
+        ]);
+        std::fs::write(repo.join("Proof.lean"), "new proof\n").unwrap();
+        std::fs::write(repo.join("Witness.lean"), "new witness\n").unwrap();
+
+        let fake_curl = bin.join("curl");
+        std::fs::write(
+            &fake_curl,
+            r#"#!/bin/sh
+output=""
+data=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) shift; output="$1" ;;
+        --data-binary) shift; data="$1" ;;
+    esac
+    shift
+done
+cp "${data#@}" "$REMOTE_BUILD_TEST_CAPTURE"
+printf 'unavailable' > "$output"
+printf '503'
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&fake_curl).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_curl, permissions).unwrap();
+
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let output = std::process::Command::new("bash")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/remote-lean-build"
+            ))
+            .current_dir(&repo)
+            .env("PATH", path)
+            .env(
+                "REMOTE_BUILD_URL",
+                "http://example.invalid/api/remote-build",
+            )
+            .env("REMOTE_BUILD_TOKEN", "test-token")
+            .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
+            .env("REMOTE_BUILD_TEST_CAPTURE", &capture)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(75));
+
+        let request: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+        assert_eq!(
+            request
+                .get("estimated_disk_bytes")
+                .and_then(serde_json::Value::as_u64),
+            Some(12 * GIB)
+        );
+        let bundle = request.get("source_bundle").unwrap();
+        let files = bundle.get("files").unwrap().as_array().unwrap();
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.get("path").unwrap().as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["Proof.lean", "Witness.lean"]
+        );
+        let manifest = files
+            .iter()
+            .map(|file| {
+                (
+                    file.get("path").unwrap().as_str().unwrap().to_string(),
+                    file.get("sha256").unwrap().as_str().unwrap().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bundle.get("manifest_sha256").unwrap().as_str().unwrap(),
+            crate::node::lean::bundle_manifest_sha256(&manifest)
         );
     }
 
@@ -1435,8 +1657,6 @@ esac
             Some("11111111-1111-1111-1111-111111111111")
         );
 
-        std::fs::write(repo.join("DIRTY-WORKTREE"), "changed after submit\n")
-            .expect("dirty checkout after accepted build");
         let resumed = run("success");
         assert!(
             resumed.status.success(),
@@ -1457,8 +1677,6 @@ esac
         assert!(String::from_utf8_lossy(&replayed.stderr).contains("replaying terminal job"));
         assert_eq!(String::from_utf8_lossy(&replayed.stdout), "remote ok\n");
 
-        std::fs::remove_file(repo.join("DIRTY-WORKTREE"))
-            .expect("restore clean checkout before new submission");
         for receipt in std::fs::read_dir(&state).expect("read receipts before persistence failure")
         {
             std::fs::remove_file(receipt.expect("read receipt entry").path())

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -360,8 +360,7 @@ async fn core_side_reservations(state: &AppState) -> Result<CoreReservations, St
                     .as_ref()
                     .and_then(|status| status.last_heartbeat.as_ref())
                     .is_some_and(|heartbeat| {
-                        heartbeat.protocol_version
-                            >= crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+                        heartbeat_protocol_has_job_counters(heartbeat.protocol_version)
                     });
                 if handle_needs_reservation(
                     &handle,
@@ -377,6 +376,10 @@ async fn core_side_reservations(state: &AppState) -> Result<CoreReservations, St
             "remote job reservations could not be loaded; disk-aware placement fails closed: {error}"
         )),
     }
+}
+
+fn heartbeat_protocol_has_job_counters(protocol_version: u32) -> bool {
+    protocol_version >= crate::remote_node::protocol::NODE_JOB_COUNTER_PROTOCOL_VERSION
 }
 
 fn heartbeat_cannot_reflect(
@@ -1052,6 +1055,13 @@ mod tests {
             Some(heartbeat_started_at)
         ));
         assert!(heartbeat_cannot_reflect(heartbeat_started_at, None));
+    }
+
+    #[test]
+    fn v2_heartbeats_still_cover_job_count_reservations() {
+        assert!(!heartbeat_protocol_has_job_counters(1));
+        assert!(heartbeat_protocol_has_job_counters(2));
+        assert!(heartbeat_protocol_has_job_counters(3));
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -3127,24 +3127,18 @@ mod tests {
 
     #[test]
     fn mission_acknowledgement_accepts_only_ack_waits_and_is_idempotent() {
-        assert_eq!(
-            mission_requires_acknowledgement(&json!({
-                "status": "awaiting_user",
-                "awaiting_kind": "ack"
-            }))
-            .unwrap(),
-            true
-        );
-        assert_eq!(
-            mission_requires_acknowledgement(&json!({
-                "mission": {
-                    "status": "acknowledged",
-                    "awaiting_kind": null
-                }
-            }))
-            .unwrap(),
-            false
-        );
+        assert!(mission_requires_acknowledgement(&json!({
+            "status": "awaiting_user",
+            "awaiting_kind": "ack"
+        }))
+        .unwrap());
+        assert!(!mission_requires_acknowledgement(&json!({
+            "mission": {
+                "status": "acknowledged",
+                "awaiting_kind": null
+            }
+        }))
+        .unwrap());
         assert!(mission_requires_acknowledgement(&json!({
             "status": "awaiting_user",
             "awaiting_kind": "decision"

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -158,6 +158,8 @@ struct StartMissionParams {
     desired_state: Option<String>,
     #[serde(default)]
     next_check_at: Option<String>,
+    #[serde(default)]
+    estimated_disk_gib: Option<u64>,
 }
 
 fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
@@ -862,7 +864,8 @@ impl AssistantMcp {
                         "writer": {"type": "boolean", "description": "Whether this mission may modify the associated PR branch. Concurrent writers for one PR are rejected."},
                         "tags": {"type": "array", "items": {"type": "string"}},
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
-                        "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."}
+                        "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."},
+                        "estimated_disk_gib": {"type": "integer", "minimum": 1, "maximum": 512, "description": "Expected peak local scratch use. Set this for Lean/build-heavy missions; omit for small/no-build work."}
                     }
                 }),
             },
@@ -1333,6 +1336,7 @@ impl AssistantMcp {
             "tags": params.tags,
             "desired_state": params.desired_state,
             "next_check_at": params.next_check_at,
+            "estimated_disk_gib": params.estimated_disk_gib,
         });
         let response = self.api_post("/api/control/missions", body).await?;
         if !response.status().is_success() {

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -116,6 +116,10 @@ struct CreateWorkerParams {
     config_profile: Option<String>,
     #[serde(default)]
     working_directory: Option<String>,
+    /// Expected peak local scratch use. Heavy build missions should set this;
+    /// small/no-build missions may omit it.
+    #[serde(default)]
+    estimated_disk_gib: Option<u64>,
     /// Workspace to spawn the worker in. If omitted, the worker inherits the
     /// boss mission's workspace so it sees the same container, mounts, and
     /// installed tooling. Pass `"00000000-0000-0000-0000-000000000000"` to
@@ -731,6 +735,12 @@ impl OrchestratorMcp {
                             "type": "string",
                             "description": "Working directory for the worker (e.g. a git worktree path). If omitted, uses the boss mission's repo directory."
                         },
+                        "estimated_disk_gib": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 512,
+                            "description": "Expected peak local scratch use for disk-aware admission."
+                        },
                         "workspace_id": {
                             "type": "string",
                             "description": "Workspace UUID to spawn the worker in. Defaults to the boss's workspace so the worker inherits the same container, mounts, and installed tooling. Pass the nil UUID to force the host workspace."
@@ -763,6 +773,7 @@ impl OrchestratorMcp {
                                     "agent": { "type": "string" },
                                     "config_profile": { "type": "string" },
                                     "working_directory": { "type": "string" },
+                                    "estimated_disk_gib": { "type": "integer", "minimum": 1, "maximum": 512 },
                                     "workspace_id": { "type": "string" },
                                     "prompt": { "type": "string" }
                                 }
@@ -1147,6 +1158,7 @@ impl OrchestratorMcp {
             "config_profile": params.config_profile,
             "parent_mission_id": self.mission_id.to_string(),
             "working_directory": params.working_directory,
+            "estimated_disk_gib": params.estimated_disk_gib,
             "workspace_id": workspace_id,
             // Atomic create+start: the API stores the prompt as the mission's
             // deferred goal and the scheduler dispatches it once capacity

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -359,7 +359,7 @@ async fn submit_job(
             "lease is scoped to a different job".to_string(),
         ));
     }
-    validate_job_payload(&request.payload)
+    validate_job_payload(&request.payload, &state.work_root)
         .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     if state
         .jobs
@@ -393,11 +393,15 @@ async fn submit_job(
     ))
 }
 
-fn validate_job_payload(payload: &sandboxed_sh::remote_node::JobPayload) -> Result<(), String> {
+fn validate_job_payload(
+    payload: &sandboxed_sh::remote_node::JobPayload,
+    work_root: &Path,
+) -> Result<(), String> {
     if let sandboxed_sh::remote_node::JobPayload::LeanBuild {
         source,
         cwd_rel,
         command,
+        estimated_disk_bytes,
         env,
         ..
     } = payload
@@ -408,6 +412,10 @@ fn validate_job_payload(payload: &sandboxed_sh::remote_node::JobPayload) -> Resu
             command,
             env,
             &sandboxed_sh::node::lean::env_allowlist_from_env(),
+        )?;
+        sandboxed_sh::node::lean::validate_disk_admission(
+            work_root,
+            estimated_disk_bytes.unwrap_or_default(),
         )?;
     }
     Ok(())
@@ -758,10 +766,12 @@ mod tests {
                     source: sandboxed_sh::remote_node::JobSource {
                         repo: "/node/local/repo".to_string(),
                         commit: "a".repeat(40),
+                        bundle: None,
                     },
                     cwd_rel: None,
                     command: vec!["lake".to_string(), "build".to_string()],
                     timeout_secs: None,
+                    estimated_disk_bytes: None,
                     cache_key: None,
                     artifacts: vec![],
                     env: Default::default(),

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -19,13 +19,15 @@ use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
+use base64::Engine;
 use fs2::FileExt;
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 use tokio_util::sync::CancellationToken;
 
 use super::job_store::JobState;
 use super::runner::{clamp_timeout, run_logged_command, CommandEnvironment};
-use crate::remote_node::{ArtifactEntry, JobPayload, JobSource};
+use crate::remote_node::{ArtifactEntry, JobPayload, JobSource, SourceBundle};
 
 /// Default allowlist for lean-build env keys
 /// (`SANDBOXED_NODE_ENV_ALLOWLIST` overrides, comma-separated).
@@ -37,6 +39,8 @@ pub const ALLOWED_COMMANDS: [&str; 2] = ["lake", "lean"];
 /// Default node GC threshold: keep at least this many GiB free on the
 /// filesystem backing the work dir (`SANDBOXED_NODE_MIN_FREE_GB` overrides).
 const DEFAULT_MIN_FREE_GB: u64 = 10;
+const DEFAULT_MAX_SOURCE_BUNDLE_BYTES: u64 = 1 << 20;
+const MAX_SOURCE_BUNDLE_FILES: usize = 256;
 
 /// Interval between node-side cache GC passes.
 const GC_INTERVAL: Duration = Duration::from_secs(30 * 60);
@@ -100,6 +104,88 @@ pub fn rel_path_is_safe(rel_clean: &str) -> bool {
         })
 }
 
+fn source_bundle_max_bytes() -> u64 {
+    std::env::var("SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|bytes| *bytes > 0)
+        .unwrap_or(DEFAULT_MAX_SOURCE_BUNDLE_BYTES)
+}
+
+fn bundle_path_is_safe(path: &str) -> bool {
+    rel_path_is_safe(path)
+        && !path.is_empty()
+        && !path
+            .split('/')
+            .any(|component| matches!(component, ".git" | ".lake"))
+}
+
+pub(crate) fn bundle_manifest_sha256(files: &[(String, String)]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"sandboxed-source-bundle-v1\n");
+    for (path, sha256) in files {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(sha256.as_bytes());
+        hasher.update(b"\n");
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
+    if bundle.files.is_empty() {
+        return Err("source.bundle.files must not be empty".to_string());
+    }
+    if bundle.files.len() > MAX_SOURCE_BUNDLE_FILES {
+        return Err(format!(
+            "source bundle has {} files; maximum is {MAX_SOURCE_BUNDLE_FILES}",
+            bundle.files.len()
+        ));
+    }
+    let mut manifest_files = Vec::with_capacity(bundle.files.len());
+    let mut previous: Option<&str> = None;
+    let mut total = 0_u64;
+    for file in &bundle.files {
+        if !bundle_path_is_safe(&file.path) {
+            return Err(format!("unsafe source bundle path '{}'", file.path));
+        }
+        if previous.is_some_and(|prior| prior >= file.path.as_str()) {
+            return Err("source bundle paths must be unique and sorted".to_string());
+        }
+        previous = Some(&file.path);
+        if file.sha256.len() != 64
+            || !file
+                .sha256
+                .chars()
+                .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch))
+        {
+            return Err(format!("invalid source bundle sha256 for '{}'", file.path));
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&file.data_base64)
+            .map_err(|_| format!("invalid source bundle base64 for '{}'", file.path))?;
+        total = total.saturating_add(bytes.len() as u64);
+        if total > source_bundle_max_bytes() {
+            return Err(format!(
+                "source bundle is {total} bytes; maximum is {}",
+                source_bundle_max_bytes()
+            ));
+        }
+        if hex::encode(Sha256::digest(&bytes)) != file.sha256 {
+            return Err(format!(
+                "source bundle content hash mismatch for '{}'",
+                file.path
+            ));
+        }
+        manifest_files.push((file.path.clone(), file.sha256.clone()));
+    }
+    let expected = bundle_manifest_sha256(&manifest_files);
+    if expected != bundle.manifest_sha256 {
+        return Err("source bundle manifest hash mismatch".to_string());
+    }
+    Ok(total)
+}
+
 /// Only remote fetch sources: git happily fetches local paths and file://
 /// URLs, which would let a remote-build token holder exfiltrate node-local
 /// git data into a checkout.
@@ -144,6 +230,9 @@ pub fn validate_lean_build(
             source.commit
         ));
     }
+    if let Some(bundle) = &source.bundle {
+        validate_source_bundle(bundle)?;
+    }
     let rel_clean = cwd_rel.unwrap_or("").trim_matches('/');
     if !rel_path_is_safe(rel_clean) {
         return Err(format!("invalid cwd_rel '{rel_clean}'"));
@@ -180,6 +269,23 @@ pub fn validate_lean_build(
                 allowlist.join(",")
             ));
         }
+    }
+    Ok(())
+}
+
+/// Reject a build if its estimated peak plus the emergency floor cannot fit
+/// on the filesystem backing the node work root.
+pub fn validate_disk_admission(work_root: &Path, estimated_disk_bytes: u64) -> Result<(), String> {
+    let available = fs2::available_space(work_root)
+        .map_err(|error| format!("cannot stat node work dir disk space: {error}"))?;
+    let required = estimated_disk_bytes.saturating_add(min_free_bytes());
+    if available < required {
+        return Err(format!(
+            "insufficient node disk: {} GiB available, {} GiB estimated plus {} GiB emergency floor",
+            available / (1 << 30),
+            estimated_disk_bytes / (1 << 30),
+            min_free_bytes() / (1 << 30)
+        ));
     }
     Ok(())
 }
@@ -721,12 +827,14 @@ async fn ensure_checkout(
 /// hardlinks would let one checkout corrupt the shared slot or another build.
 /// `dest` must not exist.
 async fn isolated_copy(src: &Path, dest: &Path) -> anyhow::Result<()> {
-    let output = tokio::process::Command::new("cp")
-        .arg("-a")
-        .arg(src)
-        .arg(dest)
-        .output()
-        .await?;
+    let mut command = tokio::process::Command::new("cp");
+    command.arg("-a");
+    // Linux runners use CoW reflinks when the backing filesystem supports
+    // them, avoiding another physical Mathlib tree while preserving mutation
+    // isolation. `auto` falls back to an ordinary copy on ext4 and similar.
+    #[cfg(target_os = "linux")]
+    command.arg("--reflink=auto");
+    let output = command.arg(src).arg(dest).output().await?;
     if !output.status.success() {
         anyhow::bail!(
             "cp -a {} -> {} failed: {}",
@@ -822,6 +930,67 @@ async fn require_safe_directory_creation_path(
     Ok(())
 }
 
+async fn apply_source_bundle(
+    checkout: &Path,
+    bundle: &SourceBundle,
+    log_path: &Path,
+) -> anyhow::Result<()> {
+    let total_bytes = validate_source_bundle(bundle).map_err(|error| anyhow::anyhow!("{error}"))?;
+    for file in &bundle.files {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&file.data_base64)
+            .map_err(|_| anyhow::anyhow!("invalid bundle base64 for '{}'", file.path))?;
+        let destination = checkout.join(&file.path);
+        let parent = destination
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("bundle path '{}' has no parent", file.path))?;
+        if parent != checkout {
+            require_safe_directory_creation_path(checkout, parent, "source bundle destination")
+                .await?;
+        }
+        tokio::fs::create_dir_all(parent).await?;
+        match tokio::fs::symlink_metadata(&destination).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "source bundle destination must not be a symlink: {}",
+                    destination.display()
+                );
+            }
+            Ok(metadata) if metadata.is_dir() => {
+                anyhow::bail!(
+                    "source bundle destination is a directory: {}",
+                    destination.display()
+                );
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        let tmp = parent.join(format!(".source-bundle-{}", uuid::Uuid::new_v4()));
+        tokio::fs::write(&tmp, &bytes).await?;
+        if let Err(error) = tokio::fs::rename(&tmp, &destination).await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(error.into());
+        }
+    }
+    let mut log = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .await?;
+    log.write_all(
+        format!(
+            "source bundle verified sha256={} files={} bytes={}\n",
+            bundle.manifest_sha256,
+            bundle.files.len(),
+            total_bytes
+        )
+        .as_bytes(),
+    )
+    .await?;
+    Ok(())
+}
+
 /// Restore only shared Lake dependencies. Every other top-level `.lake` entry
 /// belongs to the root project and is commit-specific (including custom Lake
 /// `buildDir` values), so copying the whole directory can make Lake trust a
@@ -882,6 +1051,7 @@ pub async fn execute_lean_build(
         cwd_rel,
         command,
         timeout_secs,
+        estimated_disk_bytes,
         cache_key,
         artifacts,
         env,
@@ -893,6 +1063,8 @@ pub async fn execute_lean_build(
     let allowlist = env_allowlist_from_env();
     validate_lean_build(source, cwd_rel.as_deref(), command, env, &allowlist)
         .map_err(|e| anyhow::anyhow!("invalid lean_build payload: {e}"))?;
+    validate_disk_admission(work_root, estimated_disk_bytes.unwrap_or_default())
+        .map_err(|e| anyhow::anyhow!("disk admission failed: {e}"))?;
 
     // Serialize builds of the same (repo, commit): one flock guards both the
     // checkout materialization and the build itself, so two jobs never run
@@ -913,6 +1085,9 @@ pub async fn execute_lean_build(
     )
     .await?;
     run_git_step(&["clean", "-ffdx"], &checkout, log_path, token).await?;
+    if let Some(bundle) = &source.bundle {
+        apply_source_bundle(&checkout, bundle, log_path).await?;
+    }
 
     let rel_clean = cwd_rel.as_deref().unwrap_or("").trim_matches('/');
     let build_cwd = if rel_clean.is_empty() {
@@ -1193,11 +1368,24 @@ mod tests {
         JobSource {
             repo: "https://github.com/example/verity.git".to_string(),
             commit: commit.to_string(),
+            bundle: None,
         }
     }
 
     fn allowlist() -> Vec<String> {
         parse_env_allowlist(DEFAULT_ENV_ALLOWLIST)
+    }
+
+    fn source_bundle(path: &str, contents: &[u8]) -> SourceBundle {
+        let sha256 = hex::encode(Sha256::digest(contents));
+        SourceBundle {
+            manifest_sha256: bundle_manifest_sha256(&[(path.to_string(), sha256.clone())]),
+            files: vec![crate::remote_node::SourceBundleFile {
+                path: path.to_string(),
+                sha256,
+                data_base64: base64::engine::general_purpose::STANDARD.encode(contents),
+            }],
+        }
     }
 
     #[test]
@@ -1318,6 +1506,73 @@ mod tests {
     }
 
     #[test]
+    fn validation_accepts_a_verified_source_bundle_and_rejects_tampering() {
+        let mut bundled_source = source(&"a".repeat(40));
+        bundled_source.bundle = Some(source_bundle(
+            "Beal/Proof.lean",
+            b"theorem ok : True := by trivial\n",
+        ));
+        assert!(validate_lean_build(
+            &bundled_source,
+            None,
+            &["lake".to_string(), "build".to_string()],
+            &HashMap::new(),
+            &allowlist(),
+        )
+        .is_ok());
+
+        let bundle = bundled_source.bundle.as_mut().unwrap();
+        bundle.files[0].data_base64 = base64::engine::general_purpose::STANDARD.encode(b"tampered");
+        assert!(validate_lean_build(
+            &bundled_source,
+            None,
+            &["lake".to_string(), "build".to_string()],
+            &HashMap::new(),
+            &allowlist(),
+        )
+        .unwrap_err()
+        .contains("content hash mismatch"));
+
+        let mut unsafe_source = source(&"a".repeat(40));
+        unsafe_source.bundle = Some(source_bundle(".lake/build/poison", b"x"));
+        assert!(validate_lean_build(
+            &unsafe_source,
+            None,
+            &["lake".to_string(), "build".to_string()],
+            &HashMap::new(),
+            &allowlist(),
+        )
+        .unwrap_err()
+        .contains("unsafe source bundle path"));
+    }
+
+    #[tokio::test]
+    async fn source_bundle_application_is_atomic_and_emits_a_receipt() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkout = temp.path().join("checkout");
+        let log = temp.path().join("job.log");
+        tokio::fs::create_dir_all(checkout.join("Beal"))
+            .await
+            .unwrap();
+        tokio::fs::write(checkout.join("Beal/Proof.lean"), b"old")
+            .await
+            .unwrap();
+        let bundle = source_bundle("Beal/Proof.lean", b"new proof\n");
+
+        apply_source_bundle(&checkout, &bundle, &log).await.unwrap();
+
+        assert_eq!(
+            tokio::fs::read(checkout.join("Beal/Proof.lean"))
+                .await
+                .unwrap(),
+            b"new proof\n"
+        );
+        let receipt = tokio::fs::read_to_string(log).await.unwrap();
+        assert!(receipt.contains(&bundle.manifest_sha256));
+        assert!(receipt.contains("files=1 bytes=10"));
+    }
+
+    #[test]
     fn validation_rejects_local_repo_sources() {
         for bad in [
             "/srv/git/private.git",
@@ -1332,6 +1587,7 @@ mod tests {
                     &JobSource {
                         repo: bad.to_string(),
                         commit: "a".repeat(40),
+                        bundle: None,
                     },
                     None,
                     &["lake".to_string(), "build".to_string()],
@@ -1352,6 +1608,7 @@ mod tests {
                     &JobSource {
                         repo: good.to_string(),
                         commit: "a".repeat(40),
+                        bundle: None,
                     },
                     None,
                     &["lake".to_string(), "build".to_string()],
@@ -1543,14 +1800,17 @@ mod tests {
         let source_a = JobSource {
             repo: "https://example.com/a.git".to_string(),
             commit: "a".repeat(40),
+            bundle: None,
         };
         let source_a_next_commit = JobSource {
             repo: source_a.repo.clone(),
             commit: "b".repeat(40),
+            bundle: None,
         };
         let source_b = JobSource {
             repo: "https://example.com/b.git".to_string(),
             commit: "a".repeat(40),
+            bundle: None,
         };
         let build = vec!["lake".to_string(), "build".to_string(), "A".to_string()];
         let build_b = vec!["lake".to_string(), "build".to_string(), "B".to_string()];

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -38,6 +38,10 @@ pub struct JobHandle {
     /// handles keep this empty and must remain conservatively reserved.
     #[serde(default)]
     pub accepted_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Scratch capacity reserved for this job until it reaches terminal state.
+    /// Older ledgers deserialize this as zero.
+    #[serde(default)]
+    pub disk_reservation_bytes: u64,
     #[serde(default)]
     pub kind: JobHandleKind,
 }
@@ -121,6 +125,7 @@ mod tests {
             job_id,
             started_at: chrono::Utc::now(),
             accepted_at: Some(chrono::Utc::now()),
+            disk_reservation_bytes: 0,
             kind: JobHandleKind::Mission,
         };
 
@@ -145,6 +150,7 @@ mod tests {
                 job_id: Uuid::new_v4(),
                 started_at: chrono::Utc::now(),
                 accepted_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
                 kind: JobHandleKind::Mission,
             },
         )
@@ -193,6 +199,7 @@ mod tests {
             job_id,
             started_at: chrono::Utc::now(),
             accepted_at: None,
+            disk_reservation_bytes: 0,
             kind: JobHandleKind::Tentative,
         };
         record(dir.path(), handle.clone()).await.unwrap();

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -300,6 +300,30 @@ pub fn select_node_auto_with_resource_reservations(
     reservations: &HashMap<String, u32>,
     disk_reservations: &HashMap<String, u64>,
 ) -> Result<String, PlacementError> {
+    select_node_auto_with_protocol_and_resource_reservations(
+        nodes,
+        statuses,
+        requirements,
+        min_disk_bytes,
+        min_mem_bytes,
+        1,
+        reservations,
+        disk_reservations,
+    )
+}
+
+/// Resource-aware placement with a minimum wire-protocol capability. This is
+/// required for payload features old nodes would otherwise ignore.
+pub fn select_node_auto_with_protocol_and_resource_reservations(
+    nodes: &[RemoteNodeConfig],
+    statuses: &HashMap<String, CachedNodeStatus>,
+    requirements: &[String],
+    min_disk_bytes: u64,
+    min_mem_bytes: u64,
+    min_protocol_version: u32,
+    reservations: &HashMap<String, u32>,
+    disk_reservations: &HashMap<String, u64>,
+) -> Result<String, PlacementError> {
     let mut reasons: Vec<(String, String)> = Vec::new();
     // (queued, specialized, load, capacity, mem_avail, id)
     //
@@ -323,6 +347,16 @@ pub fn select_node_auto_with_resource_reservations(
             reasons.push((node.id.clone(), "no heartbeat data".to_string()));
             continue;
         };
+        if heartbeat.protocol_version < min_protocol_version {
+            reasons.push((
+                node.id.clone(),
+                format!(
+                    "protocol v{} is below required v{}",
+                    heartbeat.protocol_version, min_protocol_version
+                ),
+            ));
+            continue;
+        }
         if requirements.iter().any(|requirement| requirement == "lean")
             && heartbeat.lean_runtime_ready == Some(false)
         {
@@ -454,13 +488,35 @@ impl FleetMonitor {
         reservations: &HashMap<String, u32>,
         disk_reservations: &HashMap<String, u64>,
     ) -> Result<String, PlacementError> {
+        self.place_auto_with_protocol_and_resource_reservations(
+            settings,
+            requirements,
+            min_disk_bytes,
+            1,
+            reservations,
+            disk_reservations,
+        )
+    }
+
+    /// Like [`Self::place_auto_with_resource_reservations`], requiring a
+    /// minimum node protocol for semantic payload features.
+    pub fn place_auto_with_protocol_and_resource_reservations(
+        &self,
+        settings: &RemoteNodeSettings,
+        requirements: &[String],
+        min_disk_bytes: u64,
+        min_protocol_version: u32,
+        reservations: &HashMap<String, u32>,
+        disk_reservations: &HashMap<String, u64>,
+    ) -> Result<String, PlacementError> {
         let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
-        select_node_auto_with_resource_reservations(
+        select_node_auto_with_protocol_and_resource_reservations(
             &settings.nodes,
             &statuses,
             requirements,
             min_disk_bytes,
             env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
+            min_protocol_version,
             reservations,
             disk_reservations,
         )
@@ -709,7 +765,7 @@ mod tests {
             "capacity_available": capacity.saturating_sub(active),
             "active_leases": 0,
             "version": "test",
-            "protocol_version": 2,
+            "protocol_version": crate::remote_node::protocol::NODE_PROTOCOL_VERSION,
             "labels": labels,
             "mem_available_bytes": mem_gb * (1u64 << 30),
             "disk_available_bytes": disk_gb * (1u64 << 30),
@@ -1029,6 +1085,27 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.reasons[0].1.contains("85 GiB reserved"));
+    }
+
+    #[test]
+    fn placement_rejects_nodes_below_a_required_protocol() {
+        let node = node_config("old");
+        let mut status = cached_online("old", &["lean"], 100, 32, 2, 0, 0);
+        status.last_heartbeat.as_mut().unwrap().protocol_version = 2;
+        let statuses = HashMap::from([("old".to_string(), status)]);
+        let error = select_node_auto_with_protocol_and_resource_reservations(
+            &[node],
+            &statuses,
+            &["lean".to_string()],
+            20 * GIB,
+            8 * GIB,
+            3,
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .unwrap_err();
+        assert!(error.reasons[0].1.contains("protocol v2"));
+        assert!(error.reasons[0].1.contains("required v3"));
     }
 
     #[test]

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -277,6 +277,29 @@ pub fn select_node_auto_with_reservations(
     min_mem_bytes: u64,
     reservations: &HashMap<String, u32>,
 ) -> Result<String, PlacementError> {
+    select_node_auto_with_resource_reservations(
+        nodes,
+        statuses,
+        requirements,
+        min_disk_bytes,
+        min_mem_bytes,
+        reservations,
+        &HashMap::new(),
+    )
+}
+
+/// Capacity-aware placement with both in-flight job-count reservations and
+/// future scratch-space reservations that heartbeat free-space figures cannot
+/// yet reflect.
+pub fn select_node_auto_with_resource_reservations(
+    nodes: &[RemoteNodeConfig],
+    statuses: &HashMap<String, CachedNodeStatus>,
+    requirements: &[String],
+    min_disk_bytes: u64,
+    min_mem_bytes: u64,
+    reservations: &HashMap<String, u32>,
+    disk_reservations: &HashMap<String, u64>,
+) -> Result<String, PlacementError> {
     let mut reasons: Vec<(String, String)> = Vec::new();
     // (queued, specialized, load, capacity, mem_avail, id)
     //
@@ -320,13 +343,16 @@ pub fn select_node_auto_with_reservations(
             reasons.push((node.id.clone(), format!("missing label '{missing}'")));
             continue;
         }
-        if heartbeat.disk_available_bytes < min_disk_bytes {
+        let disk_reserved = disk_reservations.get(&node.id).copied().unwrap_or(0);
+        let effective_disk_available = heartbeat.disk_available_bytes.saturating_sub(disk_reserved);
+        if effective_disk_available < min_disk_bytes {
             reasons.push((
                 node.id.clone(),
                 format!(
-                    "low disk ({} GiB available, {} GiB required)",
-                    heartbeat.disk_available_bytes / (1 << 30),
-                    min_disk_bytes / (1 << 30)
+                    "low disk ({} GiB effective available after {} GiB reserved, {} GiB required)",
+                    effective_disk_available / (1 << 30),
+                    disk_reserved / (1 << 30),
+                    min_disk_bytes / (1 << 30),
                 ),
             ));
             continue;
@@ -415,6 +441,28 @@ impl FleetMonitor {
             env_gb_bytes("REMOTE_NODE_MIN_DISK_GB", DEFAULT_MIN_DISK_GB),
             env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
             reservations,
+        )
+    }
+
+    /// Like [`Self::place_auto_with_reservations`], with an explicit disk
+    /// admission floor and scratch reservations for non-terminal jobs.
+    pub fn place_auto_with_resource_reservations(
+        &self,
+        settings: &RemoteNodeSettings,
+        requirements: &[String],
+        min_disk_bytes: u64,
+        reservations: &HashMap<String, u32>,
+        disk_reservations: &HashMap<String, u64>,
+    ) -> Result<String, PlacementError> {
+        let statuses = self.statuses.read().unwrap_or_else(|e| e.into_inner());
+        select_node_auto_with_resource_reservations(
+            &settings.nodes,
+            &statuses,
+            requirements,
+            min_disk_bytes,
+            env_gb_bytes("REMOTE_NODE_MIN_MEM_GB", DEFAULT_MIN_MEM_GB),
+            reservations,
+            disk_reservations,
         )
     }
 }
@@ -942,6 +990,45 @@ mod tests {
         )
         .unwrap();
         assert_eq!(picked, "b");
+    }
+
+    #[test]
+    fn placement_subtracts_nonterminal_disk_reservations() {
+        let nodes = vec![node_config("a"), node_config("b")];
+        let statuses = HashMap::from([
+            (
+                "a".to_string(),
+                cached_online("a", &["lean"], 100, 64, 4, 0, 0),
+            ),
+            (
+                "b".to_string(),
+                cached_online("b", &["lean"], 40, 32, 4, 0, 0),
+            ),
+        ]);
+        let disk_reservations = HashMap::from([("a".to_string(), 85 * GIB)]);
+        let picked = select_node_auto_with_resource_reservations(
+            &nodes,
+            &statuses,
+            &["lean".to_string()],
+            20 * GIB,
+            8 * GIB,
+            &HashMap::new(),
+            &disk_reservations,
+        )
+        .unwrap();
+        assert_eq!(picked, "b");
+
+        let error = select_node_auto_with_resource_reservations(
+            &[node_config("a")],
+            &statuses,
+            &["lean".to_string()],
+            20 * GIB,
+            8 * GIB,
+            &HashMap::new(),
+            &disk_reservations,
+        )
+        .unwrap_err();
+        assert!(error.reasons[0].1.contains("85 GiB reserved"));
     }
 
     #[test]

--- a/src/remote_node/monitor.rs
+++ b/src/remote_node/monitor.rs
@@ -314,6 +314,7 @@ pub fn select_node_auto_with_resource_reservations(
 
 /// Resource-aware placement with a minimum wire-protocol capability. This is
 /// required for payload features old nodes would otherwise ignore.
+#[allow(clippy::too_many_arguments)] // Pure placement inputs stay explicit for auditability.
 pub fn select_node_auto_with_protocol_and_resource_reservations(
     nodes: &[RemoteNodeConfig],
     statuses: &HashMap<String, CachedNodeStatus>,

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -16,6 +16,8 @@ type HmacSha256 = Hmac<Sha256>;
 
 /// Current node protocol version reported by heartbeats.
 pub const NODE_PROTOCOL_VERSION: u32 = 3;
+/// First protocol that reports `active_jobs` and `queued_jobs` in heartbeats.
+pub const NODE_JOB_COUNTER_PROTOCOL_VERSION: u32 = 2;
 
 /// Lease scope for the synchronous `/execute` path.
 pub const SCOPE_MISSION_EXECUTE: &str = "mission:execute";

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -14,8 +14,8 @@ use super::RemoteNodeError;
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Protocol version reported by heartbeat v2 nodes.
-pub const NODE_PROTOCOL_VERSION: u32 = 2;
+/// Current node protocol version reported by heartbeats.
+pub const NODE_PROTOCOL_VERSION: u32 = 3;
 
 /// Lease scope for the synchronous `/execute` path.
 pub const SCOPE_MISSION_EXECUTE: &str = "mission:execute";

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -125,6 +125,24 @@ pub struct JobSource {
     /// Full 40-char lowercase hex commit SHA. Branch names are rejected so a
     /// job always builds a pinned, reproducible tree.
     pub commit: String,
+    /// Optional bounded overlay applied after resetting the pinned checkout.
+    /// This lets a local-only proof source run remotely without creating or
+    /// pushing a Git commit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle: Option<SourceBundle>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceBundleFile {
+    pub path: String,
+    pub sha256: String,
+    pub data_base64: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceBundle {
+    pub manifest_sha256: String,
+    pub files: Vec<SourceBundleFile>,
 }
 
 /// One artifact produced by a build job, relative to the checkout root.
@@ -168,6 +186,10 @@ pub enum JobPayload {
         /// `SANDBOXED_NODE_MAX_JOB_SECS`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout_secs: Option<u64>,
+        /// Expected peak scratch consumption. Node and core admission reserve
+        /// this capacity before accepting the job.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        estimated_disk_bytes: Option<u64>,
         /// Lake cache slot key. Defaults to a digest of the checkout's
         /// `lean-toolchain` + `lake-manifest.json` contents.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -464,10 +486,12 @@ mod tests {
             source: JobSource {
                 repo: "https://github.com/example/verity.git".to_string(),
                 commit: "a".repeat(40),
+                bundle: None,
             },
             cwd_rel: Some("morpho-verity".to_string()),
             command: vec!["lake".to_string(), "build".to_string()],
             timeout_secs: Some(3600),
+            estimated_disk_bytes: Some(12 << 30),
             cache_key: Some("abc123".to_string()),
             artifacts: vec![".lake/build/lib/*".to_string()],
             env: [("LEAN_NUM_THREADS".to_string(), "4".to_string())]
@@ -491,6 +515,7 @@ mod tests {
             JobPayload::LeanBuild {
                 cwd_rel,
                 timeout_secs,
+                estimated_disk_bytes,
                 cache_key,
                 artifacts,
                 env,
@@ -498,6 +523,7 @@ mod tests {
             } => {
                 assert_eq!(cwd_rel, None);
                 assert_eq!(timeout_secs, None);
+                assert_eq!(estimated_disk_bytes, None);
                 assert_eq!(cache_key, None);
                 assert!(artifacts.is_empty());
                 assert!(env.is_empty());

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -391,6 +391,16 @@ impl Workspace {
         {
             m.insert("REMOTE_BUILD_TIMEOUT_SECS".to_string(), timeout.to_string());
         }
+        if let Some(estimated_disk_gb) = remote_config
+            .and_then(|config| config.get("estimated_disk_gb"))
+            .and_then(|value| value.as_u64())
+            .filter(|value| *value > 0)
+        {
+            m.insert(
+                "REMOTE_BUILD_ESTIMATED_DISK_GB".to_string(),
+                estimated_disk_gb.to_string(),
+            );
+        }
         let wrapper = remote_build_wrapper_path(self, mission_id);
         m.insert(
             "REMOTE_BUILD_COMMAND".to_string(),


### PR DESCRIPTION
## What changed

- keep warn-level Hermes operation alive for small/no-build lanes instead of treating it as a fleet-wide stop
- add local mission scratch estimates and an emergency reserve
- reserve declared scratch capacity during remote placement and re-check it on the runner
- ship bounded, content-hashed dirty Lean source overlays to a pinned remote checkout
- reuse content-addressed Lake dependency caches with CoW reflinks when supported
- document retention, admission, and continuity behavior

## Root cause

Repeated cold Mathlib hydration consumed the production host's remaining disk. The controller classified the host-wide warning as a global fleet blocker, although several remote Lean nodes had ample storage. Dirty local proof work could not move because the remote path accepted only a pushed commit, and placement tracked slots but not future scratch demand.

## Validation

- `cargo test --all-targets` — 1,397 passed, 1 ignored
- `cargo check --all-targets`
- `cargo fmt --all --check`
- `bash -n scripts/remote-lean-build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission admission, remote placement, job ledger semantics, and node build execution—areas that can block work or mis-place builds if misconfigured, but changes are fail-closed with protocol gating and extensive tests.
> 
> **Overview**
> Adds **disk-aware admission** so warn-level operation can continue for light lanes while heavy work is gated or offloaded instead of treating disk pressure as a fleet-wide stop.
> 
> **Local missions** can declare `estimated_disk_gib`; creation fails with `INSUFFICIENT_STORAGE` only when that estimate plus `MISSION_DISK_EMERGENCY_RESERVE_GB` would breach free space (remote missions skip this check). MCP create-mission paths expose the same field.
> 
> **Remote Lean builds** carry `estimated_disk_bytes` (default 12 GiB). Core records scratch reservations on the job ledger until jobs finish; auto-placement subtracts reserved bytes from heartbeat free disk and requires estimate + emergency floor. Explicit node picks get the same effective-disk check. Ledger load failures fail placement closed.
> 
> **`remote-lean-build`** no longer rejects a dirty tree for new submits. It builds a bounded, content-hashed **source bundle** from modified/untracked Lean-related files (deletions/renames/symlinks/oversize bundles fail with exit 2) and sends `estimated_disk_bytes`. Receipts store `source_bundle_sha256` instead of full bundle payloads.
> 
> **Nodes** bump heartbeat to **protocol v3**; source-bundle jobs require v3 so older runners cannot silently ignore overlays. Runners validate and apply bundles after `git reset`/`clean`, enforce scratch admission via `SANDBOXED_NODE_MIN_FREE_GB`, and use `cp --reflink=auto` on Linux for cache copies.
> 
> Docs and `.env.example` document the new env knobs and continuity behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5320d19c205a39f7bcf414fb9059023022947b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->