### PR TITLE
Harden storage lifecycle and simplify Hermes control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,14 +205,23 @@ JWT_TTL_DAYS=30
 #
 # Disk health thresholds (percent of root filesystem used). At warn, alerts
 # fire; at critical, new mission creation is refused (DISK_ADMISSION_ENABLED=0
-# to bypass). Alerts repeat every DISK_ALERT_REPEAT_HOURS while elevated.
+# to bypass). Set DISK_ADMISSION_AT_WARN=1 on build-heavy hosts to stop earlier.
+# Alerts repeat every DISK_ALERT_REPEAT_HOURS while elevated.
 # DISK_WARN_PCT=90
 # DISK_CRITICAL_PCT=95
 # DISK_ADMISSION_ENABLED=1
+# DISK_ADMISSION_AT_WARN=0
 # Local disk-heavy mission requests can declare `estimated_disk_gib`; they are
-# rejected before creation if this emergency floor would be crossed.
+# rejected before creation if this emergency floor would be crossed. Setting a
+# default estimate makes omitted estimates fail safe for all local missions.
 # MISSION_DISK_EMERGENCY_RESERVE_GB=64
+# MISSION_DISK_DEFAULT_ESTIMATE_GIB=
 # DISK_ALERT_REPEAT_HOURS=24
+# Executing mission-workspace GC is opt-in. The scan defaults to hourly; lower
+# the interval on high-churn build hosts. Default retention is 1 day for
+# terminal missions and 7 days for AwaitingUser/Paused missions.
+# WORKSPACE_GC_EXECUTE=0
+# WORKSPACE_GC_INTERVAL_MINUTES=60
 #
 # Exec-scope lifecycle. Mission-end teardown stops a mission's
 # sandboxed-exec-*.scope units (harness processes); the periodic reaper

--- a/dashboard/src/components/hermes/alerts-feed.test.tsx
+++ b/dashboard/src/components/hermes/alerts-feed.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { listAlerts } from "@/lib/api";
+import { AlertsFeed } from "./alerts-feed";
+
+vi.mock("@/lib/api", () => ({
+  listAlerts: vi.fn(),
+}));
+
+const mockedListAlerts = vi.mocked(listAlerts);
+
+describe("AlertsFeed", () => {
+  beforeEach(() => {
+    mockedListAlerts.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("stops pagination after the final older page", async () => {
+    mockedListAlerts
+      .mockResolvedValueOnce({
+        alerts: [alert("mission-1", "2026-07-10T10:00:00Z")],
+        next_cursor: "cursor-1",
+      })
+      .mockResolvedValueOnce({
+        alerts: [alert("mission-2", "2026-07-09T10:00:00Z")],
+        next_cursor: null,
+      });
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <AlertsFeed />
+      </SWRConfig>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Load older" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Load older" })).not.toBeInTheDocument();
+    });
+    expect(mockedListAlerts).toHaveBeenCalledTimes(2);
+  });
+});
+
+function alert(missionId: string, timestamp: string) {
+  return {
+    mission_id: missionId,
+    status: "completed",
+    summary: "Mission completed",
+    timestamp,
+  };
+}

