### PR TITLE
Harden remote validation recovery and exact-head evidence

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -397,6 +397,8 @@ Request body:
   "token": "<REMOTE_BUILD_TOKEN>",
   "repo": "https://github.com/org/repo.git",
   "commit": "<40-hex sha>",
+  "expected_head": "<40-hex sha>",
+  "toolchain": "leanprover/lean4:v4.19.0",
   "cwd_rel": "verity",
   "command": ["lake", "build"],
   "timeout_secs": 3600,
@@ -410,9 +412,19 @@ Request body:
 `requirements` defaults to `["lean"]`, `node_id` to `"auto"`, `wait` to
 `true`. With `wait: true` the call polls the node every 3s (client-side cap
 2h) and returns `{exit_code, state, duration_secs, log_tail, node_id,
-job_id, artifacts}`. With `wait: false` it returns `202 {job_id, node_id}`;
-poll `GET /api/remote-build/:job_id?mission_id=...&node_id=...` with the
-capability in `Authorization: Bearer $REMOTE_BUILD_TOKEN` for the job status.
+job_id, artifacts}`. With `wait: false` it returns `202` with the job/node plus
+the credential-free immutable validation identity (repository, commit, command,
+toolchain, and source-bundle digest). Poll
+`GET /api/remote-build/:job_id?mission_id=...&node_id=...` with the capability
+in `Authorization: Bearer $REMOTE_BUILD_TOKEN` for the job status. Pass
+`expected_head=<live sha>` while polling to receive
+`receipt_state=stale_success` and `current_head_match=false` when a green job
+validated an older commit. Submission returns `409 STALE_VALIDATION_REQUEST`
+when `expected_head` already differs from `commit`.
+The core retains bounded terminal receipts in
+`.sandboxed-sh/remote-job-receipts.json`, including the credential-free
+repository, commit, command, toolchain, overlay digest, node, and job ID. This
+keeps exact-head evidence available after the active reservation is released.
 Capabilities expire after six hours by default (`REMOTE_BUILD_TOKEN_TTL_SECS`)
 and new submissions require a live mission. Placement failures and
 unconfigured/unavailable fleets
@@ -429,9 +441,10 @@ remote-lean-build lake build Verity
 ```
 
 It derives `repo` (`git remote get-url origin`), `commit`
-(`git rev-parse HEAD`) and `cwd_rel` (`git rev-parse --show-prefix`),
-refuses a dirty tree for a new submission (exit 2 — the node builds a pinned
-commit, so uncommitted changes would be silently ignored), submits asynchronously to
+(`git rev-parse HEAD`), the Lean toolchain, and `cwd_rel`
+(`git rev-parse --show-prefix`). Dirty Lean sources and build metadata are sent
+as a bounded hashed overlay; unsupported deletions/renames fail before
+submission. It submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
 persists the returned job/node receipt under
 `${XDG_STATE_HOME:-$HOME/.local/state}/sandboxed-sh/remote-builds/`, then polls
@@ -459,7 +472,10 @@ response and never falls back. It also persists a secret-free `ambiguous`
 receipt, so an identical retry cannot submit a second job before operators
 confirm reconciliation; `REMOTE_BUILD_FORCE_NEW=1` is an explicit override.
 
