### PR TITLE
fix: preserve live run lease on remote wake

### DIFF
--- a/src/api/control/events.rs
+++ b/src/api/control/events.rs
@@ -484,6 +484,13 @@ pub enum ControlCommand {
     ListRunning {
         respond: oneshot::Sender<Vec<crate::api::mission_runner::RunningMissionInfo>>,
     },
+    /// Return the durable lease identity only when a harness process currently
+    /// owns this mission. Parked parallel runners remain registered for queue
+    /// continuity but deliberately return `None` here.
+    GetActorRunLease {
+        mission_id: Uuid,
+        respond: oneshot::Sender<Option<(Uuid, u64)>>,
+    },
     /// Resume an interrupted mission
     ResumeMission {
         mission_id: Uuid,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -7257,6 +7257,49 @@ async fn record_suppressed_remote_build_terminal_event(
     Ok(())
 }
 
+/// Ask the live control actor whether it still owns the mission process.
+///
+/// The durable run can still say `waiting_remote_job` for a short window after
+/// the synchronous remote-build tool has returned: the harness may already be
+/// consuming the result or running its next tool. Closing that lease from the
+/// receipt outbox would leave a live actor emitting stale-generation events.
+/// Query the actor directly instead of inferring process ownership from the
+/// persisted execution state.
+async fn control_actor_mission_run(
+    cmd_tx: &mpsc::Sender<ControlCommand>,
+    mission_id: Uuid,
+) -> Result<Option<(Uuid, u64)>, String> {
+    let (respond, response) = oneshot::channel();
+    cmd_tx
+        .send(ControlCommand::GetActorRunLease {
+            mission_id,
+            respond,
+        })
+        .await
+        .map_err(|_| "remote-build control actor is unavailable".to_string())?;
+    tokio::time::timeout(std::time::Duration::from_secs(5), response)
+        .await
+        .map_err(|_| "remote-build control actor ownership query timed out".to_string())?
+        .map_err(|_| "remote-build control actor ownership query was dropped".to_string())
+}
+
+fn select_actor_run_lease(
+    mission_id: Uuid,
+    main_running: bool,
+    main_mission_id: Option<Uuid>,
+    main_lease: Option<(Uuid, u64)>,
+    parallel_running: bool,
+    parallel_lease: Option<(Uuid, u64)>,
+) -> Option<(Uuid, u64)> {
+    if main_running && main_mission_id == Some(mission_id) {
+        main_lease
+    } else if parallel_running {
+        parallel_lease
+    } else {
+        None
+    }
+}
+
 async fn deliver_remote_build_terminal_wake(
     state: &AppState,
     receipt: &crate::remote_node::job_ledger::RemoteJobReceipt,
@@ -7299,24 +7342,42 @@ async fn deliver_remote_build_terminal_wake(
         owner.send(event);
         return Ok(true);
     }
-    if let Some(run) = owner
+    let active_run = owner
         .mission_store
         .get_active_mission_run(receipt.mission_id)
-        .await?
-    {
+        .await?;
+    let actor_run = if let Some(session) = live_session.as_ref() {
+        control_actor_mission_run(&session.cmd_tx, receipt.mission_id).await?
+    } else {
+        None
+    };
+    if let Some((actor_run_id, actor_generation)) = actor_run {
+        let actor_matches_lease = active_run
+            .as_ref()
+            .is_some_and(|run| run.run_id == actor_run_id && run.generation == actor_generation);
+        if !actor_matches_lease {
+            return Err(format!(
+                "remote-build actor/run lease conflict for mission {}: actor run {:?} generation {:?}",
+                receipt.mission_id, actor_run_id, actor_generation
+            ));
+        }
+    }
+    if let Some(run) = active_run {
         if run.execution_state != MissionExecutionState::WaitingRemoteJob {
             // The harness is still consuming the synchronous result. Let that
             // turn finish rather than racing it with a second continuation.
             return Ok(false);
         }
-        owner
-            .mission_store
-            .finish_mission_run(
-                run.run_id,
-                run.generation,
-                Some(&format!("remote_build_{}", receipt.state)),
-            )
-            .await?;
+        if actor_run.is_none() {
+            owner
+                .mission_store
+                .finish_mission_run(
+                    run.run_id,
+                    run.generation,
+                    Some(&format!("remote_build_{}", receipt.state)),
+                )
+                .await?;
+        }
     }
 
     let content = remote_build_terminal_message(receipt);
@@ -16121,6 +16182,22 @@ async fn control_actor_loop(
 
                         let _ = respond.send(running_list);
                     }
+                    ControlCommand::GetActorRunLease { mission_id, respond } => {
+                        let parallel_runner = parallel_runners.get(&mission_id);
+                        let actor_run = select_actor_run_lease(
+                            mission_id,
+                            running.is_some(),
+                            running_mission_id,
+                            running_run
+                                .as_ref()
+                                .map(|run| (run.run_id, run.generation)),
+                            parallel_runner.is_some_and(|runner| runner.is_running()),
+                            parallel_runner
+                                .and_then(|runner| runner.durable_run.as_ref())
+                                .map(|run| (run.run_id, run.generation)),
+                        );
+                        let _ = respond.send(actor_run);
+                    }
                     ControlCommand::ResumeMission { mission_id, clean_workspace, skip_message, respond } => {
                         // Resumable terminal writers do not hold a lease, so a replacement
                         // writer may have been created since this mission stopped. Serialize
@@ -22180,6 +22257,69 @@ mod tests {
         assert_eq!(
             mission_heartbeat_state(1, false, true),
             MissionExecutionState::WaitingRemoteJob
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_terminal_wake_detects_live_actor_ownership() {
+        let mission_id = Uuid::new_v4();
+        let run_id = Uuid::new_v4();
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let Some(ControlCommand::GetActorRunLease {
+                mission_id: requested_mission_id,
+                respond,
+            }) = cmd_rx.recv().await
+            else {
+                panic!("expected GetActorRunLease query");
+            };
+            assert_eq!(requested_mission_id, mission_id);
+            let _ = respond.send(Some((run_id, 7)));
+        });
+
+        assert_eq!(
+            control_actor_mission_run(&cmd_tx, mission_id)
+                .await
+                .unwrap(),
+            Some((run_id, 7))
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_terminal_wake_does_not_confuse_another_actor() {
+        let target_mission_id = Uuid::new_v4();
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            let Some(ControlCommand::GetActorRunLease {
+                mission_id: requested_mission_id,
+                respond,
+            }) = cmd_rx.recv().await
+            else {
+                panic!("expected GetActorRunLease query");
+            };
+            assert_eq!(requested_mission_id, target_mission_id);
+            let _ = respond.send(None);
+        });
+
+        assert!(control_actor_mission_run(&cmd_tx, target_mission_id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn remote_terminal_wake_closes_parked_parallel_lease() {
+        let mission_id = Uuid::new_v4();
+        let run_id = Uuid::new_v4();
+
+        assert_eq!(
+            select_actor_run_lease(mission_id, false, None, None, false, Some((run_id, 9)),),
+            None,
+            "a parked parallel runner retains its lease but owns no process"
+        );
+        assert_eq!(
+            select_actor_run_lease(mission_id, false, None, None, true, Some((run_id, 9)),),
+            Some((run_id, 9))
         );
     }
 


### PR DESCRIPTION
## Summary

- query the live control actor before closing a `waiting_remote_job` lease
- keep the exact run/generation alive when the harness is already consuming the remote result or executing its next tool
- fail closed on actor/lease identity conflicts instead of hiding them
- close detached waiting leases only when no actor owns them

## Production finding

The Verity #2205 canary proved remote wake ordering/coalescing, then exposed a second race: both receipts settled while the live harness had already started `gh pr checks --watch`. The wake closed generation 12, leaving that actor to emit stale-generation heartbeats and later tool events.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (1464 passed, 1 ignored; companion and doc tests green)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission run lifecycle and remote-build wake ordering; incorrect lease logic could leave stuck runs or double-continue, but changes are narrowly scoped with conflict detection and tests.
> 
> **Overview**
> Remote-build **terminal wake** no longer closes a `waiting_remote_job` durable lease based only on persisted state. It now asks the live control actor whether a harness still owns the mission (`GetActorRunLease`), and **skips** `finish_mission_run` when an actor holds the matching run/generation so the harness can keep consuming the sync result or run the next tool.
> 
> **Parked** parallel runners still keep their lease for queue continuity but report **no** process ownership. Actor vs store identity mismatches **fail closed** with an explicit error instead of silently finishing the run. Unit tests cover the lease query, cross-mission `None`, and parked-vs-running parallel selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7504a67b9f8f9087d481786c3c8cb080d1fca5ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->