### PR TITLE
fix(remote-build): include node in reused receipts

### DIFF
--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -1192,6 +1192,7 @@ pub struct RemoteBuildStatusQuery {
 struct RemoteBuildStatusResponse {
     #[serde(flatten)]
     status: NodeJobStatus,
+    node_id: String,
     receipt_state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     current_head_match: Option<bool>,
@@ -1232,6 +1233,7 @@ fn remote_build_status_from_receipt(
     };
     RemoteBuildStatusResponse {
         status,
+        node_id: receipt.node_id,
         receipt_state,
         current_head_match,
         validation: Some(receipt.identity),
@@ -1395,6 +1397,7 @@ async fn get_remote_build(
     }
     Ok(Json(RemoteBuildStatusResponse {
         status,
+        node_id: node.id,
         receipt_state,
         current_head_match,
         validation,
@@ -1738,7 +1741,15 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         .0;
 
         assert_eq!(response.status.job_id, job_id);
+        assert_eq!(response.node_id, "offline-node");
         assert_eq!(response.receipt_state, "stale_success");
+        assert_eq!(
+            serde_json::to_value(&response)
+                .unwrap()
+                .get("node_id")
+                .and_then(serde_json::Value::as_str),
+            Some("offline-node")
+        );
         assert_eq!(response.current_head_match, Some(false));
         assert_eq!(
             response

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -663,6 +663,10 @@ mod tests {
         let headers = auth_headers(&state.shared_token);
         let mission_id = Uuid::new_v4();
         let job_id = Uuid::new_v4();
+        let mission_dir = work_root.path().join(mission_id.to_string());
+        tokio::fs::create_dir_all(&mission_dir)
+            .await
+            .expect("mission dir");
         let job_claims = LeaseClaims {
             mission_id,
             node_id: state.node_id.clone(),
@@ -713,15 +717,9 @@ mod tests {
         )
         .await;
         assert_eq!(rejected.unwrap_err().0, StatusCode::TOO_MANY_REQUESTS);
-        tokio::fs::write(
-            work_root
-                .path()
-                .join(mission_id.to_string())
-                .join("release"),
-            b"",
-        )
-        .await
-        .expect("release async job");
+        tokio::fs::write(mission_dir.join("release"), b"")
+            .await
+            .expect("release async job");
         let terminal = tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
                 if let Some(record) = state.jobs.get(job_id).await.expect("read job") {

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -679,7 +679,7 @@ mod tests {
                 lease_token: create_lease_token(&job_claims, &state.shared_token)
                     .expect("lease token"),
                 payload: sandboxed_sh::remote_node::JobPayload::RawCommand {
-                    command: "sleep 0.2".to_string(),
+                    command: "while [ ! -e release ]; do sleep 0.01; done".to_string(),
                     timeout_secs: Some(30),
                     env: None,
                 },
@@ -713,6 +713,28 @@ mod tests {
         )
         .await;
         assert_eq!(rejected.unwrap_err().0, StatusCode::TOO_MANY_REQUESTS);
+        tokio::fs::write(
+            work_root
+                .path()
+                .join(mission_id.to_string())
+                .join("release"),
+            b"",
+        )
+        .await
+        .expect("release async job");
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Some(record) = state.jobs.get(job_id).await.expect("read job") {
+                    if record.state.is_terminal() {
+                        break record;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("async job should finish");
+        assert_eq!(terminal.state, sandboxed_sh::node::JobState::Succeeded);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- include `node_id` in every remote-build status response
- preserve the node identity when reusing a terminal durable receipt
- cover serialized stale-success receipts with a regression assertion

## Production incident
The Verity #2205 acceptance canary received HTTP 200 for an immutable terminal receipt, but the response omitted `node_id`. `remote-lean-build` correctly rejected it as `invalid reused remote-build receipt` and did not resubmit or fall back locally.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1471 passed, 0 failed, 1 ignored; all binary and doc-test suites green)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API response shape fix with targeted tests; no auth or placement logic changes.
> 
> **Overview**
> **Remote-build status** now always includes **`node_id`** on `GET /api/remote-build/:job_id` responses—both when polling a live runner and when serving a **durable terminal receipt** (offline node, missing token, or node lookup failure).
> 
> Previously, receipt-backed paths built `RemoteBuildStatusResponse` without `node_id`, so HTTP 200 on immutable reuse could omit it. **`remote-lean-build`** treats that as an invalid reused receipt and aborts instead of resuming or falling back locally (the Verity #2205 canary incident).
> 
> A regression test asserts **`node_id`** on stale-success receipt serialization. The **sandboxed-node** capacity test is stabilized by using a file-wait loop instead of a fixed `sleep`, then releasing the async job and asserting it reaches **Succeeded**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ef37fa883df0cedd17ff4e5ec2a1df64729e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->