### PR TITLE
fix(chatgpt-ui): support durable proxied browser sessions

### DIFF
--- a/dashboard/src/app/settings/backends/page.test.tsx
+++ b/dashboard/src/app/settings/backends/page.test.tsx
@@ -20,6 +20,8 @@ const { refreshBackendConfigs, backendConfigsFixture } = vi.hoisted(() => ({
         profile_dir: null,
         driver_path: null,
         python_path: null,
+        proxy_server: null,
+        display: null,
         model: null,
         timeout_secs: 900,
         headless: true,
@@ -106,6 +108,10 @@ describe('BackendsPage ChatGPT UI settings', () => {
     expect(screen.getByLabelText('Python executable')).toHaveValue(
       '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python'
     );
+    expect(screen.getByLabelText('X11 display')).toHaveValue(':93');
+    fireEvent.change(screen.getByLabelText('Browser proxy server'), {
+      target: { value: 'socks5://127.0.0.1:10880' },
+    });
     expect(screen.getByText('Runtime paths configured')).toBeVisible();
 
     fireEvent.click(screen.getByRole('button', { name: 'Save ChatGPT UI' }));
@@ -117,7 +123,10 @@ describe('BackendsPage ChatGPT UI settings', () => {
           profile_dir: '/var/lib/sandboxed-sh/chatgpt-profile',
           driver_path: '/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py',
           python_path: '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python',
+          proxy_server: 'socks5://127.0.0.1:10880',
+          display: ':93',
           browser: 'chromium',
+          headless: false,
           timeout_secs: 900,
         }),
         { enabled: true }

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -33,6 +33,8 @@ const CHATGPT_UI_PRODUCTION_DEFAULTS = {
   profile_dir: '/var/lib/sandboxed-sh/chatgpt-profile',
   driver_path: '/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py',
   python_path: '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python',
+  display: ':93',
+  headless: false,
 };
 
 export default function BackendsPage() {
@@ -101,6 +103,8 @@ export default function BackendsPage() {
     profile_dir: '',
     driver_path: '',
     python_path: 'python3',
+    proxy_server: '',
+    display: '',
     model: '',
     timeout_secs: 900,
     headless: true,
@@ -183,6 +187,8 @@ export default function BackendsPage() {
       profile_dir: typeof settings.profile_dir === 'string' ? settings.profile_dir : '',
       driver_path: typeof settings.driver_path === 'string' ? settings.driver_path : '',
       python_path: typeof settings.python_path === 'string' ? settings.python_path : 'python3',
+      proxy_server: typeof settings.proxy_server === 'string' ? settings.proxy_server : '',
+      display: typeof settings.display === 'string' ? settings.display : '',
       model: typeof settings.model === 'string' ? settings.model : '',
       timeout_secs: typeof settings.timeout_secs === 'number' ? settings.timeout_secs : 900,
       headless: settings.headless !== false,
@@ -325,6 +331,8 @@ export default function BackendsPage() {
           profile_dir: chatgptUiForm.profile_dir,
           driver_path: chatgptUiForm.driver_path || null,
           python_path: chatgptUiForm.python_path || 'python3',
+          proxy_server: chatgptUiForm.proxy_server || null,
+          display: chatgptUiForm.display || null,
           browser: 'chromium',
           headless: chatgptUiForm.headless,
           timeout_secs: chatgptUiForm.timeout_secs,
@@ -705,6 +713,20 @@ export default function BackendsPage() {
                 <label htmlFor="chatgpt-ui-python-path" className="block text-xs text-white/60 mb-1.5">Python executable</label>
                 <input id="chatgpt-ui-python-path" type="text" value={chatgptUiForm.python_path} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, python_path: e.target.value }))} placeholder="/opt/sandboxed-sh/chatgpt-ui-venv/bin/python" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
               </div>
+              <div>
+                <label htmlFor="chatgpt-ui-proxy-server" className="block text-xs text-white/60 mb-1.5">Browser proxy server</label>
+                <input id="chatgpt-ui-proxy-server" type="text" value={chatgptUiForm.proxy_server} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, proxy_server: e.target.value }))} placeholder="socks5://127.0.0.1:10880" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+                <p className="mt-1.5 text-xs text-white/30">
+                  Optional egress proxy for ChatGPT only. Credentials in the URL are rejected.
+                </p>
+              </div>
+              <div>
+                <label htmlFor="chatgpt-ui-display" className="block text-xs text-white/60 mb-1.5">X11 display</label>
+                <input id="chatgpt-ui-display" type="text" value={chatgptUiForm.display} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, display: e.target.value }))} placeholder=":93" disabled={chatgptUiForm.headless} className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50 disabled:opacity-40" />
+                <p className="mt-1.5 text-xs text-white/30">
+                  Required for visible Chromium when anti-bot checks reject headless mode.
+                </p>
+              </div>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
                   <label htmlFor="chatgpt-ui-model" className="block text-xs text-white/60 mb-1.5">Exact visible model label</label>
