### PR TITLE
fix: make ChatGPT UI setup and smoke reproducible

### DIFF
--- a/docs/CHATGPT_UI_HARNESS.md
+++ b/docs/CHATGPT_UI_HARNESS.md
@@ -3,6 +3,8 @@
 `chatgpt_ui` runs a mission turn through the operator's existing ChatGPT web
 session. It consumes the subscription allowance shown in that account's web UI,
 not Codex CLI/API allowance. This is browser automation, not an OpenAI API.
+It does not reuse OpenAI/Codex OAuth credentials from backend settings: login
+state lives only in the dedicated Playwright browser profile configured below.
 
 ## Status and limitations
 
@@ -29,6 +31,8 @@ account:
 python3 -m venv /opt/sandboxed-sh/chatgpt-ui-venv
 /opt/sandboxed-sh/chatgpt-ui-venv/bin/pip install playwright
 /opt/sandboxed-sh/chatgpt-ui-venv/bin/playwright install chromium
+install -D -m 0755 scripts/chatgpt_ui_driver.py \
+  /opt/sandboxed-sh/scripts/chatgpt_ui_driver.py
 ```
 
 Create a dedicated profile directory outside repositories and mission
@@ -78,10 +82,17 @@ not independently prove backend model identity or deep-research capabilities.
 For a one-turn operator smoke test:
 
 ```bash
