### PR TITLE
fix: preserve ChatGPT UI auth diagnostics

### DIFF
--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -70,6 +70,13 @@ async def assert_blank_chat(page) -> None:
         raise RuntimeError("fresh-chat baseline contains prior content")
 
 
+async def close_context_quietly(context) -> None:
+    try:
+        await context.close()
+    except Exception:
+        pass
+
+
 async def establish_fresh_chat(page) -> int:
     """Prove an authenticated, settled blank chat before observing responses."""
     await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
@@ -192,7 +199,7 @@ async def run(args, request) -> None:
         )
     finally:
         if context is not None:
-            await context.close()
+            await close_context_quietly(context)
 
 
 def main() -> None:

--- a/scripts/harness_contract_tests.sh
+++ b/scripts/harness_contract_tests.sh
@@ -21,6 +21,7 @@ cargo test --locked --workspace --lib test_parse_result_event
 echo "== Harness contract tests: ChatGPT UI protocol and smoke wrapper =="
 bash -n scripts/chatgpt_ui_smoke.sh
 python3 -m unittest \
+  scripts/test_chatgpt_ui_driver.py \
   scripts/test_chatgpt_ui_mock_driver.py \
   scripts/test_chatgpt_ui_smoke.py
 

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import asyncio
+import unittest
+
+from scripts.chatgpt_ui_driver import close_context_quietly
+
+
+class ClosedContext:
+    async def close(self) -> None:
+        raise RuntimeError("already closed")
+
+
+class ChatGptUiDriverTests(unittest.TestCase):
+    def test_cleanup_preserves_existing_protocol_result(self) -> None:
+        asyncio.run(close_context_quietly(ClosedContext()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Preserve typed ChatGPT UI authentication diagnostics when Chromium has already closed its Playwright context. Adds a cleanup regression test and runs it in the harness contract suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to teardown error handling in the ChatGPT UI driver with a focused unit test; no auth or protocol logic changes.
> 
> **Overview**
> ChatGPT UI driver teardown no longer lets a failing `context.close()` override protocol outcomes (e.g. `auth_required`) when Chromium has already torn down the Playwright context.
> 
> Adds `close_context_quietly` and uses it in the driver's `finally` block instead of a bare `await context.close()`. A unit test asserts cleanup stays silent when `close()` raises, and the harness contract suite runs `scripts/test_chatgpt_ui_driver.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28dcbcdeef621b1a88c2dfdd6d9d6272c417e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->