### PR TITLE
Allow read-only Fable integration orchestration

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5370,6 +5370,30 @@ fn fable_mandate_requests_integration(intent: Option<&str>, prompt: Option<&str>
     })
 }
 
+/// Decide whether a Fable mission must be rejected at admission.
+///
+/// Fable may coordinate repository integration as an explicitly read-only
+/// orchestrator. In that mode the prompt necessarily discusses commits,
+/// pushes, rebases, and merges, so prompt vocabulary alone cannot distinguish
+/// orchestration from direct write authority. The structured `writer` field is
+/// the capability boundary: `writer=false` permits read-only orchestration,
+/// while `writer=true` is always invalid for Fable. Legacy requests that omit
+/// the field retain the historical prompt guard.
+fn fable_mandate_requires_rejection(
+    model: Option<&str>,
+    writer: Option<bool>,
+    intent: Option<&str>,
+    prompt: Option<&str>,
+) -> bool {
+    if !is_fable_model(model) {
+        return false;
+    }
+    if writer == Some(true) {
+        return true;
+    }
+    writer != Some(false) && fable_mandate_requests_integration(intent, prompt)
+}
+
 static PR_WRITER_CREATE_LOCK: std::sync::LazyLock<Mutex<()>> =
     std::sync::LazyLock::new(|| Mutex::new(()));
 
@@ -6105,12 +6129,15 @@ pub async fn create_mission(
         }
     }
 
-    if is_fable_model(model_override.as_deref())
-        && fable_mandate_requests_integration(req.intent.as_deref(), req.prompt.as_deref())
-    {
+    if fable_mandate_requires_rejection(
+        model_override.as_deref(),
+        req.writer,
+        req.intent.as_deref(),
+        req.prompt.as_deref(),
+    ) {
         return Err((
             StatusCode::BAD_REQUEST,
-            "Fable is restricted to mathematical hypothesis generation and cannot receive review, commit, push, conflict-resolution, or merge mandates. Use Codex or Claude Opus for repository integration."
+            "Fable cannot receive repository write authority. Use writer=false for read-only orchestration, or use Codex or Claude Opus for repository integration."
                 .to_string(),
         ));
     }
@@ -23333,6 +23360,45 @@ And the report:
         assert!(fable_mandate_requests_integration(
             None,
             Some("Resolve the conflicts, commit, and push")
+        ));
+    }
+
+    #[test]
+    fn fable_admission_uses_explicit_writer_capability() {
+        let orchestration_prompt = Some(concat!(
+            "Coordinate the repair: delegate implementation to the designated Sol writer, then ",
+            "instruct that writer to commit, push, and merge after exact-head review",
+        ));
+
+        assert!(!fable_mandate_requires_rejection(
+            Some("claude-fable-5"),
+            Some(false),
+            Some("goal_orchestration"),
+            orchestration_prompt,
+        ));
+        assert!(fable_mandate_requires_rejection(
+            Some("claude-fable-5"),
+            None,
+            Some("goal_orchestration"),
+            orchestration_prompt,
+        ));
+        assert!(fable_mandate_requires_rejection(
+            Some("claude-fable-5"),
+            Some(true),
+            Some("hypothesis_generation"),
+            Some("Explore mathematical hypotheses"),
+        ));
+        assert!(!fable_mandate_requires_rejection(
+            Some("claude-fable-5"),
+            None,
+            Some("hypothesis_generation"),
+            Some("Explore mathematical hypotheses"),
+        ));
+        assert!(!fable_mandate_requires_rejection(
+            Some("claude-opus-4-7"),
+            Some(true),
+            Some("review_merge_pr"),
+            Some("Review and merge the PR"),
         ));
     }
 


### PR DESCRIPTION
## What changed

- treat the structured `writer` field as the Fable admission capability boundary
- allow Fable to coordinate integration mandates when `writer=false`
- reject every explicit `writer=true` Fable mission
- preserve the legacy prompt guard when callers omit `writer`
- return an actionable error explaining the read-only option

## Why

The old admission guard rejected any Fable prompt containing Git mutation vocabulary. That also rejected safe read-only `/goal` orchestrators whose job was to delegate implementation to a designated writer.

## Validation

- `cargo fmt --all --check`
- `cargo test fable_ --lib`
- `cargo check --all-targets`
- `cargo test --all-targets` (all passing: 1401 library tests plus all binary targets)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission admission for a restricted model and could allow previously blocked Fable missions when `writer=false`; mis-set `writer` could widen orchestration surface without direct write authority.
> 
> **Overview**
> Fable mission admission now keys off the structured **`writer`** flag instead of treating any Git-mutation wording in the prompt as a hard reject.
> 
> **`writer=false`** on a Fable model allows read-only integration orchestration (prompts can still mention commit/push/merge when delegating to another writer). **`writer=true`** is always rejected for Fable. When **`writer` is omitted**, behavior stays the same as before: the existing prompt/intent integration guard still applies.
> 
> The create-mission error text is updated to point callers at **`writer=false`** or non-Fable writers for real repo integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a97c553adfa89a0b744b25bd24632ef1a731ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->