### PR TITLE
fix: complete ChatGPT UI harness integration

### DIFF
--- a/dashboard/src/components/assistant/assistant-page.tsx
+++ b/dashboard/src/components/assistant/assistant-page.tsx
@@ -80,6 +80,7 @@ const BACKEND_LABELS: Record<string, string> = {
   codex: 'Codex',
   gemini: 'Gemini',
   grok: 'Grok Build',
+  chatgpt_ui: 'ChatGPT UI (experimental)',
 };
 
 function gatewayLabel(bot: AssistantGateway) {
@@ -1692,7 +1693,7 @@ export default function AssistantPage() {
                           {BACKEND_LABELS[b.id] || b.name || b.id}
                         </option>
                       ))
-                    : ['claudecode', 'opencode', 'codex', 'gemini', 'grok'].map((id) => (
+                    : ['claudecode', 'opencode', 'codex', 'gemini', 'grok', 'chatgpt_ui'].map((id) => (
                         <option key={id} value={id}>
                           {BACKEND_LABELS[id] || id}
                         </option>
@@ -1884,7 +1885,7 @@ export default function AssistantPage() {
                           {BACKEND_LABELS[b.id] || b.name || b.id}
                         </option>
                       ))
-                    : ['claudecode', 'opencode', 'codex', 'gemini', 'grok'].map((id) => (
+                    : ['claudecode', 'opencode', 'codex', 'gemini', 'grok', 'chatgpt_ui'].map((id) => (
                         <option key={id} value={id}>
                           {BACKEND_LABELS[id] || id}
                         </option>

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -19257,6 +19257,11 @@ async fn run_single_control_turn(
         config.default_model = None;
     } else if backend_id.as_deref() == Some("gemini") && requested_model.is_none() {
         config.default_model = Some(resolve_gemini_default_model());
+    } else if backend_id.as_deref() == Some("chatgpt_ui") && requested_model.is_none() {
+        // Web model labels are account-specific. Never invent or inherit a
+        // CLI/API model slug for the browser harness.
+        config.default_model =
+            super::mission_runner::get_backend_string_setting("chatgpt_ui", "model");
     }
     if let Some(ref agent) = agent_override {
         config.opencode_agent = Some(agent.clone());
@@ -19525,6 +19530,35 @@ async fn run_single_control_turn(
                     cancel,
                     app_working_dir: &config.working_dir,
                     session_id: session_id.as_deref(),
+                    is_continuation: false,
+                    extras: crate::api::runners::TurnExtras::None,
+                }),
+            )
+            .await
+        }
+        Some("chatgpt_ui") => {
+            let mid = match require_mission_id(mission_id, "ChatGPT UI", &events_tx) {
+                Ok(id) => id,
+                Err(r) => return r,
+            };
+            use crate::api::runners::HarnessRunner as _;
+            Box::pin(
+                crate::api::runners::ChatGptUiRunner.run_turn(crate::api::runners::TurnContext {
+                    workspace: exec_workspace,
+                    work_dir: &ctx.working_dir,
+                    // The browser always starts a fresh chat, so include the
+                    // bounded conversation frame on follow-up turns.
+                    message: &convo,
+                    model: requested_model
+                        .as_deref()
+                        .or(config.default_model.as_deref()),
+                    model_effort: None,
+                    agent: None,
+                    mission_id: mid,
+                    events_tx: events_tx.clone(),
+                    cancel,
+                    app_working_dir: &config.working_dir,
+                    session_id: None,
                     is_continuation: false,
                     extras: crate::api::runners::TurnExtras::None,
                 }),

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7378,6 +7378,33 @@ fn resolve_host_executable(program: &str) -> Option<std::path::PathBuf> {
     None
 }
 
+fn host_executable_available(program: &str) -> bool {
+    let executable = if std::path::Path::new(program).components().count() > 1 {
+        let path = std::path::PathBuf::from(program);
+        path.is_file().then_some(path)
+    } else {
+        std::env::var_os("PATH").and_then(|path| {
+            std::env::split_paths(&path)
+                .map(|dir| dir.join(program))
+                .find(|candidate| candidate.is_file())
+        })
+    };
+    let Some(executable) = executable else {
+        return false;
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        executable
+            .metadata()
+            .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
 fn copy_host_executable_into_container(
     workspace: &crate::workspace::Workspace,
     host_executable: &std::path::Path,
@@ -7800,26 +7827,39 @@ pub async fn check_backend_prerequisites(
                 },
             }
         }
-        "chatgpt_ui" => BackendPreflightResult {
-            backend_id: "chatgpt_ui".to_string(),
-            // Authentication cannot be established without opening a clean
-            // browser page. The turn driver performs that check; preflight
-            // only confirms that the explicitly configured driver exists.
-            available: cli_path.is_some_and(|path| std::path::Path::new(path).is_file()),
-            cli_available: cli_path.is_some_and(|path| std::path::Path::new(path).is_file()),
-            auto_install_possible: false,
-            missing_dependencies: if cli_path
-                .is_some_and(|path| std::path::Path::new(path).is_file())
-            {
-                Vec::new()
-            } else {
-                vec!["configured ChatGPT UI driver".to_string()]
-            },
-            message: Some(
-                "Browser driver presence checked; authentication remains unknown until a clean UI turn"
-                    .to_string(),
-            ),
-        },
+        "chatgpt_ui" => {
+            let driver_available =
+                cli_path.is_some_and(|path| std::path::Path::new(path).is_file());
+            let profile_available = get_backend_string_setting("chatgpt_ui", "profile_dir")
+                .is_some_and(|path| std::path::Path::new(&path).is_dir());
+            let python_path = get_backend_string_setting("chatgpt_ui", "python_path")
+                .unwrap_or_else(|| "python3".to_string());
+            let python_available = host_executable_available(&python_path);
+            let available = driver_available && profile_available && python_available;
+            let mut missing_dependencies = Vec::new();
+            if !driver_available {
+                missing_dependencies.push("configured ChatGPT UI driver".to_string());
+            }
+            if !profile_available {
+                missing_dependencies.push("configured ChatGPT UI profile directory".to_string());
+            }
+            if !python_available {
+                missing_dependencies.push("configured ChatGPT UI Python executable".to_string());
+            }
+            BackendPreflightResult {
+                backend_id: "chatgpt_ui".to_string(),
+                // Authentication cannot be established without opening a
+                // clean browser page. The turn driver performs that check.
+                available,
+                cli_available: available,
+                auto_install_possible: false,
+                missing_dependencies,
+                message: Some(
+                    "Driver, Python executable, and profile directory checked; authentication remains unknown until a clean UI turn"
+                        .to_string(),
+                ),
+            }
+        }
         _ => BackendPreflightResult {
             backend_id: backend_id.to_string(),
             available: false,

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -7800,6 +7800,26 @@ pub async fn check_backend_prerequisites(
                 },
             }
         }
+        "chatgpt_ui" => BackendPreflightResult {
+            backend_id: "chatgpt_ui".to_string(),
+            // Authentication cannot be established without opening a clean
+            // browser page. The turn driver performs that check; preflight
+            // only confirms that the explicitly configured driver exists.
+            available: cli_path.is_some_and(|path| std::path::Path::new(path).is_file()),
+            cli_available: cli_path.is_some_and(|path| std::path::Path::new(path).is_file()),
+            auto_install_possible: false,
+            missing_dependencies: if cli_path
+                .is_some_and(|path| std::path::Path::new(path).is_file())
+            {
+                Vec::new()
+            } else {
+                vec!["configured ChatGPT UI driver".to_string()]
+            },
+            message: Some(
+                "Browser driver presence checked; authentication remains unknown until a clean UI turn"
+                    .to_string(),
+            ),
+        },
         _ => BackendPreflightResult {
             backend_id: backend_id.to_string(),
             available: false,
@@ -7807,7 +7827,7 @@ pub async fn check_backend_prerequisites(
             auto_install_possible: false,
             missing_dependencies: vec![format!("unknown backend: {}", backend_id)],
             message: Some(format!(
-                "Unknown backend '{}'. Supported backends: claudecode, opencode, codex, gemini, grok",
+                "Unknown backend '{}'. Supported backends: claudecode, opencode, codex, gemini, grok, chatgpt_ui",
                 backend_id
             )),
         },

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -202,6 +202,8 @@ pub async fn run_chatgpt_ui_turn(
                 .with_terminal_reason(TerminalReason::LlmError)
         }
     };
+    #[cfg(unix)]
+    let process_group = child.id().map(|pid| -(pid as i32));
 
     let request = serde_json::json!({
         "type": "run",
@@ -379,6 +381,14 @@ pub async fn run_chatgpt_ui_turn(
                 .with_terminal_reason(TerminalReason::LlmError);
         }
     };
+    // A well-behaved driver closes its browser before exiting, but enforce
+    // that boundary even if it leaves descendants behind after a clean exit.
+    #[cfg(unix)]
+    if let Some(process_group) = process_group {
+        unsafe {
+            libc::kill(process_group, libc::SIGKILL);
+        }
+    }
     if let Err(message) = validate_completion(
         completed,
         &output,

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::broadcast;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -226,7 +227,8 @@ pub async fn run_chatgpt_ui_turn(
     let mut model_used = model.map(str::to_string);
     let mut pending_tools: HashMap<String, String> = HashMap::new();
     let mut completed = false;
-    let deadline = tokio::time::sleep(settings.timeout);
+    let deadline_at = Instant::now() + settings.timeout;
+    let deadline = tokio::time::sleep_until(deadline_at);
     tokio::pin!(deadline);
 
     loop {
@@ -246,7 +248,7 @@ pub async fn run_chatgpt_ui_turn(
                 });
             }
             _ = &mut deadline => {
-                terminate_child_tree(&mut child).await;
+                kill_child_tree(&mut child).await;
                 return AgentResult::failure(
                     format!("chatgpt_ui timed out after {} seconds", settings.timeout.as_secs()), 0
                 ).with_terminal_reason(TerminalReason::LlmError);
@@ -318,6 +320,18 @@ pub async fn run_chatgpt_ui_turn(
             }
         }
     }
+    let remaining = deadline_at.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        kill_child_tree(&mut child).await;
+        return AgentResult::failure(
+            format!(
+                "chatgpt_ui timed out after {} seconds",
+                settings.timeout.as_secs()
+            ),
+            0,
+        )
+        .with_terminal_reason(TerminalReason::LlmError);
+    }
     let status = tokio::select! {
         _ = cancel.cancelled() => {
             terminate_child_tree(&mut child).await;
@@ -335,12 +349,12 @@ pub async fn run_chatgpt_ui_turn(
             });
         }
         _ = &mut deadline => {
-            terminate_child_tree(&mut child).await;
+            kill_child_tree(&mut child).await;
             return AgentResult::failure(
                 format!("chatgpt_ui timed out after {} seconds", settings.timeout.as_secs()), 0
             ).with_terminal_reason(TerminalReason::LlmError);
         }
-        status = tokio::time::timeout(Duration::from_secs(5), child.wait()) => status,
+        status = tokio::time::timeout(remaining.min(Duration::from_secs(5)), child.wait()) => status,
     };
     let status = match status {
         Ok(Ok(status)) => Some(status),
@@ -349,18 +363,29 @@ pub async fn run_chatgpt_ui_turn(
                 .with_terminal_reason(TerminalReason::LlmError);
         }
         Err(_) => {
+            if Instant::now() >= deadline_at {
+                kill_child_tree(&mut child).await;
+                return AgentResult::failure(
+                    format!(
+                        "chatgpt_ui timed out after {} seconds",
+                        settings.timeout.as_secs()
+                    ),
+                    0,
+                )
+                .with_terminal_reason(TerminalReason::LlmError);
+            }
             terminate_child_tree(&mut child).await;
             return AgentResult::failure("chatgpt_ui driver did not exit after completion", 0)
                 .with_terminal_reason(TerminalReason::LlmError);
         }
     };
-    if !pending_tools.is_empty() {
-        return AgentResult::failure("chatgpt_ui ended with unresolved tool calls", 0)
-            .with_terminal_reason(TerminalReason::LlmError);
-    }
-    if !completed || output.trim().is_empty() || status.is_none_or(|status| !status.success()) {
-        return AgentResult::failure("chatgpt_ui driver exited without a completed response", 0)
-            .with_terminal_reason(TerminalReason::LlmError);
+    if let Err(message) = validate_completion(
+        completed,
+        &output,
+        pending_tools.len(),
+        status.is_some_and(|status| status.success()),
+    ) {
+        return AgentResult::failure(message, 0).with_terminal_reason(TerminalReason::LlmError);
     }
     let mut result = AgentResult::success(output, 0)
         .with_terminal_reason(TerminalReason::TurnComplete)
@@ -369,6 +394,21 @@ pub async fn run_chatgpt_ui_turn(
         result = result.with_model(model);
     }
     result
+}
+
+fn validate_completion(
+    completed: bool,
+    output: &str,
+    pending_tool_count: usize,
+    exit_success: bool,
+) -> Result<(), &'static str> {
+    if pending_tool_count != 0 {
+        return Err("chatgpt_ui ended with unresolved tool calls");
+    }
+    if !completed || output.trim().is_empty() || !exit_success {
+        return Err("chatgpt_ui driver exited without a completed response");
+    }
+    Ok(())
 }
 
 async fn terminate_child_tree(child: &mut tokio::process::Child) {
@@ -390,6 +430,19 @@ async fn terminate_child_tree(child: &mut tokio::process::Child) {
         if !exited {
             let _ = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
         }
+        return;
+    }
+    let _ = child.kill().await;
+}
+
+/// Enforce a hard deadline without adding a graceful-shutdown tail to it.
+async fn kill_child_tree(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGKILL);
+        }
+        let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
         return;
     }
     let _ = child.kill().await;
@@ -417,5 +470,20 @@ mod tests {
         assert!(lock_profile(&profile).is_err());
         drop(first);
         assert!(lock_profile(&profile).is_ok());
+    }
+
+    #[test]
+    fn completion_requires_signal_content_clean_exit_and_balanced_tools() {
+        assert!(validate_completion(true, "done", 0, true).is_ok());
+        assert_eq!(
+            validate_completion(false, "partial", 0, true),
+            Err("chatgpt_ui driver exited without a completed response")
+        );
+        assert_eq!(
+            validate_completion(true, "done", 1, true),
+            Err("chatgpt_ui ended with unresolved tool calls")
+        );
+        assert!(validate_completion(true, " ", 0, true).is_err());
+        assert!(validate_completion(true, "done", 0, false).is_err());
     }
 }

--- a/src/api/runners/mod.rs
+++ b/src/api/runners/mod.rs
@@ -29,7 +29,7 @@ use crate::workspace::Workspace;
 
 /// Everything a harness needs to run one turn.
 ///
-/// The common fields are identical across all five backends; backend-specific
+/// The common fields are identical across all harness backends; backend-specific
 /// inputs travel in [`TurnExtras`]. Message framing (raw vs history-framed
 /// `convo`, `/goal` passthrough) is the caller's responsibility — by the time
 /// a `TurnContext` exists, `message` is exactly what the harness should see.
@@ -333,7 +333,7 @@ mod tests {
             runner_for("codex").unwrap().mid_turn_kind(),
             MidTurnKind::CodexAppServer
         );
-        for backend in ["opencode", "grok", "gemini"] {
+        for backend in ["opencode", "grok", "gemini", "chatgpt_ui"] {
             assert_eq!(
                 runner_for(backend).unwrap().mid_turn_kind(),
                 MidTurnKind::None

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -2329,8 +2329,10 @@ async fn check_backend_preflight(
 ) -> Result<Json<super::mission_runner::BackendPreflightResult>, (StatusCode, String)> {
     let workspace = require_workspace(&state.workspaces, workspace_id).await?;
 
-    let cli_path = if backend_id == "claudecode" || backend_id == "codex" || backend_id == "gemini"
-    {
+    let cli_path = if matches!(
+        backend_id.as_str(),
+        "claudecode" | "codex" | "gemini" | "chatgpt_ui"
+    ) {
         state
             .backend_configs
             .get(&backend_id)
@@ -2338,7 +2340,11 @@ async fn check_backend_preflight(
             .and_then(|config| {
                 config
                     .settings
-                    .get("cli_path")
+                    .get(if backend_id == "chatgpt_ui" {
+                        "driver_path"
+                    } else {
+                        "cli_path"
+                    })
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
             })

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,10 +609,19 @@ impl Config {
         // Default backend configuration
         let default_backend = std::env::var("DEFAULT_BACKEND").ok().and_then(|v| {
             let backend = v.trim().to_lowercase();
-            if backend.is_empty() || !["claudecode", "opencode", "grok", "gemini", "codex"].contains(&backend.as_str())
+            if backend.is_empty()
+                || ![
+                    "claudecode",
+                    "opencode",
+                    "grok",
+                    "gemini",
+                    "codex",
+                    "chatgpt_ui",
+                ]
+                .contains(&backend.as_str())
             {
                 tracing::warn!(
-                    "Invalid DEFAULT_BACKEND '{}'. Expected one of: claudecode, opencode, grok, gemini, codex",
+                    "Invalid DEFAULT_BACKEND '{}'. Expected one of: claudecode, opencode, grok, gemini, codex, chatgpt_ui",
                     v
                 );
                 None


### PR DESCRIPTION
## Architecture

- routes `chatgpt_ui` through both initial mission and control/follow-up runner paths with bounded history framed into a fresh web chat
- validates explicit profile/driver paths and preflight state without treating directory presence as authentication
- adds hard-deadline process-group shutdown, strict Complete/clean-exit/balanced-tool success requirements, and truthful cancellation/shutdown outcomes
- completes default-backend, workspace preflight, assistant, agent, and dashboard surfaces
- preserves the original isolated-profile security boundary and CatGPT-Gateway attribution; no upstream code is vendored

## Verification

- `cargo test chatgpt_ui --lib` — PASS (3 passed)
- `python3 -m unittest scripts/test_chatgpt_ui_mock_driver.py -v` — PASS (4 passed)
- `python3 -m py_compile scripts/chatgpt_ui_driver.py scripts/chatgpt_ui_mock_driver.py scripts/test_chatgpt_ui_mock_driver.py` — PASS
- `bash -n scripts/chatgpt_ui_smoke.sh` — PASS
- `cargo check --all-targets` — PASS
- `cargo fmt --all -- --check` — PASS
- `bun run lint` — PASS with 23 pre-existing warnings, 0 errors
- `bun run build` — PASS
- `bun run test:unit` — first full run PASS (30 files, 248 tests); post-rebase run had one unrelated lazy-highlighter timeout (247/248), isolated rerun PASS (3/3)
- `cargo test --lib` — 1483 passed, 1 failed, 1 ignored; reproducible unrelated failure: `api::remote_build::tests::wrapper_resumes_an_interrupted_async_job_without_resubmitting`
- `cargo clippy --lib --bins -- -D warnings` — blocked by two pre-existing lints in `src/api/runners/errors.rs` and `src/library/mod.rs`

## Browser smoke / capability evidence

No safely identified pre-provisioned authenticated browser profile was available, so no real browser was launched and no screenshot was captured. There are no screenshot or smoke artifact paths. GPT-5.6 Pro, deep research, live authentication, and account-specific model selection remain **unproven**.

Operator verification: provision a dedicated profile outside every repository/workspace, close the provisioning browser, then run `scripts/chatgpt_ui_smoke.sh /absolute/profile/path "<exact visible model label>" /tmp/chatgpt-ui-smoke.json`. The artifact contains only sanitized booleans/event types. Complete MFA/CAPTCHA manually; the harness does not bypass anti-bot controls.

## Security review

Final diff scanned for credentials/tokens/cookies; none found. `.codex/`, profiles, browser state, screenshots, private content, and temporary artifacts are not tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new mission backend that spawns browser/driver subprocesses and touches control routing and process lifecycle; scope is bounded but failures affect turn execution and resource cleanup.
> 
> **Overview**
> Wires the experimental **`chatgpt_ui`** backend through mission/control turns, config, workspace preflight, and the assistant dashboard so it behaves like other harness backends end-to-end.
> 
> **Runtime routing:** Control turns now dispatch to `ChatGptUiRunner` with the bounded **`convo`** frame (fresh web chat per turn, no CLI session id). Default model for this backend comes only from backend settings (`model`), not inherited API/CLI slugs.
> 
> **Preflight & config:** Workspace preflight resolves **`driver_path`** for `chatgpt_ui` and checks driver file, profile directory, and Python on the host; auth is still deferred to the driver. `DEFAULT_BACKEND` and unknown-backend messages include `chatgpt_ui`.
> 
> **Driver hardening:** The ChatGPT UI runner uses a fixed deadline (`sleep_until`), **`kill_child_tree`** on timeout (SIGKILL, no graceful tail), optional process-group cleanup after exit, and shared **`validate_completion`** rules (complete event, non-empty output, clean exit, no pending tools).
> 
> **UI:** Assistant gateway create/edit pickers label and list **ChatGPT UI (experimental)** when the backends API is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78855caf1fcc55a23655f3945a686f7a83262837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->