### PR TITLE
fix(mcp): protect active ChatGPT UI reasoning

### DIFF
--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -77,6 +77,13 @@ Match the signal to the fix. The health `recommendation` usually tells you which
   the answer is Y, move on to Z"), or switch model.
 - **Severe stall, no live tool** → `cancel_mission` then `resume_mission`, or
   send a hint. A `warning` stall with a tool running is fine — leave it.
+- **Running `chatgpt_ui` mission** → event silence alone is never stall
+  evidence. GPT Pro can expose only `Pro thinking` until visible answer text
+  begins. While the run is non-terminal and its durable heartbeat advances,
+  wait for the driver's result or explicit absolute timeout. Do **not** cancel,
+  resume, or submit a replacement: the browser profile is exclusive and the
+  duplicate would either waste the in-flight answer or contend for the same
+  profile.
 - **Idle but goal not done (gave up early)** → the #1 failure mode. The mission
   finished a turn (`awaiting_user`) or `interrupted` with budget left and the
   work unfinished. **Push it to continue**, don't let it sit:
@@ -119,7 +126,9 @@ Match the signal to the fix. The health `recommendation` usually tells you which
    mission ID before doing anything else.
 3. Treat the call as asynchronous. Poll `get_mission_health` or
    `get_mission_digest`; do not repeatedly submit replacements while the same
-   mission is active.
+   mission is active. A fresh durable run heartbeat is the liveness proof;
+   `seconds_since_activity` only measures visible UI events and may remain stale
+   during a long hidden Pro reasoning phase.
 4. Read the completed text from the mission events. If the response generated
    files, call `list_mission_shared_files`, then `download_shared_file` for each
    file you actually need.

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -2068,7 +2068,8 @@ impl AssistantMcp {
         let events = events.as_array().unwrap_or(&empty);
         let analysis = analyze_trace_events(events);
         let last_assistant = self.last_assistant_message(&id).await;
-        let mut recommendation = build_recommendation(&status, &live, &analysis);
+        let backend = mission.get("backend").and_then(Value::as_str);
+        let mut recommendation = build_recommendation(&status, backend, &live, &analysis);
         if let Some(warning) = &live_warning {
             recommendation =
                 format!("{recommendation} (Note: live runner state unavailable — {warning})");
@@ -2684,7 +2685,12 @@ fn analyze_trace_events(events: &[Value]) -> TraceAnalysis {
 }
 
 /// Synthesize a single actionable next-step hint for the babysitter.
-fn build_recommendation(status: &str, live: &Value, analysis: &TraceAnalysis) -> String {
+fn build_recommendation(
+    status: &str,
+    backend: Option<&str>,
+    live: &Value,
+    analysis: &TraceAnalysis,
+) -> String {
     if analysis.signals.contains("rate_limited") || analysis.signals.contains("capacity_limited") {
         return "Provider is rate-limiting or at capacity. Switch to a different backend/provider \
                 with update_mission_settings, or wait and resume_mission."
@@ -2721,6 +2727,16 @@ fn build_recommendation(status: &str, live: &Value, analysis: &TraceAnalysis) ->
         .get("health")
         .and_then(|health| health.get("severity"))
         .and_then(Value::as_str);
+    let live_state = live.get("state").and_then(Value::as_str);
+    if backend == Some("chatgpt_ui") && live_state == Some("running") {
+        return "ChatGPT UI Pro is still generating. The web UI may expose only a generic \
+                `Pro thinking` marker until the final answer begins, so event silence is not \
+                evidence of a stall. The driver has its own absolute timeout and the durable \
+                run heartbeat proves ownership. Do not cancel, resume, or submit another \
+                ChatGPT UI mission while this run is non-terminal; wait for its result or \
+                explicit timeout."
+            .to_string();
+    }
     if health_status == Some("stalled") {
         let seconds = live
             .get("seconds_since_activity")
@@ -3147,7 +3163,7 @@ mod tests {
         analysis.signals.insert("rate_limited");
         analysis.loop_tool = Some("read_file".to_string());
         analysis.loop_repeats = 5;
-        let rec = build_recommendation("active", &Value::Null, &analysis);
+        let rec = build_recommendation("active", None, &Value::Null, &analysis);
         assert!(rec.contains("rate-limiting") || rec.contains("capacity"));
     }
 
@@ -3158,8 +3174,23 @@ mod tests {
             "seconds_since_activity": 600,
             "health": {"status": "stalled", "severity": "severe"}
         });
-        let rec = build_recommendation("active", &live, &analysis);
+        let rec = build_recommendation("active", None, &live, &analysis);
         assert!(rec.contains("stalled"));
+    }
+
+    #[test]
+    fn recommendation_does_not_cancel_running_chatgpt_ui_for_event_silence() {
+        let analysis = TraceAnalysis::default();
+        let live = json!({
+            "state": "running",
+            "seconds_since_activity": 686,
+            "heartbeat_at": "2026-07-25T10:45:00Z",
+            "health": {"status": "stalled", "severity": "severe"}
+        });
+        let rec = build_recommendation("active", Some("chatgpt_ui"), &live, &analysis);
+        assert!(rec.contains("Pro thinking"));
+        assert!(rec.contains("Do not cancel"));
+        assert!(rec.contains("explicit timeout"));
     }
 
     #[test]
@@ -3168,7 +3199,7 @@ mod tests {
         // in src/api/control.rs). The recommendation must steer the babysitter
         // away from calling resume_mission, otherwise it gets a hard failure.
         let analysis = TraceAnalysis::default();
-        let rec = build_recommendation("not_feasible", &Value::Null, &analysis);
+        let rec = build_recommendation("not_feasible", None, &Value::Null, &analysis);
         assert!(
             !rec.contains("resume_mission with a hint"),
             "recommendation must not suggest resume_mission for not_feasible, got: {rec}"
@@ -3183,7 +3214,7 @@ mod tests {
     fn recommendation_still_recommends_resume_for_resumable_statuses() {
         for status in ["interrupted", "blocked", "failed"] {
             let analysis = TraceAnalysis::default();
-            let rec = build_recommendation(status, &Value::Null, &analysis);
+            let rec = build_recommendation(status, None, &Value::Null, &analysis);
             assert!(
                 rec.contains("resume_mission"),
                 "expected resume_mission recommendation for status {status}, got: {rec}"


### PR DESCRIPTION
## Summary
- make mission-health recommendations backend-aware
- never cancel a running ChatGPT UI Pro lane solely because visible UI events are quiet
- document durable-heartbeat and exclusive-profile handling in the Hermes mission-control skill

## Verification
- cargo fmt --all --check
- cargo check --all-targets
- cargo test (1489 passed, 1 ignored; assistant-mcp 26 passed)
- cargo clippy --all-targets -- -D warnings
- production generation-2 heartbeat observed advancing while ChatGPT Pro exposed only `Pro thinking`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to recommendation text and operator guidance; no auth, persistence, or runner control paths are modified.
> 
> **Overview**
> **Mission health** now passes the mission **backend** into `build_recommendation`. When `backend` is `chatgpt_ui` and live runner **state** is `running`, the recommendation tells babysitters to wait—visible event silence (including severe stall signals) is not treated as grounds to cancel, resume, or start a duplicate mission, because Pro can show only `Pro thinking` while the durable heartbeat still advances.
> 
> The **hermes-mission-control** skill documents the same rules: heartbeat vs `seconds_since_activity`, exclusive browser profile, and no replacement submissions during an in-flight Pro run.
> 
> Tests cover the new recommendation path and existing `build_recommendation` call sites use the added `backend` argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be8a4e966d823daf271881e3c5c03203e48dc3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->