### PR TITLE
Support ChatGPT Pro artifacts and Hermes escalation

### DIFF
--- a/dashboard/src/app/settings/backends/page.test.tsx
+++ b/dashboard/src/app/settings/backends/page.test.tsx
@@ -109,9 +109,10 @@ describe('BackendsPage ChatGPT UI settings', () => {
       '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python'
     );
     expect(screen.getByLabelText('X11 display')).toHaveValue(':93');
-    fireEvent.change(screen.getByLabelText('Browser proxy server'), {
-      target: { value: 'socks5://127.0.0.1:10880' },
-    });
+    expect(screen.getByLabelText('Browser proxy server')).toHaveValue(
+      'socks5://127.0.0.1:10880'
+    );
+    expect(screen.getByLabelText('Canonical model ID')).toHaveValue('gpt-5.6-pro');
     expect(screen.getByText('Runtime paths configured')).toBeVisible();
 
     fireEvent.click(screen.getByRole('button', { name: 'Save ChatGPT UI' }));
@@ -125,6 +126,7 @@ describe('BackendsPage ChatGPT UI settings', () => {
           python_path: '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python',
           proxy_server: 'socks5://127.0.0.1:10880',
           display: ':93',
+          model: 'gpt-5.6-pro',
           browser: 'chromium',
           headless: false,
           timeout_secs: 900,

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -33,7 +33,9 @@ const CHATGPT_UI_PRODUCTION_DEFAULTS = {
   profile_dir: '/var/lib/sandboxed-sh/chatgpt-profile',
   driver_path: '/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py',
   python_path: '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python',
+  proxy_server: 'socks5://127.0.0.1:10880',
   display: ':93',
+  model: 'gpt-5.6-pro',
   headless: false,
 };
 
@@ -729,8 +731,8 @@ export default function BackendsPage() {
               </div>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div>
-                  <label htmlFor="chatgpt-ui-model" className="block text-xs text-white/60 mb-1.5">Exact visible model label</label>
-                  <input id="chatgpt-ui-model" type="text" value={chatgptUiForm.model} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, model: e.target.value }))} placeholder="GPT-5.6 Pro" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+                  <label htmlFor="chatgpt-ui-model" className="block text-xs text-white/60 mb-1.5">Canonical model ID</label>
+                  <input id="chatgpt-ui-model" type="text" value={chatgptUiForm.model} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, model: e.target.value }))} placeholder="gpt-5.6-pro" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
                 </div>
                 <div>
                   <label htmlFor="chatgpt-ui-timeout" className="block text-xs text-white/60 mb-1.5">Timeout (seconds)</label>

--- a/docs/CHATGPT_UI_HARNESS.md
+++ b/docs/CHATGPT_UI_HARNESS.md
@@ -12,9 +12,13 @@ state lives only in the dedicated Playwright browser profile configured below.
   model labels, account entitlements, rate limits, and anti-automation controls
   can change without notice.
 - It supports text turns and translates driver text, diagnostic, tool-call,
-  tool-result, completion, and error events. The current ChatGPT web UI does not
-  expose sandboxed.sh's local tools. A response with an unresolved tool call is
-  failed rather than falsely reported complete.
+  tool-result, artifact, completion, and error events. The current ChatGPT web
+  UI does not expose sandboxed.sh's local tools. A response with an unresolved
+  tool call is failed rather than falsely reported complete.
+- Downloadable files in the latest assistant response are copied into the
+  mission workspace and exposed as ordinary sandboxed.sh shared files. A turn
+  accepts at most 8 files and 50 MiB total; paths are canonicalized and must
+  remain inside that mission workspace.
 - Conversation continuation currently sends sandboxed.sh's bounded text
   history in a fresh ChatGPT conversation. It does not persist ChatGPT
   conversation URLs.
@@ -61,7 +65,7 @@ Configure the backend through `PUT /api/backends/chatgpt_ui/config`:
     "headless": false,
     "display": ":93",
     "timeout_secs": 900,
-    "model": "GPT-5.6 Pro"
+    "model": "gpt-5.6-pro"
   }
 }
 ```
@@ -80,11 +84,13 @@ mission.
 
 ## Model selection
 
-Set `model` to the exact label visibly offered by the account. The driver opens
-the model picker and requires an exact text match; it fails with a compatibility
-diagnostic instead of silently substituting another model. A requested label
-being present proves only that the UI exposed and selected that label. It does
-not independently prove backend model identity or deep-research capabilities.
+Use the canonical `gpt-5.6-pro` model ID for ChatGPT Pro. The driver maps it to
+the current visible `Pro` intelligence option, clicks that exact radio item, and
+verifies that the composer picker changed to `Pro`. Other values remain exact
+visible-label lookups for compatibility. Selection failure is terminal; the
+driver never silently substitutes another model. A selected label proves only
+what the account UI exposed and selected, not independent backend model
+identity or deep-research capabilities.
 
 For a one-turn operator smoke test:
 
@@ -94,7 +100,7 @@ CHATGPT_UI_DRIVER=/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py \
 CHATGPT_UI_PROXY=socks5://127.0.0.1:10880 \
 CHATGPT_UI_HEADLESS=false DISPLAY=:93 \
   scripts/chatgpt_ui_smoke.sh \
-  /var/lib/sandboxed-sh/chatgpt-profile "GPT-5.6 Pro"
+  /var/lib/sandboxed-sh/chatgpt-profile gpt-5.6-pro
 ```
 
 Run without a model argument to test the account's current UI default.
