### PR TITLE
feat: add experimental ChatGPT UI harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ deployment:
 
 ### Architecture & APIs
 - **[Harness System](docs/HARNESS_SYSTEM.md)** - Backend integration architecture
+- **[ChatGPT UI harness](docs/CHATGPT_UI_HARNESS.md)** - Experimental subscription-backed browser harness
 - **[Workspaces](docs/WORKSPACES.md)** - Isolated execution environments
 - **[Mission API](docs/MISSION_API.md)** - Mission lifecycle and control
 - **[Workspace API](docs/WORKSPACE_API.md)** - Workspace management endpoints

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -19,10 +19,11 @@ import { ServerConnectionCard } from '@/components/server-connection-card';
 import { ModelRoutingDebug } from '@/components/model-routing-debug';
 import { useBackendConfigs } from '@/lib/use-backend-configs';
 
-const SETTINGS_BACKEND_IDS = ['opencode', 'claudecode', 'grok'] as const;
+const SETTINGS_BACKEND_IDS = ['opencode', 'claudecode', 'grok', 'chatgpt_ui'] as const;
+type SettingsBackendId = typeof SETTINGS_BACKEND_IDS[number];
 
 export default function BackendsPage() {
-  const [activeBackendTab, setActiveBackendTab] = useState<'opencode' | 'claudecode' | 'grok'>('opencode');
+  const [activeBackendTab, setActiveBackendTab] = useState<SettingsBackendId>('opencode');
   const [savingBackend, setSavingBackend] = useState(false);
   const [savingMissionLimit, setSavingMissionLimit] = useState(false);
   const [savingTaskLimit, setSavingTaskLimit] = useState(false);
@@ -83,6 +84,15 @@ export default function BackendsPage() {
     cli_path: '',
     enabled: true,
   });
+  const [chatgptUiForm, setChatgptUiForm] = useState({
+    profile_dir: '',
+    driver_path: '',
+    python_path: 'python3',
+    model: '',
+    timeout_secs: 900,
+    headless: true,
+    enabled: false,
+  });
 
   // SWR: fetch backends
   const { data: backends = [] } = useSWR('backends', listBackends, {
@@ -91,6 +101,7 @@ export default function BackendsPage() {
       { id: 'opencode', name: 'OpenCode' },
       { id: 'claudecode', name: 'Claude Code' },
       { id: 'grok', name: 'Grok Build' },
+      { id: 'chatgpt_ui', name: 'ChatGPT UI (experimental)' },
     ],
   });
 
@@ -103,6 +114,7 @@ export default function BackendsPage() {
   const opencodeBackendConfig = backendConfigs.opencode;
   const claudecodeBackendConfig = backendConfigs.claudecode;
   const grokBackendConfig = backendConfigs.grok;
+  const chatgptUiBackendConfig = backendConfigs.chatgpt_ui;
 
   // Fetch Claude Code provider status (Anthropic provider configured for claudecode)
   const { data: claudecodeProvider } = useSWR<BackendProviderResponse>(
@@ -141,6 +153,20 @@ export default function BackendsPage() {
       enabled: grokBackendConfig.enabled,
     });
   }, [grokBackendConfig]);
