### PR TITLE
fix: close post-merge reliability review gaps

### DIFF
--- a/dashboard/src/components/hermes/alerts-feed.test.tsx
+++ b/dashboard/src/components/hermes/alerts-feed.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { SWRConfig, useSWRConfig } from "swr";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { listAlerts } from "@/lib/api";
@@ -44,7 +44,60 @@ describe("AlertsFeed", () => {
     });
     expect(mockedListAlerts).toHaveBeenCalledTimes(2);
   });
+
+  test("reopens pagination when a refresh moves the first-page boundary", async () => {
+    mockedListAlerts
+      .mockResolvedValueOnce({
+        alerts: [alert("mission-2", "2026-07-10T10:00:00Z")],
+        next_cursor: "cursor-2",
+      })
+      .mockResolvedValueOnce({
+        alerts: [alert("mission-1", "2026-07-09T10:00:00Z")],
+        next_cursor: null,
+      })
+      .mockResolvedValueOnce({
+        alerts: [alert("mission-3", "2026-07-11T10:00:00Z")],
+        next_cursor: "cursor-3",
+      })
+      .mockResolvedValueOnce({
+        alerts: [alert("mission-2", "2026-07-10T10:00:00Z")],
+        next_cursor: "cursor-2",
+      });
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <RefreshAlerts />
+        <AlertsFeed />
+      </SWRConfig>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Load older" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Load older" })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh feed" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Load older" }));
+
+    await waitFor(() => {
+      expect(mockedListAlerts).toHaveBeenLastCalledWith(
+        expect.objectContaining({ before: "cursor-3" }),
+      );
+    });
+  });
 });
