### PR TITLE
Retain remote wait leases before actor recovery

### DIFF
--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -50,6 +50,9 @@ req = {
     "commit": commit,
     "command": command,
     "wait": False,
+    # The HTTP request returns a job id, but this wrapper keeps the harness
+    # tool attached by polling that durable job to terminal state.
+    "resume_mission_on_terminal": True,
 }
 repo_root = pathlib.Path(
     subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
@@ -174,6 +177,7 @@ import hashlib, json, sys
 request = json.load(open(sys.argv[1]))
 request.pop("token", None)
 request.pop("wait", None)
+request.pop("resume_mission_on_terminal", None)
 # `expected_head` is a live freshness gate, not part of the immutable job
 # identity. A retry after the branch advances must resume the accepted job for
 # the pinned commit and report it as stale, never submit a duplicate.
@@ -351,6 +355,7 @@ if repo:
     except ValueError:
         request["repository"] = repo
 request.pop("wait", None)
+request.pop("resume_mission_on_terminal", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
     request["source_bundle_sha256"] = bundle.get("manifest_sha256")
@@ -437,6 +442,7 @@ if repo:
     except ValueError:
         request["repository"] = repo
 request.pop("wait", None)
+request.pop("resume_mission_on_terminal", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
     request["source_bundle_sha256"] = bundle.get("manifest_sha256")
@@ -504,6 +510,7 @@ if repo:
     except ValueError:
         request["repository"] = repo
 request.pop("wait", None)
+request.pop("resume_mission_on_terminal", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
     request["source_bundle_sha256"] = bundle.get("manifest_sha256")

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -4487,6 +4487,7 @@ fn remote_build_handle_proves_liveness(
 ) -> bool {
     if handle.kind != crate::remote_node::job_ledger::JobHandleKind::RemoteBuild
         || handle.accepted_at.is_none()
+        || !handle.expects_mission_continuation()
     {
         return false;
     }
@@ -4507,7 +4508,47 @@ async fn mission_has_unresolved_remote_build(
     else {
         return false;
     };
-    current_handle.wake_on_terminal
+    current_handle.expects_mission_continuation()
+}
+
+async fn recoverable_inherited_remote_wait(
+    working_dir: &std::path::Path,
+    mission_id: Uuid,
+    execution_state: MissionExecutionState,
+    mission_status: MissionStatus,
+) -> anyhow::Result<Option<Uuid>> {
+    if execution_state != MissionExecutionState::WaitingRemoteJob
+        || mission_status != MissionStatus::Active
+    {
+        return Ok(None);
+    }
+    if let Some(handle) =
+        crate::remote_node::job_ledger::current_remote_build_wait_handle(working_dir, mission_id)
+            .await?
+    {
+        return Ok(handle
+            .expects_mission_continuation()
+            .then_some(handle.job_id));
+    }
+
+    // `finalize` atomically moves a terminal job from the active ledger to
+    // the receipt outbox. A crash after that move but before delivery leaves
+    // no handle, yet the pending receipt still owns the mission continuation.
+    let receipt =
+        crate::remote_node::job_ledger::recoverable_terminal_continuations(working_dir, mission_id)
+            .await?
+            .into_iter()
+            .max_by_key(|receipt| receipt.finished_at);
+    let Some(receipt) = receipt else {
+        return Ok(None);
+    };
+    if crate::remote_node::job_ledger::require_terminal_receipt_wake(working_dir, receipt.job_id)
+        .await?
+    {
+        Ok(Some(receipt.job_id))
+    } else {
+        Ok(None)
+    }
 }
 
 async fn arm_unresolved_remote_build_wake(working_dir: &std::path::Path, mission_id: Uuid) -> bool {
@@ -7136,6 +7177,17 @@ pub(crate) async fn ensure_remote_build_wait(
         );
         return Ok(false);
     }
+    if !current_job
+        .as_ref()
+        .is_some_and(|handle| handle.expects_mission_continuation())
+    {
+        tracing::debug!(
+            %mission_id,
+            %job_id,
+            "fire-and-forget remote build retained without a mission wait lease"
+        );
+        return Ok(false);
+    }
     let Some((owner, _)) = remote_build_wait_owner(state, mission_id).await? else {
         return Ok(false);
     };
@@ -7644,6 +7696,7 @@ async fn dispatch_remote_job(
             disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
             identity: None,
+            wait_for_completion: None,
             wake_on_terminal: false,
         },
     )
@@ -7693,6 +7746,7 @@ async fn dispatch_remote_job(
             disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::Mission,
             identity: None,
+            wait_for_completion: None,
             wake_on_terminal: false,
         },
     )
@@ -7992,20 +8046,24 @@ async fn reconcile_pending_handles(
                 continue;
             }
             if handle.kind == crate::remote_node::job_ledger::JobHandleKind::RemoteBuild {
-                if let Err(error) = crate::remote_node::job_ledger::require_terminal_wake(
-                    working_dir,
-                    handle.job_id,
-                )
-                .await
-                {
-                    tracing::warn!(job_id = %handle.job_id, ?error, "recovered remote build wake requirement could not be persisted");
-                    continue;
-                }
-                if let Err(error) =
-                    ensure_remote_build_wait(state.as_ref(), handle.mission_id, handle.job_id).await
-                {
-                    tracing::warn!(mission_id = %handle.mission_id, job_id = %handle.job_id, %error, "recovered remote build run lease could not be reconciled");
-                    continue;
+                let expects_continuation = handle.expects_mission_continuation();
+                if expects_continuation {
+                    if let Err(error) = crate::remote_node::job_ledger::require_terminal_wake(
+                        working_dir,
+                        handle.job_id,
+                    )
+                    .await
+                    {
+                        tracing::warn!(job_id = %handle.job_id, ?error, "recovered remote build wake requirement could not be persisted");
+                        continue;
+                    }
+                    if let Err(error) =
+                        ensure_remote_build_wait(state.as_ref(), handle.mission_id, handle.job_id)
+                            .await
+                    {
+                        tracing::warn!(mission_id = %handle.mission_id, job_id = %handle.job_id, %error, "recovered remote build run lease could not be reconciled");
+                        continue;
+                    }
                 }
                 let node = state.config.remote_nodes.node(&handle.node_id).cloned();
                 let shared_token = node
@@ -8024,6 +8082,7 @@ async fn reconcile_pending_handles(
                                 handle.mission_id,
                                 handle.job_id,
                                 handle.started_at,
+                                expects_continuation,
                             )
                             .await;
                         });
@@ -8162,6 +8221,7 @@ async fn poll_recovered_remote_build(
     mission_id: Uuid,
     job_id: Uuid,
     started_at: chrono::DateTime<chrono::Utc>,
+    expects_continuation: bool,
 ) {
     let working_dir = state.config.working_dir.clone();
     let client = crate::remote_node::RemoteNodeClient::default();
@@ -8215,8 +8275,10 @@ async fn poll_recovered_remote_build(
                 {
                     tracing::warn!(%job_id, ?error, "recovered remote build heartbeat persistence failed");
                 }
-                if let Err(error) = ensure_remote_build_wait(&state, mission_id, job_id).await {
-                    tracing::warn!(%mission_id, %job_id, %error, "recovered remote build mission lease heartbeat failed");
+                if expects_continuation {
+                    if let Err(error) = ensure_remote_build_wait(&state, mission_id, job_id).await {
+                        tracing::warn!(%mission_id, %job_id, %error, "recovered remote build mission lease heartbeat failed");
+                    }
                 }
             }
             Err(_) => {}
@@ -13699,6 +13761,63 @@ async fn control_actor_loop(
     // below re-drives task-mode missions (assistant-mode missions remain idle).
     if let Ok(inherited_runs) = mission_store.list_active_mission_runs().await {
         for run in inherited_runs {
+            if run.execution_state == MissionExecutionState::WaitingRemoteJob {
+                let mission_status = match mission_store.get_mission(run.mission_id).await {
+                    Ok(Some(mission)) => mission.status,
+                    Ok(None) => MissionStatus::Interrupted,
+                    Err(error) => {
+                        // Do not destroy detached work while its presentation
+                        // status cannot be read. The remote reconciler will
+                        // retry once the store is available.
+                        tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            %error,
+                            "Control actor startup: mission status unavailable; preserving wait lease"
+                        );
+                        continue;
+                    }
+                };
+                match recoverable_inherited_remote_wait(
+                    &config.working_dir,
+                    run.mission_id,
+                    run.execution_state,
+                    mission_status,
+                )
+                .await
+                {
+                    Ok(Some(job_id)) => {
+                        tracing::info!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            generation = run.generation,
+                            %job_id,
+                            "Control actor startup: preserving recoverable remote-build wait lease"
+                        );
+                        continue;
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            "Control actor startup: remote wait has no accepted ledger handle; interrupting stale lease"
+                        );
+                    }
+                    Err(error) => {
+                        // The ledger is execution truth for detached remote
+                        // work. Fail closed and let its reconciler retry rather
+                        // than destroying a possibly-live lease on a transient
+                        // read failure.
+                        tracing::warn!(
+                            mission_id = %run.mission_id,
+                            run_id = %run.run_id,
+                            %error,
+                            "Control actor startup: remote job ledger unavailable; preserving wait lease"
+                        );
+                        continue;
+                    }
+                }
+            }
             let _ = mission_store
                 .finish_mission_run(run.run_id, run.generation, Some("server_shutdown"))
                 .await;
@@ -22437,6 +22556,7 @@ mod tests {
             disk_reservation_bytes: 0,
             kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
             identity: None,
+            wait_for_completion: Some(true),
             wake_on_terminal: false,
         };
         assert!(remote_build_handle_proves_liveness(&handle, now));
@@ -22445,6 +22565,9 @@ mod tests {
         handle.heartbeat_at = Some(now - chrono::Duration::seconds(1));
         assert!(remote_build_handle_proves_liveness(&handle, now));
         handle.kind = crate::remote_node::job_ledger::JobHandleKind::Mission;
+        assert!(!remote_build_handle_proves_liveness(&handle, now));
+        handle.kind = crate::remote_node::job_ledger::JobHandleKind::RemoteBuild;
+        handle.wait_for_completion = Some(false);
         assert!(!remote_build_handle_proves_liveness(&handle, now));
     }
 
@@ -22465,6 +22588,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
                 identity: None,
+                wait_for_completion: None,
                 wake_on_terminal: true,
             },
         )
@@ -22489,14 +22613,15 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
                 identity: None,
+                wait_for_completion: Some(true),
                 wake_on_terminal: false,
             },
         )
         .await
         .unwrap();
         assert!(
-            !mission_has_unresolved_remote_build(dir.path(), synchronous_mission_id).await,
-            "a synchronous waiter must not park a second mission continuation"
+            mission_has_unresolved_remote_build(dir.path(), synchronous_mission_id).await,
+            "a synchronous waiter must keep its mission continuation recoverable"
         );
         crate::remote_node::job_ledger::require_terminal_wake(dir.path(), synchronous_job_id)
             .await
@@ -22529,6 +22654,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
                 identity: None,
+                wait_for_completion: None,
                 wake_on_terminal: true,
             },
         )
