### PR TITLE
Deduplicate immutable remote Lean validations

### DIFF
--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -399,7 +399,61 @@ if [ -z "$job_id" ]; then
         cat "$response_file" >&2; echo >&2
         exit 75  # EX_TEMPFAIL: caller should fall back to a local build
     fi
-    if [ "$http_code" != "202" ]; then
+    reused_terminal=0
+    if [ "$http_code" = "200" ]; then
+        reuse_fields="$(python3 - "$response_file" <<'PY'
+import json, re, sys
+response = json.load(open(sys.argv[1]))
+job = str(response.get("job_id") or "")
+node = str(response.get("node_id") or "")
+state = str(response.get("receipt_state") or response.get("state") or "")
+if not re.fullmatch(r"[0-9a-fA-F-]{36}", job):
+    raise SystemExit("invalid job_id in reused receipt")
+if not node.strip() or any(ch in node for ch in "\t\r\n"):
+    raise SystemExit("invalid node_id in reused receipt")
+if state not in {"succeeded", "stale_success", "failed", "cancelled", "lost"}:
+    raise SystemExit("non-terminal reused receipt")
+print(job, node, state, sep="\t")
+PY
+        )" || die "invalid reused remote-build receipt"
+        IFS=$'\t' read -r job_id node_id receipt_state <<< "$reuse_fields"
+        python3 - "$state_file" "$request_file" "$response_file" <<'PY'
+import json, os, sys, tempfile
+path, request_path, response_path = sys.argv[1:]
+request = json.load(open(request_path))
+response = json.load(open(response_path))
+request.pop("token", None)
+repo = request.pop("repo", None)
+if repo:
+    from urllib.parse import urlsplit, urlunsplit
+    try:
+        parsed = urlsplit(repo)
+        host = parsed.hostname or ""
+        if parsed.port:
+            host += ":%d" % parsed.port
+        request["repository"] = urlunsplit(
+            (parsed.scheme, host, parsed.path, "", "")
+        ) if parsed.scheme else repo
+    except ValueError:
+        request["repository"] = repo
+request.pop("wait", None)
+bundle = request.pop("source_bundle", None)
+if bundle:
+    request["source_bundle_sha256"] = bundle.get("manifest_sha256")
+request.update(response)
+fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
+try:
+    with os.fdopen(fd, "w") as out:
+        json.dump(request, out, sort_keys=True)
+        out.write("\n")
+    os.replace(tmp, path)
+finally:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+PY
+        reused_terminal=1
+        echo "remote-lean-build: reusing terminal job $job_id on node '$node_id' for ${commit:0:12}; no new build submitted" >&2
+    elif [ "$http_code" != "202" ]; then
         case "$http_code" in
             5??)
                 if [ "$http_code" != "503" ] && ! persist_ambiguous_receipt "http-$http_code"; then
@@ -413,11 +467,12 @@ if [ -z "$job_id" ]; then
         exit 1
     fi
 
-    # From this point the node has accepted work. Keep the pre-created blocker
-    # unless a complete durable receipt is written below.
-    submit_lock_persistent=1
+    if [ "$reused_terminal" = "0" ]; then
+        # From this point the node has accepted work. Keep the pre-created
+        # blocker unless a complete durable receipt is written below.
+        submit_lock_persistent=1
 
-    IFS=$'\t' read -r job_id node_id < <(python3 - "$response_file" <<'PY'
+        IFS=$'\t' read -r job_id node_id < <(python3 - "$response_file" <<'PY'
 import json, re, sys
 response = json.load(open(sys.argv[1]))
 job = str(response.get("job_id") or "")
@@ -428,9 +483,9 @@ if not node.strip() or any(ch in node for ch in "\t\r\n"):
     raise SystemExit("invalid node_id in submit response")
 print(job, node, sep="\t")
 PY
-    ) || die "invalid remote-build submit response"
+        ) || die "invalid remote-build submit response"
 
-    python3 - "$state_file" "$request_file" "$job_id" "$node_id" <<'PY'
+        python3 - "$state_file" "$request_file" "$job_id" "$node_id" <<'PY'
 import json, os, sys, tempfile
 path, request_path, job_id, node_id = sys.argv[1:]
 request = json.load(open(request_path))