@@ -721,7 +743,7 @@ export default function BackendsPage() {
               </label>
               <button
                 onClick={handleSaveChatgptUiBackend}
-                disabled={savingBackend || !chatgptUiIsConfigured || chatgptUiForm.timeout_secs < 30 || chatgptUiForm.timeout_secs > 7200}
+                disabled={savingBackend || !chatgptUiIsConfigured || (!chatgptUiForm.headless && !chatgptUiForm.display) || chatgptUiForm.timeout_secs < 30 || chatgptUiForm.timeout_secs > 7200}
                 className="flex items-center gap-2 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs text-white hover:bg-indigo-600 transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {savingBackend ? <Loader className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}

--- a/deploy/systemd/chatgpt-ui-dgx-proxy.service
+++ b/deploy/systemd/chatgpt-ui-dgx-proxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ChatGPT UI browser egress through DGX Spark
+Wants=network-online.target
+After=network-online.target tailscaled.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/ssh -N -D 127.0.0.1:10880 -i /root/.ssh/agent-core-dgx-tunnel -o BatchMode=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=3 -o StrictHostKeyChecking=yes root@100.77.4.93
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/chatgpt-ui-xvfb.service
+++ b/deploy/systemd/chatgpt-ui-xvfb.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Virtual X11 display for the ChatGPT UI browser harness
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/Xvfb :93 -screen 0 1440x1000x24 -nolisten tcp
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/CHATGPT_UI_HARNESS.md
+++ b/docs/CHATGPT_UI_HARNESS.md
@@ -57,7 +57,9 @@ Configure the backend through `PUT /api/backends/chatgpt_ui/config`:
     "driver_path": "/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py",
     "python_path": "/opt/sandboxed-sh/chatgpt-ui-venv/bin/python",
     "browser": "chromium",
-    "headless": true,
+    "proxy_server": "socks5://127.0.0.1:10880",
+    "headless": false,
+    "display": ":93",
     "timeout_secs": 900,
     "model": "GPT-5.6 Pro"
   }
@@ -67,6 +69,11 @@ Configure the backend through `PUT /api/backends/chatgpt_ui/config`:
 `profile_dir` must exist, be absolute, and be outside the sandboxed.sh working
 directory. `driver_path` must be the absolute installed path of the included
 driver script.
+`proxy_server` is optional and applies only to the browser process. Supported
+schemes are `http`, `https`, `socks5`, and `socks5h`; URLs containing embedded
+credentials are rejected.
+When anti-bot checks reject headless Chromium, set `headless` to `false` and
+configure `display` with a dedicated Xvfb display such as `:93`.
 Timeouts are clamped to 30–7200 seconds. A cross-process profile lock rejects
 concurrent use; configure a distinct dedicated profile for each concurrent
 mission.
@@ -84,6 +91,8 @@ For a one-turn operator smoke test:
 ```bash
 CHATGPT_UI_PYTHON=/opt/sandboxed-sh/chatgpt-ui-venv/bin/python \
 CHATGPT_UI_DRIVER=/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py \
+CHATGPT_UI_PROXY=socks5://127.0.0.1:10880 \
+CHATGPT_UI_HEADLESS=false DISPLAY=:93 \
   scripts/chatgpt_ui_smoke.sh \
   /var/lib/sandboxed-sh/chatgpt-profile "GPT-5.6 Pro"
 ```
