### PR TITLE
Fix dashboard Hermes session envelopes

### DIFF
--- a/dashboard/src/lib/api/hermes.test.ts
+++ b/dashboard/src/lib/api/hermes.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { apiFetch } from "./core";
-import { createHermesSession, hermesChatStream } from "./hermes";
+import { apiFetch, apiGet } from "./core";
+import {
+  createHermesSession,
+  getHermesSessionMessages,
+  hermesChatStream,
+  listHermesSessions,
+} from "./hermes";
 
 vi.mock("./core", () => ({
   apiDel: vi.fn(),
@@ -12,10 +17,68 @@ vi.mock("./core", () => ({
 }));
 
 const mockedApiFetch = vi.mocked(apiFetch);
+const mockedApiGet = vi.mocked(apiGet);
 
 describe("Hermes chat stream", () => {
   beforeEach(() => {
     mockedApiFetch.mockReset();
+    mockedApiGet.mockReset();
+  });
+
+  test("reads the current Hermes session and message envelopes", async () => {
+    mockedApiGet
+      .mockResolvedValueOnce({
+        sessions: [{ id: "session-1", title: "Production canary" }],
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          {
+            id: 1,
+            session_id: "session-1",
+            role: "assistant",
+            content: "Done",
+          },
+        ],
+      });
+
+    await expect(listHermesSessions()).resolves.toEqual([
+      { id: "session-1", title: "Production canary" },
+    ]);
+    await expect(getHermesSessionMessages("session-1")).resolves.toEqual([
+      {
+        id: 1,
+        session_id: "session-1",
+        role: "assistant",
+        content: "Done",
+      },
+    ]);
+  });
+
+  test("keeps compatibility with legacy data envelopes", async () => {
+    mockedApiGet
+      .mockResolvedValueOnce({ data: [{ id: "session-legacy" }] })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 2,
+            role: "user",
+            content: "Hello",
+          },
+        ],
+      });
+
+    await expect(listHermesSessions()).resolves.toEqual([
+      { id: "session-legacy" },
+    ]);
+    await expect(
+      getHermesSessionMessages("session-legacy"),
+    ).resolves.toEqual([
+      {
+        id: 2,
+        role: "user",
+        content: "Hello",
+      },
+    ]);
   });
 
   test("parses valid SSE streams that use CRLF separators", async () => {

--- a/dashboard/src/lib/api/hermes.ts
+++ b/dashboard/src/lib/api/hermes.ts
@@ -41,12 +41,24 @@ export interface HermesMessage {
   reasoning_content?: string | null;
 }
 
+interface HermesSessionsResponse {
+  sessions?: HermesSession[];
+  /** Compatibility with older proxy responses. */
+  data?: HermesSession[];
+}
+
+interface HermesMessagesResponse {
+  messages?: HermesMessage[];
+  /** Compatibility with older proxy responses. */
+  data?: HermesMessage[];
+}
+
 export async function listHermesSessions(limit = 50): Promise<HermesSession[]> {
-  const res = await apiGet<{ data: HermesSession[] }>(
+  const res = await apiGet<HermesSessionsResponse>(
     `${HERMES_PROXY}/api/sessions?source=api_server&limit=${limit}`,
     "Failed to list Hermes sessions",
   );
-  return res.data ?? [];
+  return res.sessions ?? res.data ?? [];
 }
 
 export async function createHermesSession(title?: string): Promise<HermesSession> {
@@ -71,11 +83,11 @@ export async function createHermesSession(title?: string): Promise<HermesSession
 export async function getHermesSessionMessages(
   sessionId: string,
 ): Promise<HermesMessage[]> {
-  const res = await apiGet<{ data: HermesMessage[] }>(
+  const res = await apiGet<HermesMessagesResponse>(
     `${HERMES_PROXY}/api/sessions/${encodeURIComponent(sessionId)}/messages`,
     "Failed to load Hermes session",
   );
-  return res.data ?? [];
+  return res.messages ?? res.data ?? [];
 }
 
 export async function renameHermesSession(


### PR DESCRIPTION
## What changed

- accept the current Hermes `{ sessions }` response envelope when listing conversations
- accept the current Hermes `{ messages }` response envelope when opening a conversation
- retain compatibility with the older `{ data }` proxy envelope
- add regression coverage for both response formats

## Root cause

The production Hermes dashboard API returned valid sessions and messages, but the Sandboxed dashboard only read `data`, so it silently rendered an empty conversation list.

## Validation

- `bun run test:unit` (250 passed)
- `bun run lint` (0 errors; pre-existing warnings only)
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API client parsing change with backward-compatible fallbacks and regression tests; no auth or data-model changes.
> 
> **Overview**
> Fixes the Hermes dashboard showing **no conversations** when the upstream API returns `{ sessions }` and `{ messages }` instead of the older `{ data }` wrapper—the client only read `data`, so lists and threads appeared empty despite valid responses.
> 
> `listHermesSessions` and `getHermesSessionMessages` now prefer `sessions` / `messages` and **fall back to `data`** for legacy proxy responses. Unit tests cover both envelope shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4067ed75f3e4f3ac923820691c57a6685af654e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->