@@ -463,12 +518,13 @@ finally:
     if os.path.exists(tmp):
         os.unlink(tmp)
 PY
-    persist_status=$?
-    if [ "$persist_status" -ne 0 ]; then
-        die "accepted job $job_id on node '$node_id' but failed to persist its receipt; do not fall back locally or resubmit" 1
+        persist_status=$?
+        if [ "$persist_status" -ne 0 ]; then
+            die "accepted job $job_id on node '$node_id' but failed to persist its receipt; do not fall back locally or resubmit" 1
+        fi
+        submit_lock_persistent=0
+        echo "remote-lean-build: submitted job $job_id on node '$node_id'; receipt $state_file" >&2
     fi
-    submit_lock_persistent=0
-    echo "remote-lean-build: submitted job $job_id on node '$node_id'; receipt $state_file" >&2
 fi
 
 release_submit_lock

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -357,7 +357,10 @@ fn remote_job_identity(
     crate::remote_node::job_ledger::RemoteJobIdentity {
         repository: repository_identity(&req.repo),
         commit: req.commit.clone(),
+        cwd_rel_known: true,
+        cwd_rel: req.cwd_rel.clone(),
         command: req.command.clone(),
+        artifacts: req.artifacts.clone(),
         toolchain: req.toolchain.clone(),
         source_bundle_digest: req
             .source_bundle
@@ -773,6 +776,64 @@ fn spawn_remote_build_observer(
     });
 }
 