@@ -92,7 +101,9 @@ Run without a model argument to test the account's current UI default.
 `CHATGPT_UI_PYTHON` must point at the interpreter where Playwright was
 installed; the smoke script otherwise uses `python3`. `CHATGPT_UI_DRIVER` is
 optional when running the script from the repository, where the adjacent
-driver is selected automatically.
+driver is selected automatically. `CHATGPT_UI_PROXY` is optional and should
+match `proxy_server` when the account requires a stable external egress.
+`CHATGPT_UI_HEADLESS=false` requires a working `DISPLAY`.
 
 ## Diagnostics
 

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -80,6 +80,7 @@ async def close_context_quietly(context) -> None:
 async def establish_fresh_chat(page) -> int:
     """Prove an authenticated, settled blank chat before observing responses."""
     await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
+    emit("diagnostic", message="stage=page_loaded")
     login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
     if "/auth/" in page.url or (await login.count() and await login.is_visible()):
         raise PermissionError("login required")
@@ -99,16 +100,19 @@ async def establish_fresh_chat(page) -> int:
             break
     if not authenticated:
         raise PermissionError("authenticated account control not found")
+    emit("diagnostic", message="stage=account_confirmed")
 
-    new_chat = page.get_by_role("link", name=re.compile(r"new chat", re.I)).first
-    if await new_chat.count() and await new_chat.is_visible():
-        await new_chat.click()
-    await page.wait_for_url(re.compile(r"^https://chatgpt\.com/(?:\?.*)?$"), timeout=20_000)
+    # A direct navigation to the root is the stable new-chat primitive. The
+    # sidebar's "New chat" control is rollout-dependent and can be a button,
+    # link, or client-side action that does not emit a navigation event.
+    await assert_blank_chat(page)
+    emit("diagnostic", message="stage=blank_route")
 
     composer = page.locator("#prompt-textarea").first
     if not await composer.count():
         composer = page.get_by_role("textbox").last
     await composer.wait_for(state="visible", timeout=20_000)
+    emit("diagnostic", message="stage=composer_ready")
     # Let hydration and lazy conversation rendering settle before taking the
     # baseline. Nothing from this page is emitted before the prompt is sent.
     await page.wait_for_timeout(2_000)
@@ -135,6 +139,7 @@ async def run(args, request) -> None:
     emit("diagnostic", message=f"compatibility={COMPAT_VERSION}; browser={args.browser}")
 
     context = None
+    stage = "launch"
     try:
         async with async_playwright() as playwright:
             browser_type = getattr(playwright, args.browser, None)
@@ -142,11 +147,16 @@ async def run(args, request) -> None:
                 fail("invalid_config", f"unsupported browser: {args.browser}")
                 return
             try:
+                launch_options = {
+                    "user_data_dir": str(Path(args.profile_dir).resolve()),
+                    "headless": args.headless == "true",
+                    "viewport": {"width": 1440, "height": 1000},
+                    "args": ["--disable-background-networking"],
+                }
+                if args.proxy_server:
+                    launch_options["proxy"] = {"server": args.proxy_server}
                 context = await browser_type.launch_persistent_context(
-                    user_data_dir=str(Path(args.profile_dir).resolve()),
-                    headless=args.headless == "true",
-                    viewport={"width": 1440, "height": 1000},
-                    args=["--disable-background-networking"],
+                    **launch_options,
                 )
             except Exception:
                 fail(
@@ -156,17 +166,23 @@ async def run(args, request) -> None:
                 return
 
             page = context.pages[0] if context.pages else await context.new_page()
+            stage = "fresh_chat"
             baseline = await establish_fresh_chat(page)
+            stage = "model_selection"
             model_used = await choose_model(page, requested_model)
+            stage = "blank_chat_check"
             await assert_blank_chat(page)
+            stage = "composer"
             composer = page.locator("#prompt-textarea").first
             if not await composer.count():
                 composer = page.get_by_role("textbox").last
             await composer.fill(message)
+            stage = "send"
             send = page.get_by_role("button", name=re.compile(r"send", re.I)).last
             await send.wait_for(state="visible", timeout=10_000)
             await send.click()
 
+            stage = "response"
             last = ""
             stable = 0
             deadline = asyncio.get_running_loop().time() + timeout_ms / 1000
@@ -195,7 +211,7 @@ async def run(args, request) -> None:
     except Exception as exc:
         fail(
             "compatibility",
-            f"{COMPAT_VERSION}: UI check failed ({type(exc).__name__}); verify selectors against a blank, non-private chat",
+            f"{COMPAT_VERSION}: UI check failed at {stage} ({type(exc).__name__}); verify selectors against a blank, non-private chat",
         )
     finally:
         if context is not None:
@@ -207,6 +223,7 @@ def main() -> None:
     parser.add_argument("--profile-dir", required=True)
     parser.add_argument("--browser", choices=("chromium", "firefox", "webkit"), default="chromium")
     parser.add_argument("--headless", choices=("true", "false"), default="true")
+    parser.add_argument("--proxy-server")
     args = parser.parse_args()
     try:
         request = json.loads(sys.stdin.readline())

--- a/scripts/chatgpt_ui_smoke.sh
+++ b/scripts/chatgpt_ui_smoke.sh
@@ -11,6 +11,8 @@ model=${2:-}
 artifact=${3:-}
 python_bin=${CHATGPT_UI_PYTHON:-python3}
 driver=${CHATGPT_UI_DRIVER:-"$(dirname "$0")/chatgpt_ui_driver.py"}
+proxy_server=${CHATGPT_UI_PROXY:-}
+headless=${CHATGPT_UI_HEADLESS:-true}
 if [[ $profile_dir != /* || ! -d $profile_dir ]]; then
   echo "profile directory must be an existing absolute path" >&2
   exit 2
@@ -29,10 +31,19 @@ if [[ ! -f $driver ]]; then
   exit 2
 fi
 
+driver_args=(
+  "$driver"
+  --profile-dir "$profile_dir"
+  --browser chromium
+  --headless "$headless"
+)
+if [[ -n $proxy_server ]]; then
+  driver_args+=(--proxy-server "$proxy_server")
+fi
+
 printf '{"type":"run","message":"Reply with exactly: SANDBOXED_CHATGPT_UI_SMOKE_OK","model":%s,"timeout_ms":120000}\n' \
   "$("$python_bin" -c 'import json,sys; print(json.dumps(sys.argv[1] or None))' "$model")" |
-  "$python_bin" "$driver" \
-    --profile-dir "$profile_dir" --browser chromium --headless true |
+  "$python_bin" "${driver_args[@]}" |
   "$python_bin" -c '
 import json, pathlib, sys
 events = [json.loads(line) for line in sys.stdin if line.strip()]

--- a/scripts/test_chatgpt_ui_smoke.py
+++ b/scripts/test_chatgpt_ui_smoke.py
@@ -24,6 +24,9 @@ class ChatGptUiSmokeTests(unittest.TestCase):
                 "import json, sys\n"
                 "request = json.loads(sys.stdin.readline())\n"
                 "assert request['model'] == 'Visible model'\n"
+                "assert '--headless' in sys.argv\n"
+                "assert sys.argv[sys.argv.index('--headless') + 1] == 'false'\n"
+                "assert sys.argv[-2:] == ['--proxy-server', 'socks5://127.0.0.1:10880']\n"
                 "print(json.dumps({'type': 'complete', 'content': "
                 "'SANDBOXED_CHATGPT_UI_SMOKE_OK'}))\n",
                 encoding="utf-8",
@@ -33,6 +36,8 @@ class ChatGptUiSmokeTests(unittest.TestCase):
                 **os.environ,
                 "CHATGPT_UI_PYTHON": sys.executable,
                 "CHATGPT_UI_DRIVER": str(driver),
+                "CHATGPT_UI_PROXY": "socks5://127.0.0.1:10880",
+                "CHATGPT_UI_HEADLESS": "false",
             }
 
             completed = subprocess.run(

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -423,14 +423,76 @@ pub async fn update_backend_config(
                     "model label must be at most 200 bytes".to_string(),
                 ));
             }
+            let proxy_server = settings
+                .get("proxy_server")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            if let Some(proxy_server) = proxy_server {
+                let parsed = url::Url::parse(proxy_server).map_err(|_| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        "proxy_server must be a URL".to_string(),
+                    )
+                })?;
+                if !matches!(parsed.scheme(), "http" | "https" | "socks5" | "socks5h") {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "proxy_server must use http, https, socks5, or socks5h".to_string(),
+                    ));
+                }
+                if !parsed.username().is_empty() || parsed.password().is_some() {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "proxy_server must not contain credentials".to_string(),
+                    ));
+                }
+            }
+            let headless = settings
+                .get("headless")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(true);
+            let display = settings
+                .get("display")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            if !headless {
+                let Some(display) = display else {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "display is required when headless is false".to_string(),
+                    ));
+                };
+                let valid = display.strip_prefix(':').is_some_and(|rest| {
+                    let mut parts = rest.split('.');
+                    let number = parts.next().unwrap_or_default();
+                    let screen = parts.next();
+                    !number.is_empty()
+                        && number.chars().all(|character| character.is_ascii_digit())
+                        && screen.is_none_or(|value| {
+                            !value.is_empty()
+                                && value.chars().all(|character| character.is_ascii_digit())
+                        })
+                        && parts.next().is_none()
+                });
+                if !valid {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "display must use X11 syntax such as :93".to_string(),
+                    ));
+                }
+            }
             serde_json::json!({
                 "profile_dir": canonical_profile,
                 "driver_path": driver_path,
                 "python_path": python_path,
                 "browser": browser,
-                "headless": settings.get("headless").and_then(|v| v.as_bool()).unwrap_or(true),
+                "headless": headless,
+                "display": display,
                 "timeout_secs": timeout_secs,
                 "model": model,
+                "proxy_server": proxy_server,
             })
         }
         _ => req.settings.clone(),

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -58,6 +58,8 @@ struct Settings {
     python_path: String,
     profile_dir: PathBuf,
     browser: String,
+    proxy_server: Option<String>,
+    display: Option<String>,
     timeout: Duration,
     headless: bool,
 }
@@ -94,6 +96,37 @@ fn lock_profile(profile_dir: &Path) -> Result<ProfileLock, String> {
 
 fn parse_bool_setting(key: &str, default: bool) -> bool {
     crate::api::mission_runner::get_backend_bool_setting("chatgpt_ui", key).unwrap_or(default)
+}
+
+fn validate_proxy_server(value: &str) -> Result<(), String> {
+    let parsed =
+        url::Url::parse(value).map_err(|_| "chatgpt_ui proxy_server must be a URL".to_string())?;
+    if !matches!(parsed.scheme(), "http" | "https" | "socks5" | "socks5h") {
+        return Err("chatgpt_ui proxy_server must use http, https, socks5, or socks5h".to_string());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("chatgpt_ui proxy_server must not contain credentials".to_string());
+    }
+    Ok(())
+}
+
+fn validate_display(value: &str) -> Result<(), String> {
+    let Some(rest) = value.strip_prefix(':') else {
+        return Err("chatgpt_ui display must use X11 syntax such as :93".to_string());
+    };
+    let mut parts = rest.split('.');
+    let display = parts.next().unwrap_or_default();
+    let screen = parts.next();
+    if display.is_empty()
+        || !display.chars().all(|character| character.is_ascii_digit())
+        || screen.is_some_and(|value| {
+            value.is_empty() || !value.chars().all(|character| character.is_ascii_digit())
+        })
+        || parts.next().is_some()
+    {
+        return Err("chatgpt_ui display must use X11 syntax such as :93".to_string());
+    }
+    Ok(())
 }
 
 fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
@@ -141,14 +174,32 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
     if !matches!(browser.as_str(), "chromium" | "firefox" | "webkit") {
         return Err("chatgpt_ui browser must be chromium, firefox, or webkit".to_string());
     }
+    let proxy_server = get_backend_string_setting("chatgpt_ui", "proxy_server")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if let Some(proxy_server) = proxy_server.as_deref() {
+        validate_proxy_server(proxy_server)?;
+    }
+    let headless = parse_bool_setting("headless", true);
+    let display = get_backend_string_setting("chatgpt_ui", "display")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if !headless {
+        let display = display
+            .as_deref()
+            .ok_or_else(|| "chatgpt_ui display is required when headless is false".to_string())?;
+        validate_display(display)?;
+    }
     Ok(Settings {
         driver_path,
         python_path: get_backend_string_setting("chatgpt_ui", "python_path")
             .unwrap_or_else(|| "python3".to_string()),
         profile_dir: canonical_profile,
         browser,
+        proxy_server,
+        display,
         timeout: Duration::from_secs(timeout_secs),
-        headless: parse_bool_setting("headless", true),
+        headless,
     })
 }
 
@@ -183,7 +234,11 @@ pub async fn run_chatgpt_ui_turn(
         .arg("--browser")
         .arg(&settings.browser)
         .arg("--headless")
-        .arg(if settings.headless { "true" } else { "false" })
+        .arg(if settings.headless { "true" } else { "false" });
+    if let Some(proxy_server) = settings.proxy_server.as_deref() {
+        command.arg("--proxy-server").arg(proxy_server);
+    }
+    command
         .current_dir(work_dir)
         .env_clear()
         .env("PATH", std::env::var("PATH").unwrap_or_default())
@@ -193,6 +248,9 @@ pub async fn run_chatgpt_ui_turn(
         // filesystem details. Do not ingest it into mission logs.
         .stderr(Stdio::null())
         .kill_on_drop(true);
+    if let Some(display) = settings.display.as_deref() {
+        command.env("DISPLAY", display);
+    }
     #[cfg(unix)]
     command.process_group(0);
     let mut child = match command.spawn() {
@@ -495,5 +553,21 @@ mod tests {
         );
         assert!(validate_completion(true, " ", 0, true).is_err());
         assert!(validate_completion(true, "done", 0, false).is_err());
+    }
+
+    #[test]
+    fn validates_proxy_server_without_embedded_credentials() {
+        assert!(validate_proxy_server("socks5://127.0.0.1:10880").is_ok());
+        assert!(validate_proxy_server("https://proxy.example.com:8443").is_ok());
+        assert!(validate_proxy_server("ftp://proxy.example.com").is_err());
+        assert!(validate_proxy_server("socks5://user:secret@127.0.0.1:10880").is_err());
+    }
+
+    #[test]
+    fn validates_x11_display_without_accepting_shell_syntax() {
+        assert!(validate_display(":93").is_ok());
+        assert!(validate_display(":93.0").is_ok());
+        assert!(validate_display("localhost:93").is_err());
+        assert!(validate_display(":93;touch /tmp/nope").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- route the ChatGPT browser through a validated per-backend proxy
- support non-headless Chromium on a dedicated Xvfb display
- remove a rollout-dependent New Chat navigation wait and add safe stage diagnostics
- add durable DGX SOCKS and Xvfb systemd units plus smoke coverage

## Verification
- cargo fmt --all --check
- cargo check --all-targets
- cargo test (1481 library tests passed; one sandboxed-node concurrency test flaked once and passed both isolated and full-bin reruns)
- Python + harness contract tests
- dashboard unit test, TypeScript, lint (0 errors, 23 existing warnings), production build
- live ChatGPT UI smoke through DGX: exact response SANDBOXED_CHATGPT_UI_SMOKE_OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission browser launch, egress routing, and backend config validation; changes are scoped to the experimental ChatGPT UI harness with credential rejection on proxy URLs.
> 
> **Overview**
> Improves **ChatGPT UI** so production can run Chromium through an optional **browser-only proxy** and on a **dedicated X11 display** when headless mode is blocked.
> 
> **Configuration and API:** New `proxy_server` and `display` settings are validated on save (allowed proxy schemes, no credentials in URLs; `display` required and must look like `:93` when `headless` is false). The Rust runner forwards `--proxy-server` and sets `DISPLAY` on the driver process. The settings UI adds fields for both, production defaults now use `display: :93` and `headless: false`, and save is blocked if visible mode lacks a display.
> 
> **Driver and ops:** Playwright launches with an optional proxy; fresh-chat setup drops the flaky sidebar “New chat” click in favor of asserting a blank root route, with **stage diagnostics** and stage names in compatibility errors. Smoke/docs gain `CHATGPT_UI_PROXY` / `CHATGPT_UI_HEADLESS` / `DISPLAY`. New **systemd** units provide a local SOCKS forward via SSH to DGX and **Xvfb** on `:93`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de33d5ec15015c2fb173d4146e0052983efbe243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->