-scripts/chatgpt_ui_smoke.sh /var/lib/sandboxed-sh/chatgpt-profile "GPT-5.6 Pro"
+CHATGPT_UI_PYTHON=/opt/sandboxed-sh/chatgpt-ui-venv/bin/python \
+CHATGPT_UI_DRIVER=/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py \
+  scripts/chatgpt_ui_smoke.sh \
+  /var/lib/sandboxed-sh/chatgpt-profile "GPT-5.6 Pro"
 ```
 
 Run without a model argument to test the account's current UI default.
+`CHATGPT_UI_PYTHON` must point at the interpreter where Playwright was
+installed; the smoke script otherwise uses `python3`. `CHATGPT_UI_DRIVER` is
+optional when running the script from the repository, where the adjacent
+driver is selected automatically.
 
 ## Diagnostics
 

--- a/scripts/chatgpt_ui_smoke.sh
+++ b/scripts/chatgpt_ui_smoke.sh
@@ -9,16 +9,31 @@ fi
 profile_dir=$1
 model=${2:-}
 artifact=${3:-}
+python_bin=${CHATGPT_UI_PYTHON:-python3}
+driver=${CHATGPT_UI_DRIVER:-"$(dirname "$0")/chatgpt_ui_driver.py"}
 if [[ $profile_dir != /* || ! -d $profile_dir ]]; then
   echo "profile directory must be an existing absolute path" >&2
   exit 2
 fi
+if [[ $python_bin == */* ]]; then
+  if [[ ! -x $python_bin ]]; then
+    echo "ChatGPT UI Python executable not found: $python_bin" >&2
+    exit 2
+  fi
+elif ! command -v "$python_bin" >/dev/null 2>&1; then
+  echo "ChatGPT UI Python executable not found in PATH: $python_bin" >&2
+  exit 2
+fi
+if [[ ! -f $driver ]]; then
+  echo "ChatGPT UI driver not found: $driver" >&2
+  exit 2
+fi
 
 printf '{"type":"run","message":"Reply with exactly: SANDBOXED_CHATGPT_UI_SMOKE_OK","model":%s,"timeout_ms":120000}\n' \
-  "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1] or None))' "$model")" |
-  python3 "$(dirname "$0")/chatgpt_ui_driver.py" \
+  "$("$python_bin" -c 'import json,sys; print(json.dumps(sys.argv[1] or None))' "$model")" |
+  "$python_bin" "$driver" \
     --profile-dir "$profile_dir" --browser chromium --headless true |
-  python3 -c '
+  "$python_bin" -c '
 import json, pathlib, sys
 events = [json.loads(line) for line in sys.stdin if line.strip()]
 complete = next((event for event in reversed(events) if event.get("type") == "complete"), None)

--- a/scripts/harness_contract_tests.sh
+++ b/scripts/harness_contract_tests.sh
@@ -18,4 +18,10 @@ cargo test --locked --workspace --lib test_parse_stream_event_delta
 cargo test --locked --workspace --lib test_parse_assistant_event
 cargo test --locked --workspace --lib test_parse_result_event
 
+echo "== Harness contract tests: ChatGPT UI protocol and smoke wrapper =="
+bash -n scripts/chatgpt_ui_smoke.sh
+python3 -m unittest \
+  scripts/test_chatgpt_ui_mock_driver.py \
+  scripts/test_chatgpt_ui_smoke.py
+
 echo "Harness contract tests passed."

--- a/scripts/test_chatgpt_ui_smoke.py
+++ b/scripts/test_chatgpt_ui_smoke.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE = ROOT / "scripts" / "chatgpt_ui_smoke.sh"
+
+
+class ChatGptUiSmokeTests(unittest.TestCase):
+    def test_uses_configured_python_and_driver(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profile = root / "profile"
+            profile.mkdir()
+            driver = root / "driver.py"
+            driver.write_text(
+                "import json, sys\n"
+                "request = json.loads(sys.stdin.readline())\n"
+                "assert request['model'] == 'Visible model'\n"
+                "print(json.dumps({'type': 'complete', 'content': "
+                "'SANDBOXED_CHATGPT_UI_SMOKE_OK'}))\n",
+                encoding="utf-8",
+            )
+            artifact = root / "result.json"
+            env = {
+                **os.environ,
+                "CHATGPT_UI_PYTHON": sys.executable,
+                "CHATGPT_UI_DRIVER": str(driver),
+            }
+
+            completed = subprocess.run(
+                [str(SMOKE), str(profile), "Visible model", str(artifact)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertTrue(json.loads(completed.stdout)["ok"])
+            self.assertTrue(json.loads(artifact.read_text(encoding="utf-8"))["ok"])
+
+    def test_rejects_missing_configured_python(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            profile = Path(temp_dir) / "profile"
+            profile.mkdir()
+            env = {
+                **os.environ,
+                "CHATGPT_UI_PYTHON": str(Path(temp_dir) / "missing-python"),
+            }
+
+            completed = subprocess.run(
+                [str(SMOKE), str(profile)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("Python executable not found", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- install the ChatGPT UI driver at the documented absolute path
- let the smoke test use the dedicated Playwright venv and an installed driver via explicit environment variables
- fail early when either executable is missing
- document that ChatGPT UI uses a separate browser session, not the OpenAI/Codex OAuth configured for API/CLI backends
- add smoke-wrapper regression tests

## Verification

- `bash -n scripts/chatgpt_ui_smoke.sh`
- `python3 -m unittest scripts/test_chatgpt_ui_smoke.py scripts/test_chatgpt_ui_mock_driver.py -v` (6 passed)
- `python3 -m py_compile scripts/chatgpt_ui_driver.py scripts/chatgpt_ui_mock_driver.py scripts/test_chatgpt_ui_mock_driver.py scripts/test_chatgpt_ui_smoke.py`
- `git diff --check`
- current master harness verification: `cargo fmt --all -- --check`, `cargo test chatgpt_ui --lib`, dashboard unit tests/lint/build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and smoke-script wiring only; no changes to mission runtime or auth flows beyond clearer operator guidance.
> 
> **Overview**
> Makes the ChatGPT UI operator smoke path match production setup by letting **`chatgpt_ui_smoke.sh`** use **`CHATGPT_UI_PYTHON`** and **`CHATGPT_UI_DRIVER`** (with defaults to `python3` and the repo-adjacent driver), and **failing fast** when the configured interpreter or driver path is missing.
> 
> **`docs/CHATGPT_UI_HARNESS.md`** now documents installing the driver to `/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py`, running smoke with the Playwright venv and installed driver, and clarifies that ChatGPT UI auth is **separate** from OpenAI/Codex OAuth in backend settings.
> 
> Adds **`scripts/test_chatgpt_ui_smoke.py`** and wires ChatGPT UI smoke checks into **`scripts/harness_contract_tests.sh`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3131fd6e54973b63ed0cdd3850508bd13feaef66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->