@@ -22545,6 +22671,204 @@ mod tests {
             .await
             .unwrap();
         assert!(!mission_should_park_on_remote_build(&store, dir.path(), mission.id).await);
+    }
+
+    #[tokio::test]
+    async fn actor_startup_preserves_only_ledger_backed_remote_waits() {
+        let dir = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+        crate::remote_node::job_ledger::record(
+            dir.path(),
+            crate::remote_node::job_ledger::JobHandle {
+                mission_id,
+                node_id: "node-a".to_string(),
+                job_id,
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
+                identity: Some(crate::remote_node::job_ledger::RemoteJobIdentity {
+                    repository: "https://example.invalid/repo.git".to_string(),
+                    commit: "abc123".to_string(),
+                    cwd_rel_known: true,
+                    cwd_rel: None,
+                    command: vec!["lake".to_string(), "build".to_string()],
+                    artifacts: Vec::new(),
+                    toolchain: Some("leanprover/lean4:v4.24.0".to_string()),
+                    source_bundle_digest: None,
+                }),
+                wait_for_completion: Some(true),
+                wake_on_terminal: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                mission_id,
+                MissionExecutionState::WaitingRemoteJob,
+                MissionStatus::Active,
+            )
+            .await
+            .unwrap(),
+            Some(job_id)
+        );
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                mission_id,
+                MissionExecutionState::Running,
+                MissionStatus::Active,
+            )
+            .await
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                Uuid::new_v4(),
+                MissionExecutionState::WaitingRemoteJob,
+                MissionStatus::Active,
+            )
+            .await
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                mission_id,
+                MissionExecutionState::WaitingRemoteJob,
+                MissionStatus::Paused,
+            )
+            .await
+            .unwrap(),
+            None,
+            "an operator-paused mission must not be resurrected on restart"
+        );
+
+        let fire_and_forget_mission_id = Uuid::new_v4();
+        crate::remote_node::job_ledger::record(
+            dir.path(),
+            crate::remote_node::job_ledger::JobHandle {
+                mission_id: fire_and_forget_mission_id,
+                node_id: "node-b".to_string(),
+                job_id: Uuid::new_v4(),
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
+                identity: None,
+                wait_for_completion: Some(false),
+                wake_on_terminal: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                fire_and_forget_mission_id,
+                MissionExecutionState::WaitingRemoteJob,
+                MissionStatus::Active,
+            )
+            .await
+            .unwrap(),
+            None,
+            "fire-and-forget jobs must not arm a continuation after restart"
+        );
+
+        let finalized_sync_mission_id = Uuid::new_v4();
+        let finalized_sync_job_id = Uuid::new_v4();
+        crate::remote_node::job_ledger::record(
+            dir.path(),
+            crate::remote_node::job_ledger::JobHandle {
+                mission_id: finalized_sync_mission_id,
+                node_id: "node-c".to_string(),
+                job_id: finalized_sync_job_id,
+                started_at: chrono::Utc::now(),
+                submission_sequence: 0,
+                accepted_at: Some(chrono::Utc::now()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                disk_reservation_bytes: 0,
+                kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
+                identity: Some(crate::remote_node::job_ledger::RemoteJobIdentity {
+                    repository: "https://example.invalid/repo.git".to_string(),
+                    commit: "def456".to_string(),
+                    cwd_rel_known: true,
+                    cwd_rel: None,
+                    command: vec!["lake".to_string(), "build".to_string()],
+                    artifacts: Vec::new(),
+                    toolchain: Some("leanprover/lean4:v4.24.0".to_string()),
+                    source_bundle_digest: None,
+                }),
+                wait_for_completion: Some(true),
+                wake_on_terminal: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(crate::remote_node::job_ledger::finalize(
+            dir.path(),
+            finalized_sync_job_id,
+            "succeeded",
+            Some(0),
+        )
+        .await
+        .unwrap());
+        assert!(
+            crate::remote_node::job_ledger::pending_terminal_wakes(dir.path())
+                .await
+                .unwrap()
+                .iter()
+                .all(|receipt| receipt.job_id != finalized_sync_job_id),
+            "normal synchronous completion must not race its HTTP result with a wake"
+        );
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                finalized_sync_mission_id,
+                MissionExecutionState::WaitingRemoteJob,
+                MissionStatus::Active,
+            )
+            .await
+            .unwrap(),
+            Some(finalized_sync_job_id),
+            "startup must arm a terminal receipt when the synchronous wait lease survived"
+        );
+        assert!(
+            crate::remote_node::job_ledger::pending_terminal_wakes(dir.path())
+                .await
+                .unwrap()
+                .iter()
+                .any(|receipt| receipt.job_id == finalized_sync_job_id)
+        );
+
+        assert!(
+            crate::remote_node::job_ledger::finalize(dir.path(), job_id, "succeeded", Some(0),)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            recoverable_inherited_remote_wait(
+                dir.path(),
+                mission_id,
+                MissionExecutionState::WaitingRemoteJob,
+                MissionStatus::Active,
+            )
+            .await
+            .unwrap(),
+            Some(job_id),
+            "an undelivered terminal receipt must survive actor startup cleanup"
+        );
     }
 
     #[test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -310,6 +310,12 @@ pub struct RemoteBuildRequest {
     /// `{job_id, node_id}` immediately; poll `GET /api/remote-build/:job_id`.
     #[serde(default = "default_wait")]
     pub wait: bool,
