### PR TITLE
Fix ChatGPT UI model picker hydration race

### DIFF
--- a/docs/CHATGPT_UI_HARNESS.md
+++ b/docs/CHATGPT_UI_HARNESS.md
@@ -118,6 +118,10 @@ match `proxy_server` when the account requires a stable external egress.
   blank page; directory presence is never treated as proof of authentication.
 - `requested model is not visibly available`: verify the exact current label
   and account entitlement; UI rollouts are account-specific.
+- `stage=composer_model_picker_not_ready`: the authenticated composer appeared,
+  but its lazily hydrated model control did not become visible within 15
+  seconds. Retry once after checking the browser/proxy path; do not silently
+  use the current default model.
 - `compatibility=chatgpt-ui-v2`: the versioned selector/download contract
   failed. Capture
   only a clean, new chat with no sidebar identity or private history visible.

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -20,6 +20,7 @@ COMPAT_VERSION = "chatgpt-ui-v2"
 CHATGPT_URL = "https://chatgpt.com/"
 MAX_DOWNLOAD_FILES = 8
 MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+MODEL_PICKER_READY_TIMEOUT_MS = 15_000
 INTELLIGENCE_LABELS = ("Instant", "5.5", "Medium", "High", "Extra High", "Pro")
 PRO_MODEL_ALIASES = {
     "gpt-5.6-pro",
@@ -47,7 +48,21 @@ def model_selection(requested: str) -> tuple[str, str]:
 
 async def choose_intelligence_model(page, label: str) -> bool:
     """Select a current composer intelligence option without touching the sidebar."""
-    picker_buttons = page.locator('button.__composer-pill[aria-haspopup="menu"]')
+    # The current ChatGPT shell hydrates the composer in two phases: the
+    # textbox can be ready several seconds before the model pill is attached.
+    # Wait for the composer-scoped control instead of snapshotting its count
+    # immediately and incorrectly falling back to the legacy model picker.
+    picker_buttons = page.locator(
+        'form button.__composer-pill[aria-haspopup="menu"]'
+    )
+    try:
+        await picker_buttons.first.wait_for(
+            state="visible", timeout=MODEL_PICKER_READY_TIMEOUT_MS
+        )
+    except Exception:
+        emit("diagnostic", message="stage=composer_model_picker_not_ready")
+        return False
+
     for index in range(await picker_buttons.count()):
         button = picker_buttons.nth(index)
         try:
@@ -56,6 +71,9 @@ async def choose_intelligence_model(page, label: str) -> bool:
             current = (await button.inner_text()).strip()
             if current not in INTELLIGENCE_LABELS:
                 continue
+            if current == label:
+                emit("diagnostic", message="stage=model_already_selected")
+                return True
             await button.click()
             overlay = page.locator(
                 '[data-testid="composer-intelligence-picker-content"]:visible'
@@ -69,6 +87,7 @@ async def choose_intelligence_model(page, label: str) -> bool:
             return True
         except Exception:
             continue
+    emit("diagnostic", message="stage=composer_model_option_unavailable")
     return False
 
 

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -4,6 +4,8 @@ import asyncio
 import unittest
 
 from scripts.chatgpt_ui_driver import (
+    MODEL_PICKER_READY_TIMEOUT_MS,
+    choose_intelligence_model,
     close_context_quietly,
     download_control_key,
     downloadable_href,
@@ -17,6 +19,48 @@ class ClosedContext:
         raise RuntimeError("already closed")
 
 
+class SelectedModelButton:
+    def __init__(self) -> None:
+        self.wait_timeout = None
+        self.clicked = False
+
+    async def wait_for(self, *, state, timeout) -> None:
+        self.wait_timeout = (state, timeout)
+
+    async def is_visible(self) -> bool:
+        return True
+
+    async def inner_text(self) -> str:
+        return "Pro"
+
+    async def click(self) -> None:
+        self.clicked = True
+
+
+class SingleModelPicker:
+    def __init__(self, button) -> None:
+        self.first = button
+        self.button = button
+
+    async def count(self) -> int:
+        return 1
+
+    def nth(self, index):
+        if index != 0:
+            raise IndexError(index)
+        return self.button
+
+
+class ComposerPage:
+    def __init__(self, picker) -> None:
+        self.picker = picker
+        self.selector = None
+
+    def locator(self, selector):
+        self.selector = selector
+        return self.picker
+
+
 class ChatGptUiDriverTests(unittest.TestCase):
     def test_cleanup_preserves_existing_protocol_result(self) -> None:
         asyncio.run(close_context_quietly(ClosedContext()))
@@ -25,6 +69,24 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertEqual(model_selection("gpt-5.6-pro"), ("Pro", "gpt-5.6-pro"))
         self.assertEqual(model_selection("GPT-5.6 Pro"), ("Pro", "gpt-5.6-pro"))
         self.assertEqual(model_selection("Extra High"), ("Extra High", "Extra High"))
+        self.assertGreaterEqual(MODEL_PICKER_READY_TIMEOUT_MS, 10_000)
+
+    def test_model_picker_waits_for_hydration_and_accepts_current_selection(
+        self,
+    ) -> None:
+        button = SelectedModelButton()
+        page = ComposerPage(SingleModelPicker(button))
+
+        selected = asyncio.run(choose_intelligence_model(page, "Pro"))
+
+        self.assertTrue(selected)
+        self.assertEqual(
+            page.selector, 'form button.__composer-pill[aria-haspopup="menu"]'
+        )
+        self.assertEqual(
+            button.wait_timeout, ("visible", MODEL_PICKER_READY_TIMEOUT_MS)
+        )
+        self.assertFalse(button.clicked)
 
     def test_download_links_are_limited_to_chatgpt_artifact_surfaces(self) -> None:
         self.assertTrue(downloadable_href("sandbox:/mnt/data/report.pdf"))

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -26,8 +26,7 @@ use crate::api::mission_runner::{get_backend_string_setting, get_backend_u64_set
 #[serde(tag = "type", rename_all = "snake_case")]
 enum DriverEvent {
     Diagnostic {
-        #[serde(rename = "message")]
-        _message: String,
+        message: String,
     },
     TextDelta {
         content: String,
@@ -413,10 +412,14 @@ pub async fn run_chatgpt_ui_turn(
                     }
                 };
                 match event {
-                    // Diagnostics are deliberately not logged: a future
-                    // third-party UI selector must not accidentally turn
-                    // account or page text into server logs.
-                    DriverEvent::Diagnostic { .. } => tracing::debug!(mission_id = %mission_id, "chatgpt_ui driver diagnostic received"),
+                    // The bundled driver emits only static compatibility and
+                    // stage markers here. It must never place account, page,
+                    // prompt, or response text in a diagnostic event.
+                    DriverEvent::Diagnostic { message } => tracing::debug!(
+                        mission_id = %mission_id,
+                        diagnostic = %message,
+                        "chatgpt_ui driver diagnostic received"
+                    ),
                     DriverEvent::TextDelta { content } => {
                         output = content;
                         let _ = events_tx.send(AgentEvent::TextDelta { content: output.clone(), mission_id: Some(mission_id) });


### PR DESCRIPTION
## Summary
- wait for the lazily hydrated composer model picker instead of snapshotting it too early
- accept an already-selected exact Pro label without reopening the picker
- expose static driver stage markers in debug logs and document the new diagnostic

## Verification
- `python3 -m unittest scripts.test_chatgpt_ui_driver scripts.test_chatgpt_ui_smoke scripts.test_chatgpt_ui_mock_driver`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test`
- live production-profile smoke returned an exact `gpt-5.6-pro` response through the DGX egress proxy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Playwright selector and timing fix in the experimental ChatGPT UI driver, plus debug logging of static stage markers; no auth, data, or core mission-path changes.
> 
> **Overview**
> Fixes a **race** where the ChatGPT UI driver could treat the composer as ready before the intelligence model pill appeared, then fall through to the legacy picker or the wrong default.
> 
> **Driver (`chatgpt_ui_driver.py`):** Waits up to **15s** for `form button.__composer-pill[aria-haspopup="menu"]` to become visible before enumerating options. On timeout it emits `stage=composer_model_picker_not_ready` and fails selection instead of silently continuing. If the requested label is already shown (e.g. **Pro** for `gpt-5.6-pro`), it short-circuits with `stage=model_already_selected` without opening the menu. When no matching intelligence option is found, it emits `stage=composer_model_option_unavailable`.
> 
> **Rust runner:** Driver **diagnostic** events are logged at debug with the static `message` field (still constrained to stage/compatibility markers, not page or account text).
> 
> **Docs:** Documents the new `stage=composer_model_picker_not_ready` diagnostic and retry guidance.
> 
> **Tests:** Unit coverage for hydration wait, composer-scoped selector, and no-click when the model is already selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c96dcd75561798287e4f55278283647635dbe6ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->