### PR TITLE
Fix guarded deployment of ChatGPT UI driver

### DIFF
--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3731,6 +3731,16 @@ async fn rollback_deployed_binary(destination: &str, backup: &str, rollback: &De
     }
 }
 
+fn chatgpt_ui_driver_install_path(configured_path: Option<&str>) -> std::path::PathBuf {
+    configured_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            std::path::PathBuf::from("/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py")
+        })
+}
+
 /// The actual deploy stream — git checkout (optional), build (optional),
 /// versioned install, then a detached `systemctl restart`. Mirrors
 /// `stream_sandboxed_update` but skips the "stop service first" step so the
@@ -3802,6 +3812,7 @@ fn stream_deploy(
         const MCP_CARGO_BIN: &str = "orchestrator-mcp";
         const ASSISTANT_MCP_CARGO_BIN: &str = "assistant-mcp";
         const PALOMA_CARGO_BIN: &str = "palomactl";
+        const CHATGPT_UI_DRIVER: &str = "chatgpt_ui_driver.py";
         let install_dest_main = current_exe.to_string_lossy().to_string();
         // Production owns the historical unsuffixed companion paths consumed
         // by Hermes. Dev/staging services install suffixed companions so their
@@ -3839,6 +3850,26 @@ fn stream_deploy(
                 }
             })
         };
