### PR TITLE
Address ChatGPT UI picker review findings

### DIFF
--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -53,7 +53,7 @@ async def choose_intelligence_model(page, label: str) -> bool:
     # Wait for the composer-scoped control instead of snapshotting its count
     # immediately and incorrectly falling back to the legacy model picker.
     picker_buttons = page.locator(
-        'form button.__composer-pill[aria-haspopup="menu"]'
+        'form button.__composer-pill[aria-haspopup="menu"]:visible'
     )
     try:
         await picker_buttons.first.wait_for(

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -81,7 +81,8 @@ class ChatGptUiDriverTests(unittest.TestCase):
 
         self.assertTrue(selected)
         self.assertEqual(
-            page.selector, 'form button.__composer-pill[aria-haspopup="menu"]'
+            page.selector,
+            'form button.__composer-pill[aria-haspopup="menu"]:visible',
         )
         self.assertEqual(
             button.wait_timeout, ("visible", MODEL_PICKER_READY_TIMEOUT_MS)

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -169,6 +169,24 @@ fn parse_bool_setting(key: &str, default: bool) -> bool {
     crate::api::mission_runner::get_backend_bool_setting("chatgpt_ui", key).unwrap_or(default)
 }
 
+fn safe_driver_diagnostic(message: &str) -> Option<&str> {
+    match message {
+        "compatibility=chatgpt-ui-v2; browser=chromium"
+        | "compatibility=chatgpt-ui-v2; browser=firefox"
+        | "compatibility=chatgpt-ui-v2; browser=webkit"
+        | "stage=page_loaded"
+        | "stage=account_confirmed"
+        | "stage=blank_route"
+        | "stage=composer_ready"
+        | "stage=composer_model_picker_not_ready"
+        | "stage=model_already_selected"
+        | "stage=composer_model_option_unavailable"
+        | "stage=artifact_size_limit"
+        | "stage=artifact_download_skipped" => Some(message),
+        _ => None,
+    }
+}
+
 fn validate_proxy_server(value: &str) -> Result<(), String> {
     let parsed =
         url::Url::parse(value).map_err(|_| "chatgpt_ui proxy_server must be a URL".to_string())?;
@@ -412,14 +430,22 @@ pub async fn run_chatgpt_ui_turn(
                     }
                 };
                 match event {
-                    // The bundled driver emits only static compatibility and
-                    // stage markers here. It must never place account, page,
-                    // prompt, or response text in a diagnostic event.
-                    DriverEvent::Diagnostic { message } => tracing::debug!(
-                        mission_id = %mission_id,
-                        diagnostic = %message,
-                        "chatgpt_ui driver diagnostic received"
-                    ),
+                    DriverEvent::Diagnostic { message } => {
+                        if let Some(diagnostic) = safe_driver_diagnostic(&message) {
+                            tracing::debug!(
+                                mission_id = %mission_id,
+                                diagnostic,
+                                "chatgpt_ui driver diagnostic received"
+                            );
+                        } else {
+                            // Driver paths are operator-configurable. Never
+                            // copy an unrecognized payload into server logs.
+                            tracing::debug!(
+                                mission_id = %mission_id,
+                                "chatgpt_ui driver emitted an unrecognized diagnostic"
+                            );
+                        }
+                    }
                     DriverEvent::TextDelta { content } => {
                         output = content;
                         let _ = events_tx.send(AgentEvent::TextDelta { content: output.clone(), mission_id: Some(mission_id) });
@@ -660,6 +686,23 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(artifact, DriverEvent::Artifact { .. }));
+    }
+
+    #[test]
+    fn driver_diagnostics_are_allowlisted_before_logging() {
+        assert_eq!(
+            safe_driver_diagnostic("stage=model_already_selected"),
+            Some("stage=model_already_selected")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("compatibility=chatgpt-ui-v2; browser=chromium"),
+            Some("compatibility=chatgpt-ui-v2; browser=chromium")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=page_loaded account=user@example.com"),
+            None
+        );
+        assert_eq!(safe_driver_diagnostic("prompt=private text"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wait on any visible composer model picker rather than the first DOM match
- allowlist static driver diagnostics before copying them into logs
- keep unrecognized configurable-driver diagnostics payload-free

Follow-up to #673.

## Verification
- `python3 -m unittest scripts.test_chatgpt_ui_driver scripts.test_chatgpt_ui_smoke scripts.test_chatgpt_ui_mock_driver`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test api::runners::chatgpt_ui::tests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive changes to UI automation and log sanitization with no auth or data-path changes beyond reducing accidental log leakage.
> 
> **Overview**
> Addresses review follow-ups for the ChatGPT UI driver by tightening **model picker hydration** and **diagnostic logging**.
> 
> The Playwright locator for the composer intelligence pill now includes **`:visible`**, so the driver waits on a shown control instead of the first DOM match (which could be hidden during hydration). The unit test expectation for that selector is updated to match.
> 
> On the Rust runner, driver **`Diagnostic`** events are filtered through **`safe_driver_diagnostic`**: only fixed compatibility/stage strings are copied into debug logs; anything else (e.g. account or prompt text from a misconfigured custom driver) is logged without the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 698e1e40f0ed98cca344469d78135a710ba17879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->