-Optional: `REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
+Optional: `REMOTE_BUILD_EXPECTED_HEAD` freezes an exact-head gate at
+submission and is also sent on status polls. A `stale_success` receipt exits
+non-zero even when the remote command itself exited zero.
+`REMOTE_BUILD_TIMEOUT_SECS` forwards a job timeout (clamped by the
 node's `SANDBOXED_NODE_MAX_JOB_SECS`). `REMOTE_BUILD_SUBMIT_TIMEOUT_SECS`
 controls the pre-receipt HTTP budget (default 90 seconds, long enough for a
 fresh probe plus node submission). Submit timeouts and response-side transport
@@ -467,7 +483,8 @@ failures are treated as ambiguous outcomes and never trigger local fallback;
 only failures that happen before connecting are fallback-safe. Failure to
 persist the receipt after a `202` is also fail-closed and reports the accepted
 job handle. `REMOTE_BUILD_STATE_DIR` overrides the receipt directory. Receipts
-never contain the capability token or the Git remote URL.
+never contain the capability token or repository credentials; they retain the
+credential-free repository identity needed to audit the validation.
 `REMOTE_BUILD_FORCE_NEW=1` deliberately bypasses a live matching receipt and
 should be reserved for operator-directed retries.
 

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -54,6 +54,14 @@ req = {
 repo_root = pathlib.Path(
     subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
 ).resolve()
+toolchain_path = repo_root / "lean-toolchain"
+if toolchain_path.is_file():
+    toolchain = toolchain_path.read_text(encoding="utf-8").strip()
+    if toolchain:
+        req["toolchain"] = toolchain[:256]
+expected_head = os.environ.get("REMOTE_BUILD_EXPECTED_HEAD", "").strip()
+if expected_head:
+    req["expected_head"] = expected_head
 
 def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
@@ -293,7 +301,7 @@ except (OSError, ValueError):
     raise SystemExit(0)
 job = str(receipt.get("job_id") or "")
 node = str(receipt.get("node_id") or "")
-state = str(receipt.get("state") or "")
+state = str(receipt.get("receipt_state") or receipt.get("state") or "")
 if state == "ambiguous":
     print("ambiguous", "ambiguous", state, sep="\t")
     raise SystemExit(0)
@@ -306,7 +314,7 @@ PY
         submitted|queued|running)
             echo "remote-lean-build: resuming job $job_id on node '$node_id' for ${commit:0:12} ..." >&2
             ;;
-        succeeded|failed|cancelled|lost)
+        succeeded|stale_success|failed|cancelled|lost)
             echo "remote-lean-build: replaying terminal job $job_id on node '$node_id' for ${commit:0:12} ..." >&2
             ;;
         ambiguous)
@@ -325,7 +333,19 @@ import json, os, sys, tempfile
 path, request_path, reason = sys.argv[1:]
 request = json.load(open(request_path))
 request.pop("token", None)
-request.pop("repo", None)
+repo = request.pop("repo", None)
+if repo:
+    from urllib.parse import urlsplit, urlunsplit
+    try:
+        parsed = urlsplit(repo)
+        host = parsed.hostname or ""
+        if parsed.port:
+            host += ":%d" % parsed.port
+        request["repository"] = urlunsplit(
+            (parsed.scheme, host, parsed.path, "", "")
+        ) if parsed.scheme else repo
+    except ValueError:
+        request["repository"] = repo
 request.pop("wait", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
@@ -411,7 +431,19 @@ import json, os, sys, tempfile
 path, request_path, job_id, node_id = sys.argv[1:]
 request = json.load(open(request_path))
 request.pop("token", None)
-request.pop("repo", None)
+repo = request.pop("repo", None)
+if repo:
+    from urllib.parse import urlsplit, urlunsplit
+    try:
+        parsed = urlsplit(repo)
+        host = parsed.hostname or ""
+        if parsed.port:
+            host += ":%d" % parsed.port
+        request["repository"] = urlunsplit(
+            (parsed.scheme, host, parsed.path, "", "")
+        ) if parsed.scheme else repo
+    except ValueError:
+        request["repository"] = repo
 request.pop("wait", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
@@ -448,6 +480,14 @@ print(urllib.parse.quote(sys.argv[1], safe=""))
 PY
 )"
 poll_url="${REMOTE_BUILD_URL%/}/$job_id?mission_id=$encoded_mission&node_id=$encoded_node"
+if [ -n "${REMOTE_BUILD_EXPECTED_HEAD:-}" ]; then
+    encoded_expected_head="$(python3 - "$REMOTE_BUILD_EXPECTED_HEAD" <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+)"
+    poll_url="$poll_url&expected_head=$encoded_expected_head"
+fi
 poll_secs="${REMOTE_BUILD_POLL_SECS:-3}"
 client_timeout_secs="${REMOTE_BUILD_CLIENT_TIMEOUT_SECS:-7500}"
 case "$poll_secs" in
@@ -458,7 +498,8 @@ case "$client_timeout_secs" in
 esac
 [ "$poll_secs" -gt 0 ] || die "REMOTE_BUILD_POLL_SECS must be greater than zero"
 [ "$client_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_CLIENT_TIMEOUT_SECS must be greater than zero"
-if [ "$receipt_state" != "succeeded" ] && [ "$receipt_state" != "failed" ] \
+if [ "$receipt_state" != "succeeded" ] && [ "$receipt_state" != "stale_success" ] \
+    && [ "$receipt_state" != "failed" ] \
     && [ "$receipt_state" != "cancelled" ] && [ "$receipt_state" != "lost" ]; then
     deadline=$(( $(date +%s) + client_timeout_secs ))
 
@@ -483,11 +524,11 @@ try:
 finally:
     if os.path.exists(tmp):
         os.unlink(tmp)
-print(status.get("state") or "")
+print(status.get("receipt_state") or status.get("state") or "")
 PY
             )" || die "invalid remote-build status response"
             case "$receipt_state" in
-                succeeded|failed|cancelled|lost) break ;;
+                succeeded|stale_success|failed|cancelled|lost) break ;;
             esac
         elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
             echo "remote-lean-build: polling authorization failed; the accepted job remains resumable" >&2
@@ -518,7 +559,8 @@ except (KeyError, TypeError, ValueError):
     pass
 sys.stderr.write(
     "remote-lean-build: job %s on node '%s' finished: %s (exit %s, %ss)\n"
-    % (resp.get("job_id"), resp.get("node_id"), resp.get("state"),
+    % (resp.get("job_id"), resp.get("node_id"),
+       resp.get("receipt_state") or resp.get("state"),
        resp.get("exit_code"), duration if duration is not None else "?")
 )
 log_tail = resp.get("log_tail") or ""
@@ -531,5 +573,8 @@ for artifact in resp.get("artifacts") or []:
         "artifact: %(path)s sha256=%(sha256)s (%(size_bytes)d bytes)\n" % artifact
     )
 exit_code = resp.get("exit_code")
+if resp.get("receipt_state") == "stale_success":
+    sys.stderr.write("remote-lean-build: validation is stale for the current expected head\n")
+    sys.exit(1)
 sys.exit(exit_code if isinstance(exit_code, int) and 0 <= exit_code <= 255 else 1)
 PY

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -174,6 +174,10 @@ import hashlib, json, sys
 request = json.load(open(sys.argv[1]))
 request.pop("token", None)
 request.pop("wait", None)
+# `expected_head` is a live freshness gate, not part of the immutable job
+# identity. A retry after the branch advances must resume the accepted job for
+# the pinned commit and report it as stale, never submit a duplicate.
+request.pop("expected_head", None)
 fingerprint = {"endpoint": sys.argv[2], "request": request}
 canonical = json.dumps(fingerprint, sort_keys=True, separators=(",", ":")).encode()
 print(hashlib.sha256(canonical).hexdigest())
@@ -546,10 +550,20 @@ PY
     done
 fi
 
-python3 - "$state_file" <<'PY'
+python3 - "$state_file" "${REMOTE_BUILD_EXPECTED_HEAD:-}" <<'PY'
 import datetime, json, sys
 with open(sys.argv[1]) as f:
     resp = json.load(f)
+expected_head = sys.argv[2].strip()
+validation = resp.get("validation") or {}
+validated_commit = validation.get("commit") or resp.get("commit") or ""
+stale_success = bool(
+    expected_head
+    and validated_commit
+    and validated_commit != expected_head
+    and resp.get("state") == "succeeded"
+)
+effective_state = "stale_success" if stale_success else resp.get("state")
 duration = None
 try:
     started = datetime.datetime.fromisoformat(resp["started_at"])
@@ -560,7 +574,7 @@ except (KeyError, TypeError, ValueError):
 sys.stderr.write(
     "remote-lean-build: job %s on node '%s' finished: %s (exit %s, %ss)\n"
     % (resp.get("job_id"), resp.get("node_id"),
-       resp.get("receipt_state") or resp.get("state"),
+       effective_state,
        resp.get("exit_code"), duration if duration is not None else "?")
 )
 log_tail = resp.get("log_tail") or ""
@@ -573,7 +587,7 @@ for artifact in resp.get("artifacts") or []:
         "artifact: %(path)s sha256=%(sha256)s (%(size_bytes)d bytes)\n" % artifact
     )
 exit_code = resp.get("exit_code")
-if resp.get("receipt_state") == "stale_success":
+if stale_success:
     sys.stderr.write("remote-lean-build: validation is stale for the current expected head\n")
     sys.exit(1)
 sys.exit(exit_code if isinstance(exit_code, int) and 0 <= exit_code <= 255 else 1)

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2477,7 +2477,10 @@ async fn get_running_missions(
                 queue_len: 0,
                 history_len: 0,
                 seconds_since_activity: heartbeat_age,
-                tool_call_in_flight: run.execution_state == MissionExecutionState::WaitingTool,
+                tool_call_in_flight: matches!(
+                    run.execution_state,
+                    MissionExecutionState::WaitingTool | MissionExecutionState::WaitingRemoteJob
+                ),
                 health: super::mission_runner::MissionHealth::Reconciling {
                     reason: "durable_run_without_registered_actor".to_string(),
                 },
@@ -4388,14 +4391,33 @@ fn tool_execution_deadline_secs(tool_kind: &str, args: &serde_json::Value) -> i6
 fn mission_heartbeat_state(
     active_tool_calls: usize,
     has_registered_user_wait: bool,
+    has_durable_remote_job: bool,
 ) -> MissionExecutionState {
-    if has_registered_user_wait {
+    if has_durable_remote_job {
+        MissionExecutionState::WaitingRemoteJob
+    } else if has_registered_user_wait {
         MissionExecutionState::WaitingUser
     } else if active_tool_calls > 0 {
         MissionExecutionState::WaitingTool
     } else {
         MissionExecutionState::Running
     }
+}
+
+fn remote_build_handle_proves_liveness(
+    handle: &crate::remote_node::job_ledger::JobHandle,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if handle.kind != crate::remote_node::job_ledger::JobHandleKind::RemoteBuild
+        || handle.accepted_at.is_none()
+    {
+        return false;
+    }
+    let last_proof = handle
+        .heartbeat_at
+        .or(handle.accepted_at)
+        .unwrap_or(handle.started_at);
+    now.signed_duration_since(last_proof) <= chrono::Duration::seconds(60)
 }
 
 pub async fn list_missions(
@@ -6989,8 +7011,10 @@ async fn dispatch_remote_job(
             job_id,
             started_at: submit_started_at,
             accepted_at: None,
+            heartbeat_at: None,
             disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
+            identity: None,
         },
     )
     .await
@@ -7034,8 +7058,10 @@ async fn dispatch_remote_job(
             job_id,
             started_at: submit_started_at,
             accepted_at: Some(chrono::Utc::now()),
+            heartbeat_at: Some(chrono::Utc::now()),
             disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::Mission,
+            identity: None,
         },
     )
     .await
@@ -7344,6 +7370,7 @@ async fn reconcile_pending_handles(
                                 handle.mission_id,
                                 handle.job_id,
                                 handle.started_at,
+                                ledger_dir.clone(),
                             )
                             .await;
                             crate::remote_node::job_ledger::remove(&ledger_dir, handle.job_id)
@@ -7484,6 +7511,7 @@ async fn poll_recovered_remote_build(
     mission_id: Uuid,
     job_id: Uuid,
     started_at: chrono::DateTime<chrono::Utc>,
+    working_dir: PathBuf,
 ) {
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
@@ -7494,6 +7522,8 @@ async fn poll_recovered_remote_build(
                     "succeeded" | "failed" | "cancelled" | "lost"
                 ) =>
             {
+                let terminal_state = status.state.clone();
+                let terminal_exit_code = status.exit_code;
                 fleet.record_outcome(crate::remote_node::DispatchOutcome {
                     mission_id,
                     node_id: node.id.clone(),
@@ -7504,9 +7534,26 @@ async fn poll_recovered_remote_build(
                     started_at,
                     finished_at: Some(chrono::Utc::now()),
                 });
+                if let Err(error) = crate::remote_node::job_ledger::finalize(
+                    &working_dir,
+                    job_id,
+                    &terminal_state,
+                    terminal_exit_code,
+                )
+                .await
+                {
+                    tracing::warn!(%job_id, ?error, "recovered remote build receipt finalization failed");
+                }
                 return;
             }
-            Ok(_) | Err(_) => {}
+            Ok(_) => {
+                if let Err(error) =
+                    crate::remote_node::job_ledger::heartbeat(&working_dir, job_id).await
+                {
+                    tracing::warn!(%job_id, ?error, "recovered remote build heartbeat persistence failed");
+                }
+            }
+            Err(_) => {}
         }
     }
 }
@@ -10490,6 +10537,7 @@ async fn paloma_webhook_forwarder_loop(
     mut events_rx: broadcast::Receiver<AgentEvent>,
     mission_store: Arc<dyn MissionStore>,
     workspaces: workspace::SharedWorkspaceStore,
+    working_dir: PathBuf,
     url: String,
     secret: Option<String>,
     http: reqwest::Client,
@@ -10514,7 +10562,8 @@ async fn paloma_webhook_forwarder_loop(
                 mission_id, status, ..
             }) => {
                 // `insert` returns the prior value; forward only on a real change.
-                let changed = last_status.insert(mission_id, status) != Some(status);
+                let old_status = last_status.insert(mission_id, status);
+                let changed = old_status != Some(status);
                 if !changed || !webhook_forwardable_status(status) {
                     continue;
                 }
@@ -10531,6 +10580,7 @@ async fn paloma_webhook_forwarder_loop(
                 let secret = secret.clone();
                 let mission_store = Arc::clone(&mission_store);
                 let workspaces = workspaces.clone();
+                let working_dir = working_dir.clone();
                 let sem = Arc::clone(&sem);
                 tokio::spawn(async move {
                     let _permit = sem.acquire_owned().await;
@@ -10540,6 +10590,40 @@ async fn paloma_webhook_forwarder_loop(
                         .and_then(|mission| mission.title.clone())
                         .unwrap_or_else(|| mission_id.to_string());
                     let project = mission.as_ref().map(|m| &m.project);
+                    let run = mission_store
+                        .get_active_mission_run(mission_id)
+                        .await
+                        .ok()
+                        .flatten();
+                    let remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|handle| handle.mission_id == mission_id)
+                        .map(|handle| {
+                            serde_json::json!({
+                                "job_id": handle.job_id,
+                                "node_id": handle.node_id,
+                                "kind": handle.kind,
+                                "accepted_at": handle.accepted_at,
+                                "heartbeat_at": handle.heartbeat_at,
+                                "identity": handle.identity,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    let terminal_reason = mission
+                        .as_ref()
+                        .and_then(|mission| mission.terminal_reason.as_deref());
+                    let recommended_action = match terminal_reason {
+                        Some("server_shutdown" | "orphan_no_runner") => "resume_once",
+                        Some("auth_error") => "disable_provider_and_reroute",
+                        Some("rate_limited" | "capacity_limited") => "reroute_or_queue",
+                        Some("watchdog_stalled" | "cancelled") => "inspect_artifacts",
+                        _ if status == MissionStatus::Interrupted => "reconcile_then_resume",
+                        _ if status == MissionStatus::Failed => "classify_failure",
+                        _ if status == MissionStatus::AwaitingUser => "inspect_result",
+                        _ => "notify",
+                    };
                     // Resolve workspace_name from the registry (the store row
                     // usually leaves it null), so the payload is self-contained.
                     let workspace_name = match mission.as_ref() {
@@ -10555,6 +10639,7 @@ async fn paloma_webhook_forwarder_loop(
                         "event_id": event_id,
                         "sequence": seq,
                         "mission_id": mission_id,
+                        "old_status": old_status,
                         "status": status,
                         // Event-type mirror of `status` so consumers with
                         // route-level event filters (e.g. the Hermes webhook
@@ -10569,6 +10654,17 @@ async fn paloma_webhook_forwarder_loop(
                         "workspace_id": mission.as_ref().map(|m| m.workspace_id),
                         "workspace_name": workspace_name,
                         "backend": mission.as_ref().map(|m| m.backend.clone()),
+                        "terminal_reason": terminal_reason,
+                        "resumable": matches!(status, MissionStatus::Interrupted | MissionStatus::Failed | MissionStatus::Blocked),
+                        "recommended_action": recommended_action,
+                        "execution": run.as_ref().map(|run| serde_json::json!({
+                            "run_id": run.run_id,
+                            "generation": run.generation,
+                            "state": run.execution_state,
+                            "heartbeat_at": run.heartbeat_at,
+                            "scope_unit": run.scope_unit,
+                        })),
+                        "remote_jobs": remote_jobs,
                         "updated_at": mission.as_ref().map(|m| m.updated_at.clone()),
                         // When the status itself last changed (P#5) — the most
                         // relevant staleness anchor for a status-change webhook.
@@ -10779,6 +10875,7 @@ fn spawn_control_session(
             events_tx.subscribe(),
             Arc::clone(&state.mission_store),
             workspaces.clone(),
+            config.working_dir.clone(),
             url.clone(),
             config.paloma_webhook_secret.clone(),
             reqwest::Client::builder()
@@ -12293,6 +12390,13 @@ fn completion_evidence_for_agent_result(
     }
 }
 
+fn is_transport_failure_evidence(evidence: &crate::agents::CompletionEvidence) -> bool {
+    matches!(
+        evidence.failure_class,
+        Some(crate::agents::FailureClass::TransportError)
+    )
+}
+
 fn is_bare_llm_error_output(output: &str) -> bool {
     if looks_like_structured_provider_error(output) {
         return true;
@@ -12987,6 +13091,10 @@ async fn control_actor_loop(
     // messages (re-injected as commands above) rely on this same guard: the
     // first occurrence runs, any later duplicate is dropped.
     let mut accepted_user_message_ids: HashSet<Uuid> = HashSet::new();
+    // One bounded same-mission retry for structured transport failures. Auth,
+    // quota/capacity, source failures, stalls, and loops are deliberately not
+    // eligible. Writer leases are re-acquired by the normal start path.
+    let mut transport_auto_resumed_missions: HashSet<Uuid> = HashSet::new();
     // Track subtasks for the main runner
     let mut main_runner_subtasks: Vec<super::mission_runner::SubtaskInfo> = Vec::new();
     // Track number of in-flight tool calls on the main runner so the stall
@@ -13285,9 +13393,31 @@ async fn control_actor_loop(
                         )
                     })
                 }));
+                let remote_jobs_by_mission = if leases.is_empty() {
+                    HashSet::new()
+                } else {
+                    match crate::remote_node::job_ledger::load(&config.working_dir).await {
+                        Ok(handles) => {
+                            let now = chrono::Utc::now();
+                            handles
+                                .into_iter()
+                                .filter(|handle| remote_build_handle_proves_liveness(handle, now))
+                                .map(|handle| handle.mission_id)
+                                .collect()
+                        }
+                        Err(error) => {
+                            tracing::warn!(?error, "Failed to inspect durable remote jobs for execution heartbeat");
+                            HashSet::new()
+                        }
+                    }
+                };
                 for (run, active_tool_calls, idle_secs) in leases {
                     let mut live_registered_tools = 0usize;
                     let mut has_registered_user_wait = false;
+                    let has_durable_remote_job = remote_jobs_by_mission.contains(&run.mission_id);
+                    if has_durable_remote_job {
+                        live_registered_tools += 1;
+                    }
                     if let Ok(tools) = mission_store
                         .list_active_tool_executions(run.run_id)
                         .await
@@ -13328,6 +13458,7 @@ async fn control_actor_loop(
                     let state = mission_heartbeat_state(
                         active_tool_calls,
                         has_registered_user_wait,
+                        has_durable_remote_job,
                     );
                     match mission_store
                         .heartbeat_mission_run(run.run_id, run.generation, state, None)
@@ -13348,6 +13479,7 @@ async fn control_actor_loop(
                     }
                     if idle_secs >= 15 * 60
                         && state != MissionExecutionState::WaitingUser
+                        && state != MissionExecutionState::WaitingRemoteJob
                         && live_registered_tools == 0
                     {
                         tracing::warn!(
@@ -15282,16 +15414,31 @@ async fn control_actor_loop(
                     ControlCommand::ListRunning { respond } => {
                         // Return info about currently running missions
                         let mut running_list = Vec::new();
+                        let remote_job_missions = crate::remote_node::job_ledger::load(
+                            &config.working_dir,
+                        )
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|handle| {
+                            remote_build_handle_proves_liveness(handle, chrono::Utc::now())
+                        })
+                        .map(|handle| handle.mission_id)
+                        .collect::<HashSet<_>>();
 
                         // Add main mission if running - use running_mission_id (the actual mission being executed)
                         // instead of current_mission (which can change when user creates a new mission)
                         if running.is_some() {
                             if let Some(mission_id) = running_mission_id {
+                                let waiting_remote_job =
+                                    remote_job_missions.contains(&mission_id);
                                 let seconds_since_activity =
                                     main_runner_last_activity.elapsed().as_secs();
                                 let state_label = {
                                     let status_guard = status.read().await;
-                                    if status_guard.mission_id == Some(mission_id)
+                                    if waiting_remote_job {
+                                        "waiting_remote_job"
+                                    } else if status_guard.mission_id == Some(mission_id)
                                         && status_guard.state == ControlRunState::WaitingForTool
                                     {
                                         "waiting_for_tool"
@@ -15304,9 +15451,10 @@ async fn control_actor_loop(
                                 } else {
                                     super::mission_runner::MissionRunState::Running
                                 };
-                                let tool_call_in_flight = main_runner_active_tool_calls
-                                    .load(std::sync::atomic::Ordering::Relaxed)
-                                    > 0;
+                                let tool_call_in_flight = waiting_remote_job
+                                    || main_runner_active_tool_calls
+                                        .load(std::sync::atomic::Ordering::Relaxed)
+                                        > 0;
                                 running_list.push(super::mission_runner::RunningMissionInfo {
                                     mission_id,
                                     state: state_label.to_string(),
@@ -15336,7 +15484,12 @@ async fn control_actor_loop(
 
                         // Add all parallel runners
                         for runner in parallel_runners.values() {
-                            running_list.push(super::mission_runner::RunningMissionInfo::from(runner));
+                            let mut info = super::mission_runner::RunningMissionInfo::from(runner);
+                            if remote_job_missions.contains(&info.mission_id) {
+                                info.state = "waiting_remote_job".to_string();
+                                info.tool_call_in_flight = true;
+                            }
+                            running_list.push(info);
                         }
 
                         let _ = respond.send(running_list);
@@ -16098,6 +16251,7 @@ async fn control_actor_loop(
                     runner_force_clear_deadline = None;
                     let mut completed_terminal_reason = None;
                     let mut completed_completion_confidence = None;
+                    let mut completed_transport_failure = false;
                     // Captured for the post-turn `grok_goal` sentinel hook (see
                     // `post_turn_handle_grok_goal`), which runs after this
                     // `match` closes — `agent_result` itself is out of scope
@@ -16111,6 +16265,8 @@ async fn control_actor_loop(
                             completed_terminal_reason = agent_result.terminal_reason;
                             completed_completion_confidence =
                                 Some(completion_evidence.completion_confidence);
+                            completed_transport_failure =
+                                is_transport_failure_evidence(&completion_evidence);
                             completed_agent_output = agent_result.output.clone();
                             if let Some(run) = running_run.take() {
                                 let reason = agent_result
@@ -16365,12 +16521,28 @@ async fn control_actor_loop(
                     // they're transient failures that the retry/recovery logic handles.
                     // Firing automations on these creates noisy retry loops.
                     if let Some(mission_id) = completed_mission_id {
+                        if completed_transport_failure
+                            && transport_auto_resumed_missions.insert(mission_id)
+                            && !queue_has_pending_target_mission(&queue, mission_id)
+                        {
+                            tracing::info!(
+                                %mission_id,
+                                "Auto-resuming mission once after structured transport failure"
+                            );
+                            queue.push_back((
+                                Uuid::new_v4(),
+                                "The previous turn ended because its provider transport disconnected. Reconcile the current workspace, remote jobs, and repository head, then resume the same task. Do not duplicate an accepted job or create a replacement writer.".to_string(),
+                                None,
+                                Some(mission_id),
+                                Some("transport_auto_resume".to_string()),
+                            ));
+                        }
                         let is_transient_infra_failure = matches!(
                             completed_terminal_reason,
                             Some(TerminalReason::AuthError)
                                 | Some(TerminalReason::RateLimited)
                                 | Some(TerminalReason::CapacityLimited)
-                        );
+                        ) || completed_transport_failure;
                         let already_queued_for_mission = queue
                             .iter()
                             .any(|(_id, _msg, _agent, target_mid, _source)| *target_mid == Some(mission_id));
@@ -16802,9 +16974,26 @@ async fn control_actor_loop(
                                 Some(TerminalReason::AuthError)
                                     | Some(TerminalReason::RateLimited)
                                     | Some(TerminalReason::CapacityLimited)
-                            );
+                            ) || is_transport_failure_evidence(&completion_evidence);
                             let cancellation_requested = runner.cancellation_requested();
                             let was_queue_empty = runner.queue.is_empty();
+                            if is_transient_infra_failure
+                                && is_transport_failure_evidence(&completion_evidence)
+                                && !cancellation_requested
+                                && was_queue_empty
+                                && transport_auto_resumed_missions.insert(*mission_id)
+                            {
+                                tracing::info!(
+                                    mission_id = %mission_id,
+                                    "Auto-resuming parallel mission once after structured transport failure"
+                                );
+                                runner.queue_message(
+                                    Uuid::new_v4(),
+                                    "The previous turn ended because its provider transport disconnected. Reconcile the current workspace, remote jobs, and repository head, then resume the same task. Do not duplicate an accepted job or create a replacement writer.".to_string(),
+                                    None,
+                                    Some("transport_auto_resume".to_string()),
+                                );
+                            }
                             // Grok /goal sentinel hook for the parallel-runner
                             // path. Same contract as the main-session hook
                             // above: runs before the AgentFinished automations
@@ -21142,17 +21331,44 @@ mod tests {
         assert!(is_user_wait_tool("ui_confirm"));
         assert!(!is_user_wait_tool("workspace_bash"));
         assert_eq!(
-            mission_heartbeat_state(1, true),
+            mission_heartbeat_state(1, true, false),
             MissionExecutionState::WaitingUser
         );
         assert_eq!(
-            mission_heartbeat_state(1, false),
+            mission_heartbeat_state(1, false, false),
             MissionExecutionState::WaitingTool
         );
         assert_eq!(
-            mission_heartbeat_state(0, false),
+            mission_heartbeat_state(0, false, false),
             MissionExecutionState::Running
         );
+        assert_eq!(
+            mission_heartbeat_state(1, false, true),
+            MissionExecutionState::WaitingRemoteJob
+        );
+    }
+
+    #[test]
+    fn only_fresh_accepted_remote_builds_prove_liveness() {
+        let now = chrono::Utc::now();
+        let mut handle = crate::remote_node::job_ledger::JobHandle {
+            mission_id: Uuid::new_v4(),
+            node_id: "node-a".to_string(),
+            job_id: Uuid::new_v4(),
+            started_at: now - chrono::Duration::seconds(120),
+            accepted_at: Some(now - chrono::Duration::seconds(30)),
+            heartbeat_at: None,
+            disk_reservation_bytes: 0,
+            kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
+            identity: None,
+        };
+        assert!(remote_build_handle_proves_liveness(&handle, now));
+        handle.heartbeat_at = Some(now - chrono::Duration::seconds(61));
+        assert!(!remote_build_handle_proves_liveness(&handle, now));
+        handle.heartbeat_at = Some(now - chrono::Duration::seconds(1));
+        assert!(remote_build_handle_proves_liveness(&handle, now));
+        handle.kind = crate::remote_node::job_ledger::JobHandleKind::Mission;
+        assert!(!remote_build_handle_proves_liveness(&handle, now));
     }
 
     #[test]
@@ -25735,6 +25951,27 @@ Investigate <service/> failures.
             evidence.completion_confidence,
             crate::agents::CompletionConfidence::High
         );
+    }
+
+    #[test]
+    fn only_structured_transport_failures_are_auto_resume_eligible() {
+        let transport = crate::agents::AgentResult::failure("disconnected", 0)
+            .with_terminal_reason(TerminalReason::LlmError)
+            .with_data(serde_json::json!({ "transport_failure_stage": "pending_tools" }));
+        let provider = crate::agents::AgentResult::failure("provider error", 0)
+            .with_terminal_reason(TerminalReason::LlmError);
+        let auth = crate::agents::AgentResult::failure("unauthorized", 0)
+            .with_terminal_reason(TerminalReason::AuthError);
+
+        assert!(is_transport_failure_evidence(
+            &completion_evidence_for_agent_result(&transport)
+        ));
+        assert!(!is_transport_failure_evidence(
+            &completion_evidence_for_agent_result(&provider)
+        ));
+        assert!(!is_transport_failure_evidence(
+            &completion_evidence_for_agent_result(&auth)
+        ));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10598,7 +10598,7 @@ async fn paloma_webhook_forwarder_loop(
                         .await
                         .ok()
                         .flatten();
-                    let remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
+                    let mut remote_jobs = crate::remote_node::job_ledger::load(&working_dir)
                         .await
                         .unwrap_or_default()
                         .into_iter()
@@ -10614,6 +10614,27 @@ async fn paloma_webhook_forwarder_loop(
                             })
                         })
                         .collect::<Vec<_>>();
+                    remote_jobs.extend(
+                        crate::remote_node::job_ledger::terminal_receipts_for_mission(
+                            &working_dir,
+                            mission_id,
+                        )
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|receipt| {
+                            serde_json::json!({
+                                "job_id": receipt.job_id,
+                                "node_id": receipt.node_id,
+                                "kind": "remote_build_receipt",
+                                "state": receipt.state,
+                                "started_at": receipt.started_at,
+                                "finished_at": receipt.finished_at,
+                                "exit_status": receipt.exit_status,
+                                "identity": receipt.identity,
+                            })
+                        }),
+                    );
                     let terminal_reason = mission
                         .as_ref()
                         .and_then(|mission| mission.terminal_reason.as_deref());
@@ -12249,17 +12270,14 @@ fn maybe_recover_soft_llm_error(result: &mut crate::agents::AgentResult) {
     if !is_recoverable {
         return;
     }
-    // Claude Code transport failures (startup timeout, incomplete turn, etc.)
-    // carry a structured `claudecode_transport_failure` marker. These are
-    // never a successful turn — treating them as TurnComplete lets the mission
-    // re-enter an automation loop where every retry fake-succeeds. Keep the
-    // failure classification so the mission is surfaced as failed.
-    if result
-        .data
-        .as_ref()
-        .and_then(|v| v.get("claudecode_transport_failure"))
-        .is_some()
-    {
+    // Structured transport failures are never successful turns. Treating
+    // either the Claude marker or the generic/Codex stage as TurnComplete
+    // would erase the failure evidence before bounded auto-resume runs.
+    let has_transport_failure = result.data.as_ref().is_some_and(|data| {
+        data.get("claudecode_transport_failure").is_some()
+            || data.get("transport_failure_stage").is_some()
+    });
+    if has_transport_failure {
         return;
     }
     let output = result.output.trim();
@@ -25974,6 +25992,27 @@ Investigate <service/> failures.
         ));
         assert!(!is_transport_failure_evidence(
             &completion_evidence_for_agent_result(&auth)
+        ));
+    }
+
+    #[test]
+    fn maybe_recover_soft_llm_error_preserves_pending_tool_transport_failure() {
+        let mut result = crate::agents::AgentResult::failure(
+            "Codex stopped while tool calls were still pending: remote build".to_string(),
+            0,
+        )
+        .with_terminal_reason(TerminalReason::LlmError)
+        .with_data(serde_json::json!({
+            "transport_failure_stage": "pending_tools",
+            "pending_tools": ["remote build"]
+        }));
+
+        maybe_recover_soft_llm_error(&mut result);
+
+        assert!(!result.success);
+        assert_eq!(result.terminal_reason, Some(TerminalReason::LlmError));
+        assert!(is_transport_failure_evidence(
+            &completion_evidence_for_agent_result(&result)
         ));
     }
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -10622,6 +10622,8 @@ async fn paloma_webhook_forwarder_loop(
                         .await
                         .unwrap_or_default()
                         .into_iter()
+                        .rev()
+                        .take(16)
                         .map(|receipt| {
                             serde_json::json!({
                                 "job_id": receipt.job_id,
@@ -12324,10 +12326,12 @@ fn completion_evidence_for_agent_result(
             terminal_reason,
             Some(TerminalReason::TurnComplete | TerminalReason::Completed)
         ));
-    let pending_tools = data
-        .and_then(|v| v.get("pending_tools"))
-        .and_then(|v| v.as_u64())
-        .and_then(|v| usize::try_from(v).ok());
+    let pending_tools = data.and_then(|v| v.get("pending_tools")).and_then(|value| {
+        value
+            .as_u64()
+            .and_then(|count| usize::try_from(count).ok())
+            .or_else(|| value.as_array().map(Vec::len))
+    });
     let transport_failure_stage = data
         .and_then(|v| v.get("transport_failure_stage"))
         .or_else(|| data.and_then(|v| v.get("claudecode_transport_failure")))
@@ -26014,6 +26018,10 @@ Investigate <service/> failures.
         assert!(is_transport_failure_evidence(
             &completion_evidence_for_agent_result(&result)
         ));
+        assert_eq!(
+            completion_evidence_for_agent_result(&result).pending_tools,
+            Some(1)
+        );
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7369,11 +7369,9 @@ async fn reconcile_pending_handles(
                                 handle.mission_id,
                                 handle.job_id,
                                 handle.started_at,
-                                ledger_dir.clone(),
+                                ledger_dir,
                             )
                             .await;
-                            crate::remote_node::job_ledger::remove(&ledger_dir, handle.job_id)
-                                .await;
                         });
                     }
                     _ => {
@@ -7533,7 +7531,7 @@ async fn poll_recovered_remote_build(
                     started_at,
                     finished_at: Some(chrono::Utc::now()),
                 });
-                if let Err(error) = crate::remote_node::job_ledger::finalize(
+                match crate::remote_node::job_ledger::finalize(
                     &working_dir,
                     job_id,
                     &terminal_state,
@@ -7541,9 +7539,15 @@ async fn poll_recovered_remote_build(
                 )
                 .await
                 {
-                    tracing::warn!(%job_id, ?error, "recovered remote build receipt finalization failed");
+                    Ok(_) => return,
+                    Err(error) => {
+                        // Keep the active handle and retry. Removing it after a
+                        // full-disk/permission failure would discard the only
+                        // durable link to the terminal validation evidence.
+                        tracing::warn!(%job_id, ?error, "recovered remote build receipt finalization failed; retrying");
+                        continue;
+                    }
                 }
-                return;
             }
             Ok(_) => {
                 if let Err(error) =

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -185,6 +185,20 @@ pub(crate) fn message_activates_mission(status: MissionStatus) -> bool {
     )
 }
 
+fn projected_running_health(
+    state: super::mission_runner::MissionRunState,
+    seconds_since_activity: u64,
+    tool_call_in_flight: bool,
+    waiting_remote_job: bool,
+) -> super::mission_runner::MissionHealth {
+    if waiting_remote_job {
+        // A fresh durable remote-job heartbeat is process-backed liveness, not
+        // the provisional unmatched-tool hint that expires after ten minutes.
+        return super::mission_runner::MissionHealth::Healthy;
+    }
+    super::mission_runner::running_health(state, seconds_since_activity, tool_call_in_flight)
+}
+
 fn remote_node_needs_on_demand_probe(
     _status: Option<&crate::remote_node::RemoteNodeStatus>,
 ) -> bool {
@@ -6132,6 +6146,20 @@ async fn activate_mission_for_message(
         });
     }
     Ok(())
+}
+
+async fn activate_mission_id_for_message(
+    control_hub: &ControlHub,
+    store: &Arc<dyn MissionStore>,
+    events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
+    mission_id: Uuid,
+    content: &str,
+) -> Result<(), String> {
+    let mission = store
+        .get_mission(mission_id)
+        .await?
+        .ok_or_else(|| format!("mission {mission_id} no longer exists"))?;
+    activate_mission_for_message(control_hub, store, events_tx, &mission, content).await
 }
 
 struct MessageWriterLeaseGuard {
@@ -15487,10 +15515,11 @@ async fn control_actor_loop(
                                     history_len: history.len(),
                                     seconds_since_activity,
                                     tool_call_in_flight,
-                                    health: super::mission_runner::running_health(
+                                    health: projected_running_health(
                                         mission_state,
                                         seconds_since_activity,
                                         tool_call_in_flight,
+                                        waiting_remote_job,
                                     ),
                                     expected_deliverables: 0,
                                     current_activity: main_runner_activity.clone(),
@@ -15513,6 +15542,7 @@ async fn control_actor_loop(
                             if remote_job_missions.contains(&info.mission_id) {
                                 info.state = "waiting_remote_job".to_string();
                                 info.tool_call_in_flight = true;
+                                info.health = super::mission_runner::MissionHealth::Healthy;
                             }
                             running_list.push(info);
                         }
@@ -16550,17 +16580,43 @@ async fn control_actor_loop(
                             && transport_auto_resumed_missions.insert(mission_id)
                             && !queue_has_pending_target_mission(&queue, mission_id)
                         {
-                            tracing::info!(
-                                %mission_id,
-                                "Auto-resuming mission once after structured transport failure"
-                            );
-                            queue.push_back((
-                                Uuid::new_v4(),
-                                "The previous turn ended because its provider transport disconnected. Reconcile the current workspace, remote jobs, and repository head, then resume the same task. Do not duplicate an accepted job or create a replacement writer.".to_string(),
-                                None,
-                                Some(mission_id),
-                                Some("transport_auto_resume".to_string()),
-                            ));
+                            let resume_message = "The previous turn ended because its provider transport disconnected. Reconcile the current workspace, remote jobs, and repository head, then resume the same task. Do not duplicate an accepted job or create a replacement writer.".to_string();
+                            let activation = activate_mission_id_for_message(
+                                &control_hub,
+                                &mission_store,
+                                &events_tx,
+                                mission_id,
+                                &resume_message,
+                            )
+                            .await;
+                            match activation {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        %mission_id,
+                                        "Auto-resuming mission once after structured transport failure"
+                                    );
+                                    queue.push_back((
+                                        Uuid::new_v4(),
+                                        resume_message,
+                                        None,
+                                        Some(mission_id),
+                                        Some("transport_auto_resume".to_string()),
+                                    ));
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        %mission_id,
+                                        "Structured transport auto-resume could not reactivate mission: {error}"
+                                    );
+                                    let _ = events_tx.send(AgentEvent::Error {
+                                        message: format!(
+                                            "Transport recovery could not reactivate mission {mission_id}: {error}"
+                                        ),
+                                        mission_id: Some(mission_id),
+                                        resumable: true,
+                                    });
+                                }
+                            }
                         }
                         let is_transient_infra_failure = matches!(
                             completed_terminal_reason,
@@ -16646,6 +16702,57 @@ async fn control_actor_loop(
                             "Queued delivery retained because dequeue persistence failed: {error}"
                         );
                         continue;
+                    }
+                    // Internal transport retries bypass the user-message
+                    // command path, so re-assert activation at dequeue too.
+                    // This also covers a retry restored from the durable queue
+                    // after a controller restart.
+                    if msg_source.as_deref() == Some("transport_auto_resume") {
+                        let activation = match msg_target_mid {
+                            Some(mission_id) => {
+                                activate_mission_id_for_message(
+                                    &control_hub,
+                                    &mission_store,
+                                    &events_tx,
+                                    mission_id,
+                                    &msg,
+                                )
+                                .await
+                            }
+                            None => Err("transport auto-resume is missing mission_id".to_string()),
+                        };
+                        if let Err(error) = activation {
+                            queue.push_front((
+                                mid,
+                                msg,
+                                per_msg_agent,
+                                msg_target_mid,
+                                msg_source,
+                            ));
+                            if let Err(persist_error) = persist_control_queue_if_changed(
+                                &mission_store,
+                                &session_user_id,
+                                &queue,
+                                &parallel_runners,
+                                &recovered_consumed_user_messages,
+                                &mut last_persisted_queue,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    "Failed to restore transport retry after activation rejection: {persist_error}"
+                                );
+                            }
+                            let _ = events_tx.send(AgentEvent::Error {
+                                message: format!(
+                                    "Transport recovery could not activate its mission: {error}"
+                                ),
+                                mission_id: msg_target_mid,
+                                resumable: true,
+                            });
+                            tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+                            continue;
+                        }
                     }
                     // Acquire the durable run before publishing the message as
                     // started or appending it to history. If a stale run lease
@@ -25671,6 +25778,31 @@ Investigate <service/> failures.
         // until the user resumes it), so they are not activation-eligible here.
         assert!(!message_activates_mission(MissionStatus::Active));
         assert!(!message_activates_mission(MissionStatus::Paused));
+    }
+
+    #[test]
+    fn durable_remote_job_heartbeat_keeps_projected_health_healthy() {
+        let health = projected_running_health(
+            crate::api::mission_runner::MissionRunState::Running,
+            600,
+            true,
+            true,
+        );
+        assert!(matches!(
+            health,
+            crate::api::mission_runner::MissionHealth::Healthy
+        ));
+
+        let without_remote_job = projected_running_health(
+            crate::api::mission_runner::MissionRunState::Running,
+            600,
+            true,
+            false,
+        );
+        assert!(matches!(
+            without_remote_job,
+            crate::api::mission_runner::MissionHealth::Stalled { .. }
+        ));
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7364,7 +7364,6 @@ async fn reconcile_pending_handles(
                         tokio::spawn(async move {
                             poll_recovered_remote_build(
                                 fleet,
-                                crate::remote_node::RemoteNodeClient::default(),
                                 node,
                                 shared_token,
                                 handle.mission_id,
@@ -7505,7 +7504,6 @@ async fn reconcile_pending_handles(
 /// not the mission's own remote execution backend.
 async fn poll_recovered_remote_build(
     fleet: Arc<crate::remote_node::FleetMonitor>,
-    client: crate::remote_node::RemoteNodeClient,
     node: crate::remote_node::RemoteNodeConfig,
     shared_token: String,
     mission_id: Uuid,
@@ -7513,6 +7511,7 @@ async fn poll_recovered_remote_build(
     started_at: chrono::DateTime<chrono::Utc>,
     working_dir: PathBuf,
 ) {
+    let client = crate::remote_node::RemoteNodeClient::default();
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
         match client.get_job(&node, &shared_token, job_id).await {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -2897,9 +2897,9 @@ impl MissionRunner {
     /// completion path so its terminal result can still be recorded.
     pub fn force_clear_cancelled_if_due(&mut self) -> bool {
         if !self.cancellation_requested
-            || !self
+            || self
                 .cancellation_force_clear_deadline
-                .is_some_and(|deadline| Instant::now() >= deadline)
+                .is_none_or(|deadline| Instant::now() < deadline)
         {
             return false;
         }

--- a/src/api/mission_store/mod.rs
+++ b/src/api/mission_store/mod.rs
@@ -150,6 +150,9 @@ pub enum MissionExecutionState {
     Starting,
     Running,
     WaitingTool,
+    /// A durable remote job owns the long-running work. Its persisted job
+    /// handle, rather than an unmatched harness tool call, proves liveness.
+    WaitingRemoteJob,
     WaitingUser,
     WaitingBackground,
     Stopping,
@@ -163,6 +166,7 @@ impl MissionExecutionState {
             Self::Starting => "starting",
             Self::Running => "running",
             Self::WaitingTool => "waiting_tool",
+            Self::WaitingRemoteJob => "waiting_remote_job",
             Self::WaitingUser => "waiting_user",
             Self::WaitingBackground => "waiting_background",
             Self::Stopping => "stopping",
@@ -176,6 +180,7 @@ impl MissionExecutionState {
             "starting" => Self::Starting,
             "running" => Self::Running,
             "waiting_tool" => Self::WaitingTool,
+            "waiting_remote_job" => Self::WaitingRemoteJob,
             "waiting_user" => Self::WaitingUser,
             "waiting_background" => Self::WaitingBackground,
             "stopping" => Self::Stopping,

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1078,6 +1078,45 @@ struct RemoteBuildStatusResponse {
     validation: Option<crate::remote_node::job_ledger::RemoteJobIdentity>,
 }
 
+fn remote_build_response_from_receipt(
+    query: &RemoteBuildStatusQuery,
+    receipt: crate::remote_node::job_ledger::RemoteJobReceipt,
+) -> Result<Json<RemoteBuildStatusResponse>, (StatusCode, String)> {
+    if receipt.mission_id != query.mission_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "job does not belong to this mission".to_string(),
+        ));
+    }
+    let current_head_match = query
+        .expected_head
+        .as_deref()
+        .map(|expected_head| receipt.identity.commit == expected_head);
+    let receipt_state = if receipt.state == "succeeded" && current_head_match == Some(false) {
+        "stale_success".to_string()
+    } else {
+        receipt.state.clone()
+    };
+    let status = NodeJobStatus {
+        job_id: receipt.job_id,
+        mission_id: receipt.mission_id,
+        state: receipt.state,
+        exit_code: receipt.exit_status,
+        created_at: receipt.started_at.to_rfc3339(),
+        started_at: Some(receipt.started_at.to_rfc3339()),
+        finished_at: Some(receipt.finished_at.to_rfc3339()),
+        error: None,
+        log_tail: None,
+        artifacts: Vec::new(),
+    };
+    Ok(Json(RemoteBuildStatusResponse {
+        status,
+        receipt_state,
+        current_head_match,
+        validation: Some(receipt.identity),
+    }))
+}
+
 /// `GET /api/remote-build/:job_id?mission_id=...&node_id=...` —
 /// job status for a build submitted with `wait: false`. Authenticated with
 /// the same per-mission capability token in `Authorization: Bearer ...` so
@@ -1105,16 +1144,40 @@ async fn get_remote_build(
             "node_id is required to poll a build".to_string(),
         ));
     }
+    // A terminal receipt is the durable authority. Serve it before touching
+    // the node so exact-head evidence remains recoverable after the runner is
+    // offline, reconfigured, or has pruned its own job record.
+    if let Some(receipt) =
+        crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
+            .await
+            .unwrap_or_default()
+    {
+        return remote_build_response_from_receipt(&query, receipt);
+    }
     let settings = &state.config.remote_nodes;
     let node = settings.node(&query.node_id).cloned().ok_or((
         StatusCode::BAD_REQUEST,
         format!("remote node '{}' is not configured", query.node_id),
     ))?;
     let shared_token = node_shared_token(&node)?;
-    let status = RemoteNodeClient::default()
+    let status = match RemoteNodeClient::default()
         .get_job(&node, &shared_token, job_id)
         .await
-        .map_err(|e| (job_status_error_status(&e), e.to_string()))?;
+    {
+        Ok(status) => status,
+        Err(error) => {
+            // Finalization can race this lookup. Recheck the durable receipt
+            // before surfacing a transient/404 node failure.
+            if let Some(receipt) =
+                crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
+                    .await
+                    .unwrap_or_default()
+            {
+                return remote_build_response_from_receipt(&query, receipt);
+            }
+            return Err((job_status_error_status(&error), error.to_string()));
+        }
+    };
     // The capability token is mission-scoped: never leak another mission's
     // job status through it.
     if status.mission_id != query.mission_id {
@@ -1444,6 +1507,49 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert!(validate_expected_head(&"a".repeat(40), Some(&"a".repeat(40))).is_ok());
         let error = validate_expected_head(&"a".repeat(40), Some(&"b".repeat(40))).unwrap_err();
         assert!(error.starts_with("STALE_VALIDATION_REQUEST:"));
+    }
+
+    #[test]
+    fn terminal_receipt_reports_stale_success_without_node_lookup() {
+        let mission_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        let started_at = chrono::Utc::now();
+        let response = remote_build_response_from_receipt(
+            &RemoteBuildStatusQuery {
+                mission_id,
+                node_id: "offline-node".to_string(),
+                expected_head: Some("b".repeat(40)),
+            },
+            crate::remote_node::job_ledger::RemoteJobReceipt {
+                mission_id,
+                node_id: "offline-node".to_string(),
+                job_id,
+                started_at,
+                finished_at: started_at,
+                state: "succeeded".to_string(),
+                exit_status: Some(0),
+                identity: crate::remote_node::job_ledger::RemoteJobIdentity {
+                    repository: "https://github.com/example/verity.git".to_string(),
+                    commit: "a".repeat(40),
+                    command: vec!["lake".to_string(), "build".to_string()],
+                    toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
+                    source_bundle_digest: None,
+                },
+            },
+        )
+        .unwrap()
+        .0;
+
+        assert_eq!(response.status.job_id, job_id);
+        assert_eq!(response.receipt_state, "stale_success");
+        assert_eq!(response.current_head_match, Some(false));
+        assert_eq!(
+            response
+                .validation
+                .as_ref()
+                .map(|identity| identity.commit.as_str()),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
     }
 
     #[test]
@@ -1947,7 +2053,7 @@ esac
             .expect("run stale exact-head validation");
         assert_eq!(stale.status.code(), Some(1));
         assert!(String::from_utf8_lossy(&stale.stderr).contains("validation is stale"));
-        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "2");
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
 
         for receipt in std::fs::read_dir(&state).expect("read receipts before persistence failure")
         {
@@ -1980,7 +2086,7 @@ esac
             .contains("previous submission stopped"));
         assert_eq!(
             std::fs::read_to_string(&submit_count).unwrap(),
-            "3",
+            "2",
             "the accepted persistence-failure submission must block an identical retry"
         );
         let forced_after_reconciliation = command("success")
@@ -1992,7 +2098,7 @@ esac
             "explicitly forced build failed: {}",
             String::from_utf8_lossy(&forced_after_reconciliation.stderr)
         );
-        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "4");
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "3");
 
         for entry in std::fs::read_dir(&state).expect("read state before ambiguous submission") {
             let path = entry.expect("read state entry").path();

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1144,22 +1144,35 @@ async fn get_remote_build(
             "node_id is required to poll a build".to_string(),
         ));
     }
-    // A terminal receipt is the durable authority. Serve it before touching
-    // the node so exact-head evidence remains recoverable after the runner is
-    // offline, reconfigured, or has pruned its own job record.
-    if let Some(receipt) =
+    // Prefer the live node because it retains bounded logs and artifact
+    // digests. Keep the durable receipt ready as the authority when the node
+    // is offline, reconfigured, or has pruned its own job record.
+    let persisted_terminal_receipt =
         crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
             .await
-            .unwrap_or_default()
-    {
-        return remote_build_response_from_receipt(&query, receipt);
-    }
+            .unwrap_or_default();
     let settings = &state.config.remote_nodes;
-    let node = settings.node(&query.node_id).cloned().ok_or((
-        StatusCode::BAD_REQUEST,
-        format!("remote node '{}' is not configured", query.node_id),
-    ))?;
-    let shared_token = node_shared_token(&node)?;
+    let node = match settings.node(&query.node_id).cloned() {
+        Some(node) => node,
+        None => {
+            if let Some(receipt) = persisted_terminal_receipt.clone() {
+                return remote_build_response_from_receipt(&query, receipt);
+            }
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("remote node '{}' is not configured", query.node_id),
+            ));
+        }
+    };
+    let shared_token = match node_shared_token(&node) {
+        Ok(token) => token,
+        Err(error) => {
+            if let Some(receipt) = persisted_terminal_receipt.clone() {
+                return remote_build_response_from_receipt(&query, receipt);
+            }
+            return Err(error);
+        }
+    };
     let status = match RemoteNodeClient::default()
         .get_job(&node, &shared_token, job_id)
         .await
@@ -1168,11 +1181,11 @@ async fn get_remote_build(
         Err(error) => {
             // Finalization can race this lookup. Recheck the durable receipt
             // before surfacing a transient/404 node failure.
-            if let Some(receipt) =
+            if let Some(receipt) = persisted_terminal_receipt.clone().or(
                 crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
                     .await
-                    .unwrap_or_default()
-            {
+                    .unwrap_or_default(),
+            ) {
                 return remote_build_response_from_receipt(&query, receipt);
             }
             return Err((job_status_error_status(&error), error.to_string()));
@@ -1192,9 +1205,14 @@ async fn get_remote_build(
         .into_iter()
         .find(|handle| handle.job_id == job_id);
     let terminal_receipt = if handle.is_none() {
-        crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
-            .await
-            .unwrap_or_default()
+        match persisted_terminal_receipt {
+            Some(receipt) => Some(receipt),
+            None => {
+                crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
+                    .await
+                    .unwrap_or_default()
+            }
+        }
     } else {
         None
     };

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -276,6 +276,15 @@ pub struct RemoteBuildRequest {
     pub repo: String,
     /// Full 40-char lowercase hex commit SHA.
     pub commit: String,
+    /// Optional exact-head gate captured by the caller immediately before
+    /// submission. A mismatch fails before placement, so an already-stale
+    /// validation can never consume remote capacity.
+    #[serde(default)]
+    pub expected_head: Option<String>,
+    /// Toolchain identity recorded in the durable receipt. The node still
+    /// reads the pinned checkout's toolchain file as the execution authority.
+    #[serde(default)]
+    pub toolchain: Option<String>,
     /// Optional, bounded source overlay whose hashes are verified by the node
     /// before it is applied over the pinned commit.
     #[serde(default)]
@@ -322,6 +331,48 @@ struct RemoteBuildWaitResponse {
 struct RemoteBuildAcceptedResponse {
     job_id: Uuid,
     node_id: String,
+    repository: String,
+    commit: String,
+    command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    toolchain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_bundle_digest: Option<String>,
+}
+
+fn repository_identity(repo: &str) -> String {
+    let Ok(mut parsed) = url::Url::parse(repo) else {
+        return repo.to_string();
+    };
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+    parsed.to_string()
+}
+
+fn remote_job_identity(
+    req: &RemoteBuildRequest,
+) -> crate::remote_node::job_ledger::RemoteJobIdentity {
+    crate::remote_node::job_ledger::RemoteJobIdentity {
+        repository: repository_identity(&req.repo),
+        commit: req.commit.clone(),
+        command: req.command.clone(),
+        toolchain: req.toolchain.clone(),
+        source_bundle_digest: req
+            .source_bundle
+            .as_ref()
+            .map(|bundle| bundle.manifest_sha256.clone()),
+    }
+}
+
+fn validate_expected_head(commit: &str, expected_head: Option<&str>) -> Result<(), String> {
+    match expected_head {
+        Some(expected_head) if expected_head != commit => Err(format!(
+            "STALE_VALIDATION_REQUEST: pinned commit {commit} does not match expected head {expected_head}"
+        )),
+        _ => Ok(()),
+    }
 }
 
 fn should_reprobe_after_placement_failure(_status: Option<&RemoteNodeStatus>) -> bool {
@@ -603,6 +654,19 @@ fn record_remote_build_status(
         .record_outcome(remote_build_dispatch_outcome(node_id, status, started_at));
 }
 
+async fn finalize_remote_build_handle(
+    working_dir: &std::path::Path,
+    job_id: Uuid,
+    state: &str,
+    exit_status: Option<i32>,
+) {
+    if let Err(error) =
+        crate::remote_node::job_ledger::finalize(working_dir, job_id, state, exit_status).await
+    {
+        tracing::warn!(%job_id, ?error, "remote build receipt finalization failed");
+    }
+}
+
 async fn remote_build_started_at(state: &AppState, job_id: Uuid) -> chrono::DateTime<chrono::Utc> {
     if let Some(started_at) = state
         .fleet
@@ -642,8 +706,13 @@ fn spawn_remote_build_observer(
             if cancel_requested {
                 if let Err(error) = client.cancel_job(&node, &shared_token, job_id).await {
                     if error.is_not_found() {
-                        crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id)
-                            .await;
+                        finalize_remote_build_handle(
+                            &state.config.working_dir,
+                            job_id,
+                            "lost",
+                            None,
+                        )
+                        .await;
                         return;
                     }
                     tracing::warn!(
@@ -658,14 +727,29 @@ fn spawn_remote_build_observer(
             match client.get_job(&node, &shared_token, job_id).await {
                 Ok(status) if remote_build_is_terminal(&status.state) => {
                     record_remote_build_status(&state, &node.id, &status, started_at);
-                    crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+                    finalize_remote_build_handle(
+                        &state.config.working_dir,
+                        job_id,
+                        &status.state,
+                        status.exit_code,
+                    )
+                    .await;
                     return;
                 }
                 Err(error) if cancel_requested && error.is_not_found() => {
-                    crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+                    finalize_remote_build_handle(&state.config.working_dir, job_id, "lost", None)
+                        .await;
                     return;
                 }
-                Ok(status) => record_remote_build_status(&state, &node.id, &status, started_at),
+                Ok(status) => {
+                    record_remote_build_status(&state, &node.id, &status, started_at);
+                    if let Err(error) =
+                        crate::remote_node::job_ledger::heartbeat(&state.config.working_dir, job_id)
+                            .await
+                    {
+                        tracing::warn!(%job_id, ?error, "remote build heartbeat persistence failed");
+                    }
+                }
                 Err(_) => {}
             }
         }
@@ -691,6 +775,9 @@ async fn submit_remote_build(
     }
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
+    }
+    if let Err(message) = validate_expected_head(&req.commit, req.expected_head.as_deref()) {
+        return (StatusCode::CONFLICT, message).into_response();
     }
     let max_estimated_disk_bytes =
         env_gib("REMOTE_BUILD_MAX_ESTIMATED_DISK_GB", MAX_ESTIMATED_DISK_GB);
@@ -772,6 +859,7 @@ async fn submit_remote_build(
         },
     };
 
+    let identity = remote_job_identity(&req);
     let client = RemoteNodeClient::default();
     let started_at = chrono::Utc::now();
     if let Err(error) = crate::remote_node::job_ledger::record(
@@ -782,8 +870,10 @@ async fn submit_remote_build(
             job_id,
             started_at,
             accepted_at: None,
+            heartbeat_at: None,
             disk_reservation_bytes: req.estimated_disk_bytes,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
+            identity: Some(identity.clone()),
         },
     )
     .await
@@ -856,8 +946,10 @@ async fn submit_remote_build(
             job_id,
             started_at,
             accepted_at: Some(chrono::Utc::now()),
+            heartbeat_at: Some(chrono::Utc::now()),
             disk_reservation_bytes: req.estimated_disk_bytes,
             kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
+            identity: Some(identity.clone()),
         },
     )
     .await
@@ -896,6 +988,11 @@ async fn submit_remote_build(
             Json(RemoteBuildAcceptedResponse {
                 job_id,
                 node_id: node.id.clone(),
+                repository: identity.repository,
+                commit: identity.commit,
+                command: identity.command,
+                toolchain: identity.toolchain,
+                source_bundle_digest: identity.source_bundle_digest,
             }),
         )
             .into_response();
@@ -911,7 +1008,13 @@ async fn submit_remote_build(
         };
         record_remote_build_status(&state, &node.id, &status, started_at);
         if remote_build_is_terminal(&status.state) {
-            crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+            finalize_remote_build_handle(
+                &state.config.working_dir,
+                job_id,
+                &status.state,
+                status.exit_code,
+            )
+            .await;
             let duration_secs = (chrono::Utc::now() - started_at).num_seconds().max(0) as u64;
             return Json(RemoteBuildWaitResponse {
                 exit_code: status.exit_code,
@@ -923,6 +1026,11 @@ async fn submit_remote_build(
                 artifacts: status.artifacts,
             })
             .into_response();
+        }
+        if let Err(error) =
+            crate::remote_node::job_ledger::heartbeat(&state.config.working_dir, job_id).await
+        {
+            tracing::warn!(%job_id, ?error, "remote build heartbeat persistence failed");
         }
     }
     state.fleet.record_outcome(outcome(
@@ -952,6 +1060,22 @@ pub struct RemoteBuildStatusQuery {
     pub mission_id: Uuid,
     #[serde(default = "default_node_id")]
     pub node_id: String,
+    /// Live head observed by a gate/controller. The node state remains
+    /// unchanged, while `receipt_state` becomes `stale_success` when a green
+    /// build validated a different immutable commit.
+    #[serde(default)]
+    pub expected_head: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RemoteBuildStatusResponse {
+    #[serde(flatten)]
+    status: NodeJobStatus,
+    receipt_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current_head_match: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    validation: Option<crate::remote_node::job_ledger::RemoteJobIdentity>,
 }
 
 /// `GET /api/remote-build/:job_id?mission_id=...&node_id=...` —
@@ -963,7 +1087,7 @@ async fn get_remote_build(
     Path(job_id): Path<Uuid>,
     Query(query): Query<RemoteBuildStatusQuery>,
     headers: HeaderMap,
-) -> Result<Json<NodeJobStatus>, (StatusCode, String)> {
+) -> Result<Json<RemoteBuildStatusResponse>, (StatusCode, String)> {
     let token = headers
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
@@ -999,12 +1123,57 @@ async fn get_remote_build(
             "job does not belong to this mission".to_string(),
         ));
     }
+    let handle = crate::remote_node::job_ledger::load(&state.config.working_dir)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .find(|handle| handle.job_id == job_id);
+    let terminal_receipt = if handle.is_none() {
+        crate::remote_node::job_ledger::terminal_receipt(&state.config.working_dir, job_id)
+            .await
+            .unwrap_or_default()
+    } else {
+        None
+    };
+    let validation = handle
+        .as_ref()
+        .and_then(|handle| handle.identity.clone())
+        .or_else(|| {
+            terminal_receipt
+                .as_ref()
+                .map(|receipt| receipt.identity.clone())
+        });
+    let current_head_match = query.expected_head.as_deref().and_then(|expected_head| {
+        validation
+            .as_ref()
+            .map(|identity| identity.commit == expected_head)
+    });
+    let receipt_state = if status.state == "succeeded" && current_head_match == Some(false) {
+        "stale_success".to_string()
+    } else {
+        status.state.clone()
+    };
     let started_at = remote_build_started_at(&state, job_id).await;
     record_remote_build_status(&state, &node.id, &status, started_at);
     if remote_build_is_terminal(&status.state) {
-        crate::remote_node::job_ledger::remove(&state.config.working_dir, job_id).await;
+        finalize_remote_build_handle(
+            &state.config.working_dir,
+            job_id,
+            &status.state,
+            status.exit_code,
+        )
+        .await;
+    } else if let Err(error) =
+        crate::remote_node::job_ledger::heartbeat(&state.config.working_dir, job_id).await
+    {
+        tracing::warn!(%job_id, ?error, "remote build heartbeat persistence failed");
     }
-    Ok(Json(status))
+    Ok(Json(RemoteBuildStatusResponse {
+        status,
+        receipt_state,
+        current_head_match,
+        validation,
+    }))
 }
 
 #[cfg(test)]
@@ -1073,8 +1242,10 @@ mod tests {
             job_id: Uuid::new_v4(),
             started_at: now,
             accepted_at: None,
+            heartbeat_at: None,
             disk_reservation_bytes: 12 * GIB,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
+            identity: None,
         };
 
         assert!(handle_needs_reservation(
@@ -1243,6 +1414,36 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert!(!verify_remote_build_token_with_secret(
             "wrong", mission, &token, now
         ));
+    }
+
+    #[test]
+    fn immutable_identity_redacts_repository_credentials() {
+        let req: RemoteBuildRequest = serde_json::from_value(serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "token": "token",
+            "repo": "https://secret-user:secret-token@example.invalid/org/repo.git?token=secret#fragment",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"],
+            "toolchain": "leanprover/lean4:v4.19.0",
+            "wait": false
+        }))
+        .unwrap();
+        let identity = remote_job_identity(&req);
+
+        assert_eq!(identity.repository, "https://example.invalid/org/repo.git");
+        assert_eq!(identity.commit, "a".repeat(40));
+        assert_eq!(identity.command, vec!["lake", "build"]);
+        assert_eq!(
+            identity.toolchain.as_deref(),
+            Some("leanprover/lean4:v4.19.0")
+        );
+    }
+
+    #[test]
+    fn exact_head_gate_rejects_an_already_stale_request() {
+        assert!(validate_expected_head(&"a".repeat(40), Some(&"a".repeat(40))).is_ok());
+        let error = validate_expected_head(&"a".repeat(40), Some(&"b".repeat(40))).unwrap_err();
+        assert!(error.starts_with("STALE_VALIDATION_REQUEST:"));
     }
 
     #[test]
@@ -1435,7 +1636,8 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         git(&["config", "user.name", "Remote Build Test"]);
         git(&["config", "user.email", "remote-build@example.invalid"]);
         std::fs::write(repo.join("Theory/Proof.lean"), "old\n").unwrap();
-        git(&["add", "Theory/Proof.lean"]);
+        std::fs::write(repo.join("lean-toolchain"), "leanprover/lean4:v4.19.0\n").unwrap();
+        git(&["add", "Theory/Proof.lean", "lean-toolchain"]);
         git(&[
             "-c",
             "commit.gpgsign=false",
@@ -1494,6 +1696,7 @@ printf '503'
             )
             .env("REMOTE_BUILD_TOKEN", "test-token")
             .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
+            .env("REMOTE_BUILD_EXPECTED_HEAD", "a".repeat(40))
             .env("REMOTE_BUILD_TEST_CAPTURE", &capture)
             .output()
             .unwrap();
@@ -1506,6 +1709,16 @@ printf '503'
                 .get("estimated_disk_bytes")
                 .and_then(serde_json::Value::as_u64),
             Some(12 * GIB)
+        );
+        assert_eq!(
+            request.get("toolchain").and_then(serde_json::Value::as_str),
+            Some("leanprover/lean4:v4.19.0")
+        );
+        assert_eq!(
+            request
+                .get("expected_head")
+                .and_then(serde_json::Value::as_str),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         );
         let bundle = request.get("source_bundle").unwrap();
         let files = bundle.get("files").unwrap().as_array().unwrap();
@@ -1594,7 +1807,15 @@ case "$url" in
         if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "fail" ]; then
             exit 7
         fi
-        printf '{"job_id":"11111111-1111-1111-1111-111111111111","mission_id":"%s","state":"succeeded","exit_code":0,"created_at":"2026-07-15T20:00:00Z","started_at":"2026-07-15T20:00:01Z","finished_at":"2026-07-15T20:00:03Z","error":null,"log_tail":"remote ok\\n","artifacts":[]}' "$REMOTE_BUILD_TEST_MISSION_ID" > "$output"
+        if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "stale" ]; then
+            case "$url" in
+                *expected_head=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb*) ;;
+                *) exit 22 ;;
+            esac
+            printf '{"job_id":"11111111-1111-1111-1111-111111111111","mission_id":"%s","state":"succeeded","receipt_state":"stale_success","current_head_match":false,"exit_code":0,"created_at":"2026-07-15T20:00:00Z","started_at":"2026-07-15T20:00:01Z","finished_at":"2026-07-15T20:00:03Z","error":null,"log_tail":"remote ok\\n","artifacts":[]}' "$REMOTE_BUILD_TEST_MISSION_ID" > "$output"
+        else
+            printf '{"job_id":"11111111-1111-1111-1111-111111111111","mission_id":"%s","state":"succeeded","receipt_state":"succeeded","current_head_match":true,"exit_code":0,"created_at":"2026-07-15T20:00:00Z","started_at":"2026-07-15T20:00:01Z","finished_at":"2026-07-15T20:00:03Z","error":null,"log_tail":"remote ok\\n","artifacts":[]}' "$REMOTE_BUILD_TEST_MISSION_ID" > "$output"
+        fi
         printf '200'
         ;;
     *)
@@ -1720,6 +1941,14 @@ esac
         assert!(String::from_utf8_lossy(&replayed.stderr).contains("replaying terminal job"));
         assert_eq!(String::from_utf8_lossy(&replayed.stdout), "remote ok\n");
 
+        let stale = command("stale")
+            .env("REMOTE_BUILD_EXPECTED_HEAD", "b".repeat(40))
+            .output()
+            .expect("run stale exact-head validation");
+        assert_eq!(stale.status.code(), Some(1));
+        assert!(String::from_utf8_lossy(&stale.stderr).contains("validation is stale"));
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "2");
+
         for receipt in std::fs::read_dir(&state).expect("read receipts before persistence failure")
         {
             std::fs::remove_file(receipt.expect("read receipt entry").path())
@@ -1751,7 +1980,7 @@ esac
             .contains("previous submission stopped"));
         assert_eq!(
             std::fs::read_to_string(&submit_count).unwrap(),
-            "2",
+            "3",
             "the accepted persistence-failure submission must block an identical retry"
         );
         let forced_after_reconciliation = command("success")
@@ -1763,7 +1992,7 @@ esac
             "explicitly forced build failed: {}",
             String::from_utf8_lossy(&forced_after_reconciliation.stderr)
         );
-        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "3");
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "4");
 
         for entry in std::fs::read_dir(&state).expect("read state before ambiguous submission") {
             let path = entry.expect("read state entry").path();

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -659,11 +659,13 @@ async fn finalize_remote_build_handle(
     job_id: Uuid,
     state: &str,
     exit_status: Option<i32>,
-) {
-    if let Err(error) =
-        crate::remote_node::job_ledger::finalize(working_dir, job_id, state, exit_status).await
-    {
-        tracing::warn!(%job_id, ?error, "remote build receipt finalization failed");
+) -> bool {
+    match crate::remote_node::job_ledger::finalize(working_dir, job_id, state, exit_status).await {
+        Ok(_) => true,
+        Err(error) => {
+            tracing::warn!(%job_id, ?error, "remote build receipt finalization failed; observation will retry");
+            false
+        }
     }
 }
 
@@ -706,14 +708,17 @@ fn spawn_remote_build_observer(
             if cancel_requested {
                 if let Err(error) = client.cancel_job(&node, &shared_token, job_id).await {
                     if error.is_not_found() {
-                        finalize_remote_build_handle(
+                        if finalize_remote_build_handle(
                             &state.config.working_dir,
                             job_id,
                             "lost",
                             None,
                         )
-                        .await;
-                        return;
+                        .await
+                        {
+                            return;
+                        }
+                        continue;
                     }
                     tracing::warn!(
                         mission_id = %mission_id,
@@ -727,19 +732,23 @@ fn spawn_remote_build_observer(
             match client.get_job(&node, &shared_token, job_id).await {
                 Ok(status) if remote_build_is_terminal(&status.state) => {
                     record_remote_build_status(&state, &node.id, &status, started_at);
-                    finalize_remote_build_handle(
+                    if finalize_remote_build_handle(
                         &state.config.working_dir,
                         job_id,
                         &status.state,
                         status.exit_code,
                     )
-                    .await;
-                    return;
+                    .await
+                    {
+                        return;
+                    }
                 }
                 Err(error) if cancel_requested && error.is_not_found() => {
-                    finalize_remote_build_handle(&state.config.working_dir, job_id, "lost", None)
-                        .await;
-                    return;
+                    if finalize_remote_build_handle(&state.config.working_dir, job_id, "lost", None)
+                        .await
+                    {
+                        return;
+                    }
                 }
                 Ok(status) => {
                     record_remote_build_status(&state, &node.id, &status, started_at);
@@ -1008,13 +1017,16 @@ async fn submit_remote_build(
         };
         record_remote_build_status(&state, &node.id, &status, started_at);
         if remote_build_is_terminal(&status.state) {
-            finalize_remote_build_handle(
+            if !finalize_remote_build_handle(
                 &state.config.working_dir,
                 job_id,
                 &status.state,
                 status.exit_code,
             )
-            .await;
+            .await
+            {
+                continue;
+            }
             let duration_secs = (chrono::Utc::now() - started_at).num_seconds().max(0) as u64;
             return Json(RemoteBuildWaitResponse {
                 exit_code: status.exit_code,
@@ -1260,6 +1272,23 @@ async fn get_remote_build(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn terminal_handle_finalization_reports_persistence_failure() {
+        let temp = tempfile::tempdir().expect("create temp directory");
+        let invalid_working_dir = temp.path().join("not-a-directory");
+        std::fs::write(&invalid_working_dir, b"file").expect("create invalid working dir");
+
+        assert!(
+            !finalize_remote_build_handle(
+                &invalid_working_dir,
+                Uuid::new_v4(),
+                "succeeded",
+                Some(0),
+            )
+            .await
+        );
+    }
 
     fn node_job_status(state: &str) -> NodeJobStatus {
         NodeJobStatus {

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -1426,7 +1426,12 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
         } else if is_auth_error(&final_message) {
             TerminalReason::AuthError
         } else if stopped_with_pending_tool_error {
-            TerminalReason::Stalled
+            // This is a provider/stream disconnect after Codex emitted tool
+            // calls, not evidence that the agent itself made no progress.
+            // Structured transport data below lets the controller perform one
+            // bounded same-mission resume without treating source failures or
+            // ordinary stalls as retryable transport.
+            TerminalReason::LlmError
         } else {
             TerminalReason::LlmError
         };
@@ -1445,6 +1450,15 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
     }
     if let Some(m) = resolved_model.as_deref() {
         result = result.with_model(m.to_string());
+    }
+    if stopped_with_pending_tool_error {
+        let mut pending_tool_names = pending_tools.values().cloned().collect::<Vec<_>>();
+        pending_tool_names.sort_unstable();
+        pending_tool_names.dedup();
+        result = result.with_data(serde_json::json!({
+            "transport_failure_stage": "pending_tools",
+            "pending_tools": pending_tool_names,
+        }));
     }
 
     result

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -319,6 +319,10 @@ fn inactivity_is_cancellable(seconds_since_activity: u64, tool_call_in_flight: b
         && (!tool_call_in_flight || seconds_since_activity >= TOOL_CALL_STALL_GRACE_SECS)
 }
 
+fn execution_state_proves_durable_liveness(state: &str) -> bool {
+    state == "waiting_remote_job"
+}
+
 pub(crate) async fn stuck_mission_watchdog_loop(
     mission_store: Arc<dyn MissionStore>,
     cmd_tx: mpsc::Sender<ControlCommand>,
@@ -398,6 +402,14 @@ pub(crate) async fn stuck_mission_watchdog_loop(
         // the row Interrupted.
         for info in &running_list {
             if info.seconds_since_activity < STUCK_SECONDS {
+                continue;
+            }
+            if execution_state_proves_durable_liveness(&info.state) {
+                tracing::debug!(
+                    mission_id = %info.mission_id,
+                    seconds_since_activity = info.seconds_since_activity,
+                    "Stuck-mission watchdog: durable remote job proves liveness"
+                );
                 continue;
             }
             if !inactivity_is_cancellable(info.seconds_since_activity, info.tool_call_in_flight) {
@@ -710,5 +722,13 @@ mod tests {
     #[test]
     fn inactivity_watchdog_eventually_cancels_stale_tool_hint() {
         assert!(inactivity_is_cancellable(STUCK_SECONDS, true));
+    }
+
+    #[test]
+    fn durable_remote_wait_is_not_an_idle_runner() {
+        assert!(execution_state_proves_durable_liveness(
+            "waiting_remote_job"
+        ));
+        assert!(!execution_state_proves_durable_liveness("waiting_tool"));
     }
 }

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -28,6 +28,20 @@ pub enum JobHandleKind {
     Tentative,
 }
 
+/// Immutable identity of a remote validation. This deliberately stores a
+/// credential-free repository identifier so the durable ledger can prove
+/// exactly what was validated without persisting clone credentials.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteJobIdentity {
+    pub repository: String,
+    pub commit: String,
+    pub command: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub toolchain: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_bundle_digest: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobHandle {
     pub mission_id: Uuid,
@@ -38,16 +52,43 @@ pub struct JobHandle {
     /// handles keep this empty and must remain conservatively reserved.
     #[serde(default)]
     pub accepted_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Last successful observation of the durable node job. A stale value
+    /// means reconciliation is needed; it does not authorize resubmission.
+    #[serde(default)]
+    pub heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Scratch capacity reserved for this job until it reaches terminal state.
     /// Older ledgers deserialize this as zero.
     #[serde(default)]
     pub disk_reservation_bytes: u64,
     #[serde(default)]
     pub kind: JobHandleKind,
+    /// Present for immutable remote build/validation jobs. Legacy and raw
+    /// command handles deserialize with no identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<RemoteJobIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteJobReceipt {
+    pub mission_id: Uuid,
+    pub node_id: String,
+    pub job_id: Uuid,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub finished_at: chrono::DateTime<chrono::Utc>,
+    pub state: String,
+    #[serde(default)]
+    pub exit_status: Option<i32>,
+    pub identity: RemoteJobIdentity,
 }
 
 fn ledger_path(working_dir: &Path) -> PathBuf {
     working_dir.join(".sandboxed-sh").join("remote-jobs.json")
+}
+
+fn receipts_path(working_dir: &Path) -> PathBuf {
+    working_dir
+        .join(".sandboxed-sh")
+        .join("remote-job-receipts.json")
 }
 
 /// Serializes read-modify-write cycles within this process. Cross-process
@@ -83,6 +124,77 @@ async fn store(working_dir: &Path, handles: &[JobHandle]) -> anyhow::Result<()> 
     Ok(())
 }
 
+async fn load_receipts_result(working_dir: &Path) -> anyhow::Result<Vec<RemoteJobReceipt>> {
+    let path = receipts_path(working_dir);
+    match tokio::fs::read(&path).await {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|err| anyhow::anyhow!("parse {}: {err}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(err) => Err(anyhow::anyhow!("read {}: {err}", path.display())),
+    }
+}
+
+async fn store_receipts(working_dir: &Path, receipts: &[RemoteJobReceipt]) -> anyhow::Result<()> {
+    let path = receipts_path(working_dir);
+    let bytes = serde_json::to_vec_pretty(receipts)?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    tokio::fs::write(&tmp, &bytes).await?;
+    tokio::fs::rename(&tmp, &path).await?;
+    Ok(())
+}
+
+pub async fn terminal_receipt(
+    working_dir: &Path,
+    job_id: Uuid,
+) -> anyhow::Result<Option<RemoteJobReceipt>> {
+    Ok(load_receipts_result(working_dir)
+        .await?
+        .into_iter()
+        .find(|receipt| receipt.job_id == job_id))
+}
+
+/// Close an active handle and retain immutable validation evidence. Raw
+/// mission and tentative handles are removed without producing a receipt.
+pub async fn finalize(
+    working_dir: &Path,
+    job_id: Uuid,
+    state: &str,
+    exit_status: Option<i32>,
+) -> anyhow::Result<bool> {
+    const MAX_RECEIPTS: usize = 2_000;
+
+    let _guard = lock().lock().await;
+    let mut handles = load_result(working_dir).await?;
+    let Some(index) = handles.iter().position(|handle| handle.job_id == job_id) else {
+        return Ok(false);
+    };
+    let handle = handles.remove(index);
+    if let Some(identity) = handle.identity {
+        let mut receipts = load_receipts_result(working_dir).await?;
+        receipts.retain(|receipt| receipt.job_id != job_id);
+        receipts.push(RemoteJobReceipt {
+            mission_id: handle.mission_id,
+            node_id: handle.node_id,
+            job_id,
+            started_at: handle.started_at,
+            finished_at: chrono::Utc::now(),
+            state: state.to_string(),
+            exit_status,
+            identity,
+        });
+        if receipts.len() > MAX_RECEIPTS {
+            receipts.sort_by_key(|receipt| receipt.finished_at);
+            receipts.drain(..receipts.len() - MAX_RECEIPTS);
+        }
+        store_receipts(working_dir, &receipts).await?;
+    }
+    store(working_dir, &handles).await?;
+    Ok(true)
+}
+
 /// Record a job handle (idempotent on job_id).
 pub async fn record(working_dir: &Path, handle: JobHandle) -> anyhow::Result<()> {
     let _guard = lock().lock().await;
@@ -111,6 +223,25 @@ pub async fn remove(working_dir: &Path, job_id: Uuid) {
     }
 }
 
+/// Advance the durable heartbeat after a successful node status observation.
+pub async fn heartbeat(working_dir: &Path, job_id: Uuid) -> anyhow::Result<bool> {
+    let _guard = lock().lock().await;
+    let mut handles = load_result(working_dir).await?;
+    let Some(handle) = handles.iter_mut().find(|handle| handle.job_id == job_id) else {
+        return Ok(false);
+    };
+    let now = chrono::Utc::now();
+    if handle
+        .heartbeat_at
+        .is_some_and(|previous| now - previous < chrono::Duration::seconds(15))
+    {
+        return Ok(true);
+    }
+    handle.heartbeat_at = Some(now);
+    store(working_dir, &handles).await?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,8 +256,10 @@ mod tests {
             job_id,
             started_at: chrono::Utc::now(),
             accepted_at: Some(chrono::Utc::now()),
+            heartbeat_at: Some(chrono::Utc::now()),
             disk_reservation_bytes: 0,
             kind: JobHandleKind::Mission,
+            identity: None,
         };
 
         record(dir.path(), handle.clone()).await.unwrap();
@@ -150,8 +283,10 @@ mod tests {
                 job_id: Uuid::new_v4(),
                 started_at: chrono::Utc::now(),
                 accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::Mission,
+                identity: None,
             },
         )
         .await;
@@ -171,6 +306,8 @@ mod tests {
 
         assert_eq!(handle.kind, JobHandleKind::Mission);
         assert_eq!(handle.accepted_at, None);
+        assert_eq!(handle.heartbeat_at, None);
+        assert_eq!(handle.identity, None);
     }
 
     #[test]
@@ -199,8 +336,10 @@ mod tests {
             job_id,
             started_at: chrono::Utc::now(),
             accepted_at: None,
+            heartbeat_at: None,
             disk_reservation_bytes: 0,
             kind: JobHandleKind::Tentative,
+            identity: None,
         };
         record(dir.path(), handle.clone()).await.unwrap();
 
@@ -212,5 +351,73 @@ mod tests {
         assert_eq!(handles.len(), 1);
         assert_eq!(handles[0].job_id, job_id);
         assert_eq!(handles[0].kind, JobHandleKind::Mission);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_advances_only_an_existing_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let handle = JobHandle {
+            mission_id: Uuid::new_v4(),
+            node_id: "node-a".to_string(),
+            job_id,
+            started_at: chrono::Utc::now(),
+            accepted_at: Some(chrono::Utc::now()),
+            heartbeat_at: None,
+            disk_reservation_bytes: 0,
+            kind: JobHandleKind::RemoteBuild,
+            identity: Some(RemoteJobIdentity {
+                repository: "https://example.invalid/repo.git".to_string(),
+                commit: "a".repeat(40),
+                command: vec!["lake".to_string(), "build".to_string()],
+                toolchain: None,
+                source_bundle_digest: None,
+            }),
+        };
+        record(dir.path(), handle).await.unwrap();
+
+        assert!(heartbeat(dir.path(), job_id).await.unwrap());
+        assert!(load_result(dir.path()).await.unwrap()[0]
+            .heartbeat_at
+            .is_some());
+        assert!(!heartbeat(dir.path(), Uuid::new_v4()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn finalization_retains_immutable_remote_validation_receipt() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let identity = RemoteJobIdentity {
+            repository: "https://example.invalid/repo.git".to_string(),
+            commit: "a".repeat(40),
+            command: vec!["lake".to_string(), "build".to_string()],
+            toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
+            source_bundle_digest: Some("b".repeat(64)),
+        };
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id: Uuid::new_v4(),
+                node_id: "node-a".to_string(),
+                job_id,
+                started_at: chrono::Utc::now(),
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity.clone()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(finalize(dir.path(), job_id, "succeeded", Some(0))
+            .await
+            .unwrap());
+        assert!(load_result(dir.path()).await.unwrap().is_empty());
+        let receipt = terminal_receipt(dir.path(), job_id).await.unwrap().unwrap();
+        assert_eq!(receipt.identity, identity);
+        assert_eq!(receipt.state, "succeeded");
+        assert_eq!(receipt.exit_status, Some(0));
     }
 }

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -156,6 +156,17 @@ pub async fn terminal_receipt(
         .find(|receipt| receipt.job_id == job_id))
 }
 
+pub async fn terminal_receipts_for_mission(
+    working_dir: &Path,
+    mission_id: Uuid,
+) -> anyhow::Result<Vec<RemoteJobReceipt>> {
+    Ok(load_receipts_result(working_dir)
+        .await?
+        .into_iter()
+        .filter(|receipt| receipt.mission_id == mission_id)
+        .collect())
+}
+
 /// Close an active handle and retain immutable validation evidence. Raw
 /// mission and tentative handles are removed without producing a receipt.
 pub async fn finalize(
@@ -387,6 +398,7 @@ mod tests {
     async fn finalization_retains_immutable_remote_validation_receipt() {
         let dir = tempfile::tempdir().unwrap();
         let job_id = Uuid::new_v4();
+        let mission_id = Uuid::new_v4();
         let identity = RemoteJobIdentity {
             repository: "https://example.invalid/repo.git".to_string(),
             commit: "a".repeat(40),
@@ -397,7 +409,7 @@ mod tests {
         record(
             dir.path(),
             JobHandle {
-                mission_id: Uuid::new_v4(),
+                mission_id,
                 node_id: "node-a".to_string(),
                 job_id,
                 started_at: chrono::Utc::now(),
@@ -419,5 +431,16 @@ mod tests {
         assert_eq!(receipt.identity, identity);
         assert_eq!(receipt.state, "succeeded");
         assert_eq!(receipt.exit_status, Some(0));
+        assert_eq!(
+            terminal_receipts_for_mission(dir.path(), mission_id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(terminal_receipts_for_mission(dir.path(), Uuid::new_v4())
+            .await
+            .unwrap()
+            .is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- classify Codex pending-tool disconnects as structured transport failures and auto-resume the same mission once
- expose `waiting_remote_job` only while durable remote heartbeats remain fresh, preventing false watchdog cancellations without granting stale jobs indefinite liveness
- persist immutable remote validation identity and bounded terminal receipts, including repo/commit/command/toolchain/overlay/node/job
- reject already-stale submissions and surface `stale_success` as a non-zero exact-head gate
- enrich Hermes mission-status callbacks with prior status, terminal reason, execution lease, remote job receipts, resumability, and recommended action

## Safety
- auth, quota, capacity, source/test, watchdog, and loop failures do not enter the transport auto-resume path
- stale remote heartbeats stop proving liveness after 60 seconds but retain their job IDs for reconciliation
- accepted submissions remain idempotent through the existing immutable request receipt/lock
- repository credentials are stripped from all persisted validation identities

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1445 library tests plus all binary/doc tests; one pre-existing timing-sensitive node capacity test was rerun and then the full suite passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches mission execution, remote job ledger persistence, exact-head gating, and auto-resume on transport failures—errors could duplicate jobs, accept stale greens, or incorrectly stall/cancel long remote builds.
> 
> **Overview**
> This PR hardens **remote Lean validation** and **mission recovery** around exact commit identity, durable evidence, and provider disconnects.
> 
> **Remote build / `remote-lean-build`:** Submissions can carry `expected_head`, `toolchain`, and credential-free validation identity. Already-stale requests fail with `409`; polling with `expected_head` can surface `receipt_state=stale_success` (non-zero exit in the wrapper). The job ledger **finalizes** remote builds into bounded terminal receipts (repo/commit/command/toolchain/overlay digest) instead of only dropping handles; heartbeats prove liveness for ~60s. Client receipts redact repo credentials, exclude `expected_head` from idempotency fingerprints, and treat `stale_success` as terminal replay.
> 
> **Control plane:** New `waiting_remote_job` execution state and fresh remote-build heartbeats keep missions healthy and off the stuck watchdog while a durable job runs. Codex **pending-tool disconnects** are structured transport failures (`transport_failure_stage`) with a **single bounded auto-resume** per mission (not for auth/quota/capacity). Paloma webhooks gain richer context (old status, terminal reason, execution lease, remote jobs/receipts, recommended action).
> 
> **Fix:** `force_clear_cancelled_if_due` logic in mission runner is corrected so cancelled runners are force-cleared when the grace deadline passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda52dc3f8b6bc333e9c22db34f2d5439218511f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->