+        let install_dest_chatgpt_ui_driver = chatgpt_ui_driver_install_path(
+            crate::api::mission_runner::get_backend_string_setting(
+                "chatgpt_ui",
+                "driver_path",
+            )
+            .as_deref(),
+        );
+        if !install_dest_chatgpt_ui_driver.is_absolute() {
+            yield sse(
+                "error",
+                format!(
+                    "Configured ChatGPT UI driver_path must be absolute: {}",
+                    install_dest_chatgpt_ui_driver.display()
+                ),
+                None,
+            );
+            return;
+        }
+        let install_dest_chatgpt_ui_driver =
+            install_dest_chatgpt_ui_driver.to_string_lossy().to_string();
 
         if !req.skip_build {
             yield sse("log", format!("Building {} + {} + {} + {} (cargo build, debug)", MAIN_CARGO_BIN, MCP_CARGO_BIN, ASSISTANT_MCP_CARGO_BIN, PALOMA_CARGO_BIN), Some(25));
@@ -3881,6 +3912,7 @@ fn stream_deploy(
             .join("debug")
             .join(ASSISTANT_MCP_CARGO_BIN);
         let src_paloma = repo_path.join("target").join("debug").join(PALOMA_CARGO_BIN);
+        let src_chatgpt_ui_driver = repo_path.join("scripts").join(CHATGPT_UI_DRIVER);
         if !src_main.exists() {
             yield sse("error", format!("Build artifact missing: {}. Either set skip_build=false, or point repo_path at a checkout that has been built.", src_main.display()), None);
             return;
@@ -3895,6 +3927,17 @@ fn stream_deploy(
         }
         if !src_paloma.exists() {
             yield sse("error", format!("Build artifact missing: {}. Either set skip_build=false, or point repo_path at a checkout that has been built.", src_paloma.display()), None);
+            return;
+        }
+        if !src_chatgpt_ui_driver.is_file() {
+            yield sse(
+                "error",
+                format!(
+                    "ChatGPT UI driver missing: {}. The guarded deploy requires the runtime driver to match the deployed source commit.",
+                    src_chatgpt_ui_driver.display()
+                ),
+                None,
+            );
             return;
         }
 
@@ -4078,6 +4121,134 @@ fn stream_deploy(
             }
         }
 
+        yield sse(
+            "log",
+            format!(
+                "Installing {} → {}",
+                src_chatgpt_ui_driver.display(),
+                install_dest_chatgpt_ui_driver
+            ),
+            Some(88),
+        );
+        let bkp_chatgpt_ui_driver =
+            format!("{}.pre-deploy-{}", install_dest_chatgpt_ui_driver, sha);
+        let rollback_chatgpt_ui_driver =
+            match prepare_deploy_backup(&install_dest_chatgpt_ui_driver, &bkp_chatgpt_ui_driver)
+                .await
+            {
+                Ok(rollback) => rollback,
+                Err(error) => {
+                    rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma)
+                        .await;
+                    rollback_deployed_binary(
+                        &install_dest_assistant_mcp,
+                        &bkp_assistant_mcp,
+                        &rollback_assistant_mcp,
+                    )
+                    .await;
+                    rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                    rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
+                    yield sse("error", error, None);
+                    return;
+                }
+            };
+        if let Some(parent) = std::path::Path::new(&install_dest_chatgpt_ui_driver).parent() {
+            if let Err(error) = tokio::fs::create_dir_all(parent).await {
+                rollback_deployed_binary(
+                    &install_dest_chatgpt_ui_driver,
+                    &bkp_chatgpt_ui_driver,
+                    &rollback_chatgpt_ui_driver,
+                )
+                .await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma)
+                    .await;
+                rollback_deployed_binary(
+                    &install_dest_assistant_mcp,
+                    &bkp_assistant_mcp,
+                    &rollback_assistant_mcp,
+                )
+                .await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
+                yield sse(
+                    "error",
+                    format!(
+                        "Failed to prepare ChatGPT UI driver directory {} (service binaries rolled back): {}",
+                        parent.display(),
+                        error
+                    ),
+                    None,
+                );
+                return;
+            }
+        }
+        let install_chatgpt_ui_driver = Command::new("install")
+            .args([
+                "-m",
+                "0755",
+                src_chatgpt_ui_driver.to_string_lossy().as_ref(),
+                &install_dest_chatgpt_ui_driver,
+            ])
+            .output()
+            .await;
+        match install_chatgpt_ui_driver {
+            Ok(output) if output.status.success() => {}
+            Ok(output) => {
+                rollback_deployed_binary(
+                    &install_dest_chatgpt_ui_driver,
+                    &bkp_chatgpt_ui_driver,
+                    &rollback_chatgpt_ui_driver,
+                )
+                .await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma)
+                    .await;
+                rollback_deployed_binary(
+                    &install_dest_assistant_mcp,
+                    &bkp_assistant_mcp,
+                    &rollback_assistant_mcp,
+                )
+                .await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
+                yield sse(
+                    "error",
+                    format!(
+                        "Install of ChatGPT UI driver failed (service binaries rolled back): {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                    None,
+                );
+                return;
+            }
+            Err(error) => {
+                rollback_deployed_binary(
+                    &install_dest_chatgpt_ui_driver,
+                    &bkp_chatgpt_ui_driver,
+                    &rollback_chatgpt_ui_driver,
+                )
+                .await;
+                rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma)
+                    .await;
+                rollback_deployed_binary(
+                    &install_dest_assistant_mcp,
+                    &bkp_assistant_mcp,
+                    &rollback_assistant_mcp,
+                )
+                .await;
+                rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
+                rollback_deployed_binary(&install_dest_main, &bkp_main, &rollback_main).await;
+                yield sse(
+                    "error",
+                    format!(
+                        "install command error for ChatGPT UI driver (service binaries rolled back): {}",
+                        error
+                    ),
+                    None,
+                );
+                return;
+            }
+        }
+
         let hermes_runtime = assistant_runtime_name(&state.config);
         match migrate_hermes_assistant_mcp_command(hermes_runtime, &install_dest_assistant_mcp).await {
             Ok(true) => {
@@ -4085,6 +4256,12 @@ fn stream_deploy(
             }
             Ok(false) => {}
             Err(error) => {
+                rollback_deployed_binary(
+                    &install_dest_chatgpt_ui_driver,
+                    &bkp_chatgpt_ui_driver,
+                    &rollback_chatgpt_ui_driver,
+                )
+                .await;
                 rollback_deployed_binary(&install_dest_paloma, &bkp_paloma, &rollback_paloma).await;
                 rollback_deployed_binary(&install_dest_assistant_mcp, &bkp_assistant_mcp, &rollback_assistant_mcp).await;
                 rollback_deployed_binary(&install_dest_mcp, &bkp_mcp, &rollback_mcp).await;
@@ -4093,7 +4270,18 @@ fn stream_deploy(
                 return;
             }
         }
-        yield sse("log", format!("Backups: {}, {}, {}, {}", bkp_main, bkp_mcp, bkp_assistant_mcp, bkp_paloma), Some(88));
+        yield sse(
+            "log",
+            format!(
+                "Backups: {}, {}, {}, {}, {}",
+                bkp_main,
+                bkp_mcp,
+                bkp_assistant_mcp,
+                bkp_paloma,
+                bkp_chatgpt_ui_driver
+            ),
+            Some(88),
+        );
 
         // Prune old backups now that every install succeeded. The rollback
         // paths above consume this deploy's backups via rename, so pruning
@@ -4107,6 +4295,7 @@ fn stream_deploy(
             &install_dest_mcp,
             &install_dest_assistant_mcp,
             &install_dest_paloma,
+            &install_dest_chatgpt_ui_driver,
         ] {
             let (pruned, freed) = prune_deploy_backups(dest, keep).await;
             pruned_total += pruned.len();
@@ -5181,12 +5370,12 @@ fn stream_claude_code_uninstall() -> impl Stream<Item = Result<Event, std::conve
 #[cfg(test)]
 mod tests {
     use super::{
-        evaluate_debounce, evaluate_deploy_request, expand_hermes_env_refs, extract_version_token,
-        hermes_chat_proxy_status, hermes_config_base_url, hermes_config_model_label,
-        hermes_config_yaml, hermes_service_unit, hermes_uses_native_codex,
-        install_versioned_binary_as, is_safe_repo_path, normalize_repo_path, prepare_deploy_backup,
-        prune_deploy_backups, rollback_deployed_binary, sandboxed_service_name_from_path,
-        sanitize_hermes_chat_proxy_headers, select_repo_path,
+        chatgpt_ui_driver_install_path, evaluate_debounce, evaluate_deploy_request,
+        expand_hermes_env_refs, extract_version_token, hermes_chat_proxy_status,
+        hermes_config_base_url, hermes_config_model_label, hermes_config_yaml, hermes_service_unit,
+        hermes_uses_native_codex, install_versioned_binary_as, is_safe_repo_path,
+        normalize_repo_path, prepare_deploy_backup, prune_deploy_backups, rollback_deployed_binary,
+        sandboxed_service_name_from_path, sanitize_hermes_chat_proxy_headers, select_repo_path,
         systemd_service_component_from_states, upsert_hermes_mcp_command, ComponentStatus,
         DebounceDecision, DeployRefusal, DeployRollback, DEPLOY_DEBOUNCE_SECS,
         HERMES_SERVICE_DRAIN_DROP_IN,
@@ -5269,6 +5458,22 @@ mod tests {
         assert!(updated
             .contains("sandboxed_assistant:\n    command: '/usr/local/bin/assistant-mcp-dev'"));
         assert!(!updated.contains("command: '/usr/local/bin/assistant-mcp'\n"));
+    }
+
+    #[test]
+    fn guarded_deploy_installs_chatgpt_ui_driver_at_configured_runtime_path() {
+        assert_eq!(
+            chatgpt_ui_driver_install_path(Some(" /srv/runtime/chatgpt_ui_driver.py ")),
+            std::path::PathBuf::from("/srv/runtime/chatgpt_ui_driver.py")
+        );
+        assert_eq!(
+            chatgpt_ui_driver_install_path(None),
+            std::path::PathBuf::from("/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py")
+        );
+        assert_eq!(
+            chatgpt_ui_driver_install_path(Some("  ")),
+            std::path::PathBuf::from("/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- install the configured ChatGPT UI driver from the deployed source checkout
- include the driver in guarded deploy backup, rollback, and pruning semantics
- fail closed when the deployed checkout lacks the runtime driver

## Verification
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1489 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy behavior on disk paths operators rely on for ChatGPT UI, but follows existing guarded-deploy patterns and fails closed on misconfiguration.
> 
> **Overview**
> **Guarded sandboxed deploy** now copies `scripts/chatgpt_ui_driver.py` from the checked-out commit to the runtime path used by ChatGPT UI (`chatgpt_ui` / `driver_path`, default `/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py`).
> 
> Deploy **fails early** if `driver_path` is not absolute or the driver file is missing from the repo checkout, so the live driver cannot drift from the deployed commit.
> 
> The driver install is wired into the same **backup, rollback, Hermes-migration failure rollback, and backup pruning** flow as the main and companion binaries. A unit test covers `chatgpt_ui_driver_install_path` trimming and defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce49d66b71b4c0e82aa8087c5c3e843ec1b0b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->