+    /// Keep the owning mission attached to an asynchronous HTTP submission.
+    /// The bundled wrapper sets this because it requests a job id with
+    /// `wait=false` but continues polling inside the harness tool. Plain
+    /// fire-and-forget clients leave it false.
+    #[serde(default)]
+    pub resume_mission_on_terminal: bool,
     /// Artifact patterns (relative to the checkout root) to digest after a
     /// successful build.
     #[serde(default)]
@@ -838,6 +844,7 @@ async fn submit_remote_build(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RemoteBuildRequest>,
 ) -> axum::response::Response {
+    let expects_mission_continuation = req.wait || req.resume_mission_on_terminal;
     // Auth: per-mission, scope-bound capability token (NOT the dashboard JWT
     // and NOT a node bearer token) — a leak only authorizes remote builds
     // for this one mission. Same trust model as the spark offload endpoint.
@@ -963,6 +970,7 @@ async fn submit_remote_build(
             disk_reservation_bytes: req.estimated_disk_bytes,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
             identity: Some(identity.clone()),
+            wait_for_completion: Some(expects_mission_continuation),
             wake_on_terminal: false,
         },
     )
@@ -1041,6 +1049,7 @@ async fn submit_remote_build(
             disk_reservation_bytes: req.estimated_disk_bytes,
             kind: crate::remote_node::job_ledger::JobHandleKind::RemoteBuild,
             identity: Some(identity.clone()),
+            wait_for_completion: Some(expects_mission_continuation),
             // The bundled wrapper uses the asynchronous HTTP API but keeps
             // polling synchronously inside the harness tool. The control
             // actor arms terminal wake-up only if that turn actually ends
@@ -1067,6 +1076,19 @@ async fn submit_remote_build(
             format!("remote build accepted but recovery handle could not be persisted: {err}"),
         )
             .into_response();
+    }
+
+    if expects_mission_continuation {
+        if let Err(error) =
+            super::control::ensure_remote_build_wait(&state, req.mission_id, job_id).await
+        {
+            tracing::warn!(
+                mission_id = %req.mission_id,
+                %job_id,
+                %error,
+                "synchronous remote build wait lease could not be recorded"
+            );
+        }
     }
 
     if !req.wait {
@@ -1469,6 +1491,7 @@ mod tests {
             disk_reservation_bytes: 12 * GIB,
             kind: crate::remote_node::job_ledger::JobHandleKind::Tentative,
             identity: None,
+            wait_for_completion: None,
             wake_on_terminal: false,
         };
 
@@ -1705,6 +1728,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
                     toolchain: Some("leanprover/lean4:v4.19.0".to_string()),
                     source_bundle_digest: None,
                 },
