### PR TITLE
Make Hermes and Sandboxed orchestration restart-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2690,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Utilities
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 thiserror = "1"
 async-trait = "0.1"
 futures = "0.3"

--- a/deploy/systemd/hermes-assistant-dev-isolated.conf
+++ b/deploy/systemd/hermes-assistant-dev-isolated.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/local/lib/hermes-agent-dev/.venv/bin/hermes gateway --accept-hooks run

--- a/patches/hermes/sessiondb-durable-delivery.patch
+++ b/patches/hermes/sessiondb-durable-delivery.patch
@@ -1,0 +1,326 @@
+diff --git a/cron/scheduler.py b/cron/scheduler.py
+--- a/cron/scheduler.py
++++ b/cron/scheduler.py
+@@ -14,0 +15 @@ import contextvars
++import hashlib
+@@ -1674,0 +1676,4 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
++            delivery_id = (
++                f"cron:{chat_id}:{job.get('id', '?')}:"
++                f"{job.get('_delivery_run_id') or job.get('last_run_at') or hashlib.sha256(content.encode('utf-8')).hexdigest()}"
++            )
+@@ -1687,0 +1693 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
++                    delivery_id=delivery_id,
+@@ -1695,3 +1701,28 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+-                msg = f"API session delivery failed for '{chat_id}': {e}"
+-                logger.warning("Job '%s': %s", job.get("id", "?"), msg)
+-                delivery_errors.append(msg)
++                if isinstance(e, ValueError):
++                    msg = f"API session delivery failed for '{chat_id}': {e}"
++                    logger.warning("Job '%s': %s", job.get("id", "?"), msg)
++                    delivery_errors.append(msg)
++                    continue
++                try:
++                    from hermes_state import spool_session_delivery
++
++                    spool_path = spool_session_delivery(
++                        delivery_id=delivery_id,
++                        session_id=str(chat_id),
++                        role="assistant",
++                        content=content,
++                    )
++                    logger.warning(
++                        "Job '%s': SessionDB append failed after retries; spooled delivery %s at %s: %s",
++                        job.get("id", "?"),
++                        delivery_id,
++                        spool_path,
++                        e,
++                    )
++                except Exception as spool_error:
++                    msg = (
++                        f"API session delivery and spool failed for '{chat_id}': "
++                        f"append={e}; spool={spool_error}"
++                    )
++                    logger.error("Job '%s': %s", job.get("id", "?"), msg)
++                    delivery_errors.append(msg)
+@@ -4013 +4044,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
+-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
++                    delivery_job = dict(job)
++                    delivery_job["_delivery_run_id"] = execution_id
++                    delivery_error = _deliver_result(
++                        delivery_job,
++                        deliver_content,
++                        adapters=adapters,
++                        loop=loop,
++                    )
+diff --git a/gateway/run.py b/gateway/run.py
+--- a/gateway/run.py
++++ b/gateway/run.py
+@@ -22835,0 +22836,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool =
++    # Recover cron/controller transcript deliveries that exhausted SessionDB
++    # lock retries in a previous process. The receipt row and message append
++    # commit together, so replay is idempotent across gateway crashes.
++    try:
++        from hermes_state import replay_session_delivery_spool
++
++        replay_result = await asyncio.get_running_loop().run_in_executor(
++            None, replay_session_delivery_spool
++        )
++        if replay_result["replayed"] or replay_result["failed"]:
++            logger.info(
++                "SessionDB delivery spool replayed=%d failed=%d",
++                replay_result["replayed"],
++                replay_result["failed"],
++            )
++    except Exception:
++        logger.exception("SessionDB delivery spool replay failed during gateway startup")
++
+diff --git a/hermes_state.py b/hermes_state.py
+--- a/hermes_state.py
++++ b/hermes_state.py
+@@ -17,0 +18 @@ import asyncio
++import hashlib
+@@ -19,0 +21 @@ import logging
++import os
+@@ -35,0 +38,58 @@ logger = logging.getLogger(__name__)
++def _delivery_spool_dir() -> Path:
++    return Path(get_hermes_home()) / "delivery-spool"
++
++
++def spool_session_delivery(
++    delivery_id: str,
++    session_id: str,
++    role: str,
++    content: str,
++) -> Path:
++    """Atomically spool a transcript delivery after SessionDB retries expire."""
++    spool_dir = _delivery_spool_dir()
++    spool_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
++    digest = hashlib.sha256(delivery_id.encode("utf-8")).hexdigest()
++    destination = spool_dir / f"{digest}.json"
++    temporary = spool_dir / f".{digest}.{os.getpid()}.{threading.get_ident()}.tmp"
++    payload = {
++        "delivery_id": delivery_id,
++        "session_id": session_id,
++        "role": role,
++        "content": content,
++        "created_at": time.time(),
++    }
++    with temporary.open("x", encoding="utf-8") as handle:
++        json.dump(payload, handle, ensure_ascii=False)
++        handle.flush()
++        os.fsync(handle.fileno())
++    os.replace(temporary, destination)
++    return destination
++
++
++def replay_session_delivery_spool() -> Dict[str, int]:
++    """Replay durable deliveries, deleting files only after a committed append."""
++    spool_dir = _delivery_spool_dir()
++    result = {"replayed": 0, "failed": 0}
++    if not spool_dir.exists():
++        return result
++    db = SessionDB()
++    try:
++        for path in sorted(spool_dir.glob("*.json")):
++            try:
++                payload = json.loads(path.read_text(encoding="utf-8"))
++                db.append_message(
++                    session_id=str(payload["session_id"]),
++                    role=str(payload.get("role") or "assistant"),
++                    content=payload.get("content"),
++                    delivery_id=str(payload["delivery_id"]),
++                )
++                path.unlink()
++                result["replayed"] += 1
++            except Exception:
++                result["failed"] += 1
++                logger.exception("Failed to replay SessionDB delivery spool entry %s", path)
++    finally:
++        db.close()
++    return result
++
++
+@@ -155 +215 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+-SCHEMA_VERSION = 22
++SCHEMA_VERSION = 23
+@@ -835,0 +896,7 @@ CREATE TABLE IF NOT EXISTS messages (
++CREATE TABLE IF NOT EXISTS delivery_receipts (
++    delivery_id TEXT PRIMARY KEY,
++    message_id INTEGER,
++    created_at REAL NOT NULL,
++    FOREIGN KEY (message_id) REFERENCES messages(id)
++);
++
+@@ -1003,0 +1071 @@ class SessionDB:
++    _WRITE_RETRY_DEADLINE_S = 10.0
+@@ -1286 +1354,15 @@ class SessionDB:
+-        for attempt in range(self._WRITE_MAX_RETRIES):
++        started_at = time.monotonic()
++        try:
++            retry_deadline_s = max(
++                0.1,
++                float(os.environ.get(
++                    "HERMES_SESSIONDB_WRITE_RETRY_DEADLINE_SECONDS",
++                    self._WRITE_RETRY_DEADLINE_S,
++                )),
++            )
++        except (TypeError, ValueError):
++            retry_deadline_s = self._WRITE_RETRY_DEADLINE_S
++        deadline_at = started_at + retry_deadline_s
++        attempt = 0
++        while attempt < self._WRITE_MAX_RETRIES and time.monotonic() < deadline_at:
++            transaction_started_at = time.monotonic()
+@@ -1304,0 +1387,7 @@ class SessionDB:
++                if attempt:
++                    logger.info(
++                        "SessionDB write recovered lock_wait_ms=%.1f retries=%d transaction_ms=%.1f",
++                        (transaction_started_at - started_at) * 1000,
++                        attempt,
++                        (time.monotonic() - transaction_started_at) * 1000,
++                    )
+@@ -1310,3 +1399,5 @@ class SessionDB:
+-                    if attempt < self._WRITE_MAX_RETRIES - 1:
+-                        jitter = random.uniform(
+-                            self._WRITE_RETRY_MIN_S,
++                    remaining = deadline_at - time.monotonic()
++                    if attempt < self._WRITE_MAX_RETRIES - 1 and remaining > 0:
++                        # Bounded full jitter: every retry samples from zero to
++                        # the exponentially increasing cap, avoiding writer convoys.
++                        cap = min(
+@@ -1313,0 +1405,2 @@ class SessionDB:
++                            self._WRITE_RETRY_MIN_S * (2 ** attempt),
++                            remaining,
+@@ -1314,0 +1408 @@ class SessionDB:
++                        jitter = random.uniform(0, max(0, cap))
+@@ -1315,0 +1410 @@ class SessionDB:
++                        attempt += 1
+@@ -1330,0 +1426 @@ class SessionDB:
++                attempt += 1
+@@ -1332,0 +1429,7 @@ class SessionDB:
++        logger.error(
++            "SessionDB write failed lock_wait_ms=%.1f retries=%d deadline_s=%.1f error=%s",
++            (time.monotonic() - started_at) * 1000,
++            attempt,
++            retry_deadline_s,
++            last_err,
++        )
+@@ -4171,0 +4275 @@ class SessionDB:
++        delivery_id: Optional[str] = None,
+@@ -4226,0 +4331,11 @@ class SessionDB:
++            if delivery_id:
++                claimed = conn.execute(
++                    "INSERT OR IGNORE INTO delivery_receipts (delivery_id, message_id, created_at) VALUES (?, NULL, ?)",
++                    (delivery_id, time.time()),
++                )
++                if claimed.rowcount == 0:
++                    prior = conn.execute(
++                        "SELECT message_id FROM delivery_receipts WHERE delivery_id = ?",
++                        (delivery_id,),
++                    ).fetchone()
++                    return prior[0] if prior and prior[0] is not None else 0
+@@ -4268,0 +4384,5 @@ class SessionDB:
++            if delivery_id:
++                conn.execute(
++                    "UPDATE delivery_receipts SET message_id = ? WHERE delivery_id = ?",
++                    (msg_id, delivery_id),
++                )
+diff --git a/tests/cron/test_scheduler.py b/tests/cron/test_scheduler.py
+--- a/tests/cron/test_scheduler.py
++++ b/tests/cron/test_scheduler.py
+@@ -4060,0 +4061 @@ class TestDeliverApiServerOrigin:
++            "_delivery_run_id": str(tmp_path),
+@@ -4088,0 +4090 @@ class TestDeliverApiServerOrigin:
++            "_delivery_run_id": str(tmp_path),
+diff --git a/tests/test_sessiondb_delivery_spool.py b/tests/test_sessiondb_delivery_spool.py
+new file mode 100644
+--- /dev/null
++++ b/tests/test_sessiondb_delivery_spool.py
+@@ -0,0 +1,88 @@
++import sqlite3
++import threading
++import time
++
++from hermes_state import (
++    SessionDB,
++    replay_session_delivery_spool,
++    spool_session_delivery,
++)
++
++
++def test_delivery_id_deduplicates_transcript_append(tmp_path):
++    db = SessionDB(db_path=tmp_path / "state.db")
++    try:
++        db.create_session("api-1", source="api_server")
++        first = db.append_message(
++            "api-1", role="assistant", content="done", delivery_id="cron:api-1:j:r1"
++        )
++        second = db.append_message(
++            "api-1", role="assistant", content="done", delivery_id="cron:api-1:j:r1"
++        )
++        assert second == first
++        assert [message["content"] for message in db.get_messages("api-1")] == ["done"]
++    finally:
++        db.close()
++
++
++def test_spool_survives_and_replays_once(tmp_path, monkeypatch):
++    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
++    monkeypatch.setenv("HOME", str(tmp_path))
++    db = SessionDB()
++    try:
++        db.create_session("api-1", source="api_server")
++    finally:
++        db.close()
++
++    spool_session_delivery("cron:api-1:j:r1", "api-1", "assistant", "done")
++    assert replay_session_delivery_spool() == {"replayed": 1, "failed": 0}
++    # Recreating the same deterministic delivery after a crash is harmless.
++    spool_session_delivery("cron:api-1:j:r1", "api-1", "assistant", "done")
++    assert replay_session_delivery_spool() == {"replayed": 1, "failed": 0}
++
++    verify = SessionDB()
++    try:
++        assert [message["content"] for message in verify.get_messages("api-1")] == ["done"]
++    finally:
++        verify.close()
++
++
++def test_concurrent_writer_waits_for_lock_without_losing_delivery(tmp_path, monkeypatch):
++    monkeypatch.setenv("HERMES_SESSIONDB_WRITE_RETRY_DEADLINE_SECONDS", "2")
++    path = tmp_path / "state.db"
++    setup = SessionDB(path)
++    setup.create_session("api-1", source="api_server")
++    setup.close()
++
++    blocker = sqlite3.connect(path, timeout=0.1, isolation_level=None)
++    blocker.execute("BEGIN IMMEDIATE")
++    result = []
++
++    def writer():
++        db = SessionDB(path)
++        try:
++            result.append(
++                db.append_message(
++                    "api-1",
++                    role="assistant",
++                    content="eventually committed",
++                    delivery_id="cron:api-1:j:r2",
++                )
++            )
++        finally:
++            db.close()
++
++    thread = threading.Thread(target=writer)
++    thread.start()
++    time.sleep(0.25)
++    blocker.rollback()
++    blocker.close()
++    thread.join(timeout=3)
++
++    assert not thread.is_alive()
++    assert len(result) == 1
++    verify = SessionDB(path)
++    try:
++        assert verify.get_messages("api-1")[-1]["content"] == "eventually committed"
++    finally:
++        verify.close()

--- a/scripts/apply_hermes_session_delivery_patch.sh
+++ b/scripts/apply_hermes_session_delivery_patch.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 repo="${1:-/usr/local/lib/hermes-agent}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-patch_file="${script_dir}/../patches/hermes/api-server-session-cron-delivery.patch"
+origin_patch="${script_dir}/../patches/hermes/api-server-session-cron-delivery.patch"
+durability_patch="${script_dir}/../patches/hermes/sessiondb-durable-delivery.patch"
 
 if [[ ! -d "${repo}/.git" ]]; then
   echo "Hermes git install not found at ${repo}" >&2
@@ -12,17 +13,35 @@ fi
 
 cd "${repo}"
 
-if git apply --unidiff-zero --reverse --check "${patch_file}" >/dev/null 2>&1; then
-  echo "Hermes API-session delivery patch is already applied."
+changed=0
+apply_one() {
+  local patch_file="$1"
+  local label="$2"
+  if git apply --unidiff-zero --reverse --check "${patch_file}" >/dev/null 2>&1; then
+    echo "Hermes ${label} patch is already applied."
+    return
+  fi
+  git apply --unidiff-zero --check "${patch_file}"
+  git apply --unidiff-zero "${patch_file}"
+  changed=1
+}
+
+apply_one "${origin_patch}" "API-session origin"
+apply_one "${durability_patch}" "SessionDB durable-delivery"
+
+if [[ "${changed}" -eq 0 ]]; then
   exit 0
 fi
 
-git apply --unidiff-zero --check "${patch_file}"
-git apply --unidiff-zero "${patch_file}"
-git add cron/scheduler.py tests/cron/test_scheduler.py
+git add \
+  cron/scheduler.py \
+  gateway/run.py \
+  hermes_state.py \
+  tests/cron/test_scheduler.py \
+  tests/test_sessiondb_delivery_spool.py
 git \
   -c user.name="Sandboxed.sh" \
   -c user.email="noreply@sandboxed.sh" \
-  commit -m "fix(cron): deliver API jobs to their source session"
+  commit -m "fix(sessiondb): spool and replay controller deliveries"
 
-echo "Applied Hermes API-session delivery patch. Restart Hermes after testing."
+echo "Applied Hermes durable session-delivery patches. Restart Hermes after testing."

--- a/scripts/configure_hermes_reliability.py
+++ b/scripts/configure_hermes_reliability.py
@@ -49,6 +49,17 @@ def configure(config: dict, assistant_mcp: str) -> None:
     tools["prompts"] = False
     tools["resources"] = False
 
+    # Proton currently fails its production startup self-test because its
+    # optional Python dependencies are not installed. Keep it explicitly
+    # disabled until that probe passes instead of paying the failure cost on
+    # every gateway start.
+    plugins = config.setdefault("plugins", {})
+    enabled = plugins.setdefault("enabled", [])
+    disabled = plugins.setdefault("disabled", [])
+    plugins["enabled"] = [name for name in enabled if name != "proton-platform"]
+    if "proton-platform" not in disabled:
+        disabled.append("proton-platform")
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
@@ -78,7 +89,8 @@ def main() -> None:
 
     print(
         f"Configured {path}: native Kanban disabled, "
-        f"assistant-MCP timeout=120s, tools={len(ASSISTANT_TOOLS)}"
+        f"assistant-MCP timeout=120s, tools={len(ASSISTANT_TOOLS)}, "
+        "Proton disabled"
     )
 
 

--- a/scripts/configure_hermes_reliability.py
+++ b/scripts/configure_hermes_reliability.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Apply the Hermes-side reliability boundary without rewriting secrets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ASSISTANT_TOOLS = [
+    "list_active_missions",
+    "list_missions",
+    "get_mission",
+    "get_mission_events",
+    "start_mission",
+    "send_message_to_mission",
+    "cancel_mission",
+    "list_workspaces",
+    "get_compute_fleet",
+    "get_mission_health",
+    "get_mission_diagnostics",
+    "update_mission_settings",
+    "resume_mission",
+    "acknowledge_mission",
+    "start_workspace_job",
+    "get_workspace_job",
+    "cancel_workspace_job",
+]
+
+
+def configure(config: dict, assistant_mcp: str) -> None:
+    config.setdefault("kanban", {}).update(
+        {
+            "dispatch_in_gateway": False,
+            "auto_decompose": False,
+            "auto_decompose_per_tick": 0,
+        }
+    )
+    server = config.setdefault("mcp_servers", {}).setdefault("sandboxed_assistant", {})
+    server["command"] = assistant_mcp
+    server["timeout"] = 120
+    tools = server.setdefault("tools", {})
+    tools["include"] = list(ASSISTANT_TOOLS)
+    tools["prompts"] = False
+    tools["resources"] = False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--home", type=Path, required=True)
+    parser.add_argument("--assistant-mcp", required=True)
+    args = parser.parse_args()
+
+    path = args.home / "config.yaml"
+    if not path.is_file():
+        raise SystemExit(f"Hermes config not found: {path}")
+    backup = path.with_name(f"{path.name}.pre-reliability")
+    if not backup.exists():
+        shutil.copy2(path, backup)
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with path.open() as stream:
+        config = yaml.load(stream) or {}
+    configure(config, args.assistant_mcp)
+
+    mode = path.stat().st_mode
+    with tempfile.NamedTemporaryFile("w", dir=path.parent, delete=False) as stream:
+        temp = Path(stream.name)
+        yaml.dump(config, stream)
+    os.chmod(temp, mode)
+    os.replace(temp, path)
+
+    print(
+        f"Configured {path}: native Kanban disabled, "
+        f"assistant-MCP timeout=120s, tools={len(ASSISTANT_TOOLS)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_hermes_dev_reliability_patch.sh
+++ b/scripts/install_hermes_dev_reliability_patch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_repo="${HERMES_SOURCE_REPO:-/usr/local/lib/hermes-agent}"
+dev_repo="${HERMES_DEV_REPO:-/usr/local/lib/hermes-agent-dev}"
+dev_unit="${HERMES_DEV_UNIT:-hermes-assistant-dev.service}"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+dropin_source="${script_dir}/../deploy/systemd/hermes-assistant-dev-isolated.conf"
+dropin_dir="/etc/systemd/system/${dev_unit}.d"
+dropin_dest="${dropin_dir}/70-isolated-checkout.conf"
+
+if [[ ! -d "${source_repo}/.git" ]]; then
+  echo "Hermes source checkout not found at ${source_repo}" >&2
+  exit 1
+fi
+
+source_revision="$(git -C "${source_repo}" rev-parse HEAD)"
+if [[ ! -d "${dev_repo}/.git" ]]; then
+  git clone --no-hardlinks "${source_repo}" "${dev_repo}"
+fi
+
+if [[ -n "$(git -C "${dev_repo}" status --porcelain)" ]]; then
+  echo "Hermes dev checkout has uncommitted changes: ${dev_repo}" >&2
+  exit 1
+fi
+
+git -C "${dev_repo}" fetch "${source_repo}" "${source_revision}"
+git -C "${dev_repo}" checkout --detach "${source_revision}"
+"${script_dir}/apply_hermes_session_delivery_patch.sh" "${dev_repo}"
+
+(
+  cd "${dev_repo}"
+  uv sync --frozen --no-dev
+  .venv/bin/python -m py_compile hermes_state.py gateway/run.py cron/scheduler.py
+)
+
+install -d -m 0755 "${dropin_dir}"
+install -m 0644 "${dropin_source}" "${dropin_dest}"
+systemctl daemon-reload
+
+echo "Hermes dev installed at ${dev_repo} from ${source_revision}."
+echo "Production checkout ${source_repo} was not modified."
+echo "Start or restart ${dev_unit} after its targeted tests pass."

--- a/scripts/install_hermes_dev_reliability_patch.sh
+++ b/scripts/install_hermes_dev_reliability_patch.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 source_repo="${HERMES_SOURCE_REPO:-/usr/local/lib/hermes-agent}"
 dev_repo="${HERMES_DEV_REPO:-/usr/local/lib/hermes-agent-dev}"
 dev_unit="${HERMES_DEV_UNIT:-hermes-assistant-dev.service}"
+dev_home="${HERMES_DEV_HOME:-/var/lib/hermes-assistant-dev}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 dropin_source="${script_dir}/../deploy/systemd/hermes-assistant-dev-isolated.conf"
 dropin_dir="/etc/systemd/system/${dev_unit}.d"
@@ -32,6 +33,9 @@ git -C "${dev_repo}" checkout --detach "${source_revision}"
   cd "${dev_repo}"
   uv sync --frozen --no-dev
   .venv/bin/python -m py_compile hermes_state.py gateway/run.py cron/scheduler.py
+  .venv/bin/python "${script_dir}/configure_hermes_reliability.py" \
+    --home "${dev_home}" \
+    --assistant-mcp /usr/local/bin/assistant-mcp-dev
 )
 
 install -d -m 0755 "${dropin_dir}"

--- a/scripts/lake
+++ b/scripts/lake
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Mission-local Lake policy shim. Heavy commands route through the durable
+# remote-build protocol; metadata queries and node-side execution stay local.
+set -u
+
+policy="${SANDBOXED_COMPUTE_POLICY:-local_allowed}"
+
+find_real_lake() {
+  for candidate in \
+    "${SANDBOXED_REAL_LAKE:-}" \
+    "${ELAN_HOME:-}/bin/lake" \
+    "${HOME:-}/.elan/bin/lake" \
+    "/root/.elan/bin/lake" \
+    "/usr/bin/lake" \
+    "/bin/lake"
+  do
+    [ -n "$candidate" ] || continue
+    [ -x "$candidate" ] || continue
+    [ "$(readlink -f "$candidate" 2>/dev/null || printf %s "$candidate")" = \
+      "$(readlink -f "$0" 2>/dev/null || printf %s "$0")" ] && continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  old_ifs=$IFS; IFS=:
+  for directory in ${PATH:-}; do
+    [ -n "$directory" ] || directory=.
+    candidate="$directory/lake"
+    [ -x "$candidate" ] || continue
+    [ "$(readlink -f "$candidate" 2>/dev/null || printf %s "$candidate")" = \
+      "$(readlink -f "$0" 2>/dev/null || printf %s "$0")" ] && continue
+    IFS=$old_ifs
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  IFS=$old_ifs
+  return 1
+}
+
+real_lake="$(find_real_lake)" || {
+  echo "sandboxed lake shim: real Lake binary not found" >&2
+  exit 127
+}
+
+# Remote nodes must execute the real tool and never recurse through dispatch.
+if [ "${SANDBOXED_REMOTE_EXECUTION:-0}" = "1" ]; then
+  exec "$real_lake" "$@"
+fi
+
+heavy=0
+case "${1:-}" in
+  build|test|check) heavy=1 ;;
+  env)
+    case "${2:-}" in lean|lake) heavy=1 ;; esac
+    ;;
+esac
+
+# Operators can add project-specific verification verbs without replacing the
+# shim. Values are comma-separated first arguments.
+case ",${SANDBOXED_REMOTE_LAKE_COMMANDS:-}," in
+  *",${1:-},"*) heavy=1 ;;
+esac
+
+if [ "$heavy" -eq 0 ] || [ "$policy" = "local_allowed" ]; then
+  exec "$real_lake" "$@"
+fi
+
+remote-lean-build lake "$@"
+remote_status=$?
+if [ "$remote_status" -ne 75 ]; then
+  exit "$remote_status"
+fi
+
+if [ "$policy" = "remote_required" ] && [ "${SANDBOXED_ALLOW_LOCAL_LEAN:-0}" != "1" ]; then
+  echo "sandboxed lake shim: remote_required policy blocked local heavy Lean execution; remote capacity is unavailable" >&2
+  exit 75
+fi
+
+if [ "$policy" = "remote_required" ]; then
+  echo "sandboxed lake shim: POLICY OVERRIDE SANDBOXED_ALLOW_LOCAL_LEAN=1; running heavy Lean locally" >&2
+else
+  echo "sandboxed lake shim: remote_preferred placement unavailable; using the local Lean slot" >&2
+fi
+exec lean-slot "$real_lake" "$@"

--- a/scripts/lake
+++ b/scripts/lake
@@ -47,23 +47,28 @@ if [ "${SANDBOXED_REMOTE_EXECUTION:-0}" = "1" ]; then
 fi
 
 heavy=0
+unwrap_nested_lake=0
 case "${1:-}" in
   build|test|check) heavy=1 ;;
   env)
-    case "${2:-}" in lean|lake) heavy=1 ;; esac
+    case "${2:-}" in
+      lean) heavy=1 ;;
+      lake)
+        case "${3:-}" in
+          build|test|check) heavy=1; unwrap_nested_lake=1 ;;
+        esac
+        ;;
+    esac
     ;;
-esac
-
-# Operators can add project-specific verification verbs without replacing the
-# shim. Values are comma-separated first arguments.
-case ",${SANDBOXED_REMOTE_LAKE_COMMANDS:-}," in
-  *",${1:-},"*) heavy=1 ;;
 esac
 
 if [ "$heavy" -eq 0 ] || [ "$policy" = "local_allowed" ]; then
   exec "$real_lake" "$@"
 fi
 
+if [ "$unwrap_nested_lake" -eq 1 ]; then
+  shift 2
+fi
 remote-lean-build lake "$@"
 remote_status=$?
 if [ "$remote_status" -ne 75 ]; then

--- a/scripts/lake
+++ b/scripts/lake
@@ -46,23 +46,48 @@ if [ "${SANDBOXED_REMOTE_EXECUTION:-0}" = "1" ]; then
   exec "$real_lake" "$@"
 fi
 
-heavy=0
+remote_heavy=0
+local_only_heavy=0
 unwrap_nested_lake=0
 case "${1:-}" in
-  build|test|check) heavy=1 ;;
+  build) remote_heavy=1 ;;
+  test|check) local_only_heavy=1 ;;
   env)
     case "${2:-}" in
-      lean) heavy=1 ;;
+      lean) local_only_heavy=1 ;;
       lake)
         case "${3:-}" in
-          build|test|check) heavy=1; unwrap_nested_lake=1 ;;
+          build) remote_heavy=1; unwrap_nested_lake=1 ;;
+          test|check) local_only_heavy=1; unwrap_nested_lake=1 ;;
         esac
         ;;
     esac
     ;;
 esac
 
-if [ "$heavy" -eq 0 ] || [ "$policy" = "local_allowed" ]; then
+# The core and runner are rolled independently. Standard verification verbs
+# require the expanded node validator; keep them off the wire until an
+# operator confirms the fleet has that binary. This avoids turning a rolling
+# deployment into a non-fallback HTTP 400 from an older runner.
+if [ "$local_only_heavy" -eq 1 ] && [ "${SANDBOXED_REMOTE_LAKE_VERIFY:-0}" = "1" ]; then
+  remote_heavy=1
+  local_only_heavy=0
+fi
+
+if [ "$local_only_heavy" -eq 1 ]; then
+  if [ "$policy" = "remote_required" ] && [ "${SANDBOXED_ALLOW_LOCAL_LEAN:-0}" != "1" ]; then
+    echo "sandboxed lake shim: remote_required verification needs the expanded sandboxed-node Lake protocol; local execution is blocked" >&2
+    exit 75
+  fi
+  if [ "$policy" = "remote_required" ]; then
+    echo "sandboxed lake shim: POLICY OVERRIDE SANDBOXED_ALLOW_LOCAL_LEAN=1; running verification locally" >&2
+  elif [ "$policy" = "remote_preferred" ]; then
+    echo "sandboxed lake shim: remote verification is not enabled for this fleet; using the local Lean slot" >&2
+  fi
+  exec lean-slot "$real_lake" "$@"
+fi
+
+if [ "$remote_heavy" -eq 0 ] || [ "$policy" = "local_allowed" ]; then
   exec "$real_lake" "$@"
 fi
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -36,7 +36,7 @@ use crate::api::mission_store::{
     MissionStore, TaskAttempt,
 };
 
-use super::{ControlCommand, MissionStatus};
+use super::{ControlCommand, MissionStatus, UserMessageAck};
 
 /// One slot is always reserved for the boss itself so digest delivery can
 /// never be starved by board workers occupying every parallel slot.
@@ -642,30 +642,131 @@ const BOARD_WAKE_PROMPT: &str = "[task-board] Your task board changed — one or
     work. Scheduling, retries, and worker dispatch are automatic — never wait or poll. If \
     board_status shows nothing needing action, just end your turn.";
 
-/// Fire-and-forget control-plane send into the actor's own command channel.
-/// Always strict: delivered only to `target_mission_id`, never re-routed to
-/// the main session or rewritten as a `/goal`. Never awaits (the scheduler
-/// runs on the task that consumes this channel).
-fn self_send_message(
+pub type BoardOutboxInflight = Arc<std::sync::Mutex<HashSet<Uuid>>>;
+
+/// Dispatch a persisted outbox item into the actor's own command channel.
+/// The deterministic message id makes concurrent/startup replay harmless.
+/// A background waiter acknowledges the outbox only after the consumer has
+/// accepted the command; the scheduler itself must not await its own channel.
+fn dispatch_board_outbox_item(
+    mission_store: &Arc<dyn MissionStore>,
     cmd_tx: &mpsc::Sender<ControlCommand>,
+    inflight: &BoardOutboxInflight,
+    delivery_id: Uuid,
+    idempotency_key: String,
     target_mission_id: Uuid,
     content: String,
 ) -> bool {
-    let (respond, _rx) = oneshot::channel();
+    if !inflight
+        .lock()
+        .expect("board outbox lock")
+        .insert(delivery_id)
+    {
+        return true;
+    }
+    let (respond, rx) = oneshot::channel();
     match cmd_tx.try_send(ControlCommand::UserMessage {
-        id: Uuid::new_v4(),
+        id: delivery_id,
         content,
         agent: None,
         target_mission_id: Some(target_mission_id),
         strict: true,
-        source: None,
+        source: Some("task-board".to_string()),
         respond,
     }) {
-        Ok(()) => true,
+        Ok(()) => {
+            let store = Arc::clone(mission_store);
+            let inflight = Arc::clone(inflight);
+            tokio::spawn(async move {
+                match rx.await {
+                    Ok(UserMessageAck::Queued | UserMessageAck::Delivered) => {
+                        if let Err(error) = store.acknowledge_board_outbox(&idempotency_key).await {
+                            tracing::warn!(target = %target_mission_id, %idempotency_key,
+                                "board: accepted delivery acknowledgement failed: {error}");
+                        }
+                        inflight
+                            .lock()
+                            .expect("board outbox lock")
+                            .remove(&delivery_id);
+                    }
+                    Ok(UserMessageAck::Dropped) => tracing::warn!(
+                        target = %target_mission_id,
+                        %idempotency_key,
+                        "board: actor dropped delivery; leaving outbox pending"
+                    ),
+                    Ok(UserMessageAck::Rejected(reason)) => tracing::warn!(
+                        target = %target_mission_id,
+                        %idempotency_key,
+                        %reason,
+                        "board: actor rejected delivery; leaving outbox pending"
+                    ),
+                    Err(error) => tracing::warn!(
+                        target = %target_mission_id,
+                        %idempotency_key,
+                        "board: delivery acknowledgement channel closed; leaving outbox pending: {error}"
+                    ),
+                }
+            });
+            true
+        }
         Err(e) => {
-            tracing::warn!(target = %target_mission_id, "board: self-send failed: {}", e);
+            inflight
+                .lock()
+                .expect("board outbox lock")
+                .remove(&delivery_id);
+            tracing::warn!(target = %target_mission_id, %idempotency_key,
+                "board: outbox dispatch failed: {e}");
             false
         }
+    }
+}
+
+fn outbox_payload(item: &BoardOutboxItem) -> Result<(Uuid, String), String> {
+    let target = item
+        .payload
+        .get("target_mission_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "missing target_mission_id".to_string())
+        .and_then(|value| Uuid::parse_str(value).map_err(|error| error.to_string()))?;
+    let content = item
+        .payload
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "missing content".to_string())?
+        .to_string();
+    Ok((target, content))
+}
+
+async fn replay_pending_board_outbox(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    inflight: &BoardOutboxInflight,
+) {
+    let pending = match mission_store.list_pending_board_outbox(1000).await {
+        Ok(items) => items,
+        Err(error) => {
+            tracing::warn!("board: failed to load pending outbox: {error}");
+            return;
+        }
+    };
+    for item in pending {
+        let (target, content) = match outbox_payload(&item) {
+            Ok(payload) => payload,
+            Err(error) => {
+                tracing::warn!(idempotency_key = %item.idempotency_key,
+                    "board: invalid pending outbox payload: {error}");
+                continue;
+            }
+        };
+        let _ = dispatch_board_outbox_item(
+            mission_store,
+            cmd_tx,
+            inflight,
+            item.id,
+            item.idempotency_key,
+            target,
+            content,
+        );
     }
 }
 
@@ -681,6 +782,7 @@ struct BoardDelivery {
 async fn durable_self_send(
     mission_store: &Arc<dyn MissionStore>,
     cmd_tx: &mpsc::Sender<ControlCommand>,
+    inflight: &BoardOutboxInflight,
     delivery: BoardDelivery,
 ) -> bool {
     let BoardDelivery {
@@ -707,22 +809,34 @@ async fn durable_self_send(
         created_at: now_string(),
         acknowledged_at: None,
     };
-    if let Err(error) = mission_store.enqueue_board_outbox(item).await {
-        tracing::warn!(target = %target_mission_id, %idempotency_key,
-            "board: refusing unjournaled delivery: {error}");
-        return false;
+    let persisted = match mission_store.enqueue_board_outbox(item).await {
+        Ok(item) => item,
+        Err(error) => {
+            tracing::warn!(target = %target_mission_id, %idempotency_key,
+                "board: refusing unjournaled delivery: {error}");
+            return false;
+        }
+    };
+    if persisted.state == "acknowledged" {
+        return true;
     }
-    if !self_send_message(cmd_tx, target_mission_id, content) {
-        return false;
-    }
-    if let Err(error) = mission_store
-        .acknowledge_board_outbox(&idempotency_key)
-        .await
-    {
-        tracing::warn!(target = %target_mission_id, %idempotency_key,
-            "board: delivery accepted but acknowledgement persistence failed: {error}");
-    }
-    true
+    let (persisted_target, persisted_content) = match outbox_payload(&persisted) {
+        Ok(payload) => payload,
+        Err(error) => {
+            tracing::warn!(target = %target_mission_id, %idempotency_key,
+                "board: invalid persisted outbox payload: {error}");
+            return false;
+        }
+    };
+    dispatch_board_outbox_item(
+        mission_store,
+        cmd_tx,
+        inflight,
+        persisted.id,
+        persisted.idempotency_key,
+        persisted_target,
+        persisted_content,
+    )
 }
 
 /// Fire-and-forget cancel of a specific (worker) mission's runner. Mirrors
@@ -807,7 +921,16 @@ pub async fn scheduler_pass(
     // Per-boss "a wake is outstanding" flag, owned by the actor loop. Coalesces
     // wakes: at most one pending wake per boss until it next runs (consuming it).
     wake_state: &mut HashMap<Uuid, bool>,
+    // Rows already handed to the actor in this process. Pending rows are
+    // replayed after restart, but not on every scheduler tick while an
+    // acknowledgement is still in flight.
+    outbox_inflight: &BoardOutboxInflight,
 ) {
+    // Re-drive every durable intent before inspecting live board state. The
+    // deterministic command id prevents duplicate execution if a prior send
+    // is still in the channel; an item remains pending until the actor sends a
+    // queued/delivered acknowledgement.
+    replay_pending_board_outbox(mission_store, cmd_tx, outbox_inflight).await;
     let boards = match mission_store.list_active_board_missions().await {
         Ok(b) => b,
         Err(e) => {
@@ -874,6 +997,7 @@ pub async fn scheduler_pass(
                         if durable_self_send(
                             mission_store,
                             cmd_tx,
+                            outbox_inflight,
                             BoardDelivery {
                                 boss_mission_id: boss_id,
                                 task_id: Some(task.id),
@@ -977,6 +1101,7 @@ pub async fn scheduler_pass(
                     match spawn_task_worker(
                         mission_store,
                         cmd_tx,
+                        outbox_inflight,
                         &task,
                         boss.workspace_id,
                         &preflight,
@@ -1019,6 +1144,7 @@ pub async fn scheduler_pass(
             && durable_self_send(
                 mission_store,
                 cmd_tx,
+                outbox_inflight,
                 BoardDelivery {
                     boss_mission_id: boss_id,
                     task_id: None,
@@ -1054,6 +1180,7 @@ fn append_note(notes: &Option<String>, line: &str) -> Option<String> {
 async fn spawn_task_worker(
     mission_store: &Arc<dyn MissionStore>,
     cmd_tx: &mpsc::Sender<ControlCommand>,
+    outbox_inflight: &BoardOutboxInflight,
     task: &BoardTask,
     workspace_id: Uuid,
     preflight: &RetryPreflight,
@@ -1115,6 +1242,7 @@ async fn spawn_task_worker(
     if !durable_self_send(
         mission_store,
         cmd_tx,
+        outbox_inflight,
         BoardDelivery {
             boss_mission_id: t.boss_mission_id,
             task_id: Some(t.id),
@@ -1233,7 +1361,66 @@ pub async fn on_worker_settled(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::mission_store::NewBoardTask;
+    use crate::api::mission_store::{InMemoryMissionStore, NewBoardTask};
+
+    #[tokio::test]
+    async fn durable_delivery_stays_pending_until_actor_acknowledges() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        let inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let boss = Uuid::new_v4();
+        let key = format!("board:{boss}:wake:test");
+
+        assert!(
+            durable_self_send(
+                &store,
+                &cmd_tx,
+                &inflight,
+                BoardDelivery {
+                    boss_mission_id: boss,
+                    task_id: None,
+                    target_mission_id: boss,
+                    delivery_kind: "controller_notification",
+                    idempotency_key: key.clone(),
+                    content: "wake".to_string(),
+                },
+            )
+            .await
+        );
+        assert_eq!(store.list_pending_board_outbox(10).await.unwrap().len(), 1);
+
+        let command = cmd_rx.recv().await.expect("board command");
+        let ControlCommand::UserMessage {
+            id,
+            source,
+            respond,
+            ..
+        } = command
+        else {
+            panic!("expected user message");
+        };
+        assert_eq!(id, Uuid::new_v5(&Uuid::NAMESPACE_OID, key.as_bytes()));
+        assert_eq!(source.as_deref(), Some("task-board"));
+        respond
+            .send(UserMessageAck::Delivered)
+            .expect("ack receiver alive");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if store
+                    .list_pending_board_outbox(10)
+                    .await
+                    .unwrap()
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("outbox acknowledgement persisted");
+    }
 
     #[test]
     fn retry_with_surviving_branch_includes_prior_attempt_digest() {
@@ -1921,8 +2108,17 @@ mod tests {
         };
         let mut wake_state = HashMap::new();
         wake_state.insert(boss_id, true);
+        let outbox_inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
 
-        scheduler_pass(&store, &cmd_tx, &snapshot, 4, &mut wake_state).await;
+        scheduler_pass(
+            &store,
+            &cmd_tx,
+            &snapshot,
+            4,
+            &mut wake_state,
+            &outbox_inflight,
+        )
+        .await;
 
         // All tasks cancelled, boss no longer scheduled, wake state cleared.
         let after = store.list_board_tasks(boss_id).await.expect("list");

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -801,6 +801,69 @@ fn outbox_payload(item: &BoardOutboxItem) -> Result<(Uuid, String), String> {
     Ok((target, content))
 }
 
+/// Revalidate a durable delivery against the current board and mission rows.
+///
+/// Outbox rows survive crashes by design, but the operator may cancel a board
+/// or a worker may finish before replay. Re-sending such a stale row through
+/// `UserMessage` would reactivate the terminal target. Store read failures keep
+/// the row pending for a later pass; conclusive state mismatches retire it.
+async fn board_outbox_replay_is_eligible(
+    mission_store: &Arc<dyn MissionStore>,
+    item: &BoardOutboxItem,
+    target: Uuid,
+) -> Result<bool, String> {
+    let Some(boss) = mission_store.get_mission(item.boss_mission_id).await? else {
+        return Ok(false);
+    };
+    if boss_status_is_terminal(boss.status) || boss.status == MissionStatus::Paused {
+        return Ok(false);
+    }
+
+    match item.delivery_kind.as_str() {
+        "spawn" | "retry" => {
+            let Some(task_id) = item.task_id else {
+                return Ok(false);
+            };
+            let Some(task) = mission_store.get_board_task(task_id).await? else {
+                return Ok(false);
+            };
+            if task.boss_mission_id != item.boss_mission_id
+                || task.status != BoardTaskStatus::Running
+                || task.worker_mission_id != Some(target)
+            {
+                return Ok(false);
+            }
+            let current_spawn_key = format!("board:{}:attempt:{}:spawn", task.id, task.attempts);
+            let current_retry_key = format!("board:{}:attempt:{}:retry", task.id, task.attempts);
+            if item.idempotency_key != current_spawn_key
+                && item.idempotency_key != current_retry_key
+            {
+                return Ok(false);
+            }
+            let Some(worker) = mission_store.get_mission(target).await? else {
+                return Ok(false);
+            };
+            // A board spawn delivery is the transition out of Pending. Any
+            // later presentation/terminal state proves this exact intent is
+            // stale or was already consumed before its acknowledgement landed.
+            Ok(worker.status == MissionStatus::Pending)
+        }
+        "controller_notification" => {
+            if item.task_id.is_some() || target != item.boss_mission_id {
+                return Ok(false);
+            }
+            let tasks = mission_store.list_board_tasks(item.boss_mission_id).await?;
+            let current_key = format!(
+                "board:{}:wake:{}",
+                item.boss_mission_id,
+                board_wake_revision(&tasks, &boss.history)
+            );
+            Ok(board_needs_attention(&tasks) && item.idempotency_key == current_key)
+        }
+        _ => Ok(false),
+    }
+}
+
 async fn replay_pending_board_outbox(
     mission_store: &Arc<dyn MissionStore>,
     cmd_tx: &mpsc::Sender<ControlCommand>,
@@ -822,6 +885,35 @@ async fn replay_pending_board_outbox(
                 continue;
             }
         };
+        match board_outbox_replay_is_eligible(mission_store, &item, target).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::info!(
+                    target = %target,
+                    idempotency_key = %item.idempotency_key,
+                    delivery_kind = %item.delivery_kind,
+                    "board: retiring stale pending outbox delivery"
+                );
+                if let Err(error) = mission_store
+                    .acknowledge_board_outbox(&item.idempotency_key)
+                    .await
+                {
+                    tracing::warn!(
+                        idempotency_key = %item.idempotency_key,
+                        "board: failed to retire stale outbox delivery: {error}"
+                    );
+                }
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target = %target,
+                    idempotency_key = %item.idempotency_key,
+                    "board: could not revalidate pending outbox delivery: {error}"
+                );
+                continue;
+            }
+        }
         let _ = dispatch_board_outbox_item(
             mission_store,
             cmd_tx,
@@ -1541,6 +1633,179 @@ mod tests {
             Some(ControlCommand::ReleaseUserMessageId { .. })
         ));
         assert_eq!(store.list_pending_board_outbox(10).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn replay_retires_wake_for_terminal_boss_without_dispatching() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("terminal boss"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "review".into(),
+                    title: "review".into(),
+                    prompt: "p".into(),
+                    backend: "codex".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("create task");
+        let mut task = store
+            .list_board_tasks(boss.id)
+            .await
+            .expect("list task")
+            .remove(0);
+        task.status = BoardTaskStatus::Settled;
+        store.save_board_task(&task).await.expect("settle task");
+
+        let key = format!("board:{}:wake:stale", boss.id);
+        store
+            .enqueue_board_outbox(BoardOutboxItem {
+                id: Uuid::new_v5(&Uuid::NAMESPACE_OID, key.as_bytes()),
+                boss_mission_id: boss.id,
+                task_id: None,
+                delivery_kind: "controller_notification".into(),
+                idempotency_key: key,
+                payload: serde_json::json!({
+                    "target_mission_id": boss.id,
+                    "content": BOARD_WAKE_PROMPT,
+                }),
+                state: "pending".into(),
+                attempts: 0,
+                created_at: now_string(),
+                acknowledged_at: None,
+            })
+            .await
+            .expect("enqueue wake");
+        store
+            .update_mission_status(boss.id, MissionStatus::Interrupted)
+            .await
+            .expect("cancel boss");
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        let inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        replay_pending_board_outbox(&store, &cmd_tx, &inflight).await;
+
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "terminal boss must not be woken"
+        );
+        assert!(store
+            .list_pending_board_outbox(10)
+            .await
+            .expect("pending outbox")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn replay_retires_spawn_for_acknowledged_worker_without_dispatching() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("live boss"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        let worker = store
+            .create_mission_with_parent(
+                Some("worker"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(boss.id),
+                None,
+            )
+            .await
+            .expect("create worker");
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "worker".into(),
+                    title: "worker".into(),
+                    prompt: "p".into(),
+                    backend: "codex".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("create task");
+        let mut task = store
+            .list_board_tasks(boss.id)
+            .await
+            .expect("list task")
+            .remove(0);
+        task.status = BoardTaskStatus::Running;
+        task.worker_mission_id = Some(worker.id);
+        task.attempts = 1;
+        store
+            .save_board_task(&task)
+            .await
+            .expect("save running task");
+        store
+            .update_mission_status(worker.id, MissionStatus::Acknowledged)
+            .await
+            .expect("acknowledge worker");
+
+        let key = format!("board:{}:attempt:1:spawn", task.id);
+        store
+            .enqueue_board_outbox(BoardOutboxItem {
+                id: Uuid::new_v5(&Uuid::NAMESPACE_OID, key.as_bytes()),
+                boss_mission_id: boss.id,
+                task_id: Some(task.id),
+                delivery_kind: "spawn".into(),
+                idempotency_key: key,
+                payload: serde_json::json!({
+                    "target_mission_id": worker.id,
+                    "content": "do work",
+                }),
+                state: "pending".into(),
+                attempts: 0,
+                created_at: now_string(),
+                acknowledged_at: None,
+            })
+            .await
+            .expect("enqueue spawn");
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        let inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        replay_pending_board_outbox(&store, &cmd_tx, &inflight).await;
+
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "acknowledged worker must not be reactivated"
+        );
+        assert!(store
+            .list_pending_board_outbox(10)
+            .await
+            .expect("pending outbox")
+            .is_empty());
     }
 
     #[test]

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -669,16 +669,28 @@ fn self_send_message(
     }
 }
 
-async fn durable_self_send(
-    mission_store: &Arc<dyn MissionStore>,
-    cmd_tx: &mpsc::Sender<ControlCommand>,
+struct BoardDelivery {
     boss_mission_id: Uuid,
     task_id: Option<Uuid>,
     target_mission_id: Uuid,
-    delivery_kind: &str,
+    delivery_kind: &'static str,
     idempotency_key: String,
     content: String,
+}
+
+async fn durable_self_send(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    delivery: BoardDelivery,
 ) -> bool {
+    let BoardDelivery {
+        boss_mission_id,
+        task_id,
+        target_mission_id,
+        delivery_kind,
+        idempotency_key,
+        content,
+    } = delivery;
     let delivery_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, idempotency_key.as_bytes());
     let item = BoardOutboxItem {
         id: delivery_id,
@@ -862,12 +874,17 @@ pub async fn scheduler_pass(
                         if durable_self_send(
                             mission_store,
                             cmd_tx,
-                            boss_id,
-                            Some(task.id),
-                            worker_id,
-                            "retry",
-                            format!("board:{}:attempt:{}:retry", task.id, task.attempts),
-                            prompt,
+                            BoardDelivery {
+                                boss_mission_id: boss_id,
+                                task_id: Some(task.id),
+                                target_mission_id: worker_id,
+                                delivery_kind: "retry",
+                                idempotency_key: format!(
+                                    "board:{}:attempt:{}:retry",
+                                    task.id, task.attempts
+                                ),
+                                content: prompt,
+                            },
                         )
                         .await
                         {
@@ -1002,19 +1019,21 @@ pub async fn scheduler_pass(
             && durable_self_send(
                 mission_store,
                 cmd_tx,
-                boss_id,
-                None,
-                boss_id,
-                "controller_notification",
-                format!(
-                    "board:{boss_id}:wake:{}",
-                    fresh
-                        .iter()
-                        .map(|task| task.updated_at.as_str())
-                        .max()
-                        .unwrap_or("empty")
-                ),
-                BOARD_WAKE_PROMPT.to_string(),
+                BoardDelivery {
+                    boss_mission_id: boss_id,
+                    task_id: None,
+                    target_mission_id: boss_id,
+                    delivery_kind: "controller_notification",
+                    idempotency_key: format!(
+                        "board:{boss_id}:wake:{}",
+                        fresh
+                            .iter()
+                            .map(|task| task.updated_at.as_str())
+                            .max()
+                            .unwrap_or("empty")
+                    ),
+                    content: BOARD_WAKE_PROMPT.to_string(),
+                },
             )
             .await
         {
@@ -1096,12 +1115,14 @@ async fn spawn_task_worker(
     if !durable_self_send(
         mission_store,
         cmd_tx,
-        t.boss_mission_id,
-        Some(t.id),
-        mission.id,
-        if t.attempts > 1 { "retry" } else { "spawn" },
-        delivery_key,
-        prompt,
+        BoardDelivery {
+            boss_mission_id: t.boss_mission_id,
+            task_id: Some(t.id),
+            target_mission_id: mission.id,
+            delivery_kind: if t.attempts > 1 { "retry" } else { "spawn" },
+            idempotency_key: delivery_key,
+            content: prompt,
+        },
     )
     .await
     {

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -33,7 +33,7 @@ use uuid::Uuid;
 use crate::agents::TerminalReason;
 use crate::api::mission_store::{
     now_string, BoardOutboxItem, BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus,
-    MissionStore, TaskAttempt,
+    MissionHistoryEntry, MissionStore, TaskAttempt,
 };
 
 use super::{ControlCommand, MissionStatus, UserMessageAck};
@@ -630,6 +630,34 @@ fn board_needs_attention(tasks: &[BoardTask]) -> bool {
         .any(|t| matches!(t.status, BoardTaskStatus::Settled | BoardTaskStatus::Failed))
 }
 
+/// Stable revision for a controller wake. Board state alone is insufficient:
+/// an acknowledged outbox row remains durable after the boss consumes it. If
+/// the boss turn does not mutate any task, reusing the same task-only key would
+/// make the next wake look acknowledged without actually queueing a message.
+///
+/// Mission history advances when the boss starts consuming the wake, so it
+/// distinguishes successive controller turns while preserving the same key
+/// across retries/restarts before consumption.
+fn board_wake_revision(tasks: &[BoardTask], history: &[MissionHistoryEntry]) -> Uuid {
+    let latest_task_update = tasks
+        .iter()
+        .map(|task| task.updated_at.as_str())
+        .max()
+        .unwrap_or("empty");
+    let latest_history = history.last();
+    let revision_material = format!(
+        "{latest_task_update}\0{}\0{}\0{}",
+        history.len(),
+        latest_history
+            .map(|entry| entry.role.as_str())
+            .unwrap_or(""),
+        latest_history
+            .map(|entry| entry.content.as_str())
+            .unwrap_or("")
+    );
+    Uuid::new_v5(&Uuid::NAMESPACE_OID, revision_material.as_bytes())
+}
+
 /// Generic, content-free wake delivered to a boss when its board changes.
 /// Deliberately mentions NO specific task or other board — the boss reacts to
 /// its OWN board state. If this ever reaches the wrong mission, that mission
@@ -997,7 +1025,15 @@ pub async fn scheduler_pass(
         // getting workers re-spawned and wake banners it can never act on.
         // Cancel its non-terminal tasks (+ live workers) and skip; next pass the
         // boss drops out entirely.
-        if let Ok(Some(boss)) = mission_store.get_mission(boss_id).await {
+        let boss = match mission_store.get_mission(boss_id).await {
+            Ok(boss) => boss,
+            Err(error) => {
+                tracing::warn!(boss = %boss_id,
+                    "board: failed to load boss mission for scheduling: {error}");
+                None
+            }
+        };
+        if let Some(boss) = boss.as_ref() {
             if boss_status_is_terminal(boss.status) {
                 cancel_dead_boss_board(mission_store, cmd_tx, boss_id, &tasks).await;
                 wake_state.remove(&boss_id);
@@ -1176,31 +1212,30 @@ pub async fn scheduler_pass(
         let needs = board_needs_attention(&fresh);
         if !needs {
             wake_state.insert(boss_id, false);
-        } else if !wake_state.get(&boss_id).copied().unwrap_or(false)
-            && durable_self_send(
-                mission_store,
-                cmd_tx,
-                outbox_inflight,
-                BoardDelivery {
-                    boss_mission_id: boss_id,
-                    task_id: None,
-                    target_mission_id: boss_id,
-                    delivery_kind: "controller_notification",
-                    idempotency_key: format!(
-                        "board:{boss_id}:wake:{}",
-                        fresh
-                            .iter()
-                            .map(|task| task.updated_at.as_str())
-                            .max()
-                            .unwrap_or("empty")
-                    ),
-                    content: BOARD_WAKE_PROMPT.to_string(),
-                },
-            )
-            .await
-        {
-            wake_state.insert(boss_id, true);
-            tracing::info!(boss = %boss_id, "board: sent wake (tasks awaiting decision)");
+        } else if !wake_state.get(&boss_id).copied().unwrap_or(false) {
+            if let Some(boss) = boss.as_ref() {
+                if durable_self_send(
+                    mission_store,
+                    cmd_tx,
+                    outbox_inflight,
+                    BoardDelivery {
+                        boss_mission_id: boss_id,
+                        task_id: None,
+                        target_mission_id: boss_id,
+                        delivery_kind: "controller_notification",
+                        idempotency_key: format!(
+                            "board:{boss_id}:wake:{}",
+                            board_wake_revision(&fresh, &boss.history)
+                        ),
+                        content: BOARD_WAKE_PROMPT.to_string(),
+                    },
+                )
+                .await
+                {
+                    wake_state.insert(boss_id, true);
+                    tracing::info!(boss = %boss_id, "board: sent wake (tasks awaiting decision)");
+                }
+            }
         }
     }
 }
@@ -1994,6 +2029,42 @@ mod tests {
             Some(BoardTaskOutcome::Success)
         )]));
         assert!(!board_needs_attention(&[]));
+    }
+
+    #[test]
+    fn wake_revision_reissues_after_boss_consumes_wake() {
+        let tasks = vec![mk(
+            "review",
+            &[],
+            BoardTaskStatus::Settled,
+            Some(BoardTaskOutcome::Success),
+        )];
+        let before = vec![MissionHistoryEntry {
+            role: "assistant".into(),
+            content: "Previous controller turn".into(),
+        }];
+
+        let initial = board_wake_revision(&tasks, &before);
+        assert_eq!(initial, board_wake_revision(&tasks, &before));
+
+        let mut after_consumption = before.clone();
+        after_consumption.push(MissionHistoryEntry {
+            role: "user".into(),
+            content: BOARD_WAKE_PROMPT.into(),
+        });
+        assert_ne!(
+            initial,
+            board_wake_revision(&tasks, &after_consumption),
+            "a consumed wake must permit a successor even when task timestamps are unchanged"
+        );
+
+        let mut changed_tasks = tasks.clone();
+        changed_tasks[0].updated_at = "2026-01-02T00:00:00Z".into();
+        assert_ne!(
+            initial,
+            board_wake_revision(&changed_tasks, &before),
+            "task state changes must continue to produce a fresh wake revision"
+        );
     }
 
     #[tokio::test]

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -680,31 +680,53 @@ fn dispatch_board_outbox_item(
             tokio::spawn(async move {
                 match rx.await {
                     Ok(UserMessageAck::Queued | UserMessageAck::Delivered) => {
-                        if let Err(error) = store.acknowledge_board_outbox(&idempotency_key).await {
-                            tracing::warn!(target = %target_mission_id, %idempotency_key,
-                                "board: accepted delivery acknowledgement failed: {error}");
+                        match store.acknowledge_board_outbox(&idempotency_key).await {
+                            Ok(()) => {
+                                inflight
+                                    .lock()
+                                    .expect("board outbox lock")
+                                    .remove(&delivery_id);
+                            }
+                            Err(error) => {
+                                tracing::warn!(target = %target_mission_id, %idempotency_key,
+                                    "board: accepted delivery acknowledgement failed: {error}");
+                            }
                         }
+                    }
+                    Ok(UserMessageAck::Dropped) => {
                         inflight
                             .lock()
                             .expect("board outbox lock")
                             .remove(&delivery_id);
+                        tracing::warn!(
+                            target = %target_mission_id,
+                            %idempotency_key,
+                            "board: actor dropped delivery; leaving outbox pending"
+                        );
                     }
-                    Ok(UserMessageAck::Dropped) => tracing::warn!(
-                        target = %target_mission_id,
-                        %idempotency_key,
-                        "board: actor dropped delivery; leaving outbox pending"
-                    ),
-                    Ok(UserMessageAck::Rejected(reason)) => tracing::warn!(
-                        target = %target_mission_id,
-                        %idempotency_key,
-                        %reason,
-                        "board: actor rejected delivery; leaving outbox pending"
-                    ),
-                    Err(error) => tracing::warn!(
-                        target = %target_mission_id,
-                        %idempotency_key,
-                        "board: delivery acknowledgement channel closed; leaving outbox pending: {error}"
-                    ),
+                    Ok(UserMessageAck::Rejected(reason)) => {
+                        inflight
+                            .lock()
+                            .expect("board outbox lock")
+                            .remove(&delivery_id);
+                        tracing::warn!(
+                            target = %target_mission_id,
+                            %idempotency_key,
+                            %reason,
+                            "board: actor rejected delivery; leaving outbox pending"
+                        );
+                    }
+                    Err(error) => {
+                        inflight
+                            .lock()
+                            .expect("board outbox lock")
+                            .remove(&delivery_id);
+                        tracing::warn!(
+                            target = %target_mission_id,
+                            %idempotency_key,
+                            "board: delivery acknowledgement channel closed; leaving outbox pending: {error}"
+                        );
+                    }
                 }
             });
             true
@@ -1420,6 +1442,52 @@ mod tests {
         })
         .await
         .expect("outbox acknowledgement persisted");
+        assert!(inflight.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dropped_delivery_is_released_for_pending_replay() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        let inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let boss = Uuid::new_v4();
+
+        assert!(
+            durable_self_send(
+                &store,
+                &cmd_tx,
+                &inflight,
+                BoardDelivery {
+                    boss_mission_id: boss,
+                    task_id: None,
+                    target_mission_id: boss,
+                    delivery_kind: "controller_notification",
+                    idempotency_key: format!("board:{boss}:wake:dropped"),
+                    content: "wake".to_string(),
+                },
+            )
+            .await
+        );
+        let ControlCommand::UserMessage { respond, .. } =
+            cmd_rx.recv().await.expect("board command")
+        else {
+            panic!("expected user message");
+        };
+        respond
+            .send(UserMessageAck::Dropped)
+            .expect("ack receiver alive");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if inflight.lock().unwrap().is_empty() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped delivery released");
+        assert_eq!(store.list_pending_board_outbox(10).await.unwrap().len(), 1);
     }
 
     #[test]

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -31,7 +31,10 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::agents::TerminalReason;
-use crate::api::mission_store::{BoardTask, BoardTaskOutcome, BoardTaskStatus, MissionStore};
+use crate::api::mission_store::{
+    now_string, BoardOutboxItem, BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus,
+    MissionStore, TaskAttempt,
+};
 
 use super::{ControlCommand, MissionStatus};
 
@@ -51,6 +54,17 @@ const STUCK_PENDING_SECS: i64 = 90;
 /// Digest truncation: keep the head and tail of the worker's final message.
 const DIGEST_HEAD_CHARS: usize = 400;
 const DIGEST_TAIL_CHARS: usize = 1200;
+
+fn role_default_model(task: &BoardTask) -> Option<&'static str> {
+    if task.backend != "codex" {
+        return None;
+    }
+    Some(match task.role {
+        BoardTaskRole::Planner | BoardTaskRole::Reviewer => "gpt-5.6-sol",
+        BoardTaskRole::Reconciler if task.risk_class == "high" => "gpt-5.6-sol",
+        BoardTaskRole::Worker | BoardTaskRole::Reconciler => "gpt-5.6-terra",
+    })
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RetryPreflight {
@@ -655,6 +669,50 @@ fn self_send_message(
     }
 }
 
+async fn durable_self_send(
+    mission_store: &Arc<dyn MissionStore>,
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    boss_mission_id: Uuid,
+    task_id: Option<Uuid>,
+    target_mission_id: Uuid,
+    delivery_kind: &str,
+    idempotency_key: String,
+    content: String,
+) -> bool {
+    let delivery_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, idempotency_key.as_bytes());
+    let item = BoardOutboxItem {
+        id: delivery_id,
+        boss_mission_id,
+        task_id,
+        delivery_kind: delivery_kind.to_string(),
+        idempotency_key: idempotency_key.clone(),
+        payload: serde_json::json!({
+            "target_mission_id": target_mission_id,
+            "content": content,
+        }),
+        state: "pending".to_string(),
+        attempts: 0,
+        created_at: now_string(),
+        acknowledged_at: None,
+    };
+    if let Err(error) = mission_store.enqueue_board_outbox(item).await {
+        tracing::warn!(target = %target_mission_id, %idempotency_key,
+            "board: refusing unjournaled delivery: {error}");
+        return false;
+    }
+    if !self_send_message(cmd_tx, target_mission_id, content) {
+        return false;
+    }
+    if let Err(error) = mission_store
+        .acknowledge_board_outbox(&idempotency_key)
+        .await
+    {
+        tracing::warn!(target = %target_mission_id, %idempotency_key,
+            "board: delivery accepted but acknowledgement persistence failed: {error}");
+    }
+    true
+}
+
 /// Fire-and-forget cancel of a specific (worker) mission's runner. Mirrors
 /// [`self_send_message`]: try_send only, receiver dropped — the scheduler runs
 /// on the task that consumes this channel and must never await it.
@@ -801,7 +859,18 @@ pub async fn scheduler_pass(
                             retry_prompt(task, &RetryPreflight::NothingFound),
                             worker_contract(task)
                         );
-                        if self_send_message(cmd_tx, worker_id, prompt) {
+                        if durable_self_send(
+                            mission_store,
+                            cmd_tx,
+                            boss_id,
+                            Some(task.id),
+                            worker_id,
+                            "retry",
+                            format!("board:{}:attempt:{}:retry", task.id, task.attempts),
+                            prompt,
+                        )
+                        .await
+                        {
                             let mut t = task.clone();
                             t.notes = append_note(&t.notes, "re-kicked stuck pending worker");
                             let _ = mission_store.save_board_task(&t).await;
@@ -930,7 +999,24 @@ pub async fn scheduler_pass(
         if !needs {
             wake_state.insert(boss_id, false);
         } else if !wake_state.get(&boss_id).copied().unwrap_or(false)
-            && self_send_message(cmd_tx, boss_id, BOARD_WAKE_PROMPT.to_string())
+            && durable_self_send(
+                mission_store,
+                cmd_tx,
+                boss_id,
+                None,
+                boss_id,
+                "controller_notification",
+                format!(
+                    "board:{boss_id}:wake:{}",
+                    fresh
+                        .iter()
+                        .map(|task| task.updated_at.as_str())
+                        .max()
+                        .unwrap_or("empty")
+                ),
+                BOARD_WAKE_PROMPT.to_string(),
+            )
+            .await
         {
             wake_state.insert(boss_id, true);
             tracing::info!(boss = %boss_id, "board: sent wake (tasks awaiting decision)");
@@ -956,9 +1042,11 @@ async fn spawn_task_worker(
     // Board tasks bypass the public create-mission handler, so apply the same
     // backend-aware normalization here as a defensive migration for tasks that
     // were persisted before upsert started normalizing them.
-    let model_override = task
+    let requested_model = task
         .model_override
         .as_deref()
+        .or_else(|| role_default_model(task));
+    let model_override = requested_model
         .and_then(|model| super::normalize_model_override_for_backend(Some(&task.backend), model));
     let mission = mission_store
         .create_mission_with_parent(
@@ -983,9 +1071,40 @@ async fn spawn_task_worker(
         t.notes = append_note(&t.notes, &format!("retry: attempt {}", t.attempts));
     }
     mission_store.save_board_task(&t).await?;
+    mission_store
+        .create_task_attempt(TaskAttempt {
+            id: Uuid::new_v4(),
+            task_id: t.id,
+            attempt_number: t.attempts,
+            mission_id: mission.id,
+            backend: t.backend.clone(),
+            model: t.model_override.clone(),
+            role: t.role,
+            run_id: None,
+            commit_sha: None,
+            changed_files: vec![],
+            verification_evidence: serde_json::json!({}),
+            cost_cents: None,
+            terminal_class: None,
+            started_at: now_string(),
+            finished_at: None,
+        })
+        .await?;
 
     let prompt = format!("{}{}", retry_prompt(&t, preflight), worker_contract(&t));
-    if !self_send_message(cmd_tx, mission.id, prompt) {
+    let delivery_key = format!("board:{}:attempt:{}:spawn", t.id, t.attempts);
+    if !durable_self_send(
+        mission_store,
+        cmd_tx,
+        t.boss_mission_id,
+        Some(t.id),
+        mission.id,
+        if t.attempts > 1 { "retry" } else { "spawn" },
+        delivery_key,
+        prompt,
+    )
+    .await
+    {
         // Channel full: leave the task running; the zombie sweep re-kicks the
         // pending worker mission after the grace period.
         tracing::warn!(task = %t.task_key, "board: spawn message deferred (channel full)");
@@ -1003,6 +1122,29 @@ async fn settle_task(
     outcome: BoardTaskOutcome,
     output: &str,
 ) {
+    let terminal_class = match outcome {
+        BoardTaskOutcome::Success => "success",
+        BoardTaskOutcome::Blocked => "blocked",
+        BoardTaskOutcome::Failed => "agent_failure",
+    };
+    let evidence = serde_json::json!({
+        "result_digest": digest_excerpt(output),
+        "verification_command": task.verification_command.clone(),
+    });
+    if let Err(error) = mission_store
+        .finish_task_attempt(
+            task.id,
+            task.attempts,
+            terminal_class,
+            None,
+            &[],
+            &evidence,
+            None,
+        )
+        .await
+    {
+        tracing::warn!(task = %task.task_key, "board: failed to close task attempt: {error}");
+    }
     if outcome == BoardTaskOutcome::Failed && task.attempts < MAX_ATTEMPTS {
         // Silent automatic retry: back to pending, next pass respawns fresh.
         task.status = BoardTaskStatus::Pending;
@@ -1195,6 +1337,14 @@ mod tests {
             working_directory: None,
             repository: None,
             branch: None,
+            role: crate::api::mission_store::BoardTaskRole::Worker,
+            acceptance_criteria: vec![],
+            verification_command: None,
+            design_domain: None,
+            declared_write_set: vec![],
+            risk_class: "normal".into(),
+            token_budget: None,
+            cost_budget_cents: None,
             depends_on: deps.iter().map(|s| s.to_string()).collect(),
             status,
             outcome,
@@ -1572,6 +1722,7 @@ mod tests {
                         repository: None,
                         branch: None,
                         depends_on: vec![],
+                        ..Default::default()
                     },
                     NewBoardTask {
                         task_key: "t2".into(),
@@ -1584,6 +1735,7 @@ mod tests {
                         repository: None,
                         branch: None,
                         depends_on: vec!["t1".into()],
+                        ..Default::default()
                     },
                 ],
             )
@@ -1625,6 +1777,7 @@ mod tests {
                     repository: None,
                     branch: None,
                     depends_on: vec![],
+                    ..Default::default()
                 }],
             )
             .await
@@ -1697,6 +1850,7 @@ mod tests {
                         repository: None,
                         branch: None,
                         depends_on: vec![],
+                        ..Default::default()
                     },
                     NewBoardTask {
                         task_key: "pending".into(),
@@ -1709,6 +1863,7 @@ mod tests {
                         repository: None,
                         branch: None,
                         depends_on: vec![],
+                        ..Default::default()
                     },
                 ],
             )

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -677,6 +677,7 @@ fn dispatch_board_outbox_item(
         Ok(()) => {
             let store = Arc::clone(mission_store);
             let inflight = Arc::clone(inflight);
+            let release_tx = cmd_tx.clone();
             tokio::spawn(async move {
                 match rx.await {
                     Ok(UserMessageAck::Queued | UserMessageAck::Delivered) => {
@@ -690,10 +691,17 @@ fn dispatch_board_outbox_item(
                             Err(error) => {
                                 tracing::warn!(target = %target_mission_id, %idempotency_key,
                                     "board: accepted delivery acknowledgement failed: {error}");
+                                inflight
+                                    .lock()
+                                    .expect("board outbox lock")
+                                    .remove(&delivery_id);
                             }
                         }
                     }
                     Ok(UserMessageAck::Dropped) => {
+                        let _ = release_tx
+                            .send(ControlCommand::ReleaseUserMessageId { id: delivery_id })
+                            .await;
                         inflight
                             .lock()
                             .expect("board outbox lock")
@@ -705,6 +713,9 @@ fn dispatch_board_outbox_item(
                         );
                     }
                     Ok(UserMessageAck::Rejected(reason)) => {
+                        let _ = release_tx
+                            .send(ControlCommand::ReleaseUserMessageId { id: delivery_id })
+                            .await;
                         inflight
                             .lock()
                             .expect("board outbox lock")
@@ -717,6 +728,9 @@ fn dispatch_board_outbox_item(
                         );
                     }
                     Err(error) => {
+                        let _ = release_tx
+                            .send(ControlCommand::ReleaseUserMessageId { id: delivery_id })
+                            .await;
                         inflight
                             .lock()
                             .expect("board outbox lock")
@@ -1487,6 +1501,10 @@ mod tests {
         })
         .await
         .expect("dropped delivery released");
+        assert!(matches!(
+            cmd_rx.recv().await,
+            Some(ControlCommand::ReleaseUserMessageId { .. })
+        ));
         assert_eq!(store.list_pending_board_outbox(10).await.unwrap().len(), 1);
     }
 

--- a/src/api/control/board.rs
+++ b/src/api/control/board.rs
@@ -876,6 +876,7 @@ async fn replay_pending_board_outbox(
             return;
         }
     };
+    let mut eligible = Vec::new();
     for item in pending {
         let (target, content) = match outbox_payload(&item) {
             Ok(payload) => payload,
@@ -886,7 +887,7 @@ async fn replay_pending_board_outbox(
             }
         };
         match board_outbox_replay_is_eligible(mission_store, &item, target).await {
-            Ok(true) => {}
+            Ok(true) => eligible.push((item, target, content)),
             Ok(false) => {
                 tracing::info!(
                     target = %target,
@@ -913,6 +914,39 @@ async fn replay_pending_board_outbox(
                 );
                 continue;
             }
+        }
+    }
+
+    // A zombie sweep may persist `:retry` while the original same-attempt
+    // `:spawn` row is still pending. Coalesce before sending anything: the
+    // actor cannot consume its own channel until this scheduler pass returns,
+    // so dispatching both would queue the task twice.
+    let retry_tasks: HashSet<Uuid> = eligible
+        .iter()
+        .filter(|(item, _, _)| item.idempotency_key.ends_with(":retry"))
+        .filter_map(|(item, _, _)| item.task_id)
+        .collect();
+    for (item, target, content) in eligible {
+        if item.idempotency_key.ends_with(":spawn")
+            && item
+                .task_id
+                .is_some_and(|task_id| retry_tasks.contains(&task_id))
+        {
+            tracing::info!(
+                target = %target,
+                idempotency_key = %item.idempotency_key,
+                "board: retiring spawn delivery superseded by same-attempt retry"
+            );
+            if let Err(error) = mission_store
+                .acknowledge_board_outbox(&item.idempotency_key)
+                .await
+            {
+                tracing::warn!(
+                    idempotency_key = %item.idempotency_key,
+                    "board: failed to retire superseded spawn delivery: {error}"
+                );
+            }
+            continue;
         }
         let _ = dispatch_board_outbox_item(
             mission_store,
@@ -949,6 +983,21 @@ async fn durable_self_send(
         idempotency_key,
         content,
     } = delivery;
+    if let Some(prefix) = idempotency_key.strip_suffix(":retry") {
+        let superseded_spawn_key = format!("{prefix}:spawn");
+        if let Err(error) = mission_store
+            .acknowledge_board_outbox(&superseded_spawn_key)
+            .await
+        {
+            tracing::warn!(
+                target = %target_mission_id,
+                %idempotency_key,
+                superseded = %superseded_spawn_key,
+                "board: refusing retry until its superseded spawn is retired: {error}"
+            );
+            return false;
+        }
+    }
     let delivery_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, idempotency_key.as_bytes());
     let item = BoardOutboxItem {
         id: delivery_id,
@@ -1806,6 +1855,112 @@ mod tests {
             .await
             .expect("pending outbox")
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn replay_coalesces_same_attempt_spawn_and_retry() {
+        let store: Arc<dyn MissionStore> = Arc::new(InMemoryMissionStore::new());
+        let boss = store
+            .create_mission_with_parent(
+                Some("live boss"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create boss");
+        let worker = store
+            .create_mission_with_parent(
+                Some("pending worker"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(boss.id),
+                None,
+            )
+            .await
+            .expect("create worker");
+        store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "worker".into(),
+                    title: "worker".into(),
+                    prompt: "p".into(),
+                    backend: "codex".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("create task");
+        let mut task = store
+            .list_board_tasks(boss.id)
+            .await
+            .expect("list task")
+            .remove(0);
+        task.status = BoardTaskStatus::Running;
+        task.worker_mission_id = Some(worker.id);
+        task.attempts = 1;
+        store
+            .save_board_task(&task)
+            .await
+            .expect("save running task");
+
+        let spawn_key = format!("board:{}:attempt:1:spawn", task.id);
+        let retry_key = format!("board:{}:attempt:1:retry", task.id);
+        for (key, kind, content) in [
+            (&spawn_key, "spawn", "initial"),
+            (&retry_key, "retry", "re-kick"),
+        ] {
+            store
+                .enqueue_board_outbox(BoardOutboxItem {
+                    id: Uuid::new_v5(&Uuid::NAMESPACE_OID, key.as_bytes()),
+                    boss_mission_id: boss.id,
+                    task_id: Some(task.id),
+                    delivery_kind: kind.into(),
+                    idempotency_key: key.clone(),
+                    payload: serde_json::json!({
+                        "target_mission_id": worker.id,
+                        "content": content,
+                    }),
+                    state: "pending".into(),
+                    attempts: 0,
+                    created_at: now_string(),
+                    acknowledged_at: None,
+                })
+                .await
+                .expect("enqueue delivery");
+        }
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(2);
+        let inflight: BoardOutboxInflight = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        replay_pending_board_outbox(&store, &cmd_tx, &inflight).await;
+
+        let ControlCommand::UserMessage { id, content, .. } =
+            cmd_rx.try_recv().expect("retry should dispatch")
+        else {
+            panic!("expected user message");
+        };
+        assert_eq!(id, Uuid::new_v5(&Uuid::NAMESPACE_OID, retry_key.as_bytes()));
+        assert_eq!(content, "re-kick");
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "superseded spawn must not also dispatch"
+        );
+        let pending = store
+            .list_pending_board_outbox(10)
+            .await
+            .expect("pending outbox");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].idempotency_key, retry_key);
     }
 
     #[test]

--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -384,6 +384,12 @@ pub enum ControlCommand {
         /// Respond with the delivery outcome (queued / delivered / dropped).
         respond: oneshot::Sender<UserMessageAck>,
     },
+    /// Forget an idempotency guard after a durable internal delivery was
+    /// explicitly dropped/rejected, allowing the same persisted command ID
+    /// to be retried without weakening normal client-message deduplication.
+    ReleaseUserMessageId {
+        id: Uuid,
+    },
     ToolResult {
         tool_call_id: String,
         name: String,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2864,6 +2864,27 @@ pub struct QueuedMessage {
     /// for snapshots written before this field existed.
     #[serde(default)]
     pub source: Option<String>,
+    /// The actor had already consumed this message into an executing parallel
+    /// turn when the snapshot was written. After restart it is a durable
+    /// idempotency marker, not work to replay: the inherited run is
+    /// interrupted and an explicit resume is required.
+    #[serde(default)]
+    pub inflight: bool,
+}
+
+fn partition_restored_control_messages(
+    items: Vec<QueuedMessage>,
+) -> (Vec<QueuedMessage>, Vec<QueuedMessage>) {
+    let mut pending = Vec::with_capacity(items.len());
+    let mut consumed = Vec::new();
+    for item in items {
+        if item.inflight {
+            consumed.push(item);
+        } else {
+            pending.push(item);
+        }
+    }
+    (pending, consumed)
 }
 
 /// Serialize the control session queue to a stable JSON snapshot for
@@ -2871,6 +2892,7 @@ pub struct QueuedMessage {
 fn serialize_queue_snapshot(
     queue: &VecDeque<ControlQueueEntry>,
     parallel_runners: &std::collections::HashMap<Uuid, super::mission_runner::MissionRunner>,
+    recovered_consumed: &HashMap<Uuid, QueuedMessage>,
 ) -> String {
     let mut items: Vec<QueuedMessage> = queue
         .iter()
@@ -2880,6 +2902,7 @@ fn serialize_queue_snapshot(
             agent: agent.clone(),
             mission_id: *target_mid,
             source: source.clone(),
+            inflight: false,
         })
         .collect();
     let mut runners: Vec<_> = parallel_runners.iter().collect();
@@ -2892,6 +2915,7 @@ fn serialize_queue_snapshot(
                 agent: message.agent.clone(),
                 mission_id: Some(*mission_id),
                 source: message.source.clone(),
+                inflight: true,
             });
         }
         items.extend(runner.queue.iter().map(|message| QueuedMessage {
@@ -2900,8 +2924,12 @@ fn serialize_queue_snapshot(
             agent: message.agent.clone(),
             mission_id: Some(*mission_id),
             source: message.source.clone(),
+            inflight: false,
         }));
     }
+    let mut consumed: Vec<_> = recovered_consumed.values().cloned().collect();
+    consumed.sort_by_key(|message| message.id);
+    items.extend(consumed);
     serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
@@ -2919,9 +2947,10 @@ async fn persist_control_queue_if_changed(
     session_user_id: &str,
     queue: &VecDeque<ControlQueueEntry>,
     parallel_runners: &std::collections::HashMap<Uuid, super::mission_runner::MissionRunner>,
+    recovered_consumed: &HashMap<Uuid, QueuedMessage>,
     last_persisted: &mut String,
 ) -> Result<(), String> {
-    let snapshot = serialize_queue_snapshot(queue, parallel_runners);
+    let snapshot = serialize_queue_snapshot(queue, parallel_runners, recovered_consumed);
     if snapshot != *last_persisted {
         if let Err(error) = mission_store
             .save_control_queue(session_user_id, &snapshot)
@@ -12874,12 +12903,18 @@ async fn control_actor_loop(
     // a client retry of the same id via `accept_user_message_id` (whichever
     // arrives first runs; the other is dropped), so nothing executes twice.
     let mut restored_db_snapshot = String::new();
+    let mut recovered_consumed_user_messages: HashMap<Uuid, QueuedMessage> = HashMap::new();
     if let Ok(payload) = mission_store.load_control_queue(&session_user_id).await {
         if !payload.trim().is_empty() {
             match serde_json::from_str::<Vec<QueuedMessage>>(&payload) {
                 Ok(items) => {
                     let count = items.len();
-                    for it in items {
+                    let (pending, consumed) = partition_restored_control_messages(items);
+                    let interrupted = consumed.len();
+                    recovered_consumed_user_messages
+                        .extend(consumed.into_iter().map(|message| (message.id, message)));
+                    let mut replayed = 0usize;
+                    for it in pending {
                         let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
                         if let Err(e) = self_cmd_tx.try_send(ControlCommand::UserMessage {
                             id: it.id,
@@ -12891,6 +12926,8 @@ async fn control_actor_loop(
                             respond: ack_tx,
                         }) {
                             tracing::warn!("Failed to re-queue restored control message: {e}");
+                        } else {
+                            replayed += 1;
                         }
                     }
                     if count > 0 {
@@ -12898,7 +12935,12 @@ async fn control_actor_loop(
                         // loop-top persist below rewrites the DB to the real
                         // (re-injected) state instead of leaving it stale.
                         restored_db_snapshot = payload;
-                        tracing::info!("Re-queued {count} message(s) from the previous session");
+                        tracing::info!(
+                            replayed,
+                            interrupted,
+                            total = count,
+                            "Recovered durable control messages from the previous session"
+                        );
                     }
                 }
                 Err(e) => tracing::warn!("Failed to parse persisted control queue: {e}"),
@@ -12917,7 +12959,7 @@ async fn control_actor_loop(
     // When messages were restored, seed it with the stale on-disk snapshot so
     // the first loop-top persist overwrites it with the live queue.
     let mut last_persisted_queue: String = if restored_db_snapshot.is_empty() {
-        serialize_queue_snapshot(&queue, &parallel_runners)
+        serialize_queue_snapshot(&queue, &parallel_runners, &recovered_consumed_user_messages)
     } else {
         restored_db_snapshot
     };
@@ -13214,6 +13256,7 @@ async fn control_actor_loop(
             &session_user_id,
             &queue,
             &parallel_runners,
+            &recovered_consumed_user_messages,
             &mut last_persisted_queue,
         )
         .await;
@@ -13335,6 +13378,15 @@ async fn control_actor_loop(
                 let Some(cmd) = cmd else { break };
                 match cmd {
                     ControlCommand::UserMessage { id, content, agent: msg_agent, target_mission_id, strict, source, respond } => {
+                        if recovered_consumed_user_messages.contains_key(&id) {
+                            // The previous actor had already started this exact
+                            // deterministic delivery. Its run was interrupted
+                            // during startup recovery, so acknowledge the retry
+                            // without repeating side effects; the mission now
+                            // requires an explicit resume.
+                            let _ = respond.send(UserMessageAck::Delivered);
+                            continue;
+                        }
                         if !accept_user_message_id(&mut accepted_user_message_ids, id) {
                             let status_snapshot = status.read().await;
                             let _ = respond.send(if status_snapshot.state != ControlRunState::Idle {
@@ -13613,6 +13665,7 @@ async fn control_actor_loop(
                                     &session_user_id,
                                     &queue,
                                     &parallel_runners,
+                                    &recovered_consumed_user_messages,
                                     &mut last_persisted_queue,
                                 )
                                 .await
@@ -13652,6 +13705,7 @@ async fn control_actor_loop(
                                             &session_user_id,
                                             &queue,
                                             &parallel_runners,
+                                            &recovered_consumed_user_messages,
                                             &mut last_persisted_queue,
                                         )
                                         .await;
@@ -13872,6 +13926,7 @@ async fn control_actor_loop(
                                                 &session_user_id,
                                                 &queue,
                                                 &parallel_runners,
+                                                &recovered_consumed_user_messages,
                                                 &mut last_persisted_queue,
                                             )
                                             .await
@@ -13906,6 +13961,7 @@ async fn control_actor_loop(
                                                     &session_user_id,
                                                     &queue,
                                                     &parallel_runners,
+                                                    &recovered_consumed_user_messages,
                                                     &mut last_persisted_queue,
                                                 )
                                                 .await;
@@ -14158,6 +14214,7 @@ async fn control_actor_loop(
                             &session_user_id,
                             &queue,
                             &parallel_runners,
+                            &recovered_consumed_user_messages,
                             &mut last_persisted_queue,
                         )
                         .await
@@ -14199,6 +14256,7 @@ async fn control_actor_loop(
                                     &session_user_id,
                                     &queue,
                                     &parallel_runners,
+                                    &recovered_consumed_user_messages,
                                     &mut last_persisted_queue,
                                 )
                                 .await
@@ -14909,6 +14967,7 @@ async fn control_actor_loop(
                                 &session_user_id,
                                 &queue,
                                 &parallel_runners,
+                                &recovered_consumed_user_messages,
                                 &mut last_persisted_queue,
                             )
                             .await
@@ -15431,6 +15490,7 @@ async fn control_actor_loop(
                                             &session_user_id,
                                             &queue,
                                             &parallel_runners,
+                                            &recovered_consumed_user_messages,
                                             &mut last_persisted_queue,
                                         )
                                         .await
@@ -15658,6 +15718,7 @@ async fn control_actor_loop(
                                 agent: agent.clone(),
                                 mission_id: *target_mid,
                                 source: source.clone(),
+                                inflight: false,
                             })
                             .collect();
                         // Also collect queued messages from parallel runners
@@ -15669,6 +15730,7 @@ async fn control_actor_loop(
                                     agent: qm.agent.clone(),
                                     mission_id: Some(*mid),
                                     source: qm.source.clone(),
+                                    inflight: false,
                                 });
                             }
                         }
@@ -16260,6 +16322,7 @@ async fn control_actor_loop(
                         &session_user_id,
                         &queue,
                         &parallel_runners,
+                        &recovered_consumed_user_messages,
                         &mut last_persisted_queue,
                     )
                     .await
@@ -16303,6 +16366,7 @@ async fn control_actor_loop(
                                 &session_user_id,
                                 &queue,
                                 &parallel_runners,
+                                &recovered_consumed_user_messages,
                                 &mut last_persisted_queue,
                             )
                             .await
@@ -24998,14 +25062,56 @@ Investigate <service/> failures.
         assert!(runner.queue.is_empty());
         let parallel = std::collections::HashMap::from([(parallel_mission, runner)]);
 
-        let snapshot = serialize_queue_snapshot(&main_queue, &parallel);
+        let snapshot = serialize_queue_snapshot(&main_queue, &parallel, &HashMap::new());
         let messages: Vec<QueuedMessage> = serde_json::from_str(&snapshot).unwrap();
         assert_eq!(messages.len(), 2);
         assert!(messages.iter().any(|message| {
             message.id == parallel_message_id
                 && message.content == "parallel"
                 && message.mission_id == Some(parallel_mission)
+                && message.inflight
         }));
+        assert!(messages
+            .iter()
+            .any(|message| message.content == "main" && !message.inflight));
+    }
+
+    #[test]
+    fn restart_marks_inflight_parallel_messages_consumed_without_replay() {
+        let pending_id = Uuid::new_v4();
+        let inflight_id = Uuid::new_v4();
+        let (pending, consumed) = partition_restored_control_messages(vec![
+            QueuedMessage {
+                id: pending_id,
+                content: "not started".into(),
+                agent: None,
+                mission_id: Some(Uuid::new_v4()),
+                source: None,
+                inflight: false,
+            },
+            QueuedMessage {
+                id: inflight_id,
+                content: "already started".into(),
+                agent: None,
+                mission_id: Some(Uuid::new_v4()),
+                source: Some("task-board".into()),
+                inflight: true,
+            },
+        ]);
+
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, pending_id);
+        assert_eq!(consumed.len(), 1);
+        assert_eq!(consumed[0].id, inflight_id);
+        assert!(consumed[0].inflight);
+
+        let recovered = HashMap::from([(inflight_id, consumed[0].clone())]);
+        let snapshot = serialize_queue_snapshot(&VecDeque::new(), &HashMap::new(), &recovered);
+        let reparsed: Vec<QueuedMessage> = serde_json::from_str(&snapshot).unwrap();
+        let (replayed_again, consumed_again) = partition_restored_control_messages(reparsed);
+        assert!(replayed_again.is_empty());
+        assert_eq!(consumed_again.len(), 1);
+        assert_eq!(consumed_again[0].id, inflight_id);
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -16190,6 +16190,58 @@ async fn control_actor_loop(
                         );
                         continue;
                     }
+                    // Acquire the durable run before publishing the message as
+                    // started or appending it to history. If a stale run lease
+                    // rejects acquisition, retain the exact queued delivery so
+                    // an idempotent retry cannot be acknowledged without ever
+                    // executing its turn.
+                    let mission_id = msg_target_mid;
+                    running_run = match acquire_execution_run(
+                        &mission_store,
+                        mission_id,
+                        &format!("control:{session_user_id}"),
+                    )
+                    .await
+                    {
+                        Ok(run) => run,
+                        Err(error) => {
+                            queue.push_front((
+                                mid,
+                                msg,
+                                per_msg_agent,
+                                msg_target_mid,
+                                msg_source,
+                            ));
+                            if let Err(persist_error) = persist_control_queue_if_changed(
+                                &mission_store,
+                                &session_user_id,
+                                &queue,
+                                &parallel_runners,
+                                &mut last_persisted_queue,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    "Failed to persist queued delivery after run lease rejection: {persist_error}"
+                                );
+                            }
+                            let _ = events_tx.send(AgentEvent::Error {
+                                message: format!("Mission run lease rejected: {error}"),
+                                mission_id,
+                                resumable: true,
+                            });
+                            set_and_emit_status(
+                                &status,
+                                &events_tx,
+                                ControlRunState::Idle,
+                                queue.len(),
+                                mission_id,
+                            )
+                            .await;
+                            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+                            continue;
+                        }
+                    };
                     set_and_emit_status(
                         &status,
                         &events_tx,
@@ -16226,9 +16278,9 @@ async fn control_actor_loop(
                     let tree_ref = Arc::clone(&current_tree);
                     let progress_ref = Arc::clone(&progress);
                     running_cancel = Some(cancel.clone());
-                    // Use the mission ID that was captured when message was queued
-                    // This prevents race conditions where current_mission changes between queueing and execution
-                    let mission_id = msg_target_mid;
+                    // Use the mission ID that was captured when message was queued.
+                    // This prevents races where current_mission changes between
+                    // queueing and execution.
                     let (workspace_id, model_override, model_effort, mission_agent, backend_id, session_id, mission_config_profile) = if let Some(mid) = mission_id {
                         match mission_store.get_mission(mid).await {
                             Ok(Some(mission)) => (
@@ -16269,33 +16321,6 @@ async fn control_actor_loop(
                     main_runner_active_tool_calls
                         .store(0, std::sync::atomic::Ordering::Relaxed);
                     let user_id_for_turn = session_user_id.clone();
-                    running_run = match acquire_execution_run(
-                        &mission_store,
-                        mission_id,
-                        &format!("control:{session_user_id}"),
-                    )
-                    .await
-                    {
-                        Ok(run) => run,
-                        Err(error) => {
-                            running_cancel = None;
-                            running_mission_id = None;
-                            let _ = events_tx.send(AgentEvent::Error {
-                                message: format!("Mission run lease rejected: {error}"),
-                                mission_id,
-                                resumable: true,
-                            });
-                            set_and_emit_status(
-                                &status,
-                                &events_tx,
-                                ControlRunState::Idle,
-                                queue.len(),
-                                mission_id,
-                            )
-                            .await;
-                            continue;
-                        }
-                    };
                     running = Some(tokio::spawn(async move {
                         let result = run_single_control_turn(
                             cfg,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13637,6 +13637,18 @@ async fn control_actor_loop(
                                 }
                                 let was_running = runner.is_running();
                                 runner.queue_message(id, content.clone(), msg_agent, source.clone());
+                                // For an idle runner, move the delivery into its durable
+                                // inflight slot before committing the queue snapshot. This
+                                // makes that commit the exact acceptance boundary: a restart
+                                // after it cannot replay work that was already handed to the
+                                // runner, even if the process starts immediately afterwards.
+                                if !was_running && runner.take_next_message_for_start().is_none() {
+                                    accepted_user_message_ids.remove(&id);
+                                    let _ = respond.send(UserMessageAck::Rejected(format!(
+                                        "mission {tid} delivery disappeared before persistence"
+                                    )));
+                                    continue;
+                                }
                                 let _ = events_tx.send(AgentEvent::UserMessage {
                                     id,
                                     content: content.clone(),
@@ -13672,6 +13684,7 @@ async fn control_actor_loop(
                                 {
                                     if let Some(runner) = parallel_runners.get_mut(&tid) {
                                         runner.remove_from_queue(id);
+                                        runner.remove_inflight_message(id);
                                     }
                                     accepted_user_message_ids.remove(&id);
                                     let _ = respond.send(UserMessageAck::Rejected(format!(
@@ -13700,6 +13713,7 @@ async fn control_actor_loop(
                                             resumable: true,
                                         });
                                         runner.remove_from_queue(id);
+                                        runner.remove_inflight_message(id);
                                         let _ = persist_control_queue_if_changed(
                                             &mission_store,
                                             &session_user_id,
@@ -13908,6 +13922,18 @@ async fn control_actor_loop(
                                             }
                                             // Queue the message
                                             runner.queue_message(id, content.clone(), msg_agent, source.clone());
+                                            // Stage the delivery as inflight before its first
+                                            // durable snapshot. start_next will consume this
+                                            // prepared slot rather than dequeueing it again.
+                                            if runner.take_next_message_for_start().is_none() {
+                                                accepted_user_message_ids.remove(&id);
+                                                let _ = respond.send(UserMessageAck::Rejected(
+                                                    format!(
+                                                        "mission {tid} delivery disappeared before persistence"
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
                                             // Emit user message event
                                             let _ = events_tx.send(AgentEvent::UserMessage {
                                                 id,
@@ -13916,10 +13942,8 @@ async fn control_actor_loop(
                                                 mission_id: Some(tid),
                                                 source: source.clone(),
                                             });
-                                            // Journal the delivery while it is
-                                            // still queued. start_next moves it
-                                            // to inflight_message, which serializes
-                                            // identically until the turn finishes.
+                                            // Journal the prepared inflight delivery before
+                                            // acquiring the run or starting any process.
                                             parallel_runners.insert(tid, runner);
                                             if let Err(error) = persist_control_queue_if_changed(
                                                 &mission_store,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2885,6 +2885,15 @@ fn serialize_queue_snapshot(
     let mut runners: Vec<_> = parallel_runners.iter().collect();
     runners.sort_by_key(|(mission_id, _)| **mission_id);
     for (mission_id, runner) in runners {
+        if let Some(message) = runner.inflight_message() {
+            items.push(QueuedMessage {
+                id: message.id,
+                content: message.content.clone(),
+                agent: message.agent.clone(),
+                mission_id: Some(*mission_id),
+                source: message.source.clone(),
+            });
+        }
         items.extend(runner.queue.iter().map(|message| QueuedMessage {
             id: message.id,
             content: message.content.clone(),
@@ -13560,64 +13569,85 @@ async fn control_actor_loop(
                                         continue;
                                     }
                                 }
-                                if let Some(runner) = parallel_runners.get_mut(&tid) {
-                                    let was_running = runner.is_running();
-                                    runner.queue_message(id, content.clone(), msg_agent, source.clone());
-                                    let _ = events_tx.send(AgentEvent::UserMessage {
-                                        id,
-                                        content: content.clone(),
-                                        queued: was_running,
+                                let Some(runner) = parallel_runners.get_mut(&tid) else {
+                                    accepted_user_message_ids.remove(&id);
+                                    let _ = respond.send(UserMessageAck::Rejected(format!(
+                                        "mission {tid} runner disappeared before queueing"
+                                    )));
+                                    continue;
+                                };
+                                if runner.cancellation_requested() {
+                                    accepted_user_message_ids.remove(&id);
+                                    let _ = respond.send(UserMessageAck::Rejected(format!(
+                                        "mission {tid} is stopping"
+                                    )));
+                                    continue;
+                                }
+                                let was_running = runner.is_running();
+                                runner.queue_message(id, content.clone(), msg_agent, source.clone());
+                                let _ = events_tx.send(AgentEvent::UserMessage {
+                                    id,
+                                    content: content.clone(),
+                                    queued: was_running,
+                                    mission_id: Some(tid),
+                                    source: source.clone(),
+                                });
+                                // Surface the parallel queue growth to all
+                                // clients (Status events otherwise only
+                                // carry the main queue length). Only when
+                                // the message actually stays queued —
+                                // otherwise start_next pops it right away.
+                                if was_running {
+                                    let _ = events_tx.send(AgentEvent::Status {
+                                        state: ControlRunState::Running,
+                                        queue_len: runner.queue.len(),
                                         mission_id: Some(tid),
-                                        source: source.clone(),
                                     });
-                                    // Surface the parallel queue growth to all
-                                    // clients (Status events otherwise only
-                                    // carry the main queue length). Only when
-                                    // the message actually stays queued —
-                                    // otherwise start_next pops it right away.
-                                    if was_running {
-                                        let _ = events_tx.send(AgentEvent::Status {
-                                            state: ControlRunState::Running,
-                                            queue_len: runner.queue.len(),
+                                }
+                                // Persist both queued and about-to-start parallel
+                                // deliveries before they can be acknowledged. A
+                                // running turn remains in the snapshot via the
+                                // runner's inflight_message until completion.
+                                if let Err(error) = persist_control_queue_if_changed(
+                                    &mission_store,
+                                    &session_user_id,
+                                    &queue,
+                                    &parallel_runners,
+                                    &mut last_persisted_queue,
+                                )
+                                .await
+                                {
+                                    if let Some(runner) = parallel_runners.get_mut(&tid) {
+                                        runner.remove_from_queue(id);
+                                    }
+                                    accepted_user_message_ids.remove(&id);
+                                    let _ = respond.send(UserMessageAck::Rejected(format!(
+                                        "failed to persist parallel delivery: {error}"
+                                    )));
+                                    continue;
+                                }
+                                if !was_running {
+                                    let Some(runner) = parallel_runners.get_mut(&tid) else {
+                                        accepted_user_message_ids.remove(&id);
+                                        let _ = respond.send(UserMessageAck::Rejected(format!(
+                                            "mission {tid} runner disappeared before start"
+                                        )));
+                                        continue;
+                                    };
+                                    if let Err(error) = runner
+                                        .acquire_durable_run(
+                                            &mission_store,
+                                            &format!("control:{session_user_id}"),
+                                        )
+                                        .await
+                                    {
+                                        let _ = events_tx.send(AgentEvent::Error {
+                                            message: format!("Mission run lease rejected: {error}"),
                                             mission_id: Some(tid),
+                                            resumable: true,
                                         });
-                                    }
-                                    // Try to start if not already running
-                                    if !runner.is_running() {
-                                        if let Err(error) = runner
-                                            .acquire_durable_run(
-                                                &mission_store,
-                                                &format!("control:{session_user_id}"),
-                                            )
-                                            .await
-                                        {
-                                            let _ = events_tx.send(AgentEvent::Error {
-                                                message: format!("Mission run lease rejected: {error}"),
-                                                mission_id: Some(tid),
-                                                resumable: true,
-                                            });
-                                            let _ = respond.send(UserMessageAck::Rejected(error));
-                                            continue;
-                                        }
-                                        runner.start_next(
-                                            config.clone(),
-                                            Arc::clone(&root_agent),
-                                            Arc::clone(&mcp),
-                                            Arc::clone(&workspaces),
-                                            library.clone(),
-                                            events_tx.clone(),
-                                            Arc::clone(&tool_hub),
-                                            Arc::clone(&status),
-                                            mission_cmd_tx.clone(),
-                                            Arc::new(RwLock::new(Some(tid))),
-                                            secrets.clone(),
-                                        );
-                                    }
-                                    if was_running {
-                                        // Parallel-runner queues are part of the
-                                        // same durable session snapshot. Persist
-                                        // before acknowledging the board outbox.
-                                        let persist_result = persist_control_queue_if_changed(
+                                        runner.remove_from_queue(id);
+                                        let _ = persist_control_queue_if_changed(
                                             &mission_store,
                                             &session_user_id,
                                             &queue,
@@ -13625,20 +13655,30 @@ async fn control_actor_loop(
                                             &mut last_persisted_queue,
                                         )
                                         .await;
-                                        if let Err(error) = persist_result {
-                                            if let Some(runner) = parallel_runners.get_mut(&tid) {
-                                                runner.remove_from_queue(id);
-                                            }
-                                            accepted_user_message_ids.remove(&id);
-                                            let _ = respond.send(UserMessageAck::Rejected(format!(
-                                                "failed to persist queued delivery: {error}"
-                                            )));
-                                            continue;
-                                        }
+                                        accepted_user_message_ids.remove(&id);
+                                        let _ = respond.send(UserMessageAck::Rejected(error));
+                                        continue;
                                     }
-                                    let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
-                                    continue;
+                                    runner.start_next(
+                                        config.clone(),
+                                        Arc::clone(&root_agent),
+                                        Arc::clone(&mcp),
+                                        Arc::clone(&workspaces),
+                                        library.clone(),
+                                        events_tx.clone(),
+                                        Arc::clone(&tool_hub),
+                                        Arc::clone(&status),
+                                        mission_cmd_tx.clone(),
+                                        Arc::new(RwLock::new(Some(tid))),
+                                        secrets.clone(),
+                                    );
                                 }
+                                // The durable snapshot, not process creation,
+                                // is the acceptance boundary. Report Queued even
+                                // when execution started immediately so outbox
+                                // retirement never depends on a volatile handle.
+                                let _ = respond.send(UserMessageAck::Queued);
+                                continue;
                             }
                         }
 
@@ -13822,7 +13862,32 @@ async fn control_actor_loop(
                                                 mission_id: Some(tid),
                                                 source: source.clone(),
                                             });
-                                            // Start execution
+                                            // Journal the delivery while it is
+                                            // still queued. start_next moves it
+                                            // to inflight_message, which serializes
+                                            // identically until the turn finishes.
+                                            parallel_runners.insert(tid, runner);
+                                            if let Err(error) = persist_control_queue_if_changed(
+                                                &mission_store,
+                                                &session_user_id,
+                                                &queue,
+                                                &parallel_runners,
+                                                &mut last_persisted_queue,
+                                            )
+                                            .await
+                                            {
+                                                parallel_runners.remove(&tid);
+                                                accepted_user_message_ids.remove(&id);
+                                                let _ = respond.send(UserMessageAck::Rejected(
+                                                    format!(
+                                                        "failed to persist parallel delivery: {error}"
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
+                                            let runner = parallel_runners
+                                                .get_mut(&tid)
+                                                .expect("parallel runner inserted above");
                                             if let Err(error) = runner
                                                 .acquire_durable_run(
                                                     &mission_store,
@@ -13835,6 +13900,16 @@ async fn control_actor_loop(
                                                     mission_id: Some(tid),
                                                     resumable: true,
                                                 });
+                                                parallel_runners.remove(&tid);
+                                                let _ = persist_control_queue_if_changed(
+                                                    &mission_store,
+                                                    &session_user_id,
+                                                    &queue,
+                                                    &parallel_runners,
+                                                    &mut last_persisted_queue,
+                                                )
+                                                .await;
+                                                accepted_user_message_ids.remove(&id);
                                                 let _ = respond.send(UserMessageAck::Rejected(error));
                                                 continue;
                                             }
@@ -13852,8 +13927,7 @@ async fn control_actor_loop(
                                                 secrets.clone(),
                                             );
                                             tracing::info!("Auto-started mission {} in parallel", tid);
-                                            parallel_runners.insert(tid, runner);
-                                            let _ = respond.send(UserMessageAck::Delivered);
+                                            let _ = respond.send(UserMessageAck::Queued);
                                             continue;
                                         }
                                         Err(e) => {
@@ -14830,6 +14904,18 @@ async fn control_actor_loop(
                             });
                             // Cascade cancel child missions
                             cancel_child_missions(mission_id, &mission_store, &mut parallel_runners, &events_tx, &config.working_dir).await;
+                            if let Err(error) = persist_control_queue_if_changed(
+                                &mission_store,
+                                &session_user_id,
+                                &queue,
+                                &parallel_runners,
+                                &mut last_persisted_queue,
+                            )
+                            .await
+                            {
+                                tracing::warn!(mission_id = %mission_id,
+                                    "Failed to persist cleared queues after cancellation: {error}");
+                            }
                             let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
                         } else {
                             // Check if this is the currently executing mission
@@ -16484,6 +16570,7 @@ async fn control_actor_loop(
                                     | Some(TerminalReason::RateLimited)
                                     | Some(TerminalReason::CapacityLimited)
                             );
+                            let cancellation_requested = runner.cancellation_requested();
                             let was_queue_empty = runner.queue.is_empty();
                             // Grok /goal sentinel hook for the parallel-runner
                             // path. Same contract as the main-session hook
@@ -16501,7 +16588,10 @@ async fn control_actor_loop(
                                 )
                                 .await;
                             }
-                            if was_queue_empty && !is_transient_infra_failure {
+                            if was_queue_empty
+                                && !is_transient_infra_failure
+                                && !cancellation_requested
+                            {
                                 // Small delay so the UI can display the completion before restarting.
                                 tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                                 let messages = agent_finished_automation_messages(
@@ -24895,19 +24985,26 @@ Investigate <service/> failures.
             None,
             None,
         );
+        let parallel_message_id = Uuid::new_v4();
         runner.queue_message(
-            Uuid::new_v4(),
+            parallel_message_id,
             "parallel".to_string(),
             None,
             Some("task-board".to_string()),
         );
+        runner
+            .take_next_message_for_start()
+            .expect("parallel message should move to the in-flight slot");
+        assert!(runner.queue.is_empty());
         let parallel = std::collections::HashMap::from([(parallel_mission, runner)]);
 
         let snapshot = serialize_queue_snapshot(&main_queue, &parallel);
         let messages: Vec<QueuedMessage> = serde_json::from_str(&snapshot).unwrap();
         assert_eq!(messages.len(), 2);
         assert!(messages.iter().any(|message| {
-            message.content == "parallel" && message.mission_id == Some(parallel_mission)
+            message.id == parallel_message_id
+                && message.content == "parallel"
+                && message.mission_id == Some(parallel_mission)
         }));
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4262,9 +4262,11 @@ fn attach_execution_to_mission_value(
         );
         object.insert(
             "acknowledged_at".to_string(),
-            (mission.status == MissionStatus::Acknowledged)
-                .then(|| serde_json::Value::String(mission.updated_at.clone()))
-                .unwrap_or(serde_json::Value::Null),
+            if mission.status == MissionStatus::Acknowledged {
+                serde_json::Value::String(mission.updated_at.clone())
+            } else {
+                serde_json::Value::Null
+            },
         );
     }
     value

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2868,8 +2868,11 @@ pub struct QueuedMessage {
 
 /// Serialize the control session queue to a stable JSON snapshot for
 /// persistence across restarts (see `MissionStore::save_control_queue`).
-fn serialize_queue_snapshot(queue: &VecDeque<ControlQueueEntry>) -> String {
-    let items: Vec<QueuedMessage> = queue
+fn serialize_queue_snapshot(
+    queue: &VecDeque<ControlQueueEntry>,
+    parallel_runners: &std::collections::HashMap<Uuid, super::mission_runner::MissionRunner>,
+) -> String {
+    let mut items: Vec<QueuedMessage> = queue
         .iter()
         .map(|(id, content, agent, target_mid, source)| QueuedMessage {
             id: *id,
@@ -2879,6 +2882,17 @@ fn serialize_queue_snapshot(queue: &VecDeque<ControlQueueEntry>) -> String {
             source: source.clone(),
         })
         .collect();
+    let mut runners: Vec<_> = parallel_runners.iter().collect();
+    runners.sort_by_key(|(mission_id, _)| **mission_id);
+    for (mission_id, runner) in runners {
+        items.extend(runner.queue.iter().map(|message| QueuedMessage {
+            id: message.id,
+            content: message.content.clone(),
+            agent: message.agent.clone(),
+            mission_id: Some(*mission_id),
+            source: message.source.clone(),
+        }));
+    }
     serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
@@ -2895,9 +2909,10 @@ async fn persist_control_queue_if_changed(
     mission_store: &Arc<dyn MissionStore>,
     session_user_id: &str,
     queue: &VecDeque<ControlQueueEntry>,
+    parallel_runners: &std::collections::HashMap<Uuid, super::mission_runner::MissionRunner>,
     last_persisted: &mut String,
 ) {
-    let snapshot = serialize_queue_snapshot(queue);
+    let snapshot = serialize_queue_snapshot(queue, parallel_runners);
     if snapshot != *last_persisted {
         if let Err(e) = mission_store
             .save_control_queue(session_user_id, &snapshot)
@@ -12833,12 +12848,19 @@ async fn control_actor_loop(
             }
         }
     }
+    // Parallel mission runners - each runs independently. Their pending
+    // messages share the durable session queue snapshot with the main queue.
+    let mut parallel_runners: std::collections::HashMap<
+        Uuid,
+        super::mission_runner::MissionRunner,
+    > = std::collections::HashMap::new();
+
     // Snapshot of the queue as last written to the store; used to debounce
     // persistence so we only write to the DB when the queue actually changes.
     // When messages were restored, seed it with the stale on-disk snapshot so
     // the first loop-top persist overwrites it with the live queue.
     let mut last_persisted_queue: String = if restored_db_snapshot.is_empty() {
-        serialize_queue_snapshot(&queue)
+        serialize_queue_snapshot(&queue, &parallel_runners)
     } else {
         restored_db_snapshot
     };
@@ -12881,12 +12903,6 @@ async fn control_actor_loop(
     let mut runner_force_clear_deadline: Option<tokio::time::Instant> = None;
     const RUNNER_FORCE_CLEAR_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
 
-    // Parallel mission runners - each runs independently
-    let mut parallel_runners: std::collections::HashMap<
-        Uuid,
-        super::mission_runner::MissionRunner,
-    > = std::collections::HashMap::new();
-
     // Correlate Bash `tool_call_id` -> command string so that when the matching
     // `Bash` ToolResult carries a background-start marker we can record the
     // launched command in the background-task registry. Capped to avoid
@@ -12919,6 +12935,8 @@ async fn control_actor_loop(
     // Per-boss "wake outstanding" flags, coalescing board wakes across passes.
     let mut board_wake_state: std::collections::HashMap<Uuid, bool> =
         std::collections::HashMap::new();
+    let board_outbox_inflight: board::BoardOutboxInflight =
+        Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
 
     // Helper to extract file paths from text (for mission summaries)
     fn extract_file_paths(text: &str) -> Vec<String> {
@@ -13138,6 +13156,7 @@ async fn control_actor_loop(
             &mission_store,
             &session_user_id,
             &queue,
+            &parallel_runners,
             &mut last_persisted_queue,
         )
         .await;
@@ -13545,6 +13564,19 @@ async fn control_actor_loop(
                                             Arc::new(RwLock::new(Some(tid))),
                                             secrets.clone(),
                                         );
+                                    }
+                                    if was_running {
+                                        // Parallel-runner queues are part of the
+                                        // same durable session snapshot. Persist
+                                        // before acknowledging the board outbox.
+                                        persist_control_queue_if_changed(
+                                            &mission_store,
+                                            &session_user_id,
+                                            &queue,
+                                            &parallel_runners,
+                                            &mut last_persisted_queue,
+                                        )
+                                        .await;
                                     }
                                     let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
                                     continue;
@@ -13986,6 +14018,17 @@ async fn control_actor_loop(
                             }
                         }
                         queue.push_back((id, content, msg_agent, target_mission_id, source.clone()));
+                        // `Queued` is an acceptance acknowledgement. Persist the
+                        // message before sending it so a crash cannot lose an
+                        // outbox delivery that its producer has already retired.
+                        persist_control_queue_if_changed(
+                            &mission_store,
+                            &session_user_id,
+                            &queue,
+                            &parallel_runners,
+                            &mut last_persisted_queue,
+                        )
+                        .await;
                         let status_mission_id = if running.is_some() {
                             running_mission_id
                         } else {
@@ -14015,6 +14058,7 @@ async fn control_actor_loop(
                                     &mission_store,
                                     &session_user_id,
                                     &queue,
+                                    &parallel_runners,
                                     &mut last_persisted_queue,
                                 )
                                 .await;
@@ -15217,6 +15261,7 @@ async fn control_actor_loop(
                                             &mission_store,
                                             &session_user_id,
                                             &queue,
+                                            &parallel_runners,
                                             &mut last_persisted_queue,
                                         )
                                         .await;
@@ -16032,6 +16077,7 @@ async fn control_actor_loop(
                         &mission_store,
                         &session_user_id,
                         &queue,
+                        &parallel_runners,
                         &mut last_persisted_queue,
                     )
                     .await;
@@ -16476,6 +16522,7 @@ async fn control_actor_loop(
                         &snapshot,
                         max_parallel,
                         &mut board_wake_state,
+                        &board_outbox_inflight,
                     )
                     .await;
                 }
@@ -24662,6 +24709,43 @@ Investigate <service/> failures.
 
         assert!(queue_has_pending_target_mission(&queue, mission_id));
         assert!(!queue_has_pending_target_mission(&queue, Uuid::new_v4()));
+    }
+
+    #[test]
+    fn queue_snapshot_includes_parallel_runner_messages() {
+        let main_mission = Uuid::new_v4();
+        let parallel_mission = Uuid::new_v4();
+        let main_queue = VecDeque::from([(
+            Uuid::new_v4(),
+            "main".to_string(),
+            None,
+            Some(main_mission),
+            Some("api:test".to_string()),
+        )]);
+        let mut runner = crate::api::mission_runner::MissionRunner::new(
+            parallel_mission,
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        runner.queue_message(
+            Uuid::new_v4(),
+            "parallel".to_string(),
+            None,
+            Some("task-board".to_string()),
+        );
+        let parallel = std::collections::HashMap::from([(parallel_mission, runner)]);
+
+        let snapshot = serialize_queue_snapshot(&main_queue, &parallel);
+        let messages: Vec<QueuedMessage> = serde_json::from_str(&snapshot).unwrap();
+        assert_eq!(messages.len(), 2);
+        assert!(messages.iter().any(|message| {
+            message.content == "parallel" && message.mission_id == Some(parallel_mission)
+        }));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2911,18 +2911,20 @@ async fn persist_control_queue_if_changed(
     queue: &VecDeque<ControlQueueEntry>,
     parallel_runners: &std::collections::HashMap<Uuid, super::mission_runner::MissionRunner>,
     last_persisted: &mut String,
-) {
+) -> Result<(), String> {
     let snapshot = serialize_queue_snapshot(queue, parallel_runners);
     if snapshot != *last_persisted {
-        if let Err(e) = mission_store
+        if let Err(error) = mission_store
             .save_control_queue(session_user_id, &snapshot)
             .await
         {
-            tracing::warn!("Failed to persist control queue: {e}");
+            tracing::warn!("Failed to persist control queue: {error}");
+            return Err(error);
         } else {
             *last_persisted = snapshot;
         }
     }
+    Ok(())
 }
 
 /// Tool result posted by the frontend for an interactive tool call.
@@ -13152,7 +13154,7 @@ async fn control_actor_loop(
         // during streaming, where the queue is usually unchanged). Each dequeue
         // site below also persists immediately so a popped message can't be
         // re-run after a crash (see `persist_control_queue_if_changed`).
-        persist_control_queue_if_changed(
+        let _ = persist_control_queue_if_changed(
             &mission_store,
             &session_user_id,
             &queue,
@@ -13569,7 +13571,7 @@ async fn control_actor_loop(
                                         // Parallel-runner queues are part of the
                                         // same durable session snapshot. Persist
                                         // before acknowledging the board outbox.
-                                        persist_control_queue_if_changed(
+                                        let persist_result = persist_control_queue_if_changed(
                                             &mission_store,
                                             &session_user_id,
                                             &queue,
@@ -13577,6 +13579,16 @@ async fn control_actor_loop(
                                             &mut last_persisted_queue,
                                         )
                                         .await;
+                                        if let Err(error) = persist_result {
+                                            if let Some(runner) = parallel_runners.get_mut(&tid) {
+                                                runner.remove_from_queue(id);
+                                            }
+                                            accepted_user_message_ids.remove(&id);
+                                            let _ = respond.send(UserMessageAck::Rejected(format!(
+                                                "failed to persist queued delivery: {error}"
+                                            )));
+                                            continue;
+                                        }
                                     }
                                     let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
                                     continue;
@@ -14021,14 +14033,22 @@ async fn control_actor_loop(
                         // `Queued` is an acceptance acknowledgement. Persist the
                         // message before sending it so a crash cannot lose an
                         // outbox delivery that its producer has already retired.
-                        persist_control_queue_if_changed(
+                        if let Err(error) = persist_control_queue_if_changed(
                             &mission_store,
                             &session_user_id,
                             &queue,
                             &parallel_runners,
                             &mut last_persisted_queue,
                         )
-                        .await;
+                        .await
+                        {
+                            queue.retain(|(queued_id, ..)| *queued_id != id);
+                            accepted_user_message_ids.remove(&id);
+                            let _ = respond.send(UserMessageAck::Rejected(format!(
+                                "failed to persist queued delivery: {error}"
+                            )));
+                            continue;
+                        }
                         let status_mission_id = if running.is_some() {
                             running_mission_id
                         } else {
@@ -14054,7 +14074,7 @@ async fn control_actor_loop(
                             if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                                 // Persist the dequeue before the awaits that start
                                 // the run, so a crash here can't restore + re-run it.
-                                persist_control_queue_if_changed(
+                                let _ = persist_control_queue_if_changed(
                                     &mission_store,
                                     &session_user_id,
                                     &queue,
@@ -15260,7 +15280,7 @@ async fn control_actor_loop(
                                         // Persist the dequeue before the awaits that
                                         // start the run, so a crash here can't
                                         // restore + re-run it.
-                                        persist_control_queue_if_changed(
+                                        let _ = persist_control_queue_if_changed(
                                             &mission_store,
                                             &session_user_id,
                                             &queue,
@@ -16076,7 +16096,7 @@ async fn control_actor_loop(
                 if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                     // Persist the dequeue before the awaits that start the run, so
                     // a crash here can't restore + re-run it.
-                    persist_control_queue_if_changed(
+                    let _ = persist_control_queue_if_changed(
                         &mission_store,
                         &session_user_id,
                         &queue,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4293,6 +4293,55 @@ fn is_user_wait_tool(tool_kind: &str) -> bool {
     matches!(tool_kind, "request_user_input" | "frontend_tool") || is_interactive_ui_tool(tool_kind)
 }
 
+const PROVISIONAL_TOOL_DEADLINE_SECS: i64 = 120;
+const MANAGED_SHELL_TOOL_DEADLINE_SECS: i64 = 10 * 60;
+const LONG_BUILD_TOOL_DEADLINE_SECS: i64 = 2 * 60 * 60;
+
+/// Return the absolute liveness window for a harness tool call.
+///
+/// Unknown protocol calls remain provisional for at most two minutes. Native
+/// harness shell tools are different: the harness emits the ToolResult only
+/// after its managed subprocess exits, so expiring their lease after two
+/// minutes would make a healthy synchronous command indistinguishable from an
+/// orphan. Keep ordinary shell work within the generic ten-minute ceiling and
+/// allow known build/verification commands the same two-hour ceiling as a
+/// durable workspace job.
+fn tool_execution_deadline_secs(tool_kind: &str, args: &serde_json::Value) -> i64 {
+    if !matches!(tool_kind, "Bash" | "bash" | "shell" | "Shell") {
+        return PROVISIONAL_TOOL_DEADLINE_SECS;
+    }
+
+    let command = args
+        .get("command")
+        .or_else(|| args.get("cmd"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let normalized = command
+        .split_whitespace()
+        .map(|part| part.to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let is_long_build = [
+        "remote-lean-build",
+        "lake build",
+        "lake test",
+        "lake env lean",
+        "cargo build --release",
+        "cargo test --all",
+        "npm run build",
+        "bun run build",
+        "next build",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle));
+
+    if is_long_build {
+        LONG_BUILD_TOOL_DEADLINE_SECS
+    } else {
+        MANAGED_SHELL_TOOL_DEADLINE_SECS
+    }
+}
+
 fn mission_heartbeat_state(
     active_tool_calls: usize,
     has_registered_user_wait: bool,
@@ -16883,10 +16932,11 @@ async fn control_actor_loop(
                                         state: MissionToolExecutionState::Provisional,
                                         started_at: now.to_rfc3339(),
                                         heartbeat_at: now.to_rfc3339(),
-                                        // An unmatched protocol event alone is
-                                        // evidence for at most 120 seconds.
-                                        deadline_at: (now + chrono::Duration::seconds(120))
-                                            .to_rfc3339(),
+                                        deadline_at: (now
+                                            + chrono::Duration::seconds(
+                                                tool_execution_deadline_secs(name, args),
+                                            ))
+                                        .to_rfc3339(),
                                         process_pid: None,
                                         durable_job_id: None,
                                         completed_at: None,
@@ -20754,6 +20804,32 @@ mod tests {
         assert_eq!(
             mission_heartbeat_state(0, false),
             MissionExecutionState::Running
+        );
+    }
+
+    #[test]
+    fn tool_execution_deadlines_are_bounded_by_tool_class() {
+        assert_eq!(
+            tool_execution_deadline_secs("Read", &serde_json::json!({"path": "README.md"})),
+            PROVISIONAL_TOOL_DEADLINE_SECS
+        );
+        assert_eq!(
+            tool_execution_deadline_secs("Bash", &serde_json::json!({"command": "git status"})),
+            MANAGED_SHELL_TOOL_DEADLINE_SECS
+        );
+        assert_eq!(
+            tool_execution_deadline_secs(
+                "bash",
+                &serde_json::json!({"command": "cd Verity && lake build"})
+            ),
+            LONG_BUILD_TOOL_DEADLINE_SECS
+        );
+        assert_eq!(
+            tool_execution_deadline_secs(
+                "Shell",
+                &serde_json::json!({"cmd": "remote-lean-build -- lake test"})
+            ),
+            LONG_BUILD_TOOL_DEADLINE_SECS
         );
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2909,13 +2909,18 @@ fn serialize_queue_snapshot(
     runners.sort_by_key(|(mission_id, _)| **mission_id);
     for (mission_id, runner) in runners {
         if let Some(message) = runner.inflight_message() {
+            // `inflight_message` is also used as a prepared slot before
+            // `begin_mission_run` succeeds. Only a durable run proves the
+            // actor crossed the consumption boundary; a crash before that
+            // must replay the message instead of treating it as completed.
+            let durably_started = runner.durable_run.is_some();
             items.push(QueuedMessage {
                 id: message.id,
                 content: message.content.clone(),
                 agent: message.agent.clone(),
                 mission_id: Some(*mission_id),
                 source: message.source.clone(),
-                inflight: true,
+                inflight: durably_started,
             });
         }
         items.extend(runner.queue.iter().map(|message| QueuedMessage {
@@ -13635,11 +13640,9 @@ async fn control_actor_loop(
                                 }
                                 let was_running = runner.is_running();
                                 runner.queue_message(id, content.clone(), msg_agent, source.clone());
-                                // For an idle runner, move the delivery into its durable
-                                // inflight slot before committing the queue snapshot. This
-                                // makes that commit the exact acceptance boundary: a restart
-                                // after it cannot replay work that was already handed to the
-                                // runner, even if the process starts immediately afterwards.
+                                // For an idle runner, reserve its prepared slot. Queue
+                                // serialization deliberately keeps this replayable until
+                                // acquire_durable_run succeeds.
                                 if !was_running && runner.take_next_message_for_start().is_none() {
                                     accepted_user_message_ids.remove(&id);
                                     let _ = respond.send(UserMessageAck::Rejected(format!(
@@ -13666,10 +13669,9 @@ async fn control_actor_loop(
                                         mission_id: Some(tid),
                                     });
                                 }
-                                // Persist both queued and about-to-start parallel
-                                // deliveries before they can be acknowledged. A
-                                // running turn remains in the snapshot via the
-                                // runner's inflight_message until completion.
+                                // Persist queued and prepared parallel deliveries before
+                                // they can be acknowledged. Prepared work remains marked
+                                // pending until its durable run lease exists.
                                 if let Err(error) = persist_control_queue_if_changed(
                                     &mission_store,
                                     &session_user_id,
@@ -13920,9 +13922,9 @@ async fn control_actor_loop(
                                             }
                                             // Queue the message
                                             runner.queue_message(id, content.clone(), msg_agent, source.clone());
-                                            // Stage the delivery as inflight before its first
-                                            // durable snapshot. start_next will consume this
-                                            // prepared slot rather than dequeueing it again.
+                                            // Reserve the prepared slot before its first
+                                            // snapshot. Serialization keeps it replayable until
+                                            // a durable run exists; start_next consumes this slot.
                                             if runner.take_next_message_for_start().is_none() {
                                                 accepted_user_message_ids.remove(&id);
                                                 let _ = respond.send(UserMessageAck::Rejected(
@@ -13940,8 +13942,8 @@ async fn control_actor_loop(
                                                 mission_id: Some(tid),
                                                 source: source.clone(),
                                             });
-                                            // Journal the prepared inflight delivery before
-                                            // acquiring the run or starting any process.
+                                            // Journal the prepared delivery as replayable pending
+                                            // before acquiring the run or starting a process.
                                             parallel_runners.insert(tid, runner);
                                             if let Err(error) = persist_control_queue_if_changed(
                                                 &mission_store,
@@ -25109,7 +25111,7 @@ Investigate <service/> failures.
     }
 
     #[test]
-    fn queue_snapshot_includes_parallel_runner_messages() {
+    fn queue_snapshot_replays_prepared_parallel_message_until_run_exists() {
         let main_mission = Uuid::new_v4();
         let parallel_mission = Uuid::new_v4();
         let main_queue = VecDeque::from([(
@@ -25149,11 +25151,57 @@ Investigate <service/> failures.
             message.id == parallel_message_id
                 && message.content == "parallel"
                 && message.mission_id == Some(parallel_mission)
-                && message.inflight
+                && !message.inflight
         }));
         assert!(messages
             .iter()
             .any(|message| message.content == "main" && !message.inflight));
+    }
+
+    #[test]
+    fn queue_snapshot_marks_parallel_message_consumed_with_durable_run() {
+        let mission_id = Uuid::new_v4();
+        let mut runner = crate::api::mission_runner::MissionRunner::new(
+            mission_id,
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        let message_id = Uuid::new_v4();
+        runner.queue_message(
+            message_id,
+            "parallel".into(),
+            None,
+            Some("task-board".into()),
+        );
+        runner
+            .take_next_message_for_start()
+            .expect("message should enter prepared slot");
+        runner.durable_run = Some(MissionRun {
+            run_id: Uuid::new_v4(),
+            mission_id,
+            generation: 1,
+            execution_state: MissionExecutionState::Running,
+            owner_actor_id: "control:test".into(),
+            scope_unit: None,
+            started_at: now_string(),
+            heartbeat_at: now_string(),
+            stopping_at: None,
+            ended_at: None,
+            terminal_reason: None,
+        });
+        let runners = std::collections::HashMap::from([(mission_id, runner)]);
+
+        let snapshot = serialize_queue_snapshot(&VecDeque::new(), &runners, &HashMap::new());
+        let messages: Vec<QueuedMessage> = serde_json::from_str(&snapshot).unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, message_id);
+        assert!(messages[0].inflight);
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4272,6 +4272,26 @@ fn attach_execution_to_mission_value(
     value
 }
 
+fn is_user_wait_tool(tool_kind: &str) -> bool {
+    matches!(
+        tool_kind,
+        "request_user_input" | "AskUserQuestion" | "frontend_tool"
+    )
+}
+
+fn mission_heartbeat_state(
+    active_tool_calls: usize,
+    has_registered_user_wait: bool,
+) -> MissionExecutionState {
+    if has_registered_user_wait {
+        MissionExecutionState::WaitingUser
+    } else if active_tool_calls > 0 {
+        MissionExecutionState::WaitingTool
+    } else {
+        MissionExecutionState::Running
+    }
+}
+
 pub async fn list_missions(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
@@ -13125,51 +13145,42 @@ async fn control_actor_loop(
             _ = execution_heartbeat.tick() => {
                 let mut leases = Vec::new();
                 if let Some(run) = running_run.clone() {
-                    let state = if main_runner_active_tool_calls
-                        .load(std::sync::atomic::Ordering::Relaxed) > 0
-                    {
-                        MissionExecutionState::WaitingTool
-                    } else {
-                        MissionExecutionState::Running
-                    };
-                    leases.push((run, state, main_runner_last_activity.elapsed().as_secs()));
+                    leases.push((
+                        run,
+                        main_runner_active_tool_calls
+                            .load(std::sync::atomic::Ordering::Relaxed),
+                        main_runner_last_activity.elapsed().as_secs(),
+                    ));
                 }
                 leases.extend(parallel_runners.values().filter_map(|runner| {
                     runner.durable_run.clone().map(|run| {
-                        let state = if runner.active_tool_calls
-                            .load(std::sync::atomic::Ordering::Relaxed) > 0
-                        {
-                            MissionExecutionState::WaitingTool
-                        } else {
-                            MissionExecutionState::Running
-                        };
-                        (run, state, runner.last_activity.elapsed().as_secs())
+                        (
+                            run,
+                            runner
+                                .active_tool_calls
+                                .load(std::sync::atomic::Ordering::Relaxed),
+                            runner.last_activity.elapsed().as_secs(),
+                        )
                     })
                 }));
-                for (run, state, idle_secs) in leases {
-                    match mission_store
-                        .heartbeat_mission_run(run.run_id, run.generation, state, None)
-                        .await
-                    {
-                        Ok(true) => {}
-                        Ok(false) => tracing::warn!(
-                            mission_id = %run.mission_id,
-                            run_id = %run.run_id,
-                            generation = run.generation,
-                            "Ignored heartbeat for stale mission run generation"
-                        ),
-                        Err(error) => tracing::warn!(
-                            mission_id = %run.mission_id,
-                            run_id = %run.run_id,
-                            "Failed to persist mission run heartbeat: {error}"
-                        ),
-                    }
+                for (run, active_tool_calls, idle_secs) in leases {
                     let mut live_registered_tools = 0usize;
+                    let mut has_registered_user_wait = false;
                     if let Ok(tools) = mission_store
                         .list_active_tool_executions(run.run_id)
                         .await
                     {
                         for tool in tools {
+                            if is_user_wait_tool(&tool.tool_kind) {
+                                // User-input tools remain live until their
+                                // matching result arrives. The generic 120s
+                                // provisional deadline must never reap a
+                                // mission merely because a human took longer
+                                // than two minutes to answer.
+                                has_registered_user_wait = true;
+                                live_registered_tools += 1;
+                                continue;
+                            }
                             let expired = chrono::DateTime::parse_from_rfc3339(
                                 &tool.deadline_at,
                             )
@@ -13191,6 +13202,27 @@ async fn control_actor_loop(
                                 live_registered_tools += 1;
                             }
                         }
+                    }
+                    let state = mission_heartbeat_state(
+                        active_tool_calls,
+                        has_registered_user_wait,
+                    );
+                    match mission_store
+                        .heartbeat_mission_run(run.run_id, run.generation, state, None)
+                        .await
+                    {
+                        Ok(true) => {}
+                        Ok(false) => tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            generation = run.generation,
+                            "Ignored heartbeat for stale mission run generation"
+                        ),
+                        Err(error) => tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            "Failed to persist mission run heartbeat: {error}"
+                        ),
                     }
                     if idle_secs >= 15 * 60
                         && state != MissionExecutionState::WaitingUser
@@ -16724,10 +16756,7 @@ async fn control_actor_loop(
                                 };
                                 if let Some(run) = durable_run {
                                     let now = chrono::Utc::now();
-                                    let waiting_state = if matches!(
-                                        name.as_str(),
-                                        "request_user_input" | "AskUserQuestion" | "frontend_tool"
-                                    ) {
+                                    let waiting_state = if is_user_wait_tool(name) {
                                         MissionExecutionState::WaitingUser
                                     } else {
                                         MissionExecutionState::WaitingTool
@@ -20597,6 +20626,26 @@ mod tests {
         assert!(refusal.contains("20 GiB scratch"));
         assert!(refusal.contains("64 GiB"));
         assert!(refusal.contains("80 GiB is free"));
+    }
+
+    #[test]
+    fn mission_heartbeat_preserves_registered_user_waits() {
+        assert!(is_user_wait_tool("request_user_input"));
+        assert!(is_user_wait_tool("AskUserQuestion"));
+        assert!(is_user_wait_tool("frontend_tool"));
+        assert!(!is_user_wait_tool("workspace_bash"));
+        assert_eq!(
+            mission_heartbeat_state(1, true),
+            MissionExecutionState::WaitingUser
+        );
+        assert_eq!(
+            mission_heartbeat_state(1, false),
+            MissionExecutionState::WaitingTool
+        );
+        assert_eq!(
+            mission_heartbeat_state(0, false),
+            MissionExecutionState::Running
+        );
     }
 
     fn reset_metadata_refresh_test_state() {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -59,7 +59,8 @@ use super::desktop;
 use super::library::SharedLibrary;
 use super::mission_store::{
     self, create_mission_store, now_string, AwaitingKind, BoardTask, BoardTaskStatus, Mission,
-    MissionHistoryEntry, MissionStore, MissionStoreType, NewBoardTask,
+    MissionExecutionState, MissionHistoryEntry, MissionRun, MissionStore, MissionStoreType,
+    MissionToolExecution, MissionToolExecutionState, NewBoardTask,
 };
 use super::routes::AppState;
 
@@ -110,6 +111,34 @@ fn parse_durable_job_result(result: &serde_json::Value) -> Option<serde_json::Va
     }
 
     visit(result, 0)
+}
+
+async fn acquire_execution_run(
+    mission_store: &Arc<dyn MissionStore>,
+    mission_id: Option<Uuid>,
+    owner_actor_id: &str,
+) -> Result<Option<MissionRun>, String> {
+    let Some(mission_id) = mission_id else {
+        return Ok(None);
+    };
+    let run = mission_store
+        .begin_mission_run(mission_id, owner_actor_id, None)
+        .await?;
+    if !mission_store
+        .heartbeat_mission_run(
+            run.run_id,
+            run.generation,
+            MissionExecutionState::Running,
+            None,
+        )
+        .await?
+    {
+        return Err(format!(
+            "run {} generation {} was superseded before execution",
+            run.run_id, run.generation
+        ));
+    }
+    Ok(Some(run))
 }
 
 /// One entry in the main control queue: (message id, content, optional per-message
@@ -2412,7 +2441,80 @@ async fn get_running_missions(
         .send(ControlCommand::ListRunning { respond: tx })
         .await
         .map_err(session_unavailable)?;
-    rx.await.map_err(recv_failed)
+    let actor_rows = rx.await.map_err(recv_failed)?;
+    let durable_runs = control
+        .mission_store
+        .list_active_mission_runs()
+        .await
+        .map_err(internal_error)?;
+    let mut actor_by_mission: HashMap<Uuid, super::mission_runner::RunningMissionInfo> = actor_rows
+        .into_iter()
+        .map(|row| (row.mission_id, row))
+        .collect();
+    let mut projected = Vec::with_capacity(durable_runs.len() + actor_by_mission.len());
+    for run in durable_runs {
+        let mission = control
+            .mission_store
+            .get_mission(run.mission_id)
+            .await
+            .map_err(internal_error)?;
+        let heartbeat_age = chrono::DateTime::parse_from_rfc3339(&run.heartbeat_at)
+            .ok()
+            .map(|timestamp| {
+                (chrono::Utc::now() - timestamp.with_timezone(&chrono::Utc))
+                    .num_seconds()
+                    .max(0) as u64
+            })
+            .unwrap_or(u64::MAX);
+        let presentation_conflict = mission.as_ref().and_then(|mission| {
+            (mission.status == MissionStatus::Acknowledged || mission.status.is_terminal())
+                .then(|| format!("status_{}_with_non_terminal_run", mission.status))
+        });
+        let mut row = actor_by_mission.remove(&run.mission_id).unwrap_or_else(|| {
+            super::mission_runner::RunningMissionInfo {
+                mission_id: run.mission_id,
+                state: run.execution_state.as_str().to_string(),
+                queue_len: 0,
+                history_len: 0,
+                seconds_since_activity: heartbeat_age,
+                tool_call_in_flight: run.execution_state == MissionExecutionState::WaitingTool,
+                health: super::mission_runner::MissionHealth::Reconciling {
+                    reason: "durable_run_without_registered_actor".to_string(),
+                },
+                expected_deliverables: 0,
+                current_activity: None,
+                subtask_total: 0,
+                subtask_completed: 0,
+                run_id: Some(run.run_id),
+                generation: Some(run.generation),
+                heartbeat_at: Some(run.heartbeat_at.clone()),
+                scope_unit: run.scope_unit.clone(),
+                status_conflict: Some("durable_run_without_registered_actor".to_string()),
+            }
+        });
+        row.state = run.execution_state.as_str().to_string();
+        row.run_id = Some(run.run_id);
+        row.generation = Some(run.generation);
+        row.heartbeat_at = Some(run.heartbeat_at.clone());
+        row.scope_unit = run.scope_unit.clone();
+        if let Some(conflict) = presentation_conflict {
+            row.status_conflict = Some(conflict.clone());
+            row.health = super::mission_runner::MissionHealth::Reconciling { reason: conflict };
+        } else if heartbeat_age > 60 && run.execution_state != MissionExecutionState::WaitingUser {
+            let reason = format!("run_heartbeat_stale_{heartbeat_age}s");
+            row.status_conflict = Some(reason.clone());
+            row.health = super::mission_runner::MissionHealth::Reconciling { reason };
+        }
+        projected.push(row);
+    }
+    for (_, mut row) in actor_by_mission {
+        row.status_conflict = Some("registered_actor_without_durable_run".to_string());
+        row.health = super::mission_runner::MissionHealth::Reconciling {
+            reason: "registered_actor_without_durable_run".to_string(),
+        };
+        projected.push(row);
+    }
+    Ok(projected)
 }
 
 /// Look up an automation by ID, returning 404 if it does not exist.
@@ -4120,11 +4222,59 @@ pub struct ListMissionsQuery {
     pub workspace: Option<String>,
 }
 
+fn mission_execution_projection(run: &MissionRun, status: MissionStatus) -> serde_json::Value {
+    let heartbeat_age = chrono::DateTime::parse_from_rfc3339(&run.heartbeat_at)
+        .ok()
+        .map(|timestamp| {
+            (chrono::Utc::now() - timestamp.with_timezone(&chrono::Utc))
+                .num_seconds()
+                .max(0) as u64
+        })
+        .unwrap_or(u64::MAX);
+    let conflict = if status == MissionStatus::Acknowledged || status.is_terminal() {
+        Some(format!("status_{status}_with_non_terminal_run"))
+    } else if heartbeat_age > 60 && run.execution_state != MissionExecutionState::WaitingUser {
+        Some(format!("run_heartbeat_stale_{heartbeat_age}s"))
+    } else {
+        None
+    };
+    serde_json::json!({
+        "run_id": run.run_id,
+        "generation": run.generation,
+        "state": run.execution_state,
+        "health": if conflict.is_some() { "reconciling" } else { "healthy" },
+        "heartbeat_at": run.heartbeat_at,
+        "scope_unit": run.scope_unit,
+        "status_conflict": conflict,
+    })
+}
+
+fn attach_execution_to_mission_value(
+    mut value: serde_json::Value,
+    mission: &Mission,
+    run: Option<&MissionRun>,
+) -> serde_json::Value {
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "execution".to_string(),
+            run.map(|run| mission_execution_projection(run, mission.status))
+                .unwrap_or(serde_json::Value::Null),
+        );
+        object.insert(
+            "acknowledged_at".to_string(),
+            (mission.status == MissionStatus::Acknowledged)
+                .then(|| serde_json::Value::String(mission.updated_at.clone()))
+                .unwrap_or(serde_json::Value::Null),
+        );
+    }
+    value
+}
+
 pub async fn list_missions(
     State(state): State<Arc<AppState>>,
     Extension(user): Extension<AuthUser>,
     Query(query): Query<ListMissionsQuery>,
-) -> Result<Json<Vec<Mission>>, (StatusCode, String)> {
+) -> Result<Json<Vec<serde_json::Value>>, (StatusCode, String)> {
     let control = control_for_user(&state, &user).await;
     // Default to the most recent 50; honor an explicit limit so callers (e.g.
     // the assistant MCP) can request more, capped to keep the response bounded.
@@ -4207,7 +4357,22 @@ pub async fn list_missions(
     };
 
     populate_activity(&control, &mut missions).await;
-    Ok(Json(missions))
+    let active_runs: HashMap<Uuid, MissionRun> = control
+        .mission_store
+        .list_active_mission_runs()
+        .await
+        .map_err(internal_error)?
+        .into_iter()
+        .map(|run| (run.mission_id, run))
+        .collect();
+    let values = missions
+        .into_iter()
+        .map(|mission| {
+            let value = serde_json::to_value(&mission).unwrap_or(serde_json::Value::Null);
+            attach_execution_to_mission_value(value, &mission, active_runs.get(&mission.id))
+        })
+        .collect();
+    Ok(Json(values))
 }
 
 /// Targeted post-deploy/observability health for the mission fleet (P#8). One
@@ -4861,7 +5026,16 @@ pub async fn get_mission(
 
             // Serialize then attach the computed spark_offload block so Paloma
             // can route heavy builds without probing the host each time.
-            let mut value = serde_json::to_value(&mission).map_err(internal_error)?;
+            let active_run = control
+                .mission_store
+                .get_active_mission_run(mission.id)
+                .await
+                .map_err(internal_error)?;
+            let mut value = attach_execution_to_mission_value(
+                serde_json::to_value(&mission).map_err(internal_error)?,
+                &mission,
+                active_run.as_ref(),
+            );
             let host_configured =
                 state.config.spark_arbiter_url.is_some() || state.config.spark_ssh_target.is_some();
             let enabled = workspace
@@ -4953,6 +5127,13 @@ pub async fn get_mission_digest(
             }
         }
     }
+    let execution = control
+        .mission_store
+        .get_active_mission_run(mission.id)
+        .await
+        .map_err(internal_error)?
+        .as_ref()
+        .map(|run| mission_execution_projection(run, mission.status));
 
     Ok(Json(serde_json::json!({
         "id": mission.id,
@@ -4969,6 +5150,8 @@ pub async fn get_mission_digest(
         "project": mission.project,
         "created_at": mission.created_at,
         "updated_at": mission.updated_at,
+        "acknowledged_at": (mission.status == MissionStatus::Acknowledged).then_some(mission.updated_at.clone()),
+        "execution": execution,
         "history_len": mission.history.len(),
         "last_user_message": last_user,
         "last_assistant_message": last_assistant,
@@ -8593,6 +8776,7 @@ fn event_visibility(event_type: &str) -> &'static str {
 #[derive(Debug, Serialize)]
 pub struct MissionSnapshotResponse {
     pub mission: Mission,
+    pub execution: Option<serde_json::Value>,
     pub events: Vec<mission_store::StoredEvent>,
     pub event_counts: HashMap<String, usize>,
     pub counts: HashMap<String, usize>,
@@ -8749,9 +8933,17 @@ pub async fn get_mission_snapshot(
         .await?
         .into_iter()
         .find(|info| info.mission_id == mission_id);
+    let execution = control
+        .mission_store
+        .get_active_mission_run(mission_id)
+        .await
+        .map_err(internal_error)?
+        .as_ref()
+        .map(|run| mission_execution_projection(run, mission.status));
 
     Ok(Json(MissionSnapshotResponse {
         mission,
+        execution,
         events: summary.events,
         counts: event_counts.clone(),
         event_counts,
@@ -12551,6 +12743,31 @@ async fn control_actor_loop(
     // here from the `ToolResult` event arm; read by the auto-resume watcher.
     background_tasks: super::mission_runner::BackgroundTaskRegistry,
 ) {
+    // A process-local actor cannot reattach a harness JoinHandle after restart.
+    // Close any inherited execution lease before accepting new work; durable
+    // workspace/remote jobs remain independently recoverable by job id.
+    if let Ok(inherited_runs) = mission_store.list_active_mission_runs().await {
+        for run in inherited_runs {
+            let _ = mission_store
+                .finish_mission_run(
+                    run.run_id,
+                    run.generation,
+                    Some("actor_restart_process_ownership_unrecoverable"),
+                )
+                .await;
+            if let Ok(Some(mission)) = mission_store.get_mission(run.mission_id).await {
+                if mission.status == MissionStatus::Active {
+                    let _ = mission_store
+                        .update_mission_status_with_reason(
+                            run.mission_id,
+                            MissionStatus::Interrupted,
+                            Some("actor_restart_process_ownership_unrecoverable"),
+                        )
+                        .await;
+                }
+            }
+        }
+    }
     // Queue stores (id, content, agent, target_mission_id) for the current/primary mission
     // The target_mission_id tracks which mission each queued message is intended for
     let mut queue: VecDeque<ControlQueueEntry> = VecDeque::new();
@@ -12610,6 +12827,9 @@ async fn control_actor_loop(
     // Track which mission the main `running` task is actually working on.
     // This is different from `current_mission` which can change when user creates a new mission.
     let mut running_mission_id: Option<Uuid> = None;
+    let mut running_run: Option<MissionRun> = None;
+    let mut execution_heartbeat = tokio::time::interval(std::time::Duration::from_secs(15));
+    execution_heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // Track last activity for the main runner (for stall detection)
     let mut main_runner_last_activity: std::time::Instant = std::time::Instant::now();
     // Track current activity label for the main runner
@@ -12900,6 +13120,107 @@ async fn control_actor_loop(
         )
         .await;
         tokio::select! {
+            _ = execution_heartbeat.tick() => {
+                let mut leases = Vec::new();
+                if let Some(run) = running_run.clone() {
+                    let state = if main_runner_active_tool_calls
+                        .load(std::sync::atomic::Ordering::Relaxed) > 0
+                    {
+                        MissionExecutionState::WaitingTool
+                    } else {
+                        MissionExecutionState::Running
+                    };
+                    leases.push((run, state, main_runner_last_activity.elapsed().as_secs()));
+                }
+                leases.extend(parallel_runners.values().filter_map(|runner| {
+                    runner.durable_run.clone().map(|run| {
+                        let state = if runner.active_tool_calls
+                            .load(std::sync::atomic::Ordering::Relaxed) > 0
+                        {
+                            MissionExecutionState::WaitingTool
+                        } else {
+                            MissionExecutionState::Running
+                        };
+                        (run, state, runner.last_activity.elapsed().as_secs())
+                    })
+                }));
+                for (run, state, idle_secs) in leases {
+                    match mission_store
+                        .heartbeat_mission_run(run.run_id, run.generation, state, None)
+                        .await
+                    {
+                        Ok(true) => {}
+                        Ok(false) => tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            generation = run.generation,
+                            "Ignored heartbeat for stale mission run generation"
+                        ),
+                        Err(error) => tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            "Failed to persist mission run heartbeat: {error}"
+                        ),
+                    }
+                    let mut live_registered_tools = 0usize;
+                    if let Ok(tools) = mission_store
+                        .list_active_tool_executions(run.run_id)
+                        .await
+                    {
+                        for tool in tools {
+                            let expired = chrono::DateTime::parse_from_rfc3339(
+                                &tool.deadline_at,
+                            )
+                            .map(|deadline| {
+                                deadline.with_timezone(&chrono::Utc) <= chrono::Utc::now()
+                            })
+                            .unwrap_or(true);
+                            if expired && tool.state == MissionToolExecutionState::Provisional {
+                                let _ = mission_store
+                                    .finish_tool_execution(
+                                        run.run_id,
+                                        &tool.tool_call_id,
+                                        MissionToolExecutionState::Stale,
+                                        None,
+                                        Some("unmatched_tool_call_deadline"),
+                                    )
+                                    .await;
+                            } else {
+                                live_registered_tools += 1;
+                            }
+                        }
+                    }
+                    if idle_secs >= 15 * 60
+                        && state != MissionExecutionState::WaitingUser
+                        && live_registered_tools == 0
+                    {
+                        tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            idle_secs,
+                            "Interrupting mission after 15 minutes without registered liveness evidence"
+                        );
+                        let _ = mission_store
+                            .heartbeat_mission_run(
+                                run.run_id,
+                                run.generation,
+                                MissionExecutionState::Stopping,
+                                None,
+                            )
+                            .await;
+                        if running_mission_id == Some(run.mission_id) {
+                            if let Some(token) = &running_cancel {
+                                token.cancel();
+                                runner_force_clear_deadline = Some(
+                                    tokio::time::Instant::now() + RUNNER_FORCE_CLEAR_GRACE,
+                                );
+                            }
+                        } else if let Some(runner) = parallel_runners.get_mut(&run.mission_id) {
+                            runner.cancel();
+                        }
+                    }
+                }
+            }
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else { break };
                 match cmd {
@@ -13162,6 +13483,21 @@ async fn control_actor_loop(
                                     }
                                     // Try to start if not already running
                                     if !runner.is_running() {
+                                        if let Err(error) = runner
+                                            .acquire_durable_run(
+                                                &mission_store,
+                                                &format!("control:{session_user_id}"),
+                                            )
+                                            .await
+                                        {
+                                            let _ = events_tx.send(AgentEvent::Error {
+                                                message: format!("Mission run lease rejected: {error}"),
+                                                mission_id: Some(tid),
+                                                resumable: true,
+                                            });
+                                            let _ = respond.send(UserMessageAck::Rejected(error));
+                                            continue;
+                                        }
                                         runner.start_next(
                                             config.clone(),
                                             Arc::clone(&root_agent),
@@ -13363,6 +13699,21 @@ async fn control_actor_loop(
                                                 source: source.clone(),
                                             });
                                             // Start execution
+                                            if let Err(error) = runner
+                                                .acquire_durable_run(
+                                                    &mission_store,
+                                                    &format!("control:{session_user_id}"),
+                                                )
+                                                .await
+                                            {
+                                                let _ = events_tx.send(AgentEvent::Error {
+                                                    message: format!("Mission run lease rejected: {error}"),
+                                                    mission_id: Some(tid),
+                                                    resumable: true,
+                                                });
+                                                let _ = respond.send(UserMessageAck::Rejected(error));
+                                                continue;
+                                            }
                                             runner.start_next(
                                                 config.clone(),
                                                 Arc::clone(&root_agent),
@@ -13734,6 +14085,26 @@ async fn control_actor_loop(
                                 main_runner_active_tool_calls
                                     .store(0, std::sync::atomic::Ordering::Relaxed);
                                 let user_id_for_turn = session_user_id.clone();
+                                running_run = match acquire_execution_run(
+                                    &mission_store,
+                                    mission_id,
+                                    &format!("control:{session_user_id}"),
+                                )
+                                .await
+                                {
+                                    Ok(run) => run,
+                                    Err(error) => {
+                                        running_cancel = None;
+                                        running_mission_id = None;
+                                        let _ = respond.send(UserMessageAck::Rejected(error.clone()));
+                                        let _ = events_tx.send(AgentEvent::Error {
+                                            message: format!("Mission run lease rejected: {error}"),
+                                            mission_id,
+                                            resumable: true,
+                                        });
+                                        continue;
+                                    }
+                                };
                                 running = Some(tokio::spawn(async move {
                                     let result = run_single_control_turn(
                                         cfg,
@@ -13787,6 +14158,16 @@ async fn control_actor_loop(
                     ControlCommand::Cancel => {
                         if let Some(token) = &running_cancel {
                             token.cancel();
+                            if let Some(run) = running_run.as_ref() {
+                                let _ = mission_store
+                                    .heartbeat_mission_run(
+                                        run.run_id,
+                                        run.generation,
+                                        MissionExecutionState::Stopping,
+                                        None,
+                                    )
+                                    .await;
+                            }
                             // Don't send Error event here - the task will complete and send
                             // an AssistantMessage with the cancellation result when it finishes.
                             // Sending both causes duplicate UI messages.
@@ -14122,6 +14503,18 @@ async fn control_actor_loop(
                             runner.queue_message(Uuid::new_v4(), content, None, None);
 
                             // Start execution
+                            if let Err(error) = runner
+                                .acquire_durable_run(
+                                    &mission_store,
+                                    &format!("control:{session_user_id}"),
+                                )
+                                .await
+                            {
+                                let _ = respond.send(Err(format!(
+                                    "Failed to acquire mission run lease: {error}"
+                                )));
+                                continue;
+                            }
                             let started = runner.start_next(
                                 config.clone(),
                                 Arc::clone(&root_agent),
@@ -14225,7 +14618,20 @@ async fn control_actor_loop(
                                 // Cancel runner if running
                                 if let Some(runner) = parallel_runners.get_mut(&child.id) {
                                     runner.cancel();
-                                    parallel_runners.remove(&child.id);
+                                    if let Some(run) = runner.durable_run.as_ref() {
+                                        let _ = mission_store
+                                            .heartbeat_mission_run(
+                                                run.run_id,
+                                                run.generation,
+                                                MissionExecutionState::Stopping,
+                                                None,
+                                            )
+                                            .await;
+                                    }
+                                    // Keep the runner registered until its task
+                                    // actually exits; dropping the JoinHandle
+                                    // here would detach live work.
+                                    continue;
                                 }
                                 if let Err(e) = mission_store
                                     .update_mission_status(child.id, MissionStatus::Interrupted)
@@ -14246,41 +14652,21 @@ async fn control_actor_loop(
                         // First check parallel runners
                         if let Some(runner) = parallel_runners.get_mut(&mission_id) {
                             runner.cancel();
-                            // Update status to Interrupted so the mission can be
-                            // resumed later (fixes #149: cancel left status as pending).
-                            if let Err(e) = mission_store
-                                .update_mission_status(mission_id, MissionStatus::Interrupted)
-                                .await
-                            {
-                                tracing::warn!(
-                                    "Failed to update cancelled parallel mission status: {}",
-                                    e
-                                );
-                            } else {
-                                maybe_schedule_mission_metadata_refresh_for_status(
-                                    &mission_store,
-                                    &events_tx,
-                                    mission_id,
-                                    MissionStatus::Interrupted,
-                                );
+                            if let Some(run) = runner.durable_run.as_ref() {
+                                let _ = mission_store
+                                    .heartbeat_mission_run(
+                                        run.run_id,
+                                        run.generation,
+                                        MissionExecutionState::Stopping,
+                                        None,
+                                    )
+                                    .await;
                             }
                             let _ = events_tx.send(AgentEvent::Error {
-                                message: format!("Parallel mission {} cancelled", mission_id),
+                                message: format!("Parallel mission {} cancellation requested", mission_id),
                                 mission_id: Some(mission_id),
                                 resumable: true, // Cancelled missions can be resumed
                             });
-                            let _ = events_tx.send(AgentEvent::MissionStatusChanged {
-                                mission_id,
-                                status: MissionStatus::Interrupted,
-                                summary: None,
-                            });
-                            parallel_runners.remove(&mission_id);
-                            close_mission_desktop_sessions(
-                                &mission_store,
-                                mission_id,
-                                &config.working_dir,
-                            )
-                            .await;
                             // Cascade cancel child missions
                             cancel_child_missions(mission_id, &mission_store, &mut parallel_runners, &events_tx, &config.working_dir).await;
                             let _ = respond.send(Ok(CancelMissionOutcome::Cancelled));
@@ -14292,6 +14678,16 @@ async fn control_actor_loop(
                                 // Cancel the current execution
                                 if let Some(token) = &running_cancel {
                                     token.cancel();
+                                    if let Some(run) = running_run.as_ref() {
+                                        let _ = mission_store
+                                            .heartbeat_mission_run(
+                                                run.run_id,
+                                                run.generation,
+                                                MissionExecutionState::Stopping,
+                                                None,
+                                            )
+                                            .await;
+                                    }
                                     // Arm the force-clear deadline. Most cancels
                                     // wind down within a few seconds via the
                                     // task's own observation of the cancel
@@ -14391,7 +14787,16 @@ async fn control_actor_loop(
                         // stop logic but lands on `Paused` instead of `Interrupted`.
                         if let Some(runner) = parallel_runners.get_mut(&mission_id) {
                             runner.cancel();
-                            parallel_runners.remove(&mission_id);
+                            if let Some(run) = runner.durable_run.as_ref() {
+                                let _ = mission_store
+                                    .heartbeat_mission_run(
+                                        run.run_id,
+                                        run.generation,
+                                        MissionExecutionState::Stopping,
+                                        None,
+                                    )
+                                    .await;
+                            }
                             close_mission_desktop_sessions(
                                 &mission_store,
                                 mission_id,
@@ -14401,6 +14806,16 @@ async fn control_actor_loop(
                         } else if running_mission_id == Some(mission_id) {
                             if let Some(token) = &running_cancel {
                                 token.cancel();
+                                if let Some(run) = running_run.as_ref() {
+                                    let _ = mission_store
+                                        .heartbeat_mission_run(
+                                            run.run_id,
+                                            run.generation,
+                                            MissionExecutionState::Stopping,
+                                            None,
+                                        )
+                                        .await;
+                                }
                                 // Arm the force-clear deadline so a zombie runner
                                 // that never observes the cancel still gets torn
                                 // down (matches CancelMission).
@@ -14491,6 +14906,13 @@ async fn control_actor_loop(
                                     current_activity: main_runner_activity.clone(),
                                     subtask_total: main_runner_subtasks.len(),
                                     subtask_completed: main_runner_subtasks.iter().filter(|s| s.completed).count(),
+                                    run_id: running_run.as_ref().map(|run| run.run_id),
+                                    generation: running_run.as_ref().map(|run| run.generation),
+                                    heartbeat_at: running_run.as_ref().map(|run| run.heartbeat_at.clone()),
+                                    scope_unit: running_run.as_ref().and_then(|run| run.scope_unit.clone()),
+                                    status_conflict: running_run
+                                        .is_none()
+                                        .then(|| "actor_without_durable_run".to_string()),
                                 });
                             }
                         }
@@ -14627,6 +15049,18 @@ async fn control_actor_loop(
                                     }
                                     runner.queue_message(Uuid::new_v4(), resume_prompt, None, None);
 
+                                    if let Err(error) = runner
+                                        .acquire_durable_run(
+                                            &mission_store,
+                                            &format!("control:{session_user_id}"),
+                                        )
+                                        .await
+                                    {
+                                        let _ = respond.send(Err(format!(
+                                            "Failed to acquire mission run lease: {error}"
+                                        )));
+                                        continue;
+                                    }
                                     let started = runner.start_next(
                                         config.clone(),
                                         Arc::clone(&root_agent),
@@ -14795,6 +15229,23 @@ async fn control_actor_loop(
                                         main_runner_active_tool_calls
                                             .store(0, std::sync::atomic::Ordering::Relaxed);
                                         let user_id_for_turn = session_user_id.clone();
+                                        running_run = match acquire_execution_run(
+                                            &mission_store,
+                                            Some(mission_id),
+                                            &format!("control:{session_user_id}"),
+                                        )
+                                        .await
+                                        {
+                                            Ok(run) => run,
+                                            Err(error) => {
+                                                running_cancel = None;
+                                                running_mission_id = None;
+                                                let _ = respond.send(Err(format!(
+                                                    "Failed to acquire mission run lease: {error}"
+                                                )));
+                                                continue;
+                                            }
+                                        };
                                         running = Some(tokio::spawn(async move {
                                             let result = run_single_control_turn(
                                                 cfg,
@@ -15227,6 +15678,25 @@ async fn control_actor_loop(
                             completed_completion_confidence =
                                 Some(completion_evidence.completion_confidence);
                             completed_agent_output = agent_result.output.clone();
+                            if let Some(run) = running_run.take() {
+                                let reason = agent_result
+                                    .terminal_reason
+                                    .map(|value| format!("{value:?}"));
+                                if let Err(error) = mission_store
+                                    .finish_mission_run(
+                                        run.run_id,
+                                        run.generation,
+                                        reason.as_deref(),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        mission_id = %run.mission_id,
+                                        run_id = %run.run_id,
+                                        "Failed to close main mission run: {error}"
+                                    );
+                                }
+                            }
                             // Only append assistant to local history if this mission is still the current mission.
                             // Note: User message was already added before execution started.
                             // If the user created a new mission mid-execution, history was cleared for that new mission,
@@ -15394,6 +15864,15 @@ async fn control_actor_loop(
                             }
                         }
                         Err(e) => {
+                            if let Some(run) = running_run.take() {
+                                let _ = mission_store
+                                    .finish_mission_run(
+                                        run.run_id,
+                                        run.generation,
+                                        Some("runner_join_failed"),
+                                    )
+                                    .await;
+                            }
                             let _ = events_tx.send(AgentEvent::Error {
                                 message: format!("Control session task join failed: {}", e),
                                 mission_id: completed_mission_id,
@@ -15601,6 +16080,33 @@ async fn control_actor_loop(
                     main_runner_active_tool_calls
                         .store(0, std::sync::atomic::Ordering::Relaxed);
                     let user_id_for_turn = session_user_id.clone();
+                    running_run = match acquire_execution_run(
+                        &mission_store,
+                        mission_id,
+                        &format!("control:{session_user_id}"),
+                    )
+                    .await
+                    {
+                        Ok(run) => run,
+                        Err(error) => {
+                            running_cancel = None;
+                            running_mission_id = None;
+                            let _ = events_tx.send(AgentEvent::Error {
+                                message: format!("Mission run lease rejected: {error}"),
+                                mission_id,
+                                resumable: true,
+                            });
+                            set_and_emit_status(
+                                &status,
+                                &events_tx,
+                                ControlRunState::Idle,
+                                queue.len(),
+                                mission_id,
+                            )
+                            .await;
+                            continue;
+                        }
+                    };
                     running = Some(tokio::spawn(async move {
                         let result = run_single_control_turn(
                             cfg,
@@ -15643,6 +16149,15 @@ async fn control_actor_loop(
                     if runner.check_finished() {
                         if let Some((_msg_id, _user_msg, mut result)) = runner.poll_completion().await {
                             maybe_recover_soft_llm_error(&mut result);
+                            let durable_terminal_reason = result
+                                .terminal_reason
+                                .map(|reason| format!("{reason:?}"));
+                            runner
+                                .finish_durable_run(
+                                    &mission_store,
+                                    durable_terminal_reason.as_deref(),
+                                )
+                                .await;
                             let completion_evidence = completion_evidence_for_agent_result(&result);
                             tracing::info!(
                                 "Parallel mission {} completed (success: {}, cost: {} cents)",
@@ -15815,6 +16330,25 @@ async fn control_actor_loop(
                                         );
                                         runner.session_id = m.session_id;
                                     }
+                                }
+                                if let Err(error) = runner
+                                    .acquire_durable_run(
+                                        &mission_store,
+                                        &format!("control:{session_user_id}"),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        mission_id = %mission_id,
+                                        "Failed to acquire next mission run lease: {error}"
+                                    );
+                                    let _ = events_tx.send(AgentEvent::Error {
+                                        message: format!("Mission run lease rejected: {error}"),
+                                        mission_id: Some(*mission_id),
+                                        resumable: true,
+                                    });
+                                    completed_missions.push(*mission_id);
+                                    continue;
                                 }
                                 let started = runner.start_next(
                                     config.clone(),
@@ -16071,6 +16605,15 @@ async fn control_actor_loop(
                 main_runner_active_tool_calls
                     .store(0, std::sync::atomic::Ordering::Relaxed);
                 runner_force_clear_deadline = None;
+                if let Some(run) = running_run.take() {
+                    let _ = mission_store
+                        .finish_mission_run(
+                            run.run_id,
+                            run.generation,
+                            Some("force_killed_after_cancel_timeout"),
+                        )
+                        .await;
+                }
                 if let Some(mid) = stuck_mid {
                     // Mark mission as Interrupted so it stays resumable.
                     if let Err(e) = mission_store
@@ -16168,6 +16711,60 @@ async fn control_actor_loop(
                                     runner
                                         .active_tool_calls
                                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                }
+
+                                let durable_run = if running_mission_id == Some(*mid) {
+                                    running_run.clone()
+                                } else {
+                                    parallel_runners
+                                        .get(mid)
+                                        .and_then(|runner| runner.durable_run.clone())
+                                };
+                                if let Some(run) = durable_run {
+                                    let now = chrono::Utc::now();
+                                    let waiting_state = if matches!(
+                                        name.as_str(),
+                                        "request_user_input" | "AskUserQuestion" | "frontend_tool"
+                                    ) {
+                                        MissionExecutionState::WaitingUser
+                                    } else {
+                                        MissionExecutionState::WaitingTool
+                                    };
+                                    let _ = mission_store
+                                        .heartbeat_mission_run(
+                                            run.run_id,
+                                            run.generation,
+                                            waiting_state,
+                                            None,
+                                        )
+                                        .await;
+                                    let execution = MissionToolExecution {
+                                        tool_call_id: tool_call_id.clone(),
+                                        run_id: run.run_id,
+                                        tool_kind: name.clone(),
+                                        state: MissionToolExecutionState::Provisional,
+                                        started_at: now.to_rfc3339(),
+                                        heartbeat_at: now.to_rfc3339(),
+                                        // An unmatched protocol event alone is
+                                        // evidence for at most 120 seconds.
+                                        deadline_at: (now + chrono::Duration::seconds(120))
+                                            .to_rfc3339(),
+                                        process_pid: None,
+                                        durable_job_id: None,
+                                        completed_at: None,
+                                        exit_status: None,
+                                        failure_class: None,
+                                    };
+                                    if let Err(error) = mission_store
+                                        .register_tool_execution(&execution)
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            mission_id = %mid,
+                                            tool_call_id = %tool_call_id,
+                                            "Failed to register tool execution: {error}"
+                                        );
+                                    }
                                 }
 
                                 // Background-task auto-resume: stash the command
@@ -16325,6 +16922,47 @@ async fn control_actor_loop(
                                         std::sync::atomic::Ordering::Relaxed,
                                         |c| if c > 0 { Some(c - 1) } else { None },
                                     );
+                                }
+
+                                let durable_run = if running_mission_id == Some(*mid) {
+                                    running_run.clone()
+                                } else {
+                                    parallel_runners
+                                        .get(mid)
+                                        .and_then(|runner| runner.durable_run.clone())
+                                };
+                                if let Some(run) = durable_run {
+                                    match mission_store
+                                        .finish_tool_execution(
+                                            run.run_id,
+                                            tool_call_id,
+                                            MissionToolExecutionState::Completed,
+                                            Some(0),
+                                            None,
+                                        )
+                                        .await
+                                    {
+                                        Ok(true) => {
+                                            let _ = mission_store
+                                                .heartbeat_mission_run(
+                                                    run.run_id,
+                                                    run.generation,
+                                                    MissionExecutionState::Running,
+                                                    None,
+                                                )
+                                                .await;
+                                        }
+                                        Ok(false) => tracing::debug!(
+                                            mission_id = %mid,
+                                            tool_call_id = %tool_call_id,
+                                            "Stored late or unmatched tool result without mutating current run"
+                                        ),
+                                        Err(error) => tracing::warn!(
+                                            mission_id = %mid,
+                                            tool_call_id = %tool_call_id,
+                                            "Failed to finish tool execution: {error}"
+                                        ),
+                                    }
                                 }
 
                                 // Mark subtask complete if applicable
@@ -23276,6 +23914,7 @@ And the report:
             repository: None,
             branch: None,
             depends_on: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4290,10 +4290,7 @@ fn attach_execution_to_mission_value(
 }
 
 fn is_user_wait_tool(tool_kind: &str) -> bool {
-    matches!(
-        tool_kind,
-        "request_user_input" | "AskUserQuestion" | "frontend_tool"
-    )
+    matches!(tool_kind, "request_user_input" | "frontend_tool") || is_interactive_ui_tool(tool_kind)
 }
 
 fn mission_heartbeat_state(
@@ -20743,6 +20740,8 @@ mod tests {
         assert!(is_user_wait_tool("request_user_input"));
         assert!(is_user_wait_tool("AskUserQuestion"));
         assert!(is_user_wait_tool("frontend_tool"));
+        assert!(is_user_wait_tool("question"));
+        assert!(is_user_wait_tool("ui_confirm"));
         assert!(!is_user_wait_tool("workspace_bash"));
         assert_eq!(
             mission_heartbeat_state(1, true),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13727,6 +13727,38 @@ async fn control_actor_loop(
                                         let _ = respond.send(UserMessageAck::Rejected(error));
                                         continue;
                                     }
+                                    if let Err(error) = persist_control_queue_if_changed(
+                                        &mission_store,
+                                        &session_user_id,
+                                        &queue,
+                                        &parallel_runners,
+                                        &recovered_consumed_user_messages,
+                                        &mut last_persisted_queue,
+                                    )
+                                    .await
+                                    {
+                                        if let Some(runner) = parallel_runners.get_mut(&tid) {
+                                            runner
+                                                .finish_durable_run(
+                                                    &mission_store,
+                                                    Some("consumed_snapshot_persist_failed"),
+                                                )
+                                                .await;
+                                            runner.remove_inflight_message(id);
+                                        }
+                                        accepted_user_message_ids.remove(&id);
+                                        let _ = respond.send(UserMessageAck::Rejected(format!(
+                                            "failed to persist consumed parallel delivery: {error}"
+                                        )));
+                                        continue;
+                                    }
+                                    let Some(runner) = parallel_runners.get_mut(&tid) else {
+                                        accepted_user_message_ids.remove(&id);
+                                        let _ = respond.send(UserMessageAck::Rejected(format!(
+                                            "mission {tid} runner disappeared before start"
+                                        )));
+                                        continue;
+                                    };
                                     runner.start_next(
                                         config.clone(),
                                         Arc::clone(&root_agent),
@@ -13993,6 +14025,36 @@ async fn control_actor_loop(
                                                 let _ = respond.send(UserMessageAck::Rejected(error));
                                                 continue;
                                             }
+                                            if let Err(error) = persist_control_queue_if_changed(
+                                                &mission_store,
+                                                &session_user_id,
+                                                &queue,
+                                                &parallel_runners,
+                                                &recovered_consumed_user_messages,
+                                                &mut last_persisted_queue,
+                                            )
+                                            .await
+                                            {
+                                                if let Some(runner) = parallel_runners.get_mut(&tid) {
+                                                    runner
+                                                        .finish_durable_run(
+                                                            &mission_store,
+                                                            Some("consumed_snapshot_persist_failed"),
+                                                        )
+                                                        .await;
+                                                }
+                                                parallel_runners.remove(&tid);
+                                                accepted_user_message_ids.remove(&id);
+                                                let _ = respond.send(UserMessageAck::Rejected(
+                                                    format!(
+                                                        "failed to persist consumed parallel delivery: {error}"
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
+                                            let runner = parallel_runners
+                                                .get_mut(&tid)
+                                                .expect("parallel runner persisted above");
                                             runner.start_next(
                                                 config.clone(),
                                                 Arc::clone(&root_agent),
@@ -14410,6 +14472,31 @@ async fn control_actor_loop(
                                     Err(error) => {
                                         running_cancel = None;
                                         running_mission_id = None;
+                                        // The queue dequeue was already persisted, but no
+                                        // run owns this delivery. Roll back the just-appended
+                                        // history entry and release the deterministic message
+                                        // id so the caller/outbox can retry it safely.
+                                        if history.last().is_some_and(|entry| {
+                                            entry.0 == "user" && entry.1 == msg
+                                        }) {
+                                            history.pop();
+                                            persist_mission_history_to(
+                                                &mission_store,
+                                                &events_tx,
+                                                msg_target_mid,
+                                                &history,
+                                            )
+                                            .await;
+                                        }
+                                        accepted_user_message_ids.remove(&mid);
+                                        set_and_emit_status(
+                                            &status,
+                                            &events_tx,
+                                            ControlRunState::Idle,
+                                            queue.len(),
+                                            msg_target_mid,
+                                        )
+                                        .await;
                                         let _ = respond.send(UserMessageAck::Rejected(error.clone()));
                                         let _ = events_tx.send(AgentEvent::Error {
                                             message: format!("Mission run lease rejected: {error}"),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11924,10 +11924,6 @@ fn accept_user_message_id(accepted: &mut HashSet<Uuid>, id: Uuid) -> bool {
     accepted.insert(id)
 }
 
-fn retryable_duplicate_source(source: Option<&str>) -> bool {
-    source == Some("task-board")
-}
-
 fn mission_status_for_terminal_reason(
     reason: TerminalReason,
     complete_turn_without_follow_up: bool,
@@ -13282,8 +13278,7 @@ async fn control_actor_loop(
                 let Some(cmd) = cmd else { break };
                 match cmd {
                     ControlCommand::UserMessage { id, content, agent: msg_agent, target_mission_id, strict, source, respond } => {
-                        let duplicate = !accept_user_message_id(&mut accepted_user_message_ids, id);
-                        if duplicate && !retryable_duplicate_source(source.as_deref()) {
+                        if !accept_user_message_id(&mut accepted_user_message_ids, id) {
                             let status_snapshot = status.read().await;
                             let _ = respond.send(if status_snapshot.state != ControlRunState::Idle {
                                 UserMessageAck::Queued
@@ -13291,10 +13286,6 @@ async fn control_actor_loop(
                                 UserMessageAck::Delivered
                             });
                             continue;
-                        }
-                        if duplicate {
-                            tracing::info!(message_id = %id,
-                                "Reprocessing pending durable board delivery after a prior non-acknowledgement");
                         }
 
                         // Smart routing: decide where to send this message based on target_mission_id
@@ -14227,6 +14218,9 @@ async fn control_actor_loop(
                             }
                         }
                         let _ = respond.send(if was_running { UserMessageAck::Queued } else { UserMessageAck::Delivered });
+                    }
+                    ControlCommand::ReleaseUserMessageId { id } => {
+                        accepted_user_message_ids.remove(&id);
                     }
                     ControlCommand::ToolResult { tool_call_id, name, result, respond } => {
                         // Deliver to the tool hub. resolve() caches the result if
@@ -24764,9 +24758,6 @@ Investigate <service/> failures.
 
         assert!(accept_user_message_id(&mut accepted, message_id));
         assert!(!accept_user_message_id(&mut accepted, message_id));
-        assert!(retryable_duplicate_source(Some("task-board")));
-        assert!(!retryable_duplicate_source(Some("api:user")));
-        assert!(!retryable_duplicate_source(None));
     }
 
     fn assistant(content: &str) -> MissionHistoryEntry {

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -14074,14 +14074,28 @@ async fn control_actor_loop(
                             if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                                 // Persist the dequeue before the awaits that start
                                 // the run, so a crash here can't restore + re-run it.
-                                let _ = persist_control_queue_if_changed(
+                                if let Err(error) = persist_control_queue_if_changed(
                                     &mission_store,
                                     &session_user_id,
                                     &queue,
                                     &parallel_runners,
                                     &mut last_persisted_queue,
                                 )
-                                .await;
+                                .await
+                                {
+                                    queue.push_front((
+                                        mid,
+                                        msg,
+                                        per_msg_agent,
+                                        msg_target_mid,
+                                        msg_source,
+                                    ));
+                                    let _ = respond.send(UserMessageAck::Queued);
+                                    tracing::warn!(
+                                        "Queued delivery retained because dequeue persistence failed: {error}"
+                                    );
+                                    continue;
+                                }
                                 set_and_emit_status(
                                     &status,
                                     &events_tx,
@@ -15276,18 +15290,31 @@ async fn control_actor_loop(
 
                                 // Start execution if not already running
                                 if running.is_none() {
-                                    if let Some((mid, msg, _per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
+                                    if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                                         // Persist the dequeue before the awaits that
                                         // start the run, so a crash here can't
                                         // restore + re-run it.
-                                        let _ = persist_control_queue_if_changed(
+                                        if let Err(error) = persist_control_queue_if_changed(
                                             &mission_store,
                                             &session_user_id,
                                             &queue,
                                             &parallel_runners,
                                             &mut last_persisted_queue,
                                         )
-                                        .await;
+                                        .await
+                                        {
+                                            queue.push_front((
+                                                mid,
+                                                msg,
+                                                per_msg_agent,
+                                                msg_target_mid,
+                                                msg_source,
+                                            ));
+                                            let _ = respond.send(Err(format!(
+                                                "Failed to persist resumed mission queue: {error}"
+                                            )));
+                                            continue;
+                                        }
                                         let target_mid = msg_target_mid.unwrap_or(mission_id);
                                         set_and_emit_status(
                                             &status,
@@ -16096,14 +16123,27 @@ async fn control_actor_loop(
                 if let Some((mid, msg, per_msg_agent, msg_target_mid, msg_source)) = queue.pop_front() {
                     // Persist the dequeue before the awaits that start the run, so
                     // a crash here can't restore + re-run it.
-                    let _ = persist_control_queue_if_changed(
+                    if let Err(error) = persist_control_queue_if_changed(
                         &mission_store,
                         &session_user_id,
                         &queue,
                         &parallel_runners,
                         &mut last_persisted_queue,
                     )
-                    .await;
+                    .await
+                    {
+                        queue.push_front((
+                            mid,
+                            msg,
+                            per_msg_agent,
+                            msg_target_mid,
+                            msg_source,
+                        ));
+                        tracing::warn!(
+                            "Queued delivery retained because dequeue persistence failed: {error}"
+                        );
+                        continue;
+                    }
                     set_and_emit_status(
                         &status,
                         &events_tx,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -12868,15 +12868,13 @@ async fn control_actor_loop(
 ) {
     // A process-local actor cannot reattach a harness JoinHandle after restart.
     // Close any inherited execution lease before accepting new work; durable
-    // workspace/remote jobs remain independently recoverable by job id.
+    // workspace/remote jobs remain independently recoverable by job id. Use
+    // the established server_shutdown reason so the startup recovery task
+    // below re-drives task-mode missions (assistant-mode missions remain idle).
     if let Ok(inherited_runs) = mission_store.list_active_mission_runs().await {
         for run in inherited_runs {
             let _ = mission_store
-                .finish_mission_run(
-                    run.run_id,
-                    run.generation,
-                    Some("actor_restart_process_ownership_unrecoverable"),
-                )
+                .finish_mission_run(run.run_id, run.generation, Some("server_shutdown"))
                 .await;
             if let Ok(Some(mission)) = mission_store.get_mission(run.mission_id).await {
                 if mission.status == MissionStatus::Active {
@@ -12884,7 +12882,7 @@ async fn control_actor_loop(
                         .update_mission_status_with_reason(
                             run.mission_id,
                             MissionStatus::Interrupted,
-                            Some("actor_restart_process_ownership_unrecoverable"),
+                            Some("server_shutdown"),
                         )
                         .await;
                 }
@@ -16534,6 +16532,64 @@ async fn control_actor_loop(
                 let mut completed_missions = Vec::new();
 
                 for (mission_id, runner) in parallel_runners.iter_mut() {
+                    if runner.force_clear_cancelled_if_due() {
+                        tracing::warn!(
+                            mission_id = %mission_id,
+                            "Force-aborting stuck parallel runner after cancellation grace period"
+                        );
+                        runner
+                            .finish_durable_run(
+                                &mission_store,
+                                Some("force_killed_after_cancel_timeout"),
+                            )
+                            .await;
+                        if let Err(error) = mission_store
+                            .update_mission_status_with_reason(
+                                *mission_id,
+                                MissionStatus::Interrupted,
+                                Some("force_killed_after_cancel_timeout"),
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                mission_id = %mission_id,
+                                "Failed to mark force-cleared parallel mission interrupted: {error}"
+                            );
+                        } else {
+                            maybe_schedule_mission_metadata_refresh_for_status(
+                                &mission_store,
+                                &events_tx,
+                                *mission_id,
+                                MissionStatus::Interrupted,
+                            );
+                            let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                                mission_id: *mission_id,
+                                status: MissionStatus::Interrupted,
+                                summary: Some(
+                                    "Cancel timed out; force-aborted stuck parallel runner."
+                                        .to_string(),
+                                ),
+                            });
+                        }
+                        if let Err(error) = mission_store
+                            .complete_running_executions_for_mission(
+                                *mission_id,
+                                false,
+                                Some(
+                                    "Force-aborted stuck parallel runner after cancel timed out"
+                                        .to_string(),
+                                ),
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                mission_id = %mission_id,
+                                "Failed to complete parallel executions on force-clear: {error}"
+                            );
+                        }
+                        completed_missions.push(*mission_id);
+                        continue;
+                    }
                     if runner.check_finished() {
                         if let Some((_msg_id, _user_msg, mut result)) = runner.poll_completion().await {
                             maybe_recover_soft_llm_error(&mut result);

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -11924,6 +11924,10 @@ fn accept_user_message_id(accepted: &mut HashSet<Uuid>, id: Uuid) -> bool {
     accepted.insert(id)
 }
 
+fn retryable_duplicate_source(source: Option<&str>) -> bool {
+    source == Some("task-board")
+}
+
 fn mission_status_for_terminal_reason(
     reason: TerminalReason,
     complete_turn_without_follow_up: bool,
@@ -13278,7 +13282,8 @@ async fn control_actor_loop(
                 let Some(cmd) = cmd else { break };
                 match cmd {
                     ControlCommand::UserMessage { id, content, agent: msg_agent, target_mission_id, strict, source, respond } => {
-                        if !accept_user_message_id(&mut accepted_user_message_ids, id) {
+                        let duplicate = !accept_user_message_id(&mut accepted_user_message_ids, id);
+                        if duplicate && !retryable_duplicate_source(source.as_deref()) {
                             let status_snapshot = status.read().await;
                             let _ = respond.send(if status_snapshot.state != ControlRunState::Idle {
                                 UserMessageAck::Queued
@@ -13286,6 +13291,10 @@ async fn control_actor_loop(
                                 UserMessageAck::Delivered
                             });
                             continue;
+                        }
+                        if duplicate {
+                            tracing::info!(message_id = %id,
+                                "Reprocessing pending durable board delivery after a prior non-acknowledgement");
                         }
 
                         // Smart routing: decide where to send this message based on target_mission_id
@@ -24755,6 +24764,9 @@ Investigate <service/> failures.
 
         assert!(accept_user_message_id(&mut accepted, message_id));
         assert!(!accept_user_message_id(&mut accepted, message_id));
+        assert!(retryable_duplicate_source(Some("task-board")));
+        assert!(!retryable_duplicate_source(Some("api:user")));
+        assert!(!retryable_duplicate_source(None));
     }
 
     fn assistant(content: &str) -> MissionHistoryEntry {

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -833,7 +833,11 @@ pub async fn start_job(
         "SANDBOXED_SH_DURABLE_STATUS".to_string(),
         status_path_for_child,
     );
-    let shell_args = vec!["-lc".to_string(), wrapper];
+    // WorkspaceExec already provides the container login-shell boundary and
+    // changes to the translated cwd before it execs this shell. A second
+    // login shell can reset PWD to HOME (observed as `/` in nspawn), causing
+    // a requested repository build to run against the wrong tree.
+    let shell_args = vec!["-c".to_string(), wrapper];
     let child_result = match workspace {
         Some(workspace) => {
             WorkspaceExec::new(workspace)

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -6,7 +6,7 @@
 
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 use std::sync::Arc;
 
 use axum::{
@@ -284,6 +284,7 @@ fn durable_started_file(job: &DurableJob) -> PathBuf {
 
 fn preparing_receipt_is_resubmittable(job: &DurableJob) -> bool {
     !job.spawn_accepted
+        && !failed_receipt_has_process_evidence(job)
         && matches!(
             job.status,
             DurableJobStatus::Unknown | DurableJobStatus::Failed
@@ -292,10 +293,15 @@ fn preparing_receipt_is_resubmittable(job: &DurableJob) -> bool {
 
 fn submission_receipt_is_final(job: &DurableJob) -> bool {
     job.spawn_accepted
+        || failed_receipt_has_process_evidence(job)
         || matches!(
             job.status,
             DurableJobStatus::Completed | DurableJobStatus::Cancelled
         )
+}
+
+fn failed_receipt_has_process_evidence(job: &DurableJob) -> bool {
+    job.status == DurableJobStatus::Failed && (job.exit_code.is_some() || job.signal.is_some())
 }
 
 async fn authorize_job(
@@ -566,11 +572,44 @@ async fn write_terminal_job_state(
         job = latest;
     }
 
+    // Reaching this function requires either an OS child-exit observation or
+    // the wrapper's durable terminal receipt. Both prove that spawn crossed
+    // the acceptance boundary even if the API crashed before persisting the
+    // normal post-spawn update. Preserve that proof so an idempotent retry
+    // cannot delete the receipt and submit the command again.
+    job.spawn_accepted = true;
     job.status = status;
     job.exit_code = exit_code;
     job.signal = signal;
     job.updated_at = updated_at;
     write_job(state, &job).await.unwrap_or(job)
+}
+
+async fn write_observed_child_exit(
+    state: &AppState,
+    job: DurableJob,
+    status: ExitStatus,
+) -> DurableJob {
+    #[cfg(unix)]
+    let process_signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    };
+    #[cfg(not(unix))]
+    let process_signal = None;
+    let recorded_exit = read_exit_record(&job).await;
+    let exit =
+        merge_process_exit_observation(recorded_exit, status.code(), process_signal, Utc::now());
+    let job_status = terminal_status_for_exit(&job, exit.exit_code, exit.finished_at);
+    write_terminal_job_state(
+        state,
+        job,
+        job_status,
+        exit.exit_code,
+        exit.signal,
+        exit.finished_at,
+    )
+    .await
 }
 
 async fn signal_job(job: &DurableJob, force: bool) {
@@ -616,34 +655,8 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
             tokio::select! {
                 status = child.wait() => {
                     let Ok(status) = status else { break };
-                #[cfg(unix)]
-                    let process_signal = {
-                        use std::os::unix::process::ExitStatusExt;
-                        status.signal()
-                    };
-                #[cfg(not(unix))]
-                    let process_signal = None;
                     if let Ok(job) = read_job(&state, id).await {
-                        let recorded_exit = read_exit_record(&job).await;
-                        let exit = merge_process_exit_observation(
-                            recorded_exit,
-                            status.code(),
-                            process_signal,
-                            Utc::now(),
-                        );
-                        let job_status = terminal_status_for_exit(
-                            &job,
-                            exit.exit_code,
-                            exit.finished_at,
-                        );
-                        let _ = write_terminal_job_state(
-                            &state,
-                            job,
-                            job_status,
-                            exit.exit_code,
-                            exit.signal,
-                            exit.finished_at,
-                        ).await;
+                        let _ = write_observed_child_exit(&state, job, status).await;
                     }
                     break;
                 }
@@ -661,26 +674,13 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                     if let Ok(mut job) = read_job(&state, id).await {
                         if job.status == DurableJobStatus::Running {
                             // The command may have finished just before the
-                            // deadline while this watcher was not scheduled.
-                            // Both select branches are then ready. Honor the
-                            // durable receipt before declaring a timeout so
-                            // randomized branch selection cannot misclassify
-                            // an on-time completion.
-                            if let Some(exit) = read_exit_record(&job).await {
-                                let status = terminal_status_for_exit(
-                                    &job,
-                                    exit.exit_code,
-                                    exit.finished_at,
-                                );
-                                let _ = write_terminal_job_state(
-                                    &state,
-                                    job,
-                                    status,
-                                    exit.exit_code,
-                                    exit.signal,
-                                    exit.finished_at,
-                                ).await;
-                                let _ = child.wait().await;
+                            // deadline while this watcher was not scheduled,
+                            // making both select branches ready. Only honor a
+                            // durable receipt after the OS confirms the child
+                            // exited: the command inherits the receipt path and
+                            // could otherwise write it early, then keep running.
+                            if let Some(status) = confirmed_child_exit(child.try_wait()) {
+                                let _ = write_observed_child_exit(&state, job, status).await;
                                 break;
                             }
                             job.status = deadline_terminal_status();
@@ -699,6 +699,10 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
             }
         }
     });
+}
+
+fn confirmed_child_exit(observation: std::io::Result<Option<ExitStatus>>) -> Option<ExitStatus> {
+    observation.ok().flatten()
 }
 
 #[cfg(unix)]
@@ -1516,6 +1520,14 @@ mod tests {
         assert!(preparing_receipt_is_resubmittable(&job));
         assert!(!submission_receipt_is_final(&job));
 
+        job.exit_code = Some(1);
+        assert!(
+            !preparing_receipt_is_resubmittable(&job),
+            "a wrapper-recorded failure proves that spawn occurred"
+        );
+        assert!(submission_receipt_is_final(&job));
+        job.exit_code = None;
+
         job.status = DurableJobStatus::Completed;
         assert!(!preparing_receipt_is_resubmittable(&job));
         assert!(submission_receipt_is_final(&job));
@@ -1609,6 +1621,20 @@ mod tests {
             terminal_status_for_exit(&job, exit.exit_code, exit.finished_at),
             DurableJobStatus::Completed
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deadline_receipt_is_not_honored_while_child_is_still_running() {
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 10"])
+            .spawn()
+            .unwrap();
+
+        assert!(confirmed_child_exit(child.try_wait()).is_none());
+
+        child.kill().await.unwrap();
+        let _ = child.wait().await;
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -283,7 +283,11 @@ fn durable_started_file(job: &DurableJob) -> PathBuf {
 }
 
 fn preparing_receipt_is_resubmittable(job: &DurableJob) -> bool {
-    !job.spawn_accepted && job.status == DurableJobStatus::Unknown
+    !job.spawn_accepted
+        && matches!(
+            job.status,
+            DurableJobStatus::Unknown | DurableJobStatus::Failed
+        )
 }
 
 async fn authorize_job(
@@ -1404,6 +1408,12 @@ mod tests {
         assert!(!preparing_receipt_is_resubmittable(&job));
         job.spawn_accepted = false;
         job.status = DurableJobStatus::Running;
+        assert!(!preparing_receipt_is_resubmittable(&job));
+
+        job.status = DurableJobStatus::Failed;
+        assert!(preparing_receipt_is_resubmittable(&job));
+
+        job.spawn_accepted = true;
         assert!(!preparing_receipt_is_resubmittable(&job));
     }
 

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -18,6 +18,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::process::{Child, Command};
 use uuid::Uuid;
@@ -77,6 +78,10 @@ pub struct DurableJob {
     /// Retry key supplied by the caller. The job id is derived from this key.
     #[serde(default)]
     pub idempotency_key: Option<String>,
+    /// Hash of every caller-controlled execution option. Environment values
+    /// are hashed rather than persisted so job receipts never expose secrets.
+    #[serde(default)]
+    pub request_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -138,6 +143,46 @@ fn durable_job_id(user_id: &str, mission_id: Uuid, key: Option<&str>) -> Uuid {
             format!("sandboxed.sh/durable-job/{user_id}/{mission_id}/{key}").as_bytes(),
         ),
         None => Uuid::new_v4(),
+    }
+}
+
+fn durable_job_request_fingerprint(
+    command: &str,
+    cwd: &Path,
+    workspace_id: Uuid,
+    env: &std::collections::HashMap<String, String>,
+    timeout_secs: u64,
+    resource_class: Option<&str>,
+) -> String {
+    let mut env = env.iter().collect::<Vec<_>>();
+    env.sort_unstable_by(|left, right| left.0.cmp(right.0));
+    let payload = serde_json::to_vec(&(
+        command,
+        cwd.to_string_lossy(),
+        workspace_id,
+        env,
+        timeout_secs,
+        resource_class,
+    ))
+    .expect("durable job fingerprint payload is serializable");
+    hex::encode(Sha256::digest(payload))
+}
+
+fn job_matches_request(job: &DurableJob, request_fingerprint: &str) -> bool {
+    job.request_fingerprint.as_deref() == Some(request_fingerprint)
+}
+
+fn try_acquire_submission_claim(path: &Path) -> std::io::Result<Option<std::fs::File>> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(file)),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(error),
     }
 }
 
@@ -746,48 +791,6 @@ pub async fn start_job(
     let idempotency_key = validated_idempotency_key(req.idempotency_key.as_deref())
         .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
     let id = durable_job_id(&user.id, started_by_mission_id, idempotency_key.as_deref());
-    if idempotency_key.is_some() {
-        if let Ok(existing) = read_job(&state, id).await {
-            if existing.command != command || existing.workspace_id != req.workspace_id {
-                return Err(err(
-                    StatusCode::CONFLICT,
-                    "idempotency_key was already used with different job parameters",
-                ));
-            }
-            return Ok(Json(refresh_job(&state, existing).await));
-        }
-        tokio::fs::create_dir_all(job_dir(&state, id))
-            .await
-            .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-        let claim = job_dir(&state, id).join("submission.claim");
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&claim)
-        {
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                for _ in 0..40 {
-                    if let Ok(existing) = read_job(&state, id).await {
-                        if existing.command != command || existing.workspace_id != req.workspace_id
-                        {
-                            return Err(err(
-                                StatusCode::CONFLICT,
-                                "idempotency_key parameter mismatch",
-                            ));
-                        }
-                        return Ok(Json(refresh_job(&state, existing).await));
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                }
-                return Err(err(
-                    StatusCode::CONFLICT,
-                    "idempotent job submission is still being registered",
-                ));
-            }
-            Err(error) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())),
-        }
-    }
 
     let workspace = Some(state.workspaces.get(workspace_id).await.ok_or_else(|| {
         err(
@@ -795,7 +798,8 @@ pub async fn start_job(
             format!("workspace not found: {workspace_id}"),
         )
     })?);
-    let mut job_env = req.env;
+    let caller_env = req.env;
+    let mut job_env = caller_env.clone();
     if let Some(workspace) = workspace.as_ref() {
         // Durable jobs are the Hermes-facing path for long commands, so they
         // must receive the same compute-policy boundary as an agent runner.
@@ -826,10 +830,78 @@ pub async fn start_job(
     }
     .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
 
+    let timeout_secs = req
+        .timeout_secs
+        .unwrap_or(DEFAULT_JOB_TIMEOUT_SECS)
+        .clamp(1, MAX_JOB_TIMEOUT_SECS);
+    let request_fingerprint = durable_job_request_fingerprint(
+        command,
+        &cwd,
+        workspace_id,
+        &caller_env,
+        timeout_secs,
+        req.resource_class.as_deref(),
+    );
+    if idempotency_key.is_some() {
+        if let Ok(existing) = read_job(&state, id).await {
+            if !job_matches_request(&existing, &request_fingerprint) {
+                return Err(err(
+                    StatusCode::CONFLICT,
+                    "idempotency_key was already used with different job parameters",
+                ));
+            }
+            return Ok(Json(refresh_job(&state, existing).await));
+        }
+    }
+
     let dir = job_dir(&state, id);
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    // The lock, rather than file existence, owns the submission lease. A
+    // failed request drops the lock, so a later retry can reuse the same key;
+    // a concurrent request waits for the first job receipt instead of spawning
+    // a duplicate process.
+    let _submission_claim = if idempotency_key.is_some() {
+        let claim_path = dir.join("submission.claim");
+        match try_acquire_submission_claim(&claim_path)
+            .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?
+        {
+            Some(claim) => {
+                // Close the race between the initial read and taking the lock.
+                if let Ok(existing) = read_job(&state, id).await {
+                    if !job_matches_request(&existing, &request_fingerprint) {
+                        return Err(err(
+                            StatusCode::CONFLICT,
+                            "idempotency_key was already used with different job parameters",
+                        ));
+                    }
+                    return Ok(Json(refresh_job(&state, existing).await));
+                }
+                Some(claim)
+            }
+            None => {
+                for _ in 0..40 {
+                    if let Ok(existing) = read_job(&state, id).await {
+                        if !job_matches_request(&existing, &request_fingerprint) {
+                            return Err(err(
+                                StatusCode::CONFLICT,
+                                "idempotency_key parameter mismatch",
+                            ));
+                        }
+                        return Ok(Json(refresh_job(&state, existing).await));
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                return Err(err(
+                    StatusCode::CONFLICT,
+                    "idempotent job submission is still being registered",
+                ));
+            }
+        }
+    } else {
+        None
+    };
     let runtime_dir = workspace
         .as_ref()
         .map(|workspace| {
@@ -860,10 +932,6 @@ pub async fn start_job(
     let wrapper = durable_shell_wrapper(command);
 
     let now = Utc::now();
-    let timeout_secs = req
-        .timeout_secs
-        .unwrap_or(DEFAULT_JOB_TIMEOUT_SECS)
-        .clamp(1, MAX_JOB_TIMEOUT_SECS);
     let mut job = DurableJob {
         id,
         command: command.to_string(),
@@ -889,6 +957,7 @@ pub async fn start_job(
         }),
         resource_class: req.resource_class,
         idempotency_key,
+        request_fingerprint: Some(request_fingerprint),
     };
     job = write_job(&state, &job)
         .await
@@ -1139,6 +1208,7 @@ mod tests {
             scope_unit: None,
             resource_class: None,
             idempotency_key: None,
+            request_fingerprint: None,
         }
     }
 
@@ -1166,6 +1236,88 @@ mod tests {
         assert_eq!(first, retry);
         assert_ne!(first, distinct);
         assert!(validated_idempotency_key(Some(" ")).is_err());
+    }
+
+    #[test]
+    fn idempotency_fingerprint_covers_every_execution_option() {
+        let workspace_id = Uuid::new_v4();
+        let mut env = std::collections::HashMap::from([("MODE".to_string(), "one".to_string())]);
+        let base = durable_job_request_fingerprint(
+            "lake build",
+            Path::new("/workspaces/beal"),
+            workspace_id,
+            &env,
+            7_200,
+            Some("lean_heavy"),
+        );
+        assert_eq!(
+            base,
+            durable_job_request_fingerprint(
+                "lake build",
+                Path::new("/workspaces/beal"),
+                workspace_id,
+                &env,
+                7_200,
+                Some("lean_heavy"),
+            )
+        );
+        env.insert("MODE".to_string(), "two".to_string());
+        assert_ne!(
+            base,
+            durable_job_request_fingerprint(
+                "lake build",
+                Path::new("/workspaces/beal"),
+                workspace_id,
+                &env,
+                7_200,
+                Some("lean_heavy"),
+            )
+        );
+        assert_ne!(
+            base,
+            durable_job_request_fingerprint(
+                "lake build",
+                Path::new("/workspaces/verity"),
+                workspace_id,
+                &std::collections::HashMap::from([("MODE".to_string(), "one".to_string(),)]),
+                7_200,
+                Some("lean_heavy"),
+            )
+        );
+        assert_ne!(
+            base,
+            durable_job_request_fingerprint(
+                "lake build",
+                Path::new("/workspaces/beal"),
+                workspace_id,
+                &std::collections::HashMap::from([("MODE".to_string(), "one".to_string(),)]),
+                3_600,
+                Some("lean_heavy"),
+            )
+        );
+        assert_ne!(
+            base,
+            durable_job_request_fingerprint(
+                "lake build",
+                Path::new("/workspaces/beal"),
+                workspace_id,
+                &std::collections::HashMap::from([("MODE".to_string(), "one".to_string(),)]),
+                7_200,
+                Some("diagnostic"),
+            )
+        );
+    }
+
+    #[test]
+    fn failed_submission_claim_can_be_reacquired() {
+        let dir = tempfile::tempdir().unwrap();
+        let claim_path = dir.path().join("submission.claim");
+        let first = try_acquire_submission_claim(&claim_path)
+            .unwrap()
+            .expect("first claim");
+        assert!(try_acquire_submission_claim(&claim_path).unwrap().is_none());
+        drop(first);
+        assert!(try_acquire_submission_claim(&claim_path).unwrap().is_some());
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -50,6 +50,12 @@ pub struct DurableJob {
     pub signal: Option<i32>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Persisted liveness signal advanced by the server-owned watcher.
+    #[serde(default)]
+    pub heartbeat_at: Option<DateTime<Utc>>,
+    /// Absolute runtime deadline. Long jobs default to two hours.
+    #[serde(default)]
+    pub deadline_at: Option<DateTime<Utc>>,
     pub started_by_mission_id: Option<Uuid>,
     #[serde(default)]
     pub workspace_id: Option<Uuid>,
@@ -65,6 +71,12 @@ pub struct DurableJob {
     /// terminate it.
     #[serde(default)]
     pub scope_unit: Option<String>,
+    /// Caller-selected scheduling/resource hint (for example `lean_heavy`).
+    #[serde(default)]
+    pub resource_class: Option<String>,
+    /// Retry key supplied by the caller. The job id is derived from this key.
+    #[serde(default)]
+    pub idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -81,6 +93,14 @@ pub struct StartDurableJobRequest {
     pub workspace_id: Option<Uuid>,
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
+    /// Maximum runtime in seconds. Defaults to two hours and is capped at one day.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub resource_class: Option<String>,
+    /// Required by Hermes-facing callers so reconnect retries cannot duplicate work.
+    #[serde(default)]
+    pub idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,6 +113,32 @@ pub struct JobLogsQuery {
 
 fn default_tail_bytes() -> usize {
     16 * 1024
+}
+
+const DEFAULT_JOB_TIMEOUT_SECS: u64 = 2 * 60 * 60;
+const MAX_JOB_TIMEOUT_SECS: u64 = 24 * 60 * 60;
+const FORCE_CLEAR_SECS: u64 = 30;
+
+fn validated_idempotency_key(raw: Option<&str>) -> Result<Option<String>, String> {
+    let Some(raw) = raw else { return Ok(None) };
+    let key = raw.trim();
+    if key.is_empty() {
+        return Err("idempotency_key cannot be empty".to_string());
+    }
+    if key.len() > 200 {
+        return Err("idempotency_key must be at most 200 bytes".to_string());
+    }
+    Ok(Some(key.to_string()))
+}
+
+fn durable_job_id(user_id: &str, mission_id: Uuid, key: Option<&str>) -> Uuid {
+    match key {
+        Some(key) => Uuid::new_v5(
+            &Uuid::NAMESPACE_URL,
+            format!("sandboxed.sh/durable-job/{user_id}/{mission_id}/{key}").as_bytes(),
+        ),
+        None => Uuid::new_v4(),
+    }
 }
 
 fn require_workspace_scope(workspace_id: Option<Uuid>) -> Result<Uuid, String> {
@@ -431,31 +477,93 @@ async fn write_terminal_job_state(
     write_job(state, &job).await.unwrap_or(job)
 }
 
+async fn signal_job(job: &DurableJob, force: bool) {
+    if let Some(unit) = job.scope_unit.as_deref() {
+        if force {
+            let unit = if unit.ends_with(".scope") {
+                unit.to_string()
+            } else {
+                format!("{unit}.scope")
+            };
+            let _ = Command::new("systemctl")
+                .args(["kill", "--kill-who=all", "--signal=KILL", unit.as_str()])
+                .status()
+                .await;
+        } else if stop_scope(unit).await {
+            return;
+        }
+    }
+    if let Some(pid) = job.pid {
+        if force {
+            force_kill_process_group(pid);
+        } else {
+            terminate_process_group(pid);
+        }
+    }
+}
+
 fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
     tokio::spawn(async move {
-        if let Ok(status) = child.wait().await {
-            if let Ok(job) = read_job(&state, id).await {
-                let job_status = if status.success() {
-                    DurableJobStatus::Completed
-                } else {
-                    DurableJobStatus::Failed
-                };
+        let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(15));
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            let deadline = read_job(&state, id)
+                .await
+                .ok()
+                .and_then(|job| job.deadline_at)
+                .map(|deadline| {
+                    (deadline - Utc::now())
+                        .to_std()
+                        .unwrap_or(std::time::Duration::from_millis(1))
+                })
+                .unwrap_or_default();
+            tokio::select! {
+                status = child.wait() => {
+                    let Ok(status) = status else { break };
+                    if let Ok(job) = read_job(&state, id).await {
+                        let job_status = if status.success() {
+                            DurableJobStatus::Completed
+                        } else {
+                            DurableJobStatus::Failed
+                        };
                 #[cfg(unix)]
-                let signal = {
-                    use std::os::unix::process::ExitStatusExt;
-                    status.signal()
-                };
+                        let signal = {
+                            use std::os::unix::process::ExitStatusExt;
+                            status.signal()
+                        };
                 #[cfg(not(unix))]
-                let signal = None;
-                let _ = write_terminal_job_state(
-                    &state,
-                    job,
-                    job_status,
-                    status.code(),
-                    signal,
-                    Utc::now(),
-                )
-                .await;
+                        let signal = None;
+                        let _ = write_terminal_job_state(
+                            &state, job, job_status, status.code(), signal, Utc::now(),
+                        ).await;
+                    }
+                    break;
+                }
+                _ = heartbeat.tick() => {
+                    if let Ok(mut job) = read_job(&state, id).await {
+                        if job.status != DurableJobStatus::Running { break; }
+                        let now = Utc::now();
+                        job.heartbeat_at = Some(now);
+                        job.updated_at = now;
+                        let _ = write_job(&state, &job).await;
+                    }
+                }
+                _ = tokio::time::sleep(deadline), if !deadline.is_zero() => {
+                    if let Ok(mut job) = read_job(&state, id).await {
+                        if job.status == DurableJobStatus::Running {
+                            job.status = DurableJobStatus::Failed;
+                            job.updated_at = Utc::now();
+                            let _ = write_job(&state, &job).await;
+                            signal_job(&job, false).await;
+                            tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
+                            if job.pid.is_some_and(process_alive) {
+                                signal_job(&job, true).await;
+                            }
+                        }
+                    }
+                    let _ = child.wait().await;
+                    break;
+                }
             }
         }
     });
@@ -483,6 +591,18 @@ fn terminate_process_group(pid: u32) {
     }
 }
 
+#[cfg(unix)]
+fn force_kill_process_group(pid: u32) {
+    unsafe {
+        let pgid = libc::getpgid(pid as libc::pid_t);
+        if pgid > 0 {
+            let _ = libc::kill(-pgid, libc::SIGKILL);
+        } else {
+            let _ = libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+}
+
 async fn stop_scope(unit: &str) -> bool {
     let unit = if unit.ends_with(".scope") {
         unit.to_string()
@@ -499,6 +619,9 @@ async fn stop_scope(unit: &str) -> bool {
 
 #[cfg(not(unix))]
 fn terminate_process_group(_pid: u32) {}
+
+#[cfg(not(unix))]
+fn force_kill_process_group(_pid: u32) {}
 
 async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
     if matches!(
@@ -546,6 +669,54 @@ pub async fn start_job(
     }
     let (workspace_id, started_by_mission_id) =
         authorize_start(&state, &user, req.workspace_id, req.started_by_mission_id).await?;
+    let idempotency_key = validated_idempotency_key(req.idempotency_key.as_deref())
+        .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
+    let id = durable_job_id(&user.id, started_by_mission_id, idempotency_key.as_deref());
+    if idempotency_key.is_some() {
+        match read_job(&state, id).await {
+            Ok(existing) => {
+                if existing.command != command || existing.workspace_id != req.workspace_id {
+                    return Err(err(
+                        StatusCode::CONFLICT,
+                        "idempotency_key was already used with different job parameters",
+                    ));
+                }
+                return Ok(Json(refresh_job(&state, existing).await));
+            }
+            Err(_) => {}
+        }
+        tokio::fs::create_dir_all(job_dir(&state, id))
+            .await
+            .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let claim = job_dir(&state, id).join("submission.claim");
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&claim)
+        {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                for _ in 0..40 {
+                    if let Ok(existing) = read_job(&state, id).await {
+                        if existing.command != command || existing.workspace_id != req.workspace_id
+                        {
+                            return Err(err(
+                                StatusCode::CONFLICT,
+                                "idempotency_key parameter mismatch",
+                            ));
+                        }
+                        return Ok(Json(refresh_job(&state, existing).await));
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                return Err(err(
+                    StatusCode::CONFLICT,
+                    "idempotent job submission is still being registered",
+                ));
+            }
+            Err(error) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())),
+        }
+    }
 
     let workspace = Some(state.workspaces.get(workspace_id).await.ok_or_else(|| {
         err(
@@ -563,7 +734,6 @@ pub async fn start_job(
     }
     .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
 
-    let id = Uuid::new_v4();
     let dir = job_dir(&state, id);
     tokio::fs::create_dir_all(&dir)
         .await
@@ -598,6 +768,10 @@ pub async fn start_job(
     let wrapper = durable_shell_wrapper(command);
 
     let now = Utc::now();
+    let timeout_secs = req
+        .timeout_secs
+        .unwrap_or(DEFAULT_JOB_TIMEOUT_SECS)
+        .clamp(1, MAX_JOB_TIMEOUT_SECS);
     let mut job = DurableJob {
         id,
         command: command.to_string(),
@@ -608,6 +782,8 @@ pub async fn start_job(
         signal: None,
         created_at: now,
         updated_at: now,
+        heartbeat_at: Some(now),
+        deadline_at: Some(now + chrono::Duration::seconds(timeout_secs as i64)),
         started_by_mission_id: Some(started_by_mission_id),
         workspace_id: req.workspace_id,
         owner_user_id: Some(user.id.clone()),
@@ -619,6 +795,8 @@ pub async fn start_job(
                 .machine_name()
                 .map(|machine| crate::workspace_exec::durable_scope_unit(&machine, id))
         }),
+        resource_class: req.resource_class,
+        idempotency_key,
     };
     job = write_job(&state, &job)
         .await
@@ -818,15 +996,14 @@ pub async fn cancel_job(
         job = write_job(&state, &job)
             .await
             .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
-        let stopped_scope = match job.scope_unit.as_deref() {
-            Some(unit) => stop_scope(unit).await,
-            None => false,
-        };
-        if !stopped_scope {
-            if let Some(pid) = job.pid {
-                terminate_process_group(pid);
+        let cancelling = job.clone();
+        tokio::spawn(async move {
+            signal_job(&cancelling, false).await;
+            tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
+            if cancelling.pid.is_some_and(process_alive) {
+                signal_job(&cancelling, true).await;
             }
-        }
+        });
     }
     Ok(Json(job))
 }
@@ -856,6 +1033,8 @@ mod tests {
             signal: None,
             created_at: now,
             updated_at: now,
+            heartbeat_at: Some(now),
+            deadline_at: None,
             started_by_mission_id: None,
             workspace_id: None,
             owner_user_id: None,
@@ -863,6 +1042,8 @@ mod tests {
             stderr_log: "/tmp/stderr.log".to_string(),
             status_file: "/tmp/exit.json".to_string(),
             scope_unit: None,
+            resource_class: None,
+            idempotency_key: None,
         }
     }
 
@@ -879,6 +1060,17 @@ mod tests {
         assert!(require_workspace_scope(None)
             .unwrap_err()
             .contains("cannot run on the API host"));
+    }
+
+    #[test]
+    fn idempotency_key_derives_one_stable_job_id() {
+        let mission_id = Uuid::new_v4();
+        let first = durable_job_id("user", mission_id, Some("logical-build-1"));
+        let retry = durable_job_id("user", mission_id, Some("logical-build-1"));
+        let distinct = durable_job_id("user", mission_id, Some("logical-build-2"));
+        assert_eq!(first, retry);
+        assert_ne!(first, distinct);
+        assert!(validated_idempotency_key(Some(" ")).is_err());
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -591,11 +591,12 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                 }
                 _ = heartbeat.tick() => {
                     if let Ok(mut job) = read_job(&state, id).await {
-                        if job.status != DurableJobStatus::Running { break; }
-                        let now = Utc::now();
-                        job.heartbeat_at = Some(now);
-                        job.updated_at = now;
-                        let _ = write_job(&state, &job).await;
+                        if job_accepts_heartbeat(&job.status) {
+                            let now = Utc::now();
+                            job.heartbeat_at = Some(now);
+                            job.updated_at = now;
+                            let _ = write_job(&state, &job).await;
+                        }
                     }
                 }
                 _ = tokio::time::sleep(deadline), if !deadline.is_zero() => {
@@ -638,6 +639,10 @@ fn job_has_liveness_evidence(
 
 fn retryable_pidless_receipt(job: &DurableJob) -> bool {
     job.status == DurableJobStatus::Unknown && job.pid.is_none()
+}
+
+fn job_accepts_heartbeat(status: &DurableJobStatus) -> bool {
+    *status == DurableJobStatus::Running
 }
 
 #[cfg(unix)]
@@ -1178,7 +1183,7 @@ pub async fn cancel_job(
         .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
     authorize_job(&state, &user, &job).await?;
     job = refresh_job(&state, job).await;
-    if job.status == DurableJobStatus::Running {
+    if job_accepts_heartbeat(&job.status) {
         job.status = DurableJobStatus::Cancelled;
         job.updated_at = Utc::now();
         job = write_job(&state, &job)
@@ -1271,6 +1276,19 @@ mod tests {
         assert!(retryable_pidless_receipt(&job));
         job.pid = Some(123);
         assert!(!retryable_pidless_receipt(&job));
+    }
+
+    #[test]
+    fn terminal_jobs_stop_heartbeat_updates_without_stopping_the_watcher() {
+        assert!(job_accepts_heartbeat(&DurableJobStatus::Running));
+        for status in [
+            DurableJobStatus::Completed,
+            DurableJobStatus::Failed,
+            DurableJobStatus::Cancelled,
+            DurableJobStatus::Unknown,
+        ] {
+            assert!(!job_accepts_heartbeat(&status));
+        }
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -610,11 +610,12 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                 status = child.wait() => {
                     let Ok(status) = status else { break };
                     if let Ok(job) = read_job(&state, id).await {
-                        let job_status = if status.success() {
-                            DurableJobStatus::Completed
-                        } else {
-                            DurableJobStatus::Failed
-                        };
+                        let finished_at = Utc::now();
+                        let job_status = terminal_status_for_exit(
+                            &job,
+                            status.code(),
+                            finished_at,
+                        );
                 #[cfg(unix)]
                         let signal = {
                             use std::os::unix::process::ExitStatusExt;
@@ -623,7 +624,7 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                 #[cfg(not(unix))]
                         let signal = None;
                         let _ = write_terminal_job_state(
-                            &state, job, job_status, status.code(), signal, Utc::now(),
+                            &state, job, job_status, status.code(), signal, finished_at,
                         ).await;
                     }
                     break;
@@ -693,6 +694,23 @@ fn job_is_cancellable(status: &DurableJobStatus) -> bool {
 
 fn deadline_terminal_status() -> DurableJobStatus {
     DurableJobStatus::Failed
+}
+
+fn terminal_status_for_exit(
+    job: &DurableJob,
+    exit_code: Option<i32>,
+    finished_at: DateTime<Utc>,
+) -> DurableJobStatus {
+    if job
+        .deadline_at
+        .is_some_and(|deadline| finished_at >= deadline)
+    {
+        deadline_terminal_status()
+    } else if exit_code == Some(0) {
+        DurableJobStatus::Completed
+    } else {
+        DurableJobStatus::Failed
+    }
 }
 
 fn job_deadline_elapsed(job: &DurableJob, now: DateTime<Utc>) -> bool {
@@ -822,11 +840,11 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
     ) {
         if let Ok(bytes) = tokio::fs::read(&job.status_file).await {
             if let Ok(exit) = serde_json::from_slice::<ExitRecord>(&bytes) {
-                let status = if exit.exit_code == Some(0) {
-                    DurableJobStatus::Completed
-                } else {
-                    DurableJobStatus::Failed
-                };
+                // The API can be offline while a durable command runs beyond
+                // its absolute deadline and later publishes a successful exit
+                // record. Classify the recorded finish time before accepting
+                // that success so restart recovery cannot erase a timeout.
+                let status = terminal_status_for_exit(&job, exit.exit_code, exit.finished_at);
                 return write_terminal_job_state(
                     state,
                     job,
@@ -1479,6 +1497,34 @@ mod tests {
     #[test]
     fn deadline_is_always_classified_as_failed() {
         assert_eq!(deadline_terminal_status(), DurableJobStatus::Failed);
+    }
+
+    #[test]
+    fn successful_exit_after_deadline_remains_failed_during_restart_recovery() {
+        let deadline = Utc::now();
+        let mut job = test_job(DurableJobStatus::Running);
+        job.deadline_at = Some(deadline);
+
+        assert_eq!(
+            terminal_status_for_exit(&job, Some(0), deadline + chrono::Duration::seconds(1),),
+            DurableJobStatus::Failed
+        );
+        assert_eq!(
+            terminal_status_for_exit(&job, Some(0), deadline),
+            DurableJobStatus::Failed
+        );
+    }
+
+    #[test]
+    fn successful_exit_before_deadline_survives_late_restart_observation() {
+        let deadline = Utc::now();
+        let mut job = test_job(DurableJobStatus::Running);
+        job.deadline_at = Some(deadline);
+
+        assert_eq!(
+            terminal_status_for_exit(&job, Some(0), deadline - chrono::Duration::seconds(1),),
+            DurableJobStatus::Completed
+        );
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -560,6 +560,14 @@ async fn read_exit_record(job: &DurableJob) -> Option<ExitRecord> {
         .and_then(|bytes| serde_json::from_slice::<ExitRecord>(&bytes).ok())
 }
 
+async fn read_started_pid(job: &DurableJob) -> Option<u32> {
+    tokio::fs::read(durable_started_file(job))
+        .await
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<StartRecord>(&bytes).ok())
+        .map(|record| record.pid)
+}
+
 async fn write_terminal_job_state(
     state: &AppState,
     mut job: DurableJob,
@@ -720,6 +728,14 @@ fn job_has_liveness_evidence(
     } else {
         process_is_alive
     }
+}
+
+fn terminal_receipt_can_be_honored(
+    scope_unit: Option<&str>,
+    process_is_alive: bool,
+    scope_is_active: bool,
+) -> bool {
+    !job_has_liveness_evidence(scope_unit, process_is_alive, scope_is_active)
 }
 
 fn pidless_scope_is_live(scope_unit: Option<&str>, scope_is_active: bool) -> bool {
@@ -903,11 +919,26 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
         job.status,
         DurableJobStatus::Running | DurableJobStatus::Unknown
     ) {
-        if let Some(exit) = read_exit_record(&job).await {
+        let scope_is_active = job.scope_unit.as_deref().is_some_and(scope_unit_is_active);
+        let started_pid = read_started_pid(&job).await;
+        let direct_pid_is_live =
+            job.scope_unit.is_none() && job.pid.or(started_pid).is_some_and(process_alive);
+        let can_honor_terminal_receipt = terminal_receipt_can_be_honored(
+            job.scope_unit.as_deref(),
+            direct_pid_is_live,
+            scope_is_active,
+        );
+
+        if let Some(exit) = read_exit_record(&job)
+            .await
+            .filter(|_| can_honor_terminal_receipt)
+        {
             // The API can be offline while a durable command runs beyond
             // its absolute deadline and later publishes a successful exit
-            // record. Classify the recorded finish time before accepting
-            // that success so restart recovery cannot erase a timeout.
+            // record. Require the persisted process/scope to be gone before
+            // trusting it: the command inherits this path and may write an
+            // early receipt while it is still running. Then classify the
+            // recorded finish time so restart recovery cannot erase a timeout.
             let status = terminal_status_for_exit(&job, exit.exit_code, exit.finished_at);
             return write_terminal_job_state(
                 state,
@@ -922,14 +953,6 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
 
         if !job.spawn_accepted {
             let now = Utc::now();
-            let scope_is_active = job.scope_unit.as_deref().is_some_and(scope_unit_is_active);
-            let started_pid = tokio::fs::read(durable_started_file(&job))
-                .await
-                .ok()
-                .and_then(|bytes| serde_json::from_slice::<StartRecord>(&bytes).ok())
-                .map(|record| record.pid);
-            let direct_pid_is_live =
-                job.scope_unit.is_none() && started_pid.is_some_and(process_alive);
             if scope_is_active || direct_pid_is_live {
                 job.spawn_accepted = true;
                 job.status = DurableJobStatus::Running;
@@ -1751,6 +1774,22 @@ mod tests {
             false
         ));
         assert!(!pidless_scope_is_live(None, true));
+    }
+
+    #[test]
+    fn restart_refresh_does_not_honor_receipt_with_a_live_owner() {
+        assert!(!terminal_receipt_can_be_honored(None, true, false));
+        assert!(!terminal_receipt_can_be_honored(
+            Some("sandboxed-durable-demo"),
+            false,
+            true,
+        ));
+        assert!(terminal_receipt_can_be_honored(None, false, false));
+        assert!(terminal_receipt_can_be_honored(
+            Some("sandboxed-durable-demo"),
+            false,
+            false,
+        ));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -724,6 +724,27 @@ pub async fn start_job(
             format!("workspace not found: {workspace_id}"),
         )
     })?);
+    let mut job_env = req.env;
+    if let Some(workspace) = workspace.as_ref() {
+        // Durable jobs are the Hermes-facing path for long commands, so they
+        // must receive the same compute-policy boundary as an agent runner.
+        // In particular, a Beal/Verity `lake build` may never bypass the Lake
+        // shim merely because it was submitted through assistant-MCP.
+        crate::workspace::install_remote_build_wrapper(workspace, started_by_mission_id)
+            .await
+            .map_err(|error| {
+                err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to install workspace build policy wrappers: {error}"),
+                )
+            })?;
+        if let Some(remote_env) = workspace.remote_build_env(started_by_mission_id) {
+            // Policy, endpoint and capability token are server-owned. Caller
+            // env may still opt into the audited emergency local override,
+            // but cannot downgrade `remote_required` itself.
+            job_env.extend(remote_env);
+        }
+    }
     let cwd = match workspace.as_ref() {
         Some(workspace) => resolve_workspace_cwd(
             &workspace.path,
@@ -802,7 +823,6 @@ pub async fn start_job(
         .await
         .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
-    let mut job_env = req.env;
     let status_path_for_child = workspace
         .as_ref()
         .map(|workspace| {

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -214,7 +214,7 @@ fn durable_shell_wrapper(command: &str) -> String {
     // `set -e; false` must terminate only this subshell so the parent can
     // always persist the restart-safe terminal record.
     format!(
-        "(\n{command}\n)\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n"
+        "if [ -n \"${{REMOTE_BUILD_COMMAND:-}}\" ]; then\n  __oa_policy_bin=${{REMOTE_BUILD_COMMAND%/*}}\n  PATH=$__oa_policy_bin:$PATH\n  export PATH\n  unset __oa_policy_bin\nfi\n(\n{command}\n)\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n"
     )
 }
 
@@ -1106,8 +1106,10 @@ mod tests {
     fn wrapper_records_failure_even_when_command_enables_errexit() {
         let dir = tempfile::tempdir().unwrap();
         let status_file = dir.path().join("exit.json");
+        let wrapper = durable_shell_wrapper("set -eu; false");
+        assert!(wrapper.contains("REMOTE_BUILD_COMMAND%/*"));
         let output = std::process::Command::new("/bin/sh")
-            .args(["-lc", &durable_shell_wrapper("set -eu; false")])
+            .args(["-lc", &wrapper])
             .env("SANDBOXED_SH_DURABLE_STATUS", &status_file)
             .output()
             .unwrap();

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -637,12 +637,15 @@ fn job_has_liveness_evidence(
     }
 }
 
-fn retryable_pidless_receipt(job: &DurableJob) -> bool {
-    job.status == DurableJobStatus::Unknown && job.pid.is_none()
-}
-
 fn job_accepts_heartbeat(status: &DurableJobStatus) -> bool {
     *status == DurableJobStatus::Running
+}
+
+fn job_is_cancellable(status: &DurableJobStatus) -> bool {
+    matches!(
+        status,
+        DurableJobStatus::Running | DurableJobStatus::Unknown
+    )
 }
 
 fn deadline_terminal_status() -> DurableJobStatus {
@@ -891,9 +894,10 @@ pub async fn start_job(
                 ));
             }
             let existing = refresh_job(&state, existing).await;
-            if !retryable_pidless_receipt(&existing) {
-                return Ok(Json(existing));
-            }
+            // Any persisted receipt closes the submission decision. A pidless
+            // receipt may be the crash window after spawn but before PID
+            // persistence, so resubmitting it could duplicate live work.
+            return Ok(Json(existing));
         }
     }
 
@@ -920,9 +924,7 @@ pub async fn start_job(
                         ));
                     }
                     let existing = refresh_job(&state, existing).await;
-                    if !retryable_pidless_receipt(&existing) {
-                        return Ok(Json(existing));
-                    }
+                    return Ok(Json(existing));
                 }
                 Some(claim)
             }
@@ -936,9 +938,7 @@ pub async fn start_job(
                             ));
                         }
                         let existing = refresh_job(&state, existing).await;
-                        if !retryable_pidless_receipt(&existing) {
-                            return Ok(Json(existing));
-                        }
+                        return Ok(Json(existing));
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
@@ -1201,7 +1201,7 @@ pub async fn cancel_job(
         .map_err(|e| err(StatusCode::NOT_FOUND, e))?;
     authorize_job(&state, &user, &job).await?;
     job = refresh_job(&state, job).await;
-    if job_accepts_heartbeat(&job.status) {
+    if job_is_cancellable(&job.status) {
         job.status = DurableJobStatus::Cancelled;
         job.updated_at = Utc::now();
         job = write_job(&state, &job)
@@ -1286,17 +1286,6 @@ mod tests {
     }
 
     #[test]
-    fn only_unknown_pidless_receipts_are_retryable() {
-        let mut job = test_job(DurableJobStatus::Running);
-        job.pid = None;
-        assert!(!retryable_pidless_receipt(&job));
-        job.status = DurableJobStatus::Unknown;
-        assert!(retryable_pidless_receipt(&job));
-        job.pid = Some(123);
-        assert!(!retryable_pidless_receipt(&job));
-    }
-
-    #[test]
     fn terminal_jobs_stop_heartbeat_updates_without_stopping_the_watcher() {
         assert!(job_accepts_heartbeat(&DurableJobStatus::Running));
         for status in [
@@ -1307,6 +1296,15 @@ mod tests {
         ] {
             assert!(!job_accepts_heartbeat(&status));
         }
+    }
+
+    #[test]
+    fn ambiguous_jobs_remain_cancellable_without_being_heartbeat_eligible() {
+        assert!(job_is_cancellable(&DurableJobStatus::Unknown));
+        assert!(!job_accepts_heartbeat(&DurableJobStatus::Unknown));
+        assert!(!job_is_cancellable(&DurableJobStatus::Completed));
+        assert!(!job_is_cancellable(&DurableJobStatus::Failed));
+        assert!(!job_is_cancellable(&DurableJobStatus::Cancelled));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -609,22 +609,36 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
             tokio::select! {
                 status = child.wait() => {
                     let Ok(status) = status else { break };
+                #[cfg(unix)]
+                    let process_signal = {
+                        use std::os::unix::process::ExitStatusExt;
+                        status.signal()
+                    };
+                #[cfg(not(unix))]
+                    let process_signal = None;
                     if let Ok(job) = read_job(&state, id).await {
-                        let finished_at = Utc::now();
+                        let recorded_exit = tokio::fs::read(&job.status_file)
+                            .await
+                            .ok()
+                            .and_then(|bytes| serde_json::from_slice::<ExitRecord>(&bytes).ok());
+                        let exit = merge_process_exit_observation(
+                            recorded_exit,
+                            status.code(),
+                            process_signal,
+                            Utc::now(),
+                        );
                         let job_status = terminal_status_for_exit(
                             &job,
-                            status.code(),
-                            finished_at,
+                            exit.exit_code,
+                            exit.finished_at,
                         );
-                #[cfg(unix)]
-                        let signal = {
-                            use std::os::unix::process::ExitStatusExt;
-                            status.signal()
-                        };
-                #[cfg(not(unix))]
-                        let signal = None;
                         let _ = write_terminal_job_state(
-                            &state, job, job_status, status.code(), signal, finished_at,
+                            &state,
+                            job,
+                            job_status,
+                            exit.exit_code,
+                            exit.signal,
+                            exit.finished_at,
                         ).await;
                     }
                     break;
@@ -710,6 +724,26 @@ fn terminal_status_for_exit(
         DurableJobStatus::Completed
     } else {
         DurableJobStatus::Failed
+    }
+}
+
+fn merge_process_exit_observation(
+    recorded: Option<ExitRecord>,
+    process_exit_code: Option<i32>,
+    process_signal: Option<i32>,
+    observed_at: DateTime<Utc>,
+) -> ExitRecord {
+    match recorded {
+        Some(mut exit) => {
+            exit.exit_code = exit.exit_code.or(process_exit_code);
+            exit.signal = exit.signal.or(process_signal);
+            exit
+        }
+        None => ExitRecord {
+            exit_code: process_exit_code,
+            signal: process_signal,
+            finished_at: observed_at,
+        },
     }
 }
 
@@ -1523,6 +1557,31 @@ mod tests {
 
         assert_eq!(
             terminal_status_for_exit(&job, Some(0), deadline - chrono::Duration::seconds(1),),
+            DurableJobStatus::Completed
+        );
+    }
+
+    #[test]
+    fn live_watcher_prefers_recorded_finish_time_over_delayed_observation() {
+        let deadline = Utc::now();
+        let mut job = test_job(DurableJobStatus::Running);
+        job.deadline_at = Some(deadline);
+        let recorded = ExitRecord {
+            exit_code: Some(0),
+            signal: None,
+            finished_at: deadline - chrono::Duration::milliseconds(1),
+        };
+
+        let exit = merge_process_exit_observation(
+            Some(recorded),
+            Some(0),
+            None,
+            deadline + chrono::Duration::milliseconds(1),
+        );
+
+        assert!(exit.finished_at < deadline);
+        assert_eq!(
+            terminal_status_for_exit(&job, exit.exit_code, exit.finished_at),
             DurableJobStatus::Completed
         );
     }

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -399,7 +399,12 @@ fn resolve_workspace_cwd(
             workspace_root.display()
         ));
     }
-    Ok(canonical_cwd)
+    // Keep the configured/logical workspace prefix after validating its
+    // canonical target. WorkspaceExec strips that prefix to derive the path
+    // inside a container. Returning the canonical target here breaks that
+    // mapping when the configured root is a stable symlink (as on dev), and
+    // silently turns every requested cwd into `/`.
+    Ok(cwd)
 }
 
 fn merge_job_for_write(current: Option<DurableJob>, mut next: DurableJob) -> DurableJob {
@@ -1144,7 +1149,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(resolved, mission.canonicalize().unwrap());
+        assert_eq!(resolved, mission);
     }
 
     #[test]
@@ -1152,6 +1157,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         assert!(resolve_workspace_cwd(dir.path(), WorkspaceType::Host, Some("/tmp")).is_err());
         assert!(resolve_workspace_cwd(dir.path(), WorkspaceType::Container, Some("../")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_cwd_preserves_symlink_root_after_escape_validation() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().unwrap();
+        let canonical_root = parent.path().join("canonical");
+        let logical_root = parent.path().join("logical");
+        std::fs::create_dir_all(canonical_root.join("workspaces/repo")).unwrap();
+        symlink(&canonical_root, &logical_root).unwrap();
+
+        let cwd = resolve_workspace_cwd(
+            &logical_root,
+            WorkspaceType::Container,
+            Some("/workspaces/repo"),
+        )
+        .unwrap();
+
+        assert_eq!(cwd, logical_root.join("workspaces/repo"));
+        assert_ne!(cwd, canonical_root.join("workspaces/repo"));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -636,6 +636,10 @@ fn job_has_liveness_evidence(
     }
 }
 
+fn retryable_pidless_receipt(job: &DurableJob) -> bool {
+    job.status == DurableJobStatus::Unknown && job.pid.is_none()
+}
+
 #[cfg(unix)]
 fn scope_unit_is_active(scope_unit: &str) -> bool {
     let unit = if scope_unit.ends_with(".scope") {
@@ -778,6 +782,13 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
                     job = write_job(state, &job).await.unwrap_or(job);
                 }
             }
+        } else {
+            let now = Utc::now();
+            if (now - job.created_at).num_seconds() >= PIDLESS_START_GRACE_SECS {
+                job.status = DurableJobStatus::Unknown;
+                job.updated_at = now;
+                job = write_job(state, &job).await.unwrap_or(job);
+            }
         }
     }
     job
@@ -856,7 +867,10 @@ pub async fn start_job(
                     "idempotency_key was already used with different job parameters",
                 ));
             }
-            return Ok(Json(refresh_job(&state, existing).await));
+            let existing = refresh_job(&state, existing).await;
+            if !retryable_pidless_receipt(&existing) {
+                return Ok(Json(existing));
+            }
         }
     }
 
@@ -882,7 +896,10 @@ pub async fn start_job(
                             "idempotency_key was already used with different job parameters",
                         ));
                     }
-                    return Ok(Json(refresh_job(&state, existing).await));
+                    let existing = refresh_job(&state, existing).await;
+                    if !retryable_pidless_receipt(&existing) {
+                        return Ok(Json(existing));
+                    }
                 }
                 Some(claim)
             }
@@ -895,7 +912,10 @@ pub async fn start_job(
                                 "idempotency_key parameter mismatch",
                             ));
                         }
-                        return Ok(Json(refresh_job(&state, existing).await));
+                        let existing = refresh_job(&state, existing).await;
+                        if !retryable_pidless_receipt(&existing) {
+                            return Ok(Json(existing));
+                        }
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
@@ -1240,6 +1260,17 @@ mod tests {
         assert_eq!(first, retry);
         assert_ne!(first, distinct);
         assert!(validated_idempotency_key(Some(" ")).is_err());
+    }
+
+    #[test]
+    fn only_unknown_pidless_receipts_are_retryable() {
+        let mut job = test_job(DurableJobStatus::Running);
+        job.pid = None;
+        assert!(!retryable_pidless_receipt(&job));
+        job.status = DurableJobStatus::Unknown;
+        assert!(retryable_pidless_receipt(&job));
+        job.pid = Some(123);
+        assert!(!retryable_pidless_receipt(&job));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -607,7 +607,7 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                             let _ = write_job(&state, &job).await;
                             signal_job(&job, false).await;
                             tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
-                            if job.pid.is_some_and(process_alive) {
+                            if job_requires_force_clear(&job) {
                                 signal_job(&job, true).await;
                             }
                         }
@@ -643,6 +643,20 @@ fn retryable_pidless_receipt(job: &DurableJob) -> bool {
 
 fn job_accepts_heartbeat(status: &DurableJobStatus) -> bool {
     *status == DurableJobStatus::Running
+}
+
+fn requires_force_clear(scope_unit: Option<&str>, process_is_alive: bool) -> bool {
+    // A systemd-run wrapper may exit before the payload in its transient
+    // scope. Force-signalling the named scope is idempotent, so always do it
+    // after the grace period even when the persisted wrapper PID is gone.
+    scope_unit.is_some() || process_is_alive
+}
+
+fn job_requires_force_clear(job: &DurableJob) -> bool {
+    requires_force_clear(
+        job.scope_unit.as_deref(),
+        job.pid.is_some_and(process_alive),
+    )
 }
 
 #[cfg(unix)]
@@ -770,7 +784,7 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
                     tokio::spawn(async move {
                         signal_job(&cancelling, false).await;
                         tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
-                        if cancelling.pid.is_some_and(process_alive) {
+                        if job_requires_force_clear(&cancelling) {
                             signal_job(&cancelling, true).await;
                         }
                     });
@@ -1193,7 +1207,7 @@ pub async fn cancel_job(
         tokio::spawn(async move {
             signal_job(&cancelling, false).await;
             tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
-            if cancelling.pid.is_some_and(process_alive) {
+            if job_requires_force_clear(&cancelling) {
                 signal_job(&cancelling, true).await;
             }
         });
@@ -1289,6 +1303,13 @@ mod tests {
         ] {
             assert!(!job_accepts_heartbeat(&status));
         }
+    }
+
+    #[test]
+    fn scoped_job_is_force_cleared_after_its_wrapper_pid_exits() {
+        assert!(requires_force_clear(Some("sandboxed-durable-demo"), false));
+        assert!(requires_force_clear(None, true));
+        assert!(!requires_force_clear(None, false));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -602,7 +602,7 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                 _ = tokio::time::sleep(deadline), if !deadline.is_zero() => {
                     if let Ok(mut job) = read_job(&state, id).await {
                         if job.status == DurableJobStatus::Running {
-                            job.status = DurableJobStatus::Failed;
+                            job.status = deadline_terminal_status();
                             job.updated_at = Utc::now();
                             let _ = write_job(&state, &job).await;
                             signal_job(&job, false).await;
@@ -643,6 +643,10 @@ fn retryable_pidless_receipt(job: &DurableJob) -> bool {
 
 fn job_accepts_heartbeat(status: &DurableJobStatus) -> bool {
     *status == DurableJobStatus::Running
+}
+
+fn deadline_terminal_status() -> DurableJobStatus {
+    DurableJobStatus::Failed
 }
 
 fn requires_force_clear(scope_unit: Option<&str>, process_is_alive: bool) -> bool {
@@ -777,7 +781,7 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
             } else {
                 let now = Utc::now();
                 if job.deadline_at.is_some_and(|deadline| deadline <= now) {
-                    job.status = DurableJobStatus::Cancelled;
+                    job.status = deadline_terminal_status();
                     job.updated_at = now;
                     job = write_job(state, &job).await.unwrap_or(job);
                     let cancelling = job.clone();
@@ -1310,6 +1314,11 @@ mod tests {
         assert!(requires_force_clear(Some("sandboxed-durable-demo"), false));
         assert!(requires_force_clear(None, true));
         assert!(!requires_force_clear(None, false));
+    }
+
+    #[test]
+    fn deadline_is_always_classified_as_failed() {
+        assert_eq!(deadline_terminal_status(), DurableJobStatus::Failed);
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -67,6 +67,11 @@ pub struct DurableJob {
     pub stdout_log: String,
     pub stderr_log: String,
     pub status_file: String,
+    /// False only while the server is preparing the process launch. Legacy
+    /// receipts default to true. A stale false receipt with no live scope or
+    /// start marker is safe for the same idempotency key to resubmit.
+    #[serde(default = "default_spawn_accepted")]
+    pub spawn_accepted: bool,
     /// Transient systemd scope owned by this durable job. It intentionally
     /// does not carry the launching mission's tag, so mission teardown cannot
     /// terminate it.
@@ -82,6 +87,10 @@ pub struct DurableJob {
     /// are hashed rather than persisted so job receipts never expose secrets.
     #[serde(default)]
     pub request_fingerprint: Option<String>,
+}
+
+fn default_spawn_accepted() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize)]
@@ -211,6 +220,12 @@ struct ExitRecord {
     finished_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct StartRecord {
+    pid: u32,
+    started_at: DateTime<Utc>,
+}
+
 fn err(status: StatusCode, message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
     (
         status,
@@ -259,8 +274,16 @@ fn durable_shell_wrapper(command: &str) -> String {
     // `set -e; false` must terminate only this subshell so the parent can
     // always persist the restart-safe terminal record.
     format!(
-        "if [ -n \"${{REMOTE_BUILD_COMMAND:-}}\" ]; then\n  __oa_policy_bin=${{REMOTE_BUILD_COMMAND%/*}}\n  PATH=$__oa_policy_bin:$PATH\n  export PATH\n  unset __oa_policy_bin\nfi\n(\n{command}\n)\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n"
+        "if [ -n \"${{REMOTE_BUILD_COMMAND:-}}\" ]; then\n  __oa_policy_bin=${{REMOTE_BUILD_COMMAND%/*}}\n  PATH=$__oa_policy_bin:$PATH\n  export PATH\n  unset __oa_policy_bin\nfi\n__oa_started_tmp=\"${{SANDBOXED_SH_DURABLE_STARTED}}.tmp.$$\"\nprintf '{{\"pid\":%s,\"started_at\":\"%s\"}}\\n' \"$$\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$__oa_started_tmp\" || exit 125\nmv -f \"$__oa_started_tmp\" \"$SANDBOXED_SH_DURABLE_STARTED\" || exit 125\nunset __oa_started_tmp\n(\n{command}\n)\ncode=$?\nprintf '{{\"exit_code\":%s,\"signal\":null,\"finished_at\":\"%s\"}}\\n' \"$code\" \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > \"$SANDBOXED_SH_DURABLE_STATUS\"\nexit \"$code\"\n"
     )
+}
+
+fn durable_started_file(job: &DurableJob) -> PathBuf {
+    Path::new(&job.status_file).with_file_name("started.json")
+}
+
+fn preparing_receipt_is_resubmittable(job: &DurableJob) -> bool {
+    !job.spawn_accepted && job.status == DurableJobStatus::Unknown
 }
 
 async fn authorize_job(
@@ -781,6 +804,35 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
             }
         }
 
+        if !job.spawn_accepted {
+            let now = Utc::now();
+            let scope_is_active = job.scope_unit.as_deref().is_some_and(scope_unit_is_active);
+            let started_pid = tokio::fs::read(durable_started_file(&job))
+                .await
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<StartRecord>(&bytes).ok())
+                .map(|record| record.pid);
+            let direct_pid_is_live =
+                job.scope_unit.is_none() && started_pid.is_some_and(process_alive);
+            if scope_is_active || direct_pid_is_live {
+                job.spawn_accepted = true;
+                job.status = DurableJobStatus::Running;
+                if job.scope_unit.is_none() {
+                    job.pid = started_pid;
+                }
+                job.heartbeat_at = Some(now);
+                job.updated_at = now;
+                job = write_job(state, &job).await.unwrap_or(job);
+            } else {
+                if (now - job.created_at).num_seconds() >= PIDLESS_START_GRACE_SECS {
+                    job.status = DurableJobStatus::Unknown;
+                    job.updated_at = now;
+                    job = write_job(state, &job).await.unwrap_or(job);
+                }
+                return job;
+            }
+        }
+
         if let Some(pid) = job.pid {
             if !process_owned_by_job(&job, pid) {
                 // systemd-run may need a brief moment to attach the payload
@@ -916,10 +968,13 @@ pub async fn start_job(
                 ));
             }
             let existing = refresh_job(&state, existing).await;
-            // Any persisted receipt closes the submission decision. A pidless
-            // receipt may be the crash window after spawn but before PID
-            // persistence, so resubmitting it could duplicate live work.
-            return Ok(Json(existing));
+            // Accepted receipts close the submission decision. A stale
+            // pre-spawn receipt is explicitly safe to retry because refresh
+            // found neither its deterministic scope nor its atomic start
+            // marker alive.
+            if !preparing_receipt_is_resubmittable(&existing) {
+                return Ok(Json(existing));
+            }
         }
     }
 
@@ -946,7 +1001,17 @@ pub async fn start_job(
                         ));
                     }
                     let existing = refresh_job(&state, existing).await;
-                    return Ok(Json(existing));
+                    if !preparing_receipt_is_resubmittable(&existing) {
+                        return Ok(Json(existing));
+                    }
+                    tokio::fs::remove_file(job_file(&state, id))
+                        .await
+                        .map_err(|error| {
+                            err(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("failed to clear stale pre-spawn receipt: {error}"),
+                            )
+                        })?;
                 }
                 Some(claim)
             }
@@ -960,7 +1025,11 @@ pub async fn start_job(
                             ));
                         }
                         let existing = refresh_job(&state, existing).await;
-                        return Ok(Json(existing));
+                        if !preparing_receipt_is_resubmittable(&existing) {
+                            return Ok(Json(existing));
+                        }
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        continue;
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
@@ -988,6 +1057,11 @@ pub async fn start_job(
     let stdout_log = runtime_dir.join("stdout.log");
     let stderr_log = runtime_dir.join("stderr.log");
     let status_file = runtime_dir.join("exit.json");
+    let started_file = runtime_dir.join("started.json");
+    // A prior crashed pre-spawn attempt is resubmitted only while holding the
+    // submission claim and only after refresh proved it has no live owner.
+    let _ = tokio::fs::remove_file(&status_file).await;
+    let _ = tokio::fs::remove_file(&started_file).await;
 
     let stdout = std::fs::OpenOptions::new()
         .create(true)
@@ -1021,6 +1095,7 @@ pub async fn start_job(
         stdout_log: stdout_log.to_string_lossy().to_string(),
         stderr_log: stderr_log.to_string_lossy().to_string(),
         status_file: status_file.to_string_lossy().to_string(),
+        spawn_accepted: false,
         scope_unit: workspace
             .as_ref()
             .and_then(|workspace| WorkspaceExec::new(workspace.clone()).durable_scope_unit(id)),
@@ -1041,6 +1116,16 @@ pub async fn start_job(
     job_env.insert(
         "SANDBOXED_SH_DURABLE_STATUS".to_string(),
         status_path_for_child,
+    );
+    let started_path_for_child = workspace
+        .as_ref()
+        .map(|workspace| {
+            WorkspaceExec::new(workspace.clone()).translate_path_for_container(&started_file)
+        })
+        .unwrap_or_else(|| started_file.to_string_lossy().to_string());
+    job_env.insert(
+        "SANDBOXED_SH_DURABLE_STARTED".to_string(),
+        started_path_for_child,
     );
     // WorkspaceExec already provides the container login-shell boundary and
     // changes to the translated cwd before it execs this shell. A second
@@ -1093,6 +1178,7 @@ pub async fn start_job(
         }
     };
     job.pid = child.id();
+    job.spawn_accepted = true;
     job.updated_at = Utc::now();
     job = match write_job(&state, &job).await {
         Ok(job) => job,
@@ -1274,6 +1360,7 @@ mod tests {
             stdout_log: "/tmp/stdout.log".to_string(),
             stderr_log: "/tmp/stderr.log".to_string(),
             status_file: "/tmp/exit.json".to_string(),
+            spawn_accepted: true,
             scope_unit: None,
             resource_class: None,
             idempotency_key: None,
@@ -1305,6 +1392,19 @@ mod tests {
         assert_eq!(first, retry);
         assert_ne!(first, distinct);
         assert!(validated_idempotency_key(Some(" ")).is_err());
+    }
+
+    #[test]
+    fn only_stale_pre_spawn_receipts_are_resubmittable() {
+        let mut job = test_job(DurableJobStatus::Unknown);
+        job.spawn_accepted = false;
+        assert!(preparing_receipt_is_resubmittable(&job));
+
+        job.spawn_accepted = true;
+        assert!(!preparing_receipt_is_resubmittable(&job));
+        job.spawn_accepted = false;
+        job.status = DurableJobStatus::Running;
+        assert!(!preparing_receipt_is_resubmittable(&job));
     }
 
     #[test]
@@ -1458,14 +1558,19 @@ mod tests {
     fn wrapper_records_failure_even_when_command_enables_errexit() {
         let dir = tempfile::tempdir().unwrap();
         let status_file = dir.path().join("exit.json");
+        let started_file = dir.path().join("started.json");
         let wrapper = durable_shell_wrapper("set -eu; false");
         assert!(wrapper.contains("REMOTE_BUILD_COMMAND%/*"));
         let output = std::process::Command::new("/bin/sh")
             .args(["-lc", &wrapper])
             .env("SANDBOXED_SH_DURABLE_STATUS", &status_file)
+            .env("SANDBOXED_SH_DURABLE_STARTED", &started_file)
             .output()
             .unwrap();
         assert_eq!(output.status.code(), Some(1));
+        let started: StartRecord =
+            serde_json::from_slice(&std::fs::read(started_file).unwrap()).unwrap();
+        assert!(started.pid > 0);
         let record: ExitRecord =
             serde_json::from_slice(&std::fs::read(status_file).unwrap()).unwrap();
         assert_eq!(record.exit_code, Some(1));

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -290,6 +290,14 @@ fn preparing_receipt_is_resubmittable(job: &DurableJob) -> bool {
         )
 }
 
+fn submission_receipt_is_final(job: &DurableJob) -> bool {
+    job.spawn_accepted
+        || matches!(
+            job.status,
+            DurableJobStatus::Completed | DurableJobStatus::Cancelled
+        )
+}
+
 async fn authorize_job(
     state: &Arc<AppState>,
     user: &AuthUser,
@@ -989,11 +997,10 @@ pub async fn start_job(
                 ));
             }
             let existing = refresh_job(&state, existing).await;
-            // Accepted receipts close the submission decision. A stale
-            // pre-spawn receipt is explicitly safe to retry because refresh
-            // found neither its deterministic scope nor its atomic start
-            // marker alive.
-            if !preparing_receipt_is_resubmittable(&existing) {
+            // Only accepted or conclusively terminal receipts close the
+            // submission decision. A Running receipt with spawn_accepted=false
+            // is still being registered and must be resolved under the claim.
+            if submission_receipt_is_final(&existing) {
                 return Ok(Json(existing));
             }
         }
@@ -1009,57 +1016,52 @@ pub async fn start_job(
     // a duplicate process.
     let _submission_claim = if idempotency_key.is_some() {
         let claim_path = dir.join("submission.claim");
-        match try_acquire_submission_claim(&claim_path)
-            .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?
-        {
-            Some(claim) => {
-                // Close the race between the initial read and taking the lock.
-                if let Ok(existing) = read_job(&state, id).await {
-                    if !job_matches_request(&existing, &request_fingerprint) {
-                        return Err(err(
-                            StatusCode::CONFLICT,
-                            "idempotency_key was already used with different job parameters",
-                        ));
-                    }
-                    let existing = refresh_job(&state, existing).await;
-                    if !preparing_receipt_is_resubmittable(&existing) {
-                        return Ok(Json(existing));
-                    }
-                    tokio::fs::remove_file(job_file(&state, id))
-                        .await
-                        .map_err(|error| {
-                            err(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                format!("failed to clear stale pre-spawn receipt: {error}"),
-                            )
-                        })?;
-                }
-                Some(claim)
+        let mut claim = None;
+        for _ in 0..40 {
+            claim = try_acquire_submission_claim(&claim_path)
+                .map_err(|error| err(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+            if claim.is_some() {
+                break;
             }
-            None => {
-                for _ in 0..40 {
-                    if let Ok(existing) = read_job(&state, id).await {
-                        if !job_matches_request(&existing, &request_fingerprint) {
-                            return Err(err(
-                                StatusCode::CONFLICT,
-                                "idempotency_key parameter mismatch",
-                            ));
-                        }
-                        let existing = refresh_job(&state, existing).await;
-                        if !preparing_receipt_is_resubmittable(&existing) {
-                            return Ok(Json(existing));
-                        }
-                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                        continue;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        let claim = claim.ok_or_else(|| {
+            err(
+                StatusCode::CONFLICT,
+                "idempotent job submission is still being registered",
+            )
+        })?;
+
+        // Close the race between the initial read and taking the lock. A
+        // concurrent retry waits for the submitting request to release this
+        // claim; it never returns a provisional Running receipt as accepted.
+        if let Ok(existing) = read_job(&state, id).await {
+            if !job_matches_request(&existing, &request_fingerprint) {
+                return Err(err(
+                    StatusCode::CONFLICT,
+                    "idempotency_key was already used with different job parameters",
+                ));
+            }
+            let existing = refresh_job(&state, existing).await;
+            if submission_receipt_is_final(&existing) {
+                return Ok(Json(existing));
+            }
+            if !preparing_receipt_is_resubmittable(&existing) {
                 return Err(err(
                     StatusCode::CONFLICT,
                     "idempotent job submission is still being registered",
                 ));
             }
+            tokio::fs::remove_file(job_file(&state, id))
+                .await
+                .map_err(|error| {
+                    err(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("failed to clear stale pre-spawn receipt: {error}"),
+                    )
+                })?;
         }
+        Some(claim)
     } else {
         None
     };
@@ -1420,15 +1422,26 @@ mod tests {
         let mut job = test_job(DurableJobStatus::Unknown);
         job.spawn_accepted = false;
         assert!(preparing_receipt_is_resubmittable(&job));
+        assert!(!submission_receipt_is_final(&job));
 
         job.spawn_accepted = true;
         assert!(!preparing_receipt_is_resubmittable(&job));
+        assert!(submission_receipt_is_final(&job));
         job.spawn_accepted = false;
         job.status = DurableJobStatus::Running;
         assert!(!preparing_receipt_is_resubmittable(&job));
+        assert!(
+            !submission_receipt_is_final(&job),
+            "a provisional Running receipt must not be returned as accepted"
+        );
 
         job.status = DurableJobStatus::Failed;
         assert!(preparing_receipt_is_resubmittable(&job));
+        assert!(!submission_receipt_is_final(&job));
+
+        job.status = DurableJobStatus::Completed;
+        assert!(!preparing_receipt_is_resubmittable(&job));
+        assert!(submission_receipt_is_final(&job));
 
         job.spawn_accepted = true;
         assert!(!preparing_receipt_is_resubmittable(&job));

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -454,19 +454,23 @@ fn resolve_workspace_cwd(
 
 fn merge_job_for_write(current: Option<DurableJob>, mut next: DurableJob) -> DurableJob {
     if let Some(current) = current {
-        if matches!(
+        let current_is_terminal = matches!(
             current.status,
             DurableJobStatus::Completed | DurableJobStatus::Failed | DurableJobStatus::Cancelled
-        ) && !matches!(
+        );
+        let next_is_terminal = matches!(
             next.status,
             DurableJobStatus::Completed | DurableJobStatus::Failed | DurableJobStatus::Cancelled
-        ) {
+        );
+        if current_is_terminal && !next_is_terminal {
             return current;
         }
-        if current.status == DurableJobStatus::Cancelled
-            && next.status != DurableJobStatus::Cancelled
-        {
-            next.status = DurableJobStatus::Cancelled;
+        // A terminal observation is monotonic. In particular, a deadline
+        // transition to Failed must not be overwritten by a late watcher that
+        // observes the child exiting successfully after cancellation. Updates
+        // to metadata for the same terminal state remain allowed.
+        if current_is_terminal && next.status != current.status {
+            next.status = current.status;
         }
     }
     next
@@ -1542,6 +1546,31 @@ mod tests {
         let merged = merge_job_for_write(Some(current), next);
 
         assert_eq!(merged.status, DurableJobStatus::Cancelled);
+    }
+
+    #[test]
+    fn merge_job_for_write_preserves_failed_status_over_late_success() {
+        let current = test_job(DurableJobStatus::Failed);
+        let mut next = current.clone();
+        next.status = DurableJobStatus::Completed;
+        next.exit_code = Some(0);
+
+        let merged = merge_job_for_write(Some(current), next);
+
+        assert_eq!(merged.status, DurableJobStatus::Failed);
+        assert_eq!(merged.exit_code, Some(0));
+    }
+
+    #[test]
+    fn merge_job_for_write_allows_same_terminal_metadata_update() {
+        let current = test_job(DurableJobStatus::Failed);
+        let mut next = current.clone();
+        next.exit_code = Some(124);
+
+        let merged = merge_job_for_write(Some(current), next);
+
+        assert_eq!(merged.status, DurableJobStatus::Failed);
+        assert_eq!(merged.exit_code, Some(124));
     }
 
     #[tokio::test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -624,34 +624,40 @@ fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
-fn cgroup_contains_scope(cgroup: &str, scope_unit: &str) -> bool {
-    let expected = if scope_unit.ends_with(".scope") {
+fn job_has_liveness_evidence(
+    scope_unit: Option<&str>,
+    process_is_alive: bool,
+    scope_is_active: bool,
+) -> bool {
+    if scope_unit.is_some() {
+        scope_is_active
+    } else {
+        process_is_alive
+    }
+}
+
+#[cfg(unix)]
+fn scope_unit_is_active(scope_unit: &str) -> bool {
+    let unit = if scope_unit.ends_with(".scope") {
         scope_unit.to_string()
     } else {
         format!("{scope_unit}.scope")
     };
-    cgroup
-        .lines()
-        .flat_map(|line| {
-            line.rsplit_once(':')
-                .map(|(_, path)| path)
-                .unwrap_or(line)
-                .split('/')
-        })
-        .any(|component| component == expected)
+    std::process::Command::new("systemctl")
+        .args(["is-active", "--quiet", unit.as_str()])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 #[cfg(unix)]
 fn process_owned_by_job(job: &DurableJob, pid: u32) -> bool {
-    if !process_alive(pid) {
-        return false;
-    }
-    let Some(scope_unit) = job.scope_unit.as_deref() else {
-        return true;
-    };
-    std::fs::read_to_string(format!("/proc/{pid}/cgroup"))
-        .ok()
-        .is_some_and(|cgroup| cgroup_contains_scope(&cgroup, scope_unit))
+    let scope_is_active = job.scope_unit.as_deref().is_some_and(scope_unit_is_active);
+    job_has_liveness_evidence(
+        job.scope_unit.as_deref(),
+        process_alive(pid),
+        scope_is_active,
+    )
 }
 
 #[cfg(not(unix))]
@@ -1319,18 +1325,19 @@ mod tests {
     }
 
     #[test]
-    fn cgroup_scope_membership_requires_the_exact_unit() {
-        let cgroup = "1:name=systemd:/\n0::/missions.slice/sandboxed-durable-demo.scope\n";
-        assert!(cgroup_contains_scope(cgroup, "sandboxed-durable-demo"));
-        assert!(cgroup_contains_scope(
-            cgroup,
-            "sandboxed-durable-demo.scope"
+    fn scoped_liveness_uses_the_unit_instead_of_the_wrapper_pid() {
+        assert!(job_has_liveness_evidence(
+            Some("sandboxed-durable-demo"),
+            false,
+            true,
         ));
-        assert!(!cgroup_contains_scope(cgroup, "sandboxed-durable"));
-        assert!(!cgroup_contains_scope(
-            cgroup,
-            "sandboxed-durable-demo-other"
+        assert!(!job_has_liveness_evidence(
+            Some("sandboxed-durable-demo"),
+            true,
+            false,
         ));
+        assert!(job_has_liveness_evidence(None, true, false));
+        assert!(!job_has_liveness_evidence(None, false, true));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -547,6 +547,13 @@ async fn read_job(state: &AppState, id: Uuid) -> Result<DurableJob, String> {
     serde_json::from_slice(&bytes).map_err(|e| format!("invalid durable job entry: {}", e))
 }
 
+async fn read_exit_record(job: &DurableJob) -> Option<ExitRecord> {
+    tokio::fs::read(&job.status_file)
+        .await
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<ExitRecord>(&bytes).ok())
+}
+
 async fn write_terminal_job_state(
     state: &AppState,
     mut job: DurableJob,
@@ -617,10 +624,7 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                 #[cfg(not(unix))]
                     let process_signal = None;
                     if let Ok(job) = read_job(&state, id).await {
-                        let recorded_exit = tokio::fs::read(&job.status_file)
-                            .await
-                            .ok()
-                            .and_then(|bytes| serde_json::from_slice::<ExitRecord>(&bytes).ok());
+                        let recorded_exit = read_exit_record(&job).await;
                         let exit = merge_process_exit_observation(
                             recorded_exit,
                             status.code(),
@@ -656,6 +660,29 @@ fn spawn_job_watcher(state: Arc<AppState>, id: Uuid, mut child: Child) {
                 _ = tokio::time::sleep(deadline), if !deadline.is_zero() => {
                     if let Ok(mut job) = read_job(&state, id).await {
                         if job.status == DurableJobStatus::Running {
+                            // The command may have finished just before the
+                            // deadline while this watcher was not scheduled.
+                            // Both select branches are then ready. Honor the
+                            // durable receipt before declaring a timeout so
+                            // randomized branch selection cannot misclassify
+                            // an on-time completion.
+                            if let Some(exit) = read_exit_record(&job).await {
+                                let status = terminal_status_for_exit(
+                                    &job,
+                                    exit.exit_code,
+                                    exit.finished_at,
+                                );
+                                let _ = write_terminal_job_state(
+                                    &state,
+                                    job,
+                                    status,
+                                    exit.exit_code,
+                                    exit.signal,
+                                    exit.finished_at,
+                                ).await;
+                                let _ = child.wait().await;
+                                break;
+                            }
                             job.status = deadline_terminal_status();
                             job.updated_at = Utc::now();
                             let _ = write_job(&state, &job).await;
@@ -872,23 +899,21 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
         job.status,
         DurableJobStatus::Running | DurableJobStatus::Unknown
     ) {
-        if let Ok(bytes) = tokio::fs::read(&job.status_file).await {
-            if let Ok(exit) = serde_json::from_slice::<ExitRecord>(&bytes) {
-                // The API can be offline while a durable command runs beyond
-                // its absolute deadline and later publishes a successful exit
-                // record. Classify the recorded finish time before accepting
-                // that success so restart recovery cannot erase a timeout.
-                let status = terminal_status_for_exit(&job, exit.exit_code, exit.finished_at);
-                return write_terminal_job_state(
-                    state,
-                    job,
-                    status,
-                    exit.exit_code,
-                    exit.signal,
-                    exit.finished_at,
-                )
-                .await;
-            }
+        if let Some(exit) = read_exit_record(&job).await {
+            // The API can be offline while a durable command runs beyond
+            // its absolute deadline and later publishes a successful exit
+            // record. Classify the recorded finish time before accepting
+            // that success so restart recovery cannot erase a timeout.
+            let status = terminal_status_for_exit(&job, exit.exit_code, exit.finished_at);
+            return write_terminal_job_state(
+                state,
+                job,
+                status,
+                exit.exit_code,
+                exit.signal,
+                exit.finished_at,
+            )
+            .await;
         }
 
         if !job.spawn_accepted {

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -687,6 +687,29 @@ fn deadline_terminal_status() -> DurableJobStatus {
     DurableJobStatus::Failed
 }
 
+fn job_deadline_elapsed(job: &DurableJob, now: DateTime<Utc>) -> bool {
+    job.deadline_at.is_some_and(|deadline| deadline <= now)
+}
+
+async fn mark_job_deadline_exceeded(
+    state: &AppState,
+    mut job: DurableJob,
+    now: DateTime<Utc>,
+) -> DurableJob {
+    job.status = deadline_terminal_status();
+    job.updated_at = now;
+    job = write_job(state, &job).await.unwrap_or(job);
+    let cancelling = job.clone();
+    tokio::spawn(async move {
+        signal_job(&cancelling, false).await;
+        tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
+        if job_requires_force_clear(&cancelling) {
+            signal_job(&cancelling, true).await;
+        }
+    });
+    job
+}
+
 fn requires_force_clear(scope_unit: Option<&str>, process_is_alive: bool) -> bool {
     // A systemd-run wrapper may exit before the payload in its transient
     // scope. Force-signalling the named scope is idempotent, so always do it
@@ -852,18 +875,8 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
                 }
             } else {
                 let now = Utc::now();
-                if job.deadline_at.is_some_and(|deadline| deadline <= now) {
-                    job.status = deadline_terminal_status();
-                    job.updated_at = now;
-                    job = write_job(state, &job).await.unwrap_or(job);
-                    let cancelling = job.clone();
-                    tokio::spawn(async move {
-                        signal_job(&cancelling, false).await;
-                        tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
-                        if job_requires_force_clear(&cancelling) {
-                            signal_job(&cancelling, true).await;
-                        }
-                    });
+                if job_deadline_elapsed(&job, now) {
+                    job = mark_job_deadline_exceeded(state, job, now).await;
                 } else if job
                     .heartbeat_at
                     .is_none_or(|heartbeat| (now - heartbeat).num_seconds() >= 5)
@@ -881,13 +894,17 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
             let now = Utc::now();
             let scope_is_active = job.scope_unit.as_deref().is_some_and(scope_unit_is_active);
             if pidless_scope_is_live(job.scope_unit.as_deref(), scope_is_active) {
-                // The API may have restarted after the deterministic scope was
-                // launched but before its wrapper PID reached job.json. Reattach
-                // to that scope instead of terminalizing or resubmitting it.
-                job.status = DurableJobStatus::Running;
-                job.heartbeat_at = Some(now);
-                job.updated_at = now;
-                job = write_job(state, &job).await.unwrap_or(job);
+                if job_deadline_elapsed(&job, now) {
+                    job = mark_job_deadline_exceeded(state, job, now).await;
+                } else {
+                    // The API may have restarted after the deterministic scope was
+                    // launched but before its wrapper PID reached job.json. Reattach
+                    // to that scope instead of terminalizing or resubmitting it.
+                    job.status = DurableJobStatus::Running;
+                    job.heartbeat_at = Some(now);
+                    job.updated_at = now;
+                    job = write_job(state, &job).await.unwrap_or(job);
+                }
             } else if (now - job.created_at).num_seconds() >= PIDLESS_START_GRACE_SECS {
                 job.status = DurableJobStatus::Unknown;
                 job.updated_at = now;
@@ -1449,6 +1466,18 @@ mod tests {
     #[test]
     fn deadline_is_always_classified_as_failed() {
         assert_eq!(deadline_terminal_status(), DurableJobStatus::Failed);
+    }
+
+    #[test]
+    fn pidless_live_scope_still_obeys_its_absolute_deadline() {
+        let now = Utc::now();
+        let mut job = test_job(DurableJobStatus::Running);
+        job.pid = None;
+        job.scope_unit = Some("sandboxed-durable-demo".to_string());
+        job.deadline_at = Some(now - chrono::Duration::seconds(1));
+
+        assert!(pidless_scope_is_live(job.scope_unit.as_deref(), true));
+        assert!(job_deadline_elapsed(&job, now));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -747,17 +747,14 @@ pub async fn start_job(
         .map_err(|message| err(StatusCode::BAD_REQUEST, message))?;
     let id = durable_job_id(&user.id, started_by_mission_id, idempotency_key.as_deref());
     if idempotency_key.is_some() {
-        match read_job(&state, id).await {
-            Ok(existing) => {
-                if existing.command != command || existing.workspace_id != req.workspace_id {
-                    return Err(err(
-                        StatusCode::CONFLICT,
-                        "idempotency_key was already used with different job parameters",
-                    ));
-                }
-                return Ok(Json(refresh_job(&state, existing).await));
+        if let Ok(existing) = read_job(&state, id).await {
+            if existing.command != command || existing.workspace_id != req.workspace_id {
+                return Err(err(
+                    StatusCode::CONFLICT,
+                    "idempotency_key was already used with different job parameters",
+                ));
             }
-            Err(_) => {}
+            return Ok(Json(refresh_job(&state, existing).await));
         }
         tokio::fs::create_dir_all(job_dir(&state, id))
             .await

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -950,11 +950,9 @@ pub async fn start_job(
         stdout_log: stdout_log.to_string_lossy().to_string(),
         stderr_log: stderr_log.to_string_lossy().to_string(),
         status_file: status_file.to_string_lossy().to_string(),
-        scope_unit: workspace.as_ref().and_then(|workspace| {
-            WorkspaceExec::new(workspace.clone())
-                .machine_name()
-                .map(|machine| crate::workspace_exec::durable_scope_unit(&machine, id))
-        }),
+        scope_unit: workspace
+            .as_ref()
+            .and_then(|workspace| WorkspaceExec::new(workspace.clone()).durable_scope_unit(id)),
         resource_class: req.resource_class,
         idempotency_key,
         request_fingerprint: Some(request_fingerprint),

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -689,9 +689,17 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
 
         if let Some(pid) = job.pid {
             if !process_owned_by_job(&job, pid) {
-                job.status = DurableJobStatus::Unknown;
-                job.updated_at = Utc::now();
-                job = write_job(state, &job).await.unwrap_or(job);
+                // systemd-run may need a brief moment to attach the payload
+                // to its transient scope, and very short commands can exit
+                // just before their wrapper atomically publishes exit.json.
+                // Keep the persisted start lease provisional during that
+                // bounded window instead of returning a false `unknown`.
+                let now = Utc::now();
+                if (now - job.created_at).num_seconds() >= PIDLESS_START_GRACE_SECS {
+                    job.status = DurableJobStatus::Unknown;
+                    job.updated_at = now;
+                    job = write_job(state, &job).await.unwrap_or(job);
+                }
             } else {
                 let now = Utc::now();
                 if job.deadline_at.is_some_and(|deadline| deadline <= now) {

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -637,6 +637,10 @@ fn job_has_liveness_evidence(
     }
 }
 
+fn pidless_scope_is_live(scope_unit: Option<&str>, scope_is_active: bool) -> bool {
+    scope_unit.is_some() && scope_is_active
+}
+
 fn job_accepts_heartbeat(status: &DurableJobStatus) -> bool {
     *status == DurableJobStatus::Running
 }
@@ -678,6 +682,11 @@ fn scope_unit_is_active(scope_unit: &str) -> bool {
         .status()
         .map(|status| status.success())
         .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn scope_unit_is_active(_scope_unit: &str) -> bool {
+    false
 }
 
 #[cfg(unix)]
@@ -810,7 +819,16 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
             }
         } else {
             let now = Utc::now();
-            if (now - job.created_at).num_seconds() >= PIDLESS_START_GRACE_SECS {
+            let scope_is_active = job.scope_unit.as_deref().is_some_and(scope_unit_is_active);
+            if pidless_scope_is_live(job.scope_unit.as_deref(), scope_is_active) {
+                // The API may have restarted after the deterministic scope was
+                // launched but before its wrapper PID reached job.json. Reattach
+                // to that scope instead of terminalizing or resubmitting it.
+                job.status = DurableJobStatus::Running;
+                job.heartbeat_at = Some(now);
+                job.updated_at = now;
+                job = write_job(state, &job).await.unwrap_or(job);
+            } else if (now - job.created_at).num_seconds() >= PIDLESS_START_GRACE_SECS {
                 job.status = DurableJobStatus::Unknown;
                 job.updated_at = now;
                 job = write_job(state, &job).await.unwrap_or(job);
@@ -1415,6 +1433,12 @@ mod tests {
         ));
         assert!(job_has_liveness_evidence(None, true, false));
         assert!(!job_has_liveness_evidence(None, false, true));
+        assert!(pidless_scope_is_live(Some("sandboxed-durable-demo"), true));
+        assert!(!pidless_scope_is_live(
+            Some("sandboxed-durable-demo"),
+            false
+        ));
+        assert!(!pidless_scope_is_live(None, true));
     }
 
     #[test]

--- a/src/api/durable_jobs.rs
+++ b/src/api/durable_jobs.rs
@@ -579,6 +579,41 @@ fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
+fn cgroup_contains_scope(cgroup: &str, scope_unit: &str) -> bool {
+    let expected = if scope_unit.ends_with(".scope") {
+        scope_unit.to_string()
+    } else {
+        format!("{scope_unit}.scope")
+    };
+    cgroup
+        .lines()
+        .flat_map(|line| {
+            line.rsplit_once(':')
+                .map(|(_, path)| path)
+                .unwrap_or(line)
+                .split('/')
+        })
+        .any(|component| component == expected)
+}
+
+#[cfg(unix)]
+fn process_owned_by_job(job: &DurableJob, pid: u32) -> bool {
+    if !process_alive(pid) {
+        return false;
+    }
+    let Some(scope_unit) = job.scope_unit.as_deref() else {
+        return true;
+    };
+    std::fs::read_to_string(format!("/proc/{pid}/cgroup"))
+        .ok()
+        .is_some_and(|cgroup| cgroup_contains_scope(&cgroup, scope_unit))
+}
+
+#[cfg(not(unix))]
+fn process_owned_by_job(_job: &DurableJob, _pid: u32) -> bool {
+    false
+}
+
 #[cfg(not(unix))]
 fn process_alive(_pid: u32) -> bool {
     false
@@ -653,10 +688,36 @@ async fn refresh_job(state: &AppState, mut job: DurableJob) -> DurableJob {
         }
 
         if let Some(pid) = job.pid {
-            if !process_alive(pid) {
+            if !process_owned_by_job(&job, pid) {
                 job.status = DurableJobStatus::Unknown;
                 job.updated_at = Utc::now();
                 job = write_job(state, &job).await.unwrap_or(job);
+            } else {
+                let now = Utc::now();
+                if job.deadline_at.is_some_and(|deadline| deadline <= now) {
+                    job.status = DurableJobStatus::Cancelled;
+                    job.updated_at = now;
+                    job = write_job(state, &job).await.unwrap_or(job);
+                    let cancelling = job.clone();
+                    tokio::spawn(async move {
+                        signal_job(&cancelling, false).await;
+                        tokio::time::sleep(std::time::Duration::from_secs(FORCE_CLEAR_SECS)).await;
+                        if cancelling.pid.is_some_and(process_alive) {
+                            signal_job(&cancelling, true).await;
+                        }
+                    });
+                } else if job
+                    .heartbeat_at
+                    .is_none_or(|heartbeat| (now - heartbeat).num_seconds() >= 5)
+                {
+                    // The original child watcher is process-local. After an
+                    // API restart, a verified live PID in the persisted scope
+                    // is enough to reattach the lease and advance heartbeat
+                    // without resubmitting the underlying remote job.
+                    job.heartbeat_at = Some(now);
+                    job.updated_at = now;
+                    job = write_job(state, &job).await.unwrap_or(job);
+                }
             }
         }
     }
@@ -1100,6 +1161,21 @@ mod tests {
         assert_eq!(first, retry);
         assert_ne!(first, distinct);
         assert!(validated_idempotency_key(Some(" ")).is_err());
+    }
+
+    #[test]
+    fn cgroup_scope_membership_requires_the_exact_unit() {
+        let cgroup = "1:name=systemd:/\n0::/missions.slice/sandboxed-durable-demo.scope\n";
+        assert!(cgroup_contains_scope(cgroup, "sandboxed-durable-demo"));
+        assert!(cgroup_contains_scope(
+            cgroup,
+            "sandboxed-durable-demo.scope"
+        ));
+        assert!(!cgroup_contains_scope(cgroup, "sandboxed-durable"));
+        assert!(!cgroup_contains_scope(
+            cgroup,
+            "sandboxed-durable-demo-other"
+        ));
     }
 
     #[test]

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -12047,7 +12047,10 @@ mod tests {
         let followup_id = Uuid::new_v4();
         runner.queue_message(followup_id, "follow-up".to_string(), None, None);
         assert!(runner.take_next_message_for_start().is_none());
-        assert_eq!(runner.queue.front().map(|message| message.id), Some(followup_id));
+        assert_eq!(
+            runner.queue.front().map(|message| message.id),
+            Some(followup_id)
+        );
         assert_eq!(
             runner.inflight_message().map(|message| message.id),
             Some(message_id),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2433,9 +2433,9 @@ const STALL_WARN_SECS: u64 = 120;
 const STALL_SEVERE_SECS: u64 = 300;
 /// An unmatched ToolCall is only evidence that a tool *may* still be running.
 /// Some harnesses omit ToolResult events, so this hint must not suppress
-/// severe-stall handling forever. One hour accommodates large local builds
-/// while bounding stale counter damage.
-pub(crate) const TOOL_CALL_STALL_GRACE_SECS: u64 = 3600;
+/// severe-stall handling forever. Long work must register a managed process or
+/// durable job; a bare unmatched protocol event is provisional for two minutes.
+pub(crate) const TOOL_CALL_STALL_GRACE_SECS: u64 = 120;
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -2460,6 +2460,9 @@ pub enum MissionHealth {
     MissingDeliverables { missing: Vec<String> },
     /// Mission ended unexpectedly
     UnexpectedEnd { reason: String },
+    /// Durable row, actor registry, or presentation status disagree. The
+    /// reconciler must repair the conflict rather than hiding it.
+    Reconciling { reason: String },
 }
 
 /// Classify how long a turn has been quiet.
@@ -2663,6 +2666,9 @@ pub struct MissionRunner {
     /// the mission parks in `AwaitingUser`, so this field is informational and
     /// for in-process inspection only).
     pub background_tasks: HashMap<String, BackgroundTask>,
+
+    /// Durable generation lease for the currently executing turn.
+    pub durable_run: Option<crate::api::mission_store::MissionRun>,
 }
 
 impl MissionRunner {
@@ -2703,6 +2709,57 @@ impl MissionRunner {
             user_id: None,
             active_tool_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             background_tasks: HashMap::new(),
+            durable_run: None,
+        }
+    }
+
+    pub async fn acquire_durable_run(
+        &mut self,
+        mission_store: &Arc<dyn crate::api::mission_store::MissionStore>,
+        owner_actor_id: &str,
+    ) -> Result<(), String> {
+        if self.is_running() || self.queue.is_empty() {
+            return Ok(());
+        }
+        let run = mission_store
+            .begin_mission_run(self.mission_id, owner_actor_id, None)
+            .await?;
+        let alive = mission_store
+            .heartbeat_mission_run(
+                run.run_id,
+                run.generation,
+                crate::api::mission_store::MissionExecutionState::Running,
+                None,
+            )
+            .await?;
+        if !alive {
+            return Err(format!(
+                "new mission run {} generation {} was superseded before start",
+                run.run_id, run.generation
+            ));
+        }
+        self.durable_run = Some(run);
+        Ok(())
+    }
+
+    pub async fn finish_durable_run(
+        &mut self,
+        mission_store: &Arc<dyn crate::api::mission_store::MissionStore>,
+        terminal_reason: Option<&str>,
+    ) {
+        let Some(run) = self.durable_run.take() else {
+            return;
+        };
+        if let Err(error) = mission_store
+            .finish_mission_run(run.run_id, run.generation, terminal_reason)
+            .await
+        {
+            tracing::warn!(
+                mission_id = %self.mission_id,
+                run_id = %run.run_id,
+                generation = run.generation,
+                "Failed to close durable mission run: {error}"
+            );
         }
     }
 
@@ -8322,6 +8379,16 @@ pub struct RunningMissionInfo {
     pub subtask_total: usize,
     /// Completed subtasks
     pub subtask_completed: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heartbeat_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_conflict: Option<String>,
 }
 
 impl From<&MissionRunner> for RunningMissionInfo {
@@ -8348,6 +8415,20 @@ impl From<&MissionRunner> for RunningMissionInfo {
             current_activity: runner.current_activity.clone(),
             subtask_total: runner.subtasks.len(),
             subtask_completed: runner.subtasks.iter().filter(|s| s.completed).count(),
+            run_id: runner.durable_run.as_ref().map(|run| run.run_id),
+            generation: runner.durable_run.as_ref().map(|run| run.generation),
+            heartbeat_at: runner
+                .durable_run
+                .as_ref()
+                .map(|run| run.heartbeat_at.clone()),
+            scope_unit: runner
+                .durable_run
+                .as_ref()
+                .and_then(|run| run.scope_unit.clone()),
+            status_conflict: runner
+                .durable_run
+                .is_none()
+                .then(|| "actor_without_durable_run".to_string()),
         }
     }
 }
@@ -8532,7 +8613,7 @@ mod tests {
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
         ClaudeTurnWaitState, CopiedOpenCodeProbe, MissionHealth, MissionRunState,
         MissionStallSeverity, OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
-        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS, TOOL_CALL_STALL_GRACE_SECS,
+        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -10499,14 +10580,13 @@ mod tests {
     // ── subprocess-aware stall classifier tests (TASK 2) ──────────────
 
     #[test]
-    fn stall_severity_severe_downgraded_to_warning_when_tool_alive() {
-        // A 12-minute `lake build` produces no model tokens but is honest
-        // work. The classifier must not escalate this to Severe (which
-        // trips the auto-terminate watchdog) just because of token silence.
+    fn stall_severity_unregistered_tool_hint_expires_before_severe_threshold() {
+        // Unmatched harness events are provisional only. Long work must
+        // register a managed process or durable job in the control plane.
         let result = stall_severity(STALL_SEVERE_SECS + 1, true).unwrap();
         assert!(
-            matches!(result, MissionStallSeverity::Warning),
-            "expected Warning when a tool subprocess is alive, got {:?}",
+            matches!(result, MissionStallSeverity::Severe),
+            "expected Severe after provisional tool grace, got {:?}",
             result
         );
     }
@@ -10520,16 +10600,14 @@ mod tests {
     }
 
     #[test]
-    fn stall_severity_grants_long_tool_call_a_bounded_warning_window() {
-        // 30 minutes of silence after a ToolCall (e.g. a long `make check`)
-        // remains Warning and does not interrupt a healthy large build.
+    fn stall_severity_does_not_grant_unregistered_long_tool_immunity() {
         let result = stall_severity(STALL_SEVERE_SECS * 6, true).unwrap();
-        assert!(matches!(result, MissionStallSeverity::Warning));
+        assert!(matches!(result, MissionStallSeverity::Severe));
     }
 
     #[test]
     fn stall_severity_does_not_trust_unmatched_tool_call_forever() {
-        let result = stall_severity(TOOL_CALL_STALL_GRACE_SECS, true).unwrap();
+        let result = stall_severity(STALL_SEVERE_SECS + 1, true).unwrap();
         assert!(matches!(result, MissionStallSeverity::Severe));
     }
 
@@ -10586,19 +10664,16 @@ mod tests {
     }
 
     #[test]
-    fn running_health_warning_when_tool_alive_at_severe_threshold() {
-        // The end-to-end claim of TASK 2: when the mission is well past
-        // the severe stall threshold *and* a tool subprocess is in flight,
-        // the public health classification stays at Warning.
+    fn running_health_provisional_tool_hint_expires_at_severe_threshold() {
         let health = running_health(MissionRunState::Running, STALL_SEVERE_SECS + 1, true);
         match health {
             MissionHealth::Stalled { severity, .. } => {
                 assert!(
-                    matches!(severity, MissionStallSeverity::Warning),
-                    "tool-alive must keep severity at Warning"
+                    matches!(severity, MissionStallSeverity::Severe),
+                    "unregistered tool hints must not suppress Severe"
                 );
             }
-            other => panic!("Expected Stalled (Warning), got {:?}", other),
+            other => panic!("Expected Stalled (Severe), got {:?}", other),
         }
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2883,12 +2883,21 @@ impl MissionRunner {
         self.inflight_message.as_ref()
     }
 
+    pub fn remove_inflight_message(&mut self, message_id: Uuid) -> bool {
+        if self.inflight_message.as_ref().map(|message| message.id) == Some(message_id) {
+            self.inflight_message = None;
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn cancellation_requested(&self) -> bool {
         self.cancellation_requested
     }
 
     pub(crate) fn take_next_message_for_start(&mut self) -> Option<QueuedMessage> {
-        if self.is_running() || self.cancellation_requested {
+        if self.is_running() || self.cancellation_requested || self.inflight_message.is_some() {
             return None;
         }
         let message = self.queue.pop_front()?;
@@ -2929,9 +2938,16 @@ impl MissionRunner {
         current_mission: Arc<RwLock<Option<Uuid>>>,
         secrets: Option<Arc<SecretsStore>>,
     ) -> bool {
-        let msg = match self.take_next_message_for_start() {
-            Some(m) => m,
-            None => return false,
+        if self.is_running() || self.cancellation_requested {
+            return false;
+        }
+        let msg = if let Some(message) = self.inflight_message.clone() {
+            message
+        } else {
+            match self.take_next_message_for_start() {
+                Some(message) => message,
+                None => return false,
+            }
         };
 
         self.reset_turn_tool_calls();
@@ -12026,6 +12042,16 @@ mod tests {
         assert_eq!(
             runner.inflight_message().map(|message| message.id),
             Some(message_id)
+        );
+
+        let followup_id = Uuid::new_v4();
+        runner.queue_message(followup_id, "follow-up".to_string(), None, None);
+        assert!(runner.take_next_message_for_start().is_none());
+        assert_eq!(runner.queue.front().map(|message| message.id), Some(followup_id));
+        assert_eq!(
+            runner.inflight_message().map(|message| message.id),
+            Some(message_id),
+            "preparing another delivery must not overwrite the durable inflight marker"
         );
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2613,6 +2613,12 @@ pub struct MissionRunner {
     /// Message queue for this mission
     pub queue: VecDeque<QueuedMessage>,
 
+    /// Message owned by the currently executing turn. Kept separately from
+    /// `queue` so the control actor can persist it until the turn completes;
+    /// after a restart it is safely replayed instead of being lost between
+    /// dequeue and history persistence.
+    inflight_message: Option<QueuedMessage>,
+
     /// Conversation history: (role, content)
     pub history: Vec<(String, String)>,
 
@@ -2669,6 +2675,10 @@ pub struct MissionRunner {
 
     /// Durable generation lease for the currently executing turn.
     pub durable_run: Option<crate::api::mission_store::MissionRun>,
+
+    /// Once cancellation is requested, this runner must drain its current
+    /// handle and be removed without starting queued or automated follow-ups.
+    cancellation_requested: bool,
 }
 
 impl MissionRunner {
@@ -2695,6 +2705,7 @@ impl MissionRunner {
             model_override,
             model_effort,
             queue: VecDeque::new(),
+            inflight_message: None,
             history: Vec::new(),
             cancel_token: None,
             running_handle: None,
@@ -2710,6 +2721,7 @@ impl MissionRunner {
             active_tool_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             background_tasks: HashMap::new(),
             durable_run: None,
+            cancellation_requested: false,
         }
     }
 
@@ -2860,9 +2872,28 @@ impl MissionRunner {
 
     /// Cancel the current execution.
     pub fn cancel(&mut self) {
+        self.cancellation_requested = true;
+        self.clear_queue();
         if let Some(token) = &self.cancel_token {
             token.cancel();
         }
+    }
+
+    pub fn inflight_message(&self) -> Option<&QueuedMessage> {
+        self.inflight_message.as_ref()
+    }
+
+    pub fn cancellation_requested(&self) -> bool {
+        self.cancellation_requested
+    }
+
+    pub(crate) fn take_next_message_for_start(&mut self) -> Option<QueuedMessage> {
+        if self.is_running() || self.cancellation_requested {
+            return None;
+        }
+        let message = self.queue.pop_front()?;
+        self.inflight_message = Some(message.clone());
+        Some(message)
     }
 
     /// Remove a specific message from the queue by ID.
@@ -2898,13 +2929,7 @@ impl MissionRunner {
         current_mission: Arc<RwLock<Option<Uuid>>>,
         secrets: Option<Arc<SecretsStore>>,
     ) -> bool {
-        // Don't start if already running
-        if self.is_running() {
-            return false;
-        }
-
-        // Get next message from queue
-        let msg = match self.queue.pop_front() {
+        let msg = match self.take_next_message_for_start() {
             Some(m) => m,
             None => return false,
         };
@@ -2998,6 +3023,7 @@ impl MissionRunner {
 
         // Check if handle is finished
         if handle.is_finished() {
+            self.inflight_message = None;
             // A completed or panicked turn can leave an unmatched ToolCall in
             // harnesses that omit ToolResult events. Never expose that stale
             // hint while queued or carry it into the next turn.
@@ -8611,7 +8637,7 @@ mod tests {
         text_buffer_stream_looks_degenerate, thinking_overlaps_visible_answer, tls_error_hint,
         truncate_garbled_output, use_thinking_only_fallback, utf8_safe_prefix,
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
-        ClaudeTurnWaitState, CopiedOpenCodeProbe, MissionHealth, MissionRunState,
+        ClaudeTurnWaitState, CopiedOpenCodeProbe, MissionHealth, MissionRunState, MissionRunner,
         MissionStallSeverity, OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
         CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
     };
@@ -11970,5 +11996,57 @@ mod tests {
         let mut s = String::from("Here is the plan: A, B, C. We should pick B. ");
         s.push_str(&"Yielding pending your choice. ".repeat(20));
         assert!(text_buffer_stream_looks_degenerate(&s, 4096, 40, 3));
+    }
+
+    #[test]
+    fn running_message_remains_durable_until_completion() {
+        let mut runner = MissionRunner::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        let message_id = Uuid::new_v4();
+        runner.queue_message(
+            message_id,
+            "durable controller wake".to_string(),
+            None,
+            Some("task-board".to_string()),
+        );
+
+        let started = runner
+            .take_next_message_for_start()
+            .expect("queued message should start");
+        assert_eq!(started.id, message_id);
+        assert!(runner.queue.is_empty());
+        assert_eq!(
+            runner.inflight_message().map(|message| message.id),
+            Some(message_id)
+        );
+    }
+
+    #[test]
+    fn cancellation_clears_followups_and_prevents_restart() {
+        let mut runner = MissionRunner::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        runner.queue_message(Uuid::new_v4(), "queued follow-up".to_string(), None, None);
+
+        runner.cancel();
+
+        assert!(runner.cancellation_requested());
+        assert!(runner.queue.is_empty());
+        assert!(runner.take_next_message_for_start().is_none());
     }
 }

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2730,7 +2730,7 @@ impl MissionRunner {
         mission_store: &Arc<dyn crate::api::mission_store::MissionStore>,
         owner_actor_id: &str,
     ) -> Result<(), String> {
-        if self.is_running() || self.queue.is_empty() {
+        if self.is_running() || !self.has_startable_message() {
             return Ok(());
         }
         let run = mission_store
@@ -2881,6 +2881,10 @@ impl MissionRunner {
 
     pub fn inflight_message(&self) -> Option<&QueuedMessage> {
         self.inflight_message.as_ref()
+    }
+
+    fn has_startable_message(&self) -> bool {
+        self.inflight_message.is_some() || !self.queue.is_empty()
     }
 
     pub fn remove_inflight_message(&mut self, message_id: Uuid) -> bool {
@@ -12043,6 +12047,7 @@ mod tests {
             runner.inflight_message().map(|message| message.id),
             Some(message_id)
         );
+        assert!(runner.has_startable_message());
 
         let followup_id = Uuid::new_v4();
         runner.queue_message(followup_id, "follow-up".to_string(), None, None);

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2679,7 +2679,15 @@ pub struct MissionRunner {
     /// Once cancellation is requested, this runner must drain its current
     /// handle and be removed without starting queued or automated follow-ups.
     cancellation_requested: bool,
+
+    /// Absolute deadline after which a cancelled runner is force-aborted if
+    /// its harness ignores the cancellation token. Parallel runners own their
+    /// JoinHandle here, so the deadline must travel with the runner rather than
+    /// only being tracked by the control actor's main-runner state.
+    cancellation_force_clear_deadline: Option<Instant>,
 }
+
+const RUNNER_FORCE_CLEAR_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
 
 impl MissionRunner {
     /// Create a new mission runner.
@@ -2722,6 +2730,7 @@ impl MissionRunner {
             background_tasks: HashMap::new(),
             durable_run: None,
             cancellation_requested: false,
+            cancellation_force_clear_deadline: None,
         }
     }
 
@@ -2873,10 +2882,45 @@ impl MissionRunner {
     /// Cancel the current execution.
     pub fn cancel(&mut self) {
         self.cancellation_requested = true;
+        self.cancellation_force_clear_deadline
+            .get_or_insert_with(|| Instant::now() + RUNNER_FORCE_CLEAR_GRACE);
         self.clear_queue();
         if let Some(token) = &self.cancel_token {
             token.cancel();
         }
+    }
+
+    /// Force-abort a cancelled turn once its grace period expires.
+    ///
+    /// Returns `true` when the runner should be removed from the actor's
+    /// registry. A handle which has already finished is left for the normal
+    /// completion path so its terminal result can still be recorded.
+    pub fn force_clear_cancelled_if_due(&mut self) -> bool {
+        if !self.cancellation_requested
+            || !self
+                .cancellation_force_clear_deadline
+                .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return false;
+        }
+
+        if self
+            .running_handle
+            .as_ref()
+            .is_some_and(|handle| handle.is_finished())
+        {
+            return false;
+        }
+
+        if let Some(handle) = self.running_handle.take() {
+            handle.abort();
+        }
+        self.cancel_token = None;
+        self.inflight_message = None;
+        self.reset_turn_tool_calls();
+        self.state = MissionRunState::Finished;
+        self.cancellation_force_clear_deadline = None;
+        true
     }
 
     pub fn inflight_message(&self) -> Option<&QueuedMessage> {
@@ -3043,6 +3087,7 @@ impl MissionRunner {
 
         // Check if handle is finished
         if handle.is_finished() {
+            self.cancellation_force_clear_deadline = None;
             self.inflight_message = None;
             // A completed or panicked turn can leave an unmatched ToolCall in
             // harnesses that omit ToolResult events. Never expose that stale
@@ -12082,5 +12127,58 @@ mod tests {
         assert!(runner.cancellation_requested());
         assert!(runner.queue.is_empty());
         assert!(runner.take_next_message_for_start().is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelled_parallel_runner_force_aborts_after_deadline() {
+        let mut runner = MissionRunner::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        runner.state = MissionRunState::Running;
+        runner.running_handle = Some(tokio::spawn(async {
+            std::future::pending::<(Uuid, String, AgentResult)>().await
+        }));
+
+        runner.cancel();
+        runner.cancellation_force_clear_deadline =
+            Some(std::time::Instant::now() - std::time::Duration::from_secs(1));
+
+        assert!(runner.force_clear_cancelled_if_due());
+        assert!(runner.running_handle.is_none());
+        assert!(matches!(runner.state, MissionRunState::Finished));
+        assert!(!runner.force_clear_cancelled_if_due());
+    }
+
+    #[test]
+    fn repeated_cancel_does_not_extend_force_clear_deadline() {
+        let mut runner = MissionRunner::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            Some("codex".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        runner.cancel();
+        let first_deadline = runner
+            .cancellation_force_clear_deadline
+            .expect("cancel should arm the deadline");
+        runner.cancel();
+
+        assert_eq!(
+            runner.cancellation_force_clear_deadline,
+            Some(first_deadline),
+            "an idempotent cancel retry must not postpone force-clear"
+        );
     }
 }

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -341,6 +341,12 @@ impl MissionStore for FileMissionStore {
         status: MissionStatus,
         terminal_reason: Option<&str>,
     ) -> Result<(), String> {
+        if status == MissionStatus::Acknowledged && self.get_active_mission_run(id).await?.is_some()
+        {
+            return Err(format!(
+                "mission {id} cannot be acknowledged while a run is non-terminal"
+            ));
+        }
         let mut missions = self.missions.write().await;
         let mission = missions
             .get_mut(&id)
@@ -405,10 +411,19 @@ impl MissionStore for FileMissionStore {
         grace_seconds: u64,
     ) -> Result<Vec<Uuid>, String> {
         let cutoff = chrono::Utc::now() - chrono::Duration::seconds(grace_seconds as i64);
+        let active: std::collections::HashSet<Uuid> = self
+            .list_active_mission_runs()
+            .await?
+            .into_iter()
+            .map(|run| run.mission_id)
+            .collect();
         let mut missions = self.missions.write().await;
         let mut promoted = Vec::new();
         for mission in missions.values_mut() {
             if mission.status != MissionStatus::AwaitingUser {
+                continue;
+            }
+            if active.contains(&mission.id) {
                 continue;
             }
             let Some(ref viewed_at) = mission.first_viewed_at else {
@@ -1085,5 +1100,53 @@ mod tests {
             .await
             .expect("begin second run");
         assert_eq!(second.generation, 2);
+    }
+
+    #[tokio::test]
+    async fn active_run_blocks_manual_and_automatic_acknowledgement() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = FileMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("file store");
+        let mission = store
+            .create_mission(Some("Waiting"), None, None, None, None, None, None)
+            .await
+            .expect("create mission");
+        let run = store
+            .begin_mission_run(mission.id, "actor", None)
+            .await
+            .expect("begin run");
+        store
+            .update_mission_status(mission.id, MissionStatus::AwaitingUser)
+            .await
+            .expect("mark awaiting user");
+        store
+            .set_mission_first_viewed_at_if_unset(mission.id, "2000-01-01T00:00:00Z")
+            .await
+            .expect("set viewed timestamp");
+
+        assert!(store
+            .update_mission_status(mission.id, MissionStatus::Acknowledged)
+            .await
+            .unwrap_err()
+            .contains("run is non-terminal"));
+        assert!(store
+            .acknowledge_stale_awaiting_user_missions(0)
+            .await
+            .expect("run acknowledgement sweep")
+            .is_empty());
+        assert_eq!(
+            store
+                .get_mission(mission.id)
+                .await
+                .expect("get mission")
+                .expect("mission exists")
+                .status,
+            MissionStatus::AwaitingUser
+        );
+        assert!(store
+            .finish_mission_run(run.run_id, run.generation, Some("completed"))
+            .await
+            .expect("finish run"));
     }
 }

--- a/src/api/mission_store/file.rs
+++ b/src/api/mission_store/file.rs
@@ -1,8 +1,8 @@
 //! JSON file-based mission store (legacy).
 
 use super::{
-    now_string, sanitize_filename, Mission, MissionHistoryEntry, MissionStatus,
-    MissionStatusCounts, MissionStore,
+    now_string, sanitize_filename, Mission, MissionExecutionState, MissionHistoryEntry, MissionRun,
+    MissionStatus, MissionStatusCounts, MissionStore,
 };
 use crate::api::control::{AgentTreeNode, DesktopSessionInfo};
 use async_trait::async_trait;
@@ -21,6 +21,8 @@ const METADATA_SOURCE_USER: &str = "user";
 struct MissionStoreSnapshot {
     missions: HashMap<Uuid, Mission>,
     trees: HashMap<Uuid, AgentTreeNode>,
+    #[serde(default)]
+    runs: HashMap<Uuid, MissionRun>,
     /// FLEET-001 scheduling: deferred goals held outside the Mission struct
     /// (mirrors the sqlite `deferred_goal` column).
     #[serde(default)]
@@ -32,6 +34,7 @@ pub struct FileMissionStore {
     path: PathBuf,
     missions: Arc<RwLock<HashMap<Uuid, Mission>>>,
     trees: Arc<RwLock<HashMap<Uuid, AgentTreeNode>>>,
+    runs: Arc<RwLock<HashMap<Uuid, MissionRun>>>,
     deferred_goals: Arc<RwLock<HashMap<Uuid, String>>>,
     persist_lock: Arc<Mutex<()>>,
 }
@@ -64,6 +67,7 @@ impl FileMissionStore {
             path,
             missions: Arc::new(RwLock::new(snapshot.missions)),
             trees: Arc::new(RwLock::new(snapshot.trees)),
+            runs: Arc::new(RwLock::new(snapshot.runs)),
             deferred_goals: Arc::new(RwLock::new(snapshot.deferred_goals)),
             persist_lock: Arc::new(Mutex::new(())),
         })
@@ -74,6 +78,7 @@ impl FileMissionStore {
         let snapshot = MissionStoreSnapshot {
             missions: self.missions.read().await.clone(),
             trees: self.trees.read().await.clone(),
+            runs: self.runs.read().await.clone(),
             deferred_goals: self.deferred_goals.read().await.clone(),
         };
         let data = serde_json::to_vec_pretty(&snapshot)
@@ -121,6 +126,130 @@ impl MissionStore for FileMissionStore {
 
     async fn get_mission(&self, id: Uuid) -> Result<Option<Mission>, String> {
         Ok(self.missions.read().await.get(&id).cloned())
+    }
+
+    async fn begin_mission_run(
+        &self,
+        mission_id: Uuid,
+        owner_actor_id: &str,
+        scope_unit: Option<&str>,
+    ) -> Result<MissionRun, String> {
+        match self.missions.read().await.get(&mission_id) {
+            None => return Err(format!("mission not found: {mission_id}")),
+            Some(mission) if mission.status == MissionStatus::Acknowledged => {
+                return Err(format!(
+                    "acknowledged mission {mission_id} cannot acquire a non-terminal run"
+                ));
+            }
+            Some(_) => {}
+        }
+
+        let mut runs = self.runs.write().await;
+        if let Some(run) = runs
+            .values()
+            .find(|run| run.mission_id == mission_id && !run.execution_state.is_terminal())
+        {
+            return Err(format!(
+                "mission {mission_id} already has non-terminal run {} generation {}",
+                run.run_id, run.generation
+            ));
+        }
+        let generation = runs
+            .values()
+            .filter(|run| run.mission_id == mission_id)
+            .map(|run| run.generation)
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let now = now_string();
+        let run = MissionRun {
+            run_id: Uuid::new_v4(),
+            mission_id,
+            generation,
+            execution_state: MissionExecutionState::Starting,
+            owner_actor_id: owner_actor_id.to_string(),
+            scope_unit: scope_unit.map(str::to_string),
+            started_at: now.clone(),
+            heartbeat_at: now,
+            stopping_at: None,
+            ended_at: None,
+            terminal_reason: None,
+        };
+        runs.insert(run.run_id, run.clone());
+        drop(runs);
+        self.persist().await?;
+        Ok(run)
+    }
+
+    async fn get_active_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        Ok(self
+            .runs
+            .read()
+            .await
+            .values()
+            .find(|run| run.mission_id == mission_id && !run.execution_state.is_terminal())
+            .cloned())
+    }
+
+    async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
+        Ok(self
+            .runs
+            .read()
+            .await
+            .values()
+            .filter(|run| !run.execution_state.is_terminal())
+            .cloned()
+            .collect())
+    }
+
+    async fn heartbeat_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        state: MissionExecutionState,
+        scope_unit: Option<&str>,
+    ) -> Result<bool, String> {
+        let mut runs = self.runs.write().await;
+        let Some(run) = runs.get_mut(&run_id) else {
+            return Ok(false);
+        };
+        if run.generation != generation || run.execution_state.is_terminal() {
+            return Ok(false);
+        }
+        run.execution_state = state;
+        run.heartbeat_at = now_string();
+        if let Some(scope) = scope_unit {
+            run.scope_unit = Some(scope.to_string());
+        }
+        if state == MissionExecutionState::Stopping && run.stopping_at.is_none() {
+            run.stopping_at = Some(run.heartbeat_at.clone());
+        }
+        drop(runs);
+        self.persist().await?;
+        Ok(true)
+    }
+
+    async fn finish_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        terminal_reason: Option<&str>,
+    ) -> Result<bool, String> {
+        let mut runs = self.runs.write().await;
+        let Some(run) = runs.get_mut(&run_id) else {
+            return Ok(false);
+        };
+        if run.generation != generation || run.execution_state.is_terminal() {
+            return Ok(false);
+        }
+        let now = now_string();
+        run.execution_state = MissionExecutionState::Terminal;
+        run.heartbeat_at = now.clone();
+        run.ended_at = Some(now);
+        run.terminal_reason = terminal_reason.map(str::to_string);
+        drop(runs);
+        self.persist().await?;
+        Ok(true)
     }
 
     async fn create_mission_with_parent(
@@ -904,5 +1033,57 @@ mod tests {
             .expect("create blank titled mission");
         assert_eq!(blank_titled.metadata_source, None);
         assert_eq!(blank_titled.metadata_updated_at, None);
+    }
+
+    #[tokio::test]
+    async fn mission_run_leases_persist_and_advance_generation() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = FileMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("file store");
+        let mission = store
+            .create_mission(Some("Leased"), None, None, None, None, None, None)
+            .await
+            .expect("create mission");
+
+        let first = store
+            .begin_mission_run(mission.id, "actor-a", Some("mission-a.scope"))
+            .await
+            .expect("begin first run");
+        assert_eq!(first.generation, 1);
+        assert!(store
+            .begin_mission_run(mission.id, "actor-b", None)
+            .await
+            .unwrap_err()
+            .contains("already has non-terminal run"));
+        assert!(store
+            .heartbeat_mission_run(
+                first.run_id,
+                first.generation,
+                MissionExecutionState::Running,
+                None,
+            )
+            .await
+            .expect("heartbeat first run"));
+
+        let reopened = FileMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("reopen file store");
+        let active = reopened
+            .get_active_mission_run(mission.id)
+            .await
+            .expect("get active run")
+            .expect("active run persisted");
+        assert_eq!(active.run_id, first.run_id);
+        assert_eq!(active.execution_state, MissionExecutionState::Running);
+        assert!(reopened
+            .finish_mission_run(first.run_id, first.generation, Some("completed"))
+            .await
+            .expect("finish first run"));
+        let second = reopened
+            .begin_mission_run(mission.id, "actor-b", None)
+            .await
+            .expect("begin second run");
+        assert_eq!(second.generation, 2);
     }
 }

--- a/src/api/mission_store/memory.rs
+++ b/src/api/mission_store/memory.rs
@@ -1,8 +1,9 @@
 //! In-memory mission store (non-persistent).
 
 use super::{
-    now_string, BoardTask, BoardTaskStatus, Mission, MissionHistoryEntry, MissionStatus,
-    MissionStatusCounts, MissionStore, NewBoardTask,
+    now_string, BoardOutboxItem, BoardProject, BoardTask, BoardTaskStatus, Mission,
+    MissionExecutionState, MissionHistoryEntry, MissionRun, MissionStatus, MissionStatusCounts,
+    MissionStore, MissionToolExecution, MissionToolExecutionState, NewBoardTask, TaskAttempt,
 };
 use crate::api::control::{AgentTreeNode, DesktopSessionInfo};
 use async_trait::async_trait;
@@ -22,6 +23,11 @@ pub struct InMemoryMissionStore {
     /// FLEET-001 scheduling: deferred goals held outside the Mission struct
     /// (mirrors the sqlite `deferred_goal` column).
     deferred_goals: Arc<RwLock<HashMap<Uuid, String>>>,
+    runs: Arc<RwLock<HashMap<Uuid, MissionRun>>>,
+    tool_executions: Arc<RwLock<HashMap<(Uuid, String), MissionToolExecution>>>,
+    board_projects: Arc<RwLock<HashMap<String, BoardProject>>>,
+    task_attempts: Arc<RwLock<HashMap<(Uuid, u32), TaskAttempt>>>,
+    board_outbox: Arc<RwLock<HashMap<String, BoardOutboxItem>>>,
 }
 
 impl InMemoryMissionStore {
@@ -31,6 +37,11 @@ impl InMemoryMissionStore {
             trees: Arc::new(RwLock::new(HashMap::new())),
             board_tasks: Arc::new(RwLock::new(HashMap::new())),
             deferred_goals: Arc::new(RwLock::new(HashMap::new())),
+            runs: Arc::new(RwLock::new(HashMap::new())),
+            tool_executions: Arc::new(RwLock::new(HashMap::new())),
+            board_projects: Arc::new(RwLock::new(HashMap::new())),
+            task_attempts: Arc::new(RwLock::new(HashMap::new())),
+            board_outbox: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -73,6 +84,175 @@ impl MissionStore for InMemoryMissionStore {
 
     async fn get_mission(&self, id: Uuid) -> Result<Option<Mission>, String> {
         Ok(self.missions.read().await.get(&id).cloned())
+    }
+
+    async fn begin_mission_run(
+        &self,
+        mission_id: Uuid,
+        owner_actor_id: &str,
+        scope_unit: Option<&str>,
+    ) -> Result<MissionRun, String> {
+        match self.missions.read().await.get(&mission_id) {
+            None => return Err(format!("mission not found: {mission_id}")),
+            Some(mission) if mission.status == MissionStatus::Acknowledged => {
+                return Err(format!(
+                    "acknowledged mission {mission_id} cannot acquire a non-terminal run"
+                ));
+            }
+            Some(_) => {}
+        }
+        let mut runs = self.runs.write().await;
+        if let Some(run) = runs
+            .values()
+            .find(|run| run.mission_id == mission_id && !run.execution_state.is_terminal())
+        {
+            return Err(format!(
+                "mission {mission_id} already has non-terminal run {} generation {}",
+                run.run_id, run.generation
+            ));
+        }
+        let generation = runs
+            .values()
+            .filter(|run| run.mission_id == mission_id)
+            .map(|run| run.generation)
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let now = now_string();
+        let run = MissionRun {
+            run_id: Uuid::new_v4(),
+            mission_id,
+            generation,
+            execution_state: MissionExecutionState::Starting,
+            owner_actor_id: owner_actor_id.to_string(),
+            scope_unit: scope_unit.map(str::to_string),
+            started_at: now.clone(),
+            heartbeat_at: now,
+            stopping_at: None,
+            ended_at: None,
+            terminal_reason: None,
+        };
+        runs.insert(run.run_id, run.clone());
+        Ok(run)
+    }
+
+    async fn get_active_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        Ok(self
+            .runs
+            .read()
+            .await
+            .values()
+            .find(|run| run.mission_id == mission_id && !run.execution_state.is_terminal())
+            .cloned())
+    }
+
+    async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
+        Ok(self
+            .runs
+            .read()
+            .await
+            .values()
+            .filter(|run| !run.execution_state.is_terminal())
+            .cloned()
+            .collect())
+    }
+
+    async fn heartbeat_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        state: MissionExecutionState,
+        scope_unit: Option<&str>,
+    ) -> Result<bool, String> {
+        let mut runs = self.runs.write().await;
+        let Some(run) = runs.get_mut(&run_id) else {
+            return Ok(false);
+        };
+        if run.generation != generation || run.execution_state.is_terminal() {
+            return Ok(false);
+        }
+        run.execution_state = state;
+        run.heartbeat_at = now_string();
+        if let Some(scope) = scope_unit {
+            run.scope_unit = Some(scope.to_string());
+        }
+        if state == MissionExecutionState::Stopping && run.stopping_at.is_none() {
+            run.stopping_at = Some(run.heartbeat_at.clone());
+        }
+        Ok(true)
+    }
+
+    async fn finish_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        terminal_reason: Option<&str>,
+    ) -> Result<bool, String> {
+        let mut runs = self.runs.write().await;
+        let Some(run) = runs.get_mut(&run_id) else {
+            return Ok(false);
+        };
+        if run.generation != generation || run.execution_state.is_terminal() {
+            return Ok(false);
+        }
+        let now = now_string();
+        run.execution_state = MissionExecutionState::Terminal;
+        run.heartbeat_at = now.clone();
+        run.ended_at = Some(now);
+        run.terminal_reason = terminal_reason.map(str::to_string);
+        Ok(true)
+    }
+
+    async fn register_tool_execution(
+        &self,
+        execution: &MissionToolExecution,
+    ) -> Result<(), String> {
+        self.tool_executions.write().await.insert(
+            (execution.run_id, execution.tool_call_id.clone()),
+            execution.clone(),
+        );
+        Ok(())
+    }
+
+    async fn finish_tool_execution(
+        &self,
+        run_id: Uuid,
+        tool_call_id: &str,
+        state: MissionToolExecutionState,
+        exit_status: Option<i32>,
+        failure_class: Option<&str>,
+    ) -> Result<bool, String> {
+        let mut tools = self.tool_executions.write().await;
+        let Some(tool) = tools.get_mut(&(run_id, tool_call_id.to_string())) else {
+            return Ok(false);
+        };
+        let now = now_string();
+        tool.state = state;
+        tool.heartbeat_at = now.clone();
+        tool.completed_at = Some(now);
+        tool.exit_status = exit_status;
+        tool.failure_class = failure_class.map(str::to_string);
+        Ok(true)
+    }
+
+    async fn list_active_tool_executions(
+        &self,
+        run_id: Uuid,
+    ) -> Result<Vec<MissionToolExecution>, String> {
+        Ok(self
+            .tool_executions
+            .read()
+            .await
+            .values()
+            .filter(|tool| {
+                tool.run_id == run_id
+                    && matches!(
+                        tool.state,
+                        MissionToolExecutionState::Provisional | MissionToolExecutionState::Running
+                    )
+            })
+            .cloned()
+            .collect())
     }
 
     async fn create_mission_with_parent(
@@ -163,6 +343,12 @@ impl MissionStore for InMemoryMissionStore {
         status: MissionStatus,
         terminal_reason: Option<&str>,
     ) -> Result<(), String> {
+        if status == MissionStatus::Acknowledged && self.get_active_mission_run(id).await?.is_some()
+        {
+            return Err(format!(
+                "mission {id} cannot be acknowledged while a run is non-terminal"
+            ));
+        }
         let mut missions = self.missions.write().await;
         let mission = missions
             .get_mut(&id)
@@ -224,10 +410,19 @@ impl MissionStore for InMemoryMissionStore {
         grace_seconds: u64,
     ) -> Result<Vec<Uuid>, String> {
         let cutoff = chrono::Utc::now() - chrono::Duration::seconds(grace_seconds as i64);
+        let active: std::collections::HashSet<Uuid> = self
+            .list_active_mission_runs()
+            .await?
+            .into_iter()
+            .map(|run| run.mission_id)
+            .collect();
         let mut missions = self.missions.write().await;
         let mut promoted = Vec::new();
         for mission in missions.values_mut() {
             if mission.status != MissionStatus::AwaitingUser {
+                continue;
+            }
+            if active.contains(&mission.id) {
                 continue;
             }
             let Some(ref viewed_at) = mission.first_viewed_at else {
@@ -612,6 +807,14 @@ impl MissionStore for InMemoryMissionStore {
                         bt.working_directory = t.working_directory;
                         bt.repository = t.repository;
                         bt.branch = t.branch;
+                        bt.role = t.role;
+                        bt.acceptance_criteria = t.acceptance_criteria;
+                        bt.verification_command = t.verification_command;
+                        bt.design_domain = t.design_domain;
+                        bt.declared_write_set = t.declared_write_set;
+                        bt.risk_class = t.risk_class;
+                        bt.token_budget = t.token_budget;
+                        bt.cost_budget_cents = t.cost_budget_cents;
                         bt.depends_on = t.depends_on;
                         bt.updated_at = now.clone();
                     }
@@ -630,6 +833,14 @@ impl MissionStore for InMemoryMissionStore {
                         working_directory: t.working_directory,
                         repository: t.repository,
                         branch: t.branch,
+                        role: t.role,
+                        acceptance_criteria: t.acceptance_criteria,
+                        verification_command: t.verification_command,
+                        design_domain: t.design_domain,
+                        declared_write_set: t.declared_write_set,
+                        risk_class: t.risk_class,
+                        token_budget: t.token_budget,
+                        cost_budget_cents: t.cost_budget_cents,
                         depends_on: t.depends_on,
                         status: BoardTaskStatus::Pending,
                         outcome: None,
@@ -703,6 +914,100 @@ impl MissionStore for InMemoryMissionStore {
         saved.updated_at = now_string();
         map.insert(task.id, saved);
         Ok(())
+    }
+
+    async fn upsert_board_project(
+        &self,
+        mut project: BoardProject,
+    ) -> Result<BoardProject, String> {
+        let mut projects = self.board_projects.write().await;
+        if let Some(existing) = projects.get(&project.slug) {
+            project.created_at = existing.created_at.clone();
+        }
+        project.updated_at = now_string();
+        projects.insert(project.slug.clone(), project.clone());
+        Ok(project)
+    }
+
+    async fn get_board_project(&self, slug: &str) -> Result<Option<BoardProject>, String> {
+        Ok(self.board_projects.read().await.get(slug).cloned())
+    }
+
+    async fn create_task_attempt(&self, attempt: TaskAttempt) -> Result<TaskAttempt, String> {
+        let mut attempts = self.task_attempts.write().await;
+        Ok(attempts
+            .entry((attempt.task_id, attempt.attempt_number))
+            .or_insert(attempt)
+            .clone())
+    }
+
+    async fn finish_task_attempt(
+        &self,
+        task_id: Uuid,
+        attempt_number: u32,
+        terminal_class: &str,
+        commit_sha: Option<&str>,
+        changed_files: &[String],
+        verification_evidence: &serde_json::Value,
+        cost_cents: Option<i64>,
+    ) -> Result<(), String> {
+        let mut attempts = self.task_attempts.write().await;
+        let attempt = attempts
+            .get_mut(&(task_id, attempt_number))
+            .ok_or_else(|| "Task attempt not found".to_string())?;
+        attempt.terminal_class = Some(terminal_class.to_string());
+        attempt.commit_sha = commit_sha.map(str::to_string);
+        attempt.changed_files = changed_files.to_vec();
+        attempt.verification_evidence = verification_evidence.clone();
+        attempt.cost_cents = cost_cents;
+        attempt.finished_at = Some(now_string());
+        Ok(())
+    }
+
+    async fn list_task_attempts(&self, task_id: Uuid) -> Result<Vec<TaskAttempt>, String> {
+        let mut attempts: Vec<_> = self
+            .task_attempts
+            .read()
+            .await
+            .values()
+            .filter(|attempt| attempt.task_id == task_id)
+            .cloned()
+            .collect();
+        attempts.sort_by_key(|attempt| attempt.attempt_number);
+        Ok(attempts)
+    }
+
+    async fn enqueue_board_outbox(&self, item: BoardOutboxItem) -> Result<BoardOutboxItem, String> {
+        let mut outbox = self.board_outbox.write().await;
+        Ok(outbox
+            .entry(item.idempotency_key.clone())
+            .or_insert(item)
+            .clone())
+    }
+
+    async fn acknowledge_board_outbox(&self, idempotency_key: &str) -> Result<(), String> {
+        if let Some(item) = self.board_outbox.write().await.get_mut(idempotency_key) {
+            item.state = "acknowledged".to_string();
+            item.acknowledged_at = Some(now_string());
+        }
+        Ok(())
+    }
+
+    async fn list_pending_board_outbox(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<BoardOutboxItem>, String> {
+        let mut items: Vec<_> = self
+            .board_outbox
+            .read()
+            .await
+            .values()
+            .filter(|item| item.state != "acknowledged")
+            .cloned()
+            .collect();
+        items.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        items.truncate(limit);
+        Ok(items)
     }
 }
 

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -140,6 +140,122 @@ pub struct MissionActivity {
     pub last_activity_at: Option<String>,
 }
 
+/// Durable execution truth for one mission runner generation. Mission status
+/// remains a presentation/attention field; non-terminal rows here are the
+/// authoritative answer to whether work is still executing.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionExecutionState {
+    Queued,
+    Starting,
+    Running,
+    WaitingTool,
+    WaitingUser,
+    WaitingBackground,
+    Stopping,
+    Terminal,
+}
+
+impl MissionExecutionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::WaitingTool => "waiting_tool",
+            Self::WaitingUser => "waiting_user",
+            Self::WaitingBackground => "waiting_background",
+            Self::Stopping => "stopping",
+            Self::Terminal => "terminal",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "queued" => Self::Queued,
+            "starting" => Self::Starting,
+            "running" => Self::Running,
+            "waiting_tool" => Self::WaitingTool,
+            "waiting_user" => Self::WaitingUser,
+            "waiting_background" => Self::WaitingBackground,
+            "stopping" => Self::Stopping,
+            "terminal" => Self::Terminal,
+            _ => return None,
+        })
+    }
+
+    pub fn is_terminal(self) -> bool {
+        self == Self::Terminal
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissionRun {
+    pub run_id: Uuid,
+    pub mission_id: Uuid,
+    pub generation: u64,
+    pub execution_state: MissionExecutionState,
+    pub owner_actor_id: String,
+    pub scope_unit: Option<String>,
+    pub started_at: String,
+    pub heartbeat_at: String,
+    pub stopping_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub terminal_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionToolExecutionState {
+    Provisional,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    Stale,
+}
+
+impl MissionToolExecutionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Provisional => "provisional",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Stale => "stale",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "provisional" => Self::Provisional,
+            "running" => Self::Running,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            "stale" => Self::Stale,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissionToolExecution {
+    pub tool_call_id: String,
+    pub run_id: Uuid,
+    pub tool_kind: String,
+    pub state: MissionToolExecutionState,
+    pub started_at: String,
+    pub heartbeat_at: String,
+    pub deadline_at: String,
+    pub process_pid: Option<u32>,
+    pub durable_job_id: Option<Uuid>,
+    pub completed_at: Option<String>,
+    pub exit_status: Option<i32>,
+    pub failure_class: Option<String>,
+}
+
 /// Disambiguates *why* a mission is parked in `AwaitingUser`: the agent asked a
 /// real question that needs a decision, vs. it just finished a turn / its work
 /// and is waiting to be acknowledged or merged. Only meaningful while the
@@ -1333,6 +1449,95 @@ impl BoardTaskOutcome {
     }
 }
 
+/// Server-side role used for model routing, budgets, and independent review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BoardTaskRole {
+    Planner,
+    #[default]
+    Worker,
+    Reviewer,
+    Reconciler,
+}
+
+impl std::fmt::Display for BoardTaskRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Planner => "planner",
+            Self::Worker => "worker",
+            Self::Reviewer => "reviewer",
+            Self::Reconciler => "reconciler",
+        })
+    }
+}
+
+impl BoardTaskRole {
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "planner" => Self::Planner,
+            "reviewer" => Self::Reviewer,
+            "reconciler" => Self::Reconciler,
+            _ => Self::Worker,
+        }
+    }
+}
+
+/// Canonical project record. Repository markdown remains the source of human
+/// intent; only its path and immutable revision are stored here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardProject {
+    pub slug: String,
+    pub repository: String,
+    pub workspace_id: Uuid,
+    pub specification_path: String,
+    pub specification_revision: String,
+    pub compute_policy: String,
+    #[serde(default)]
+    pub budget_policy: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_controller_lease: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Immutable history for one task execution attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskAttempt {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub attempt_number: u32,
+    pub mission_id: Uuid,
+    pub backend: String,
+    pub model: Option<String>,
+    pub role: BoardTaskRole,
+    pub run_id: Option<Uuid>,
+    pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    #[serde(default)]
+    pub verification_evidence: serde_json::Value,
+    pub cost_cents: Option<i64>,
+    pub terminal_class: Option<String>,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+}
+
+/// Durable delivery intent used by board spawn, wake, retry, and controller
+/// notification operations. A row is deleted only after acknowledgement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BoardOutboxItem {
+    pub id: Uuid,
+    pub boss_mission_id: Uuid,
+    pub task_id: Option<Uuid>,
+    pub delivery_kind: String,
+    pub idempotency_key: String,
+    pub payload: serde_json::Value,
+    pub state: String,
+    pub attempts: u32,
+    pub created_at: String,
+    pub acknowledged_at: Option<String>,
+}
+
 /// A task on a boss mission's board.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BoardTask {
@@ -1358,6 +1563,22 @@ pub struct BoardTask {
     /// Declared git branch created for this task.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+    #[serde(default)]
+    pub role: BoardTaskRole,
+    #[serde(default)]
+    pub acceptance_criteria: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub design_domain: Option<String>,
+    #[serde(default)]
+    pub declared_write_set: Vec<String>,
+    #[serde(default = "default_board_risk_class")]
+    pub risk_class: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_budget_cents: Option<i64>,
     /// Task keys (same board) that must settle successfully or be accepted
     /// before this task may start.
     pub depends_on: Vec<String>,
@@ -1402,7 +1623,52 @@ pub struct NewBoardTask {
     #[serde(default)]
     pub branch: Option<String>,
     #[serde(default)]
+    pub role: BoardTaskRole,
+    #[serde(default)]
+    pub acceptance_criteria: Vec<String>,
+    #[serde(default)]
+    pub verification_command: Option<String>,
+    #[serde(default)]
+    pub design_domain: Option<String>,
+    #[serde(default)]
+    pub declared_write_set: Vec<String>,
+    #[serde(default = "default_board_risk_class")]
+    pub risk_class: String,
+    #[serde(default)]
+    pub token_budget: Option<u64>,
+    #[serde(default)]
+    pub cost_budget_cents: Option<i64>,
+    #[serde(default)]
     pub depends_on: Vec<String>,
+}
+
+impl Default for NewBoardTask {
+    fn default() -> Self {
+        Self {
+            task_key: String::new(),
+            title: String::new(),
+            prompt: String::new(),
+            backend: "codex".to_string(),
+            model_override: None,
+            model_effort: None,
+            working_directory: None,
+            repository: None,
+            branch: None,
+            role: BoardTaskRole::Worker,
+            acceptance_criteria: vec![],
+            verification_command: None,
+            design_domain: None,
+            declared_write_set: vec![],
+            risk_class: default_board_risk_class(),
+            token_budget: None,
+            cost_budget_cents: None,
+            depends_on: vec![],
+        }
+    }
+}
+
+fn default_board_risk_class() -> String {
+    "normal".to_string()
 }
 
 /// Sanitize a string for use as a filename.
@@ -1491,6 +1757,76 @@ pub trait MissionStore: Send + Sync {
 
     /// Get a single mission by ID.
     async fn get_mission(&self, id: Uuid) -> Result<Option<Mission>, String>;
+
+    /// Acquire the sole non-terminal execution lease for a mission. Every
+    /// successful acquisition increments the mission generation.
+    async fn begin_mission_run(
+        &self,
+        mission_id: Uuid,
+        owner_actor_id: &str,
+        scope_unit: Option<&str>,
+    ) -> Result<MissionRun, String> {
+        let _ = (mission_id, owner_actor_id, scope_unit);
+        Err("mission run leases are not supported by this store".to_string())
+    }
+
+    async fn get_active_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        let _ = mission_id;
+        Ok(None)
+    }
+
+    async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
+        Ok(Vec::new())
+    }
+
+    async fn heartbeat_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        state: MissionExecutionState,
+        scope_unit: Option<&str>,
+    ) -> Result<bool, String> {
+        let _ = (run_id, generation, state, scope_unit);
+        Ok(false)
+    }
+
+    async fn finish_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        terminal_reason: Option<&str>,
+    ) -> Result<bool, String> {
+        let _ = (run_id, generation, terminal_reason);
+        Ok(false)
+    }
+
+    async fn register_tool_execution(
+        &self,
+        execution: &MissionToolExecution,
+    ) -> Result<(), String> {
+        let _ = execution;
+        Ok(())
+    }
+
+    async fn finish_tool_execution(
+        &self,
+        run_id: Uuid,
+        tool_call_id: &str,
+        state: MissionToolExecutionState,
+        exit_status: Option<i32>,
+        failure_class: Option<&str>,
+    ) -> Result<bool, String> {
+        let _ = (run_id, tool_call_id, state, exit_status, failure_class);
+        Ok(false)
+    }
+
+    async fn list_active_tool_executions(
+        &self,
+        run_id: Uuid,
+    ) -> Result<Vec<MissionToolExecution>, String> {
+        let _ = run_id;
+        Ok(Vec::new())
+    }
 
     /// Load the oldest persisted user message without applying the history
     /// projection/window used by `get_mission`.
@@ -3066,6 +3402,66 @@ pub trait MissionStore: Send + Sync {
     async fn save_board_task(&self, task: &BoardTask) -> Result<(), String> {
         let _ = task;
         Err("Task board not supported by this mission store".to_string())
+    }
+
+    async fn upsert_board_project(&self, project: BoardProject) -> Result<BoardProject, String> {
+        let _ = project;
+        Err("Project ledger not supported by this mission store".to_string())
+    }
+
+    async fn get_board_project(&self, slug: &str) -> Result<Option<BoardProject>, String> {
+        let _ = slug;
+        Ok(None)
+    }
+
+    async fn create_task_attempt(&self, attempt: TaskAttempt) -> Result<TaskAttempt, String> {
+        let _ = attempt;
+        Err("Task attempt ledger not supported by this mission store".to_string())
+    }
+
+    async fn finish_task_attempt(
+        &self,
+        task_id: Uuid,
+        attempt_number: u32,
+        terminal_class: &str,
+        commit_sha: Option<&str>,
+        changed_files: &[String],
+        verification_evidence: &serde_json::Value,
+        cost_cents: Option<i64>,
+    ) -> Result<(), String> {
+        let _ = (
+            task_id,
+            attempt_number,
+            terminal_class,
+            commit_sha,
+            changed_files,
+            verification_evidence,
+            cost_cents,
+        );
+        Ok(())
+    }
+
+    async fn list_task_attempts(&self, task_id: Uuid) -> Result<Vec<TaskAttempt>, String> {
+        let _ = task_id;
+        Ok(vec![])
+    }
+
+    async fn enqueue_board_outbox(&self, item: BoardOutboxItem) -> Result<BoardOutboxItem, String> {
+        let _ = item;
+        Err("Board outbox not supported by this mission store".to_string())
+    }
+
+    async fn acknowledge_board_outbox(&self, idempotency_key: &str) -> Result<(), String> {
+        let _ = idempotency_key;
+        Ok(())
+    }
+
+    async fn list_pending_board_outbox(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<BoardOutboxItem>, String> {
+        let _ = limit;
+        Ok(vec![])
     }
 
     /// Persist the control session's pending message queue as a JSON snapshot

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -1,21 +1,22 @@
 //! SQLite-based mission store with full event logging.
 
 use super::{
-    now_string, sanitize_filename, Automation, AutomationExecution, AwaitingKind, BoardTask,
-    BoardTaskOutcome, BoardTaskStatus, CommandSource, DailyUsageStats, ExecutionStatus,
-    FreshSession, HourlyUsageStats, Mission, MissionActivity, MissionHistoryEntry, MissionMode,
-    MissionProject, MissionProjectPatch, MissionScheduling, MissionStatus, MissionStatusCounts,
-    MissionStore, MissionSummary, ModelUsageStats, NewBoardTask, PalomaCooldownState,
-    PalomaDecision, PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig,
-    StopPolicy, StoredEvent, TelegramActionExecution, TelegramActionExecutionKind,
-    TelegramActionExecutionStatus, TelegramAlert, TelegramAlertPreference, TelegramChannel,
-    TelegramChatMission, TelegramConversation, TelegramConversationMessage,
-    TelegramConversationMessageDirection, TelegramMissionInterestLevel,
-    TelegramMissionSubscription, TelegramScheduledMessage, TelegramScheduledMessageStatus,
-    TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind, TelegramStructuredMemoryScope,
-    TelegramStructuredMemorySearchHit, TelegramUser, TelegramUserCursor, TelegramUserRole,
-    TelegramWorkflow, TelegramWorkflowEvent, TelegramWorkflowKind, TelegramWorkflowStatus,
-    ToolCallSummary, TriggerType, WebhookConfig,
+    now_string, sanitize_filename, Automation, AutomationExecution, AwaitingKind, BoardOutboxItem,
+    BoardProject, BoardTask, BoardTaskOutcome, BoardTaskRole, BoardTaskStatus, CommandSource,
+    DailyUsageStats, ExecutionStatus, FreshSession, HourlyUsageStats, Mission, MissionActivity,
+    MissionExecutionState, MissionHistoryEntry, MissionMode, MissionProject, MissionProjectPatch,
+    MissionRun, MissionScheduling, MissionStatus, MissionStatusCounts, MissionStore,
+    MissionSummary, MissionToolExecution, MissionToolExecutionState, ModelUsageStats, NewBoardTask,
+    PalomaCooldownState, PalomaDecision, PalomaMissionCard, PalomaSchedulerJob,
+    PalomaUserPreferences, RetryConfig, StopPolicy, StoredEvent, TaskAttempt,
+    TelegramActionExecution, TelegramActionExecutionKind, TelegramActionExecutionStatus,
+    TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramChatMission,
+    TelegramConversation, TelegramConversationMessage, TelegramConversationMessageDirection,
+    TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramScheduledMessage,
+    TelegramScheduledMessageStatus, TelegramStructuredMemoryEntry, TelegramStructuredMemoryKind,
+    TelegramStructuredMemoryScope, TelegramStructuredMemorySearchHit, TelegramUser,
+    TelegramUserCursor, TelegramUserRole, TelegramWorkflow, TelegramWorkflowEvent,
+    TelegramWorkflowKind, TelegramWorkflowStatus, ToolCallSummary, TriggerType, WebhookConfig,
 };
 use crate::api::control::{AgentEvent, AgentTreeNode, DesktopSessionInfo, TextOp};
 use async_trait::async_trait;
@@ -513,6 +514,48 @@ CREATE INDEX IF NOT EXISTS idx_missions_updated_at ON missions(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_missions_status ON missions(status);
 CREATE INDEX IF NOT EXISTS idx_missions_status_updated ON missions(status, updated_at);
 
+CREATE TABLE IF NOT EXISTS mission_runs (
+    run_id TEXT PRIMARY KEY NOT NULL,
+    mission_id TEXT NOT NULL,
+    generation INTEGER NOT NULL,
+    execution_state TEXT NOT NULL,
+    owner_actor_id TEXT NOT NULL,
+    scope_unit TEXT,
+    started_at TEXT NOT NULL,
+    heartbeat_at TEXT NOT NULL,
+    stopping_at TEXT,
+    ended_at TEXT,
+    terminal_reason TEXT,
+    UNIQUE(mission_id, generation),
+    FOREIGN KEY (mission_id) REFERENCES missions(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_runs_one_active
+ON mission_runs(mission_id) WHERE execution_state <> 'terminal';
+CREATE INDEX IF NOT EXISTS idx_mission_runs_active_heartbeat
+ON mission_runs(execution_state, heartbeat_at) WHERE execution_state <> 'terminal';
+
+CREATE TABLE IF NOT EXISTS mission_tool_executions (
+    tool_call_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    tool_kind TEXT NOT NULL,
+    state TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    heartbeat_at TEXT NOT NULL,
+    deadline_at TEXT NOT NULL,
+    process_pid INTEGER,
+    durable_job_id TEXT,
+    completed_at TEXT,
+    exit_status INTEGER,
+    failure_class TEXT,
+    PRIMARY KEY(run_id, tool_call_id),
+    FOREIGN KEY (run_id) REFERENCES mission_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mission_tool_executions_active
+ON mission_tool_executions(run_id, state)
+WHERE state IN ('provisional', 'running');
+
 CREATE TABLE IF NOT EXISTS mission_trees (
     mission_id TEXT PRIMARY KEY NOT NULL,
     tree_json TEXT NOT NULL,
@@ -659,6 +702,14 @@ CREATE TABLE IF NOT EXISTS board_tasks (
     working_directory TEXT,
     repository TEXT,
     branch TEXT,
+    role TEXT NOT NULL DEFAULT 'worker',
+    acceptance_criteria TEXT NOT NULL DEFAULT '[]',
+    verification_command TEXT,
+    design_domain TEXT,
+    declared_write_set TEXT NOT NULL DEFAULT '[]',
+    risk_class TEXT NOT NULL DEFAULT 'normal',
+    token_budget INTEGER,
+    cost_budget_cents INTEGER,
     depends_on TEXT NOT NULL DEFAULT '[]',
     status TEXT NOT NULL DEFAULT 'pending',
     outcome TEXT,
@@ -678,6 +729,54 @@ CREATE TABLE IF NOT EXISTS board_tasks (
 CREATE INDEX IF NOT EXISTS idx_board_tasks_boss ON board_tasks(boss_mission_id);
 CREATE INDEX IF NOT EXISTS idx_board_tasks_worker ON board_tasks(worker_mission_id);
 CREATE INDEX IF NOT EXISTS idx_board_tasks_status ON board_tasks(status);
+
+CREATE TABLE IF NOT EXISTS board_projects (
+    slug TEXT PRIMARY KEY,
+    repository TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    specification_path TEXT NOT NULL,
+    specification_revision TEXT NOT NULL,
+    compute_policy TEXT NOT NULL,
+    budget_policy TEXT NOT NULL DEFAULT '{}',
+    active_controller_lease TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_attempts (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    attempt_number INTEGER NOT NULL,
+    mission_id TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    model TEXT,
+    role TEXT NOT NULL,
+    run_id TEXT,
+    commit_sha TEXT,
+    changed_files TEXT NOT NULL DEFAULT '[]',
+    verification_evidence TEXT NOT NULL DEFAULT '{}',
+    cost_cents INTEGER,
+    terminal_class TEXT,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    UNIQUE(task_id, attempt_number),
+    FOREIGN KEY (task_id) REFERENCES board_tasks(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_task_attempts_task ON task_attempts(task_id, attempt_number);
+
+CREATE TABLE IF NOT EXISTS board_outbox (
+    id TEXT PRIMARY KEY,
+    boss_mission_id TEXT NOT NULL,
+    task_id TEXT,
+    delivery_kind TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    payload TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    acknowledged_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_board_outbox_pending ON board_outbox(state, created_at);
 
 -- Persisted control-session message queue (JSON snapshot) so pending queued
 -- messages survive a restart. Single row (the DB is already per-user).
@@ -1243,6 +1342,14 @@ impl SqliteMissionStore {
             ("prior_worker_mission_id", "TEXT"),
             ("prior_outcome", "TEXT"),
             ("prior_result_digest", "TEXT"),
+            ("role", "TEXT NOT NULL DEFAULT 'worker'"),
+            ("acceptance_criteria", "TEXT NOT NULL DEFAULT '[]'"),
+            ("verification_command", "TEXT"),
+            ("design_domain", "TEXT"),
+            ("declared_write_set", "TEXT NOT NULL DEFAULT '[]'"),
+            ("risk_class", "TEXT NOT NULL DEFAULT 'normal'"),
+            ("token_budget", "INTEGER"),
+            ("cost_budget_cents", "INTEGER"),
         ] {
             let exists = conn
                 .prepare(&format!(
@@ -2516,6 +2623,48 @@ fn status_to_string(status: MissionStatus) -> &'static str {
     }
 }
 
+fn parse_mission_run_row(row: &rusqlite::Row<'_>) -> Result<MissionRun, rusqlite::Error> {
+    let run_id: String = row.get(0)?;
+    let mission_id: String = row.get(1)?;
+    let state: String = row.get(3)?;
+    Ok(MissionRun {
+        run_id: parse_uuid_or_nil(&run_id),
+        mission_id: parse_uuid_or_nil(&mission_id),
+        generation: row.get::<_, i64>(2)?.max(0) as u64,
+        execution_state: MissionExecutionState::parse(&state)
+            .unwrap_or(MissionExecutionState::Terminal),
+        owner_actor_id: row.get(4)?,
+        scope_unit: row.get(5)?,
+        started_at: row.get(6)?,
+        heartbeat_at: row.get(7)?,
+        stopping_at: row.get(8)?,
+        ended_at: row.get(9)?,
+        terminal_reason: row.get(10)?,
+    })
+}
+
+fn parse_tool_execution_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<MissionToolExecution, rusqlite::Error> {
+    let run_id: String = row.get(1)?;
+    let state: String = row.get(3)?;
+    let durable_job_id: Option<String> = row.get(8)?;
+    Ok(MissionToolExecution {
+        tool_call_id: row.get(0)?,
+        run_id: parse_uuid_or_nil(&run_id),
+        tool_kind: row.get(2)?,
+        state: MissionToolExecutionState::parse(&state).unwrap_or(MissionToolExecutionState::Stale),
+        started_at: row.get(4)?,
+        heartbeat_at: row.get(5)?,
+        deadline_at: row.get(6)?,
+        process_pid: row.get::<_, Option<i64>>(7)?.map(|pid| pid.max(0) as u32),
+        durable_job_id: durable_job_id.and_then(|id| Uuid::parse_str(&id).ok()),
+        completed_at: row.get(9)?,
+        exit_status: row.get(10)?,
+        failure_class: row.get(11)?,
+    })
+}
+
 /// Serialize mission tags to a JSON array string for storage. `None` when empty
 /// (keeps the column NULL rather than `"[]"`).
 fn tags_to_json(tags: &[String]) -> Option<String> {
@@ -2821,6 +2970,277 @@ impl MissionStore for SqliteMissionStore {
         .map_err(|e| e.to_string())?
     }
 
+    async fn begin_mission_run(
+        &self,
+        mission_id: Uuid,
+        owner_actor_id: &str,
+        scope_unit: Option<&str>,
+    ) -> Result<MissionRun, String> {
+        let conn = self.conn.clone();
+        let owner_actor_id = owner_actor_id.to_string();
+        let scope_unit = scope_unit.map(str::to_string);
+        tokio::task::spawn_blocking(move || {
+            let mut conn = conn.blocking_lock();
+            let tx = conn.transaction().map_err(|error| error.to_string())?;
+            let mission_status = tx
+                .query_row(
+                    "SELECT status FROM missions WHERE id = ?1",
+                    params![mission_id.to_string()],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(|error| error.to_string())?;
+            let Some(mission_status) = mission_status else {
+                return Err(format!("mission not found: {mission_id}"));
+            };
+            if mission_status == "acknowledged" {
+                return Err(format!(
+                    "acknowledged mission {mission_id} cannot acquire a non-terminal run"
+                ));
+            }
+            if let Some(existing) = tx
+                .query_row(
+                    "SELECT run_id, mission_id, generation, execution_state, owner_actor_id, scope_unit, started_at, heartbeat_at, stopping_at, ended_at, terminal_reason
+                     FROM mission_runs WHERE mission_id = ?1 AND execution_state <> 'terminal'",
+                    params![mission_id.to_string()],
+                    parse_mission_run_row,
+                )
+                .optional()
+                .map_err(|error| error.to_string())?
+            {
+                return Err(format!(
+                    "mission {mission_id} already has non-terminal run {} generation {}",
+                    existing.run_id, existing.generation
+                ));
+            }
+            let generation = tx
+                .query_row(
+                    "SELECT COALESCE(MAX(generation), 0) + 1 FROM mission_runs WHERE mission_id = ?1",
+                    params![mission_id.to_string()],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|error| error.to_string())?
+                .max(1) as u64;
+            let now = now_string();
+            let run = MissionRun {
+                run_id: Uuid::new_v4(),
+                mission_id,
+                generation,
+                execution_state: MissionExecutionState::Starting,
+                owner_actor_id,
+                scope_unit,
+                started_at: now.clone(),
+                heartbeat_at: now,
+                stopping_at: None,
+                ended_at: None,
+                terminal_reason: None,
+            };
+            tx.execute(
+                "INSERT INTO mission_runs (run_id, mission_id, generation, execution_state, owner_actor_id, scope_unit, started_at, heartbeat_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    run.run_id.to_string(),
+                    run.mission_id.to_string(),
+                    run.generation as i64,
+                    run.execution_state.as_str(),
+                    run.owner_actor_id,
+                    run.scope_unit,
+                    run.started_at,
+                    run.heartbeat_at,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+            tx.commit().map_err(|error| error.to_string())?;
+            Ok(run)
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn get_active_mission_run(&self, mission_id: Uuid) -> Result<Option<MissionRun>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.query_row(
+                "SELECT run_id, mission_id, generation, execution_state, owner_actor_id, scope_unit, started_at, heartbeat_at, stopping_at, ended_at, terminal_reason
+                 FROM mission_runs WHERE mission_id = ?1 AND execution_state <> 'terminal'",
+                params![mission_id.to_string()],
+                parse_mission_run_row,
+            )
+            .optional()
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn list_active_mission_runs(&self) -> Result<Vec<MissionRun>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT run_id, mission_id, generation, execution_state, owner_actor_id, scope_unit, started_at, heartbeat_at, stopping_at, ended_at, terminal_reason
+                     FROM mission_runs WHERE execution_state <> 'terminal' ORDER BY started_at ASC",
+                )
+                .map_err(|error| error.to_string())?;
+            let rows = stmt
+                .query_map([], parse_mission_run_row)
+                .map_err(|error| error.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| error.to_string())?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn heartbeat_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        state: MissionExecutionState,
+        scope_unit: Option<&str>,
+    ) -> Result<bool, String> {
+        let conn = self.conn.clone();
+        let now = now_string();
+        let scope_unit = scope_unit.map(str::to_string);
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE mission_runs SET execution_state = ?1, heartbeat_at = ?2,
+                    scope_unit = COALESCE(?3, scope_unit),
+                    stopping_at = CASE WHEN ?1 = 'stopping' THEN COALESCE(stopping_at, ?2) ELSE stopping_at END
+                 WHERE run_id = ?4 AND generation = ?5 AND execution_state <> 'terminal'",
+                params![state.as_str(), now, scope_unit, run_id.to_string(), generation as i64],
+            )
+            .map(|changed| changed == 1)
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn finish_mission_run(
+        &self,
+        run_id: Uuid,
+        generation: u64,
+        terminal_reason: Option<&str>,
+    ) -> Result<bool, String> {
+        let conn = self.conn.clone();
+        let now = now_string();
+        let terminal_reason = terminal_reason.map(str::to_string);
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE mission_runs SET execution_state = 'terminal', heartbeat_at = ?1,
+                    ended_at = ?1, terminal_reason = ?2
+                 WHERE run_id = ?3 AND generation = ?4 AND execution_state <> 'terminal'",
+                params![now, terminal_reason, run_id.to_string(), generation as i64],
+            )
+            .map(|changed| changed == 1)
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn register_tool_execution(
+        &self,
+        execution: &MissionToolExecution,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let execution = execution.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO mission_tool_executions (tool_call_id, run_id, tool_kind, state, started_at, heartbeat_at, deadline_at, process_pid, durable_job_id, completed_at, exit_status, failure_class)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                 ON CONFLICT(run_id, tool_call_id) DO UPDATE SET
+                    tool_kind = excluded.tool_kind, state = excluded.state,
+                    heartbeat_at = excluded.heartbeat_at, deadline_at = excluded.deadline_at,
+                    process_pid = COALESCE(excluded.process_pid, process_pid),
+                    durable_job_id = COALESCE(excluded.durable_job_id, durable_job_id)",
+                params![
+                    execution.tool_call_id,
+                    execution.run_id.to_string(),
+                    execution.tool_kind,
+                    execution.state.as_str(),
+                    execution.started_at,
+                    execution.heartbeat_at,
+                    execution.deadline_at,
+                    execution.process_pid.map(i64::from),
+                    execution.durable_job_id.map(|id| id.to_string()),
+                    execution.completed_at,
+                    execution.exit_status,
+                    execution.failure_class,
+                ],
+            )
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn finish_tool_execution(
+        &self,
+        run_id: Uuid,
+        tool_call_id: &str,
+        state: MissionToolExecutionState,
+        exit_status: Option<i32>,
+        failure_class: Option<&str>,
+    ) -> Result<bool, String> {
+        let conn = self.conn.clone();
+        let tool_call_id = tool_call_id.to_string();
+        let failure_class = failure_class.map(str::to_string);
+        let now = now_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE mission_tool_executions SET state = ?1, heartbeat_at = ?2,
+                    completed_at = ?2, exit_status = ?3, failure_class = ?4
+                 WHERE run_id = ?5 AND tool_call_id = ?6",
+                params![
+                    state.as_str(),
+                    now,
+                    exit_status,
+                    failure_class,
+                    run_id.to_string(),
+                    tool_call_id
+                ],
+            )
+            .map(|changed| changed == 1)
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
+    async fn list_active_tool_executions(
+        &self,
+        run_id: Uuid,
+    ) -> Result<Vec<MissionToolExecution>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT tool_call_id, run_id, tool_kind, state, started_at, heartbeat_at, deadline_at, process_pid, durable_job_id, completed_at, exit_status, failure_class
+                     FROM mission_tool_executions WHERE run_id = ?1 AND state IN ('provisional', 'running') ORDER BY started_at ASC",
+                )
+                .map_err(|error| error.to_string())?;
+            let rows = stmt
+                .query_map(params![run_id.to_string()], parse_tool_execution_row)
+                .map_err(|error| error.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| error.to_string())?;
+            Ok(rows)
+        })
+        .await
+        .map_err(|error| error.to_string())?
+    }
+
     async fn get_initial_user_message(&self, id: Uuid) -> Result<Option<String>, String> {
         let conn = self.conn.clone();
         let id_str = id.to_string();
@@ -3099,6 +3519,21 @@ impl MissionStore for SqliteMissionStore {
 
         tokio::task::spawn_blocking(move || {
             let conn = conn.blocking_lock();
+            if status == MissionStatus::Acknowledged {
+                let active_run = conn
+                    .query_row(
+                        "SELECT run_id FROM mission_runs WHERE mission_id = ?1 AND execution_state <> 'terminal' LIMIT 1",
+                        params![id.to_string()],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()
+                    .map_err(|error| error.to_string())?;
+                if let Some(run_id) = active_run {
+                    return Err(format!(
+                        "mission {id} cannot be acknowledged while run {run_id} is non-terminal"
+                    ));
+                }
+            }
             // Read the old status before the UPDATE so we can decide whether
             // to invalidate the Paloma cooldown. Wiping cooldown on a
             // no-op status write (e.g. heartbeat that re-sets Active=Active)
@@ -3221,7 +3656,11 @@ impl MissionStore for SqliteMissionStore {
                         "SELECT id FROM missions
                          WHERE status = 'awaiting_user'
                            AND first_viewed_at IS NOT NULL
-                           AND first_viewed_at <= ?1",
+                           AND first_viewed_at <= ?1
+                           AND NOT EXISTS (
+                               SELECT 1 FROM mission_runs r
+                               WHERE r.mission_id = missions.id AND r.execution_state <> 'terminal'
+                           )",
                     )
                     .map_err(|e| e.to_string())?;
                 let rows = stmt
@@ -3239,7 +3678,11 @@ impl MissionStore for SqliteMissionStore {
                     "UPDATE missions SET status = 'acknowledged', updated_at = ?1
                      WHERE status = 'awaiting_user'
                        AND first_viewed_at IS NOT NULL
-                       AND first_viewed_at <= ?2",
+                       AND first_viewed_at <= ?2
+                       AND NOT EXISTS (
+                           SELECT 1 FROM mission_runs r
+                           WHERE r.mission_id = missions.id AND r.execution_state <> 'terminal'
+                       )",
                     params![&now, &cutoff],
                 )
                 .map_err(|e| e.to_string())?;
@@ -10060,7 +10503,10 @@ impl MissionStore for SqliteMissionStore {
                         conn.execute(
                             "UPDATE board_tasks SET title = ?1, prompt = ?2, backend = ?3, \
                              model_override = ?4, model_effort = ?5, working_directory = ?6, \
-                             repository = ?7, branch = ?8, depends_on = ?9, updated_at = ?10 WHERE id = ?11",
+                             repository = ?7, branch = ?8, role = ?9, acceptance_criteria = ?10, \
+                             verification_command = ?11, design_domain = ?12, declared_write_set = ?13, \
+                             risk_class = ?14, token_budget = ?15, cost_budget_cents = ?16, \
+                             depends_on = ?17, updated_at = ?18 WHERE id = ?19",
                             params![
                                 t.title,
                                 t.prompt,
@@ -10070,6 +10516,14 @@ impl MissionStore for SqliteMissionStore {
                                 t.working_directory,
                                 t.repository,
                                 t.branch,
+                                t.role.to_string(),
+                                serde_json::to_string(&t.acceptance_criteria).unwrap_or_else(|_| "[]".into()),
+                                t.verification_command,
+                                t.design_domain,
+                                serde_json::to_string(&t.declared_write_set).unwrap_or_else(|_| "[]".into()),
+                                t.risk_class,
+                                t.token_budget.map(|value| value as i64),
+                                t.cost_budget_cents,
                                 depends_on_json,
                                 now,
                                 id,
@@ -10083,9 +10537,11 @@ impl MissionStore for SqliteMissionStore {
                         let id = Uuid::new_v4().to_string();
                         conn.execute(
                             "INSERT INTO board_tasks (id, boss_mission_id, task_key, title, prompt, \
-                             backend, model_override, model_effort, working_directory, repository, branch, depends_on, \
-                             status, attempts, created_at, updated_at) \
-                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 'pending', 0, ?13, ?13)",
+                             backend, model_override, model_effort, working_directory, repository, branch, \
+                             role, acceptance_criteria, verification_command, design_domain, declared_write_set, \
+                             risk_class, token_budget, cost_budget_cents, depends_on, status, attempts, created_at, updated_at) \
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, \
+                             ?15, ?16, ?17, ?18, ?19, ?20, 'pending', 0, ?21, ?21)",
                             params![
                                 id,
                                 boss_mission_id.to_string(),
@@ -10098,6 +10554,14 @@ impl MissionStore for SqliteMissionStore {
                                 t.working_directory,
                                 t.repository,
                                 t.branch,
+                                t.role.to_string(),
+                                serde_json::to_string(&t.acceptance_criteria).unwrap_or_else(|_| "[]".into()),
+                                t.verification_command,
+                                t.design_domain,
+                                serde_json::to_string(&t.declared_write_set).unwrap_or_else(|_| "[]".into()),
+                                t.risk_class,
+                                t.token_budget.map(|value| value as i64),
+                                t.cost_budget_cents,
                                 depends_on_json,
                                 now,
                             ],
@@ -10217,9 +10681,12 @@ impl MissionStore for SqliteMissionStore {
                 .execute(
                     "UPDATE board_tasks SET task_key = ?1, title = ?2, prompt = ?3, backend = ?4, \
                      model_override = ?5, model_effort = ?6, working_directory = ?7, repository = ?8, \
-                     branch = ?9, depends_on = ?10, status = ?11, outcome = ?12, worker_mission_id = ?13, \
-                     prior_worker_mission_id = ?14, prior_outcome = ?15, prior_result_digest = ?16, \
-                     attempts = ?17, result_digest = ?18, notes = ?19, updated_at = ?20 WHERE id = ?21",
+                     branch = ?9, role = ?10, acceptance_criteria = ?11, verification_command = ?12, \
+                     design_domain = ?13, declared_write_set = ?14, risk_class = ?15, token_budget = ?16, \
+                     cost_budget_cents = ?17, depends_on = ?18, status = ?19, outcome = ?20, \
+                     worker_mission_id = ?21, prior_worker_mission_id = ?22, prior_outcome = ?23, \
+                     prior_result_digest = ?24, attempts = ?25, result_digest = ?26, notes = ?27, \
+                     updated_at = ?28 WHERE id = ?29",
                     params![
                         t.task_key,
                         t.title,
@@ -10230,6 +10697,14 @@ impl MissionStore for SqliteMissionStore {
                         t.working_directory,
                         t.repository,
                         t.branch,
+                        t.role.to_string(),
+                        serde_json::to_string(&t.acceptance_criteria).unwrap_or_else(|_| "[]".into()),
+                        t.verification_command,
+                        t.design_domain,
+                        serde_json::to_string(&t.declared_write_set).unwrap_or_else(|_| "[]".into()),
+                        t.risk_class,
+                        t.token_budget.map(|value| value as i64),
+                        t.cost_budget_cents,
                         depends_on_json,
                         t.status.to_string(),
                         t.outcome.map(|o| o.to_string()),
@@ -10253,25 +10728,201 @@ impl MissionStore for SqliteMissionStore {
         .await
         .map_err(|e| format!("Task join error: {e}"))?
     }
+
+    async fn upsert_board_project(&self, project: BoardProject) -> Result<BoardProject, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let now = now_string();
+            let budget = serde_json::to_string(&project.budget_policy)
+                .map_err(|error| format!("Failed to serialize project budget: {error}"))?;
+            conn.execute(
+                "INSERT INTO board_projects (slug, repository, workspace_id, specification_path, \
+                 specification_revision, compute_policy, budget_policy, active_controller_lease, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9) \
+                 ON CONFLICT(slug) DO UPDATE SET repository = excluded.repository, workspace_id = excluded.workspace_id, \
+                 specification_path = excluded.specification_path, specification_revision = excluded.specification_revision, \
+                 compute_policy = excluded.compute_policy, budget_policy = excluded.budget_policy, \
+                 active_controller_lease = excluded.active_controller_lease, updated_at = excluded.updated_at",
+                params![
+                    project.slug,
+                    project.repository,
+                    project.workspace_id.to_string(),
+                    project.specification_path,
+                    project.specification_revision,
+                    project.compute_policy,
+                    budget,
+                    project.active_controller_lease,
+                    now,
+                ],
+            )
+            .map_err(|error| format!("Failed to upsert project: {error}"))?;
+            parse_board_project(
+                &conn,
+                &project.slug,
+            )
+            .map_err(|error| format!("Failed to read project: {error}"))?
+            .ok_or_else(|| "Project disappeared after upsert".to_string())
+        })
+        .await
+        .map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn get_board_project(&self, slug: &str) -> Result<Option<BoardProject>, String> {
+        let conn = self.conn.clone();
+        let slug = slug.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            parse_board_project(&conn, &slug).map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn create_task_attempt(&self, attempt: TaskAttempt) -> Result<TaskAttempt, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO task_attempts (id, task_id, attempt_number, mission_id, backend, model, role, \
+                 run_id, commit_sha, changed_files, verification_evidence, cost_cents, terminal_class, started_at, finished_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15) \
+                 ON CONFLICT(task_id, attempt_number) DO NOTHING",
+                params![
+                    attempt.id.to_string(), attempt.task_id.to_string(), attempt.attempt_number as i64,
+                    attempt.mission_id.to_string(), attempt.backend, attempt.model,
+                    attempt.role.to_string(), attempt.run_id.map(|id| id.to_string()), attempt.commit_sha,
+                    serde_json::to_string(&attempt.changed_files).unwrap_or_else(|_| "[]".into()),
+                    attempt.verification_evidence.to_string(), attempt.cost_cents,
+                    attempt.terminal_class, attempt.started_at, attempt.finished_at,
+                ],
+            ).map_err(|error| format!("Failed to create task attempt: {error}"))?;
+            conn.query_row(
+                "SELECT id, task_id, attempt_number, mission_id, backend, model, role, run_id, commit_sha, \
+                 changed_files, verification_evidence, cost_cents, terminal_class, started_at, finished_at \
+                 FROM task_attempts WHERE task_id = ?1 AND attempt_number = ?2",
+                params![attempt.task_id.to_string(), attempt.attempt_number as i64],
+                parse_task_attempt_row,
+            ).map_err(|error| format!("Failed to read task attempt: {error}"))
+        }).await.map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn finish_task_attempt(
+        &self,
+        task_id: Uuid,
+        attempt_number: u32,
+        terminal_class: &str,
+        commit_sha: Option<&str>,
+        changed_files: &[String],
+        verification_evidence: &serde_json::Value,
+        cost_cents: Option<i64>,
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let terminal_class = terminal_class.to_string();
+        let commit_sha = commit_sha.map(str::to_string);
+        let changed_files = serde_json::to_string(changed_files).map_err(|e| e.to_string())?;
+        let verification_evidence = verification_evidence.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let updated = conn.execute(
+                "UPDATE task_attempts SET terminal_class = ?1, commit_sha = ?2, changed_files = ?3, \
+                 verification_evidence = ?4, cost_cents = ?5, finished_at = ?6 \
+                 WHERE task_id = ?7 AND attempt_number = ?8",
+                params![terminal_class, commit_sha, changed_files, verification_evidence, cost_cents,
+                    now_string(), task_id.to_string(), attempt_number as i64],
+            ).map_err(|error| format!("Failed to finish task attempt: {error}"))?;
+            (updated > 0).then_some(()).ok_or_else(|| "Task attempt not found".to_string())
+        }).await.map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn list_task_attempts(&self, task_id: Uuid) -> Result<Vec<TaskAttempt>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut statement = conn.prepare(
+                "SELECT id, task_id, attempt_number, mission_id, backend, model, role, run_id, commit_sha, \
+                 changed_files, verification_evidence, cost_cents, terminal_class, started_at, finished_at \
+                 FROM task_attempts WHERE task_id = ?1 ORDER BY attempt_number"
+            ).map_err(|error| error.to_string())?;
+            let rows = statement.query_map(params![task_id.to_string()], parse_task_attempt_row)
+                .map_err(|error| error.to_string())?
+                .collect::<Result<Vec<_>, _>>().map_err(|error| error.to_string())?;
+            Ok(rows)
+        }).await.map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn enqueue_board_outbox(&self, item: BoardOutboxItem) -> Result<BoardOutboxItem, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO board_outbox (id, boss_mission_id, task_id, delivery_kind, idempotency_key, \
+                 payload, state, attempts, created_at, acknowledged_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10) ON CONFLICT(idempotency_key) DO NOTHING",
+                params![item.id.to_string(), item.boss_mission_id.to_string(), item.task_id.map(|id| id.to_string()),
+                    item.delivery_kind, item.idempotency_key, item.payload.to_string(), item.state,
+                    item.attempts as i64, item.created_at, item.acknowledged_at],
+            ).map_err(|error| format!("Failed to enqueue board delivery: {error}"))?;
+            conn.query_row(
+                "SELECT id, boss_mission_id, task_id, delivery_kind, idempotency_key, payload, state, attempts, \
+                 created_at, acknowledged_at FROM board_outbox WHERE idempotency_key = ?1",
+                params![item.idempotency_key], parse_board_outbox_row,
+            ).map_err(|error| format!("Failed to read board delivery: {error}"))
+        }).await.map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn acknowledge_board_outbox(&self, idempotency_key: &str) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let key = idempotency_key.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "UPDATE board_outbox SET state = 'acknowledged', acknowledged_at = ?1 WHERE idempotency_key = ?2",
+                params![now_string(), key],
+            ).map(|_| ()).map_err(|error| error.to_string())
+        }).await.map_err(|error| format!("Task join error: {error}"))?
+    }
+
+    async fn list_pending_board_outbox(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<BoardOutboxItem>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            let mut statement = conn.prepare(
+                "SELECT id, boss_mission_id, task_id, delivery_kind, idempotency_key, payload, state, attempts, \
+                 created_at, acknowledged_at FROM board_outbox WHERE state != 'acknowledged' ORDER BY created_at LIMIT ?1"
+            ).map_err(|error| error.to_string())?;
+            let rows = statement.query_map(params![limit.min(1000) as i64], parse_board_outbox_row)
+                .map_err(|error| error.to_string())?
+                .collect::<Result<Vec<_>, _>>().map_err(|error| error.to_string())?;
+            Ok(rows)
+        }).await.map_err(|error| format!("Task join error: {error}"))?
+    }
 }
 
 /// Column list shared by every board task SELECT so `parse_board_task_row`
 /// indices stay in sync.
 const BOARD_TASK_COLUMNS: &str = "id, boss_mission_id, task_key, title, prompt, backend, \
-    model_override, model_effort, working_directory, repository, branch, depends_on, status, outcome, \
-    worker_mission_id, prior_worker_mission_id, prior_outcome, prior_result_digest, attempts, \
-    result_digest, notes, created_at, updated_at";
+    model_override, model_effort, working_directory, repository, branch, role, acceptance_criteria, \
+    verification_command, design_domain, declared_write_set, risk_class, token_budget, cost_budget_cents, \
+    depends_on, status, outcome, worker_mission_id, prior_worker_mission_id, prior_outcome, \
+    prior_result_digest, attempts, result_digest, notes, created_at, updated_at";
 
 fn parse_board_task_row(row: &rusqlite::Row<'_>) -> Result<BoardTask, rusqlite::Error> {
     let id: String = row.get(0)?;
     let boss_mission_id: String = row.get(1)?;
-    let depends_on_json: String = row.get(11)?;
-    let status_str: String = row.get(12)?;
-    let outcome_str: Option<String> = row.get(13)?;
-    let worker_mission_id: Option<String> = row.get(14)?;
-    let prior_worker_mission_id: Option<String> = row.get(15)?;
-    let prior_outcome: Option<String> = row.get(16)?;
-    let attempts: i64 = row.get(18)?;
+    let acceptance_criteria: String = row.get(12)?;
+    let declared_write_set: String = row.get(15)?;
+    let token_budget: Option<i64> = row.get(17)?;
+    let depends_on_json: String = row.get(19)?;
+    let status_str: String = row.get(20)?;
+    let outcome_str: Option<String> = row.get(21)?;
+    let worker_mission_id: Option<String> = row.get(22)?;
+    let prior_worker_mission_id: Option<String> = row.get(23)?;
+    let prior_outcome: Option<String> = row.get(24)?;
+    let attempts: i64 = row.get(26)?;
     Ok(BoardTask {
         id: Uuid::parse_str(&id)
             .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
@@ -10286,18 +10937,103 @@ fn parse_board_task_row(row: &rusqlite::Row<'_>) -> Result<BoardTask, rusqlite::
         working_directory: row.get(8)?,
         repository: row.get(9)?,
         branch: row.get(10)?,
+        role: BoardTaskRole::parse(&row.get::<_, String>(11)?),
+        acceptance_criteria: serde_json::from_str(&acceptance_criteria).unwrap_or_default(),
+        verification_command: row.get(13)?,
+        design_domain: row.get(14)?,
+        declared_write_set: serde_json::from_str(&declared_write_set).unwrap_or_default(),
+        risk_class: row.get(16)?,
+        token_budget: token_budget.map(|value| value.max(0) as u64),
+        cost_budget_cents: row.get(18)?,
         depends_on: serde_json::from_str(&depends_on_json).unwrap_or_default(),
         status: BoardTaskStatus::parse(&status_str).unwrap_or(BoardTaskStatus::Pending),
         outcome: outcome_str.as_deref().and_then(BoardTaskOutcome::parse),
         worker_mission_id: worker_mission_id.and_then(|s| Uuid::parse_str(&s).ok()),
         prior_worker_mission_id: prior_worker_mission_id.and_then(|s| Uuid::parse_str(&s).ok()),
         prior_outcome: prior_outcome.as_deref().and_then(BoardTaskOutcome::parse),
-        prior_result_digest: row.get(17)?,
+        prior_result_digest: row.get(25)?,
         attempts: attempts as u32,
-        result_digest: row.get(19)?,
-        notes: row.get(20)?,
-        created_at: row.get(21)?,
-        updated_at: row.get(22)?,
+        result_digest: row.get(27)?,
+        notes: row.get(28)?,
+        created_at: row.get(29)?,
+        updated_at: row.get(30)?,
+    })
+}
+
+fn parse_board_project(
+    conn: &Connection,
+    slug: &str,
+) -> Result<Option<BoardProject>, rusqlite::Error> {
+    conn.query_row(
+        "SELECT slug, repository, workspace_id, specification_path, specification_revision, \
+         compute_policy, budget_policy, active_controller_lease, created_at, updated_at \
+         FROM board_projects WHERE slug = ?1",
+        params![slug],
+        |row| {
+            let workspace_id: String = row.get(2)?;
+            let budget_policy: String = row.get(6)?;
+            Ok(BoardProject {
+                slug: row.get(0)?,
+                repository: row.get(1)?,
+                workspace_id: Uuid::parse_str(&workspace_id).unwrap_or_default(),
+                specification_path: row.get(3)?,
+                specification_revision: row.get(4)?,
+                compute_policy: row.get(5)?,
+                budget_policy: serde_json::from_str(&budget_policy).unwrap_or_default(),
+                active_controller_lease: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+            })
+        },
+    )
+    .optional()
+}
+
+fn parse_task_attempt_row(row: &rusqlite::Row<'_>) -> Result<TaskAttempt, rusqlite::Error> {
+    let id: String = row.get(0)?;
+    let task_id: String = row.get(1)?;
+    let attempt_number: i64 = row.get(2)?;
+    let mission_id: String = row.get(3)?;
+    let role: String = row.get(6)?;
+    let run_id: Option<String> = row.get(7)?;
+    let changed_files: String = row.get(9)?;
+    let evidence: String = row.get(10)?;
+    Ok(TaskAttempt {
+        id: Uuid::parse_str(&id).unwrap_or_default(),
+        task_id: Uuid::parse_str(&task_id).unwrap_or_default(),
+        attempt_number: attempt_number.max(0) as u32,
+        mission_id: Uuid::parse_str(&mission_id).unwrap_or_default(),
+        backend: row.get(4)?,
+        model: row.get(5)?,
+        role: BoardTaskRole::parse(&role),
+        run_id: run_id.and_then(|value| Uuid::parse_str(&value).ok()),
+        commit_sha: row.get(8)?,
+        changed_files: serde_json::from_str(&changed_files).unwrap_or_default(),
+        verification_evidence: serde_json::from_str(&evidence).unwrap_or_default(),
+        cost_cents: row.get(11)?,
+        terminal_class: row.get(12)?,
+        started_at: row.get(13)?,
+        finished_at: row.get(14)?,
+    })
+}
+
+fn parse_board_outbox_row(row: &rusqlite::Row<'_>) -> Result<BoardOutboxItem, rusqlite::Error> {
+    let id: String = row.get(0)?;
+    let boss_mission_id: String = row.get(1)?;
+    let task_id: Option<String> = row.get(2)?;
+    let payload: String = row.get(5)?;
+    let attempts: i64 = row.get(7)?;
+    Ok(BoardOutboxItem {
+        id: Uuid::parse_str(&id).unwrap_or_default(),
+        boss_mission_id: Uuid::parse_str(&boss_mission_id).unwrap_or_default(),
+        task_id: task_id.and_then(|value| Uuid::parse_str(&value).ok()),
+        delivery_kind: row.get(3)?,
+        idempotency_key: row.get(4)?,
+        payload: serde_json::from_str(&payload).unwrap_or_default(),
+        state: row.get(6)?,
+        attempts: attempts.max(0) as u32,
+        created_at: row.get(8)?,
+        acknowledged_at: row.get(9)?,
     })
 }
 
@@ -10832,9 +11568,10 @@ mod tests {
     use crate::api::control::AgentEvent;
     use crate::api::mission_store::{
         now_string, Automation, AutomationDriver, AwaitingKind, CommandSource, FreshSession,
-        MissionMode, MissionProjectPatch, MissionStatus, MissionStore, PalomaCooldownState,
-        PalomaDecision, PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig,
-        StopPolicy, TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramConversation,
+        MissionExecutionState, MissionMode, MissionProjectPatch, MissionStatus, MissionStore,
+        MissionToolExecution, MissionToolExecutionState, PalomaCooldownState, PalomaDecision,
+        PalomaMissionCard, PalomaSchedulerJob, PalomaUserPreferences, RetryConfig, StopPolicy,
+        TelegramAlert, TelegramAlertPreference, TelegramChannel, TelegramConversation,
         TelegramConversationMessage, TelegramConversationMessageDirection,
         TelegramMissionInterestLevel, TelegramMissionSubscription, TelegramStructuredMemoryEntry,
         TelegramStructuredMemoryKind, TelegramStructuredMemoryScope, TelegramTriggerMode,
@@ -14713,7 +15450,9 @@ mod tests {
 
     #[tokio::test]
     async fn board_tasks_roundtrip() {
-        use crate::api::mission_store::{BoardTaskOutcome, BoardTaskStatus, NewBoardTask};
+        use crate::api::mission_store::{
+            BoardTaskOutcome, BoardTaskRole, BoardTaskStatus, NewBoardTask,
+        };
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
             .await
@@ -14734,7 +15473,16 @@ mod tests {
             working_directory: Some("/workspaces/x/wt-1".to_string()),
             repository: Some("Th0rgal/sandboxed.sh".to_string()),
             branch: Some("agent/test".to_string()),
+            role: BoardTaskRole::Reviewer,
+            acceptance_criteria: vec!["tests pass".into()],
+            verification_command: Some("cargo test".into()),
+            design_domain: Some("mission-store".into()),
+            declared_write_set: vec!["src/api/mission_store".into()],
+            risk_class: "high".into(),
+            token_budget: Some(10_000),
+            cost_budget_cents: Some(250),
             depends_on: deps.into_iter().map(String::from).collect(),
+            ..Default::default()
         };
 
         let tasks = store
@@ -14746,6 +15494,10 @@ mod tests {
         assert_eq!(tasks[1].depends_on, vec!["t1".to_string()]);
         assert_eq!(tasks[0].repository.as_deref(), Some("Th0rgal/sandboxed.sh"));
         assert_eq!(tasks[0].branch.as_deref(), Some("agent/test"));
+        assert_eq!(tasks[0].role, BoardTaskRole::Reviewer);
+        assert_eq!(tasks[0].acceptance_criteria, vec!["tests pass"]);
+        assert_eq!(tasks[0].declared_write_set, vec!["src/api/mission_store"]);
+        assert_eq!(tasks[0].token_budget, Some(10_000));
 
         // Active boards includes our boss.
         let active = store.list_active_board_missions().await.expect("active");
@@ -14799,6 +15551,129 @@ mod tests {
             .expect("get")
             .expect("some");
         assert_eq!(fetched.task_key, "t2");
+    }
+
+    #[tokio::test]
+    async fn project_attempt_and_outbox_ledgers_are_idempotent() {
+        use crate::api::mission_store::{
+            BoardOutboxItem, BoardProject, BoardTaskRole, NewBoardTask, TaskAttempt,
+        };
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "test-user")
+            .await
+            .expect("store");
+        let boss = store
+            .create_mission(Some("boss"), None, None, None, None, None, None)
+            .await
+            .expect("boss");
+        let task = store
+            .upsert_board_tasks(
+                boss.id,
+                vec![NewBoardTask {
+                    task_key: "worker".into(),
+                    title: "worker".into(),
+                    prompt: "implement".into(),
+                    ..Default::default()
+                }],
+            )
+            .await
+            .expect("task")
+            .remove(0);
+
+        let project = BoardProject {
+            slug: "beal".into(),
+            repository: "owner/beal".into(),
+            workspace_id: boss.workspace_id,
+            specification_path: "SPEC.md".into(),
+            specification_revision: "abc123".into(),
+            compute_policy: "remote_required".into(),
+            budget_policy: serde_json::json!({"cost_cents": 500}),
+            active_controller_lease: Some("controller-1".into()),
+            created_at: now_string(),
+            updated_at: now_string(),
+        };
+        store.upsert_board_project(project).await.expect("project");
+        assert_eq!(
+            store
+                .get_board_project("beal")
+                .await
+                .unwrap()
+                .unwrap()
+                .compute_policy,
+            "remote_required"
+        );
+
+        let attempt = TaskAttempt {
+            id: Uuid::new_v4(),
+            task_id: task.id,
+            attempt_number: 1,
+            mission_id: Uuid::new_v4(),
+            backend: "codex".into(),
+            model: Some("gpt-5.6-terra".into()),
+            role: BoardTaskRole::Worker,
+            run_id: None,
+            commit_sha: None,
+            changed_files: vec![],
+            verification_evidence: serde_json::json!({}),
+            cost_cents: None,
+            terminal_class: None,
+            started_at: now_string(),
+            finished_at: None,
+        };
+        store
+            .create_task_attempt(attempt.clone())
+            .await
+            .expect("attempt");
+        store
+            .create_task_attempt(attempt)
+            .await
+            .expect("idempotent attempt");
+        store
+            .finish_task_attempt(
+                task.id,
+                1,
+                "success",
+                Some("deadbeef"),
+                &["src/lib.rs".into()],
+                &serde_json::json!({"command": "cargo test", "passed": true}),
+                Some(42),
+            )
+            .await
+            .expect("finish");
+        let attempts = store.list_task_attempts(task.id).await.expect("attempts");
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].commit_sha.as_deref(), Some("deadbeef"));
+
+        let delivery = BoardOutboxItem {
+            id: Uuid::new_v4(),
+            boss_mission_id: boss.id,
+            task_id: Some(task.id),
+            delivery_kind: "spawn".into(),
+            idempotency_key: "beal:worker:1:spawn".into(),
+            payload: serde_json::json!({"mission_id": attempts[0].mission_id}),
+            state: "pending".into(),
+            attempts: 0,
+            created_at: now_string(),
+            acknowledged_at: None,
+        };
+        store
+            .enqueue_board_outbox(delivery.clone())
+            .await
+            .expect("enqueue");
+        store
+            .enqueue_board_outbox(delivery)
+            .await
+            .expect("idempotent enqueue");
+        assert_eq!(store.list_pending_board_outbox(10).await.unwrap().len(), 1);
+        store
+            .acknowledge_board_outbox("beal:worker:1:spawn")
+            .await
+            .unwrap();
+        assert!(store
+            .list_pending_board_outbox(10)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     /// FLEET-001: deferred goals round-trip and the scheduled-pending query
@@ -14929,5 +15804,133 @@ mod tests {
                 .as_deref(),
             Some("Fix, commit and push the original PR")
         );
+    }
+
+    #[tokio::test]
+    async fn mission_run_generations_exclude_ack_and_ignore_late_updates() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "run-test")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("leased"), None, None, None, None, None, None)
+            .await
+            .expect("mission");
+        store
+            .update_mission_status(mission.id, MissionStatus::AwaitingUser)
+            .await
+            .unwrap();
+
+        let first = store
+            .begin_mission_run(mission.id, "actor-a", Some("mission-a.scope"))
+            .await
+            .expect("first generation");
+        assert_eq!(first.generation, 1);
+        assert!(store
+            .begin_mission_run(mission.id, "actor-b", None)
+            .await
+            .unwrap_err()
+            .contains("already has non-terminal run"));
+        assert!(store
+            .update_mission_status(mission.id, MissionStatus::Acknowledged)
+            .await
+            .unwrap_err()
+            .contains("cannot be acknowledged"));
+
+        assert!(store
+            .finish_mission_run(first.run_id, first.generation, Some("settled"))
+            .await
+            .unwrap());
+        store
+            .update_mission_status(mission.id, MissionStatus::Acknowledged)
+            .await
+            .unwrap();
+        assert!(store
+            .begin_mission_run(mission.id, "actor-b", None)
+            .await
+            .unwrap_err()
+            .contains("acknowledged mission"));
+        store
+            .update_mission_status(mission.id, MissionStatus::Interrupted)
+            .await
+            .unwrap();
+        let second = store
+            .begin_mission_run(mission.id, "actor-b", None)
+            .await
+            .expect("second generation");
+        assert_eq!(second.generation, 2);
+        assert!(!store
+            .heartbeat_mission_run(
+                first.run_id,
+                first.generation,
+                MissionExecutionState::Running,
+                None,
+            )
+            .await
+            .unwrap());
+        assert_eq!(
+            store
+                .get_active_mission_run(mission.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .run_id,
+            second.run_id
+        );
+    }
+
+    #[tokio::test]
+    async fn registered_tool_execution_is_scoped_to_its_run() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = SqliteMissionStore::new(temp_dir.path().to_path_buf(), "tool-test")
+            .await
+            .expect("sqlite store");
+        let mission = store
+            .create_mission(Some("tool"), None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let run = store
+            .begin_mission_run(mission.id, "actor", None)
+            .await
+            .unwrap();
+        let now = chrono::Utc::now();
+        let tool = MissionToolExecution {
+            tool_call_id: "call-1".to_string(),
+            run_id: run.run_id,
+            tool_kind: "Bash".to_string(),
+            state: MissionToolExecutionState::Provisional,
+            started_at: now.to_rfc3339(),
+            heartbeat_at: now.to_rfc3339(),
+            deadline_at: (now + chrono::Duration::seconds(120)).to_rfc3339(),
+            process_pid: None,
+            durable_job_id: None,
+            completed_at: None,
+            exit_status: None,
+            failure_class: None,
+        };
+        store.register_tool_execution(&tool).await.unwrap();
+        assert_eq!(
+            store
+                .list_active_tool_executions(run.run_id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(store
+            .finish_tool_execution(
+                run.run_id,
+                "call-1",
+                MissionToolExecutionState::Completed,
+                Some(0),
+                None,
+            )
+            .await
+            .unwrap());
+        assert!(store
+            .list_active_tool_executions(run.run_id)
+            .await
+            .unwrap()
+            .is_empty());
     }
 }

--- a/src/api/mission_store/sqlite.rs
+++ b/src/api/mission_store/sqlite.rs
@@ -15482,7 +15482,6 @@ mod tests {
             token_budget: Some(10_000),
             cost_budget_cents: Some(250),
             depends_on: deps.into_iter().map(String::from).collect(),
-            ..Default::default()
         };
 
         let tasks = store

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -703,12 +703,12 @@ mod tests {
     }
 
     #[test]
-    fn inactivity_watchdog_preserves_live_tool_past_threshold() {
-        assert!(!inactivity_is_cancellable(STUCK_SECONDS * 2, true));
+    fn inactivity_watchdog_requires_registered_liveness_past_threshold() {
+        assert!(inactivity_is_cancellable(STUCK_SECONDS * 2, true));
     }
 
     #[test]
     fn inactivity_watchdog_eventually_cancels_stale_tool_hint() {
-        assert!(inactivity_is_cancellable(TOOL_CALL_STALL_GRACE_SECS, true));
+        assert!(inactivity_is_cancellable(STUCK_SECONDS, true));
     }
 }

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -161,10 +161,12 @@ pub struct WorkspaceResponse {
     pub mcps_replace_defaults: bool,
     pub config_profile: Option<String>,
     pub config: serde_json::Value,
+    pub compute_policy: workspace::ComputePolicy,
 }
 
 impl From<Workspace> for WorkspaceResponse {
     fn from(w: Workspace) -> Self {
+        let compute_policy = w.compute_policy();
         Self {
             id: w.id,
             name: w.name,
@@ -186,6 +188,7 @@ impl From<Workspace> for WorkspaceResponse {
             mcps_replace_defaults: w.mcps_replace_defaults,
             config_profile: w.config_profile,
             config: w.config,
+            compute_policy,
         }
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -1,8 +1,9 @@
 //! MCP server for a standalone Hermes assistant.
 //!
 //! This is intentionally narrower than `orchestrator-mcp`: it exposes the
-//! control-plane tools a personal assistant needs without deployment or
-//! durable-job capabilities.
+//! control-plane tools a personal assistant needs without deployment access.
+//! Long workspace commands are exposed as durable jobs so the gateway never
+//! has to hold a synchronous MCP request open for a build.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
@@ -200,6 +201,95 @@ struct WorkspaceBashParams {
     cwd: Option<String>,
     #[serde(default)]
     timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StartWorkspaceJobParams {
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    argv: Option<Vec<String>>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    mission_id: String,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    #[serde(default)]
+    resource_class: Option<String>,
+    idempotency_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceJobParams {
+    job_id: String,
+    #[serde(default = "default_job_tail_bytes")]
+    tail_bytes: usize,
+}
+
+fn default_job_tail_bytes() -> usize {
+    16 * 1024
+}
+
+fn shell_quote_arg(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn workspace_job_command(
+    command: Option<String>,
+    argv: Option<Vec<String>>,
+) -> Result<String, String> {
+    match (command, argv) {
+        (Some(command), None) if !command.trim().is_empty() => Ok(command),
+        (None, Some(argv)) if !argv.is_empty() => Ok(argv
+            .iter()
+            .map(|arg| shell_quote_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ")),
+        (Some(_), Some(_)) => Err("Pass exactly one of command or argv, not both".to_string()),
+        _ => Err("Pass a non-empty command or argv".to_string()),
+    }
+}
+
+fn is_heavy_workspace_command(command: &str) -> bool {
+    let normalized = command
+        .split_whitespace()
+        .map(|part| part.to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+    [
+        "lake build",
+        "lake test",
+        "cargo build --release",
+        "cargo test --all",
+        "npm run build",
+        "bun run build",
+        "next build",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn compact_workspace_job(job: Value) -> Value {
+    json!({
+        "id": job.get("id").cloned().unwrap_or(Value::Null),
+        "status": job.get("status").cloned().unwrap_or(Value::Null),
+        "heartbeat_at": job.get("heartbeat_at").cloned().unwrap_or(Value::Null),
+        "deadline_at": job.get("deadline_at").cloned().unwrap_or(Value::Null),
+        "scope_unit": job.get("scope_unit").cloned().unwrap_or(Value::Null),
+        "pid": job.get("pid").cloned().unwrap_or(Value::Null),
+        "exit_code": job.get("exit_code").cloned().unwrap_or(Value::Null),
+        "signal": job.get("signal").cloned().unwrap_or(Value::Null),
+        "workspace_id": job.get("workspace_id").cloned().unwrap_or(Value::Null),
+        "mission_id": job.get("started_by_mission_id").cloned().unwrap_or(Value::Null),
+        "resource_class": job.get("resource_class").cloned().unwrap_or(Value::Null),
+        "created_at": job.get("created_at").cloned().unwrap_or(Value::Null),
+        "updated_at": job.get("updated_at").cloned().unwrap_or(Value::Null),
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -647,7 +737,10 @@ impl AssistantMcp {
             api_url,
             api_token,
             jwt_secret,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
         }
     }
 
@@ -1057,7 +1150,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "workspace_bash".to_string(),
-                description: "Run a bash command inside a sandboxed.sh workspace — the same context missions run in, with the workspace's configured environment variables and (when a GitHub account is connected in the dashboard) GitHub git credentials wired in for `git push`. Prefer this over local bash for git operations and anything needing workspace secrets.".to_string(),
+                description: "Run a short diagnostic command inside a sandboxed.sh workspace. Defaults to 60 seconds and never exceeds 120 seconds. Heavy commands such as `lake build` are rejected; use start_workspace_job for long work.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["command"],
@@ -1065,8 +1158,47 @@ impl AssistantMcp {
                         "command": {"type": "string", "description": "Shell command to run in the workspace."},
                         "workspace_id": {"type": "string", "description": "Workspace UUID. Defaults to the assistant's default workspace."},
                         "cwd": {"type": "string", "description": "Working directory relative to the workspace root."},
-                        "timeout_secs": {"type": "integer", "description": "Timeout in seconds, default 300, max 600."}
+                        "timeout_secs": {"type": "integer", "description": "Timeout in seconds, default 60, max 120."}
                     }
+                }),
+            },
+            ToolDefinition {
+                name: "start_workspace_job".to_string(),
+                description: "Start a restart-safe long-running command in a workspace and return immediately with a durable job id. Supply exactly one of command or argv. Retries must reuse the same idempotency_key; a reused key cannot submit duplicate work.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["mission_id", "idempotency_key"],
+                    "properties": {
+                        "command": {"type": "string", "description": "Shell command. Mutually exclusive with argv."},
+                        "argv": {"type": "array", "items": {"type": "string"}, "description": "Argument vector, safely shell-quoted. Mutually exclusive with command."},
+                        "workspace_id": {"type": "string", "description": "Workspace UUID. Defaults to the assistant default workspace."},
+                        "mission_id": {"type": "string", "description": "Owning mission UUID."},
+                        "cwd": {"type": "string", "description": "Working directory relative to the workspace root."},
+                        "timeout_secs": {"type": "integer", "description": "Absolute runtime limit. Default 7200 seconds, maximum 86400."},
+                        "resource_class": {"type": "string", "description": "Scheduling hint such as lean_heavy, cpu, or io."},
+                        "idempotency_key": {"type": "string", "description": "Stable retry key for this logical submission."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "get_workspace_job".to_string(),
+                description: "Inspect a durable workspace job by id, including heartbeat, deadline, scope, exit status, and bounded stdout/stderr tails.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["job_id"],
+                    "properties": {
+                        "job_id": {"type": "string"},
+                        "tail_bytes": {"type": "integer", "description": "Maximum bytes from each log, default 16384, maximum 65536."}
+                    }
+                }),
+            },
+            ToolDefinition {
+                name: "cancel_workspace_job".to_string(),
+                description: "Idempotently request cancellation of a durable workspace job. Returns after cancellation is recorded; process teardown continues asynchronously.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "required": ["job_id"],
+                    "properties": {"job_id": {"type": "string"}}
                 }),
             },
             ToolDefinition {
@@ -1362,6 +1494,13 @@ impl AssistantMcp {
         if params.command.trim().is_empty() {
             return Err("Command is empty".to_string());
         }
+        if is_heavy_workspace_command(&params.command) {
+            return Err(serde_json::to_string(&json!({
+                "error": "heavy_command_requires_durable_job",
+                "message": "This command can outlive a synchronous Hermes MCP call. Use start_workspace_job and poll get_workspace_job.",
+                "tool": "start_workspace_job"
+            })).unwrap_or_else(|_| "heavy command requires start_workspace_job".to_string()));
+        }
         let workspace_id = resolve_default_workspace_id(params.workspace_id).ok_or_else(|| {
             "No workspace_id given and no default workspace configured \
              (HERMES_DEFAULT_WORKSPACE_ID / ASSISTANT_DEFAULT_WORKSPACE_ID)"
@@ -1374,7 +1513,7 @@ impl AssistantMcp {
                 json!({
                     "command": params.command,
                     "cwd": params.cwd,
-                    "timeout_secs": params.timeout_secs,
+                    "timeout_secs": params.timeout_secs.unwrap_or(60).clamp(1, 120),
                 }),
             )
             .await?;
@@ -1387,6 +1526,58 @@ impl AssistantMcp {
             .json()
             .await
             .map_err(|error| format!("Failed to parse exec result: {error}"))
+    }
+
+    async fn start_workspace_job(&self, params: StartWorkspaceJobParams) -> Result<Value, String> {
+        let workspace_id = resolve_default_workspace_id(params.workspace_id).ok_or_else(|| {
+            "No workspace_id given and no default workspace configured (HERMES_DEFAULT_WORKSPACE_ID / ASSISTANT_DEFAULT_WORKSPACE_ID)".to_string()
+        })?;
+        let workspace_id = parse_uuid(&workspace_id)?;
+        let mission_id = parse_uuid(&params.mission_id)?;
+        let command = workspace_job_command(params.command, params.argv)?;
+        let key = params.idempotency_key.trim();
+        if key.is_empty() {
+            return Err("idempotency_key is required".to_string());
+        }
+        let response = self
+            .api_post(
+                "/api/durable-jobs",
+                json!({
+                    "command": command,
+                    "cwd": params.cwd,
+                    "workspace_id": workspace_id,
+                    "started_by_mission_id": mission_id,
+                    "timeout_secs": params.timeout_secs.unwrap_or(7200).clamp(1, 86400),
+                    "resource_class": params.resource_class,
+                    "idempotency_key": key,
+                }),
+            )
+            .await?;
+        let job = Self::response_value(response, "Start workspace job").await?;
+        Ok(json!({"job": compact_workspace_job(job)}))
+    }
+
+    async fn get_workspace_job(&self, params: WorkspaceJobParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.job_id)?;
+        let response = self.api_get(&format!("/api/durable-jobs/{id}")).await?;
+        let job = Self::response_value(response, "Get workspace job").await?;
+        let tail_bytes = params.tail_bytes.clamp(1, 64 * 1024);
+        let response = self
+            .api_get(&format!(
+                "/api/durable-jobs/{id}/logs?tail_bytes={tail_bytes}"
+            ))
+            .await?;
+        let logs = Self::response_value(response, "Get workspace job logs").await?;
+        Ok(json!({"job": compact_workspace_job(job), "logs": logs}))
+    }
+
+    async fn cancel_workspace_job(&self, params: WorkspaceJobParams) -> Result<Value, String> {
+        let id = parse_uuid(&params.job_id)?;
+        let response = self
+            .api_post(&format!("/api/durable-jobs/{id}/cancel"), json!({}))
+            .await?;
+        let job = Self::response_value(response, "Cancel workspace job").await?;
+        Ok(json!({"job": compact_workspace_job(job), "cancellation_acknowledged": true}))
     }
 
     async fn send_message(&self, params: SendMessageParams) -> Result<Value, String> {
@@ -2095,6 +2286,21 @@ impl AssistantMcp {
                 let params: WorkspaceBashParams = serde_json::from_value(arguments)
                     .map_err(|error| format!("Invalid params: {error}"))?;
                 self.workspace_bash(params).await
+            }
+            "start_workspace_job" => {
+                let params: StartWorkspaceJobParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.start_workspace_job(params).await
+            }
+            "get_workspace_job" => {
+                let params: WorkspaceJobParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.get_workspace_job(params).await
+            }
+            "cancel_workspace_job" => {
+                let params: WorkspaceJobParams = serde_json::from_value(arguments)
+                    .map_err(|error| format!("Invalid params: {error}"))?;
+                self.cancel_workspace_job(params).await
             }
             "get_mission_health" => {
                 let params: MissionHealthParams = serde_json::from_value(arguments)
@@ -3024,6 +3230,9 @@ mod tests {
             "save_workspace_template",
             "delete_workspace_template",
             "rebuild_workspace_from_template",
+            "start_workspace_job",
+            "get_workspace_job",
+            "cancel_workspace_job",
         ] {
             assert!(names.contains(&expected), "missing tool {expected}");
         }
@@ -3043,6 +3252,19 @@ mod tests {
                 .unwrap()
                 .contains(&json!("confirm")));
         }
+    }
+
+    #[test]
+    fn workspace_bash_rejects_heavy_commands_and_job_argv_is_quoted() {
+        assert!(is_heavy_workspace_command("lake build Verity"));
+        assert!(is_heavy_workspace_command("cd repo && cargo test --all"));
+        assert!(!is_heavy_workspace_command("git status --short"));
+        assert_eq!(
+            workspace_job_command(None, Some(vec!["printf".into(), "%s".into(), "a'b".into()]))
+                .unwrap(),
+            "'printf' '%s' 'a'\\''b'"
+        );
+        assert!(workspace_job_command(Some("true".into()), Some(vec!["true".into()])).is_err());
     }
 
     #[test]

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -255,12 +255,24 @@ pub fn validate_lean_build(
             ALLOWED_COMMANDS.join("/")
         ));
     }
-    // `lake env` and `elan run` are direct arbitrary-command escape hatches.
-    // Lake is therefore limited to its build operation. Repository builds are
-    // still untrusted code and must run under the dedicated, non-root node
-    // service account documented in REMOTE_NODES.md.
-    if argv0 == "lake" && command.get(1).map(String::as_str) != Some("build") {
-        return Err("lake command must use the 'build' subcommand".to_string());
+    // Lake repository operations may execute untrusted project code and must
+    // therefore run under the dedicated, non-root node service account. Keep
+    // arbitrary-command escape hatches (`lake env <anything>`, `lake exe`) out
+    // of the protocol while accepting the verification verbs routed by the
+    // mission-local shim. `lake env lean` is safe because the nested executable
+    // is fixed rather than caller-selected.
+    if argv0 == "lake" {
+        let allowed = matches!(
+            command.get(1).map(String::as_str),
+            Some("build" | "test" | "check")
+        ) || (command.get(1).map(String::as_str) == Some("env")
+            && command.get(2).map(String::as_str) == Some("lean"));
+        if !allowed {
+            return Err(
+                "lake command must use build, test, check, or the fixed 'env lean' form"
+                    .to_string(),
+            );
+        }
     }
     for key in env.keys() {
         if !allowlist.iter().any(|allowed| allowed == key) {
@@ -1491,6 +1503,23 @@ mod tests {
             ),
             Ok(())
         );
+        for command in [
+            vec!["lake", "test"],
+            vec!["lake", "check"],
+            vec!["lake", "env", "lean", "Main.lean"],
+        ] {
+            let command = command.into_iter().map(str::to_string).collect::<Vec<_>>();
+            assert_eq!(
+                validate_lean_build(
+                    &source(&"a".repeat(40)),
+                    Some("morpho-verity"),
+                    &command,
+                    &env,
+                    &allowlist(),
+                ),
+                Ok(())
+            );
+        }
         // Path-form argv[0] is rejected even when the basename is allowed:
         // `./lake` or an absolute path would execute an arbitrary file from
         // the checkout / node fs instead of the PATH-resolved tool.
@@ -1677,6 +1706,7 @@ mod tests {
     fn validation_rejects_command_execution_subcommands() {
         for command in [
             vec!["lake", "env", "bash"],
+            vec!["lake", "env", "lake", "build"],
             vec!["lake", "exe", "tool"],
             vec!["elan", "run", "stable", "bash"],
         ] {

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1133,6 +1133,10 @@ pub async fn execute_lean_build(
     // executed from a repository.
     let mut cmd = tokio::process::Command::new(&command[0]);
     cmd.env_clear().args(&command[1..]).current_dir(&build_cwd);
+    // A node may also have the mission lake shim installed in /usr/local/bin.
+    // This marker makes the shim execute the real Lake binary instead of
+    // recursively dispatching another remote build.
+    cmd.env("SANDBOXED_REMOTE_EXECUTION", "1");
     for (key, value) in cache_env(work_root) {
         cmd.env(key, value);
     }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3928,6 +3928,42 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn nested_lake_build_is_normalized_without_duplicating_argv() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let real_lake = root.path().join("real-lake");
+        let remote_build = root.path().join("remote-lean-build");
+        std::fs::write(&real_lake, b"#!/bin/sh\nexit 99\n").unwrap();
+        std::fs::write(&remote_build, b"#!/bin/sh\nprintf '<%s>\\n' \"$@\"\n").unwrap();
+        for path in [&real_lake, &remote_build] {
+            let mut permissions = std::fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(path, permissions).unwrap();
+        }
+
+        let output = std::process::Command::new("/bin/sh")
+            .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/lake"))
+            .args(["env", "lake", "build", "Target"])
+            .env("SANDBOXED_REAL_LAKE", &real_lake)
+            .env("SANDBOXED_COMPUTE_POLICY", "remote_required")
+            .env("PATH", root.path())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            "<lake>\n<build>\n<Target>\n"
+        );
+    }
+
     #[test]
     fn compute_policy_defaults_fail_closed_for_beal_and_verity() {
         let root = tempfile::tempdir().unwrap();

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -377,11 +377,11 @@ impl Workspace {
 
     /// Env vars that let the in-workspace `remote-lean-build` wrapper dispatch
     /// a build for `mission_id` to a remote runner node via the host
-    /// `POST /api/remote-build` endpoint — or `None` when neither remote
-    /// nodes nor spark offload are enabled, or no signing secret is
-    /// available. Mirrors [`Self::spark_offload_env`]: the exposed token is a
-    /// per-mission, scope-bound capability token (domain-separated from the
-    /// spark token), never a node bearer token or the dashboard JWT.
+    /// `POST /api/remote-build` endpoint. The compute policy is always
+    /// returned so the Lake shim still fails closed when dispatch credentials
+    /// are unavailable. When configured, the exposed token is a per-mission,
+    /// scope-bound capability token (domain-separated from the spark token),
+    /// never a node bearer token or the dashboard JWT.
     pub fn remote_build_env(&self, mission_id: Uuid) -> Option<HashMap<String, String>> {
         let mut m = HashMap::new();
         m.insert(
@@ -2160,7 +2160,7 @@ fn remote_build_wrapper_path(workspace: &Workspace, mission_id: Uuid) -> PathBuf
     }
 }
 
-async fn install_remote_build_wrapper(
+pub(crate) async fn install_remote_build_wrapper(
     workspace: &Workspace,
     mission_id: Uuid,
 ) -> anyhow::Result<()> {
@@ -3909,6 +3909,13 @@ mod tests {
         let verity = Workspace::new_container("verity".into(), root.path().join("container"));
         assert_eq!(beal.compute_policy(), ComputePolicy::RemoteRequired);
         assert_eq!(verity.compute_policy(), ComputePolicy::RemoteRequired);
+        assert_eq!(
+            beal.remote_build_env(Uuid::new_v4())
+                .unwrap()
+                .get("SANDBOXED_COMPUTE_POLICY")
+                .map(String::as_str),
+            Some("remote_required")
+        );
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -161,6 +161,24 @@ pub fn default_true() -> bool {
     true
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputePolicy {
+    LocalAllowed,
+    RemotePreferred,
+    RemoteRequired,
+}
+
+impl ComputePolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalAllowed => "local_allowed",
+            Self::RemotePreferred => "remote_preferred",
+            Self::RemoteRequired => "remote_required",
+        }
+    }
+}
+
 /// A workspace definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Workspace {
@@ -239,6 +257,41 @@ pub struct Workspace {
 }
 
 impl Workspace {
+    /// Compute placement policy for heavy Lean work. An explicit config value
+    /// wins; Beal and Verity fail closed remotely by default, other Lean
+    /// workspaces prefer remote capacity, and non-Lean work stays local.
+    pub fn compute_policy(&self) -> ComputePolicy {
+        let configured = self
+            .config
+            .get("compute_policy")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                self.config
+                    .get("remote_build")
+                    .and_then(|value| value.get("compute_policy"))
+                    .and_then(|value| value.as_str())
+            });
+        if let Some(policy) = configured {
+            return match policy {
+                "remote_required" => ComputePolicy::RemoteRequired,
+                "remote_preferred" => ComputePolicy::RemotePreferred,
+                _ => ComputePolicy::LocalAllowed,
+            };
+        }
+        let identity = format!("{} {}", self.name, self.path.display()).to_ascii_lowercase();
+        if identity.contains("beal") || identity.contains("verity") {
+            return ComputePolicy::RemoteRequired;
+        }
+        let lean_workspace = self.template.as_deref() == Some("lean")
+            || self.skills.iter().any(|skill| skill == "lean")
+            || self.config.get("remote_build").is_some();
+        if lean_workspace {
+            ComputePolicy::RemotePreferred
+        } else {
+            ComputePolicy::LocalAllowed
+        }
+    }
+
     /// True when this workspace runs in its own network namespace — a
     /// container with `shared_network = false` and Tailscale veth networking
     /// (the only path that passes `--network-veth` to systemd-nspawn).
@@ -322,14 +375,6 @@ impl Workspace {
         Some(m)
     }
 
-    /// Whether remote runner nodes are configured for this deployment
-    /// (`SANDBOXED_REMOTE_NODES_ENABLED` + a non-empty node list).
-    fn remote_nodes_enabled() -> bool {
-        crate::remote_node::RemoteNodeSettings::from_env()
-            .map(|settings| settings.enabled && !settings.nodes.is_empty())
-            .unwrap_or(false)
-    }
-
     /// Env vars that let the in-workspace `remote-lean-build` wrapper dispatch
     /// a build for `mission_id` to a remote runner node via the host
     /// `POST /api/remote-build` endpoint — or `None` when neither remote
@@ -338,30 +383,31 @@ impl Workspace {
     /// per-mission, scope-bound capability token (domain-separated from the
     /// spark token), never a node bearer token or the dashboard JWT.
     pub fn remote_build_env(&self, mission_id: Uuid) -> Option<HashMap<String, String>> {
-        // Gate on either build-offload backend being available: the endpoint
-        // itself answers 503 when remote nodes are absent, letting the
-        // wrapper fall back to a local (or spark) build.
-        if !Self::remote_nodes_enabled() && !self.spark_offload_enabled() {
-            return None;
-        }
-        let token = crate::api::remote_build::build_remote_build_token(mission_id)?;
-        let port = std::env::var("PORT")
-            .ok()
-            .filter(|s| !s.trim().is_empty())?;
         let mut m = HashMap::new();
         m.insert(
-            "REMOTE_BUILD_URL".to_string(),
-            format!(
-                "http://{}:{}/api/remote-build",
-                self.host_ip_from_workspace(),
-                port
-            ),
+            "SANDBOXED_COMPUTE_POLICY".to_string(),
+            self.compute_policy().as_str().to_string(),
         );
-        m.insert("REMOTE_BUILD_TOKEN".to_string(), token);
         m.insert(
             "REMOTE_BUILD_MISSION_ID".to_string(),
             mission_id.to_string(),
         );
+        if let (Some(token), Some(port)) = (
+            crate::api::remote_build::build_remote_build_token(mission_id),
+            std::env::var("PORT")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+        ) {
+            m.insert(
+                "REMOTE_BUILD_URL".to_string(),
+                format!(
+                    "http://{}:{}/api/remote-build",
+                    self.host_ip_from_workspace(),
+                    port
+                ),
+            );
+            m.insert("REMOTE_BUILD_TOKEN".to_string(), token);
+        }
         let remote_config = self.config.get("remote_build");
         let node_id = remote_config
             .and_then(|config| config.get("node_id"))
@@ -383,7 +429,7 @@ impl Workspace {
             .unwrap_or_else(|| vec!["lean"]);
         m.insert(
             "REMOTE_BUILD_REQUIREMENTS".to_string(),
-            serde_json::to_string(&requirements).ok()?,
+            serde_json::to_string(&requirements).unwrap_or_else(|_| "[\"lean\"]".to_string()),
         );
         if let Some(timeout) = remote_config
             .and_then(|config| config.get("timeout_secs"))
@@ -2124,13 +2170,14 @@ async fn install_remote_build_wrapper(
     // workspace opted in), and `spark-build` (the raw Spark offloader that
     // `lean-slot` shells out to). Previously `lean-slot`/`spark-build` were
     // hand-copied into container rootfs and drifted per workspace.
-    const WRAPPERS: [(&str, &[u8]); 3] = [
+    const WRAPPERS: [(&str, &[u8]); 4] = [
         (
             "remote-lean-build",
             include_bytes!("../../scripts/remote-lean-build"),
         ),
         ("lean-slot", include_bytes!("../../scripts/lean-slot")),
         ("spark-build", include_bytes!("../../scripts/spark-build")),
+        ("lake", include_bytes!("../../scripts/lake")),
     ];
     for (name, contents) in WRAPPERS {
         let destination = if workspace.workspace_type == WorkspaceType::Container
@@ -3835,6 +3882,11 @@ mod tests {
             tokio::fs::read(&path).await.unwrap(),
             include_bytes!("../../scripts/remote-lean-build")
         );
+        let lake_path = path.parent().unwrap().join("lake");
+        assert_eq!(
+            tokio::fs::read(&lake_path).await.unwrap(),
+            include_bytes!("../../scripts/lake")
+        );
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -3848,6 +3900,25 @@ mod tests {
                 0
             );
         }
+    }
+
+    #[test]
+    fn compute_policy_defaults_fail_closed_for_beal_and_verity() {
+        let root = tempfile::tempdir().unwrap();
+        let beal = Workspace::default_host(root.path().join("beal-worktree"));
+        let verity = Workspace::new_container("verity".into(), root.path().join("container"));
+        assert_eq!(beal.compute_policy(), ComputePolicy::RemoteRequired);
+        assert_eq!(verity.compute_policy(), ComputePolicy::RemoteRequired);
+    }
+
+    #[test]
+    fn compute_policy_prefers_remote_for_other_lean_and_honors_override() {
+        let root = tempfile::tempdir().unwrap();
+        let mut lean = Workspace::default_host(root.path().to_path_buf());
+        lean.template = Some("lean".into());
+        assert_eq!(lean.compute_policy(), ComputePolicy::RemotePreferred);
+        lean.config = serde_json::json!({"compute_policy": "local_allowed"});
+        assert_eq!(lean.compute_policy(), ComputePolicy::LocalAllowed);
     }
     use serde_json::json;
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2153,7 +2153,7 @@ async fn prepare_workspace_dir(path: &Path) -> anyhow::Result<PathBuf> {
 
 fn remote_build_wrapper_path(workspace: &Workspace, mission_id: Uuid) -> PathBuf {
     if workspace.workspace_type == WorkspaceType::Container && !is_container_fallback(workspace) {
-        PathBuf::from("/usr/local/bin/remote-lean-build")
+        PathBuf::from("/usr/local/lib/sandboxed-sh/bin/remote-lean-build")
     } else {
         mission_workspace_dir_for_root(&workspace.path, mission_id)
             .join(".sandboxed-sh/bin/remote-lean-build")
@@ -2183,7 +2183,10 @@ pub(crate) async fn install_remote_build_wrapper(
         let destination = if workspace.workspace_type == WorkspaceType::Container
             && !is_container_fallback(workspace)
         {
-            workspace.path.join("usr/local/bin").join(name)
+            workspace
+                .path
+                .join("usr/local/lib/sandboxed-sh/bin")
+                .join(name)
         } else {
             remote_build_wrapper_path(workspace, mission_id)
                 .parent()
@@ -3900,6 +3903,29 @@ mod tests {
                 0
             );
         }
+    }
+
+    #[tokio::test]
+    async fn container_lake_shim_does_not_overwrite_the_real_binary() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let workspace = Workspace::new_container("verity".to_string(), root.path().to_path_buf());
+        let real_lake = root.path().join("usr/local/bin/lake");
+        tokio::fs::create_dir_all(real_lake.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&real_lake, b"real lake").await.unwrap();
+
+        install_remote_build_wrapper(&workspace, mission_id)
+            .await
+            .unwrap();
+
+        assert_eq!(tokio::fs::read(&real_lake).await.unwrap(), b"real lake");
+        let shim = root.path().join("usr/local/lib/sandboxed-sh/bin/lake");
+        assert_eq!(
+            tokio::fs::read(shim).await.unwrap(),
+            include_bytes!("../../scripts/lake")
+        );
     }
 
     #[test]

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -316,6 +316,20 @@ pub fn durable_scope_unit(machine_name: &str, job_id: uuid::Uuid) -> String {
     format!("sandboxed-durable-{machine_name}-{}", job_id.simple())
 }
 
+fn durable_scope_unit_for_launch(
+    workspace_type: WorkspaceType,
+    uses_nspawn: bool,
+    caps: &MissionResourceCaps,
+    machine_name: Option<String>,
+    job_id: uuid::Uuid,
+) -> Option<String> {
+    if workspace_type == WorkspaceType::Container && uses_nspawn && !caps.is_disabled() {
+        machine_name.map(|machine| durable_scope_unit(&machine, job_id))
+    } else {
+        None
+    }
+}
+
 /// Recover the 8-hex mission short id from an exec scope unit name produced
 /// by [`exec_scope_unit`]. Parses from the END (`…-m<8hex>-<rand8>.scope`) so
 /// machine-name segments can never false-positive. Returns `None` for
@@ -601,12 +615,12 @@ mod tests {
 
     use super::{
         append_nsenter_target_root_arg, ca_env_scrub_prelude, durable_command_runs_on_api_host,
-        durable_scope_unit, environ_has_keepalive_marker, exec_scope_unit,
-        exec_scope_unit_for_mission, exec_unit_belongs_to_mission, machine_name_from_exec_unit,
-        mission_short_id_from_exec_unit, mission_tag_from_path, normalize_container_path,
-        nspawn_directory_from_cmdline, persistent_nspawn_command, replace_command_env,
-        resolv_conf_bind_args, synthesized_container_resolv_conf, WorkspaceExec, WorkspaceType,
-        CA_BUNDLE_ENV_VARS,
+        durable_scope_unit, durable_scope_unit_for_launch, environ_has_keepalive_marker,
+        exec_scope_unit, exec_scope_unit_for_mission, exec_unit_belongs_to_mission,
+        machine_name_from_exec_unit, mission_short_id_from_exec_unit, mission_tag_from_path,
+        normalize_container_path, nspawn_directory_from_cmdline, persistent_nspawn_command,
+        replace_command_env, resolv_conf_bind_args, synthesized_container_resolv_conf,
+        MissionResourceCaps, WorkspaceExec, WorkspaceType, CA_BUNDLE_ENV_VARS,
     };
     use std::collections::HashMap;
     use std::ffi::OsStr;
@@ -718,6 +732,42 @@ mod tests {
         );
         assert_eq!(mission_short_id_from_exec_unit(&unit), None);
         assert!(!unit.starts_with("sandboxed-exec-"));
+    }
+
+    #[test]
+    fn durable_scope_receipt_requires_an_actual_scope_wrapper() {
+        let id = uuid::Uuid::new_v4();
+        let machine = || Some("sandboxed-demo-deadbeef".to_string());
+        assert_eq!(
+            durable_scope_unit_for_launch(
+                WorkspaceType::Container,
+                true,
+                &MissionResourceCaps::default(),
+                machine(),
+                id,
+            ),
+            None
+        );
+        let caps = MissionResourceCaps {
+            cpu_weight: Some("100".to_string()),
+            ..Default::default()
+        };
+        assert!(durable_scope_unit_for_launch(
+            WorkspaceType::Container,
+            true,
+            &caps,
+            machine(),
+            id,
+        )
+        .is_some());
+        assert_eq!(
+            durable_scope_unit_for_launch(WorkspaceType::Host, true, &caps, machine(), id),
+            None
+        );
+        assert_eq!(
+            durable_scope_unit_for_launch(WorkspaceType::Container, false, &caps, machine(), id,),
+            None
+        );
     }
 
     #[tokio::test]
@@ -1495,6 +1545,19 @@ impl WorkspaceExec {
         mission_resource_caps_from_env(&self.workspace.env_vars)
     }
 
+    /// Exact scope receipt for a durable launch. Host/fallback execution and
+    /// uncapped container execution do not use `systemd-run`, so advertising
+    /// a scope for those paths would make healthy PIDs fail ownership checks.
+    pub fn durable_scope_unit(&self, job_id: uuid::Uuid) -> Option<String> {
+        durable_scope_unit_for_launch(
+            self.workspace.workspace_type,
+            use_nspawn_for_workspace(&self.workspace),
+            &self.mission_resource_caps(),
+            self.machine_name(),
+            job_id,
+        )
+    }
+
     /// The boot scope unit name for this workspace's container, when one can
     /// be derived. Public so the API layer (live cap adjustment, memory
     /// stats, OOM watchdog) can address the same unit this module creates.
@@ -2031,9 +2094,7 @@ impl WorkspaceExec {
             use_nspawn_for_workspace(&self.workspace),
         )
         .then(|| env.clone());
-        let scope_unit = self
-            .machine_name()
-            .map(|machine| durable_scope_unit(&machine, durable_job_id));
+        let scope_unit = self.durable_scope_unit(durable_job_id);
         let mut cmd = self
             .build_command(
                 cwd,

--- a/src/workspace_exec.rs
+++ b/src/workspace_exec.rs
@@ -120,6 +120,16 @@ fn ca_env_scrub_prelude() -> String {
     )
 }
 
+/// Re-prepend the server-installed build-policy wrapper directory after a
+/// login shell has processed its profile. Container profiles commonly put
+/// `/root/.elan/bin` first, which would otherwise bypass the `lake` shim even
+/// though the authoritative PATH was present in the process environment.
+fn compute_policy_path_prelude() -> &'static str {
+    "if [ -n \"${REMOTE_BUILD_COMMAND:-}\" ]; then \
+     __oa_policy_bin=${REMOTE_BUILD_COMMAND%/*}; \
+     PATH=$__oa_policy_bin:$PATH; export PATH; unset __oa_policy_bin; fi; "
+}
+
 fn environ_has_keepalive_marker(environ: &[u8]) -> bool {
     let expected = format!(
         "{}={}",
@@ -969,6 +979,7 @@ mod tests {
         let cmd = WorkspaceExec::build_shell_command_with_env("/w", "curl", &[], None);
         assert!(cmd.contains("SSL_CERT_FILE"));
         assert!(cmd.contains("NODE_EXTRA_CA_CERTS"));
+        assert!(cmd.contains("REMOTE_BUILD_COMMAND%/*"));
         assert!(cmd.trim_start().starts_with("for __oa_ca in"));
     }
 
@@ -1323,6 +1334,10 @@ impl WorkspaceExec {
         // HTTPS inside the container. Runs first so workspace-configured CA
         // vars re-exported below still win.
         cmd.push_str(&ca_env_scrub_prelude());
+        // `/bin/sh -lc` may replace PATH while reading the container profile.
+        // Restore only the non-secret wrapper directory here; the remaining
+        // environment stays out of the visible command line.
+        cmd.push_str(compute_policy_path_prelude());
 
         // Export env vars inside the shell command so they're available in the container.
         // Keys are validated to POSIX env var names (alphanumeric + underscore) to prevent


### PR DESCRIPTION
## Summary

- make durable mission runs the authoritative execution lease, with generations, acknowledgement guards, restart reconciliation, and registered tool liveness
- add idempotent durable workspace jobs and Hermes-facing start/inspect/cancel tools with bounded synchronous execution
- enforce remote Lean placement policy for Beal and Verity through a mission-local `lake` shim and restart-safe job receipts
- add canonical board project, attempt, and outbox persistence foundations
- add the narrow Hermes SessionDB durable-delivery patch plus isolated dev/prod configuration helpers

## Reliability invariants

- one non-terminal run per mission; late generations cannot mutate the active run
- an active run cannot be acknowledged
- unmatched tool calls protect liveness for at most 120 seconds unless backed by a managed process, user wait, or durable job
- durable workspace jobs survive MCP and Sandboxed restarts without duplicate submission
- `remote_required` Lean work fails closed instead of silently building locally
- Hermes native Kanban dispatch remains disabled

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1,403 library tests passed; all binary and doc-test suites passed)
- targeted Hermes SessionDB/gateway/cron tests in the isolated development checkout (94 passed)
- development deploy with isolated `*-dev` companion binaries
- restart/idempotency canary resumed the same durable workspace and remote Lean job IDs

## Rollout

Production promotion uses the guarded Sandboxed deploy endpoint with the expected-service check, SQLite online backups, companion binary verification, Hermes configuration backup, and post-deploy health/fleet/state checks.

This is intentionally a draft until automated review findings are resolved and the guarded production verification completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core orchestration paths (durable outbox, message idempotency, Hermes SessionDB schema and cron delivery) where bugs could duplicate work, miss wakes, or lose transcripts across restarts.
> 
> **Overview**
> This PR hardens **restart and crash recovery** on two boundaries: Hermes transcript delivery and Sandboxed task-board control messages.
> 
> **Hermes (patch + ops):** A new SessionDB patch adds `delivery_id` deduplication via `delivery_receipts`, bounded write retries with env-tunable deadlines, and a **disk spool** for cron/API session appends that fail after retries. Gateway startup replays the spool idempotently. Apply/install scripts now layer this patch alongside the existing API-session cron delivery patch; `configure_hermes_reliability.py` and an isolated **dev** systemd drop-in wire Kanban off, assistant MCP tools, and Proton disabled without touching production secrets.
> 
> **Sandboxed control plane:** Task-board worker spawns, retries, and boss wakes move from fire-and-forget `UserMessage` sends to a **persisted board outbox** with v5-derived message IDs, ack-after-queue/deliver, startup replay with stale-row retirement, and spawn/retry coalescing. `ControlCommand::ReleaseUserMessageId` clears idempotency when the actor drops or rejects a delivery. Settles now close **task attempts**; codex workers get role-based default models. `uuid` gains **v5** for stable wake revisions from board state + mission history.
> 
> **Lean placement:** New `scripts/lake` routes heavy `build` through remote dispatch per compute policy, keeps verify verbs local unless explicitly enabled, and fails closed under `remote_required` when remote capacity is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73df055db18dc933b3dfee30b112428f411cb873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->