@@ -112,7 +118,8 @@ match `proxy_server` when the account requires a stable external egress.
   blank page; directory presence is never treated as proof of authentication.
 - `requested model is not visibly available`: verify the exact current label
   and account entitlement; UI rollouts are account-specific.
-- `compatibility=chatgpt-ui-v1`: the versioned selector contract failed. Capture
+- `compatibility=chatgpt-ui-v2`: the versioned selector/download contract
+  failed. Capture
   only a clean, new chat with no sidebar identity or private history visible.
 - Profile lock errors: close every browser using the profile, or configure a
   separate dedicated profile for each concurrent mission.
@@ -134,6 +141,13 @@ Every turn navigates to a new-chat surface and refuses to send if assistant
 content is already present. Streaming events carry accumulated text snapshots,
 but success requires an explicit `complete` event, a clean driver exit, and
 balanced tool events.
+
+When ChatGPT presents an attached file, the driver follows only scoped artifact
+links or the filename-labelled artifact preview control in the latest assistant
+message. It then activates the preview's exact `Download` action. Arbitrary
+external links and generic page buttons are never followed. The Rust runner
+revalidates every receipt, converts it to a `<file>` tag, and the assistant MCP
+exposes it through `list_mission_shared_files` and `download_shared_file`.
 
 ## Inspiration and provenance
 

--- a/docs/HERMES_ASSISTANT_MIGRATION.md
+++ b/docs/HERMES_ASSISTANT_MIGRATION.md
@@ -74,6 +74,8 @@ actually required; full histories are not injected by the status tools.
 - `get_mission_health` — diagnose stalls/loops/errors + a one-line recommendation
 - `get_mission_diagnostics` — tool-call timeline, repeated calls, error events
 - `start_mission`
+- `list_mission_shared_files`
+- `download_shared_file`
 - `send_message_to_mission`
 - `update_mission_settings` — switch backend/model/effort/agent for the next turn (between-turns)
 - `resume_mission` — restart an interrupted/blocked/failed mission, optionally with a steering hint
@@ -108,6 +110,13 @@ Security choices from the dev smoke:
 - Tool output is recursively scrubbed for secret-like keys and values.
 - Mission list tools return compact summaries instead of raw mission rows.
 - Detailed mission/event access requires explicit tool calls.