+                continuation_expected: false,
                 wake_required: false,
                 wake_delivered_at: None,
                 wake_suppressed_by: None,
@@ -1742,6 +1766,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert_eq!(req.requirements, vec!["lean".to_string()]);
         assert_eq!(req.cwd_rel, None);
         assert_eq!(req.timeout_secs, None);
+        assert!(!req.resume_mission_on_terminal);
         assert_eq!(req.estimated_disk_bytes, 12 * GIB);
         assert!(req.source_bundle.is_none());
         assert!(req.artifacts.is_empty());
@@ -1757,11 +1782,13 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             "requirements": ["lean", "bigmem"],
             "node_id": "babylon",
             "wait": false,
+            "resume_mission_on_terminal": true,
             "artifacts": [".lake/build/lib/*"],
         }))
         .unwrap();
         assert_eq!(req.node_id, "babylon");
         assert!(!req.wait);
+        assert!(req.resume_mission_on_terminal);
         assert_eq!(req.requirements, vec!["lean", "bigmem"]);
         assert_eq!(req.cwd_rel.as_deref(), Some("verity"));
         assert_eq!(req.timeout_secs, Some(1200));

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -83,12 +83,35 @@ pub struct JobHandle {
     /// command handles deserialize with no identity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<RemoteJobIdentity>,
+    /// Whether the build owns a mission continuation. This is independent of
+    /// the HTTP response mode: the bundled wrapper requests a job id
+    /// asynchronously but keeps polling inside the harness tool. `None`
+    /// denotes a legacy ledger entry; recovery treats it conservatively so an
+    /// upgrade cannot discard an in-flight continuation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_for_completion: Option<bool>,
     /// The submitting harness no longer waits on the HTTP response, so the
     /// terminal receipt must wake the owning mission. Recovered remote builds
     /// are promoted to this mode because a restart severed any synchronous
     /// waiter that may have existed.
     #[serde(default)]
     pub wake_on_terminal: bool,
+}
+
+impl JobHandle {
+    /// Request-level continuation intent, also available while a submission
+    /// is still tentative and its node acceptance is ambiguous.
+    pub fn continuation_requested(&self) -> bool {
+        self.wake_on_terminal || self.wait_for_completion != Some(false)
+    }
+
+    /// True when this remote build owns a mission continuation. Newly written
+    /// fire-and-forget handles carry `Some(false)` and are excluded. Legacy
+    /// remote-build handles remain recoverable because their request mode was
+    /// not recorded.
+    pub fn expects_mission_continuation(&self) -> bool {
+        self.kind == JobHandleKind::RemoteBuild && self.continuation_requested()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -104,6 +127,12 @@ pub struct RemoteJobReceipt {
     #[serde(default)]
     pub exit_status: Option<i32>,
     pub identity: RemoteJobIdentity,
+    /// The accepted request owned a mission continuation even if its terminal
+    /// wake had not yet been armed. This lets startup recover the narrow
+    /// crash window after finalization but before a synchronous result reaches
+    /// the harness. Legacy receipts default to false.
+    #[serde(default)]
+    pub continuation_expected: bool,
     /// Remote-build receipts are also a durable wake-up outbox. Legacy
     /// receipts predate that contract and default to `false`, so upgrading
     /// never replays old validations into missions.
@@ -155,6 +184,7 @@ pub async fn current_remote_build_wait_handle(
             handle.mission_id == mission_id
                 && handle.kind == JobHandleKind::RemoteBuild
                 && handle.accepted_at.is_some()
+                && handle.expects_mission_continuation()
         })
         .max_by_key(|handle| validation_order(handle.submission_sequence, handle.started_at));
     let Some(current_handle) = current_handle else {
@@ -166,7 +196,9 @@ pub async fn current_remote_build_wait_handle(
         current_handle.started_at,
     );
     let newer_terminal_exists = receipts.iter().any(|receipt| {
-        if receipt.mission_id != mission_id {
+        if receipt.mission_id != mission_id
+            || (!receipt.wake_required && !receipt.continuation_expected)
+        {
             return false;
         }
         let receipt_order = validation_order(receipt.submission_sequence, receipt.started_at);
@@ -177,6 +209,7 @@ pub async fn current_remote_build_wait_handle(
     let newer_ambiguous_submission_exists = handles.iter().any(|handle| {
         handle.mission_id == mission_id
             && handle.kind == JobHandleKind::Tentative
+            && handle.continuation_requested()
             && validation_order(handle.submission_sequence, handle.started_at) > current_order
     });
 
@@ -334,6 +367,48 @@ pub async fn pending_terminal_wakes(working_dir: &Path) -> anyhow::Result<Vec<Re
         .collect())
 }
 
+/// Terminal receipts that can recover an inherited `waiting_remote_job`
+/// lease. Unlike `pending_terminal_wakes`, this includes a synchronous result
+/// finalized immediately before a core crash, while its normal HTTP/tool
+/// delivery was still in flight.
+pub async fn recoverable_terminal_continuations(
+    working_dir: &Path,
+    mission_id: Uuid,
+) -> anyhow::Result<Vec<RemoteJobReceipt>> {
+    Ok(load_receipts_result(working_dir)
+        .await?
+        .into_iter()
+        .filter(|receipt| {
+            receipt.mission_id == mission_id
+                && receipt.wake_delivered_at.is_none()
+                && (receipt.wake_required || receipt.continuation_expected)
+        })
+        .collect())
+}
+
+/// Promote a terminal continuation into the durable wake outbox after startup
+/// proved that its mission still had an inherited remote-wait lease.
+pub async fn require_terminal_receipt_wake(
+    working_dir: &Path,
+    job_id: Uuid,
+) -> anyhow::Result<bool> {
+    let _guard = lock().lock().await;
+    let mut receipts = load_receipts_result(working_dir).await?;
+    let Some(receipt) = receipts.iter_mut().find(|receipt| receipt.job_id == job_id) else {
+        return Ok(false);
+    };
+    if receipt.wake_delivered_at.is_some()
+        || (!receipt.wake_required && !receipt.continuation_expected)
+    {
+        return Ok(false);
+    }
+    if !receipt.wake_required {
+        receipt.wake_required = true;
+        store_receipts(working_dir, &receipts).await?;
+    }
+    Ok(true)
+}
+
 /// Decide whether a durable terminal callback still owns the mission wake.
 ///
 /// Missions may advance their immutable head while an older validation is in
@@ -355,6 +430,7 @@ pub async fn terminal_wake_disposition(
         .iter()
         .filter(|handle| {
             handle.kind == JobHandleKind::RemoteBuild
+                && handle.expects_mission_continuation()
                 && handle.mission_id == receipt.mission_id
                 && handle.job_id != receipt.job_id
                 && validation_order(handle.submission_sequence, handle.started_at) > receipt_order
@@ -367,6 +443,7 @@ pub async fn terminal_wake_disposition(
         .iter()
         .filter(|candidate| {
             candidate.mission_id == receipt.mission_id
+                && (candidate.wake_required || candidate.continuation_expected)
                 && candidate.job_id != receipt.job_id
                 && validation_order(candidate.submission_sequence, candidate.started_at)
                     > receipt_order
@@ -379,6 +456,7 @@ pub async fn terminal_wake_disposition(
     }
     if handles.iter().any(|handle| {
         handle.kind == JobHandleKind::Tentative
+            && handle.continuation_requested()
             && handle.mission_id == receipt.mission_id
             && handle.job_id != receipt.job_id
             && validation_order(handle.submission_sequence, handle.started_at) >= receipt_order
@@ -387,6 +465,7 @@ pub async fn terminal_wake_disposition(
     }
     if handles.iter().any(|handle| {
         handle.kind == JobHandleKind::RemoteBuild
+            && handle.expects_mission_continuation()
             && handle.mission_id == receipt.mission_id
             && handle.job_id != receipt.job_id
             && validation_order(handle.submission_sequence, handle.started_at) == receipt_order
@@ -448,6 +527,7 @@ pub async fn finalize(
     };
     let handle = handles.remove(index);
     if handle.kind == JobHandleKind::RemoteBuild {
+        let continuation_expected = handle.expects_mission_continuation();
         let Some(identity) = handle.identity else {
             store(working_dir, &handles).await?;
             return Ok(true);
@@ -468,6 +548,7 @@ pub async fn finalize(
             state: state.to_string(),
             exit_status,
             identity,
+            continuation_expected,
             wake_required: handle.kind == JobHandleKind::RemoteBuild && handle.wake_on_terminal,
             wake_delivered_at: previous_wake_delivered_at,
             wake_suppressed_by: None,
@@ -580,6 +661,41 @@ pub async fn require_terminal_wake(working_dir: &Path, job_id: Uuid) -> anyhow::
 mod tests {
     use super::*;
 
+    #[test]
+    fn remote_build_continuation_mode_is_explicit_and_legacy_safe() {
+        let base = JobHandle {
+            mission_id: Uuid::new_v4(),
+            node_id: "node-a".to_string(),
+            job_id: Uuid::new_v4(),
+            started_at: chrono::Utc::now(),
+            submission_sequence: 1,
+            accepted_at: Some(chrono::Utc::now()),
+            heartbeat_at: Some(chrono::Utc::now()),
+            disk_reservation_bytes: 0,
+            kind: JobHandleKind::RemoteBuild,
+            identity: None,
+            wait_for_completion: Some(false),
+            wake_on_terminal: false,
+        };
+
+        assert!(!base.expects_mission_continuation());
+        assert!(JobHandle {
+            wait_for_completion: Some(true),
+            ..base.clone()
+        }
+        .expects_mission_continuation());
+        assert!(JobHandle {
+            wait_for_completion: None,
+            ..base.clone()
+        }
+        .expects_mission_continuation());
+        assert!(JobHandle {
+            wake_on_terminal: true,
+            ..base
+        }
+        .expects_mission_continuation());
+    }
+
     #[tokio::test]
     async fn record_is_durable_and_idempotent() {
         let dir = tempfile::tempdir().unwrap();
@@ -595,6 +711,7 @@ mod tests {
             disk_reservation_bytes: 0,
             kind: JobHandleKind::Mission,
             identity: None,
+            wait_for_completion: None,
             wake_on_terminal: false,
         };
 
@@ -624,6 +741,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::Mission,
                 identity: None,
+                wait_for_completion: None,
                 wake_on_terminal: false,
             },
         )
@@ -694,6 +812,7 @@ mod tests {
             disk_reservation_bytes: 0,
             kind: JobHandleKind::Tentative,
             identity: None,
+            wait_for_completion: None,
             wake_on_terminal: false,
         };
         record(dir.path(), handle.clone()).await.unwrap();
@@ -733,6 +852,7 @@ mod tests {
                 toolchain: None,
                 source_bundle_digest: None,
             }),
+            wait_for_completion: None,
             wake_on_terminal: false,
         };
         record(dir.path(), handle).await.unwrap();
@@ -772,6 +892,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::RemoteBuild,
                 identity: Some(identity.clone()),
+                wait_for_completion: None,
                 wake_on_terminal: true,
             },
         )
@@ -833,6 +954,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::RemoteBuild,
                 identity: Some(identity.clone()),
+                wait_for_completion: None,
                 wake_on_terminal: false,
             },
         )
@@ -883,6 +1005,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::RemoteBuild,
                 identity: Some(artifact_identity.clone()),
+                wait_for_completion: None,
                 wake_on_terminal: false,
             },
         )
@@ -941,6 +1064,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::RemoteBuild,
                 identity: Some(identity('a')),
+                wait_for_completion: None,
                 wake_on_terminal: true,
             },
         )
@@ -967,6 +1091,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::RemoteBuild,
                 identity: Some(identity('b')),
+                wait_for_completion: None,
                 wake_on_terminal: false,
             },
         )
@@ -1021,6 +1146,7 @@ mod tests {
                 toolchain: None,
                 source_bundle_digest: None,
             }),
+            wait_for_completion: None,
             wake_on_terminal: true,
         };
 
@@ -1051,6 +1177,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fire_and_forget_validation_never_supersedes_a_continuation_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let continuation_job_id = Uuid::new_v4();
+        let detached_job_id = Uuid::new_v4();
+        let identity = |commit: char| RemoteJobIdentity {
+            repository: "https://example.invalid/verity.git".to_string(),
+            commit: commit.to_string().repeat(40),
+            cwd_rel_known: true,
+            cwd_rel: None,
+            command: vec!["lake".to_string(), "build".to_string()],
+            artifacts: Vec::new(),
+            toolchain: None,
+            source_bundle_digest: None,
+        };
+        let continuation_started_at = chrono::Utc::now() - chrono::Duration::minutes(2);
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id,
+                node_id: "node-a".to_string(),
+                job_id: continuation_job_id,
+                started_at: continuation_started_at,
+                submission_sequence: 0,
+                accepted_at: Some(continuation_started_at),
+                heartbeat_at: Some(continuation_started_at),
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity('a')),
+                wait_for_completion: Some(true),
+                wake_on_terminal: true,
+            },
+        )
+        .await
+        .unwrap();
+        let detached_started_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+        record(
+            dir.path(),
+            JobHandle {
+                mission_id,
+                node_id: "node-b".to_string(),
+                job_id: detached_job_id,
+                started_at: detached_started_at,
+                submission_sequence: 0,
+                accepted_at: Some(detached_started_at),
+                heartbeat_at: Some(detached_started_at),
+                disk_reservation_bytes: 0,
+                kind: JobHandleKind::RemoteBuild,
+                identity: Some(identity('b')),
+                wait_for_completion: Some(false),
+                wake_on_terminal: false,
+            },
+        )
+        .await
+        .unwrap();
+        finalize(dir.path(), detached_job_id, "succeeded", Some(0))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            current_remote_build_wait_handle(dir.path(), mission_id)
+                .await
+                .unwrap()
+                .map(|handle| handle.job_id),
+            Some(continuation_job_id),
+            "detached terminal evidence must not hide the live continuation owner"
+        );
+
+        finalize(dir.path(), continuation_job_id, "succeeded", Some(0))
+            .await
+            .unwrap();
+        let continuation_receipt = load_receipts_result(dir.path())
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|receipt| receipt.job_id == continuation_job_id)
+            .unwrap();
+        assert_eq!(
+            terminal_wake_disposition(dir.path(), &continuation_receipt)
+                .await
+                .unwrap(),
+            TerminalWakeDisposition::Ready,
+            "a newer detached receipt must not suppress the owning terminal wake"
+        );
+    }
+
+    #[tokio::test]
     async fn submission_sequence_breaks_equal_timestamp_ties_without_using_uuid_order() {
         let dir = tempfile::tempdir().unwrap();
         let mission_id = Uuid::new_v4();
@@ -1068,6 +1281,7 @@ mod tests {
             disk_reservation_bytes: 0,
             kind: JobHandleKind::RemoteBuild,
             identity: None,
+            wait_for_completion: None,
             wake_on_terminal: true,
         };
 
@@ -1130,6 +1344,7 @@ mod tests {
                     disk_reservation_bytes: 0,
                     kind: JobHandleKind::RemoteBuild,
                     identity: Some(identity.clone()),
+                    wait_for_completion: None,
                     wake_on_terminal,
                 },
             )