+async fn equivalent_remote_validation_response(
+    state: &AppState,
+    req: &RemoteBuildRequest,
+    identity: &crate::remote_node::job_ledger::RemoteJobIdentity,
+) -> Option<axum::response::Response> {
+    match crate::remote_node::job_ledger::equivalent_remote_validation(
+        &state.config.working_dir,
+        identity,
+    )
+    .await
+    {
+        Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Succeeded(
+            receipt,
+        ))) => {
+            tracing::info!(
+                mission_id = %req.mission_id,
+                canonical_mission_id = %receipt.mission_id,
+                job_id = %receipt.job_id,
+                "reusing successful immutable remote validation receipt"
+            );
+            let response = remote_build_status_from_receipt(
+                req.mission_id,
+                req.expected_head.as_deref(),
+                receipt,
+                true,
+            );
+            Some((StatusCode::OK, Json(response)).into_response())
+        }
+        Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Active(handle))) => {
+            Some(
+                (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "code": "REMOTE_VALIDATION_ALREADY_ACTIVE",
+                        "message": "an equivalent immutable remote validation is already unresolved; reconcile or attach to its canonical job before retrying",
+                        "job_id": handle.job_id,
+                        "node_id": handle.node_id,
+                        "mission_id": handle.mission_id,
+                        "accepted": handle.accepted_at.is_some(),
+                        "validation": identity,
+                    })),
+                )
+                    .into_response(),
+            )
+        }
+        Ok(None) => None,
+        Err(error) => Some(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "remote validation ledger could not be reconciled before submission: {error}"
+                ),
+            )
+                .into_response(),
+        ),
+    }
+}
+
 async fn submit_remote_build(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RemoteBuildRequest>,
@@ -818,15 +879,26 @@ async fn submit_remote_build(
     // placement labels, but may not remove the runtime readiness gate by
     // sending an empty or unrelated requirements list.
     let requirements = normalized_lean_requirements(&req.requirements);
+    let identity = remote_job_identity(&req);
+
+    // Reuse completed evidence even when every runner is currently offline.
+    // This optimistic read is repeated under the placement lock after any
+    // explicit network probe, which closes the concurrent-submit race.
+    if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await {
+        return response;
+    }
     if let Err((status, message)) =
         probe_explicit_lean_node(&state, &req.node_id, &requirements).await
     {
         return (status, message).into_response();
     }
-
-    // Serialize placement through tentative-handle persistence. Otherwise a
-    // burst can select the same idle node before its next heartbeat.
+    // Serialize the authoritative second identity check, placement, and
+    // tentative-handle persistence. No network probe runs while this mutex is
+    // held, so a slow explicit runner cannot block unrelated auto placement.
     let placement_guard = placement_lock().lock().await;
+    if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await {
+        return response;
+    }
     let node = match resolve_node(
         &state,
         &req.node_id,
@@ -876,7 +948,6 @@ async fn submit_remote_build(
         },
     };
 
-    let identity = remote_job_identity(&req);
     let client = RemoteNodeClient::default();
     let started_at = chrono::Utc::now();
     if let Err(error) = crate::remote_node::job_ledger::record(
@@ -1102,6 +1173,47 @@ struct RemoteBuildStatusResponse {
     current_head_match: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     validation: Option<crate::remote_node::job_ledger::RemoteJobIdentity>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    reused: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canonical_mission_id: Option<Uuid>,
+}
+
+fn remote_build_status_from_receipt(
+    response_mission_id: Uuid,
+    expected_head: Option<&str>,
+    receipt: crate::remote_node::job_ledger::RemoteJobReceipt,
+    reused: bool,
+) -> RemoteBuildStatusResponse {
+    let canonical_mission_id =
+        (receipt.mission_id != response_mission_id).then_some(receipt.mission_id);
+    let current_head_match =
+        expected_head.map(|expected_head| receipt.identity.commit == expected_head);
+    let receipt_state = if receipt.state == "succeeded" && current_head_match == Some(false) {
+        "stale_success".to_string()
+    } else {
+        receipt.state.clone()
+    };
+    let status = NodeJobStatus {
+        job_id: receipt.job_id,
+        mission_id: response_mission_id,
+        state: receipt.state,
+        exit_code: receipt.exit_status,
+        created_at: receipt.started_at.to_rfc3339(),
+        started_at: Some(receipt.started_at.to_rfc3339()),
+        finished_at: Some(receipt.finished_at.to_rfc3339()),
+        error: None,
+        log_tail: Some("reused durable terminal receipt".to_string()),
+        artifacts: Vec::new(),
+    };
+    RemoteBuildStatusResponse {
+        status,
+        receipt_state,
+        current_head_match,
+        validation: Some(receipt.identity),
+        reused,
+        canonical_mission_id,
+    }
 }
 
 fn remote_build_response_from_receipt(
@@ -1114,33 +1226,12 @@ fn remote_build_response_from_receipt(
             "job does not belong to this mission".to_string(),
         ));
     }
-    let current_head_match = query
-        .expected_head
-        .as_deref()
-        .map(|expected_head| receipt.identity.commit == expected_head);
-    let receipt_state = if receipt.state == "succeeded" && current_head_match == Some(false) {
-        "stale_success".to_string()
-    } else {
-        receipt.state.clone()
-    };
-    let status = NodeJobStatus {
-        job_id: receipt.job_id,
-        mission_id: receipt.mission_id,
-        state: receipt.state,
-        exit_code: receipt.exit_status,
-        created_at: receipt.started_at.to_rfc3339(),
-        started_at: Some(receipt.started_at.to_rfc3339()),
-        finished_at: Some(receipt.finished_at.to_rfc3339()),
-        error: None,
-        log_tail: None,
-        artifacts: Vec::new(),
-    };
-    Ok(Json(RemoteBuildStatusResponse {
-        status,
-        receipt_state,
-        current_head_match,
-        validation: Some(receipt.identity),
-    }))
+    Ok(Json(remote_build_status_from_receipt(
+        query.mission_id,
+        query.expected_head.as_deref(),
+        receipt,
+        false,
+    )))
 }
 
 /// `GET /api/remote-build/:job_id?mission_id=...&node_id=...` —
@@ -1283,6 +1374,8 @@ async fn get_remote_build(
         receipt_state,
         current_head_match,
         validation,
+        reused: false,
+        canonical_mission_id: None,
     }))
 }
 
@@ -1551,7 +1644,9 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             "token": "token",
             "repo": "https://secret-user:secret-token@example.invalid/org/repo.git?token=secret#fragment",
             "commit": "a".repeat(40),
+            "cwd_rel": "Compiler",
             "command": ["lake", "build"],
+            "artifacts": ["build/report.json"],
             "toolchain": "leanprover/lean4:v4.19.0",
             "wait": false
         }))