+
+For exceptional read-only research or design-conflict questions, Hermes may
+start `backend=chatgpt_ui` with `model_override=gpt-5.6-pro` and `writer=false`.
+The mission is asynchronous like every other Sandboxed mission. Generated
+ChatGPT files are available through `list_mission_shared_files` followed by
+`download_shared_file`; repository work remains owned by normal coding
+backends.
 
 ## Readiness Checks
 

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -5,16 +5,28 @@ Protocol: one JSON request on stdin, NDJSON events on stdout. This helper
 references a profile by path but never reads, enumerates, or exports its files.
 """
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import json
+import mimetypes
 import re
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
-COMPAT_VERSION = "chatgpt-ui-v1"
+COMPAT_VERSION = "chatgpt-ui-v2"
 CHATGPT_URL = "https://chatgpt.com/"
+MAX_DOWNLOAD_FILES = 8
+MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+INTELLIGENCE_LABELS = ("Instant", "5.5", "Medium", "High", "Extra High", "Pro")
+PRO_MODEL_ALIASES = {
+    "gpt-5.6-pro",
+    "gpt 5.6 pro",
+    "gpt-5.6 pro",
+    "gpt 5.6-pro",
+}
 
 
 def emit(event_type: str, **payload) -> None:
@@ -25,12 +37,55 @@ def fail(code: str, message: str) -> None:
     emit("error", code=code, message=message)
 
 
+def model_selection(requested: str) -> tuple[str, str]:
+    """Return the exact visible picker label and canonical model identifier."""
+    normalized = " ".join(requested.strip().lower().split())
+    if normalized in PRO_MODEL_ALIASES:
+        return "Pro", "gpt-5.6-pro"
+    return requested.strip(), requested.strip()
+
+
+async def choose_intelligence_model(page, label: str) -> bool:
+    """Select a current composer intelligence option without touching the sidebar."""
+    picker_buttons = page.locator('button.__composer-pill[aria-haspopup="menu"]')
+    for index in range(await picker_buttons.count()):
+        button = picker_buttons.nth(index)
+        try:
+            if not await button.is_visible():
+                continue
+            current = (await button.inner_text()).strip()
+            if current not in INTELLIGENCE_LABELS:
+                continue
+            await button.click()
+            overlay = page.locator(
+                '[data-testid="composer-intelligence-picker-content"]:visible'
+            ).last
+            await overlay.wait_for(state="visible", timeout=3_000)
+            option = overlay.get_by_role("menuitemradio", name=label, exact=True)
+            await option.wait_for(state="visible", timeout=3_000)
+            await option.click()
+            selected = button.get_by_text(label, exact=True)
+            await selected.wait_for(state="visible", timeout=3_000)
+            return True
+        except Exception:
+            continue
+    return False
+
+
 async def choose_model(page, requested: str) -> str:
-    """Select an exact visible model label; never infer aliases."""
+    """Select a verified current option or exact legacy model label."""
     if not requested:
         return ""
+    visible_label, canonical_model = model_selection(requested)
+    if visible_label in INTELLIGENCE_LABELS and await choose_intelligence_model(
+        page, visible_label
+    ):
+        return canonical_model
+
+    # Legacy ChatGPT rollouts expose a dedicated model picker. Keep this exact
+    # lookup as a compatibility path, but never scan arbitrary buttons whose
+    # aria-label may be a private conversation title.
     candidates = [
-        page.get_by_role("button", name=re.compile(r"(model|chatgpt)", re.I)).first,
         page.locator('[data-testid="model-switcher-dropdown-button"]').first,
     ]
     for candidate in candidates:
@@ -52,13 +107,132 @@ async def choose_model(page, requested: str) -> str:
     for overlay in overlays:
         try:
             if await overlay.is_visible(timeout=1000):
-                option = overlay.get_by_text(requested, exact=True).last
+                option = overlay.get_by_text(visible_label, exact=True).last
                 await option.wait_for(state="visible", timeout=3000)
                 await option.click()
-                return requested
+                return canonical_model
         except Exception:
             continue
     raise RuntimeError("requested model is not visibly available in the model picker")
+
+
+def safe_download_name(value: str, index: int) -> str:
+    basename = Path(value).name.strip()
+    if not basename:
+        basename = f"chatgpt-artifact-{index}"
+    safe = re.sub(r"[^A-Za-z0-9._ -]+", "_", basename).strip(" .")
+    return (safe or f"chatgpt-artifact-{index}")[:180]
+
+
+def downloadable_href(value: str | None) -> bool:
+    if not value:
+        return False
+    if value.startswith(("sandbox:", "blob:")):
+        return True
+    parsed = urlparse(value)
+    host = parsed.netloc.lower()
+    if not host and value.startswith("/"):
+        return "/files/" in parsed.path or "/download" in parsed.path
+    return (
+        host in {"chatgpt.com", "chat.openai.com"}
+        and ("/files/" in parsed.path or "/download" in parsed.path)
+    ) or host.endswith(".oaiusercontent.com")
+
+
+def download_control_key(
+    tag_name: str,
+    href: str | None,
+    aria_label: str | None,
+    class_name: str | None,
+    text: str | None,
+) -> str | None:
+    """Identify a narrowly scoped ChatGPT artifact control."""
+    if tag_name.lower() == "a" and downloadable_href(href):
+        return f"href:{href}"
+    if tag_name.lower() != "button" or "behavior-btn" not in (class_name or "").split():
+        return None
+    label = (aria_label or text or "").strip()
+    # Current ChatGPT artifact entities are buttons labelled with the generated
+    # filename. Requiring a filename suffix avoids clicking generic entity,
+    # citation, or action buttons that happen to share the behavior class.
+    if not label or not Path(label).suffix or "/" in label or "\\" in label:
+        return None
+    return f"button:{label}"
+
+
+async def collect_downloads(page, response, download_dir: Path) -> None:
+    """Download bounded assistant-generated artifacts and emit typed receipts."""
+    controls = response.locator('a[href], button.behavior-btn[aria-label]')
+    seen_controls: set[str] = set()
+    used_names: set[str] = set()
+    total_bytes = 0
+    emitted = 0
+    for index in range(await controls.count()):
+        if emitted >= MAX_DOWNLOAD_FILES:
+            break
+        control = controls.nth(index)
+        tag_name = await control.evaluate("(element) => element.tagName")
+        href = await control.get_attribute("href")
+        aria_label = await control.get_attribute("aria-label")
+        class_name = await control.get_attribute("class")
+        text = await control.inner_text()
+        control_key = download_control_key(
+            tag_name, href, aria_label, class_name, text
+        )
+        if control_key is None or control_key in seen_controls:
+            continue
+        seen_controls.add(control_key)
+        preview_open = False
+        try:
+            if tag_name.lower() == "button":
+                # Current ChatGPT opens an artifact preview first. The preview
+                # owns the actual browser download action.
+                await control.click()
+                preview_open = True
+                download_button = page.get_by_role(
+                    "button", name="Download", exact=True
+                ).last
+                await download_button.wait_for(state="visible", timeout=5_000)
+                async with page.expect_download(timeout=15_000) as pending:
+                    await download_button.click(no_wait_after=True)
+            else:
+                async with page.expect_download(timeout=15_000) as pending:
+                    await control.click(no_wait_after=True)
+            download = await pending.value
+            name = safe_download_name(download.suggested_filename, emitted + 1)
+            stem = Path(name).stem
+            suffix = Path(name).suffix
+            candidate = name
+            duplicate = 2
+            while candidate in used_names or (download_dir / candidate).exists():
+                candidate = safe_download_name(f"{stem}-{duplicate}{suffix}", emitted + 1)
+                duplicate += 1
+            destination = download_dir / candidate
+            await download.save_as(destination)
+            size = destination.stat().st_size
+            if size > MAX_DOWNLOAD_BYTES or total_bytes + size > MAX_DOWNLOAD_BYTES:
+                destination.unlink(missing_ok=True)
+                emit("diagnostic", message="stage=artifact_size_limit")
+                continue
+            total_bytes += size
+            emitted += 1
+            used_names.add(candidate)
+            content_type = mimetypes.guess_type(candidate)[0] or "application/octet-stream"
+            emit(
+                "artifact",
+                path=str(destination),
+                name=candidate,
+                content_type=content_type,
+                size_bytes=size,
+            )
+        except Exception:
+            emit("diagnostic", message="stage=artifact_download_skipped")
+        finally:
+            if preview_open:
+                try:
+                    await page.keyboard.press("Escape")
+                except Exception:
+                    pass
 
 
 async def assert_blank_chat(page) -> None:
@@ -136,6 +310,15 @@ async def run(args, request) -> None:
         return
     timeout_ms = max(30_000, min(int(request.get("timeout_ms", 900_000)), 7_200_000))
     requested_model = request.get("model") or ""
+    requested_download_dir = request.get("download_dir")
+    download_dir = None
+    if requested_download_dir is not None:
+        candidate = Path(str(requested_download_dir))
+        if not candidate.is_absolute():
+            fail("invalid_request", "download_dir must be an absolute path")
+            return
+        candidate.mkdir(parents=True, exist_ok=True)
+        download_dir = candidate.resolve()
     emit("diagnostic", message=f"compatibility={COMPAT_VERSION}; browser={args.browser}")
 
     context = None
@@ -152,7 +335,10 @@ async def run(args, request) -> None:
                     "headless": args.headless == "true",
                     "viewport": {"width": 1440, "height": 1000},
                     "args": ["--disable-background-networking"],
+                    "accept_downloads": True,
                 }
+                if download_dir is not None:
+                    launch_options["downloads_path"] = str(download_dir)
                 if args.proxy_server:
                     launch_options["proxy"] = {"server": args.proxy_server}
                 context = await browser_type.launch_persistent_context(
@@ -199,6 +385,11 @@ async def run(args, request) -> None:
                 stop = page.get_by_role("button", name=re.compile(r"stop", re.I)).last
                 stop_visible = await stop.count() and await stop.is_visible()
                 if last and count > baseline and not stop_visible and stable >= 2:
+                    if download_dir is not None:
+                        stage = "artifacts"
+                        await collect_downloads(
+                            page, responses.nth(count - 1), download_dir
+                        )
                     emit("complete", content=last, model=model_used or None)
                     return
                 await asyncio.sleep(0.75)

--- a/scripts/chatgpt_ui_mock_driver.py
+++ b/scripts/chatgpt_ui_mock_driver.py
@@ -5,11 +5,13 @@ import argparse
 import json
 import sys
 import time
+from pathlib import Path
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--profile-dir", required=True)
 parser.add_argument("--browser")
 parser.add_argument("--headless")
+parser.add_argument("--proxy-server")
 parser.parse_args()
 request = json.loads(sys.stdin.readline())
 message = request.get("message", "")
@@ -28,6 +30,19 @@ elif message == "__tools__":
     emit("tool_call", id="mock-tool", name="mock", args={"safe": True})
     emit("tool_result", id="mock-tool", name="mock", result={"ok": True})
     emit("complete", content="mock tool response", model="mock-model")
+elif message == "__artifact__":
+    download_dir = Path(request["download_dir"])
+    download_dir.mkdir(parents=True, exist_ok=True)
+    artifact = download_dir / "mock-artifact.txt"
+    artifact.write_text("mock artifact\n", encoding="utf-8")
+    emit(
+        "artifact",
+        path=str(artifact),
+        name=artifact.name,
+        content_type="text/plain",
+        size_bytes=artifact.stat().st_size,
+    )
+    emit("complete", content="mock artifact response", model="mock-model")
 else:
     response = f"mock response: {message}"
     emit("text_delta", content=response[: max(1, len(response) // 2)])

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -3,7 +3,13 @@
 import asyncio
 import unittest
 
-from scripts.chatgpt_ui_driver import close_context_quietly
+from scripts.chatgpt_ui_driver import (
+    close_context_quietly,
+    download_control_key,
+    downloadable_href,
+    model_selection,
+    safe_download_name,
+)
 
 
 class ClosedContext:
@@ -14,6 +20,44 @@ class ClosedContext:
 class ChatGptUiDriverTests(unittest.TestCase):
     def test_cleanup_preserves_existing_protocol_result(self) -> None:
         asyncio.run(close_context_quietly(ClosedContext()))
+
+    def test_pro_model_alias_maps_to_current_verified_picker_option(self) -> None:
+        self.assertEqual(model_selection("gpt-5.6-pro"), ("Pro", "gpt-5.6-pro"))
+        self.assertEqual(model_selection("GPT-5.6 Pro"), ("Pro", "gpt-5.6-pro"))
+        self.assertEqual(model_selection("Extra High"), ("Extra High", "Extra High"))
+
+    def test_download_links_are_limited_to_chatgpt_artifact_surfaces(self) -> None:
+        self.assertTrue(downloadable_href("sandbox:/mnt/data/report.pdf"))
+        self.assertTrue(
+            downloadable_href("https://files.oaiusercontent.com/file-123/report.pdf")
+        )
+        self.assertTrue(downloadable_href("/backend-api/files/file-123"))
+        self.assertFalse(downloadable_href("https://example.com/report.pdf"))
+        self.assertFalse(downloadable_href("https://chatgpt.com/share/example"))
+
+    def test_download_filename_cannot_escape_the_artifact_directory(self) -> None:
+        self.assertEqual(safe_download_name("../../report.pdf", 1), "report.pdf")
+        self.assertEqual(safe_download_name('bad"name.txt', 1), "bad_name.txt")
+
+    def test_current_artifact_button_is_narrowly_identified(self) -> None:
+        self.assertEqual(
+            download_control_key(
+                "BUTTON",
+                None,
+                "report.pdf",
+                "behavior-btn entity-underline",
+                "report.pdf",
+            ),
+            "button:report.pdf",
+        )
+        self.assertIsNone(
+            download_control_key(
+                "BUTTON", None, "Open citation", "behavior-btn", "Open citation"
+            )
+        )
+        self.assertIsNone(
+            download_control_key("BUTTON", None, "report.pdf", "generic", "report.pdf")
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_chatgpt_ui_mock_driver.py
+++ b/scripts/test_chatgpt_ui_mock_driver.py
@@ -12,9 +12,26 @@ DRIVER = Path(__file__).with_name("chatgpt_ui_mock_driver.py")
 
 def run_driver(message):
     with tempfile.TemporaryDirectory() as profile:
-        request = json.dumps({"message": message, "model": None}) + "\n"
+        download_dir = Path(profile) / "downloads"
+        request = (
+            json.dumps(
+                {
+                    "message": message,
+                    "model": None,
+                    "download_dir": str(download_dir),
+                }
+            )
+            + "\n"
+        )
         result = subprocess.run(
-            ["python3", str(DRIVER), "--profile-dir", profile],
+            [
+                "python3",
+                str(DRIVER),
+                "--profile-dir",
+                profile,
+                "--proxy-server",
+                "socks5://127.0.0.1:10880",
+            ],
             input=request,
             text=True,
             capture_output=True,
@@ -44,6 +61,15 @@ class MockDriverProtocolTests(unittest.TestCase):
             [event["type"] for event in events],
             ["diagnostic", "tool_call", "tool_result", "complete"],
         )
+
+    def test_artifact_event_precedes_completion(self):
+        events = run_driver("__artifact__")
+        self.assertEqual(
+            [event["type"] for event in events],
+            ["diagnostic", "artifact", "complete"],
+        )
+        self.assertEqual(events[1]["name"], "mock-artifact.txt")
+        self.assertEqual(events[1]["content_type"], "text/plain")
 
 
 if __name__ == "__main__":

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -5,7 +5,7 @@ description: >
   weeks): diagnose where a model is struggling, switch backends/models, push it
   to exhaust its budget instead of giving up, and send targeted hints. Trigger
   terms: mission, sandboxed.sh, babysit, monitor, /goal, switch backend, stalled,
-  resume, keep going.
+  resume, keep going, very hard question, ChatGPT UI, gpt-5.6-pro.
 ---
 
 # Hermes Mission Control
@@ -13,6 +13,8 @@ description: >
 You manage sandboxed.sh missions on the operator's behalf. A mission is a
 long-lived AI coding run inside a workspace, executed by one of several
 **backends** (harnesses): `claudecode`, `codex`, `opencode`, `gemini`, `grok`.
+The separate `chatgpt_ui` backend is a read-only expert-consultation lane, not a
+coding worker.
 Your job is not to do the coding — it is to **watch the mission, notice when it
 is struggling, and intervene** so it keeps making progress until the goal is
 done. Some missions run for days or weeks; you check in periodically, fix what
@@ -103,6 +105,26 @@ Match the signal to the fix. The health `recommendation` usually tells you which
   issue and want a different routing path.
 - `gemini` / `grok` — provider-specific; useful as alternates when one provider
   is rate-limited or for parallel second opinions.
+- `chatgpt_ui` with `model_override: gpt-5.6-pro` — reserve for exceptionally
+  difficult, self-contained research, synthesis, or design-conflict questions.
+  Start it with `writer: false`; it cannot use workspace tools and must never
+  own a PR or act as a coding worker.
+
+### Very-hard-question escalation
+
+1. Make the question self-contained. Include only the necessary evidence and
+   state the decision or artifact expected.
+2. Call `start_mission` with `backend: chatgpt_ui`,
+   `model_override: gpt-5.6-pro`, and `writer: false`. Persist the returned
+   mission ID before doing anything else.
+3. Treat the call as asynchronous. Poll `get_mission_health` or
+   `get_mission_digest`; do not repeatedly submit replacements while the same
+   mission is active.
+4. Read the completed text from the mission events. If the response generated
+   files, call `list_mission_shared_files`, then `download_shared_file` for each
+   file you actually need.
+5. Use the result as evidence or advice. Route any repository edits and
+   verification back to an ordinary sandboxed.sh worker/reviewer mission.
 
 When a model "isn't working," first prove it's the **model** and not the
 **transport** (check `get_mission_diagnostics` for 429/network errors) before

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -13183,7 +13183,15 @@ fn maybe_recover_soft_llm_error(result: &mut crate::agents::AgentResult) {
         data.get("claudecode_transport_failure").is_some()
             || data.get("transport_failure_stage").is_some()
     });
-    if has_transport_failure {
+    // A backend that supplied an explicit failure class has already made a
+    // structured terminal decision. Its human-readable error text must never
+    // be reinterpreted as substantive assistant output by this legacy
+    // heuristic (for example, a ChatGPT UI selector compatibility failure).
+    let has_structured_failure = result.data.as_ref().is_some_and(|data| {
+        data.get("failure_class")
+            .is_some_and(|failure_class| !failure_class.is_null())
+    });
+    if has_transport_failure || has_structured_failure {
         return;
     }
     let output = result.output.trim();
@@ -28047,6 +28055,29 @@ Investigate <service/> failures.
         assert_eq!(
             completion_evidence_for_agent_result(&result).pending_tools,
             Some(1)
+        );
+    }
+
+    #[test]
+    fn maybe_recover_soft_llm_error_preserves_structured_provider_failure() {
+        let mut result = crate::agents::AgentResult::failure(
+            "chatgpt_ui: chatgpt-ui-v2: UI check failed at model_selection".to_string(),
+            0,
+        )
+        .with_terminal_reason(TerminalReason::LlmError)
+        .with_data(serde_json::json!({
+            "provider_error_source": "chatgpt_ui_driver",
+            "failure_class": crate::agents::FailureClass::ProviderError,
+            "classification_source": "structured",
+        }));
+
+        maybe_recover_soft_llm_error(&mut result);
+
+        assert!(!result.success);
+        assert_eq!(result.terminal_reason, Some(TerminalReason::LlmError));
+        assert_eq!(
+            completion_evidence_for_agent_result(&result).failure_class,
+            Some(crate::agents::FailureClass::ProviderError)
         );
     }
 

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -46,6 +46,14 @@ enum DriverEvent {
         content: String,
         model: Option<String>,
     },
+    Artifact {
+        path: String,
+        name: String,
+        #[serde(rename = "content_type")]
+        _content_type: String,
+        #[serde(rename = "size_bytes")]
+        _size_bytes: u64,
+    },
     Error {
         code: Option<String>,
         message: String,
@@ -92,6 +100,70 @@ fn lock_profile(profile_dir: &Path) -> Result<ProfileLock, String> {
         "ChatGPT UI profile is already in use; each concurrent mission needs a separate profile directory".to_string()
     })?;
     Ok(ProfileLock(file))
+}
+
+async fn prepare_download_dir(work_dir: &Path) -> Result<PathBuf, String> {
+    let canonical_work_dir = work_dir
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve ChatGPT UI working directory: {error}"))?;
+    let download_dir = work_dir.join("chatgpt-ui-downloads");
+    tokio::fs::create_dir_all(&download_dir)
+        .await
+        .map_err(|error| format!("cannot create ChatGPT UI download directory: {error}"))?;
+    let canonical_download_dir = download_dir
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve ChatGPT UI download directory: {error}"))?;
+    if !canonical_download_dir.starts_with(&canonical_work_dir) {
+        return Err("chatgpt_ui download directory escapes the mission workspace".to_string());
+    }
+    Ok(canonical_download_dir)
+}
+
+fn escape_rich_tag_attribute(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn validate_artifact_receipt(
+    work_dir: &Path,
+    path: &str,
+    name: &str,
+) -> Result<(String, u64), String> {
+    const MAX_ARTIFACT_BYTES: u64 = 50 * 1024 * 1024;
+    let canonical_work_dir = work_dir
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve ChatGPT UI working directory: {error}"))?;
+    let canonical_path = Path::new(path)
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve ChatGPT UI artifact: {error}"))?;
+    if !canonical_path.starts_with(&canonical_work_dir) || !canonical_path.is_file() {
+        return Err("chatgpt_ui artifact path is outside the mission workspace".to_string());
+    }
+    let metadata = canonical_path
+        .metadata()
+        .map_err(|error| format!("cannot inspect ChatGPT UI artifact: {error}"))?;
+    if metadata.len() > MAX_ARTIFACT_BYTES {
+        return Err("chatgpt_ui artifact exceeds the 50 MiB limit".to_string());
+    }
+    let relative = canonical_path
+        .strip_prefix(&canonical_work_dir)
+        .map_err(|_| "chatgpt_ui artifact path is outside the mission workspace".to_string())?;
+    let display_name = Path::new(name)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("chatgpt-artifact");
+    Ok((
+        format!(
+            r#"<file path="{}" name="{}" />"#,
+            escape_rich_tag_attribute(&relative.to_string_lossy()),
+            escape_rich_tag_attribute(display_name),
+        ),
+        metadata.len(),
+    ))
 }
 
 fn parse_bool_setting(key: &str, default: bool) -> bool {
@@ -225,6 +297,12 @@ pub async fn run_chatgpt_ui_turn(
             return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::LlmError)
         }
     };
+    let download_dir = match prepare_download_dir(work_dir).await {
+        Ok(path) => path,
+        Err(error) => {
+            return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::LlmError)
+        }
+    };
 
     let mut command = Command::new(&settings.python_path);
     command
@@ -268,6 +346,7 @@ pub async fn run_chatgpt_ui_turn(
         "message": message,
         "model": model,
         "timeout_ms": settings.timeout.as_millis() as u64,
+        "download_dir": download_dir,
     });
     if let Some(mut stdin) = child.stdin.take() {
         if stdin
@@ -286,6 +365,7 @@ pub async fn run_chatgpt_ui_turn(
     let mut output = String::new();
     let mut model_used = model.map(str::to_string);
     let mut pending_tools: HashMap<String, String> = HashMap::new();
+    let mut artifact_receipts: Vec<(String, String)> = Vec::new();
     let mut completed = false;
     let deadline_at = Instant::now() + settings.timeout;
     let deadline = tokio::time::sleep_until(deadline_at);
@@ -365,6 +445,9 @@ pub async fn run_chatgpt_ui_turn(
                         completed = true;
                         break;
                     }
+                    DriverEvent::Artifact { path, name, .. } => {
+                        artifact_receipts.push((path, name));
+                    }
                     DriverEvent::Error { code, message } => {
                         let reason = if code.as_deref() == Some("auth_required") {
                             TerminalReason::AuthError
@@ -373,8 +456,21 @@ pub async fn run_chatgpt_ui_turn(
                         } else {
                             TerminalReason::LlmError
                         };
+                        let failure_class = match reason {
+                            TerminalReason::AuthError => crate::agents::FailureClass::AuthError,
+                            TerminalReason::RateLimited => {
+                                crate::agents::FailureClass::RateLimited
+                            }
+                            _ => crate::agents::FailureClass::ProviderError,
+                        };
                         terminate_child_tree(&mut child).await;
-                        return AgentResult::failure(format!("chatgpt_ui: {message}"), 0).with_terminal_reason(reason);
+                        return AgentResult::failure(format!("chatgpt_ui: {message}"), 0)
+                            .with_terminal_reason(reason)
+                            .with_data(serde_json::json!({
+                                "provider_error_source": "chatgpt_ui_driver",
+                                "failure_class": failure_class,
+                                "classification_source": "structured",
+                            }));
                     }
                 }
             }
@@ -455,9 +551,38 @@ pub async fn run_chatgpt_ui_turn(
     ) {
         return AgentResult::failure(message, 0).with_terminal_reason(TerminalReason::LlmError);
     }
+    const MAX_ARTIFACT_FILES: usize = 8;
+    const MAX_ARTIFACT_BYTES: u64 = 50 * 1024 * 1024;
+    let mut artifact_count = 0usize;
+    let mut artifact_bytes = 0u64;
+    for (path, name) in artifact_receipts {
+        if artifact_count >= MAX_ARTIFACT_FILES {
+            tracing::warn!(mission_id = %mission_id, "Rejected excess ChatGPT UI artifact receipt");
+            break;
+        }
+        match validate_artifact_receipt(work_dir, &path, &name) {
+            Ok((tag, size)) if artifact_bytes.saturating_add(size) <= MAX_ARTIFACT_BYTES => {
+                output.push_str("\n\n");
+                output.push_str(&tag);
+                artifact_count += 1;
+                artifact_bytes += size;
+            }
+            Ok((_tag, _size)) => {
+                tracing::warn!(mission_id = %mission_id, "Rejected ChatGPT UI artifact receipts exceeding the 50 MiB turn limit");
+            }
+            Err(error) => {
+                tracing::warn!(mission_id = %mission_id, error = %error, "Rejected ChatGPT UI artifact receipt");
+            }
+        }
+    }
     let mut result = AgentResult::success(output, 0)
         .with_terminal_reason(TerminalReason::TurnComplete)
-        .with_data(serde_json::json!({"backend": "chatgpt_ui", "usage_source": "chatgpt_web_subscription"}));
+        .with_data(serde_json::json!({
+            "backend": "chatgpt_ui",
+            "usage_source": "chatgpt_web_subscription",
+            "artifact_count": artifact_count,
+            "artifact_bytes": artifact_bytes,
+        }));
     if let Some(model) = model_used {
         result = result.with_model(model);
     }
@@ -527,6 +652,11 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(event, DriverEvent::ToolCall { .. }));
+        let artifact: DriverEvent = serde_json::from_str(
+            r#"{"type":"artifact","path":"/tmp/work/report.txt","name":"report.txt","content_type":"text/plain","size_bytes":12}"#,
+        )
+        .unwrap();
+        assert!(matches!(artifact, DriverEvent::Artifact { .. }));
     }
 
     #[test]
@@ -569,5 +699,27 @@ mod tests {
         assert!(validate_display(":93.0").is_ok());
         assert!(validate_display("localhost:93").is_err());
         assert!(validate_display(":93;touch /tmp/nope").is_err());
+    }
+
+    #[test]
+    fn artifact_receipt_must_resolve_inside_the_mission_workspace() {
+        let root = tempfile::tempdir().unwrap();
+        let work_dir = root.path().join("mission");
+        let outside = root.path().join("outside.txt");
+        std::fs::create_dir(&work_dir).unwrap();
+        std::fs::write(&outside, "outside").unwrap();
+        let artifact = work_dir.join("report.txt");
+        std::fs::write(&artifact, "report").unwrap();
+
+        let validated =
+            validate_artifact_receipt(&work_dir, artifact.to_str().unwrap(), "report.txt").unwrap();
+        assert_eq!(
+            validated.0,
+            r#"<file path="report.txt" name="report.txt" />"#
+        );
+        assert_eq!(validated.1, 6);
+        assert!(
+            validate_artifact_receipt(&work_dir, outside.to_str().unwrap(), "outside.txt").is_err()
+        );
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -911,7 +911,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "list_mission_shared_files".to_string(),
-                description: "List files and screenshots shared by assistant messages in a sandboxed.sh mission.".to_string(),
+                description: "List files and screenshots shared by assistant messages in a sandboxed.sh mission, including bounded files downloaded from a ChatGPT UI response.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id"],
@@ -923,7 +923,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "download_shared_file".to_string(),
-                description: "Download a mission shared file URL to a local /tmp artifact path suitable for email attachments.".to_string(),
+                description: "Download a mission shared file URL to a local /tmp artifact path suitable for inspection or attachments. Use list_mission_shared_files first, including after ChatGPT UI missions that generated files.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["mission_id", "url"],
@@ -937,7 +937,7 @@ impl AssistantMcp {
             },
             ToolDefinition {
                 name: "start_mission".to_string(),
-                description: "Create a new sandboxed.sh mission and send its initial prompt. Set backend explicitly when possible. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title). Mark PR-changing work with writer=true; the API rejects concurrent writers for the same PR.".to_string(),
+                description: "Create a new sandboxed.sh mission and send its initial prompt. Set backend explicitly when possible. Use backend=chatgpt_ui with model_override=gpt-5.6-pro only for exceptionally difficult read-only synthesis, research, or design-conflict questions; keep writer=false, then retrieve any generated files with list_mission_shared_files and download_shared_file. For compatibility, a native agent name (codex/claudecode/gemini/grok) selects the matching backend when backend is omitted; ordinary library agent names do not. Pass project/track/intent/github_pr/tags so the mission carries structured metadata (so watchdogs/dashboards don't have to parse the title). Mark PR-changing work with writer=true; the API rejects concurrent writers for the same PR.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "required": ["title", "prompt"],
@@ -946,7 +946,7 @@ impl AssistantMcp {
                         "prompt": {"type": "string"},
                         "workspace_id": {"type": "string"},
                         "backend": {"type": "string", "enum": ["opencode", "claudecode", "codex", "gemini", "grok", "chatgpt_ui"]},
-                        "model_override": {"type": "string", "description": "Exact account-supported model ID. For Codex Terra use gpt-5.6-terra with medium effort. Never invent variants such as gpt-5.5-sol."},
+                        "model_override": {"type": "string", "description": "Exact account-supported model ID. For ChatGPT UI Pro use the canonical ID gpt-5.6-pro; the harness verifies the visible Pro picker option. For Codex Terra use gpt-5.6-terra with medium effort. Never invent variants such as gpt-5.5-sol."},
                         "model_effort": {"type": "string", "enum": ["low", "medium", "high", "xhigh", "max"]},
                         "config_profile": {"type": "string"},
                         "agent": {"type": "string"},


### PR DESCRIPTION
## What changed

- select the current ChatGPT **Pro** intelligence option from canonical `gpt-5.6-pro` requests and verify the picker state
- download bounded assistant-generated artifacts into the mission workspace and expose them through existing shared-file MCP tools
- preserve structured ChatGPT UI failures instead of falsely promoting selector errors to successful turns
- add production-safe dashboard defaults, documentation, and a Hermes escalation workflow for exceptionally hard read-only questions

## Why

The ChatGPT UI changed from a legacy model selector to the composer intelligence picker, and generated files required an explicit preview/download flow. Selector failures were also vulnerable to a legacy soft-error recovery heuristic. Together these prevented a reliable Pro lane and could misreport provider failures as success.

## Validation

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test -q` (1,483 passed; 1 ignored)
- dashboard lint (0 errors; pre-existing warnings only)
- dashboard Vitest (251 passed)
- dashboard production build
- Python driver protocol tests
- live authenticated ChatGPT UI Pro text smoke
- live generated-file download smoke with exact-byte verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser automation, file download validation, and mission completion heuristics; misclassification could still affect turn outcomes, but path canonicalization and structured failure handling reduce the worst cases.
> 
> **Overview**
> Extends the **ChatGPT UI** harness for the current composer **Pro** intelligence picker and downloadable assistant files, and wires that lane into **Hermes** for hard read-only questions.
> 
> The Playwright driver bumps to **`chatgpt-ui-v2`**: canonical **`gpt-5.6-pro`** maps to the visible **Pro** option (legacy exact-label selection remains), and after a completed reply it downloads bounded artifacts (≤8 files, 50 MiB) via scoped controls into a mission **`download_dir`**, emitting **`artifact`** NDJSON events. The Rust runner validates paths inside the workspace, appends **`<file>`** tags to turn output, attaches structured **`failure_class`** on driver errors, and **`maybe_recover_soft_llm_error`** no longer treats those structured failures as soft successes.
> 
> Dashboard production defaults and docs now use **`gpt-5.6-pro`**, proxy, and canonical model labeling; Hermes docs, **`assistant-mcp`** tool text, and the mission-control skill document **`chatgpt_ui`** + **`list_mission_shared_files`** / **`download_shared_file`** escalation with **`writer: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9a6598ac27e4672f07a9301a4751d1c832f8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->