+
+  useEffect(() => {
+    if (!chatgptUiBackendConfig?.settings) return;
+    const settings = chatgptUiBackendConfig.settings as Record<string, unknown>;
+    setChatgptUiForm({
+      profile_dir: typeof settings.profile_dir === 'string' ? settings.profile_dir : '',
+      driver_path: typeof settings.driver_path === 'string' ? settings.driver_path : '',
+      python_path: typeof settings.python_path === 'string' ? settings.python_path : 'python3',
+      model: typeof settings.model === 'string' ? settings.model : '',
+      timeout_secs: typeof settings.timeout_secs === 'number' ? settings.timeout_secs : 900,
+      headless: settings.headless !== false,
+      enabled: chatgptUiBackendConfig.enabled,
+    });
+  }, [chatgptUiBackendConfig]);
 
   useEffect(() => {
     const limit = serverSettings?.max_parallel_missions;
@@ -263,6 +289,31 @@ export default function BackendsPage() {
           err instanceof Error ? err.message : 'Unknown error'
         }`
       );
+    } finally {
+      setSavingBackend(false);
+    }
+  };
+
+  const handleSaveChatgptUiBackend = async () => {
+    setSavingBackend(true);
+    try {
+      const result = await updateBackendConfig(
+        'chatgpt_ui',
+        {
+          profile_dir: chatgptUiForm.profile_dir,
+          driver_path: chatgptUiForm.driver_path || null,
+          python_path: chatgptUiForm.python_path || 'python3',
+          browser: 'chromium',
+          headless: chatgptUiForm.headless,
+          timeout_secs: chatgptUiForm.timeout_secs,
+          model: chatgptUiForm.model || null,
+        },
+        { enabled: chatgptUiForm.enabled }
+      );
+      toast.success(result.message || 'ChatGPT UI settings updated');
+      refreshBackendConfigs();
+    } catch (err) {
+      toast.error(`Failed to update ChatGPT UI settings: ${err instanceof Error ? err.message : 'Unknown error'}`);
     } finally {
       setSavingBackend(false);
     }
@@ -405,7 +456,7 @@ export default function BackendsPage() {
                 key={backend.id}
                 onClick={() =>
                   setActiveBackendTab(
-                    backend.id as 'opencode' | 'claudecode' | 'grok'
+                    backend.id as SettingsBackendId
                   )
                 }
                 className={cn(
@@ -553,6 +604,46 @@ export default function BackendsPage() {
                   Save Claude Code
                 </button>
               </div>
+            </div>
+          ) : activeBackendTab === 'chatgpt_ui' ? (
+            <div className="space-y-3">
+              <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] p-3 text-xs text-amber-200/80">
+                Experimental browser automation. Use a dedicated profile, review ChatGPT terms, and never place the profile in a repository or mission workspace.
+              </div>
+              <label className="flex items-center gap-2 text-xs text-white/60 cursor-pointer">
+                <input type="checkbox" checked={chatgptUiForm.enabled} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, enabled: e.target.checked }))} />
+                Enabled
+              </label>
+              <div>
+                <label className="block text-xs text-white/60 mb-1.5">Browser profile directory</label>
+                <input type="text" value={chatgptUiForm.profile_dir} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, profile_dir: e.target.value }))} placeholder="/var/lib/sandboxed-sh/chatgpt-profile" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+              </div>
+              <div>
+                <label className="block text-xs text-white/60 mb-1.5">Driver path</label>
+                <input type="text" value={chatgptUiForm.driver_path} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, driver_path: e.target.value }))} placeholder="/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+              </div>
+              <div>
+                <label className="block text-xs text-white/60 mb-1.5">Python executable</label>
+                <input type="text" value={chatgptUiForm.python_path} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, python_path: e.target.value }))} placeholder="/opt/sandboxed-sh/chatgpt-ui-venv/bin/python" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-white/60 mb-1.5">Exact visible model label</label>
+                  <input type="text" value={chatgptUiForm.model} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, model: e.target.value }))} placeholder="GPT-5.6 Pro" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+                </div>
+                <div>
+                  <label className="block text-xs text-white/60 mb-1.5">Timeout (seconds)</label>
+                  <input type="number" min={30} max={7200} value={chatgptUiForm.timeout_secs} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, timeout_secs: Number(e.target.value) }))} className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+                </div>
+              </div>
+              <label className="flex items-center gap-2 text-xs text-white/60 cursor-pointer">
+                <input type="checkbox" checked={chatgptUiForm.headless} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, headless: e.target.checked }))} />
+                Headless after interactive login provisioning
+              </label>
+              <button onClick={handleSaveChatgptUiBackend} disabled={savingBackend || !chatgptUiForm.profile_dir || !chatgptUiForm.driver_path} className="flex items-center gap-2 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs text-white hover:bg-indigo-600 transition-colors disabled:opacity-50">
+                {savingBackend ? <Loader className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                Save ChatGPT UI
+              </button>
             </div>
           ) : activeBackendTab === 'grok' ? (
             <div className="space-y-3">

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -11,7 +11,7 @@ import type { Workspace } from '@/lib/api';
 import { isBackendAvailable, useBackendConfigs } from '@/lib/use-backend-configs';
 import { toast } from '@/components/toast';
 
-const KNOWN_BACKEND_IDS = ['opencode', 'claudecode', 'codex', 'gemini', 'grok'] as const;
+const KNOWN_BACKEND_IDS = ['opencode', 'claudecode', 'codex', 'gemini', 'grok', 'chatgpt_ui'] as const;
 
 // Kept in sync with src/api/control.rs `normalize_model_effort_for_backend`.
 // Codex and Claude Code both accept the GPT reasoning-effort ladder. Other
@@ -153,6 +153,7 @@ export function NewMissionDialog({
       { id: 'codex', name: 'Codex' },
       { id: 'gemini', name: 'Gemini CLI' },
       { id: 'grok', name: 'Grok Build' },
+      { id: 'chatgpt_ui', name: 'ChatGPT UI (experimental)' },
     ],
     }
   );

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -216,6 +216,11 @@ export function NewMissionDialog({
     () => listBackendAgents('grok'),
     { revalidateOnFocus: true, dedupingInterval: 5000 }
   );
+  const { data: chatgptUiAgents, mutate: mutateChatgptUiAgents } = useSWR<BackendAgent[]>(
+    open && enabledBackends.some(b => b.id === 'chatgpt_ui') ? 'backend-chatgpt-ui-agents' : null,
+    () => listBackendAgents('chatgpt_ui'),
+    { revalidateOnFocus: true, dedupingInterval: 5000 }
+  );
 
   // SWR: fallback for opencode agents
   const { data: agentsPayload, mutate: mutateAgentsPayload } = useSWR(open ? 'opencode-agents' : null, getVisibleAgents, {
@@ -280,6 +285,10 @@ export function NewMissionDialog({
           { id: 'build', name: 'Build' },
           { id: 'plan', name: 'Plan' },
         ];
+      } else if (backend.id === 'chatgpt_ui') {
+        agents = chatgptUiAgents || [
+          { id: 'chat', name: 'ChatGPT web conversation' },
+        ];
       }
 
       // Use agent.id for CLI value, agent.name for display (consistent across all backends)
@@ -295,7 +304,7 @@ export function NewMissionDialog({
     }
 
     return result;
-  }, [enabledBackends, opencodeAgents, claudecodeAgents, codexAgents, geminiAgents, grokAgents, agentsPayload, config, claudeCodeLibConfig]);
+  }, [enabledBackends, opencodeAgents, claudecodeAgents, codexAgents, geminiAgents, grokAgents, chatgptUiAgents, agentsPayload, config, claudeCodeLibConfig]);
 
   // Group agents by backend for display
   const agentsByBackend = useMemo(() => {
@@ -575,6 +584,7 @@ export function NewMissionDialog({
       mutateCodexAgents?.(),
       mutateGeminiAgents?.(),
       mutateGrokAgents?.(),
+      mutateChatgptUiAgents?.(),
       mutateAgentsPayload?.(),
       mutateConfig?.(),
     ]);

--- a/docs/CHATGPT_UI_HARNESS.md
+++ b/docs/CHATGPT_UI_HARNESS.md
@@ -1,0 +1,122 @@
+# ChatGPT UI harness (experimental)
+
+`chatgpt_ui` runs a mission turn through the operator's existing ChatGPT web
+session. It consumes the subscription allowance shown in that account's web UI,
+not Codex CLI/API allowance. This is browser automation, not an OpenAI API.
+
+## Status and limitations
+
+- The integration is experimental and opt-in. ChatGPT markup, rollout flags,
+  model labels, account entitlements, rate limits, and anti-automation controls
+  can change without notice.
+- It supports text turns and translates driver text, diagnostic, tool-call,
+  tool-result, completion, and error events. The current ChatGPT web UI does not
+  expose sandboxed.sh's local tools. A response with an unresolved tool call is
+  failed rather than falsely reported complete.
+- Conversation continuation currently sends sandboxed.sh's bounded text
+  history in a fresh ChatGPT conversation. It does not persist ChatGPT
+  conversation URLs.
+- There is no CAPTCHA bypass, fingerprint spoofing, or anti-bot evasion.
+- Check the applicable ChatGPT terms and your organization's policy. UI
+  automation can lead to challenges, throttling, or account restrictions.
+
+## Install and provision
+
+Install Playwright in a dedicated environment beside the sandboxed.sh service
+account:
+
+```bash
+python3 -m venv /opt/sandboxed-sh/chatgpt-ui-venv
+/opt/sandboxed-sh/chatgpt-ui-venv/bin/pip install playwright
+/opt/sandboxed-sh/chatgpt-ui-venv/bin/playwright install chromium
+```
+
+Create a dedicated profile directory outside repositories and mission
+workspaces, with access restricted to the service account:
+
+```bash
+install -d -m 700 /var/lib/sandboxed-sh/chatgpt-profile
+```
+
+Provision login interactively using Playwright/Chromium with that exact
+`user-data-dir`. Close the browser before starting missions; Chromium locks a
+profile while it is open. Complete MFA or CAPTCHA yourself. Never copy profile
+contents into a repository, support bundle, screenshot, or mission artifact.
+
+Configure the backend through `PUT /api/backends/chatgpt_ui/config`:
+
+```json
+{
+  "enabled": true,
+  "settings": {
+    "profile_dir": "/var/lib/sandboxed-sh/chatgpt-profile",
+    "driver_path": "/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py",
+    "python_path": "/opt/sandboxed-sh/chatgpt-ui-venv/bin/python",
+    "browser": "chromium",
+    "headless": true,
+    "timeout_secs": 900,
+    "model": "GPT-5.6 Pro"
+  }
+}
+```
+
+`profile_dir` must exist, be absolute, and be outside the sandboxed.sh working
+directory. `driver_path` must be the absolute installed path of the included
+driver script.
+Timeouts are clamped to 30–7200 seconds. A cross-process profile lock rejects
+concurrent use; configure a distinct dedicated profile for each concurrent
+mission.
+
+## Model selection
+
+Set `model` to the exact label visibly offered by the account. The driver opens
+the model picker and requires an exact text match; it fails with a compatibility
+diagnostic instead of silently substituting another model. A requested label
+being present proves only that the UI exposed and selected that label. It does
+not independently prove backend model identity or deep-research capabilities.
+
+For a one-turn operator smoke test:
+
+```bash
+scripts/chatgpt_ui_smoke.sh /var/lib/sandboxed-sh/chatgpt-profile "GPT-5.6 Pro"
+```
+
+Run without a model argument to test the account's current UI default.
+
+## Diagnostics
+
+- `auth_required`: provision or refresh login interactively.
+- Auth status in the settings API stays unknown until a driver turn loads a
+  blank page; directory presence is never treated as proof of authentication.
+- `requested model is not visibly available`: verify the exact current label
+  and account entitlement; UI rollouts are account-specific.
+- `compatibility=chatgpt-ui-v1`: the versioned selector contract failed. Capture
+  only a clean, new chat with no sidebar identity or private history visible.
+- Profile lock errors: close every browser using the profile, or configure a
+  separate dedicated profile for each concurrent mission.
+- `dependency_missing`: install Playwright and its selected browser.
+- timeout/rate-limit errors: wait for the account's UI allowance to recover;
+  sandboxed.sh cannot read or predict subscription quota.
+
+## Security boundary
+
+The Rust process passes only the profile path, prompt, requested visible model
+label, and timeout to the driver. It clears inherited environment variables
+except `PATH`; the driver never enumerates or exports cookies, tokens, local
+storage, browser databases, profile files, account identity, or prior chats.
+The profile is still a powerful bearer credential: isolate it, back it up only
+under your own encrypted credential policy, and revoke sessions from ChatGPT if
+the host is compromised.
+
+Every turn navigates to a new-chat surface and refuses to send if assistant
+content is already present. Streaming events carry accumulated text snapshots,
+but success requires an explicit `complete` event, a clean driver exit, and
+balanced tool events.
+
+## Inspiration and provenance
+
+The architecture was informed by CatGPT-Gateway at commit
+`79a1b69d429fa9951d796289b60470fb595cbb42` (MIT, copyright GautamVhavle).
+No source code was copied or vendored. This adapter is an original,
+smaller process protocol integrated with sandboxed.sh's lifecycle rather than
+an OpenAI-compatible proxy.

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Versioned, conservative ChatGPT UI driver for sandboxed.sh.
+
+Protocol: one JSON request on stdin, NDJSON events on stdout. This helper
+references a profile by path but never reads, enumerates, or exports its files.
+"""
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+
+COMPAT_VERSION = "chatgpt-ui-v1"
+CHATGPT_URL = "https://chatgpt.com/"
+
+
+def emit(event_type: str, **payload) -> None:
+    print(json.dumps({"type": event_type, **payload}, separators=(",", ":")), flush=True)
+
+
+def fail(code: str, message: str) -> None:
+    emit("error", code=code, message=message)
+
+
+async def choose_model(page, requested: str) -> str:
+    """Select an exact visible model label; never infer aliases."""
+    if not requested:
+        return ""
+    candidates = [
+        page.get_by_role("button", name=re.compile(r"(model|chatgpt)", re.I)).first,
+        page.locator('[data-testid="model-switcher-dropdown-button"]').first,
+    ]
+    for candidate in candidates:
+        try:
+            if await candidate.is_visible(timeout=1500):
+                await candidate.click()
+                break
+        except Exception:
+            continue
+    else:
+        raise RuntimeError("model picker not found")
+    option = page.get_by_text(requested, exact=True).last
+    try:
+        await option.wait_for(state="visible", timeout=5000)
+        await option.click()
+    except Exception as exc:
+        raise RuntimeError("requested model is not visibly available") from exc
+    return requested
+
+
+async def establish_fresh_chat(page) -> int:
+    """Open a blank chat and prove no assistant content predates this turn."""
+    await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
+    login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
+    if "/auth/" in page.url or (await login.count() and await login.is_visible()):
+        raise PermissionError("login required")
+
+    new_chat = page.get_by_role("link", name=re.compile(r"new chat", re.I)).first
+    if await new_chat.count() and await new_chat.is_visible():
+        await new_chat.click()
+        await page.wait_for_load_state("domcontentloaded")
+
+    composer = page.locator("#prompt-textarea").first
+    if not await composer.count():
+        composer = page.get_by_role("textbox").last
+    await composer.wait_for(state="visible", timeout=20_000)
+    baseline = await page.locator('[data-message-author-role="assistant"]').count()
+    if baseline:
+        raise RuntimeError("fresh-chat baseline contains prior content")
+    return baseline
+
+
+async def run(args, request) -> None:
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError:
+        fail(
+            "dependency_missing",
+            "Python package playwright is required; install it and its selected browser",
+        )
+        return
+
+    message = request.get("message")
+    if not isinstance(message, str) or not message.strip():
+        fail("invalid_request", "message must be a non-empty string")
+        return
+    timeout_ms = max(30_000, min(int(request.get("timeout_ms", 900_000)), 7_200_000))
+    requested_model = request.get("model") or ""
+    emit("diagnostic", message=f"compatibility={COMPAT_VERSION}; browser={args.browser}")
+
+    context = None
+    try:
+        async with async_playwright() as playwright:
+            browser_type = getattr(playwright, args.browser, None)
+            if browser_type is None:
+                fail("invalid_config", f"unsupported browser: {args.browser}")
+                return
+            try:
+                context = await browser_type.launch_persistent_context(
+                    user_data_dir=str(Path(args.profile_dir).resolve()),
+                    headless=args.headless == "true",
+                    viewport={"width": 1440, "height": 1000},
+                    args=["--disable-background-networking"],
+                )
+            except Exception:
+                fail(
+                    "browser_launch",
+                    "Browser failed to launch. Verify the browser install, profile permissions, and that no other browser is using the profile.",
+                )
+                return
+
+            page = context.pages[0] if context.pages else await context.new_page()
+            baseline = await establish_fresh_chat(page)
+            model_used = await choose_model(page, requested_model)
+            composer = page.locator("#prompt-textarea").first
+            if not await composer.count():
+                composer = page.get_by_role("textbox").last
+            await composer.fill(message)
+            send = page.get_by_role("button", name=re.compile(r"send", re.I)).last
+            await send.wait_for(state="visible", timeout=10_000)
+            await send.click()
+
+            last = ""
+            stable = 0
+            deadline = asyncio.get_running_loop().time() + timeout_ms / 1000
+            while asyncio.get_running_loop().time() < deadline:
+                responses = page.locator('[data-message-author-role="assistant"]')
+                count = await responses.count()
+                if count > baseline:
+                    text = (await responses.nth(count - 1).inner_text()).strip()
+                    if text and text != last:
+                        last, stable = text, 0
+                        emit("text_delta", content=text)
+                    elif text:
+                        stable += 1
+                stop = page.get_by_role("button", name=re.compile(r"stop", re.I)).last
+                stop_visible = await stop.count() and await stop.is_visible()
+                if last and count > baseline and not stop_visible and stable >= 2:
+                    emit("complete", content=last, model=model_used or None)
+                    return
+                await asyncio.sleep(0.75)
+            fail("timeout", f"ChatGPT response did not complete within {timeout_ms // 1000} seconds")
+    except PermissionError:
+        fail(
+            "auth_required",
+            "ChatGPT login is required in the configured profile; provision it interactively",
+        )
+    except Exception as exc:
+        fail(
+            "compatibility",
+            f"{COMPAT_VERSION}: UI check failed ({type(exc).__name__}); verify selectors against a blank, non-private chat",
+        )
+    finally:
+        if context is not None:
+            await context.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile-dir", required=True)
+    parser.add_argument("--browser", choices=("chromium", "firefox", "webkit"), default="chromium")
+    parser.add_argument("--headless", choices=("true", "false"), default="true")
+    args = parser.parse_args()
+    try:
+        request = json.loads(sys.stdin.readline())
+    except (json.JSONDecodeError, EOFError):
+        fail("invalid_request", "expected one JSON request on stdin")
+        return
+    asyncio.run(run(args, request))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -11,6 +11,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 COMPAT_VERSION = "chatgpt-ui-v1"
 CHATGPT_URL = "https://chatgpt.com/"
@@ -41,35 +42,71 @@ async def choose_model(page, requested: str) -> str:
             continue
     else:
         raise RuntimeError("model picker not found")
-    option = page.get_by_text(requested, exact=True).last
-    try:
-        await option.wait_for(state="visible", timeout=5000)
-        await option.click()
-    except Exception as exc:
-        raise RuntimeError("requested model is not visibly available") from exc
-    return requested
+    # Keep the lookup inside the picker overlay. A global text lookup could
+    # click a same-named private conversation in the sidebar.
+    overlays = [
+        page.get_by_role("menu").last,
+        page.get_by_role("dialog").last,
+        page.locator('[data-radix-popper-content-wrapper]:visible').last,
+    ]
+    for overlay in overlays:
+        try:
+            if await overlay.is_visible(timeout=1000):
+                option = overlay.get_by_text(requested, exact=True).last
+                await option.wait_for(state="visible", timeout=3000)
+                await option.click()
+                return requested
+        except Exception:
+            continue
+    raise RuntimeError("requested model is not visibly available in the model picker")
+
+
+async def assert_blank_chat(page) -> None:
+    """Reject any route or rendered content that could belong to a prior chat."""
+    parsed = urlparse(page.url)
+    if parsed.netloc != "chatgpt.com" or parsed.path not in ("", "/"):
+        raise RuntimeError("new-chat navigation did not reach a blank route")
+    if await page.locator('[data-message-author-role="assistant"]').count():
+        raise RuntimeError("fresh-chat baseline contains prior content")
 
 
 async def establish_fresh_chat(page) -> int:
-    """Open a blank chat and prove no assistant content predates this turn."""
+    """Prove an authenticated, settled blank chat before observing responses."""
     await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
     login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
     if "/auth/" in page.url or (await login.count() and await login.is_visible()):
         raise PermissionError("login required")
 
+    # Anonymous ChatGPT can expose a working composer, so its presence is not
+    # authentication evidence. Require an account-only control and fail closed
+    # when a UI rollout makes that evidence unavailable.
+    account_controls = page.locator(
+        '[data-testid="accounts-profile-button"], '
+        'button[aria-label*="account" i], '
+        'button[aria-label*="profile" i]'
+    )
+    authenticated = False
+    for index in range(await account_controls.count()):
+        if await account_controls.nth(index).is_visible():
+            authenticated = True
+            break
+    if not authenticated:
+        raise PermissionError("authenticated account control not found")
+
     new_chat = page.get_by_role("link", name=re.compile(r"new chat", re.I)).first
     if await new_chat.count() and await new_chat.is_visible():
         await new_chat.click()
-        await page.wait_for_load_state("domcontentloaded")
+    await page.wait_for_url(re.compile(r"^https://chatgpt\.com/(?:\?.*)?$"), timeout=20_000)
 
     composer = page.locator("#prompt-textarea").first
     if not await composer.count():
         composer = page.get_by_role("textbox").last
     await composer.wait_for(state="visible", timeout=20_000)
-    baseline = await page.locator('[data-message-author-role="assistant"]').count()
-    if baseline:
-        raise RuntimeError("fresh-chat baseline contains prior content")
-    return baseline
+    # Let hydration and lazy conversation rendering settle before taking the
+    # baseline. Nothing from this page is emitted before the prompt is sent.
+    await page.wait_for_timeout(2_000)
+    await assert_blank_chat(page)
+    return 0
 
 
 async def run(args, request) -> None:
@@ -114,6 +151,7 @@ async def run(args, request) -> None:
             page = context.pages[0] if context.pages else await context.new_page()
             baseline = await establish_fresh_chat(page)
             model_used = await choose_model(page, requested_model)
+            await assert_blank_chat(page)
             composer = page.locator("#prompt-textarea").first
             if not await composer.count():
                 composer = page.get_by_role("textbox").last

--- a/scripts/chatgpt_ui_mock_driver.py
+++ b/scripts/chatgpt_ui_mock_driver.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Deterministic chatgpt_ui protocol fixture; never starts a browser."""
+
+import argparse
+import json
+import sys
+import time
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--profile-dir", required=True)
+parser.add_argument("--browser")
+parser.add_argument("--headless")
+parser.parse_args()
+request = json.loads(sys.stdin.readline())
+message = request.get("message", "")
+
+def emit(kind, **data):
+    print(json.dumps({"type": kind, **data}), flush=True)
+
+emit("diagnostic", message="compatibility=mock-v1")
+if message == "__error__":
+    emit("error", code="auth_required", message="deterministic auth failure")
+elif message == "__timeout__":
+    time.sleep(60)
+elif message == "__partial__":
+    emit("text_delta", content="partial response must not succeed")
+elif message == "__tools__":
+    emit("tool_call", id="mock-tool", name="mock", args={"safe": True})
+    emit("tool_result", id="mock-tool", name="mock", result={"ok": True})
+    emit("complete", content="mock tool response", model="mock-model")
+else:
+    response = f"mock response: {message}"
+    emit("text_delta", content=response[: max(1, len(response) // 2)])
+    emit("text_delta", content=response)
+    emit("complete", content=response, model=request.get("model") or "mock-model")

--- a/scripts/chatgpt_ui_smoke.sh
+++ b/scripts/chatgpt_ui_smoke.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 ABSOLUTE_PROFILE_DIR [MODEL_LABEL] [SAFE_RESULT_JSON]" >&2
+  exit 2
+fi
+
+profile_dir=$1
+model=${2:-}
+artifact=${3:-}
+if [[ $profile_dir != /* || ! -d $profile_dir ]]; then
+  echo "profile directory must be an existing absolute path" >&2
+  exit 2
+fi
+
+printf '{"type":"run","message":"Reply with exactly: SANDBOXED_CHATGPT_UI_SMOKE_OK","model":%s,"timeout_ms":120000}\n' \
+  "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1] or None))' "$model")" |
+  python3 "$(dirname "$0")/chatgpt_ui_driver.py" \
+    --profile-dir "$profile_dir" --browser chromium --headless true |
+  python3 -c '
+import json, pathlib, sys
+events = [json.loads(line) for line in sys.stdin if line.strip()]
+complete = next((event for event in reversed(events) if event.get("type") == "complete"), None)
+ok = bool(complete and complete.get("content", "").strip() == "SANDBOXED_CHATGPT_UI_SMOKE_OK")
+summary = {"ok": ok, "complete_signal": complete is not None, "event_types": [event.get("type") for event in events]}
+encoded = json.dumps(summary, separators=(",", ":")) + "\n"
+artifact = sys.argv[1]
+if artifact:
+    path = pathlib.Path(artifact)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(encoded, encoding="utf-8")
+sys.stdout.write(encoded)
+raise SystemExit(0 if ok else 1)
+' "$artifact"

--- a/scripts/test_chatgpt_ui_mock_driver.py
+++ b/scripts/test_chatgpt_ui_mock_driver.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Deterministic protocol tests; no browser or profile contents are accessed."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+DRIVER = Path(__file__).with_name("chatgpt_ui_mock_driver.py")
+
+
+def run_driver(message):
+    with tempfile.TemporaryDirectory() as profile:
+        request = json.dumps({"message": message, "model": None}) + "\n"
+        result = subprocess.run(
+            ["python3", str(DRIVER), "--profile-dir", profile],
+            input=request,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=True,
+        )
+    return [json.loads(line) for line in result.stdout.splitlines()]
+
+
+class MockDriverProtocolTests(unittest.TestCase):
+    def test_success_requires_explicit_complete(self):
+        events = run_driver("hello")
+        self.assertEqual(events[-1]["type"], "complete")
+        self.assertEqual(events[-1]["content"], "mock response: hello")
+
+    def test_partial_stream_has_no_complete(self):
+        events = run_driver("__partial__")
+        self.assertEqual([event["type"] for event in events], ["diagnostic", "text_delta"])
+
+    def test_auth_failure_is_typed(self):
+        events = run_driver("__error__")
+        self.assertEqual(events[-1]["code"], "auth_required")
+
+    def test_tool_events_are_balanced(self):
+        events = run_driver("__tools__")
+        self.assertEqual(
+            [event["type"] for event in events],
+            ["diagnostic", "tool_call", "tool_result", "complete"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -313,6 +313,126 @@ pub async fn update_backend_config(
             }
             settings
         }
+        "chatgpt_ui" => {
+            let settings = req.settings.as_object().ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Invalid settings payload".to_string(),
+                )
+            })?;
+            let profile = settings
+                .get("profile_dir")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        "profile_dir is required".to_string(),
+                    )
+                })?;
+            let profile_path = std::path::Path::new(profile);
+            if !profile_path.is_absolute() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "profile_dir must be an absolute path".to_string(),
+                ));
+            }
+            if !profile_path.is_dir() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "profile_dir must name an existing directory".to_string(),
+                ));
+            }
+            let canonical_profile = profile_path.canonicalize().map_err(|error| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("failed to resolve profile_dir: {error}"),
+                )
+            })?;
+            let canonical_working_dir =
+                state.config.working_dir.canonicalize().map_err(|error| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("failed to resolve server working directory: {error}"),
+                    )
+                })?;
+            if canonical_profile.starts_with(&canonical_working_dir) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "profile_dir must be outside the sandboxed.sh working directory".to_string(),
+                ));
+            }
+            let driver_path = settings
+                .get("driver_path")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            let driver_path = driver_path.ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "driver_path is required".to_string(),
+                )
+            })?;
+            if !std::path::Path::new(driver_path).is_absolute() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "driver_path must be absolute when set".to_string(),
+                ));
+            }
+            if !std::path::Path::new(driver_path).is_file() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "driver_path must name an existing file".to_string(),
+                ));
+            }
+            let python_path = settings
+                .get("python_path")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("python3");
+            let timeout_secs = settings
+                .get("timeout_secs")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(900);
+            if !(30..=7200).contains(&timeout_secs) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "timeout_secs must be between 30 and 7200".to_string(),
+                ));
+            }
+            let browser = settings
+                .get("browser")
+                .and_then(|value| value.as_str())
+                .unwrap_or("chromium");
+            if !matches!(browser, "chromium" | "firefox" | "webkit") {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "browser must be chromium, firefox, or webkit".to_string(),
+                ));
+            }
+            let model = settings
+                .get("model")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            if model.is_some_and(|value| value.len() > 200) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "model label must be at most 200 bytes".to_string(),
+                ));
+            }
+            serde_json::json!({
+                "profile_dir": canonical_profile,
+                "driver_path": driver_path,
+                "python_path": python_path,
+                "browser": browser,
+                "headless": settings.get("headless").and_then(|v| v.as_bool()).unwrap_or(true),
+                "timeout_secs": timeout_secs,
+                "model": model,
+            })
+        }
         _ => req.settings.clone(),
     };
 

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -6629,8 +6629,10 @@ pub async fn create_mission(
     // Skip validation for Claude Code, Codex, Gemini, and Grok - they have their own built-in agents
     if let Some(ref agent_name) = agent {
         let backend_id = backend.as_deref();
-        let skip_validation =
-            matches!(backend_id, Some("claudecode" | "codex" | "gemini" | "grok"));
+        let skip_validation = matches!(
+            backend_id,
+            Some("claudecode" | "codex" | "gemini" | "grok" | "chatgpt_ui")
+        );
         if !skip_validation {
             super::library::validate_agent_exists(
                 &state,
@@ -8772,7 +8774,7 @@ pub async fn update_mission_settings(
     if let Some(ref agent_name) = effective_agent {
         let skip_validation = matches!(
             effective_backend.as_str(),
-            "claudecode" | "codex" | "gemini" | "grok"
+            "claudecode" | "codex" | "gemini" | "grok" | "chatgpt_ui"
         );
         if !skip_validation {
             super::library::validate_agent_exists(

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3779,7 +3779,7 @@ async fn run_mission_turn(
             // session and --session/--continue must fire.
             is_continuation || has_opencode_session,
         ),
-        "grok" | "codex" => (
+        "grok" | "codex" | "chatgpt_ui" => (
             if is_goal_mode {
                 user_message.clone()
             } else {

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3518,6 +3518,10 @@ async fn run_mission_turn(
         // confusing chdir error from the rejected-CLI path. See prod
         // mission 1aef657a (2026-05-16).
         config.default_model = Some(resolve_grok_default_model());
+    } else if backend_id == "chatgpt_ui" && model_override.is_none() {
+        // Model labels in the web UI are account/rollout dependent. Only use
+        // an explicit operator setting; never claim a hard-coded model exists.
+        config.default_model = get_backend_string_setting("chatgpt_ui", "model");
     }
     tracing::info!(
         mission_id = %mission_id,
@@ -3923,8 +3927,11 @@ pub(crate) fn get_backend_string_setting(backend_id: &str, key: &str) -> Option<
                 .and_then(|v| v.as_str())
             {
                 if !val.is_empty() {
-                    if key == "api_key" {
-                        tracing::debug!("Using {} {} from backend config", backend_id, key);
+                    if matches!(
+                        key,
+                        "api_key" | "profile_dir" | "driver_path" | "python_path"
+                    ) {
+                        tracing::debug!("Using configured {} {}", backend_id, key);
                     } else {
                         tracing::info!("Using {} {} from backend config: {}", backend_id, key, val);
                     }
@@ -3934,6 +3941,16 @@ pub(crate) fn get_backend_string_setting(backend_id: &str, key: &str) -> Option<
         }
     }
     None
+}
+
+/// Read an unsigned integer setting from a backend's config entry.
+pub(crate) fn get_backend_u64_setting(backend_id: &str, key: &str) -> Option<u64> {
+    let configs = read_backend_configs()?;
+    configs.into_iter().find_map(|config| {
+        (config.get("id")?.as_str()? == backend_id)
+            .then(|| config.get("settings")?.get(key)?.as_u64())
+            .flatten()
+    })
 }
 
 /// Read a boolean setting from a backend's config entry.

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -298,6 +298,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         Box::new(crate::backend::codex::CodexBackend::new()),
         Box::new(crate::backend::gemini::GeminiBackend::new()),
         Box::new(crate::backend::grok::GrokBackend::new()),
+        Box::new(crate::backend::chatgpt_ui::ChatGptUiBackend::new()),
     ];
     struct BackendProbe {
         id: String,
@@ -327,10 +328,21 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
                     "default_agent": config.opencode_agent,
                     "permissive": config.opencode_permissive,
                 }),
+                "chatgpt_ui" => serde_json::json!({
+                    "profile_dir": null,
+                    "driver_path": null,
+                    "python_path": "python3",
+                    "browser": "chromium",
+                    "headless": true,
+                    "timeout_secs": 900,
+                    "model": null
+                }),
                 _ => serde_json::json!({}),
             };
             let mut entry = BackendConfigEntry::new(&p.id, &p.name, settings);
-            entry.enabled = p.detected;
+            // UI automation is opt-in even when Python is installed: the
+            // operator must provision an isolated browser profile explicitly.
+            entry.enabled = p.detected && p.id != "chatgpt_ui";
             entry
         })
         .collect();
@@ -411,8 +423,9 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     backend_registry.register(crate::backend::codex::registry_entry());
     backend_registry.register(crate::backend::gemini::registry_entry());
     backend_registry.register(crate::backend::grok::registry_entry());
+    backend_registry.register(crate::backend::chatgpt_ui::registry_entry());
     let backend_registry = Arc::new(RwLock::new(backend_registry));
-    tracing::info!("Backend registry initialized with {} backends", 5);
+    tracing::info!("Backend registry initialized with {} backends", 6);
 
     // Note: No central OpenCode server cleanup needed - missions use per-workspace CLI execution
 

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -1,0 +1,374 @@
+//! Conservative ChatGPT web-UI turn driver.
+//!
+//! The browser helper speaks NDJSON on stdout. Browser profiles remain outside
+//! mission workspaces and are referenced by an operator-supplied absolute path.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use fs2::FileExt;
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::agents::{AgentResult, TerminalReason};
+use crate::api::control::AgentEvent;
+use crate::api::mission_runner::{get_backend_string_setting, get_backend_u64_setting};
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum DriverEvent {
+    Diagnostic {
+        message: String,
+    },
+    TextDelta {
+        content: String,
+    },
+    ToolCall {
+        id: String,
+        name: String,
+        args: serde_json::Value,
+    },
+    ToolResult {
+        id: String,
+        name: String,
+        result: serde_json::Value,
+    },
+    Complete {
+        content: String,
+        model: Option<String>,
+    },
+    Error {
+        code: Option<String>,
+        message: String,
+    },
+}
+
+#[derive(Debug)]
+struct Settings {
+    driver_path: PathBuf,
+    python_path: String,
+    profile_dir: PathBuf,
+    browser: String,
+    timeout: Duration,
+    headless: bool,
+}
+
+struct ProfileLock(File);
+
+impl Drop for ProfileLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.0);
+    }
+}
+
+fn lock_profile(profile_dir: &Path) -> Result<ProfileLock, String> {
+    let name = profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("profile");
+    let lock_path = profile_dir
+        .parent()
+        .unwrap_or_else(|| Path::new("/"))
+        .join(format!(".{name}.sandboxed-chatgpt-ui.lock"));
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| format!("cannot create ChatGPT UI profile lock: {error}"))?;
+    file.try_lock_exclusive().map_err(|_| {
+        "ChatGPT UI profile is already in use; each concurrent mission needs a separate profile directory".to_string()
+    })?;
+    Ok(ProfileLock(file))
+}
+
+fn parse_bool_setting(key: &str, default: bool) -> bool {
+    crate::api::mission_runner::get_backend_bool_setting("chatgpt_ui", key).unwrap_or(default)
+}
+
+fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
+    let profile = get_backend_string_setting("chatgpt_ui", "profile_dir")
+        .ok_or_else(|| "chatgpt_ui profile_dir is required".to_string())?;
+    let profile_dir = PathBuf::from(profile);
+    if !profile_dir.is_absolute() {
+        return Err("chatgpt_ui profile_dir must be an absolute path".to_string());
+    }
+    if !profile_dir.is_dir() {
+        return Err(format!(
+            "chatgpt_ui profile_dir does not exist or is not a directory: {}",
+            profile_dir.display()
+        ));
+    }
+    let driver_path = get_backend_string_setting("chatgpt_ui", "driver_path")
+        .map(PathBuf::from)
+        .ok_or_else(|| "chatgpt_ui driver_path is required".to_string())?;
+    if !driver_path.is_file() {
+        return Err(format!(
+            "chatgpt_ui browser driver not found: {}",
+            driver_path.display()
+        ));
+    }
+    let canonical_profile = profile_dir
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve chatgpt_ui profile_dir: {error}"))?;
+    if let Ok(canonical_working_dir) = app_working_dir.canonicalize() {
+        if canonical_profile.starts_with(canonical_working_dir) {
+            return Err(
+                "chatgpt_ui profile_dir must be outside the sandboxed.sh working directory"
+                    .to_string(),
+            );
+        }
+    }
+    let timeout_secs = get_backend_u64_setting("chatgpt_ui", "timeout_secs")
+        .unwrap_or(900)
+        .clamp(30, 7200);
+    Ok(Settings {
+        driver_path,
+        python_path: get_backend_string_setting("chatgpt_ui", "python_path")
+            .unwrap_or_else(|| "python3".to_string()),
+        profile_dir,
+        browser: get_backend_string_setting("chatgpt_ui", "browser")
+            .unwrap_or_else(|| "chromium".to_string()),
+        timeout: Duration::from_secs(timeout_secs),
+        headless: parse_bool_setting("headless", true),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_chatgpt_ui_turn(
+    work_dir: &Path,
+    message: &str,
+    model: Option<&str>,
+    mission_id: Uuid,
+    events_tx: broadcast::Sender<AgentEvent>,
+    cancel: CancellationToken,
+    app_working_dir: &Path,
+) -> AgentResult {
+    let settings = match validated_settings(app_working_dir) {
+        Ok(settings) => settings,
+        Err(error) => {
+            return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::AuthError)
+        }
+    };
+    let _profile_lock = match lock_profile(&settings.profile_dir) {
+        Ok(lock) => lock,
+        Err(error) => {
+            return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::LlmError)
+        }
+    };
+
+    let mut command = Command::new(&settings.python_path);
+    command
+        .arg(&settings.driver_path)
+        .arg("--profile-dir")
+        .arg(&settings.profile_dir)
+        .arg("--browser")
+        .arg(&settings.browser)
+        .arg("--headless")
+        .arg(if settings.headless { "true" } else { "false" })
+        .current_dir(work_dir)
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // Driver stderr can contain browser/OS diagnostics with account or
+        // filesystem details. Do not ingest it into mission logs.
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    command.process_group(0);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return AgentResult::failure(format!("failed to start chatgpt_ui driver: {error}"), 0)
+                .with_terminal_reason(TerminalReason::LlmError)
+        }
+    };
+
+    let request = serde_json::json!({
+        "type": "run",
+        "message": message,
+        "model": model,
+        "timeout_ms": settings.timeout.as_millis() as u64,
+    });
+    if let Some(mut stdin) = child.stdin.take() {
+        if stdin
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .is_err()
+        {
+            let _ = child.kill().await;
+            return AgentResult::failure("failed to send request to chatgpt_ui driver", 0)
+                .with_terminal_reason(TerminalReason::LlmError);
+        }
+    }
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let mut lines = BufReader::new(stdout).lines();
+    let mut output = String::new();
+    let mut model_used = model.map(str::to_string);
+    let mut pending_tools: HashMap<String, String> = HashMap::new();
+    let mut completed = false;
+    let deadline = tokio::time::sleep(settings.timeout);
+    tokio::pin!(deadline);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                terminate_child_tree(&mut child).await;
+                return AgentResult::failure(
+                    if crate::api::routes::is_shutdown_initiated() {
+                        "Server restart — paused. Click Resume to continue."
+                    } else {
+                        "Mission cancelled"
+                    }, 0
+                ).with_terminal_reason(if crate::api::routes::is_shutdown_initiated() {
+                    TerminalReason::ServerShutdown
+                } else {
+                    TerminalReason::Cancelled
+                });
+            }
+            _ = &mut deadline => {
+                terminate_child_tree(&mut child).await;
+                return AgentResult::failure(
+                    format!("chatgpt_ui timed out after {} seconds", settings.timeout.as_secs()), 0
+                ).with_terminal_reason(TerminalReason::LlmError);
+            }
+            line = lines.next_line() => {
+                let line = match line {
+                    Ok(Some(line)) => line,
+                    Ok(None) => break,
+                    Err(error) => return AgentResult::failure(format!("chatgpt_ui stream read failed: {error}"), 0)
+                        .with_terminal_reason(TerminalReason::LlmError),
+                };
+                let event: DriverEvent = match serde_json::from_str(&line) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "Ignoring invalid chatgpt_ui driver event");
+                        continue;
+                    }
+                };
+                match event {
+                    DriverEvent::Diagnostic { message } => tracing::info!(mission_id = %mission_id, "{message}"),
+                    DriverEvent::TextDelta { content } => {
+                        output = content;
+                        let _ = events_tx.send(AgentEvent::TextDelta { content: output.clone(), mission_id: Some(mission_id) });
+                    }
+                    DriverEvent::ToolCall { id, name, args } => {
+                        pending_tools.insert(id.clone(), name.clone());
+                        let _ = events_tx.send(AgentEvent::ToolCall { tool_call_id: id, name, args, mission_id: Some(mission_id) });
+                    }
+                    DriverEvent::ToolResult { id, name, result } => {
+                        pending_tools.remove(&id);
+                        let _ = events_tx.send(AgentEvent::ToolResult { tool_call_id: id, name, result, mission_id: Some(mission_id) });
+                    }
+                    DriverEvent::Complete { content, model } => {
+                        output = content;
+                        model_used = model.or(model_used);
+                        completed = true;
+                        break;
+                    }
+                    DriverEvent::Error { code, message } => {
+                        let reason = if code.as_deref() == Some("auth_required") {
+                            TerminalReason::AuthError
+                        } else if code.as_deref() == Some("rate_limited") {
+                            TerminalReason::RateLimited
+                        } else {
+                            TerminalReason::LlmError
+                        };
+                        terminate_child_tree(&mut child).await;
+                        return AgentResult::failure(format!("chatgpt_ui: {message}"), 0).with_terminal_reason(reason);
+                    }
+                }
+            }
+        }
+    }
+    let status = tokio::select! {
+        _ = cancel.cancelled() => {
+            terminate_child_tree(&mut child).await;
+            return AgentResult::failure("Mission cancelled", 0)
+                .with_terminal_reason(TerminalReason::Cancelled);
+        }
+        status = tokio::time::timeout(Duration::from_secs(5), child.wait()) => status,
+    };
+    let status = match status {
+        Ok(Ok(status)) => Some(status),
+        Ok(Err(error)) => {
+            return AgentResult::failure(format!("chatgpt_ui driver wait failed: {error}"), 0)
+                .with_terminal_reason(TerminalReason::LlmError);
+        }
+        Err(_) => {
+            terminate_child_tree(&mut child).await;
+            return AgentResult::failure("chatgpt_ui driver did not exit after completion", 0)
+                .with_terminal_reason(TerminalReason::LlmError);
+        }
+    };
+    if !pending_tools.is_empty() {
+        return AgentResult::failure("chatgpt_ui ended with unresolved tool calls", 0)
+            .with_terminal_reason(TerminalReason::LlmError);
+    }
+    if !completed || output.trim().is_empty() || status.is_none_or(|status| !status.success()) {
+        return AgentResult::failure("chatgpt_ui driver exited without a completed response", 0)
+            .with_terminal_reason(TerminalReason::LlmError);
+    }
+    let mut result = AgentResult::success(output, 0)
+        .with_terminal_reason(TerminalReason::TurnComplete)
+        .with_data(serde_json::json!({"backend": "chatgpt_ui", "usage_source": "chatgpt_web_subscription"}));
+    if let Some(model) = model_used {
+        result = result.with_model(model);
+    }
+    result
+}
+
+async fn terminate_child_tree(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGTERM);
+        }
+        if tokio::time::timeout(Duration::from_secs(2), child.wait())
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGKILL);
+        }
+        let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
+        return;
+    }
+    let _ = child.kill().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_driver_events() {
+        let event: DriverEvent = serde_json::from_str(
+            r#"{"type":"tool_call","id":"1","name":"read_file","args":{"path":"a"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(event, DriverEvent::ToolCall { .. }));
+    }
+
+    #[test]
+    fn profile_lock_is_exclusive_and_reusable() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        let first = lock_profile(&profile).unwrap();
+        assert!(lock_profile(&profile).is_err());
+        drop(first);
+        assert!(lock_profile(&profile).is_ok());
+    }
+}

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -25,7 +25,8 @@ use crate::api::mission_runner::{get_backend_string_setting, get_backend_u64_set
 #[serde(tag = "type", rename_all = "snake_case")]
 enum DriverEvent {
     Diagnostic {
-        message: String,
+        #[serde(rename = "message")]
+        _message: String,
     },
     TextDelta {
         content: String,
@@ -110,6 +111,9 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
     let driver_path = get_backend_string_setting("chatgpt_ui", "driver_path")
         .map(PathBuf::from)
         .ok_or_else(|| "chatgpt_ui driver_path is required".to_string())?;
+    if !driver_path.is_absolute() {
+        return Err("chatgpt_ui driver_path must be an absolute path".to_string());
+    }
     if !driver_path.is_file() {
         return Err(format!(
             "chatgpt_ui browser driver not found: {}",
@@ -127,16 +131,21 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
             );
         }
     }
-    let timeout_secs = get_backend_u64_setting("chatgpt_ui", "timeout_secs")
-        .unwrap_or(900)
-        .clamp(30, 7200);
+    let timeout_secs = get_backend_u64_setting("chatgpt_ui", "timeout_secs").unwrap_or(900);
+    if !(30..=7200).contains(&timeout_secs) {
+        return Err("chatgpt_ui timeout_secs must be between 30 and 7200".to_string());
+    }
+    let browser = get_backend_string_setting("chatgpt_ui", "browser")
+        .unwrap_or_else(|| "chromium".to_string());
+    if !matches!(browser.as_str(), "chromium" | "firefox" | "webkit") {
+        return Err("chatgpt_ui browser must be chromium, firefox, or webkit".to_string());
+    }
     Ok(Settings {
         driver_path,
         python_path: get_backend_string_setting("chatgpt_ui", "python_path")
             .unwrap_or_else(|| "python3".to_string()),
-        profile_dir,
-        browser: get_backend_string_setting("chatgpt_ui", "browser")
-            .unwrap_or_else(|| "chromium".to_string()),
+        profile_dir: canonical_profile,
+        browser,
         timeout: Duration::from_secs(timeout_secs),
         headless: parse_bool_setting("headless", true),
     })
@@ -205,7 +214,7 @@ pub async fn run_chatgpt_ui_turn(
             .await
             .is_err()
         {
-            let _ = child.kill().await;
+            terminate_child_tree(&mut child).await;
             return AgentResult::failure("failed to send request to chatgpt_ui driver", 0)
                 .with_terminal_reason(TerminalReason::LlmError);
         }
@@ -246,28 +255,46 @@ pub async fn run_chatgpt_ui_turn(
                 let line = match line {
                     Ok(Some(line)) => line,
                     Ok(None) => break,
-                    Err(error) => return AgentResult::failure(format!("chatgpt_ui stream read failed: {error}"), 0)
-                        .with_terminal_reason(TerminalReason::LlmError),
+                    Err(error) => {
+                        terminate_child_tree(&mut child).await;
+                        return AgentResult::failure(format!("chatgpt_ui stream read failed: {error}"), 0)
+                            .with_terminal_reason(TerminalReason::LlmError);
+                    }
                 };
                 let event: DriverEvent = match serde_json::from_str(&line) {
                     Ok(event) => event,
                     Err(error) => {
-                        tracing::warn!(error = %error, "Ignoring invalid chatgpt_ui driver event");
-                        continue;
+                        terminate_child_tree(&mut child).await;
+                        return AgentResult::failure(
+                            format!("chatgpt_ui emitted an invalid protocol event: {error}"), 0
+                        ).with_terminal_reason(TerminalReason::LlmError);
                     }
                 };
                 match event {
-                    DriverEvent::Diagnostic { message } => tracing::info!(mission_id = %mission_id, "{message}"),
+                    // Diagnostics are deliberately not logged: a future
+                    // third-party UI selector must not accidentally turn
+                    // account or page text into server logs.
+                    DriverEvent::Diagnostic { .. } => tracing::debug!(mission_id = %mission_id, "chatgpt_ui driver diagnostic received"),
                     DriverEvent::TextDelta { content } => {
                         output = content;
                         let _ = events_tx.send(AgentEvent::TextDelta { content: output.clone(), mission_id: Some(mission_id) });
                     }
                     DriverEvent::ToolCall { id, name, args } => {
-                        pending_tools.insert(id.clone(), name.clone());
+                        if pending_tools.insert(id.clone(), name.clone()).is_some() {
+                            terminate_child_tree(&mut child).await;
+                            return AgentResult::failure(
+                                "chatgpt_ui emitted a duplicate unresolved tool call id", 0
+                            ).with_terminal_reason(TerminalReason::LlmError);
+                        }
                         let _ = events_tx.send(AgentEvent::ToolCall { tool_call_id: id, name, args, mission_id: Some(mission_id) });
                     }
                     DriverEvent::ToolResult { id, name, result } => {
-                        pending_tools.remove(&id);
+                        if pending_tools.remove(&id).as_deref() != Some(name.as_str()) {
+                            terminate_child_tree(&mut child).await;
+                            return AgentResult::failure(
+                                "chatgpt_ui emitted an unmatched tool result", 0
+                            ).with_terminal_reason(TerminalReason::LlmError);
+                        }
                         let _ = events_tx.send(AgentEvent::ToolResult { tool_call_id: id, name, result, mission_id: Some(mission_id) });
                     }
                     DriverEvent::Complete { content, model } => {
@@ -294,8 +321,24 @@ pub async fn run_chatgpt_ui_turn(
     let status = tokio::select! {
         _ = cancel.cancelled() => {
             terminate_child_tree(&mut child).await;
-            return AgentResult::failure("Mission cancelled", 0)
-                .with_terminal_reason(TerminalReason::Cancelled);
+            let shutdown = crate::api::routes::is_shutdown_initiated();
+            return AgentResult::failure(
+                if shutdown {
+                    "Server restart — paused. Click Resume to continue."
+                } else {
+                    "Mission cancelled"
+                }, 0
+            ).with_terminal_reason(if shutdown {
+                TerminalReason::ServerShutdown
+            } else {
+                TerminalReason::Cancelled
+            });
+        }
+        _ = &mut deadline => {
+            terminate_child_tree(&mut child).await;
+            return AgentResult::failure(
+                format!("chatgpt_ui timed out after {} seconds", settings.timeout.as_secs()), 0
+            ).with_terminal_reason(TerminalReason::LlmError);
         }
         status = tokio::time::timeout(Duration::from_secs(5), child.wait()) => status,
     };
@@ -331,19 +374,22 @@ pub async fn run_chatgpt_ui_turn(
 async fn terminate_child_tree(child: &mut tokio::process::Child) {
     #[cfg(unix)]
     if let Some(pid) = child.id() {
+        let process_group = -(pid as i32);
         unsafe {
-            libc::kill(-(pid as i32), libc::SIGTERM);
+            libc::kill(process_group, libc::SIGTERM);
         }
-        if tokio::time::timeout(Duration::from_secs(2), child.wait())
+        let exited = tokio::time::timeout(Duration::from_secs(2), child.wait())
             .await
-            .is_ok()
-        {
-            return;
-        }
+            .is_ok();
+        // The group leader can exit before Chromium descendants. Always send
+        // SIGKILL to the original process group after the grace period; ESRCH
+        // simply means the group is already empty.
         unsafe {
-            libc::kill(-(pid as i32), libc::SIGKILL);
+            libc::kill(process_group, libc::SIGKILL);
         }
-        let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
+        if !exited {
+            let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
+        }
         return;
     }
     let _ = child.kill().await;

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -79,6 +79,7 @@ fn lock_profile(profile_dir: &Path) -> Result<ProfileLock, String> {
         .join(format!(".{name}.sandboxed-chatgpt-ui.lock"));
     let file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(&lock_path)

--- a/src/api/runners/mod.rs
+++ b/src/api/runners/mod.rs
@@ -5,6 +5,7 @@
 //! backend turn runners themselves) move here so `mission_runner.rs` can
 //! shrink down to orchestration (dispatch, retry/fallback, TerminalReason).
 
+pub(crate) mod chatgpt_ui;
 pub(crate) mod claudecode;
 pub(crate) mod codex;
 pub(crate) mod errors;
@@ -94,6 +95,7 @@ pub(crate) struct OpenCodeRunner;
 pub(crate) struct CodexRunner;
 pub(crate) struct GrokRunner;
 pub(crate) struct GeminiRunner;
+pub(crate) struct ChatGptUiRunner;
 
 impl HarnessRunner for ClaudeCodeRunner {
     fn name(&self) -> &'static str {
@@ -247,6 +249,27 @@ impl HarnessRunner for GeminiRunner {
     }
 }
 
+impl HarnessRunner for ChatGptUiRunner {
+    fn name(&self) -> &'static str {
+        "chatgpt_ui"
+    }
+
+    fn run_turn<'a>(
+        &'a self,
+        ctx: TurnContext<'a>,
+    ) -> Pin<Box<dyn Future<Output = AgentResult> + Send + 'a>> {
+        Box::pin(chatgpt_ui::run_chatgpt_ui_turn(
+            ctx.work_dir,
+            ctx.message,
+            ctx.model,
+            ctx.mission_id,
+            ctx.events_tx,
+            ctx.cancel,
+            ctx.app_working_dir,
+        ))
+    }
+}
+
 /// Resolve a backend id to its turn runner.
 pub(crate) fn runner_for(backend_id: &str) -> Option<&'static dyn HarnessRunner> {
     match backend_id {
@@ -255,6 +278,7 @@ pub(crate) fn runner_for(backend_id: &str) -> Option<&'static dyn HarnessRunner>
         "codex" => Some(&CodexRunner),
         "grok" => Some(&GrokRunner),
         "gemini" => Some(&GeminiRunner),
+        "chatgpt_ui" => Some(&ChatGptUiRunner),
         _ => None,
     }
 }
@@ -287,7 +311,14 @@ mod tests {
 
     #[test]
     fn runner_for_maps_every_backend() {
-        for backend in ["claudecode", "opencode", "codex", "grok", "gemini"] {
+        for backend in [
+            "claudecode",
+            "opencode",
+            "codex",
+            "grok",
+            "gemini",
+            "chatgpt_ui",
+        ] {
             let runner = runner_for(backend).expect("runner exists");
             assert_eq!(runner.name(), backend);
         }

--- a/src/backend/chatgpt_ui/mod.rs
+++ b/src/backend/chatgpt_ui/mod.rs
@@ -1,0 +1,73 @@
+//! ChatGPT web-UI harness metadata.
+//!
+//! Mission execution lives in `api::runners::chatgpt_ui`; this registry entry
+//! exposes configuration/auth diagnostics without ever reading profile data.
+
+use anyhow::Error;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::backend::events::ExecutionEvent;
+use crate::backend::{AgentInfo, Backend, Session, SessionConfig};
+
+pub struct ChatGptUiBackend;
+
+impl ChatGptUiBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ChatGptUiBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Backend for ChatGptUiBackend {
+    fn id(&self) -> &str {
+        "chatgpt_ui"
+    }
+
+    fn name(&self) -> &str {
+        "ChatGPT UI (experimental)"
+    }
+
+    async fn check_auth_configured(&self, _ctx: &crate::backend::AuthContext<'_>) -> Option<bool> {
+        // A directory does not prove that ChatGPT is authenticated. Verifying
+        // the session requires launching the browser; the driver reports an
+        // explicit auth_required diagnostic at turn start.
+        None
+    }
+
+    async fn list_agents(&self) -> Result<Vec<AgentInfo>, Error> {
+        Ok(vec![AgentInfo {
+            id: "chat".to_string(),
+            name: "ChatGPT web conversation".to_string(),
+        }])
+    }
+
+    async fn create_session(&self, config: SessionConfig) -> Result<Session, Error> {
+        Ok(Session {
+            id: uuid::Uuid::new_v4().to_string(),
+            directory: config.directory,
+            model: config.model,
+            agent: config.agent,
+        })
+    }
+
+    async fn send_message_streaming(
+        &self,
+        _session: &Session,
+        _message: &str,
+    ) -> Result<(mpsc::Receiver<ExecutionEvent>, JoinHandle<()>), Error> {
+        anyhow::bail!("ChatGPT UI streaming is handled by the mission runner")
+    }
+}
+
+pub fn registry_entry() -> Arc<dyn Backend> {
+    Arc::new(ChatGptUiBackend::new())
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,3 +1,4 @@
+pub mod chatgpt_ui;
 pub mod claudecode;
 pub mod codex;
 pub mod events;

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -945,7 +945,7 @@ impl AssistantMcp {
                         "title": {"type": "string"},
                         "prompt": {"type": "string"},
                         "workspace_id": {"type": "string"},
-                        "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok"]},
+                        "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok", "chatgpt_ui"]},
                         "model_override": {"type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort. Never invent variants such as gpt-5.5-sol."},
                         "model_effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"]},
                         "config_profile": {"type": "string"},
@@ -1224,13 +1224,13 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "update_mission_settings".to_string(),
-                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok), model, reasoning effort, or agent. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. Note: model_effort only applies to claudecode and codex (low/medium/high/xhigh/max).".to_string(),
+                description: "Change a mission's run settings for its NEXT turn: switch backend (claudecode/codex/opencode/gemini/grok/chatgpt_ui), model, reasoning effort, or agent. Applies between turns — the mission must be idle (awaiting_user/acknowledged/interrupted), not actively running. If it is running, cancel_mission first (or wait), then update, then send_message_to_mission or resume_mission to kick the next turn. Note: model_effort only applies to claudecode and codex (low/medium/high/xhigh/max).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
                     "properties": {
                         "mission_id": {"type": "string"},
-                        "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok"]},
+                        "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok", "chatgpt_ui"]},
                         "model_override": {"type": "string", "description": "Model id. Empty string clears it. When backend changes this is reset unless set explicitly."},
                         "model_effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"]},
                         "agent": {"type": "string", "description": "Agent name. Empty string clears it."},

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -548,7 +548,7 @@ impl OrchestratorMcp {
                     "properties": {
                         "backend": {
                             "type": "string",
-                            "enum": ["claudecode", "codex", "gemini", "opencode", "grok"],
+                            "enum": ["claudecode", "codex", "gemini", "opencode", "grok", "chatgpt_ui"],
                             "description": "Optional single backend to inspect. If omitted, returns all common backends."
                         }
                     }
@@ -711,8 +711,8 @@ impl OrchestratorMcp {
                         },
                         "backend": {
                             "type": "string",
-                            "enum": ["claudecode", "codex", "gemini", "opencode", "grok"],
-                            "description": "Backend/harness to use. MUST match the model: claudecode for Claude models, codex for OpenAI/GPT models, gemini for Gemini models, grok for Grok models, opencode for any model via provider routing."
+                            "enum": ["claudecode", "codex", "gemini", "opencode", "grok", "chatgpt_ui"],
+                            "description": "Backend/harness to use. MUST match the model: claudecode for Claude models, codex for OpenAI/GPT models, gemini for Gemini models, grok for Grok models, opencode for provider routing, or chatgpt_ui with an exact visible web model label."
                         },
                         "model_override": {
                             "type": "string",
@@ -767,7 +767,7 @@ impl OrchestratorMcp {
                                 "required": ["title", "prompt"],
                                 "properties": {
                                     "title": { "type": "string" },
-                                    "backend": { "type": "string", "enum": ["claudecode", "codex", "gemini", "opencode", "grok"] },
+                                    "backend": { "type": "string", "enum": ["claudecode", "codex", "gemini", "opencode", "grok", "chatgpt_ui"] },
                                     "model_override": { "type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort; gpt-5.5-sol is unsupported." },
                                     "model_effort": { "type": "string", "enum": ["low", "medium", "high", "xhigh", "max"] },
                                     "agent": { "type": "string" },
@@ -1557,6 +1557,12 @@ impl OrchestratorMcp {
                     "provider_targeted": provider_targets_backend(&workspace_root, ProviderType::Xai, "grok"),
                     "reason": "Grok Build can use a targeted xAI provider API key or the CLI's own X login cache.",
                     "default_backends": default_backends_for_provider(ProviderType::Xai),
+                }),
+                "chatgpt_ui" => json!({
+                    "backend": "chatgpt_ui",
+                    "ready": null,
+                    "auth_status": "unknown",
+                    "reason": "Browser profile presence cannot prove authentication; a harness turn verifies the session on a blank ChatGPT page.",
                 }),
                 other => json!({
                     "backend": other,


### PR DESCRIPTION
## Architecture

- Adds a first-class, opt-in `chatgpt_ui` backend across registry, mission runner, API configuration, and dashboard surfaces.
- Uses an original Python/Playwright adapter with a small NDJSON event protocol; no CatGPT-Gateway source is copied or vendored.
- Keeps the persistent browser profile outside repositories/workspaces, clears inherited environment variables, serializes profile use with a cross-process lock, and kills the entire browser process group on cancellation/timeout.
- Translates text, diagnostics, tool calls/results, typed errors, and explicit completion into sandboxed.sh events. Partial streams and unresolved tool calls fail closed.

## Proven

- Deterministic mock protocol covers success, typed auth failure, incomplete output, and balanced tool events.
- Rust configuration and runner code validates paths/browser/model/timeout and enforces explicit completion, bounded shutdown, and exclusive profile use.
- Dashboard settings and mission backend selection are wired and TypeScript-clean.

## Not proven in this environment

- No authenticated, pre-provisioned ChatGPT browser profile was available, and Playwright was not installed globally. Therefore no real ChatGPT account turn, GPT-5.6 Pro selection, deep-research behavior, or subscription allowance consumption is claimed.
- A conservative operator smoke script and exact provisioning steps are included for account-side verification.

## Verification

- `python3 scripts/test_chatgpt_ui_mock_driver.py -v` — 4 passed.
- Rust focused runner tests — 3 passed (2 protocol/locking + backend mapping).
- `python3 -m py_compile scripts/chatgpt_ui_driver.py scripts/chatgpt_ui_mock_driver.py` — passed.
- `bash -n scripts/chatgpt_ui_smoke.sh` — passed.
- `cd dashboard && bun run lint` — 0 errors (23 existing warnings).
- `cd dashboard && bun x tsc --noEmit` — passed.
- `cargo fmt --check` and `git diff --check` — passed.
- Rust 1.91 compiled the backend test target successfully.

## Risk and limitations

This relies on unsupported, change-prone web UI automation. ChatGPT selectors, model labels, entitlements, quotas, anti-automation controls, and terms can change. The adapter does not bypass CAPTCHA, evade bot controls, or infer model identity. Operators must review applicable terms and accept possible challenges, throttling, or account restrictions. Use a dedicated least-privilege profile and never commit or export it.

## Provenance

Inspired by CatGPT-Gateway at `79a1b69d429fa9951d796289b60470fb595cbb42` (MIT, GautamVhavle). This is an original adapter; documentation records the inspiration and license review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New mission execution path drives a bearer browser profile and fragile third-party UI automation; misconfiguration or UI changes can break turns or affect account access.
> 
> **Overview**
> Adds an **opt-in `chatgpt_ui` harness** so missions can run turns against the operator’s ChatGPT web session (subscription UI), not the OpenAI API.
> 
> **Server:** Registers the backend, wires `ChatGptUiRunner`, and runs a Python Playwright driver over a small NDJSON protocol (text deltas, typed errors, explicit `complete`, balanced tool events). The Rust runner validates profile/driver paths, keeps profiles outside the working tree, clears env except `PATH`, enforces an exclusive profile lock, and tears down the browser process group on cancel/timeout. API config for `chatgpt_ui` is validated on save; missions skip library agent checks like other native harnesses.
> 
> **UI & tooling:** Dashboard backend settings and new-mission backend selection include ChatGPT UI. Docs, a smoke script, a real driver, and a mock driver with protocol tests support provisioning and CI.
> 
> **MCP:** Assistant and orchestrator tools accept `chatgpt_ui` as a backend choice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243423b96620d248f85195d9ff1288835e7703a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->