### PR TITLE
Default Claude Code and Anthropic to Claude Opus 5

### DIFF
--- a/dashboard/src/app/config/settings/page.tsx
+++ b/dashboard/src/app/config/settings/page.tsx
@@ -111,11 +111,20 @@ function normalizeJson(value: unknown): string {
   return JSON.stringify(sortKeys(value));
 }
 
+const CLAUDE_CODE_DEFAULT_MODEL = 'claude-opus-5';
+
 const coerceClaudeCodeConfig = (value: Record<string, unknown> | null): ClaudeCodeConfig => {
   if (!value) {
-    return { default_model: null, default_agent: null, hidden_agents: [] };
+    return { default_model: CLAUDE_CODE_DEFAULT_MODEL, default_agent: null, hidden_agents: [] };
   }
-  const defaultModel = typeof value.default_model === 'string' ? value.default_model : null;
+  const configuredModel = typeof value.default_model === 'string'
+    ? value.default_model.trim()
+    : '';
+  const defaultModel =
+    !configuredModel ||
+    ['claude-opus-4-8', 'claude-opus-4.8', 'anthropic/claude-opus-4-8', 'anthropic/claude-opus-4.8'].includes(configuredModel)
+      ? CLAUDE_CODE_DEFAULT_MODEL
+      : configuredModel;
   const defaultAgent = typeof value.default_agent === 'string' ? value.default_agent : null;
   const hiddenAgentsRaw = value.hidden_agents;
   const hiddenAgents = Array.isArray(hiddenAgentsRaw)

--- a/dashboard/src/components/assistant/assistant-page.tsx
+++ b/dashboard/src/components/assistant/assistant-page.tsx
@@ -1709,7 +1709,7 @@ export default function AssistantPage() {
                 >
                   <option value="">
                     {createBackend === 'claudecode'
-                      ? 'No override (Claude Opus 5 · claude-opus-5)'
+                      ? 'No override (configured default; fallback claude-opus-5)'
                       : 'No override (use default)'}
                   </option>
                   {(() => {
@@ -1905,7 +1905,7 @@ export default function AssistantPage() {
                 >
                   <option value="">
                     {(editBackend || 'claudecode') === 'claudecode'
-                      ? 'No override (Claude Opus 5 · claude-opus-5)'
+                      ? 'No override (configured default; fallback claude-opus-5)'
                       : 'No override (use default)'}
                   </option>
                   {(() => {

--- a/dashboard/src/components/assistant/assistant-page.tsx
+++ b/dashboard/src/components/assistant/assistant-page.tsx
@@ -1707,7 +1707,11 @@ export default function AssistantPage() {
                   onChange={(e) => setCreateModelOverride(e.target.value)}
                   className="w-full px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.08] text-white focus:outline-none focus:border-indigo-500/50 text-sm [&>option]:bg-slate-800 [&>option]:text-white [&>optgroup]:bg-slate-900 [&>optgroup]:text-white/70"
                 >
-                  <option value="">No override (use default)</option>
+                  <option value="">
+                    {createBackend === 'claudecode'
+                      ? 'No override (Claude Opus 5 · claude-opus-5)'
+                      : 'No override (use default)'}
+                  </option>
                   {(() => {
                     const groupedOptions = new Map<string, Array<{ value: string; label: string; description?: string }>>();
                     for (const option of modelOptions) {
@@ -1899,7 +1903,11 @@ export default function AssistantPage() {
                   onChange={(e) => setEditModelOverride(e.target.value)}
                   className="w-full px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.08] text-white focus:outline-none focus:border-indigo-500/50 text-sm [&>option]:bg-slate-800 [&>option]:text-white [&>optgroup]:bg-slate-900 [&>optgroup]:text-white/70"
                 >
-                  <option value="">No override (use default)</option>
+                  <option value="">
+                    {(editBackend || 'claudecode') === 'claudecode'
+                      ? 'No override (Claude Opus 5 · claude-opus-5)'
+                      : 'No override (use default)'}
+                  </option>
                   {(() => {
                     const groupedOptions = new Map<string, Array<{ value: string; label: string; description?: string }>>();
                     for (const option of editModelOptions) {

--- a/dashboard/src/components/new-mission-dialog.test.tsx
+++ b/dashboard/src/components/new-mission-dialog.test.tsx
@@ -113,7 +113,7 @@ describe('NewMissionDialog', () => {
 
     expect(
       await screen.findByRole('option', {
-        name: 'No override (Claude Opus 5 · claude-opus-5)',
+        name: 'No override (configured default; fallback claude-opus-5)',
       })
     ).toBeVisible();
   });

--- a/dashboard/src/components/new-mission-dialog.test.tsx
+++ b/dashboard/src/components/new-mission-dialog.test.tsx
@@ -101,6 +101,23 @@ describe('NewMissionDialog', () => {
     expect(openSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('shows Claude Opus 5 as the Claude Code default', async () => {
+    vi.mocked(listBackends).mockResolvedValue([
+      { id: 'claudecode', name: 'Claude Code' },
+    ]);
+    const onCreate = vi.fn().mockResolvedValue({ id: 'claude-mission' });
+
+    renderDialog(onCreate);
+
+    fireEvent.click(screen.getByRole('button', { name: /new mission/i }));
+
+    expect(
+      await screen.findByRole('option', {
+        name: 'No override (Claude Opus 5 · claude-opus-5)',
+      })
+    ).toBeVisible();
+  });
+
   it('uses one host-only canonical Pro option for ChatGPT UI missions', async () => {
     vi.mocked(listBackends).mockResolvedValue([
       { id: 'chatgpt_ui', name: 'ChatGPT UI (experimental)' },

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -898,7 +898,7 @@ export function NewMissionDialog({
                 >
                   <option value="">
                     {selectedBackend === 'claudecode'
-                      ? `No override (Claude Opus 5 · ${CLAUDE_CODE_DEFAULT_MODEL})`
+                      ? `No override (configured default; fallback ${CLAUDE_CODE_DEFAULT_MODEL})`
                       : 'No override (use default)'}
                   </option>
                   {(() => {

--- a/dashboard/src/components/new-mission-dialog.tsx
+++ b/dashboard/src/components/new-mission-dialog.tsx
@@ -14,6 +14,7 @@ import { toast } from '@/components/toast';
 const KNOWN_BACKEND_IDS = ['opencode', 'claudecode', 'codex', 'gemini', 'grok', 'chatgpt_ui'] as const;
 const CHATGPT_UI_BACKEND_ID = 'chatgpt_ui';
 const CHATGPT_UI_CANONICAL_MODEL = 'gpt-5.6-pro';
+const CLAUDE_CODE_DEFAULT_MODEL = 'claude-opus-5';
 
 // Kept in sync with src/api/control.rs `normalize_model_effort_for_backend`.
 // Codex and Claude Code both accept the GPT reasoning-effort ladder. Other
@@ -895,7 +896,11 @@ export function NewMissionDialog({
                   onChange={(e) => setModelOverride(e.target.value)}
                   className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5 text-sm text-white focus:border-indigo-500/50 focus:outline-none disabled:opacity-60 [&>option]:bg-slate-800 [&>option]:text-white [&>optgroup]:bg-slate-900 [&>optgroup]:text-white/70"
                 >
-                  <option value="">No override (use default)</option>
+                  <option value="">
+                    {selectedBackend === 'claudecode'
+                      ? `No override (Claude Opus 5 · ${CLAUDE_CODE_DEFAULT_MODEL})`
+                      : 'No override (use default)'}
+                  </option>
                   {(() => {
                     if (modelOptionsLoading || providersLoading) {
                       return (
@@ -946,7 +951,7 @@ export function NewMissionDialog({
                 <p className="text-xs text-white/30 mt-1.5">
                   {selectedBackend === 'opencode'
                     ? 'Use provider/model format (e.g., openai/gpt-5.6-sol).'
-                    : 'Use the raw model ID (e.g., gpt-5.6-sol or claude-fable-5).'}
+                    : 'Use the raw model ID (e.g., gpt-5.6-sol or claude-opus-5).'}
                 </p>
               </div>
             )}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -285,7 +285,7 @@ Configure your mission:
    - **Custom agents** - Native agents configured in `.opencode/agents/`
 
 3. **Model Override (optional)** - Force a specific model for this mission:
-   - **Claude Code**: use a raw model ID (e.g., `claude-opus-4-7`)
+   - **Claude Code**: use a raw model ID (e.g., `claude-opus-5`)
    - **Codex**: use a raw model ID (e.g., `gpt-5.5` or `gpt-5.3-codex`)
    - **Gemini**: use a raw model ID (e.g., `gemini-3.1-pro-preview`)
    - **Grok**: use the canonical raw CLI model ID `grok-4.5`; availability is

--- a/skills/orchestrator-executor/SKILL.md
+++ b/skills/orchestrator-executor/SKILL.md
@@ -22,7 +22,7 @@ are stuck.
 create_worker_mission(
   title: "Advisor",
   backend: "claudecode",
-  model_override: "claude-opus-4-8",   // or the strongest model available — check get_backend_auth_status
+  model_override: "claude-opus-5",     // current Claude Code default — check get_backend_auth_status
   prompt: "You are my persistent advisor for this mission: <one-paragraph mission summary>. Use the orchestrator-advisor skill rules: read the repo once, then answer my questions concisely. First question: <your first question>"
 )
 ```

--- a/src/agent_config.rs
+++ b/src/agent_config.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 pub struct AgentConfig {
     pub id: Uuid,
     pub name: String,
-    /// Model ID (e.g., "claude-opus-4-5-20251101")
+    /// Model ID (e.g., "claude-opus-5")
     pub model_id: String,
     /// MCP server names from library to enable
     #[serde(default)]

--- a/src/api/claudecode.rs
+++ b/src/api/claudecode.rs
@@ -26,11 +26,29 @@ fn resolve_claudecode_config_path() -> std::path::PathBuf {
     std::path::PathBuf::from(home_dir()).join(".claude/settings.json")
 }
 
+fn upgrade_legacy_opus_default(mut config: Value) -> Value {
+    if let Some(object) = config.as_object_mut() {
+        for key in ["default_model", "model"] {
+            let configured = object.get(key).and_then(Value::as_str).map(str::to_string);
+            if configured.is_some() {
+                object.insert(
+                    key.to_string(),
+                    Value::String(crate::library::normalize_claude_code_default_model(
+                        configured,
+                    )),
+                );
+            }
+        }
+    }
+    config
+}
+
 /// GET /api/claudecode/config - Read Claude Code host settings.
 pub async fn get_claudecode_config() -> Result<Json<Value>, (StatusCode, String)> {
     let path = resolve_claudecode_config_path();
     read_json_config(&path, "Claude Code config")
         .await
+        .map(upgrade_legacy_opus_default)
         .map(Json)
 }
 
@@ -39,6 +57,27 @@ pub async fn update_claudecode_config(
     Json(config): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     let path = resolve_claudecode_config_path();
+    let config = upgrade_legacy_opus_default(config);
     write_json_config(&path, &config, "Claude Code config").await?;
     Ok(Json(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upgrades_legacy_model_keys_without_overwriting_other_models() {
+        let upgraded = upgrade_legacy_opus_default(serde_json::json!({
+            "model": "claude-opus-4-8",
+            "default_model": "anthropic/claude-opus-4.8"
+        }));
+        assert_eq!(upgraded["model"], "claude-opus-5");
+        assert_eq!(upgraded["default_model"], "claude-opus-5");
+
+        let explicit = upgrade_legacy_opus_default(serde_json::json!({
+            "model": "claude-sonnet-5"
+        }));
+        assert_eq!(explicit["model"], "claude-sonnet-5");
+    }
 }

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5831,18 +5831,8 @@ fn normalize_model_override_for_backend(backend: Option<&str>, raw_model: &str) 
             if backend == Some("codex") && model_id == "gpt-5.6" {
                 return Some("gpt-5.6-sol".to_string());
             }
-            if backend == Some("claudecode") {
-                return Some(crate::library::normalize_claude_code_default_model(Some(
-                    model_id.to_string(),
-                )));
-            }
             return Some(model_id.to_string());
         }
-    }
-    if backend == Some("claudecode") {
-        return Some(crate::library::normalize_claude_code_default_model(Some(
-            trimmed.to_string(),
-        )));
     }
     Some(trimmed.to_string())
 }
@@ -19341,11 +19331,7 @@ async fn run_single_control_turn(
     let requested_model = model_override;
     let requested_model_effort = model_effort;
     if let Some(ref model) = requested_model {
-        config.default_model = Some(if is_claudecode {
-            crate::library::normalize_claude_code_default_model(Some(model.clone()))
-        } else {
-            model.clone()
-        });
+        config.default_model = Some(model.clone());
     } else if is_claudecode && config.default_model.is_some() {
         config.default_model = config
             .default_model
@@ -26567,7 +26553,7 @@ And the report:
         );
         assert_eq!(
             normalize_model_override_for_backend(Some("claudecode"), "anthropic/claude-opus-4-8"),
-            Some("claude-opus-5".to_string())
+            Some("claude-opus-4-8".to_string())
         );
         assert_eq!(
             normalize_model_override_for_backend(Some("codex"), "   "),

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -2782,38 +2782,28 @@ pub(crate) async fn resolve_claudecode_default_model(
     config_profile: Option<&str>,
 ) -> Option<String> {
     // Keep this fallback aligned with Anthropic's model catalog:
-    // https://docs.anthropic.com/en/docs/about-claude/models/overview
-    const CLAUDECODE_DEFAULT_MODEL: &str = "claude-fable-5";
-
+    // https://platform.claude.com/docs/en/about-claude/models/overview
     let lib = {
         let guard = library.read().await;
         guard.clone()
     };
 
     let Some(lib) = lib else {
-        return Some(CLAUDECODE_DEFAULT_MODEL.to_string());
+        return Some(crate::library::CLAUDE_CODE_DEFAULT_MODEL.to_string());
     };
 
     let profile = config_profile.unwrap_or("default");
     match lib.get_claudecode_config_for_profile(profile).await {
-        Ok(config) => {
-            let configured = config.default_model.and_then(|model| {
-                let trimmed = model.trim().to_string();
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(trimmed)
-                }
-            });
-            configured.or_else(|| Some(CLAUDECODE_DEFAULT_MODEL.to_string()))
-        }
+        Ok(config) => Some(crate::library::normalize_claude_code_default_model(
+            config.default_model,
+        )),
         Err(err) => {
             tracing::warn!(
                 "Failed to load Claude Code config from library (profile: {}): {}",
                 profile,
                 err
             );
-            Some(CLAUDECODE_DEFAULT_MODEL.to_string())
+            Some(crate::library::CLAUDE_CODE_DEFAULT_MODEL.to_string())
         }
     }
 }
@@ -5841,8 +5831,18 @@ fn normalize_model_override_for_backend(backend: Option<&str>, raw_model: &str) 
             if backend == Some("codex") && model_id == "gpt-5.6" {
                 return Some("gpt-5.6-sol".to_string());
             }
+            if backend == Some("claudecode") {
+                return Some(crate::library::normalize_claude_code_default_model(Some(
+                    model_id.to_string(),
+                )));
+            }
             return Some(model_id.to_string());
         }
+    }
+    if backend == Some("claudecode") {
+        return Some(crate::library::normalize_claude_code_default_model(Some(
+            trimmed.to_string(),
+        )));
     }
     Some(trimmed.to_string())
 }
@@ -19341,7 +19341,16 @@ async fn run_single_control_turn(
     let requested_model = model_override;
     let requested_model_effort = model_effort;
     if let Some(ref model) = requested_model {
-        config.default_model = Some(model.clone());
+        config.default_model = Some(if is_claudecode {
+            crate::library::normalize_claude_code_default_model(Some(model.clone()))
+        } else {
+            model.clone()
+        });
+    } else if is_claudecode && config.default_model.is_some() {
+        config.default_model = config
+            .default_model
+            .take()
+            .map(|model| crate::library::normalize_claude_code_default_model(Some(model)));
     } else if is_claudecode && config.default_model.is_none() {
         if let Some(default_model) =
             resolve_claudecode_default_model(&library, effective_config_profile.as_deref()).await
@@ -26557,8 +26566,38 @@ And the report:
             Some("claude-opus-4-7".to_string())
         );
         assert_eq!(
+            normalize_model_override_for_backend(Some("claudecode"), "anthropic/claude-opus-4-8"),
+            Some("claude-opus-5".to_string())
+        );
+        assert_eq!(
             normalize_model_override_for_backend(Some("codex"), "   "),
             None
+        );
+    }
+
+    #[test]
+    fn claudecode_default_is_opus_5_and_upgrades_legacy_opus_48() {
+        assert_eq!(
+            crate::library::normalize_claude_code_default_model(None),
+            "claude-opus-5"
+        );
+        assert_eq!(
+            crate::library::normalize_claude_code_default_model(Some(
+                "claude-opus-4-8".to_string()
+            )),
+            "claude-opus-5"
+        );
+        assert_eq!(
+            crate::library::normalize_claude_code_default_model(Some(
+                "anthropic/claude-opus-4.8".to_string()
+            )),
+            "claude-opus-5"
+        );
+        assert_eq!(
+            crate::library::normalize_claude_code_default_model(Some(
+                "claude-sonnet-5".to_string()
+            )),
+            "claude-sonnet-5"
         );
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3474,7 +3474,16 @@ async fn run_mission_turn(
         config.opencode_agent = Some(agent.clone());
     }
     if let Some(ref model) = model_override {
-        config.default_model = Some(model.clone());
+        config.default_model = Some(if backend_id == "claudecode" {
+            crate::library::normalize_claude_code_default_model(Some(model.clone()))
+        } else {
+            model.clone()
+        });
+    } else if backend_id == "claudecode" {
+        config.default_model = config
+            .default_model
+            .take()
+            .map(|model| crate::library::normalize_claude_code_default_model(Some(model)));
     }
     // Get config profile: mission's config_profile takes priority over workspace's
     let workspace_config_profile = if let Some(ws_id) = workspace_id {
@@ -3512,7 +3521,7 @@ async fn run_mission_turn(
         config.default_model = Some(resolve_gemini_default_model());
     } else if backend_id == "grok" && model_override.is_none() {
         // Pin Grok Build to its own default model. Without this the global
-        // DEFAULT_MODEL (typically `anthropic/claude-opus-4-8`) flows
+        // DEFAULT_MODEL (typically `anthropic/claude-opus-5`) flows
         // through to `--model` and the grok CLI rejects it as "unknown
         // model id" — the mission then fails on the first turn with a
         // confusing chdir error from the rejected-CLI path. See prod

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3474,11 +3474,7 @@ async fn run_mission_turn(
         config.opencode_agent = Some(agent.clone());
     }
     if let Some(ref model) = model_override {
-        config.default_model = Some(if backend_id == "claudecode" {
-            crate::library::normalize_claude_code_default_model(Some(model.clone()))
-        } else {
-            model.clone()
-        });
+        config.default_model = Some(model.clone());
     } else if backend_id == "claudecode" {
         config.default_model = config
             .default_model

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -60,7 +60,7 @@ const OPENROUTER_PROVIDER_ID: &str = "open-router";
 /// Best-effort seed slugs kept in the default config; prioritized when capping
 /// the models.dev OpenRouter catalog (which has no popularity sort).
 const OPENROUTER_SEED_MODEL_IDS: &[&str] = &[
-    "anthropic/claude-opus-4.8",
+    "anthropic/claude-opus-5",
     "anthropic/claude-sonnet-4.6",
     "google/gemini-3.1-pro-preview",
     "openai/gpt-5.6",
@@ -726,7 +726,15 @@ fn default_providers_config() -> ProvidersConfig {
                 description: "Included in Claude Max".to_string(),
                 models: vec![
                     // Check Anthropic's current model IDs here:
-                    // https://docs.anthropic.com/en/docs/about-claude/models/overview
+                    // https://platform.claude.com/docs/en/about-claude/models/overview
+                    ProviderModel {
+                        id: "claude-opus-5".to_string(),
+                        name: "Claude Opus 5".to_string(),
+                        description: Some(
+                            "Default for complex agentic coding, adaptive thinking, 1M context"
+                                .to_string(),
+                        ),
+                    },
                     ProviderModel {
                         id: "claude-fable-5".to_string(),
                         name: "Claude Fable 5".to_string(),
@@ -739,7 +747,7 @@ fn default_providers_config() -> ProvidersConfig {
                         id: "claude-opus-4-8".to_string(),
                         name: "Claude Opus 4.8".to_string(),
                         description: Some(
-                            "Latest Opus model, recommended for hard coding and agentic tasks"
+                            "Previous-generation Opus model retained for explicit compatibility"
                                 .to_string(),
                         ),
                     },
@@ -888,12 +896,12 @@ fn default_providers_config() -> ProvidersConfig {
                     // The live catalog is merged from models.dev and /v1/models
                     // when available; these keep the picker useful before the
                     // background catalog finishes. IDs verified against
-                    // OpenRouter's public catalog on 2026-06-17 — treat as
+                    // OpenRouter's public catalog on 2026-07-25 — treat as
                     // best-effort seeds that the live catalog supersedes (slugs
                     // can drift as models are retired).
                     ProviderModel {
-                        id: "anthropic/claude-opus-4.8".to_string(),
-                        name: "Claude Opus 4.8".to_string(),
+                        id: "anthropic/claude-opus-5".to_string(),
+                        name: "Claude Opus 5".to_string(),
                         description: Some("Anthropic Claude via OpenRouter".to_string()),
                     },
                     ProviderModel {
@@ -2310,7 +2318,7 @@ pub async fn validate_model_override(
                     Ok(())
                 } else {
                     Err(format!(
-                        "Anthropic provider not configured. Expected a Claude model ID (e.g., 'claude-opus-4-7'), got '{}'",
+                        "Anthropic provider not configured. Expected a Claude model ID (e.g., 'claude-opus-5'), got '{}'",
                         model_override
                     ))
                 }
@@ -2464,17 +2472,18 @@ mod tests {
     }
 
     #[test]
-    fn default_anthropic_catalog_includes_opus_47() {
+    fn default_anthropic_catalog_leads_with_opus_5() {
         let defaults = default_providers_config();
         let anthropic = defaults
             .providers
             .iter()
             .find(|provider| provider.id == "anthropic")
             .expect("anthropic provider");
+        assert_eq!(anthropic.models[0].id, "claude-opus-5");
         assert!(anthropic
             .models
             .iter()
-            .any(|model| model.id == "claude-opus-4-7"));
+            .any(|model| model.id == "claude-opus-4-8"));
     }
 
     #[test]
@@ -2557,7 +2566,7 @@ mod tests {
         assert!(openrouter
             .models
             .iter()
-            .any(|model| model.id == "anthropic/claude-opus-4.8"));
+            .any(|model| model.id == "anthropic/claude-opus-5"));
         assert!(openrouter.models.iter().all(|model| model.id.contains('/')));
     }
 
@@ -2582,7 +2591,7 @@ mod tests {
         let mut entries: Vec<CatalogEntry> = (0..150)
             .map(|i| make(&format!("vendor/model-{i:03}")))
             .collect();
-        entries.push(make("anthropic/claude-opus-4.8"));
+        entries.push(make("anthropic/claude-opus-5"));
         entries.push(make("openai/gpt-5.6"));
         entries.push(make("openai/gpt-5.5"));
 
@@ -2592,7 +2601,7 @@ mod tests {
             OPENROUTER_SEED_MODEL_IDS,
         );
         assert_eq!(capped.len(), MAX_CATALOG_MODELS_PER_PROVIDER);
-        assert_eq!(capped[0].id, "anthropic/claude-opus-4.8");
+        assert_eq!(capped[0].id, "anthropic/claude-opus-5");
         assert!(capped.iter().any(|entry| entry.id == "openai/gpt-5.6"));
         assert!(capped.iter().any(|entry| entry.id == "openai/gpt-5.5"));
     }
@@ -2698,7 +2707,7 @@ mod tests {
         assert!(anthropic
             .models
             .iter()
-            .any(|model| model.id == "claude-opus-4-7"));
+            .any(|model| model.id == "claude-opus-5"));
     }
 
     #[test]
@@ -2730,7 +2739,7 @@ mod tests {
         assert!(anthropic
             .models
             .iter()
-            .any(|model| model.id == "claude-opus-4-7"));
+            .any(|model| model.id == "claude-opus-5"));
         assert_eq!(
             anthropic
                 .models

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -2267,6 +2267,7 @@ fn rewrite_model(body: &[u8], new_model: &str) -> Result<bytes::Bytes, String> {
 /// `top_k`) when extended thinking is active, so we strip them for these IDs.
 fn anthropic_model_omits_sampling_params(model_id: &str) -> bool {
     model_id.contains("claude-fable-5")
+        || model_id.contains("claude-opus-5")
         || model_id.contains("claude-opus-4-8")
         || model_id.contains("claude-opus-4-7")
 }
@@ -2391,6 +2392,22 @@ fn anthropic_body_drop_thinking_and_disable(body: &[u8]) -> Result<bytes::Bytes,
             "thinking".to_string(),
             serde_json::json!({ "type": "disabled" }),
         );
+        // Opus 5 rejects disabled thinking at xhigh/max effort. This recovery
+        // path deliberately disables thinking for one turn, so cap an
+        // incompatible explicit effort instead of turning a recoverable stale
+        // signature into a second 400.
+        if let Some(output_config) = obj
+            .get_mut("output_config")
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            let incompatible = output_config
+                .get("effort")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|effort| matches!(effort, "xhigh" | "max"));
+            if incompatible {
+                output_config.insert("effort".to_string(), serde_json::json!("high"));
+            }
+        }
         // Sampling params are valid again once thinking is disabled, but the
         // original request already omitted them for these models; leave as-is.
     }
@@ -5961,7 +5978,7 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_cli_proxy_rewrite_drops_deprecated_opus_47_sampling_params() {
+    fn anthropic_cli_proxy_rewrite_drops_opus_5_sampling_params() {
         let body = serde_json::json!({
             "model": "opus",
             "messages": [{ "role": "user", "content": "ok" }],
@@ -5973,12 +5990,12 @@ mod tests {
         });
         let payload = rewrite_model_for_anthropic_cli_proxy(
             serde_json::to_vec(&body).unwrap().as_slice(),
-            "claude-opus-4-7",
+            "claude-opus-5",
         )
         .unwrap();
         let value: serde_json::Value = serde_json::from_slice(payload.as_ref()).unwrap();
 
-        assert_eq!(value["model"], "claude-opus-4-7");
+        assert_eq!(value["model"], "claude-opus-5");
         assert!(value.get("temperature").is_none());
         assert!(value.get("top_p").is_none());
         assert!(value.get("top_k").is_none());
@@ -6080,9 +6097,10 @@ mod tests {
     #[test]
     fn drop_thinking_and_disable_strips_and_disables() {
         let body = serde_json::json!({
-            "model": "claude-opus-4-8",
+            "model": "claude-opus-5",
             "max_tokens": 16,
             "thinking": { "type": "enabled", "budget_tokens": 2048 },
+            "output_config": { "effort": "max" },
             "messages": [
                 { "role": "user", "content": "hi" },
                 { "role": "assistant", "content": [
@@ -6096,6 +6114,7 @@ mod tests {
                 .unwrap();
         let value: serde_json::Value = serde_json::from_slice(out.as_ref()).unwrap();
         assert_eq!(value["thinking"], serde_json::json!({ "type": "disabled" }));
+        assert_eq!(value["output_config"]["effort"], "high");
         let blocks = value["messages"][1]["content"].as_array().unwrap();
         assert!(blocks.iter().all(|b| b["type"] != "thinking"));
         assert!(blocks.iter().any(|b| b["type"] == "text"));

--- a/src/api/runners/claudecode.rs
+++ b/src/api/runners/claudecode.rs
@@ -977,8 +977,8 @@ pub fn run_claudecode_turn<'a>(
         }
 
         if let Some(m) = model {
-            // Claude Code expects bare model IDs (e.g. "claude-opus-4-7"),
-            // not provider-prefixed ones (e.g. "anthropic/claude-opus-4-7").
+            // Claude Code expects bare model IDs (e.g. "claude-opus-5"),
+            // not provider-prefixed ones (e.g. "anthropic/claude-opus-5").
             let bare = m.strip_prefix("anthropic/").unwrap_or(m);
             args.push("--model".to_string());
             args.push(bare.to_string());

--- a/src/backend/claudecode/client.rs
+++ b/src/backend/claudecode/client.rs
@@ -90,8 +90,8 @@ impl ClaudeCodeClient {
             }
         }
 
-        // Model selection — Claude Code expects bare model IDs (e.g. "claude-opus-4-7"),
-        // not provider-prefixed ones (e.g. "anthropic/claude-opus-4-7").
+        // Model selection — Claude Code expects bare model IDs (e.g. "claude-opus-5"),
+        // not provider-prefixed ones (e.g. "anthropic/claude-opus-5").
         let effective_model = model.or(self.config.default_model.as_deref());
         if let Some(m) = effective_model {
             let bare = m.strip_prefix("anthropic/").unwrap_or(m);

--- a/src/bin/orchestrator_mcp.rs
+++ b/src/bin/orchestrator_mcp.rs
@@ -716,7 +716,7 @@ impl OrchestratorMcp {
                         },
                         "model_override": {
                             "type": "string",
-                            "description": "Exact account-supported model ID. Must match the backend: Claude models (e.g. 'claude-opus-4-7') for claudecode, GPT models (e.g. 'gpt-5.6-terra', recommended with medium effort) for codex, Gemini models for gemini, Grok models for grok, 'provider/model' format for opencode. Never invent variants such as 'gpt-5.5-sol'."
+                            "description": "Exact account-supported model ID. Must match the backend: Claude models (e.g. 'claude-opus-5') for claudecode, GPT models (e.g. 'gpt-5.6-terra', recommended with medium effort) for codex, Gemini models for gemini, Grok models for grok, 'provider/model' format for opencode. Never invent variants such as 'gpt-5.5-sol'."
                         },
                         "model_effort": {
                             "type": "string",

--- a/src/config.rs
+++ b/src/config.rs
@@ -420,7 +420,9 @@ impl Config {
             .transpose()?
             .unwrap_or(true);
 
-        let default_model = std::env::var("DEFAULT_MODEL").ok();
+        let default_model = std::env::var("DEFAULT_MODEL")
+            .ok()
+            .map(upgrade_legacy_anthropic_default_model);
 
         // WORKING_DIR: default working directory for relative paths.
         // In production (release build), default to /root. In dev, default to current directory.
@@ -725,5 +727,36 @@ fn parse_bool(value: &str) -> Result<bool, String> {
         "1" | "true" | "t" | "yes" | "y" | "on" => Ok(true),
         "0" | "false" | "f" | "no" | "n" | "off" => Ok(false),
         other => Err(format!("expected boolean-like value, got: {}", other)),
+    }
+}
+
+fn upgrade_legacy_anthropic_default_model(model: String) -> String {
+    match model.trim() {
+        "claude-opus-4-8" | "claude-opus-4.8" => "claude-opus-5".to_string(),
+        "anthropic/claude-opus-4-8" | "anthropic/claude-opus-4.8" => {
+            "anthropic/claude-opus-5".to_string()
+        }
+        _ => model,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upgrade_legacy_anthropic_default_model;
+
+    #[test]
+    fn upgrades_legacy_anthropic_default_model() {
+        assert_eq!(
+            upgrade_legacy_anthropic_default_model("anthropic/claude-opus-4-8".to_string()),
+            "anthropic/claude-opus-5"
+        );
+        assert_eq!(
+            upgrade_legacy_anthropic_default_model("claude-opus-4.8".to_string()),
+            "claude-opus-5"
+        );
+        assert_eq!(
+            upgrade_legacy_anthropic_default_model("claude-sonnet-5".to_string()),
+            "claude-sonnet-5"
+        );
     }
 }

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -92,6 +92,11 @@ const PRICING_ENTRIES: &[PricingEntry] = &[
         pricing: pricing(10_000, 50_000, Some(12_500), Some(1_000)),
     },
     PricingEntry {
+        canonical: "claude-opus-5",
+        aliases: &["claude-opus-5", "claude-5-opus"],
+        pricing: pricing(5_000, 25_000, Some(6_250), Some(500)),
+    },
+    PricingEntry {
         canonical: "claude-opus-4-8",
         aliases: &["claude-opus-4-8", "claude-4-8-opus"],
         pricing: pricing(5_000, 25_000, Some(6_250), Some(500)),
@@ -567,6 +572,7 @@ mod tests {
             "claude-3-5-sonnet"
         );
         assert_eq!(normalize_model("claude-opus-4-7"), "claude-opus-4-7");
+        assert_eq!(normalize_model("claude-5-opus"), "claude-opus-5");
         assert_eq!(
             normalize_model("claude-opus-4-5-20251101"),
             "claude-opus-4-5"
@@ -618,6 +624,7 @@ mod tests {
     fn test_pricing_for_known_models() {
         assert!(pricing_for_model("claude-3-5-sonnet").is_some());
         assert!(pricing_for_model("claude-opus-4-7").is_some());
+        assert!(pricing_for_model("claude-opus-5").is_some());
         assert!(pricing_for_model("claude-opus-4-5").is_some());
         assert!(pricing_for_model("claude-sonnet-4-5").is_some());
         assert!(pricing_for_model("claude-haiku-4-5").is_some());

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -2054,7 +2054,10 @@ impl LibraryStore {
             .await
             .context("Failed to read claudecode config")?;
 
-        serde_json::from_str(&content).context("Failed to parse claudecode config")
+        let mut config: ClaudeCodeConfig =
+            serde_json::from_str(&content).context("Failed to parse claudecode config")?;
+        config.default_model = Some(normalize_claude_code_default_model(config.default_model));
+        Ok(config)
     }
 
     /// Get Claude Code raw settings.json from a profile as untyped JSON.
@@ -2073,7 +2076,23 @@ impl LibraryStore {
         let content = fs::read_to_string(&path)
             .await
             .context("Failed to read claudecode settings")?;
-        serde_json::from_str(&content).context("Failed to parse claudecode settings")
+        let mut settings: serde_json::Value =
+            serde_json::from_str(&content).context("Failed to parse claudecode settings")?;
+        if let Some(object) = settings.as_object_mut() {
+            for key in ["default_model", "model"] {
+                let configured = object
+                    .get(key)
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                if configured.is_some() {
+                    object.insert(
+                        key.to_string(),
+                        serde_json::Value::String(normalize_claude_code_default_model(configured)),
+                    );
+                }
+            }
+        }
+        Ok(settings)
     }
 
     /// Get Codex raw config.toml from a profile as a plain string.
@@ -2348,6 +2367,42 @@ impl LibraryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn claudecode_config_defaults_to_opus_5_and_upgrades_opus_48() {
+        assert_eq!(
+            ClaudeCodeConfig::default().default_model.as_deref(),
+            Some("claude-opus-5")
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = LibraryStore::with_test_store(temp.path().to_path_buf()).await;
+        let config_dir = temp
+            .path()
+            .join(CONFIGS_DIR)
+            .join(DEFAULT_PROFILE)
+            .join(".claudecode");
+        fs::create_dir_all(&config_dir).await.unwrap();
+        fs::write(
+            config_dir.join("settings.json"),
+            serde_json::json!({
+                "default_model": "anthropic/claude-opus-4-8",
+                "hidden_agents": []
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let typed = store.get_claudecode_config().await.unwrap();
+        assert_eq!(typed.default_model.as_deref(), Some("claude-opus-5"));
+
+        let raw = store
+            .get_claudecode_raw_settings_for_profile(DEFAULT_PROFILE)
+            .await
+            .unwrap();
+        assert_eq!(raw["default_model"], "claude-opus-5");
+    }
 
     #[test]
     fn test_parse_frontmatter() {

--- a/src/library/types.rs
+++ b/src/library/types.rs
@@ -483,10 +483,29 @@ pub struct ClaudeCodeAttribution {
 
 /// Claude Code configuration stored in the Library.
 /// Controls default model, agent preferences, and visibility for Claude Code backend.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub const CLAUDE_CODE_DEFAULT_MODEL: &str = "claude-opus-5";
+
+pub fn normalize_claude_code_default_model(model: Option<String>) -> String {
+    let configured = model.unwrap_or_default();
+    let trimmed = configured.trim();
+    if trimmed.is_empty()
+        || matches!(
+            trimmed,
+            "claude-opus-4-8"
+                | "claude-opus-4.8"
+                | "anthropic/claude-opus-4-8"
+                | "anthropic/claude-opus-4.8"
+        )
+    {
+        return CLAUDE_CODE_DEFAULT_MODEL.to_string();
+    }
+    trimmed.to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeCodeConfig {
     /// Default model to use for Claude Code missions.
-    /// Example: "claude-sonnet-4-20250514", "claude-opus-4-20250514"
+    /// Example: "claude-sonnet-5", "claude-opus-5"
     #[serde(default)]
     pub default_model: Option<String>,
     /// Default agent to pre-select for Claude Code missions.
@@ -500,6 +519,17 @@ pub struct ClaudeCodeConfig {
     /// Set commit/pr to empty strings to disable co-author attribution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attribution: Option<ClaudeCodeAttribution>,
+}
+
+impl Default for ClaudeCodeConfig {
+    fn default() -> Self {
+        Self {
+            default_model: Some(CLAUDE_CODE_DEFAULT_MODEL.to_string()),
+            default_agent: None,
+            hidden_agents: Vec::new(),
+            attribution: None,
+        }
+    }
 }
 
 /// Codex configuration metadata stored in the Library.


### PR DESCRIPTION
## What changed

- add Claude Opus 5 to the Anthropic and OpenRouter catalogs and make it the first/default Claude Code model
- migrate legacy Opus 4.8 defaults in profiles and environment configuration to Opus 5 while preserving deliberate per-mission 4.8 pins
- update proxy compatibility, adaptive-thinking recovery, pricing, settings, mission pickers, documentation, and orchestration examples
- add backend and frontend regression coverage

## Why

Anthropic now recommends `claude-opus-5` as the direct replacement for `claude-opus-4-8`. Existing persisted defaults otherwise keep new missions on the previous generation and the UI does not communicate the effective Claude Code default.

## Validation

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test --quiet` (1,488 library tests plus all binary/integration suites)
- `bun run lint` (0 errors; 23 existing warnings)
- `bun run test:unit` (253 passed)
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default model selection across missions, persisted profiles, env config, and Anthropic proxy request rewriting—wide blast radius but mostly deterministic migrations with tests; wrong normalization could surprise operators who expected Opus 4.8 as an implicit default.
> 
> **Overview**
> **Claude Code and Anthropic defaults move to `claude-opus-5`**, with a shared `normalize_claude_code_default_model` path so empty or legacy Opus 4.8 profile/host settings upgrade on read/write while **explicit `claude-opus-4-8` model overrides stay pinned**.
> 
> Backend mission resolution, library config loading, `DEFAULT_MODEL` env handling, provider/OpenRouter catalogs, and cost pricing are aligned to Opus 5 as the primary Claude default. The **Anthropic proxy** treats Opus 5 like other adaptive-thinking models (sampling param stripping) and **caps `xhigh`/`max` effort to `high`** when stale-thinking recovery disables thinking.
> 
> Dashboard mission/gateway pickers and settings coercion **surface the configured default with fallback `claude-opus-5`**; docs, orchestrator skill examples, and MCP hints are updated. Regression tests cover normalization, config upgrade, proxy behavior, and the new-mission UI label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 177b2ea7a4468ef865f493a0e2dc6527149de23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->