+
+function RefreshAlerts() {
+  const { mutate } = useSWRConfig();
+  return (
+    <button
+      type="button"
+      onClick={() => void mutate(["hermes-alerts", "all"])}
+    >
+      Refresh feed
+    </button>
+  );
+}
 
 function alert(missionId: string, timestamp: string) {
   return {

--- a/dashboard/src/components/hermes/alerts-feed.tsx
+++ b/dashboard/src/components/hermes/alerts-feed.tsx
@@ -35,7 +35,17 @@ export function AlertsFeed() {
   const [filter, setFilter] = useState<FeedFilter>("all");
   // Older pages fetched via "load more"; reset when the filter changes.
   const [olderPages, setOlderPages] = useState<AlertFeedEntry[]>([]);
-  const [olderCursor, setOlderCursor] = useState<string | null>(null);
+  // `undefined` means no older page has been requested yet. `null` means the
+  // server explicitly reported that pagination is exhausted.
+  const [olderCursor, setOlderCursor] = useState<string | null | undefined>(
+    undefined,
+  );
+  // First-page boundary for which `olderCursor` was obtained. If SWR later
+  // refreshes to a different boundary, page the new gap before trusting the
+  // previously exhausted/deeper cursor again.
+  const [paginationAnchor, setPaginationAnchor] = useState<
+    string | null | undefined
+  >(undefined);
   const [loadingMore, setLoadingMore] = useState(false);
 
   const { data, isLoading } = useSWR(
@@ -49,24 +59,35 @@ export function AlertsFeed() {
   );
 
   const firstPage = useMemo(() => data?.alerts ?? [], [data]);
-  // Drop older entries that already appear in the (refreshing) first page.
+  // Drop duplicates and keep refreshed gap pages in chronological order even
+  // when they were fetched after an already-loaded older tail.
   const entries = useMemo(() => {
     if (olderPages.length === 0) return firstPage;
-    const seen = new Set(
-      firstPage.map((a) => `${a.mission_id}:${a.timestamp}`),
-    );
-    return [
-      ...firstPage,
-      ...olderPages.filter((a) => !seen.has(`${a.mission_id}:${a.timestamp}`)),
-    ];
+    const seen = new Set<string>();
+    return [...firstPage, ...olderPages]
+      .filter((alert) => {
+        const key = `${alert.mission_id}:${alert.timestamp}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .sort(
+        (left, right) =>
+          Date.parse(right.timestamp) - Date.parse(left.timestamp),
+      );
   }, [firstPage, olderPages]);
 
-  const cursor = olderCursor ?? data?.next_cursor ?? null;
+  const firstPageCursor = data?.next_cursor ?? null;
+  const cursor =
+    olderCursor === undefined || paginationAnchor !== firstPageCursor
+      ? firstPageCursor
+      : olderCursor;
 
   const changeFilter = useCallback((f: FeedFilter) => {
     setFilter(f);
     setOlderPages([]);
-    setOlderCursor(null);
+    setOlderCursor(undefined);
+    setPaginationAnchor(undefined);
   }, []);
 
   const loadMore = useCallback(async () => {
@@ -80,10 +101,11 @@ export function AlertsFeed() {
       });
       setOlderPages((prev) => [...prev, ...page.alerts]);
       setOlderCursor(page.next_cursor);
+      setPaginationAnchor(firstPageCursor);
     } finally {
       setLoadingMore(false);
     }
-  }, [cursor, filter, loadingMore]);
+  }, [cursor, filter, firstPageCursor, loadingMore]);
 
   return (
     <div className="flex h-full min-h-0 flex-col rounded-xl border border-border bg-[rgb(var(--foreground)/0.025)] p-3">

--- a/dashboard/src/components/hermes/hermes-thread.test.tsx
+++ b/dashboard/src/components/hermes/hermes-thread.test.tsx
@@ -89,4 +89,23 @@ describe("HermesThread", () => {
     expect(composer).toHaveValue("Review active missions");
     expect(screen.getByRole("button", { name: "Retry" })).toBeVisible();
   });
+
+  test("preserves retry when Hermes reports an in-stream failure", async () => {
+    mockedHermesChatStream.mockImplementationOnce(
+      async (_sessionId, _message, handlers) => {
+        handlers.onError("Provider disconnected");
+      },
+    );
+    render(<HermesThread />);
+
+    const composer = screen.getByPlaceholderText("Message Hermes…");
+    fireEvent.change(composer, { target: { value: "Resume the mission" } });
+    fireEvent.click(screen.getByTitle("Send"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Provider disconnected",
+    );
+    expect(composer).toHaveValue("Resume the mission");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeVisible();
+  });
 });

--- a/dashboard/src/components/hermes/hermes-thread.tsx
+++ b/dashboard/src/components/hermes/hermes-thread.tsx
@@ -248,6 +248,7 @@ export function HermesThread({ className }: { className?: string }) {
         prev.map((r) => (r.id === id ? { ...r, ...patch } : r)),
       );
     };
+    let streamFailure: string | null = null;
 
     try {
       let sid = sessionId;
@@ -362,11 +363,14 @@ export function HermesThread({ className }: { className?: string }) {
           },
           onError: (message) => {
             if (stale()) return;
-            setError(message);
+            streamFailure = message;
           },
         },
         controller.signal,
       );
+      if (streamFailure) {
+        throw new Error(streamFailure);
+      }
       if (!stale()) void refreshSessions();
     } catch (e) {
       if (!stale()) {

--- a/dashboard/src/lib/api/core.test.ts
+++ b/dashboard/src/lib/api/core.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { isNetworkError, LibraryUnavailableError } from './core';
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getStoredJwt, setJwt } from "../auth";
+import { apiFetch, isNetworkError, LibraryUnavailableError } from "./core";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
 
 describe('API Core', () => {
   describe('isNetworkError', () => {
@@ -9,61 +16,114 @@ describe('API Core', () => {
     });
 
     it('should return false for non-Error objects', () => {
-      expect(isNetworkError('string error')).toBe(false);
-      expect(isNetworkError({ message: 'object error' })).toBe(false);
+      expect(isNetworkError("string error")).toBe(false);
+      expect(isNetworkError({ message: "object error" })).toBe(false);
       expect(isNetworkError(42)).toBe(false);
     });
 
     it('should return true for "Failed to fetch" errors', () => {
-      expect(isNetworkError(new Error('Failed to fetch'))).toBe(true);
-      expect(isNetworkError(new Error('failed to fetch'))).toBe(true);
-      expect(isNetworkError(new Error('FAILED TO FETCH'))).toBe(true);
+      expect(isNetworkError(new Error("Failed to fetch"))).toBe(true);
+      expect(isNetworkError(new Error("failed to fetch"))).toBe(true);
+      expect(isNetworkError(new Error("FAILED TO FETCH"))).toBe(true);
     });
 
     it('should return true for "NetworkError" errors', () => {
-      expect(isNetworkError(new Error('NetworkError when attempting to fetch'))).toBe(true);
-      expect(isNetworkError(new Error('networkerror'))).toBe(true);
+      expect(isNetworkError(new Error("NetworkError when attempting to fetch"))).toBe(true);
+      expect(isNetworkError(new Error("networkerror"))).toBe(true);
     });
 
     it('should return true for "Load failed" errors', () => {
-      expect(isNetworkError(new Error('Load failed'))).toBe(true);
-      expect(isNetworkError(new Error('load failed'))).toBe(true);
+      expect(isNetworkError(new Error("Load failed"))).toBe(true);
+      expect(isNetworkError(new Error("load failed"))).toBe(true);
     });
 
     it('should return true for "Network request failed" errors', () => {
-      expect(isNetworkError(new Error('Network request failed'))).toBe(true);
+      expect(isNetworkError(new Error("Network request failed"))).toBe(true);
     });
 
     it('should return true for "offline" errors', () => {
-      expect(isNetworkError(new Error('The network is offline'))).toBe(true);
-      expect(isNetworkError(new Error('offline'))).toBe(true);
+      expect(isNetworkError(new Error("The network is offline"))).toBe(true);
+      expect(isNetworkError(new Error("offline"))).toBe(true);
     });
 
     it('should return false for other errors', () => {
-      expect(isNetworkError(new Error('Some other error'))).toBe(false);
-      expect(isNetworkError(new Error('401 Unauthorized'))).toBe(false);
+      expect(isNetworkError(new Error("Some other error"))).toBe(false);
+      expect(isNetworkError(new Error("401 Unauthorized"))).toBe(false);
     });
   });
 
   describe('LibraryUnavailableError', () => {
     it('should be an instance of Error', () => {
-      const error = new LibraryUnavailableError('test message');
+      const error = new LibraryUnavailableError("test message");
       expect(error).toBeInstanceOf(Error);
     });
 
     it('should have correct name', () => {
-      const error = new LibraryUnavailableError('test message');
-      expect(error.name).toBe('LibraryUnavailableError');
+      const error = new LibraryUnavailableError("test message");
+      expect(error.name).toBe("LibraryUnavailableError");
     });
 
     it('should have status 503', () => {
-      const error = new LibraryUnavailableError('test message');
+      const error = new LibraryUnavailableError("test message");
       expect(error.status).toBe(503);
     });
 
     it('should preserve error message', () => {
-      const error = new LibraryUnavailableError('Library not initialized');
-      expect(error.message).toBe('Library not initialized');
+      const error = new LibraryUnavailableError("Library not initialized");
+      expect(error.message).toBe("Library not initialized");
     });
+  });
+
+  it("does not clear a newer login token for a delayed stale 401", async () => {
+    let finishRequest: (response: Response) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            finishRequest = resolve;
+          }),
+      ),
+    );
+    setJwt("old-token", 4_102_444_800);
+
+    const request = apiFetch("/api/test");
+    setJwt("new-token", 4_102_444_800);
+    finishRequest(new Response(null, { status: 401 }));
+
+    await request;
+    expect(getStoredJwt()?.token).toBe("new-token");
+  });
+
+  it("signals for a 401 when no login token was sent", async () => {
+    const authRequired = vi.fn();
+    window.addEventListener("openagent:auth:required", authRequired, {
+      once: true,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+
+    await apiFetch("/api/test");
+
+    expect(authRequired).toHaveBeenCalledOnce();
+  });
+
+  it("signals for a 401 after an expired token was withheld", async () => {
+    const authRequired = vi.fn();
+    window.addEventListener("openagent:auth:required", authRequired, {
+      once: true,
+    });
+    setJwt("expired-token", 1);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+
+    await apiFetch("/api/test");
+
+    expect(getStoredJwt()).toBeNull();
+    expect(authRequired).toHaveBeenCalledOnce();
   });
 });

--- a/dashboard/src/lib/api/core.ts
+++ b/dashboard/src/lib/api/core.ts
@@ -3,7 +3,12 @@
  * All other API modules import from this file.
  */
 
-import { authHeader, clearJwt, signalAuthRequired } from "../auth";
+import {
+  authHeader,
+  clearJwt,
+  getStoredJwt,
+  signalAuthRequired,
+} from "../auth";
 import { getRuntimeApiBase } from "../settings";
 
 // ---------------------------------------------------------------------------
@@ -70,13 +75,22 @@ export function isHttpStatusError(
 // ---------------------------------------------------------------------------
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  const authentication = authHeader();
+  const requestJwt = authentication.Authorization?.startsWith("Bearer ")
+    ? authentication.Authorization.slice("Bearer ".length)
+    : null;
   const headers: Record<string, string> = {
     ...(init?.headers ? (init.headers as Record<string, string>) : {}),
-    ...authHeader(),
+    ...authentication,
   };
 
   const res = await fetch(apiUrl(path), { ...init, headers });
-  if (res.status === 401) {
+  // A delayed 401 from a request carrying an old token must not erase a token
+  // issued by a newer successful login.
+  if (
+    res.status === 401 &&
+    (getStoredJwt()?.token ?? null) === requestJwt
+  ) {
     clearJwt();
     signalAuthRequired();
   }

--- a/patches/hermes/api-server-session-cron-delivery.patch
+++ b/patches/hermes/api-server-session-cron-delivery.patch
@@ -24,20 +24,21 @@ index c595707..9e25672 100644
 +                from hermes_state import SessionDB
 +
 +                db = SessionDB()
-+                session = db.get_session(str(chat_id))
++                resolved_chat_id = db.resolve_resume_session_id(str(chat_id))
++                session = db.get_session(resolved_chat_id)
 +                if not session or str(session.get("source") or "") != "api_server":
 +                    raise ValueError(
 +                        f"API session '{chat_id}' does not exist or is not an api_server session"
 +                    )
 +                db.append_message(
-+                    session_id=str(chat_id),
++                    session_id=resolved_chat_id,
 +                    role="assistant",
 +                    content=content,
 +                )
 +                logger.info(
 +                    "Job '%s': appended durable delivery to API session %s",
 +                    job.get("id", "?"),
-+                    chat_id,
++                    resolved_chat_id,
 +                )
 +            except Exception as e:
 +                msg = f"API session delivery failed for '{chat_id}': {e}"

--- a/patches/hermes/sessiondb-durable-delivery.patch
+++ b/patches/hermes/sessiondb-durable-delivery.patch
@@ -1,16 +1,39 @@
 diff --git a/cron/scheduler.py b/cron/scheduler.py
+index 61fd1b76b..33202333f 100644
 --- a/cron/scheduler.py
 +++ b/cron/scheduler.py
-@@ -14,0 +15 @@ import contextvars
+@@ -12,6 +12,7 @@ import asyncio
+ import atexit
+ import concurrent.futures
+ import contextvars
 +import hashlib
-@@ -1674,0 +1676,4 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+ import json
+ import logging
+ import os
+@@ -1537,6 +1538,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+         # conversation without falling back to a configured home platform
+         # such as Telegram.
+         if str(platform_name).lower() == "api_server":
++            resolved_chat_id = str(chat_id)
 +            delivery_id = (
 +                f"cron:{chat_id}:{job.get('id', '?')}:"
 +                f"{job.get('_delivery_run_id') or job.get('last_run_at') or hashlib.sha256(content.encode('utf-8')).hexdigest()}"
 +            )
-@@ -1687,0 +1693 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+             db = None
+             try:
+                 from hermes_state import SessionDB
+@@ -1552,6 +1558,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+                     session_id=resolved_chat_id,
+                     role="assistant",
+                     content=content,
 +                    delivery_id=delivery_id,
-@@ -1695,3 +1701,28 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+                 )
+                 logger.info(
+                     "Job '%s': appended durable delivery to API session %s",
+@@ -1559,9 +1566,34 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
+                     resolved_chat_id,
+                 )
+             except Exception as e:
 -                msg = f"API session delivery failed for '{chat_id}': {e}"
 -                logger.warning("Job '%s': %s", job.get("id", "?"), msg)
 -                delivery_errors.append(msg)
@@ -24,7 +47,7 @@ diff --git a/cron/scheduler.py b/cron/scheduler.py
 +
 +                    spool_path = spool_session_delivery(
 +                        delivery_id=delivery_id,
-+                        session_id=str(chat_id),
++                        session_id=resolved_chat_id,
 +                        role="assistant",
 +                        content=content,
 +                    )
@@ -42,7 +65,12 @@ diff --git a/cron/scheduler.py b/cron/scheduler.py
 +                    )
 +                    logger.error("Job '%s': %s", job.get("id", "?"), msg)
 +                    delivery_errors.append(msg)
-@@ -4013 +4044,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
+             finally:
+                 if db is not None:
+                     db.close()
+@@ -3877,6 +3909,13 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
+             if should_deliver:
+                 try:
 -                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
 +                    delivery_job = dict(job)
 +                    delivery_job["_delivery_run_id"] = execution_id
@@ -52,6 +80,9 @@ diff --git a/cron/scheduler.py b/cron/scheduler.py
 +                        adapters=adapters,
 +                        loop=loop,
 +                    )
+                 except Exception as de:
+                     delivery_error = str(de)
+                     logger.error("Delivery failed for job %s: %s", job["id"], de)
 diff --git a/gateway/run.py b/gateway/run.py
 --- a/gateway/run.py
 +++ b/gateway/run.py
@@ -81,7 +112,7 @@ diff --git a/hermes_state.py b/hermes_state.py
 +import hashlib
 @@ -19,0 +21 @@ import logging
 +import os
-@@ -35,0 +38,58 @@ logger = logging.getLogger(__name__)
+@@ -35,0 +38,62 @@ logger = logging.getLogger(__name__)
 +def _delivery_spool_dir() -> Path:
 +    return Path(get_hermes_home()) / "delivery-spool"
 +
@@ -124,8 +155,12 @@ diff --git a/hermes_state.py b/hermes_state.py
 +        for path in sorted(spool_dir.glob("*.json")):
 +            try:
 +                payload = json.loads(path.read_text(encoding="utf-8"))
++                session_id = str(payload["session_id"])
++                resolve_resume = getattr(db, "resolve_resume_session_id", None)
++                if callable(resolve_resume):
++                    session_id = resolve_resume(session_id)
 +                db.append_message(
-+                    session_id=str(payload["session_id"]),
++                    session_id=session_id,
 +                    role=str(payload.get("role") or "assistant"),
 +                    content=payload.get("content"),
 +                    delivery_id=str(payload["delivery_id"]),
@@ -140,10 +175,10 @@ diff --git a/hermes_state.py b/hermes_state.py
 +    return result
 +
 +
-@@ -155 +215 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+@@ -155 +219 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 -SCHEMA_VERSION = 22
 +SCHEMA_VERSION = 23
-@@ -835,0 +896,7 @@ CREATE TABLE IF NOT EXISTS messages (
+@@ -835,0 +900,7 @@ CREATE TABLE IF NOT EXISTS messages (
 +CREATE TABLE IF NOT EXISTS delivery_receipts (
 +    delivery_id TEXT PRIMARY KEY,
 +    message_id INTEGER,
@@ -151,9 +186,9 @@ diff --git a/hermes_state.py b/hermes_state.py
 +    FOREIGN KEY (message_id) REFERENCES messages(id)
 +);
 +
-@@ -1003,0 +1071 @@ class SessionDB:
+@@ -1003,0 +1075 @@ class SessionDB:
 +    _WRITE_RETRY_DEADLINE_S = 10.0
-@@ -1286 +1354,15 @@ class SessionDB:
+@@ -1286 +1358,15 @@ class SessionDB:
 -        for attempt in range(self._WRITE_MAX_RETRIES):
 +        started_at = time.monotonic()
 +        try:
@@ -170,7 +205,7 @@ diff --git a/hermes_state.py b/hermes_state.py
 +        attempt = 0
 +        while attempt < self._WRITE_MAX_RETRIES and time.monotonic() < deadline_at:
 +            transaction_started_at = time.monotonic()
-@@ -1304,0 +1387,7 @@ class SessionDB:
+@@ -1304,0 +1391,7 @@ class SessionDB:
 +                if attempt:
 +                    logger.info(
 +                        "SessionDB write recovered lock_wait_ms=%.1f retries=%d transaction_ms=%.1f",
@@ -178,7 +213,7 @@ diff --git a/hermes_state.py b/hermes_state.py
 +                        attempt,
 +                        (time.monotonic() - transaction_started_at) * 1000,
 +                    )
-@@ -1310,3 +1399,5 @@ class SessionDB:
+@@ -1310,3 +1403,5 @@ class SessionDB:
 -                    if attempt < self._WRITE_MAX_RETRIES - 1:
 -                        jitter = random.uniform(
 -                            self._WRITE_RETRY_MIN_S,
@@ -187,16 +222,16 @@ diff --git a/hermes_state.py b/hermes_state.py
 +                        # Bounded full jitter: every retry samples from zero to
 +                        # the exponentially increasing cap, avoiding writer convoys.
 +                        cap = min(
-@@ -1313,0 +1405,2 @@ class SessionDB:
+@@ -1313,0 +1409,2 @@ class SessionDB:
 +                            self._WRITE_RETRY_MIN_S * (2 ** attempt),
 +                            remaining,
-@@ -1314,0 +1408 @@ class SessionDB:
+@@ -1314,0 +1412 @@ class SessionDB:
 +                        jitter = random.uniform(0, max(0, cap))
-@@ -1315,0 +1410 @@ class SessionDB:
+@@ -1315,0 +1414 @@ class SessionDB:
 +                        attempt += 1
-@@ -1330,0 +1426 @@ class SessionDB:
+@@ -1330,0 +1430 @@ class SessionDB:
 +                attempt += 1
-@@ -1332,0 +1429,7 @@ class SessionDB:
+@@ -1332,0 +1433,7 @@ class SessionDB:
 +        logger.error(
 +            "SessionDB write failed lock_wait_ms=%.1f retries=%d deadline_s=%.1f error=%s",
 +            (time.monotonic() - started_at) * 1000,
@@ -204,9 +239,9 @@ diff --git a/hermes_state.py b/hermes_state.py
 +            retry_deadline_s,
 +            last_err,
 +        )
-@@ -4171,0 +4275 @@ class SessionDB:
+@@ -4171,0 +4279 @@ class SessionDB:
 +        delivery_id: Optional[str] = None,
-@@ -4226,0 +4331,11 @@ class SessionDB:
+@@ -4226,0 +4335,11 @@ class SessionDB:
 +            if delivery_id:
 +                claimed = conn.execute(
 +                    "INSERT OR IGNORE INTO delivery_receipts (delivery_id, message_id, created_at) VALUES (?, NULL, ?)",
@@ -218,27 +253,77 @@ diff --git a/hermes_state.py b/hermes_state.py
 +                        (delivery_id,),
 +                    ).fetchone()
 +                    return prior[0] if prior and prior[0] is not None else 0
-@@ -4268,0 +4384,5 @@ class SessionDB:
+@@ -4268,0 +4388,5 @@ class SessionDB:
 +            if delivery_id:
 +                conn.execute(
 +                    "UPDATE delivery_receipts SET message_id = ? WHERE delivery_id = ?",
 +                    (msg_id, delivery_id),
 +                )
 diff --git a/tests/cron/test_scheduler.py b/tests/cron/test_scheduler.py
+index 2554de37e..ad6ebf74c 100644
 --- a/tests/cron/test_scheduler.py
 +++ b/tests/cron/test_scheduler.py
-@@ -4060,0 +4061 @@ class TestDeliverApiServerOrigin:
+@@ -4059,5 +4059,6 @@ class TestDeliverApiServerOrigin:
+         job = {
+             "id": "desktop-watch",
 +            "_delivery_run_id": str(tmp_path),
-@@ -4088,0 +4090 @@ class TestDeliverApiServerOrigin:
+             "name": "Desktop build watcher",
+             "deliver": "origin",
+             "origin": {
+@@ -4087,5 +4088,6 @@ class TestDeliverApiServerOrigin:
+         job = {
+             "id": "bad-target",
 +            "_delivery_run_id": str(tmp_path),
+             "deliver": "origin",
+             "origin": {
+                 "platform": "api_server",
+@@ -4098,0 +4101,37 @@ class TestDeliverApiServerOrigin:
++    def test_spools_failed_append_to_resolved_continuation(self, tmp_path, monkeypatch):
++        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
++        monkeypatch.setenv("HOME", str(tmp_path))
++
++        mock_db = MagicMock()
++        mock_db.resolve_resume_session_id.return_value = "api-session-child"
++        mock_db.get_session.return_value = {
++            "id": "api-session-child",
++            "source": "api_server",
++        }
++        mock_db.append_message.side_effect = RuntimeError("database is locked")
++
++        with patch("hermes_state.SessionDB", return_value=mock_db), patch(
++            "hermes_state.spool_session_delivery",
++            return_value=tmp_path / "delivery-spool" / "receipt.json",
++        ) as spool:
++            result = _deliver_result(
++                {
++                    "id": "desktop-watch",
++                    "_delivery_run_id": "run-1",
++                    "deliver": "origin",
++                    "origin": {
++                        "platform": "api_server",
++                        "chat_id": "api-session-parent",
++                    },
++                },
++                "The build finished successfully.",
++            )
++
++        assert result is None
++        spool.assert_called_once_with(
++            delivery_id="cron:api-session-parent:desktop-watch:run-1",
++            session_id="api-session-child",
++            role="assistant",
++            content="The build finished successfully.",
++        )
++
 diff --git a/tests/test_sessiondb_delivery_spool.py b/tests/test_sessiondb_delivery_spool.py
 new file mode 100644
 --- /dev/null
 +++ b/tests/test_sessiondb_delivery_spool.py
-@@ -0,0 +1,88 @@
+@@ -0,0 +1,109 @@
 +import sqlite3
 +import threading
 +import time
++from unittest.mock import MagicMock
 +
 +from hermes_state import (
 +    SessionDB,
@@ -324,3 +409,24 @@ new file mode 100644
 +        assert verify.get_messages("api-1")[-1]["content"] == "eventually committed"
 +    finally:
 +        verify.close()
++
++
++def test_replay_resolves_spooled_parent_to_live_continuation(tmp_path, monkeypatch):
++    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
++    monkeypatch.setenv("HOME", str(tmp_path))
++    spool_session_delivery(
++        "cron:api-parent:j:r3", "api-parent", "assistant", "done"
++    )
++
++    mock_db = MagicMock()
++    mock_db.resolve_resume_session_id.return_value = "api-child"
++    monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
++
++    assert replay_session_delivery_spool() == {"replayed": 1, "failed": 0}
++    mock_db.append_message.assert_called_once_with(
++        session_id="api-child",
++        role="assistant",
++        content="done",
++        delivery_id="cron:api-parent:j:r3",
++    )
++    mock_db.close.assert_called_once()

--- a/src/agents/types.rs
+++ b/src/agents/types.rs
@@ -228,7 +228,12 @@ impl AgentResult {
 
     /// Add additional data to the result.
     pub fn with_data(mut self, data: serde_json::Value) -> Self {
-        self.data = Some(data);
+        match (self.data.as_mut(), data) {
+            (Some(serde_json::Value::Object(existing)), serde_json::Value::Object(additional)) => {
+                existing.extend(additional);
+            }
+            (_, replacement) => self.data = Some(replacement),
+        }
         self
     }
 
@@ -373,6 +378,24 @@ mod tests {
         assert_eq!(data["native_terminal_seen"], true);
         assert_eq!(data["classification_source"], "structured");
         assert_eq!(data["turn_outcome"]["outcome"], "complete");
+    }
+
+    #[test]
+    fn additional_object_data_preserves_turn_outcome_metadata() {
+        let result = AgentResult::success("done", 0)
+            .with_turn_outcome(TurnOutcome::Complete {
+                signal: CompletionSignal::NativeTerminal,
+                confidence: CompletionConfidence::High,
+                message: None,
+            })
+            .with_data(serde_json::json!({
+                "transport_failure_stage": "pending_tools"
+            }));
+
+        let data = result.data.expect("metadata");
+        assert_eq!(data["turn_outcome"]["outcome"], "complete");
+        assert_eq!(data["completion_signal"], "native_terminal");
+        assert_eq!(data["transport_failure_stage"], "pending_tools");
     }
 
     #[test]

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -146,6 +146,14 @@ async fn acquire_execution_run(
 /// clippy's `type_complexity` threshold.
 type ControlQueueEntry = (Uuid, String, Option<String>, Option<Uuid>, Option<String>);
 
+fn enqueue_control_message(queue: &mut VecDeque<ControlQueueEntry>, entry: ControlQueueEntry) {
+    if entry.4.as_deref() == Some("remote-build-terminal") {
+        queue.push_front(entry);
+    } else {
+        queue.push_back(entry);
+    }
+}
+
 /// Pop the first queued delivery whose target is not explicitly paused or
 /// still owned by a detached durable wait. Parked deliveries remain durable
 /// and rotate behind runnable work; when all entries are parked the queue
@@ -4538,7 +4546,12 @@ async fn recoverable_inherited_remote_wait(
         crate::remote_node::job_ledger::recoverable_terminal_continuations(working_dir, mission_id)
             .await?
             .into_iter()
-            .max_by_key(|receipt| receipt.finished_at);
+            .max_by_key(|receipt| {
+                crate::remote_node::job_ledger::validation_order(
+                    receipt.submission_sequence,
+                    receipt.started_at,
+                )
+            });
     let Some(receipt) = receipt else {
         return Ok(None);
     };
@@ -5946,6 +5959,14 @@ fn inferred_pr_writer(explicit: Option<bool>, intent: Option<&str>, prompt: Opti
         "not", "never", "no", "without", "dont", "cannot", "cant", "forbid",
     ];
     const NEGATORS_AFTER: [&str; 4] = ["prohibited", "forbidden", "banned", "disallowed"];
+    const POLICY_ADVERBS: [&str; 6] = [
+        "currently",
+        "temporarily",
+        "explicitly",
+        "strictly",
+        "now",
+        "still",
+    ];
 
     clauses.iter().any(|words| {
         words.iter().enumerate().any(|(index, word)| {
@@ -5961,11 +5982,34 @@ fn inferred_pr_writer(explicit: Option<bool>, intent: Option<&str>, prompt: Opti
             });
             let stopped_before =
                 index >= 2 && words[index - 2] == "stop" && words[index - 1] == "before";
-            let after_end = (index + 4).min(words.len());
-            let negated_after = words[(index + 1).min(words.len())..after_end]
-                .iter()
-                .any(|next| NEGATORS_AFTER.contains(next));
-            !(negated_immediately || coordinated_negation || stopped_before || negated_after)
+            let mut prohibition_index = index + 1;
+            let has_copula = words
+                .get(prohibition_index)
+                .is_some_and(|word| matches!(*word, "is" | "are" | "was" | "were"));
+            if has_copula {
+                prohibition_index += 1;
+            }
+            let mut policy_adverbs = 0;
+            while policy_adverbs < 2
+                && words
+                    .get(prohibition_index)
+                    .is_some_and(|word| POLICY_ADVERBS.contains(word))
+            {
+                prohibition_index += 1;
+                policy_adverbs += 1;
+            }
+            let policy_prohibition = words
+                .get(prohibition_index)
+                .is_some_and(|word| NEGATORS_AFTER.contains(word))
+                && (has_copula
+                    || policy_adverbs > 0
+                    || words.get(prohibition_index + 1).is_none_or(|next| {
+                        matches!(
+                            *next,
+                            "by" | "under" | "here" | "globally" | "currently" | "temporarily"
+                        )
+                    }));
+            !(negated_immediately || coordinated_negation || stopped_before || policy_prohibition)
         })
     })
 }
@@ -7375,6 +7419,31 @@ async fn deliver_remote_build_terminal_wake(
             | MissionStatus::Blocked
             | MissionStatus::NotFeasible
     ) {
+        let actor_still_owns_run = if let Some(session) = live_session.as_ref() {
+            control_actor_mission_run(&session.cmd_tx, receipt.mission_id)
+                .await?
+                .is_some()
+        } else {
+            false
+        };
+        if !actor_still_owns_run {
+            if let Some(run) = owner
+                .mission_store
+                .get_active_mission_run(receipt.mission_id)
+                .await?
+            {
+                if run.execution_state == MissionExecutionState::WaitingRemoteJob {
+                    owner
+                        .mission_store
+                        .finish_mission_run(
+                            run.run_id,
+                            run.generation,
+                            Some("remote_build_terminal_after_mission_parked"),
+                        )
+                        .await?;
+                }
+            }
+        }
         let event = AgentEvent::AssistantMessage {
             id: Uuid::new_v5(
                 &Uuid::NAMESPACE_URL,
@@ -15259,7 +15328,10 @@ async fn control_actor_loop(
                                 }
                             }
                         }
-                        queue.push_back((id, content, msg_agent, target_mission_id, source.clone()));
+                        enqueue_control_message(
+                            &mut queue,
+                            (id, content, msg_agent, target_mission_id, source.clone()),
+                        );
                         // `Queued` is an acceptance acknowledgement. Persist the
                         // message before sending it so a crash cannot lose an
                         // outbox delivery that its producer has already retired.
@@ -22989,6 +23061,32 @@ mod tests {
             None,
             Some("Do not commit or push; fix the failing branch")
         ));
+        assert!(inferred_pr_writer(
+            None,
+            None,
+            Some("Fix the prohibited dependency usage")
+        ));
+        assert!(inferred_pr_writer(
+            None,
+            None,
+            Some("Implement the banned-import repair")
+        ));
+        assert!(!inferred_pr_writer(
+            None,
+            None,
+            Some("Merge prohibited by policy")
+        ));
+        assert!(!inferred_pr_writer(None, None, Some("Push forbidden")));
+        assert!(!inferred_pr_writer(
+            None,
+            None,
+            Some("Merging is currently prohibited")
+        ));
+        assert!(!inferred_pr_writer(
+            None,
+            None,
+            Some("Push is temporarily forbidden")
+        ));
         assert!(!inferred_pr_writer(
             None,
             Some("read_only_audit"),
@@ -23025,6 +23123,52 @@ mod tests {
             Some("read_only_audit"),
             None
         ));
+    }
+
+    #[test]
+    fn remote_terminal_wake_precedes_parked_user_followups() {
+        let mission_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let wake_id = Uuid::new_v4();
+        let mut queue = VecDeque::new();
+        enqueue_control_message(
+            &mut queue,
+            (
+                user_id,
+                "user follow-up".to_string(),
+                None,
+                Some(mission_id),
+                None,
+            ),
+        );
+        enqueue_control_message(
+            &mut queue,
+            (
+                wake_id,
+                "terminal receipt".to_string(),
+                None,
+                Some(mission_id),
+                Some("remote-build-terminal".to_string()),
+            ),
+        );
+
+        assert_eq!(queue.pop_front().map(|entry| entry.0), Some(wake_id));
+        assert_eq!(queue.pop_front().map(|entry| entry.0), Some(user_id));
+    }
+
+    #[test]
+    fn startup_recovery_prefers_submission_order_over_completion_order() {
+        let older_started_at = chrono::Utc::now() - chrono::Duration::minutes(5);
+        let newer_started_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+
+        assert!(
+            crate::remote_node::job_ledger::validation_order(2, newer_started_at)
+                > crate::remote_node::job_ledger::validation_order(1, older_started_at)
+        );
+        assert!(
+            crate::remote_node::job_ledger::validation_order(0, newer_started_at)
+                > crate::remote_node::job_ledger::validation_order(0, older_started_at)
+        );
     }
 
     #[tokio::test]

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -802,13 +802,44 @@ async fn equivalent_remote_validation_response(
                 job_id = %receipt.job_id,
                 "reusing successful immutable remote validation receipt"
             );
-            let response = remote_build_status_from_receipt(
-                req.mission_id,
-                req.expected_head.as_deref(),
-                receipt,
-                true,
-            );
-            Some((StatusCode::OK, Json(response)).into_response())
+            if req.wait {
+                let duration_secs = (receipt.finished_at - receipt.started_at)
+                    .num_seconds()
+                    .max(0) as u64;
+                let state = if receipt.state == "succeeded"
+                    && req
+                        .expected_head
+                        .as_deref()
+                        .is_some_and(|head| head != receipt.identity.commit)
+                {
+                    "stale_success".to_string()
+                } else {
+                    receipt.state
+                };
+                Some(
+                    (
+                        StatusCode::OK,
+                        Json(RemoteBuildWaitResponse {
+                            exit_code: receipt.exit_status,
+                            state,
+                            duration_secs,
+                            log_tail: "reused durable terminal receipt".to_string(),
+                            node_id: receipt.node_id,
+                            job_id: receipt.job_id,
+                            artifacts: Vec::new(),
+                        }),
+                    )
+                        .into_response(),
+                )
+            } else {
+                let response = remote_build_status_from_receipt(
+                    req.mission_id,
+                    req.expected_head.as_deref(),
+                    receipt,
+                    true,
+                );
+                Some((StatusCode::OK, Json(response)).into_response())
+            }
         }
         Ok(Some(crate::remote_node::job_ledger::EquivalentRemoteValidation::Active(handle))) => {
             Some(

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1932,6 +1932,14 @@ pub async fn hermes_remote_proxy(
 
 pub const HERMES_CHAT_PROXY_PATH: &str = "/api/assistant/hermes";
 
+fn hermes_chat_proxy_status(status: StatusCode) -> StatusCode {
+    if status == StatusCode::UNAUTHORIZED {
+        StatusCode::BAD_GATEWAY
+    } else {
+        status
+    }
+}
+
 fn sanitize_hermes_chat_proxy_headers(headers: &mut axum::http::HeaderMap) {
     for header in [
         axum::http::header::HOST,
@@ -2020,7 +2028,10 @@ pub async fn hermes_chat_proxy(
         .await
     {
         Ok(upstream) => {
-            let status = upstream.status();
+            // The dashboard JWT has already passed protected_routes. A 401
+            // here comes from Hermes rejecting the server-injected
+            // API_SERVER_KEY, not from the browser login.
+            let status = hermes_chat_proxy_status(upstream.status());
             let mut response_headers = upstream.headers().clone();
             for hop in [
                 axum::http::header::CONTENT_LENGTH,
@@ -5171,10 +5182,11 @@ fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::conve
 mod tests {
     use super::{
         evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
-        hermes_config_base_url, hermes_config_model_label, hermes_config_yaml, hermes_service_unit,
-        hermes_uses_native_codex, install_versioned_binary_as, is_safe_repo_path,
-        normalize_repo_path, prepare_deploy_backup, prune_deploy_backups, rollback_deployed_binary,
-        sandboxed_service_name_from_path, sanitize_hermes_chat_proxy_headers, select_repo_path,
+        hermes_chat_proxy_status, hermes_config_base_url, hermes_config_model_label,
+        hermes_config_yaml, hermes_service_unit, hermes_uses_native_codex,
+        install_versioned_binary_as, is_safe_repo_path, normalize_repo_path, prepare_deploy_backup,
+        prune_deploy_backups, rollback_deployed_binary, sandboxed_service_name_from_path,
+        sanitize_hermes_chat_proxy_headers, select_repo_path,
         systemd_service_component_from_states, upsert_hermes_mcp_command, ComponentStatus,
         DebounceDecision, DeployRefusal, DeployRollback, DEPLOY_DEBOUNCE_SECS,
         HERMES_SERVICE_DRAIN_DROP_IN,
@@ -5198,6 +5210,18 @@ mod tests {
         assert_eq!(
             headers.get(axum::http::header::CONTENT_TYPE),
             Some(&axum::http::HeaderValue::from_static("application/json"))
+        );
+    }
+
+    #[test]
+    fn hermes_upstream_auth_failure_is_not_reported_as_dashboard_auth_failure() {
+        assert_eq!(
+            hermes_chat_proxy_status(axum::http::StatusCode::UNAUTHORIZED),
+            axum::http::StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            hermes_chat_proxy_status(axum::http::StatusCode::FORBIDDEN),
+            axum::http::StatusCode::FORBIDDEN
         );
     }
 

--- a/src/remote_node/job_ledger.rs
+++ b/src/remote_node/job_ledger.rs
@@ -161,7 +161,10 @@ pub enum TerminalWakeDisposition {
     SupersededBy(Uuid),
 }
 
-fn validation_order(sequence: u64, started_at: chrono::DateTime<chrono::Utc>) -> (u64, i64) {
+pub(crate) fn validation_order(
+    sequence: u64,
+    started_at: chrono::DateTime<chrono::Utc>,
+) -> (u64, i64) {
     (sequence, started_at.timestamp_micros())
 }
 


### PR DESCRIPTION
## Summary

Closes the valid reliability findings left on the already-merged Hermes/remote-execution PR series (#641, #643–#657):

- preserve retryable Hermes messages after in-stream failures and stop stale 401 responses from clearing a newer dashboard login
- distinguish upstream Hermes authentication failures from dashboard authentication failures
- preserve Codex turn-outcome metadata when backend data is attached
- prioritize terminal remote-build wakes and close detached waiting leases safely
- recover the newest remote validation by submission sequence, not misleading completion timestamps
- return the documented synchronous response shape when an immutable remote validation receipt is reused
- fix alerts pagination exhaustion and compressed-session cron delivery
- tighten PR writer inference around policy adjectives such as “prohibited dependency”

## Verification

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test --locked --workspace` (1,475 passed; 1 ignored)
- `cargo clippy --locked --workspace -- -D clippy::all`
- `scripts/harness_contract_tests.sh`
- `scripts/check-capability-matrix.sh`
- `cd dashboard && bun run test:unit` (245 passed)
- `cd dashboard && bun run lint` (no errors; pre-existing warnings only)
- `cd dashboard && bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission control queue ordering, remote-build lease lifecycle, JWT clearing, and Hermes SessionDB schema/delivery—important paths but changes are narrowly scoped with tests.
> 
> **Overview**
> Closes reliability gaps across the dashboard, control plane, Hermes delivery, and remote validation paths.
> 
> **Dashboard:** `apiFetch` only clears JWT and signals auth when the 401 matches the token that was sent, so a slow stale request cannot log out a newer session. Hermes chat streams that fail mid-turn now surface like other send errors (draft + Retry). **Alerts** pagination tracks a first-page anchor so a refresh can reopen “Load older” and merge/dedupe/sort correctly. The Hermes chat proxy maps upstream **401** to **502** so dashboard login is not blamed for bad `API_SERVER_KEY`.
> 
> **Backend:** `AgentResult::with_data` merges object fields so turn-outcome metadata is not wiped when extra diagnostics are attached. Remote-build terminal wakes are **enqueued at the front**; recovery picks continuations by **submission sequence**; parked missions can finish detached `waiting_remote_job` runs; PR-writer inference respects policy phrasing like “prohibited by policy” vs repair intents. Reused immutable remote validation receipts with `wait=true` return the documented wait response shape.
> 
> **Hermes patches:** API-server cron delivery resolves **resume/continuation** session IDs; durable delivery uses **delivery_id** receipts, bounded SessionDB write retries, **spool + gateway replay** on lock failure, and idempotent replay through resumed sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7963ebf1a569096ebb2cfca9c89e9ef46bf129af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->