### PR TITLE
Preserve detached remote waits during supervision

### DIFF
--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -29,7 +29,7 @@ use super::control::MissionStatus;
 #[allow(unused_imports)]
 use super::control::*;
 use super::mission_runner::TOOL_CALL_STALL_GRACE_SECS;
-use super::mission_store::MissionStore;
+use super::mission_store::{MissionExecutionState, MissionStore};
 
 mod bg_autoresume;
 
@@ -52,6 +52,28 @@ pub(crate) async fn recover_server_shutdown_missions(
                         "Startup recovery: leaving assistant-mode active mission idle"
                     );
                     continue;
+                }
+
+                match mission_has_detached_durable_run(mission_store.as_ref(), mission.id).await {
+                    Ok(true) => {
+                        tracing::info!(
+                            mission_id = %mission.id,
+                            "Startup recovery: durable detached execution will be reattached"
+                        );
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        // Execution truth is authoritative. Defer instead of
+                        // overwriting it with a server-shutdown presentation
+                        // status while the store is temporarily unavailable.
+                        tracing::warn!(
+                            mission_id = %mission.id,
+                            %error,
+                            "Startup recovery: could not inspect active run; deferring recovery"
+                        );
+                        continue;
+                    }
                 }
 
                 tracing::warn!(
@@ -323,6 +345,20 @@ fn execution_state_proves_durable_liveness(state: &str) -> bool {
     state == "waiting_remote_job"
 }
 
+fn detached_run_proves_durable_liveness(state: MissionExecutionState) -> bool {
+    state == MissionExecutionState::WaitingRemoteJob
+}
+
+async fn mission_has_detached_durable_run(
+    mission_store: &dyn MissionStore,
+    mission_id: Uuid,
+) -> Result<bool, String> {
+    Ok(mission_store
+        .get_active_mission_run(mission_id)
+        .await?
+        .is_some_and(|run| detached_run_proves_durable_liveness(run.execution_state)))
+}
+
 pub(crate) async fn stuck_mission_watchdog_loop(
     mission_store: Arc<dyn MissionStore>,
     cmd_tx: mpsc::Sender<ControlCommand>,
@@ -500,6 +536,33 @@ pub(crate) async fn stuck_mission_watchdog_loop(
                     "Stuck-mission watchdog: leaving idle assistant-mode mission active"
                 );
                 continue;
+            }
+            // A remote build deliberately outlives the harness process. The
+            // durable run lease is authoritative here: the remote-build
+            // reconciler owns its heartbeat and terminal transition after the
+            // conversational runner exits. Marking the presentation row
+            // interrupted would make that reconciler flip it back to Active on
+            // every tick, producing a false orphan/reconcile loop.
+            match mission_has_detached_durable_run(mission_store.as_ref(), mission.id).await {
+                Ok(true) => {
+                    tracing::debug!(
+                        mission_id = %mission.id,
+                        "Stuck-mission watchdog: detached durable execution owns liveness"
+                    );
+                    continue;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    // Fail closed: if execution truth is temporarily
+                    // unavailable, do not write a conflicting terminal
+                    // presentation status. The next watchdog tick retries.
+                    tracing::warn!(
+                        mission_id = %mission.id,
+                        %error,
+                        "Stuck-mission watchdog: could not inspect active run; deferring orphan reconciliation"
+                    );
+                    continue;
+                }
             }
             tracing::warn!(
                 "Stuck-mission watchdog: orphan {} (no live runner); marking interrupted",
@@ -730,5 +793,21 @@ mod tests {
             "waiting_remote_job"
         ));
         assert!(!execution_state_proves_durable_liveness("waiting_tool"));
+    }
+
+    #[test]
+    fn detached_durable_run_is_not_an_orphan() {
+        assert!(detached_run_proves_durable_liveness(
+            MissionExecutionState::WaitingRemoteJob
+        ));
+        assert!(!detached_run_proves_durable_liveness(
+            MissionExecutionState::WaitingBackground
+        ));
+        assert!(!detached_run_proves_durable_liveness(
+            MissionExecutionState::Running
+        ));
+        assert!(!detached_run_proves_durable_liveness(
+            MissionExecutionState::WaitingTool
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- treat an active `waiting_remote_job` run lease as authoritative when its conversational runner has exited
- preserve that lease during startup recovery so the remote-job reconciler can reattach it
- fail closed if execution truth cannot be read, avoiding presentation/run status conflicts
- add regression coverage for detached durable run classification

## Production incident
A healthy Verity remote build entered `waiting_remote_job`, then the one-minute orphan watchdog repeatedly marked its mission interrupted while the remote reconciler restored it to active. The job itself remained healthy and was not duplicated, but mission presentation oscillated.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1468 library tests passed, all bin and doc tests passed; one sandboxed-node capacity test was flaky on the first run, passed isolated and in the full rerun)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission supervision and recovery paths that can mark missions interrupted; behavior is narrowly scoped to `WaitingRemoteJob` with fail-closed store errors, but incorrect classification could still affect mission status presentation.
> 
> **Overview**
> Supervision now treats an active mission run in **`WaitingRemoteJob`** as proof the work is still alive even when no in-process runner exists, so detached remote builds are not misclassified as orphans.
> 
> **Startup recovery** skips marking those missions interrupted with `server_shutdown` and defers to the remote-job reconciler to reattach. The **stuck-mission watchdog** applies the same check before orphan reconciliation, avoiding the interrupt/active flip-flop when the reconciler restores presentation status.
> 
> If **`get_active_mission_run`** fails, both paths **fail closed** (skip status writes and retry later) so presentation rows are not overwritten while execution truth is unavailable. Unit tests cover detached durable run classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10245aaec19012b5056d256b0d7b6a2c0f046837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->