### PR TITLE
fix: mark Hermes systemd stops as planned

### DIFF
--- a/docs/examples/hermes-assistant-dev.service.example
+++ b/docs/examples/hermes-assistant-dev.service.example
@@ -11,7 +11,10 @@ WorkingDirectory=/var/lib/hermes-assistant-dev
 # Install Hermes on the host first. The gateway process owns Telegram and loads
 # config.yaml/.env from HERMES_HOME. `run` keeps the gateway in the foreground
 # for systemd supervision.
-ExecStart=/usr/local/bin/hermes gateway --accept-hooks run
+ExecStart=/usr/local/bin/hermes gateway run --accept-hooks
+# Write Hermes's planned-stop marker before signalling the gateway. This keeps
+# operator-requested systemd stop/restart distinct from an unexpected SIGTERM.
+ExecStop=/usr/local/bin/hermes gateway stop
 
 Restart=always
 RestartSec=5

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -1359,7 +1359,11 @@ Wants=network-online.target
 Type=simple
 EnvironmentFile={env_path}
 WorkingDirectory=/var/lib/{runtime_name}
-ExecStart=/usr/local/bin/hermes gateway --accept-hooks run
+ExecStart=/usr/local/bin/hermes gateway run --accept-hooks
+# Hermes distinguishes an operator stop from an unexpected SIGTERM with a
+# short-lived marker. The CLI writes that marker before signalling the gateway,
+# allowing the drain to finish with exit code 0 during systemd stop/restart.
+ExecStop=/usr/local/bin/hermes gateway stop
 Restart=always
 RestartSec=5
 TimeoutStopSec=240
@@ -1375,7 +1379,8 @@ WantedBy=multi-user.target
     )
 }
 
-const HERMES_SERVICE_DRAIN_DROP_IN: &str = "[Service]\nKillMode=mixed\n";
+const HERMES_SERVICE_DRAIN_DROP_IN: &str =
+    "[Service]\nKillMode=mixed\nExecStop=/usr/local/bin/hermes gateway stop\n";
 
 /// Migrate an already-installed Hermes service to the same drain-safe process
 /// policy used by newly generated units.
@@ -1383,6 +1388,9 @@ const HERMES_SERVICE_DRAIN_DROP_IN: &str = "[Service]\nKillMode=mixed\n";
 /// A regular systemd stop signals every process in the service cgroup when the
 /// default `KillMode=control-group` is in effect. That kills `assistant-mcp`
 /// while the Hermes gateway is still draining an in-flight controller turn.
+/// A raw systemd SIGTERM is also classified by Hermes as an unexpected
+/// shutdown and exits non-zero; the explicit CLI stop writes Hermes's planned
+/// stop marker before signalling the gateway.
 /// Installing a drop-in is deliberately narrower than re-running adoption: it
 /// preserves the existing Hermes environment, plugins, credentials, and unit
 /// customizations.
@@ -5361,8 +5369,13 @@ mod tests {
 
         assert!(unit.contains("TimeoutStopSec=240\n"));
         assert!(unit.contains("KillMode=mixed\n"));
+        assert!(unit.contains("ExecStart=/usr/local/bin/hermes gateway run --accept-hooks\n"));
+        assert!(unit.contains("ExecStop=/usr/local/bin/hermes gateway stop\n"));
         assert!(!unit.contains("KillMode=control-group"));
-        assert_eq!(HERMES_SERVICE_DRAIN_DROP_IN, "[Service]\nKillMode=mixed\n");
+        assert_eq!(
+            HERMES_SERVICE_DRAIN_DROP_IN,
+            "[Service]\nKillMode=mixed\nExecStop=/usr/local/bin/hermes gateway stop\n"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- run Hermes with the canonical `gateway run --accept-hooks` argument order
- invoke `hermes gateway stop` from systemd so Hermes writes its planned-stop marker before SIGTERM
- reconcile the stop behavior into existing Hermes service drop-ins

## Verification
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1479 passed, 0 failed, 1 ignored; companion suites pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to systemd unit templates, docs example, and migration drop-ins for Hermes gateway lifecycle; no auth or data-path changes.
> 
> **Overview**
> **Hermes systemd units** now start with `hermes gateway run --accept-hooks` and stop via `ExecStop=/usr/local/bin/hermes gateway stop` so the CLI writes Hermes’s planned-stop marker before the gateway is signalled. That separates operator stop/restart from a bare SIGTERM (which Hermes treats as unexpected and can exit non-zero) while keeping the existing **drain** behavior (`KillMode=mixed`, long `TimeoutStopSec`).
> 
> The same **ExecStop** line is added to generated units in `hermes_service_unit`, the example unit, and the **`60-sandboxed-drain.conf`** drop-in content reconciled by `reconcile_hermes_service_drain_policy` for already-installed services. Unit tests assert the new **ExecStart**/**ExecStop** strings and drop-in constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f715ae420d1e017938f9d929a3bb8031a451ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->