@@ -1560,7 +1655,10 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
 
         assert_eq!(identity.repository, "https://example.invalid/org/repo.git");
         assert_eq!(identity.commit, "a".repeat(40));
+        assert!(identity.cwd_rel_known);
+        assert_eq!(identity.cwd_rel.as_deref(), Some("Compiler"));
         assert_eq!(identity.command, vec!["lake", "build"]);
+        assert_eq!(identity.artifacts, vec!["build/report.json"]);
         assert_eq!(
             identity.toolchain.as_deref(),
             Some("leanprover/lean4:v4.19.0")
@@ -1596,7 +1694,10 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                 identity: crate::remote_node::job_ledger::RemoteJobIdentity {
                     repository: "https://github.com/example/verity.git".to_string(),
                     commit: "a".repeat(40),
+                    cwd_rel_known: true,
+                    cwd_rel: None,
                     command: vec!["lake".to_string(), "build".to_string()],
+                    artifacts: Vec::new(),
                     toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
                     source_bundle_digest: None,
                 },
@@ -2002,6 +2103,11 @@ case "$url" in
         if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "ambiguous" ]; then
             exit 28
         fi
+        if [ "$REMOTE_BUILD_TEST_POLL_MODE" = "reused" ]; then
+            printf '{"job_id":"22222222-2222-2222-2222-222222222222","mission_id":"%s","node_id":"lean:cpu","state":"succeeded","receipt_state":"succeeded","current_head_match":true,"exit_code":0,"created_at":"2026-07-15T20:00:00Z","started_at":"2026-07-15T20:00:01Z","finished_at":"2026-07-15T20:00:03Z","error":null,"log_tail":"reused durable terminal receipt","artifacts":[],"reused":true}' "$REMOTE_BUILD_TEST_MISSION_ID" > "$output"
+            printf '200'
+            exit 0
+        fi
         printf '{"job_id":"11111111-1111-1111-1111-111111111111","node_id":"lean:gpu"}' > "$output"
         printf '202'
         ;;
@@ -2203,6 +2309,29 @@ esac
         );
         assert!(receipt.get("token").is_none());
         assert!(receipt.get("repo").is_none());
