### PR TITLE
Document DGX sentinel Tailscale recovery

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -71,6 +71,22 @@ No output means every monitored filesystem is reachable and below its alert
 threshold. The current cron job ID is `6bfc537e6dc9`; a manual cron execution
 must also finish successfully before closing the incident.
 
+DGX is the one sentinel target that depends on the control plane's Tailscale
+service. If only `dgx-spark` is unknown, verify the route before changing SSH
+keys or adding a relay:
+
+```bash
+systemctl is-enabled tailscaled
+systemctl is-active tailscaled
+tailscale ping -c 2 100.77.4.93
+```
+
+`tailscaled` must be both enabled and active on `agent-core`. Recover the
+expected persisted service with `systemctl enable --now tailscaled`, then
+require all three checks to pass: Tailscale ping, strict-host-key SSH to DGX,
+and a silent `disk-sentinel.sh` run. Never restore the retired `old-agent`
+tunnel to mask a stopped local Tailscale service.
+
 | Service | Port | Domain | Binary |
 |---------|------|--------|--------|
 | `sandboxed-sh-prod` | 3000 | agent-backend.thomas.md | `/usr/local/bin/sandboxed-sh-prod` |


### PR DESCRIPTION
## What changed

- document that DGX disk checks depend on the agent-core `tailscaled` service
- add the exact enabled/active, Tailscale ping, strict SSH, and sentinel verification sequence
- explicitly forbid reviving the retired old-agent tunnel as a workaround

## Incident

`disk-sentinel` reproduced `DISK UNKNOWN dgx-spark` while the other nodes remained reachable. The control-plane Tailscale service was not active. Enabling and starting the persisted unit restored direct ping, SSH, node heartbeat, and a silent sentinel run.

## Validation

- `tailscaled`: enabled + active
- direct `tailscale ping 100.77.4.93`: pass
- strict-host-key SSH to DGX: pass
- `disk-sentinel.sh`: exit 0, zero output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to operator runbooks; no application, auth, or infrastructure code paths are modified.
> 
> **Overview**
> Adds **disk-sentinel** runbook steps for when only **`dgx-spark`** reports `DISK UNKNOWN`, clarifying that DGX checks depend on **`tailscaled` on `agent-core`** (not just SSH keys or relays).
> 
> The new section lists **`systemctl`** enabled/active checks, **`tailscale ping`** to `100.77.4.93`, recovery via **`systemctl enable --now tailscaled`**, and the bar for closing the incident: Tailscale ping, strict-host-key SSH to DGX, and a silent **`disk-sentinel.sh`** run. It explicitly warns **not** to bring back the retired **`old-agent`** tunnel as a workaround for a stopped local Tailscale service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73765ff10db54ff045e65f8e9e6568422148640e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->