@@ -1183,6 +1398,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::RemoteBuild,
                 identity: Some(identity.clone()),
+                wait_for_completion: None,
                 wake_on_terminal: true,
             },
         )
@@ -1204,6 +1420,7 @@ mod tests {
                 disk_reservation_bytes: 0,
                 kind: JobHandleKind::Tentative,
                 identity: Some(identity),
+                wait_for_completion: None,
                 wake_on_terminal: false,
             },
         )
@@ -1252,6 +1469,7 @@ mod tests {
                     toolchain: None,
                     source_bundle_digest: None,
                 }),
+                wait_for_completion: None,
                 wake_on_terminal: false,
             },
         )


### PR DESCRIPTION
## Summary
- preserve an inherited `waiting_remote_job` run before the control actor performs generic server-shutdown cleanup
- require an accepted current remote-build ledger handle before preserving the lease
- fail closed on transient ledger read errors so possibly-live work is not terminalized
- cover ledger-backed, non-remote, and missing-handle startup cases

## Review follow-up
Addresses the valid exact-startup race reported on #655: the actor previously closed inherited leases before the later startup reconciler could inspect them.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1469 passed, 1 ignored; all bin and doc tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes mission execution, remote-build ledger semantics, and control-actor startup recovery—areas where mistakes can drop live remote work or resume missions incorrectly.
> 
> **Overview**
> **Remote lean builds** can now declare whether they own a **mission continuation** separately from HTTP `wait`. The API adds `resume_mission_on_terminal`; the job ledger stores `wait_for_completion` on handles and `continuation_expected` on terminal receipts, with `expects_mission_continuation()` driving liveness, parking, wake delivery, and supersession logic so **fire-and-forget** jobs no longer block or wake missions.
> 
> **`remote-lean-build`** sends `resume_mission_on_terminal: true` with `wait: false` and excludes that flag from request fingerprints. Submissions that expect continuation call `ensure_remote_build_wait` at accept time; recovery only arms terminal wakes and mission lease heartbeats when continuation is expected.
> 
> **Control actor startup** no longer applies generic `server_shutdown` cleanup to every inherited `waiting_remote_job` run. It uses `recoverable_inherited_remote_wait` to keep **Active** leases when the ledger (or an undelivered terminal receipt) still owns continuation, fails closed on ledger read errors, and interrupts only stale waits with no backing handle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101f83dbcecf637850802f049df0241c2d12cd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->