+
+        for entry in std::fs::read_dir(&state).expect("read state before terminal reuse") {
+            let path = entry.expect("read state entry").path();
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).expect("remove stale test lock directory");
+            } else {
+                std::fs::remove_file(path).expect("remove prior test receipt");
+            }
+        }
+        std::fs::write(&submit_count, "0").expect("reset submit counter");
+        let reused = run("reused");
+        assert!(
+            reused.status.success(),
+            "terminal receipt reuse failed: {}",
+            String::from_utf8_lossy(&reused.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(&submit_count).unwrap(), "1");
+        assert!(String::from_utf8_lossy(&reused.stderr)
+            .contains("reusing terminal job 22222222-2222-2222-2222-222222222222"));
+        assert_eq!(
+            String::from_utf8_lossy(&reused.stdout),
+            "reused durable terminal receipt\n"
+        );
     }
 
     #[test]

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -35,7 +35,19 @@ pub enum JobHandleKind {
 pub struct RemoteJobIdentity {
     pub repository: String,
     pub commit: String,
+    /// `false` means this identity predates cwd persistence. Such receipts are
+    /// intentionally not equal to new root-cwd requests because their actual
+    /// execution directory is unknowable after upgrade.
+    #[serde(default)]
+    pub cwd_rel_known: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd_rel: Option<String>,
     pub command: Vec<String>,
+    /// Requested artifact digests are part of execution identity. Terminal
+    /// receipt reuse is disabled when this is non-empty until receipts retain
+    /// the resulting artifact entries as well.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub toolchain: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -94,6 +106,17 @@ pub struct RemoteJobReceipt {
     /// continuation (live control queue or persisted deferred goal).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wake_delivered_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum EquivalentRemoteValidation {
+    /// An accepted or ambiguously submitted job with the same immutable
+    /// validation identity is still unresolved. A new submission must fail
+    /// closed until that canonical job is reconciled.
+    Active(JobHandle),
+    /// A successful terminal receipt already proves this exact validation.
+    /// Callers may replay it without consuming remote capacity.
+    Succeeded(RemoteJobReceipt),
 }
 
 fn ledger_path(working_dir: &Path) -> PathBuf {
@@ -180,6 +203,44 @@ pub async fn terminal_receipts_for_mission(
         .into_iter()
         .filter(|receipt| receipt.mission_id == mission_id)
         .collect())
+}
+
+/// Resolve an immutable validation identity across mission boundaries.
+///
+/// The ledger and receipt files are inspected under one lock so finalization
+/// cannot move a matching job between them during the lookup. Successful
+/// receipts take precedence over a redundant in-flight job left by an older
+/// client: once exact evidence exists, no third build should be dispatched.
+pub async fn equivalent_remote_validation(
+    working_dir: &Path,
+    identity: &RemoteJobIdentity,
+) -> anyhow::Result<Option<EquivalentRemoteValidation>> {
+    let _guard = lock().lock().await;
+    let receipts = load_receipts_result(working_dir).await?;
+    if let Some(receipt) = receipts
+        .into_iter()
+        .filter(|receipt| {
+            receipt.identity == *identity
+                && identity.artifacts.is_empty()
+                && receipt.state == "succeeded"
+                && receipt.exit_status == Some(0)
+        })
+        .max_by_key(|receipt| receipt.finished_at)
+    {
+        return Ok(Some(EquivalentRemoteValidation::Succeeded(receipt)));
+    }
+    Ok(load_result(working_dir)
+        .await?
+        .into_iter()
+        .filter(|handle| {
+            handle.identity.as_ref() == Some(identity)
+                && matches!(
+                    handle.kind,
+                    JobHandleKind::RemoteBuild | JobHandleKind::Tentative
+                )
+        })
+        .min_by_key(|handle| handle.started_at)
+        .map(EquivalentRemoteValidation::Active))
 }
 
 /// Terminal remote-build receipts whose mission continuation has not yet
@@ -409,6 +470,20 @@ mod tests {
         assert_eq!(handle.kind, JobHandleKind::Tentative);
     }
 
+    #[test]
+    fn legacy_validation_identity_keeps_cwd_unknown() {
+        let identity: RemoteJobIdentity = serde_json::from_value(serde_json::json!({
+            "repository": "https://example.invalid/repo.git",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"]
+        }))
+        .unwrap();
+
+        assert!(!identity.cwd_rel_known);
+        assert_eq!(identity.cwd_rel, None);
+        assert!(identity.artifacts.is_empty());
+    }
+
     #[tokio::test]
     async fn accepted_handle_replaces_pre_submit_tentative_handle() {
         let dir = tempfile::tempdir().unwrap();
@@ -454,7 +529,10 @@ mod tests {
             identity: Some(RemoteJobIdentity {
                 repository: "https://example.invalid/repo.git".to_string(),
                 commit: "a".repeat(40),
+                cwd_rel_known: true,
+                cwd_rel: None,
                 command: vec!["lake".to_string(), "build".to_string()],
+                artifacts: Vec::new(),
                 toolchain: None,
                 source_bundle_digest: None,
             }),
@@ -477,7 +555,10 @@ mod tests {
         let identity = RemoteJobIdentity {
             repository: "https://example.invalid/repo.git".to_string(),
             commit: "a".repeat(40),
+            cwd_rel_known: true,
+            cwd_rel: None,
             command: vec!["lake".to_string(), "build".to_string()],
+            artifacts: Vec::new(),
             toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
             source_bundle_digest: Some("b".repeat(64)),
         };
@@ -525,5 +606,106 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn immutable_validation_lookup_blocks_active_and_reuses_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_id = Uuid::new_v4();
+        let identity = RemoteJobIdentity {
+            repository: "https://example.invalid/repo.git".to_string(),
+            commit: "a".repeat(40),
+            cwd_rel_known: true,
+            cwd_rel: None,
+            command: vec!["lake".to_string(), "build".to_string()],
+            artifacts: Vec::new(),
+            toolchain: Some("leanprover/lean4:v4.24.0".to_string()),
+            source_bundle_digest: None,
+        };
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id: Uuid::new_v4(),
+                node_id: "node-a".to_string(),
+                job_id,
+                started_at: chrono::Utc::now(),
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity.clone()),
+                wake_on_terminal: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            equivalent_remote_validation(dir.path(), &identity)
+                .await
+                .unwrap(),
+            Some(EquivalentRemoteValidation::Active(handle)) if handle.job_id == job_id
+        ));
+
+        finalize(dir.path(), job_id, "succeeded", Some(0))
+            .await
+            .unwrap();
+        assert!(matches!(
+            equivalent_remote_validation(dir.path(), &identity)
+                .await
+                .unwrap(),
+            Some(EquivalentRemoteValidation::Succeeded(receipt)) if receipt.job_id == job_id
+        ));
+
+        let changed_cwd = RemoteJobIdentity {
+            cwd_rel: Some("subproject".to_string()),
+            ..identity.clone()
+        };
+        assert!(equivalent_remote_validation(dir.path(), &changed_cwd)
+            .await
+            .unwrap()
+            .is_none());
+
+        let artifact_identity = RemoteJobIdentity {
+            artifacts: vec!["build/report.json".to_string()],
+            ..identity.clone()
+        };
+        let artifact_job_id = Uuid::new_v4();
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id: Uuid::new_v4(),
+                node_id: "node-b".to_string(),
+                job_id: artifact_job_id,
+                started_at: chrono::Utc::now(),
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(artifact_identity.clone()),
+                wake_on_terminal: false,
+            },
+        )
+        .await
+        .unwrap();
+        finalize(dir.path(), artifact_job_id, "succeeded", Some(0))
+            .await
+            .unwrap();
+        assert!(
+            equivalent_remote_validation(dir.path(), &artifact_identity)
+                .await
+                .unwrap()
+                .is_none(),
+            "artifact-producing validation cannot replay until receipts retain artifact digests"
+        );
+
+        let changed_overlay = RemoteJobIdentity {
+            source_bundle_digest: Some("b".repeat(64)),
+            ..identity
+        };
+        assert!(equivalent_remote_validation(dir.path(), &changed_overlay)
+            .await
+            .unwrap()
+            .is_none());
     }
 }