--- a/dashboard/src/components/hermes/hermes-page.test.tsx
+++ b/dashboard/src/components/hermes/hermes-page.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getHermesAssistantStatus, getHermesMissionControl } from "@/lib/api";
+import HermesPage from "./hermes-page";
+
+vi.mock("@/lib/api", () => ({
+  getHermesAssistantStatus: vi.fn(),
+  getHermesMissionControl: vi.fn(),
+}));
+
+vi.mock("@/components/hermes/hermes-thread", () => ({
+  HermesThread: () => <div data-testid="hermes-thread">conversation</div>,
+}));
+
+vi.mock("@/components/hermes/alerts-feed", () => ({
+  AlertsFeed: () => <div>updates</div>,
+}));
+
+const mockedStatus = vi.mocked(getHermesAssistantStatus);
+const mockedControl = vi.mocked(getHermesMissionControl);
+
+describe("HermesPage", () => {
+  beforeEach(() => {
+    mockedStatus.mockReset();
+    mockedControl.mockReset();
+    mockedStatus.mockResolvedValue({
+      service_name: "hermes-assistant",
+      service_active: true,
+      model: "builtin/smart",
+      env_path: "",
+      config_path: "",
+      env_present: true,
+      config_present: true,
+      token_present: true,
+      telegram_ok: true,
+      telegram_bot_username: null,
+      telegram_webhook_configured: false,
+      telegram_pending_update_count: 0,
+      telegram_last_error: null,
+      notes: [],
+    });
+    mockedControl.mockResolvedValue({
+      generated_at: "2026-07-10T10:00:00Z",
+      runtime: {
+        service_name: "hermes-assistant",
+        service_active: true,
+        model: "builtin/smart",
+        base_url: "http://localhost:3000/v1",
+        expected_base_url: "http://localhost:3000/v1",
+        uses_sandboxed_proxy: true,
+        env_present: true,
+        config_present: true,
+        token_present: true,
+        notes: [],
+      },
+      sessions: {
+        since: "2026-07-07T10:00:00Z",
+        total: 2,
+        by_source: { api_server: 2 },
+        messages: 10,
+        tool_calls: 3,
+        open: 1,
+      },
+      active: [],
+      needs_attention: [],
+      handled_recently: [],
+      failures: [],
+      mission_status_counts: {},
+      remote_nodes: {
+        enabled: false,
+        configured_nodes: 0,
+        status: "disabled",
+        notes: [],
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("keeps conversation primary and mission control closed by default", async () => {
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <HermesPage />
+      </SWRConfig>,
+    );
+
+    expect(await screen.findByTestId("hermes-thread")).toBeVisible();
+    expect(screen.queryByRole("dialog", { name: "Mission control" })).not.toBeInTheDocument();
+
+    const missionsButton = screen.getByRole("button", { name: "Missions" });
+    missionsButton.focus();
+    fireEvent.click(missionsButton);
+    expect(screen.getByRole("dialog", { name: "Mission control" })).toBeVisible();
+
+    fireEvent.click(missionsButton);
+    expect(screen.queryByRole("dialog", { name: "Mission control" })).not.toBeInTheDocument();
+
+    missionsButton.focus();
+    fireEvent.click(missionsButton);
+    expect(screen.getByRole("dialog", { name: "Mission control" })).toBeVisible();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Mission control" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Missions" })).toHaveFocus();
+  });
+});

--- a/dashboard/src/components/hermes/hermes-page.tsx
+++ b/dashboard/src/components/hermes/hermes-page.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import type { ReactNode } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import useSWR from "swr";
 import type { LucideIcon } from "lucide-react";
 import {
   Activity,
   AlertTriangle,
   ArrowUpRight,
+  Bell,
   Bot,
   CheckCircle2,
   CircleOff,
@@ -15,6 +22,7 @@ import {
   Loader,
   MessageSquare,
   RadioTower,
+  X,
 } from "lucide-react";
 
 import {
@@ -28,6 +36,11 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { cn } from "@/lib/utils";
 
 export default function HermesPage() {
+  const [openPanel, setOpenPanel] = useState<"missions" | "updates" | null>(
+    null,
+  );
+  const missionsButtonRef = useRef<HTMLButtonElement | null>(null);
+  const updatesButtonRef = useRef<HTMLButtonElement | null>(null);
   const { data: status, isLoading } = useSWR(
     "hermes-assistant-status",
     getHermesAssistantStatus,
@@ -45,14 +58,37 @@ export default function HermesPage() {
   const sessionSources = Object.entries(control?.sessions.by_source ?? {})
     .sort((a, b) => b[1] - a[1])
     .slice(0, 4);
+  const attentionCount = control?.needs_attention.length ?? 0;
+
+  const closePanel = useCallback((restoreFocus = false) => {
+    setOpenPanel((current) => {
+      if (restoreFocus) {
+        const button =
+          current === "missions"
+            ? missionsButtonRef.current
+            : updatesButtonRef.current;
+        window.setTimeout(() => button?.focus(), 0);
+      }
+      return null;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!openPanel) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closePanel(true);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [closePanel, openPanel]);
 
   return (
     <div className="flex flex-col lg:h-screen lg:overflow-hidden">
-      <div className="flex items-center justify-between border-b border-white/[0.06] px-6 py-4">
+      <div className="relative z-[60] flex items-center justify-between border-b border-white/[0.06] bg-[rgb(var(--background))] px-6 py-4">
         <div>
           <h1 className="text-xl font-semibold text-white">Hermes</h1>
           <p className="text-sm text-white/50">
-            Mission control, assistant runtime, and operator chat.
+            Your assistant for missions, follow-ups, and answers.
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -73,120 +109,219 @@ export default function HermesPage() {
             />
             {isLoading ? "checking..." : runtimeReady ? "online" : "offline"}
           </span>
+          <button
+            ref={missionsButtonRef}
+            type="button"
+            onClick={() =>
+              setOpenPanel((current) =>
+                current === "missions" ? null : "missions",
+              )
+            }
+            className="relative inline-flex items-center gap-1.5 rounded-lg border border-white/[0.06] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/[0.06] hover:text-white/85"
+          >
+            <Activity className="h-3.5 w-3.5" />
+            Missions
+            {attentionCount > 0 && (
+              <span className="inline-flex min-w-4 items-center justify-center rounded-full bg-amber-400/15 px-1 text-[10px] font-medium text-amber-200">
+                {attentionCount}
+              </span>
+            )}
+          </button>
+          <button
+            ref={updatesButtonRef}
+            type="button"
+            aria-label="Open mission updates"
+            onClick={() =>
+              setOpenPanel((current) =>
+                current === "updates" ? null : "updates",
+              )
+            }
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-white/[0.06] bg-white/[0.03] text-white/50 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+            title="Mission updates"
+          >
+            <Bell className="h-3.5 w-3.5" />
+          </button>
           <Link
             href="/assistant"
-            className="inline-flex items-center gap-1 text-xs text-white/45 transition-colors hover:text-white/75"
+            className="hidden items-center gap-1 text-xs text-white/45 transition-colors hover:text-white/75 sm:inline-flex"
           >
             Manage <ArrowUpRight className="h-3 w-3" />
           </Link>
         </div>
       </div>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden xl:grid-cols-[minmax(420px,1fr)_360px_300px]">
-        <main className="min-h-0 overflow-y-auto px-5 py-4">
-          {controlLoading && !control ? (
-            <div className="flex items-center gap-2 text-sm text-white/45">
-              <Loader className="h-4 w-4 animate-spin" /> Loading mission control...
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <section className="grid grid-cols-1 gap-3 md:grid-cols-3">
-                <Metric
-                  icon={Activity}
-                  label="Active"
-                  value={String(control?.active.length ?? 0)}
-                  detail={`${control?.mission_status_counts.active ?? 0} running / ${control?.mission_status_counts.waiting_background ?? 0} background`}
-                />
-                <Metric
-                  icon={AlertTriangle}
-                  label="Needs Attention"
-                  value={String(control?.needs_attention.length ?? 0)}
-                  detail={
-                    control?.failures[0]
-                      ? `${control.failures[0].class}: ${control.failures[0].count}`
-                      : "No grouped failures"
-                  }
-                  tone={(control?.needs_attention.length ?? 0) > 0 ? "warn" : "ok"}
-                />
-                <Metric
-                  icon={MessageSquare}
-                  label="Hermes Sessions"
-                  value={String(control?.sessions.total ?? 0)}
-                  detail={`${control?.sessions.messages ?? 0} messages / ${control?.sessions.tool_calls ?? 0} tools`}
-                />
-              </section>
-
-              <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                <RuntimePanel
-                  serviceActive={runtimeReady}
-                  model={runtime?.model ?? status?.model ?? null}
-                  baseUrl={runtime?.base_url ?? null}
-                  expectedBaseUrl={runtime?.expected_base_url ?? null}
-                  usesProxy={runtime?.uses_sandboxed_proxy ?? false}
-                  notes={runtime?.notes ?? status?.notes ?? []}
-                />
-                <Panel title="Watchers" icon={RadioTower}>
-                  <div className="space-y-2">
-                    {sessionSources.length === 0 ? (
-                      <p className="text-xs text-white/35">
-                        No recent Hermes session activity.
-                      </p>
-                    ) : (
-                      sessionSources.map(([source, count]) => (
-                        <div
-                          key={source}
-                          className="flex items-center justify-between text-xs"
-                        >
-                          <span className="capitalize text-white/65">{source}</span>
-                          <span className="font-mono text-white/40">{count}</span>
-                        </div>
-                      ))
-                    )}
-                    <div className="border-t border-white/[0.06] pt-2 text-xs text-white/40">
-                      Remote nodes:{" "}
-                      {control?.remote_nodes.enabled ? "enabled" : "disabled"}
-                      {control?.remote_nodes.configured_nodes
-                        ? ` / ${control.remote_nodes.configured_nodes} configured`
-                        : ""}
-                    </div>
-                  </div>
-                </Panel>
-              </section>
-
-              <MissionList
-                title="Now"
-                icon={Clock3}
-                missions={control?.active ?? []}
-                empty="No active supervised missions."
-              />
-              <MissionList
-                title="Needs Attention"
-                icon={AlertTriangle}
-                missions={control?.needs_attention ?? []}
-                empty="No stuck or failed missions in the current scan."
-              />
-              <MissionList
-                title="Handled Recently"
-                icon={CheckCircle2}
-                missions={control?.handled_recently ?? []}
-                empty="No recent acknowledged missions."
-              />
-            </div>
-          )}
-        </main>
-
-        <aside className="min-h-0 border-t border-white/[0.06] xl:border-l xl:border-t-0">
+      <main className="mx-auto min-h-0 w-full max-w-5xl flex-1 overflow-hidden border-x border-white/[0.04]">
+        <div className="h-full min-h-[560px]">
           {runtimeReady || runtimeChecking ? (
             <HermesThread className="h-full" />
           ) : (
             <HermesOfflinePanel />
           )}
-        </aside>
+        </div>
+      </main>
 
-        <aside className="min-h-0 border-t border-white/[0.06] p-4 xl:border-l xl:border-t-0">
+      {openPanel === "missions" && (
+        <Drawer title="Mission control" onClose={() => closePanel()}>
+          {controlLoading && !control ? (
+            <div className="flex items-center gap-2 text-sm text-white/45">
+              <Loader className="h-4 w-4 animate-spin" /> Loading mission
+              control...
+            </div>
+          ) : (
+            <MissionControlContent
+              control={control}
+              runtimeReady={runtimeReady}
+              runtimeModel={runtime?.model ?? status?.model ?? null}
+              sessionSources={sessionSources}
+            />
+          )}
+        </Drawer>
+      )}
+
+      {openPanel === "updates" && (
+        <Drawer title="Mission updates" onClose={() => closePanel()}>
           <AlertsFeed />
-        </aside>
-      </div>
+        </Drawer>
+      )}
+    </div>
+  );
+}
+
+function Drawer({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <button
+        type="button"
+        aria-label={`Close ${title}`}
+        onClick={onClose}
+        className="absolute inset-0 bg-black/55 backdrop-blur-sm"
+      />
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="relative flex h-full w-full max-w-[560px] animate-fade-in flex-col border-l border-white/[0.08] bg-[rgb(var(--background-elevated))] shadow-2xl"
+      >
+        <div className="flex h-16 shrink-0 items-center justify-between border-b border-white/[0.06] px-5">
+          <h2 className="text-sm font-semibold text-white/90">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={`Close ${title}`}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-white/45 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">{children}</div>
+      </section>
+    </div>
+  );
+}
+
+function MissionControlContent({
+  control,
+  runtimeReady,
+  runtimeModel,
+  sessionSources,
+}: {
+  control: Awaited<ReturnType<typeof getHermesMissionControl>> | undefined;
+  runtimeReady: boolean;
+  runtimeModel: string | null;
+  sessionSources: [string, number][];
+}) {
+  const runtime = control?.runtime;
+  return (
+    <div className="space-y-4">
+      <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Metric
+          icon={Activity}
+          label="Active"
+          value={String(control?.active.length ?? 0)}
+          detail={`${control?.mission_status_counts.active ?? 0} running / ${control?.mission_status_counts.waiting_background ?? 0} background`}
+        />
+        <Metric
+          icon={AlertTriangle}
+          label="Needs Attention"
+          value={String(control?.needs_attention.length ?? 0)}
+          detail={
+            control?.failures[0]
+              ? `${control.failures[0].class}: ${control.failures[0].count}`
+              : "No grouped failures"
+          }
+          tone={(control?.needs_attention.length ?? 0) > 0 ? "warn" : "ok"}
+        />
+        <Metric
+          icon={MessageSquare}
+          label="Hermes Sessions"
+          value={String(control?.sessions.total ?? 0)}
+          detail={`${control?.sessions.messages ?? 0} messages / ${control?.sessions.tool_calls ?? 0} tools`}
+        />
+      </section>
+
+      <RuntimePanel
+        serviceActive={runtimeReady}
+        model={runtimeModel}
+        baseUrl={runtime?.base_url ?? null}
+        expectedBaseUrl={runtime?.expected_base_url ?? null}
+        usesProxy={runtime?.uses_sandboxed_proxy ?? false}
+        notes={runtime?.notes ?? []}
+      />
+
+      {(sessionSources.length > 0 || control?.remote_nodes.enabled) && (
+        <Panel title="Watchers" icon={RadioTower}>
+          <div className="space-y-2">
+            {sessionSources.map(([source, count]) => (
+              <div
+                key={source}
+                className="flex items-center justify-between text-xs"
+              >
+                <span className="capitalize text-white/65">{source}</span>
+                <span className="font-mono text-white/40">{count}</span>
+              </div>
+            ))}
+            {control?.remote_nodes.enabled && (
+              <div className="border-t border-white/[0.06] pt-2 text-xs text-white/40">
+                Remote nodes enabled
+                {control.remote_nodes.configured_nodes
+                  ? ` / ${control.remote_nodes.configured_nodes} configured`
+                  : ""}
+              </div>
+            )}
+          </div>
+        </Panel>
+      )}
+
+      <MissionList
+        title="Now"
+        icon={Clock3}
+        missions={control?.active ?? []}
+        empty="No active supervised missions."
+      />
+      {(control?.needs_attention.length ?? 0) > 0 && (
+        <MissionList
+          title="Needs Attention"
+          icon={AlertTriangle}
+          missions={control?.needs_attention ?? []}
+          empty=""
+        />
+      )}
+      {(control?.handled_recently.length ?? 0) > 0 && (
+        <MissionList
+          title="Handled Recently"
+          icon={CheckCircle2}
+          missions={control?.handled_recently ?? []}
+          empty=""
+        />
+      )}
     </div>
   );
 }

--- a/dashboard/src/components/hermes/hermes-thread.test.tsx
+++ b/dashboard/src/components/hermes/hermes-thread.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createHermesSession,
+  hermesChatStream,
+  listHermesSessions,
+} from "@/lib/api";
+import { HermesThread } from "./hermes-thread";
+
+vi.mock("@/lib/api", () => ({
+  createHermesSession: vi.fn(),
+  deleteHermesSession: vi.fn(),
+  getHermesSessionMessages: vi.fn(),
+  hermesChatStream: vi.fn(),
+  listHermesSessions: vi.fn(),
+}));
+
+vi.mock("@/components/markdown-content", () => ({
+  LazyMarkdownContent: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+const mockedCreateHermesSession = vi.mocked(createHermesSession);
+const mockedHermesChatStream = vi.mocked(hermesChatStream);
+const mockedListHermesSessions = vi.mocked(listHermesSessions);
+
+describe("HermesThread", () => {
+  beforeEach(() => {
+    mockedCreateHermesSession.mockReset();
+    mockedHermesChatStream.mockReset();
+    mockedListHermesSessions.mockReset();
+    mockedListHermesSessions.mockResolvedValue([]);
+    mockedCreateHermesSession.mockResolvedValue({ id: "session-1" });
+    mockedHermesChatStream.mockImplementation(
+      (_sessionId, _message, _handlers, signal) =>
+        new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("returns to an idle composer when a new conversation cancels a stream", async () => {
+    render(<HermesThread className="h-full" />);
+
+    fireEvent.change(screen.getByPlaceholderText("Message Hermes…"), {
+      target: { value: "Check every active mission" },
+    });
+    fireEvent.click(screen.getByTitle("Send"));
+
+    expect(await screen.findByTitle("Stop")).toBeVisible();
+    fireEvent.click(screen.getByTitle("New conversation"));
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Send")).toBeVisible();
+      expect(screen.queryByText("Hermes is working…")).not.toBeInTheDocument();
+    });
+  });
+
+  test("fills the composer from a mission action without sending immediately", () => {
+    render(<HermesThread />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Review attention" }));
+
+    expect(screen.getByPlaceholderText("Message Hermes…")).toHaveValue(
+      "Review the missions that need my attention and recommend the next action for each.",
+    );
+    expect(mockedHermesChatStream).not.toHaveBeenCalled();
+  });
+
+  test("preserves a failed draft and offers retry next to the composer", async () => {
+    mockedCreateHermesSession.mockRejectedValueOnce(
+      new Error("Could not start a Hermes conversation (403)"),
+    );
+    render(<HermesThread />);
+
+    const composer = screen.getByPlaceholderText("Message Hermes…");
+    fireEvent.change(composer, { target: { value: "Review active missions" } });
+    fireEvent.click(screen.getByTitle("Send"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not start a Hermes conversation (403)",
+    );
+    expect(composer).toHaveValue("Review active missions");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeVisible();
+  });
+});

--- a/dashboard/src/components/hermes/hermes-thread.tsx
+++ b/dashboard/src/components/hermes/hermes-thread.tsx
@@ -192,9 +192,14 @@ export function HermesThread({ className }: { className?: string }) {
   const newSession = useCallback(() => {
     genRef.current += 1;
     abortRef.current?.abort();
+    abortRef.current = null;
+    streamAssistantIdRef.current = null;
+    streamThinkingIdRef.current = null;
     setSessionId(null);
     setItems([]);
     setError(null);
+    setLoading(false);
+    setHistoryLoading(false);
     setShowSessions(false);
   }, []);
 
@@ -460,12 +465,36 @@ export function HermesThread({ className }: { className?: string }) {
         )}
         {!historyLoading && items.length === 0 && (
           <div className="mt-16 text-center">
-            <p className="text-sm text-white/60">Talk to Hermes</p>
+            <p className="text-sm text-white/60">What should Hermes handle?</p>
             <p className="mx-auto mt-1 max-w-sm text-xs text-white/35">
               Your assistant can start missions, check on running ones and
               answer questions about your fleet. Mission IDs it mentions become
               clickable.
             </p>
+            <div className="mt-4 flex flex-wrap justify-center gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  setInput(
+                    "Review the missions that need my attention and recommend the next action for each.",
+                  )
+                }
+                className="rounded-lg border border-white/[0.07] bg-white/[0.03] px-3 py-1.5 text-xs text-white/55 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+              >
+                Review attention
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setInput(
+                    "Summarize the active missions, their latest progress, and anything currently blocked.",
+                  )
+                }
+                className="rounded-lg border border-white/[0.07] bg-white/[0.03] px-3 py-1.5 text-xs text-white/55 transition-colors hover:bg-white/[0.06] hover:text-white/80"
+              >
+                Summarize active work
+              </button>
+            </div>
           </div>
         )}
         {items.map((item) => (
@@ -477,7 +506,10 @@ export function HermesThread({ className }: { className?: string }) {
           </div>
         )}
         {error && (
-          <p className="rounded-lg border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+          <p
+            role="alert"
+            className="rounded-lg border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-300"
+          >
             {error}
           </p>
         )}
@@ -485,6 +517,17 @@ export function HermesThread({ className }: { className?: string }) {
 
       {/* Composer — same row grammar as the Ask panel composer */}
       <div className="border-t border-white/[0.06] px-6 py-3">
+        {error && input.trim() && !loading && (
+          <div className="mb-2 flex justify-end">
+            <button
+              type="button"
+              onClick={() => void send()}
+              className="rounded-md border border-red-400/20 bg-red-400/10 px-2 py-1 text-[11px] font-medium text-red-200 transition-colors hover:bg-red-400/15"
+            >
+              Retry
+            </button>
+          </div>
+        )}
         <div className="flex items-center gap-2 rounded-xl border border-[rgb(var(--foreground)/0.08)] bg-[rgb(var(--foreground)/0.03)] px-3.5 py-2 transition-[border-color] duration-150 ease-out focus-within:border-indigo-400/50">
           <textarea
             ref={textareaRef}

--- a/dashboard/src/lib/api/hermes.test.ts
+++ b/dashboard/src/lib/api/hermes.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { apiFetch } from "./core";
+import { createHermesSession, hermesChatStream } from "./hermes";
+
+vi.mock("./core", () => ({
+  apiDel: vi.fn(),
+  apiFetch: vi.fn(),
+  apiGet: vi.fn(),
+  apiPatch: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+describe("Hermes chat stream", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  test("parses valid SSE streams that use CRLF separators", async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'event: assistant.delta\r\ndata: {"delta":"Hello"}\r\n\r\n',
+          ),
+        );
+        controller.enqueue(
+          encoder.encode(
+            'event: assistant.completed\r\ndata: {"content":"Hello there"}\r\n\r\nevent: done\r\ndata: {}\r\n\r\n',
+          ),
+        );
+        controller.close();
+      },
+    });
+    mockedApiFetch.mockResolvedValue(new Response(body, { status: 200 }));
+    const onDelta = vi.fn();
+    const onCompleted = vi.fn();
+    const onError = vi.fn();
+
+    await hermesChatStream(
+      "session-1",
+      "hello",
+      { onDelta, onCompleted, onError },
+    );
+
+    expect(onDelta).toHaveBeenCalledWith("Hello");
+    expect(onCompleted).toHaveBeenCalledWith("Hello there");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("surfaces session creation status and upstream detail", async () => {
+    mockedApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Origin not allowed" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(createHermesSession()).rejects.toThrow(
+      "Could not start a Hermes conversation (403): Origin not allowed",
+    );
+  });
+
+  test("throws before chat when Hermes rejects the stream request", async () => {
+    mockedApiFetch.mockResolvedValue(new Response(null, { status: 502 }));
+    const onError = vi.fn();
+
+    await expect(
+      hermesChatStream("session-1", "hello", { onDelta: vi.fn(), onError }),
+    ).rejects.toThrow("Hermes chat failed (502)");
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/lib/api/hermes.ts
+++ b/dashboard/src/lib/api/hermes.ts
@@ -7,7 +7,7 @@
  * `/api/control/alerts`.
  */
 
-import { apiDel, apiFetch, apiGet, apiPatch, apiPost } from "./core";
+import { apiDel, apiFetch, apiGet, apiPatch } from "./core";
 
 const HERMES_PROXY = "/api/assistant/hermes";
 
@@ -50,12 +50,22 @@ export async function listHermesSessions(limit = 50): Promise<HermesSession[]> {
 }
 
 export async function createHermesSession(title?: string): Promise<HermesSession> {
-  const res = await apiPost<{ session: HermesSession }>(
-    `${HERMES_PROXY}/api/sessions`,
-    title ? { title } : {},
-    "Failed to create Hermes session",
-  );
-  return res.session;
+  const res = await apiFetch(`${HERMES_PROXY}/api/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(title ? { title } : {}),
+  });
+  if (!res.ok) {
+    const detail = await responseErrorDetail(res);
+    throw new Error(
+      `Could not start a Hermes conversation (${res.status})${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  const payload = (await res.json()) as { session?: HermesSession };
+  if (!payload.session) {
+    throw new Error("Hermes created a conversation without returning it");
+  }
+  return payload.session;
 }
 
 export async function getHermesSessionMessages(
@@ -129,11 +139,14 @@ export async function hermesChatStream(
       signal,
     },
   );
-  if (!res.ok || !res.body) {
-    handlers.onError(
-      res.ok ? "No response stream" : `Hermes chat failed (${res.status})`,
+  if (!res.ok) {
+    const detail = await responseErrorDetail(res);
+    throw new Error(
+      `Hermes chat failed (${res.status})${detail ? `: ${detail}` : ""}`,
     );
-    return;
+  }
+  if (!res.body) {
+    throw new Error("Hermes chat returned no response stream");
   }
 
   const reader = res.body.getReader();
@@ -196,6 +209,10 @@ export async function hermesChatStream(
     const { done, value } = await reader.read();
     if (done) break;
     buf += decoder.decode(value, { stream: true });
+    // Normalize before frame splitting. Hermes is normally behind nginx,
+    // which can preserve upstream CRLF line endings and can split `\r\n`
+    // across transport chunks.
+    buf = buf.replace(/\r\n/g, "\n");
     let sep: number;
     while ((sep = buf.indexOf("\n\n")) >= 0) {
       handleFrame(buf.slice(0, sep));
@@ -207,6 +224,21 @@ export async function hermesChatStream(
   if (!sawTerminal) {
     handlers.onError("Stream ended before completion");
   }
+}
+
+async function responseErrorDetail(res: Response): Promise<string> {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const payload = await res.json().catch(() => null);
+    if (payload && typeof payload === "object") {
+      const detail = "detail" in payload ? payload.detail : undefined;
+      const message = "message" in payload ? payload.message : undefined;
+      if (typeof detail === "string" && detail.trim()) return detail.trim();
+      if (typeof message === "string" && message.trim()) return message.trim();
+    }
+    return "";
+  }
+  return (await res.text().catch(() => "")).trim();
 }
 
 // ---------------------------------------------------------------------------

--- a/dashboard/tests/hermes.spec.ts
+++ b/dashboard/tests/hermes.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+const missionControl = {
+  generated_at: "2026-07-10T10:00:00Z",
+  runtime: {
+    service_name: "hermes-assistant",
+    service_active: true,
+    model: "builtin/smart",
+    base_url: "http://localhost:3000/v1",
+    expected_base_url: "http://localhost:3000/v1",
+    uses_sandboxed_proxy: true,
+    env_present: true,
+    config_present: true,
+    token_present: true,
+    notes: [],
+  },
+  sessions: {
+    since: "2026-07-07T10:00:00Z",
+    total: 8,
+    by_source: { api_server: 5, telegram: 3 },
+    messages: 42,
+    tool_calls: 12,
+    open: 2,
+  },
+  active: [
+    {
+      id: "11111111-1111-4111-8111-111111111111",
+      title: "Review sandbox isolation",
+      status: "active",
+      workspace_name: "sandboxed-sh",
+      backend: "codex",
+      model_override: null,
+      model_effort: "high",
+      terminal_reason: null,
+      updated_at: "2026-07-10T09:58:00Z",
+      last_agent_event_at: "2026-07-10T09:58:00Z",
+      last_activity_at: "2026-07-10T09:58:00Z",
+      attention: null,
+    },
+  ],
+  needs_attention: [],
+  handled_recently: [],
+  failures: [],
+  mission_status_counts: { active: 1 },
+  remote_nodes: {
+    enabled: false,
+    configured_nodes: 0,
+    status: "disabled",
+    notes: [],
+  },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/health", (route) =>
+    route.fulfill({ json: { auth_required: false, version: "test" } }),
+  );
+  await page.route("**/api/system/hermes-assistant/status", (route) =>
+    route.fulfill({
+      json: {
+        service_name: "hermes-assistant",
+        service_active: true,
+        model: "builtin/smart",
+        env_path: "",
+        config_path: "",
+        env_present: true,
+        config_present: true,
+        token_present: true,
+        telegram_ok: true,
+        telegram_bot_username: "hermes",
+        telegram_webhook_configured: false,
+        telegram_pending_update_count: 0,
+        telegram_last_error: null,
+        notes: [],
+      },
+    }),
+  );
+  await page.route("**/api/system/hermes-assistant/mission-control", (route) =>
+    route.fulfill({ json: missionControl }),
+  );
+  await page.route("**/api/assistant/hermes/api/sessions**", (route) =>
+    route.fulfill({ json: { data: [] } }),
+  );
+  await page.route("**/api/control/alerts**", (route) =>
+    route.fulfill({ json: { alerts: [], next_cursor: null } }),
+  );
+});
+
+test("keeps Hermes chat primary and mission control closed", async ({ page }, testInfo) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Hermes" })).toBeVisible();
+  await expect(page.getByText("What should Hermes handle?")).toBeVisible();
+  await expect(page.getByRole("dialog", { name: "Mission control" })).toHaveCount(0);
+
+  const viewport = page.viewportSize();
+  const thread = await page.getByPlaceholder("Message Hermes…").boundingBox();
+  expect(viewport).not.toBeNull();
+  expect(thread).not.toBeNull();
+  expect(thread!.width).toBeGreaterThan(500);
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+  ).toBe(true);
+
+  if (process.env.CAPTURE_HERMES_UI) {
+    await page.screenshot({ path: testInfo.outputPath("hermes-default.png"), fullPage: true });
+  }
+
+  await page.getByRole("button", { name: "Missions" }).click();
+  const drawer = page.getByRole("dialog", { name: "Mission control" });
+  await expect(drawer).toBeVisible();
+  expect((await drawer.boundingBox())!.width).toBeLessThanOrEqual(580);
+
+  await page.getByRole("button", { name: "Missions" }).click();
+  await expect(drawer).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Missions" }).click();
+  await expect(drawer).toBeVisible();
+
+  if (process.env.CAPTURE_HERMES_UI) {
+    await page.screenshot({ path: testInfo.outputPath("hermes-desktop.png"), fullPage: true });
+  }
+});
+
+test("uses drawers without overflow on a compact viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto("/");
+
+  await expect(page.getByText("What should Hermes handle?")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Open mission updates" })).toBeVisible();
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+  ).toBe(true);
+
+  await page.getByRole("button", { name: "Open mission updates" }).click();
+  await expect(page.getByRole("dialog", { name: "Mission updates" })).toBeVisible();
+});

--- a/docs/STORAGE_LIFECYCLE.md
+++ b/docs/STORAGE_LIFECYCLE.md
@@ -37,8 +37,11 @@ The background mission-directory retention sweep is also dry-run by default.
 With cleanup enabled in Settings, it emits structured `mission GC audit` logs
 with `action=would_remove`, ownership identifiers, size, path, and reason. It
 will execute only if an operator explicitly sets `WORKSPACE_GC_EXECUTE=1` on
-the service and restarts it. Do not set that flag until the candidate report has
-been reviewed and backed up; it is deliberately off by default.
+the service and restarts it. The default retention is one day for terminal
+missions and seven days for AwaitingUser/Paused missions. The normal sweep is
+hourly unless `WORKSPACE_GC_INTERVAL_MINUTES` is set. While disk pressure is at
+Warn or Critical, the disk watcher requests the same configured sweep every
+five minutes; a shared lock prevents overlapping scans.
 
 Resource limits are separate from retention. Use `GET
 /api/workspaces/:id/resources` to inspect effective memory/swap/CPU limits and
@@ -46,11 +49,33 @@ matching live scopes before changing a workspace shared by concurrent missions.
 
 ## Admission and continuity
 
-Disk warning is not a portfolio-wide stop. Small/no-build controller, review,
-Fable and source-analysis lanes remain eligible at warn level. A local
-disk-heavy mission should set `estimated_disk_gib`; the API rejects only that
-mission when its estimate would cross `MISSION_DISK_EMERGENCY_RESERVE_GB`
-(default 64 GiB). Critical level still rejects all new local missions.
+By default, disk warning is not a portfolio-wide stop. Set
+`DISK_ADMISSION_AT_WARN=1` on build-heavy hosts to refuse all new missions at
+Warn instead of waiting for Critical. A local disk-heavy mission should set
+`estimated_disk_gib`; the API rejects it when its estimate would cross
+`MISSION_DISK_EMERGENCY_RESERVE_GB` (default 64 GiB).
+`MISSION_DISK_DEFAULT_ESTIMATE_GIB` supplies a fail-safe estimate when a local
+request omits one. Critical level always rejects all new local missions.
+
+For a high-churn Lean/build host, a deliberately aggressive profile is:
+
+```bash
+DISK_WARN_PCT=80
+DISK_CRITICAL_PCT=88
+DISK_ADMISSION_AT_WARN=1
+MISSION_DISK_EMERGENCY_RESERVE_GB=200
+MISSION_DISK_DEFAULT_ESTIMATE_GIB=64
+WORKSPACE_GC_EXECUTE=1
+WORKSPACE_GC_INTERVAL_MINUTES=10
+```
+
+Host-level caches and harness logs are outside the mission ownership model.
+Install `scripts/storage_hard_cleanup.sh --apply` from an hourly systemd timer
+on dedicated build hosts. It removes expired mission-store backups, old
+OpenCode logs, reconstructible OpenCode cache entries, Hermes staging and
+quarantine content, truncates oversized harness logs, and caps the journal.
+Its retention and size controls are environment-configurable; run it without
+`--apply` for an inventory.
 
 Lean builds should use `remote-lean-build`. The wrapper can ship modified and
 untracked regular source files as a bounded, content-hashed overlay on top of a

--- a/scripts/storage_hard_cleanup.sh
+++ b/scripts/storage_hard_cleanup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:---dry-run}"
+if [[ "$mode" != "--dry-run" && "$mode" != "--apply" ]]; then
+  echo "usage: $0 [--dry-run|--apply]" >&2
+  exit 2
+fi
+
+data_root="${SANDBOXED_DATA_ROOT:-/root/.sandboxed-sh}"
+opencode_cache="${OPENCODE_CACHE_ROOT:-/var/lib/opencode/.cache}"
+hermes_home="${HERMES_HOME:-/var/lib/hermes-assistant}"
+backup_days="${STORAGE_BACKUP_RETENTION_DAYS:-1}"
+log_days="${STORAGE_LOG_RETENTION_DAYS:-3}"
+cache_days="${STORAGE_CACHE_RETENTION_DAYS:-3}"
+log_max_mib="${STORAGE_LOG_MAX_MIB:-512}"
+journal_max="${STORAGE_JOURNAL_MAX_SIZE:-1G}"
+
+delete_old_files() {
+  local root="$1"
+  local days="$2"
+  shift 2
+  [[ -d "$root" ]] || return 0
+  if [[ "$mode" == "--apply" ]]; then
+    find "$root" -xdev -type f "$@" -mtime "+$days" -print -delete
+  else
+    find "$root" -xdev -type f "$@" -mtime "+$days" -print
+  fi
+}
+
+delete_old_tree_contents() {
+  local root="$1"
+  local days="$2"
+  [[ -d "$root" ]] || return 0
+  if [[ "$mode" == "--apply" ]]; then
+    find "$root" -xdev -type f -mtime "+$days" -print -delete
+    find "$root" -xdev -mindepth 1 -depth -type d -empty -print -delete
+  else
+    find "$root" -xdev -type f -mtime "+$days" -print
+  fi
+}
+
+echo "sandboxed storage cleanup: $mode"
+
+missions_dir="$data_root/missions"
+if [[ -d "$missions_dir" ]]; then
+  if [[ "$mode" == "--apply" ]]; then
+    find "$missions_dir" -xdev -maxdepth 1 -type f \
+      \( -name "*.bak.*" -o -name "*.backup-*" \) \
+      -mtime "+$backup_days" -print -delete
+  else
+    find "$missions_dir" -xdev -maxdepth 1 -type f \
+      \( -name "*.bak.*" -o -name "*.backup-*" \) \
+      -mtime "+$backup_days" -print
+  fi
+fi
+
+containers_dir="$data_root/containers"
+if [[ -d "$containers_dir" ]]; then
+  while IFS= read -r -d '' log_dir; do
+    delete_old_files "$log_dir" "$log_days"
+    while IFS= read -r -d '' oversized; do
+      echo "$oversized"
+      if [[ "$mode" == "--apply" ]]; then
+        truncate -s 0 -- "$oversized"
+      fi
+    done < <(
+      find "$log_dir" -xdev -type f -size "+${log_max_mib}M" -print0
+    )
+  done < <(
+    find "$containers_dir" -xdev -type d \
+      -path "*/root/.local/share/opencode/log" -print0
+  )
+fi
+
+delete_old_tree_contents "$opencode_cache" "$cache_days"
+delete_old_tree_contents "$hermes_home/workspace/.quarantine" "$cache_days"
+delete_old_tree_contents "$hermes_home/backups/staging" "$backup_days"
+
+if [[ "$mode" == "--apply" ]] && command -v journalctl >/dev/null 2>&1; then
+  journalctl "--vacuum-size=$journal_max"
+fi
+
+df -h /

--- a/src/api/ask/mod.rs
+++ b/src/api/ask/mod.rs
@@ -1108,6 +1108,7 @@ async fn execute_tool(turn: &AskTurn, name: &str, arguments: &str) -> String {
                     parent_mission_id: None,
                     working_directory: None,
                     scheduling: Default::default(),
+                    requires_local_disk: true,
                     respond: tx,
                 })
                 .await

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -418,6 +418,9 @@ pub enum ControlCommand {
         working_directory: Option<String>,
         /// FLEET-001 scheduling metadata (priority, not_before, deadline).
         scheduling: crate::api::mission_store::MissionScheduling,
+        /// Whether creation consumes the API host's local scratch space.
+        /// Remote-node missions bypass the host disk-pressure gate.
+        requires_local_disk: bool,
         respond: oneshot::Sender<Result<Mission, String>>,
     },
     /// Update mission status

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4235,8 +4235,8 @@ pub struct FleetHealth {
 }
 
 /// Admission preflight: `Some(reason)` when new missions must be refused
-/// because the root filesystem is critically full. `DISK_ADMISSION_ENABLED=0`
-/// is the escape hatch. Warn level admits but logs.
+/// because the root filesystem is critically full, or is at warn level while
+/// `DISK_ADMISSION_AT_WARN=1`. `DISK_ADMISSION_ENABLED=0` is the escape hatch.
 fn disk_admission_refusal() -> Option<String> {
     let enabled = std::env::var("DISK_ADMISSION_ENABLED")
         .map(|v| v.trim() != "0" && !v.trim().eq_ignore_ascii_case("false"))
@@ -4251,6 +4251,18 @@ fn disk_admission_refusal() -> Option<String> {
              Free space or raise DISK_CRITICAL_PCT, then retry.",
             total.saturating_sub(used) / (1024 * 1024 * 1024)
         )),
+        crate::api::monitoring::DiskHealthLevel::Warn
+            if std::env::var("DISK_ADMISSION_AT_WARN")
+                .map(|value| value.trim() == "1" || value.trim().eq_ignore_ascii_case("true"))
+                .unwrap_or(false) =>
+        {
+            Some(format!(
+                "mission creation refused: disk above the admission warning threshold \
+                 ({percent:.1}% used, {} GB free). Wait for workspace GC, select a remote \
+                 node, or free space.",
+                total.saturating_sub(used) / (1024 * 1024 * 1024)
+            ))
+        }
         crate::api::monitoring::DiskHealthLevel::Warn => {
             tracing::warn!(
                 disk_percent = percent,
@@ -6106,19 +6118,29 @@ pub async fn create_mission(
     // Writer creation is checked once before actor creation and again while
     // tagging the returned mission. Never hold this mutex while waiting on the
     // control actor: actor commands also acquire it when resuming writers.
-    if let Some(estimated_gib) = req.estimated_disk_gib {
+    let local_mission = req
+        .remote_node_id
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty);
+    let effective_estimated_disk_gib = req.estimated_disk_gib.or_else(|| {
+        local_mission
+            .then(|| {
+                std::env::var("MISSION_DISK_DEFAULT_ESTIMATE_GIB")
+                    .ok()
+                    .and_then(|raw| raw.trim().parse::<u64>().ok())
+                    .filter(|estimate| (1..=512).contains(estimate))
+            })
+            .flatten()
+    });
+    if let Some(estimated_gib) = effective_estimated_disk_gib {
         if estimated_gib == 0 || estimated_gib > 512 {
             return Err((
                 StatusCode::BAD_REQUEST,
                 "estimated_disk_gib must be between 1 and 512".to_string(),
             ));
         }
-        if req
-            .remote_node_id
-            .as_deref()
-            .map(str::trim)
-            .is_none_or(str::is_empty)
-        {
+        if local_mission {
             let (used, total, _) = crate::api::monitoring::current_disk_usage();
             let reserve_gib = std::env::var("MISSION_DISK_EMERGENCY_RESERVE_GB")
                 .ok()
@@ -6132,7 +6154,7 @@ pub async fn create_mission(
         }
     }
     let mut normalized_request_tags = normalize_mission_tags(req.tags.as_deref());
-    if let Some(estimated_gib) = req.estimated_disk_gib {
+    if let Some(estimated_gib) = effective_estimated_disk_gib {
         let tag = format!("disk-estimate-gib:{estimated_gib}");
         let tags = normalized_request_tags.get_or_insert_with(Vec::new);
         if !tags.iter().any(|existing| existing == &tag) {
@@ -6282,6 +6304,7 @@ pub async fn create_mission(
                 not_before: req.not_before.map(|t| t.to_rfc3339()),
                 deadline: req.deadline.map(|t| t.to_rfc3339()),
             },
+            requires_local_disk: local_mission,
             respond: tx,
         })
         .await
@@ -13859,15 +13882,17 @@ async fn control_actor_loop(
                             }
                         }
                     }
-                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, backend, config_profile, parent_mission_id, working_directory, scheduling, respond } => {
+                    ControlCommand::CreateMission { title, workspace_id, agent, model_override, model_effort, backend, config_profile, parent_mission_id, working_directory, scheduling, requires_local_disk, respond } => {
                         // Disk preflight: refuse new missions when the root
                         // filesystem is critically full instead of letting
                         // workers die mid-flight on ENOSPC. Actor-level so
                         // the HTTP, Ask and Telegram entrypoints are all
                         // covered by this single gate.
-                        if let Some(refusal) = disk_admission_refusal() {
-                            let _ = respond.send(Err(refusal));
-                            continue;
+                        if requires_local_disk {
+                            if let Some(refusal) = disk_admission_refusal() {
+                                let _ = respond.send(Err(refusal));
+                                continue;
+                            }
                         }
                         // First persist current mission history
                         persist_mission_history(

--- a/src/api/disk_watch.rs
+++ b/src/api/disk_watch.rs
@@ -68,6 +68,13 @@ async fn run_loop(state: Arc<AppState>) {
         let recovered = alerted_level != DiskHealthLevel::Ok
             && percent < monitoring::disk_warn_pct() - RECOVERY_MARGIN_PCT;
 
+        if level != DiskHealthLevel::Ok {
+            let gc_state = Arc::clone(&state);
+            tokio::spawn(async move {
+                super::mission_workspace_gc::run_pressure_sweep(&gc_state).await;
+            });
+        }
+
         if level != DiskHealthLevel::Ok && (escalated || repeat_due) {
             let free_gb = total.saturating_sub(used) / (1024 * 1024 * 1024);
             let message = format!(

--- a/src/api/mission_workspace_gc.rs
+++ b/src/api/mission_workspace_gc.rs
@@ -26,14 +26,11 @@ use super::control::MissionStatus;
 use super::routes::AppState;
 use crate::workspace;
 
-/// How often the GC wakes up to scan for collectible workspaces.
-const TICK_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour
-
 /// Default retention when no value is configured in settings.
-pub const DEFAULT_RETENTION_DAYS: u32 = 7;
+pub const DEFAULT_RETENTION_DAYS: u32 = 1;
 
 /// Default long-stop retention for AwaitingUser/Paused mission dirs.
-pub const DEFAULT_STOPPED_RETENTION_DAYS: u32 = 30;
+pub const DEFAULT_STOPPED_RETENTION_DAYS: u32 = 7;
 
 /// Page size for `list_missions` pagination — keeps the scan bounded in
 /// memory even when a session has thousands of missions.
@@ -44,6 +41,20 @@ const LIST_PAGE_SIZE: usize = 200;
 /// and prevents a configuration migration from deleting historical work.
 const EXECUTE_ENV: &str = "WORKSPACE_GC_EXECUTE";
 
+fn tick_interval() -> Duration {
+    let minutes = std::env::var("WORKSPACE_GC_INTERVAL_MINUTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|minutes| (1..=24 * 60).contains(minutes))
+        .unwrap_or(60);
+    Duration::from_secs(minutes * 60)
+}
+
+fn sweep_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 /// Spawn the background GC loop. Safe to call once at server start.
 pub fn spawn(state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -52,41 +63,61 @@ pub fn spawn(state: Arc<AppState>) {
 }
 
 async fn run_loop(state: Arc<AppState>) {
-    let mut interval = tokio::time::interval(TICK_INTERVAL);
+    let mut interval = tokio::time::interval(tick_interval());
     // First tick fires immediately; skip it so we don't run on the same
     // hot-path tick that's still booting telegram/openroute/etc.
     interval.tick().await;
     loop {
         interval.tick().await;
-        let started = std::time::Instant::now();
-        let settings = read_settings(&state).await;
-        if !settings.enabled {
-            tracing::trace!("mission workspace GC disabled");
-            continue;
-        }
-        let now = Utc::now();
-        let params = SweepParams {
-            cutoff: now - chrono::Duration::days(settings.days as i64),
-            stopped_cutoff: now - chrono::Duration::days(settings.stopped_days as i64),
-            orphans_enabled: settings.orphans_enabled,
-            dry_run: !gc_execution_enabled(),
-        };
-        let report = run_once(&state, &params).await;
-        tracing::info!(
-            removed = report.removed,
-            proposed = report.proposed,
-            orphans_removed = report.orphans_removed,
-            stopped_removed = report.stopped_removed,
-            errors = report.errors,
-            scanned = report.scanned,
-            bytes_freed = report.bytes_freed,
-            duration_ms = started.elapsed().as_millis() as u64,
-            retention_days = settings.days,
-            stopped_retention_days = settings.stopped_days,
-            dry_run = params.dry_run,
-            "mission workspace GC sweep finished",
-        );
+        run_configured_sweep(&state, "scheduled").await;
     }
+}
+
+/// Run the normal configured sweep immediately when the disk watcher observes
+/// pressure. The shared try-lock keeps a five-minute pressure watcher from
+/// piling up behind a slow scheduled scan.
+pub(crate) async fn run_pressure_sweep(state: &Arc<AppState>) {
+    if !gc_execution_enabled() {
+        tracing::trace!("mission workspace GC pressure sweep skipped in dry-run mode");
+        return;
+    }
+    run_configured_sweep(state, "disk-pressure").await;
+}
+
+async fn run_configured_sweep(state: &Arc<AppState>, trigger: &'static str) {
+    let settings = read_settings(state).await;
+    if !settings.enabled {
+        tracing::trace!(trigger, "mission workspace GC disabled");
+        return;
+    }
+    let Ok(_guard) = sweep_lock().try_lock() else {
+        tracing::debug!(trigger, "mission workspace GC sweep already running");
+        return;
+    };
+    let started = std::time::Instant::now();
+    let now = Utc::now();
+    let params = SweepParams {
+        cutoff: now - chrono::Duration::days(settings.days as i64),
+        stopped_cutoff: now - chrono::Duration::days(settings.stopped_days as i64),
+        orphans_enabled: settings.orphans_enabled,
+        dry_run: !gc_execution_enabled(),
+    };
+    let report = run_once(state, &params).await;
+    tracing::info!(
+        trigger,
+        removed = report.removed,
+        proposed = report.proposed,
+        orphans_removed = report.orphans_removed,
+        stopped_removed = report.stopped_removed,
+        errors = report.errors,
+        scanned = report.scanned,
+        bytes_freed = report.bytes_freed,
+        duration_ms = started.elapsed().as_millis() as u64,
+        retention_days = settings.days,
+        stopped_retention_days = settings.stopped_days,
+        dry_run = params.dry_run,
+        "mission workspace GC sweep finished",
+    );
 }
 
 fn gc_execution_enabled() -> bool {

--- a/src/api/telegram.rs
+++ b/src/api/telegram.rs
@@ -3666,6 +3666,7 @@ async fn resolve_or_create_mission(
             parent_mission_id: None,
             working_directory: None,
             scheduling: Default::default(),
+            requires_local_disk: true,
             respond: tx,
         })
         .await;


### PR DESCRIPTION
## Summary

- enforce aggressive, configurable workspace GC and disk-pressure admission guards
- add an operational hard-clean script and production-oriented storage defaults
- make Hermes chat the primary control surface, with diagnostics hidden in drawers by default
- surface Hermes HTTP/upstream failures, support CRLF SSE streams, and recover cleanly from aborted sessions
- add unit and browser coverage for the Hermes control flow

## Validation

- `cargo fmt --all --check`
- `cargo check`
- `cargo test mission_workspace_gc --lib`
- `cargo test disk_estimate_preserves_emergency_free_space --lib`
- `bash -n scripts/storage_hard_cleanup.sh`
- dashboard unit suite: 243 tests
- dashboard TypeScript check and targeted ESLint
- Hermes Playwright suite: 2 tests
- dashboard production build
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mission creation and workspace deletion behavior change under new env defaults and admission rules; Hermes UI is a large UX shift but storage changes are the main operational risk on production hosts.
> 
> **Overview**
> **Disk and mission admission** get stricter, more configurable behavior: optional refusal of new missions at disk **warn** (`DISK_ADMISSION_AT_WARN`), a fail-safe default local disk estimate (`MISSION_DISK_DEFAULT_ESTIMATE_GIB`), and disk gates that apply only when `requires_local_disk` is true so **remote-node** missions skip host pressure checks. Workspace GC defaults shorten retention (1d terminal / 7d paused), honor `WORKSPACE_GC_INTERVAL_MINUTES`, run extra sweeps under disk pressure with a shared lock, and the disk watcher triggers those sweeps. A new **`storage_hard_cleanup.sh`** (dry-run/`--apply`) prunes host-level backups, logs, caches, and journal size; **`.env.example`** and **`STORAGE_LIFECYCLE.md`** document the aggressive build-host profile.
> 
> **Hermes dashboard** is reworked so **chat is the main surface**; mission control and mission updates live in **slide-over drawers** (Missions badge, updates bell, Escape to close). The thread gains quick-action chips, **retry** on failed sends, and clean reset when starting a new conversation mid-stream. **`hermes.ts`** improves HTTP errors (JSON `detail`), throws on failed stream setup, and **normalizes CRLF in SSE** parsing. Unit and Playwright tests cover pagination, layout, streaming abort, and API edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f904d8d95228a383854cd3064abc4f9a390dc16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->