### PR DESCRIPTION
## Summary
- serialize global immutable validation lookup with remote placement
- replay an exact successful receipt across missions without consuming compute
- fail closed with `REMOTE_VALIDATION_ALREADY_ACTIVE` while an equivalent job is unresolved
- include cwd and dirty-overlay digest in validation identity
- teach `remote-lean-build` to persist and replay a server-returned terminal receipt

## Production evidence
The Verity #2205 canary submitted job `db4c3576-5c6d-4054-bd2a-432fd1d11e89` for the same repo/SHA/command/toolchain already proven by successful job `03aad138-66fd-4784-9d29-9052bcf3be0d`. This patch turns that race/controller drift into a receipt replay rather than another remote job.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (1456 passed, 1 ignored; companion and doc tests green)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-build submission, placement locking, and durable identity matching; incorrect dedup could skip needed builds or block retries until reconciliation, but behavior is fail-closed for active duplicates and covered by ledger/API tests.
> 
> **Overview**
> **Deduplicates immutable remote Lean validations** so the same repo/commit/command (plus cwd, toolchain, and source bundle digest) does not spawn another runner job when evidence already exists.
> 
> The job ledger gains `equivalent_remote_validation`, which under lock prefers a prior **successful** terminal receipt (cross-mission) or returns an **active** equivalent handle. `POST /api/remote-build` checks this before and again under the placement lock: matches return **200** with a reused receipt (`reused`, optional `canonical_mission_id`) or **409** `REMOTE_VALIDATION_ALREADY_ACTIVE`. `RemoteJobIdentity` now includes `cwd_rel`/`cwd_rel_known` and `artifacts` (non-empty artifacts disable replay until receipts carry artifact digests).
> 
> **`remote-lean-build`** treats submit **HTTP 200** as server-side terminal reuse: validates the payload, persists the receipt locally, and skips a new **202** submission path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a08140cd559135c85f7cf7ab9c5670d99232799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->