### PR TITLE
fix(chatgpt-ui): preserve long Pro reasoning runs

### DIFF
--- a/dashboard/src/app/settings/backends/page.test.tsx
+++ b/dashboard/src/app/settings/backends/page.test.tsx
@@ -18,6 +18,7 @@ const { refreshBackendConfigs, backendConfigsFixture } = vi.hoisted(() => ({
       enabled: false,
       settings: {
         profile_dir: null,
+        profile_dirs: [],
         driver_path: null,
         python_path: null,
         proxy_server: null,
@@ -122,6 +123,7 @@ describe('BackendsPage ChatGPT UI settings', () => {
         'chatgpt_ui',
         expect.objectContaining({
           profile_dir: '/var/lib/sandboxed-sh/chatgpt-profile',
+          profile_dirs: [],
           driver_path: '/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py',
           python_path: '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python',
           proxy_server: 'socks5://127.0.0.1:10880',
@@ -129,7 +131,7 @@ describe('BackendsPage ChatGPT UI settings', () => {
           model: 'gpt-5.6-pro',
           browser: 'chromium',
           headless: false,
-          timeout_secs: 900,
+          timeout_secs: 14400,
         }),
         { enabled: true }
       );

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -31,11 +31,13 @@ const SETTINGS_BACKEND_NAMES: Record<SettingsBackendId, string> = {
 
 const CHATGPT_UI_PRODUCTION_DEFAULTS = {
   profile_dir: '/var/lib/sandboxed-sh/chatgpt-profile',
+  profile_dirs: '',
   driver_path: '/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py',
   python_path: '/opt/sandboxed-sh/chatgpt-ui-venv/bin/python',
   proxy_server: 'socks5://127.0.0.1:10880',
   display: ':93',
   model: 'gpt-5.6-pro',
+  timeout_secs: 14400,
   headless: false,
 };
 
@@ -103,12 +105,13 @@ export default function BackendsPage() {
   });
   const [chatgptUiForm, setChatgptUiForm] = useState({
     profile_dir: '',
+    profile_dirs: '',
     driver_path: '',
     python_path: 'python3',
     proxy_server: '',
     display: '',
     model: '',
-    timeout_secs: 900,
+    timeout_secs: 14400,
     headless: true,
     enabled: false,
   });
@@ -139,7 +142,7 @@ export default function BackendsPage() {
     name: backends.find((backend) => backend.id === id)?.name || SETTINGS_BACKEND_NAMES[id],
   }));
   const chatgptUiIsConfigured = Boolean(
-    chatgptUiForm.profile_dir.trim()
+    (chatgptUiForm.profile_dir.trim() || chatgptUiForm.profile_dirs.trim())
       && chatgptUiForm.driver_path.trim()
       && chatgptUiForm.python_path.trim()
   );
@@ -187,12 +190,15 @@ export default function BackendsPage() {
     const settings = chatgptUiBackendConfig.settings as Record<string, unknown>;
     setChatgptUiForm({
       profile_dir: typeof settings.profile_dir === 'string' ? settings.profile_dir : '',
+      profile_dirs: Array.isArray(settings.profile_dirs)
+        ? settings.profile_dirs.filter((value): value is string => typeof value === 'string').join('\n')
+        : '',
       driver_path: typeof settings.driver_path === 'string' ? settings.driver_path : '',
       python_path: typeof settings.python_path === 'string' ? settings.python_path : 'python3',
       proxy_server: typeof settings.proxy_server === 'string' ? settings.proxy_server : '',
       display: typeof settings.display === 'string' ? settings.display : '',
       model: typeof settings.model === 'string' ? settings.model : '',
-      timeout_secs: typeof settings.timeout_secs === 'number' ? settings.timeout_secs : 900,
+      timeout_secs: typeof settings.timeout_secs === 'number' ? settings.timeout_secs : 14400,
       headless: settings.headless !== false,
       enabled: chatgptUiBackendConfig.enabled,
     });
@@ -331,6 +337,10 @@ export default function BackendsPage() {
         'chatgpt_ui',
         {
           profile_dir: chatgptUiForm.profile_dir,
+          profile_dirs: chatgptUiForm.profile_dirs
+            .split('\n')
+            .map((value) => value.trim())
+            .filter((value, index, values) => value.length > 0 && values.indexOf(value) === index),
           driver_path: chatgptUiForm.driver_path || null,
           python_path: chatgptUiForm.python_path || 'python3',
           proxy_server: chatgptUiForm.proxy_server || null,
@@ -708,6 +718,20 @@ export default function BackendsPage() {
                 </p>
               </div>
               <div>
+                <label htmlFor="chatgpt-ui-profile-dirs" className="block text-xs text-white/60 mb-1.5">Additional browser profile pool</label>
+                <textarea
+                  id="chatgpt-ui-profile-dirs"
+                  value={chatgptUiForm.profile_dirs}
+                  onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, profile_dirs: e.target.value }))}
+                  placeholder={'/var/lib/sandboxed-sh/chatgpt-profile-2\n/var/lib/sandboxed-sh/chatgpt-profile-3'}
+                  rows={3}
+                  className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 font-mono text-sm text-white focus:outline-none focus:border-indigo-500/50"
+                />
+                <p className="mt-1.5 text-xs text-white/30">
+                  One authenticated profile per line. Each concurrent GPT Pro mission leases one free profile; missions wait when the pool is full.
+                </p>
+              </div>
+              <div>
                 <label htmlFor="chatgpt-ui-driver-path" className="block text-xs text-white/60 mb-1.5">Driver path</label>
                 <input id="chatgpt-ui-driver-path" type="text" value={chatgptUiForm.driver_path} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, driver_path: e.target.value }))} placeholder="/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
               </div>
@@ -736,7 +760,10 @@ export default function BackendsPage() {
                 </div>
                 <div>
                   <label htmlFor="chatgpt-ui-timeout" className="block text-xs text-white/60 mb-1.5">Timeout (seconds)</label>
-                  <input id="chatgpt-ui-timeout" type="number" min={30} max={7200} value={chatgptUiForm.timeout_secs} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, timeout_secs: Number(e.target.value) }))} className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+                  <input id="chatgpt-ui-timeout" type="number" min={30} max={86400} value={chatgptUiForm.timeout_secs} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, timeout_secs: Number(e.target.value) }))} className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />
+                  <p className="mt-1.5 text-xs text-white/30">
+                    Default 4 hours for long GPT Pro research; maximum 24 hours.
+                  </p>
                 </div>
               </div>
               <label className="flex items-center gap-2 text-xs text-white/60 cursor-pointer">
@@ -745,7 +772,7 @@ export default function BackendsPage() {
               </label>
               <button
                 onClick={handleSaveChatgptUiBackend}
-                disabled={savingBackend || !chatgptUiIsConfigured || (!chatgptUiForm.headless && !chatgptUiForm.display) || chatgptUiForm.timeout_secs < 30 || chatgptUiForm.timeout_secs > 7200}
+                disabled={savingBackend || !chatgptUiIsConfigured || (!chatgptUiForm.headless && !chatgptUiForm.display) || chatgptUiForm.timeout_secs < 30 || chatgptUiForm.timeout_secs > 86400}
                 className="flex items-center gap-2 rounded-lg bg-indigo-500 px-3 py-1.5 text-xs text-white hover:bg-indigo-600 transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {savingBackend ? <Loader className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -327,7 +327,9 @@ async def run(args, request) -> None:
     if not isinstance(message, str) or not message.strip():
         fail("invalid_request", "message must be a non-empty string")
         return
-    timeout_ms = max(30_000, min(int(request.get("timeout_ms", 900_000)), 7_200_000))
+    timeout_ms = max(
+        30_000, min(int(request.get("timeout_ms", 14_400_000)), 86_400_000)
+    )
     requested_model = request.get("model") or ""
     requested_download_dir = request.get("download_dir")
     download_dir = None

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -324,32 +324,30 @@ pub async fn update_backend_config(
                 .get("profile_dir")
                 .and_then(|value| value.as_str())
                 .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .ok_or_else(|| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "profile_dir is required".to_string(),
-                    )
-                })?;
-            let profile_path = std::path::Path::new(profile);
-            if !profile_path.is_absolute() {
+                .filter(|value| !value.is_empty());
+            let profile_dirs = settings
+                .get("profile_dirs")
+                .and_then(|value| value.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str())
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            if profile.is_none() && profile_dirs.is_empty() {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    "profile_dir must be an absolute path".to_string(),
+                    "profile_dir or profile_dirs is required".to_string(),
                 ));
             }
-            if !profile_path.is_dir() {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "profile_dir must name an existing directory".to_string(),
-                ));
-            }
-            let canonical_profile = profile_path.canonicalize().map_err(|error| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("failed to resolve profile_dir: {error}"),
-                )
-            })?;
+            let stored_profile = profile.map(str::to_string);
+            let stored_profile_dirs = profile_dirs
+                .iter()
+                .map(|profile| (*profile).to_string())
+                .collect::<Vec<_>>();
             let canonical_working_dir =
                 state.config.working_dir.canonicalize().map_err(|error| {
                     (
@@ -357,11 +355,32 @@ pub async fn update_backend_config(
                         format!("failed to resolve server working directory: {error}"),
                     )
                 })?;
-            if canonical_profile.starts_with(&canonical_working_dir) {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "profile_dir must be outside the sandboxed.sh working directory".to_string(),
-                ));
+            for profile in profile.into_iter().chain(profile_dirs) {
+                let profile_path = std::path::Path::new(profile);
+                if !profile_path.is_absolute() {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "ChatGPT UI profile directories must be absolute paths".to_string(),
+                    ));
+                }
+                if !profile_path.is_dir() {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!("ChatGPT UI profile directory does not exist: {profile}"),
+                    ));
+                }
+                let canonical_profile = profile_path.canonicalize().map_err(|error| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        format!("failed to resolve ChatGPT UI profile directory: {error}"),
+                    )
+                })?;
+                if canonical_profile.starts_with(&canonical_working_dir) {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "ChatGPT UI profile directories must be outside the sandboxed.sh working directory".to_string(),
+                    ));
+                }
             }
             let driver_path = settings
                 .get("driver_path")
@@ -395,11 +414,11 @@ pub async fn update_backend_config(
             let timeout_secs = settings
                 .get("timeout_secs")
                 .and_then(|value| value.as_u64())
-                .unwrap_or(900);
-            if !(30..=7200).contains(&timeout_secs) {
+                .unwrap_or(14_400);
+            if !(30..=86_400).contains(&timeout_secs) {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    "timeout_secs must be between 30 and 7200".to_string(),
+                    "timeout_secs must be between 30 and 86400".to_string(),
                 ));
             }
             let browser = settings
@@ -484,7 +503,8 @@ pub async fn update_backend_config(
                 }
             }
             serde_json::json!({
-                "profile_dir": canonical_profile,
+                "profile_dir": stored_profile,
+                "profile_dirs": stored_profile_dirs,
                 "driver_path": driver_path,
                 "python_path": python_path,
                 "browser": browser,

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -250,10 +250,17 @@ fn projected_running_health(
     seconds_since_activity: u64,
     tool_call_in_flight: bool,
     waiting_remote_job: bool,
+    backend: Option<&str>,
 ) -> super::mission_runner::MissionHealth {
-    if waiting_remote_job {
+    if waiting_remote_job
+        || (backend == Some("chatgpt_ui")
+            && state == super::mission_runner::MissionRunState::Running)
+    {
         // A fresh durable remote-job heartbeat is process-backed liveness, not
         // the provisional unmatched-tool hint that expires after ten minutes.
+        // ChatGPT UI is likewise bounded by its driver's absolute timeout, but
+        // Pro may expose no visible answer events during a long reasoning
+        // phase. Its run heartbeat, rather than DOM text, is execution truth.
         return super::mission_runner::MissionHealth::Healthy;
     }
     super::mission_runner::running_health(state, seconds_since_activity, tool_call_in_flight)
@@ -2549,6 +2556,10 @@ async fn get_running_missions(
         let mut row = actor_by_mission.remove(&run.mission_id).unwrap_or_else(|| {
             super::mission_runner::RunningMissionInfo {
                 mission_id: run.mission_id,
+                // A detached durable row does not prove which backend process
+                // owns the in-flight turn. Do not infer it from mutable
+                // next-turn mission settings.
+                backend_id: None,
                 state: run.execution_state.as_str().to_string(),
                 queue_len: 0,
                 history_len: 0,
@@ -14061,6 +14072,10 @@ async fn control_actor_loop(
     // Track which mission the main `running` task is actually working on.
     // This is different from `current_mission` which can change when user creates a new mission.
     let mut running_mission_id: Option<Uuid> = None;
+    // Backend captured for the currently executing primary turn. Updating a
+    // mission's settings while it runs must not change watchdog semantics for
+    // that in-flight process.
+    let mut running_backend_id: Option<String> = None;
     let mut running_run: Option<MissionRun> = None;
     let mut execution_heartbeat = tokio::time::interval(std::time::Duration::from_secs(15));
     execution_heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -14361,6 +14376,7 @@ async fn control_actor_loop(
                 if let Some(run) = running_run.clone() {
                     leases.push((
                         run,
+                        running_backend_id.clone(),
                         main_runner_active_tool_calls
                             .load(std::sync::atomic::Ordering::Relaxed),
                         main_runner_last_activity.elapsed().as_secs(),
@@ -14370,6 +14386,7 @@ async fn control_actor_loop(
                     runner.durable_run.clone().map(|run| {
                         (
                             run,
+                            Some(runner.backend_id.clone()),
                             runner
                                 .active_tool_calls
                                 .load(std::sync::atomic::Ordering::Relaxed),
@@ -14395,7 +14412,7 @@ async fn control_actor_loop(
                         }
                     }
                 };
-                for (run, active_tool_calls, idle_secs) in leases {
+                for (run, backend_id, active_tool_calls, idle_secs) in leases {
                     let mut live_registered_tools = 0usize;
                     let mut has_registered_user_wait = false;
                     let has_durable_remote_job = remote_jobs_by_mission.contains(&run.mission_id);
@@ -14466,6 +14483,15 @@ async fn control_actor_loop(
                         && state != MissionExecutionState::WaitingRemoteJob
                         && live_registered_tools == 0
                     {
+                        if backend_id.as_deref() == Some("chatgpt_ui") {
+                            tracing::debug!(
+                                mission_id = %run.mission_id,
+                                run_id = %run.run_id,
+                                idle_secs,
+                                "Keeping ChatGPT UI run alive until its managed absolute timeout"
+                            );
+                            continue;
+                        }
                         tracing::warn!(
                             mission_id = %run.mission_id,
                             run_id = %run.run_id,
@@ -15573,6 +15599,7 @@ async fn control_actor_loop(
                                 let agent_override = per_msg_agent.or(mission_agent);
                                 running_cancel = Some(cancel.clone());
                                 running_mission_id = mission_id;
+                                running_backend_id = backend_id.clone();
                                 // Reset activity tracking when new task starts
                                 main_runner_last_activity = std::time::Instant::now();
                                 main_runner_activity = None;
@@ -15591,6 +15618,7 @@ async fn control_actor_loop(
                                     Err(error) => {
                                         running_cancel = None;
                                         running_mission_id = None;
+                                        running_backend_id = None;
                                         // The queue dequeue was already persisted, but no
                                         // run owns this delivery. Roll back the just-appended
                                         // history entry and release the deterministic message
@@ -16471,6 +16499,7 @@ async fn control_actor_loop(
                                         > 0;
                                 running_list.push(super::mission_runner::RunningMissionInfo {
                                     mission_id,
+                                    backend_id: running_backend_id.clone(),
                                     state: state_label.to_string(),
                                     queue_len: queue.len(),
                                     history_len: history.len(),
@@ -16481,6 +16510,7 @@ async fn control_actor_loop(
                                         seconds_since_activity,
                                         tool_call_in_flight,
                                         waiting_remote_job,
+                                        running_backend_id.as_deref(),
                                     ),
                                     expected_deliverables: 0,
                                     current_activity: main_runner_activity.clone(),
@@ -16854,6 +16884,7 @@ async fn control_actor_loop(
                                         running_cancel = Some(cancel.clone());
                                         // Capture which mission this task is working on (the resumed mission)
                                         running_mission_id = Some(mission_id);
+                                        running_backend_id = backend_id.clone();
                                         // Reset activity tracking so stall detection starts fresh
                                         main_runner_last_activity = std::time::Instant::now();
                                         main_runner_activity = None;
@@ -16872,6 +16903,7 @@ async fn control_actor_loop(
                                             Err(error) => {
                                                 running_cancel = None;
                                                 running_mission_id = None;
+                                                running_backend_id = None;
                                                 let _ = respond.send(Err(format!(
                                                     "Failed to acquire mission run lease: {error}"
                                                 )));
@@ -17307,6 +17339,7 @@ async fn control_actor_loop(
                     running = None;
                     running_cancel = None;
                     running_mission_id = None;
+                    running_backend_id = None;
                     main_runner_activity = None;
                     main_runner_active_tool_calls
                         .store(0, std::sync::atomic::Ordering::Relaxed);
@@ -17932,6 +17965,7 @@ async fn control_actor_loop(
                     // Per-message agent overrides mission agent
                     let agent_override = per_msg_agent.or(mission_agent);
                     running_mission_id = mission_id;
+                    running_backend_id = backend_id.clone();
                     // Reset activity tracking when new task starts
                     main_runner_last_activity = std::time::Instant::now();
                     main_runner_activity = None;
@@ -18584,6 +18618,7 @@ async fn control_actor_loop(
                 }
                 running_cancel = None;
                 running_mission_id = None;
+                running_backend_id = None;
                 main_runner_activity = None;
                 main_runner_active_tool_calls
                     .store(0, std::sync::atomic::Ordering::Relaxed);
@@ -27714,6 +27749,7 @@ Investigate <service/> failures.
             600,
             true,
             true,
+            None,
         );
         assert!(matches!(
             health,
@@ -27725,10 +27761,26 @@ Investigate <service/> failures.
             600,
             true,
             false,
+            None,
         );
         assert!(matches!(
             without_remote_job,
             crate::api::mission_runner::MissionHealth::Stalled { .. }
+        ));
+    }
+
+    #[test]
+    fn chatgpt_ui_hidden_reasoning_keeps_projected_health_healthy() {
+        let health = projected_running_health(
+            crate::api::mission_runner::MissionRunState::Running,
+            STUCK_SECONDS * 2,
+            false,
+            false,
+            Some("chatgpt_ui"),
+        );
+        assert!(matches!(
+            health,
+            crate::api::mission_runner::MissionHealth::Healthy
         ));
     }
 

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -3948,6 +3948,31 @@ pub(crate) fn get_backend_string_setting(backend_id: &str, key: &str) -> Option<
     None
 }
 
+/// Read a string-array setting from a backend's config entry.
+pub(crate) fn get_backend_string_list_setting(backend_id: &str, key: &str) -> Vec<String> {
+    let Some(configs) = read_backend_configs() else {
+        return Vec::new();
+    };
+    configs
+        .into_iter()
+        .find_map(|config| {
+            (config.get("id")?.as_str()? == backend_id).then(|| {
+                config
+                    .get("settings")
+                    .and_then(|settings| settings.get(key))
+                    .and_then(|value| value.as_array())
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+        })
+        .unwrap_or_default()
+}
+
 /// Read an unsigned integer setting from a backend's config entry.
 pub(crate) fn get_backend_u64_setting(backend_id: &str, key: &str) -> Option<u64> {
     let configs = read_backend_configs()?;
@@ -8536,6 +8561,10 @@ fn find_subslice(haystack: &[char], needle: &str, from: usize) -> Option<usize> 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RunningMissionInfo {
     pub mission_id: Uuid,
+    /// Backend captured when this runner started. Mission settings may change
+    /// concurrently, but those changes apply only to a later turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_id: Option<String>,
     pub state: String,
     pub queue_len: usize,
     pub history_len: usize,
@@ -8573,6 +8602,7 @@ impl From<&MissionRunner> for RunningMissionInfo {
             > 0;
         Self {
             mission_id: runner.mission_id,
+            backend_id: Some(runner.backend_id.clone()),
             state: match runner.state {
                 MissionRunState::Queued => "queued".to_string(),
                 MissionRunState::Running => "running".to_string(),
@@ -8583,7 +8613,15 @@ impl From<&MissionRunner> for RunningMissionInfo {
             history_len: runner.history.len(),
             seconds_since_activity,
             tool_call_in_flight,
-            health: running_health(runner.state, seconds_since_activity, tool_call_in_flight),
+            health: if runner.backend_id == "chatgpt_ui" && runner.state == MissionRunState::Running
+            {
+                // GPT Pro can keep its visible DOM at `Pro thinking` for the
+                // whole hidden reasoning phase. The runner/driver owns an
+                // absolute deadline, so DOM-event age is not stall evidence.
+                MissionHealth::Healthy
+            } else {
+                running_health(runner.state, seconds_since_activity, tool_call_in_flight)
+            },
             expected_deliverables: runner.deliverables.deliverables.len(),
             current_activity: runner.current_activity.clone(),
             subtask_total: runner.subtasks.len(),

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -330,11 +330,12 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
                 }),
                 "chatgpt_ui" => serde_json::json!({
                     "profile_dir": null,
+                    "profile_dirs": [],
                     "driver_path": null,
                     "python_path": "python3",
                     "browser": "chromium",
                     "headless": true,
-                    "timeout_secs": 900,
+                    "timeout_secs": 14400,
                     "model": null
                 }),
                 _ => serde_json::json!({}),

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -20,7 +20,9 @@ use uuid::Uuid;
 
 use crate::agents::{AgentResult, TerminalReason};
 use crate::api::control::AgentEvent;
-use crate::api::mission_runner::{get_backend_string_setting, get_backend_u64_setting};
+use crate::api::mission_runner::{
+    get_backend_string_list_setting, get_backend_string_setting, get_backend_u64_setting,
+};
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -63,7 +65,7 @@ enum DriverEvent {
 struct Settings {
     driver_path: PathBuf,
     python_path: String,
-    profile_dir: PathBuf,
+    profile_dirs: Vec<PathBuf>,
     browser: String,
     proxy_server: Option<String>,
     display: Option<String>,
@@ -79,7 +81,7 @@ impl Drop for ProfileLock {
     }
 }
 
-fn lock_profile(profile_dir: &Path) -> Result<ProfileLock, String> {
+fn try_lock_profile(profile_dir: &Path) -> Result<Option<ProfileLock>, String> {
     let name = profile_dir
         .file_name()
         .and_then(|name| name.to_str())
@@ -95,10 +97,59 @@ fn lock_profile(profile_dir: &Path) -> Result<ProfileLock, String> {
         .write(true)
         .open(&lock_path)
         .map_err(|error| format!("cannot create ChatGPT UI profile lock: {error}"))?;
-    file.try_lock_exclusive().map_err(|_| {
-        "ChatGPT UI profile is already in use; each concurrent mission needs a separate profile directory".to_string()
-    })?;
-    Ok(ProfileLock(file))
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(ProfileLock(file))),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(format!("cannot lock ChatGPT UI profile: {error}")),
+    }
+}
+
+async fn acquire_profile(
+    profile_dirs: &[PathBuf],
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    cancel: &CancellationToken,
+) -> Result<(usize, PathBuf, ProfileLock), AgentResult> {
+    let mut announced_wait = false;
+    loop {
+        for (slot, profile_dir) in profile_dirs.iter().enumerate() {
+            match try_lock_profile(profile_dir) {
+                Ok(Some(lock)) => return Ok((slot, profile_dir.clone(), lock)),
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(AgentResult::failure(error, 0)
+                        .with_terminal_reason(TerminalReason::LlmError))
+                }
+            }
+        }
+        if !announced_wait {
+            let _ = events_tx.send(AgentEvent::MissionActivity {
+                label: "Waiting for a ChatGPT UI browser slot…".to_string(),
+                tool_name: "chatgpt_ui_profile_pool".to_string(),
+                mission_id: Some(mission_id),
+            });
+            announced_wait = true;
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let shutdown = crate::api::routes::is_shutdown_initiated();
+                return Err(AgentResult::failure(
+                    if shutdown {
+                        "Server restart — paused while waiting for a ChatGPT UI browser slot."
+                    } else {
+                        "Mission cancelled while waiting for a ChatGPT UI browser slot"
+                    },
+                    0,
+                )
+                .with_terminal_reason(if shutdown {
+                    TerminalReason::ServerShutdown
+                } else {
+                    TerminalReason::Cancelled
+                }));
+            }
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+        }
+    }
 }
 
 async fn prepare_download_dir(work_dir: &Path) -> Result<PathBuf, String> {
@@ -165,6 +216,19 @@ fn validate_artifact_receipt(
     ))
 }
 
+fn timeout_result(timeout: Duration) -> AgentResult {
+    AgentResult::failure(
+        format!("chatgpt_ui timed out after {} seconds", timeout.as_secs()),
+        0,
+    )
+    .with_terminal_reason(TerminalReason::LlmError)
+    .with_data(serde_json::json!({
+        "provider_error_source": "chatgpt_ui_driver",
+        "failure_class": crate::agents::FailureClass::ProviderError,
+        "classification_source": "structured",
+    }))
+}
+
 fn parse_bool_setting(key: &str, default: bool) -> bool {
     crate::api::mission_runner::get_backend_bool_setting("chatgpt_ui", key).unwrap_or(default)
 }
@@ -219,17 +283,17 @@ fn validate_display(value: &str) -> Result<(), String> {
 }
 
 fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
-    let profile = get_backend_string_setting("chatgpt_ui", "profile_dir")
-        .ok_or_else(|| "chatgpt_ui profile_dir is required".to_string())?;
-    let profile_dir = PathBuf::from(profile);
-    if !profile_dir.is_absolute() {
-        return Err("chatgpt_ui profile_dir must be an absolute path".to_string());
-    }
-    if !profile_dir.is_dir() {
-        return Err(format!(
-            "chatgpt_ui profile_dir does not exist or is not a directory: {}",
-            profile_dir.display()
-        ));
+    let mut configured_profiles = get_backend_string_setting("chatgpt_ui", "profile_dir")
+        .into_iter()
+        .chain(get_backend_string_list_setting(
+            "chatgpt_ui",
+            "profile_dirs",
+        ))
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    configured_profiles.dedup();
+    if configured_profiles.is_empty() {
+        return Err("chatgpt_ui profile_dir or profile_dirs is required".to_string());
     }
     let driver_path = get_backend_string_setting("chatgpt_ui", "driver_path")
         .map(PathBuf::from)
@@ -243,20 +307,37 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
             driver_path.display()
         ));
     }
-    let canonical_profile = profile_dir
-        .canonicalize()
-        .map_err(|error| format!("failed to resolve chatgpt_ui profile_dir: {error}"))?;
-    if let Ok(canonical_working_dir) = app_working_dir.canonicalize() {
-        if canonical_profile.starts_with(canonical_working_dir) {
+    let canonical_working_dir = app_working_dir.canonicalize().ok();
+    let mut profile_dirs = Vec::with_capacity(configured_profiles.len());
+    for profile_dir in configured_profiles {
+        if !profile_dir.is_absolute() {
+            return Err("chatgpt_ui profile directories must be absolute paths".to_string());
+        }
+        if !profile_dir.is_dir() {
+            return Err(format!(
+                "chatgpt_ui profile directory does not exist or is not a directory: {}",
+                profile_dir.display()
+            ));
+        }
+        let canonical_profile = profile_dir
+            .canonicalize()
+            .map_err(|error| format!("failed to resolve chatgpt_ui profile directory: {error}"))?;
+        if canonical_working_dir
+            .as_ref()
+            .is_some_and(|working_dir| canonical_profile.starts_with(working_dir))
+        {
             return Err(
-                "chatgpt_ui profile_dir must be outside the sandboxed.sh working directory"
+                "chatgpt_ui profile directories must be outside the sandboxed.sh working directory"
                     .to_string(),
             );
         }
+        if !profile_dirs.contains(&canonical_profile) {
+            profile_dirs.push(canonical_profile);
+        }
     }
-    let timeout_secs = get_backend_u64_setting("chatgpt_ui", "timeout_secs").unwrap_or(900);
-    if !(30..=7200).contains(&timeout_secs) {
-        return Err("chatgpt_ui timeout_secs must be between 30 and 7200".to_string());
+    let timeout_secs = get_backend_u64_setting("chatgpt_ui", "timeout_secs").unwrap_or(14_400);
+    if !(30..=86_400).contains(&timeout_secs) {
+        return Err("chatgpt_ui timeout_secs must be between 30 and 86400".to_string());
     }
     let browser = get_backend_string_setting("chatgpt_ui", "browser")
         .unwrap_or_else(|| "chromium".to_string());
@@ -283,7 +364,7 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
         driver_path,
         python_path: get_backend_string_setting("chatgpt_ui", "python_path")
             .unwrap_or_else(|| "python3".to_string()),
-        profile_dir: canonical_profile,
+        profile_dirs,
         browser,
         proxy_server,
         display,
@@ -308,12 +389,11 @@ pub async fn run_chatgpt_ui_turn(
             return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::AuthError)
         }
     };
-    let _profile_lock = match lock_profile(&settings.profile_dir) {
-        Ok(lock) => lock,
-        Err(error) => {
-            return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::LlmError)
-        }
-    };
+    let (profile_slot, profile_dir, _profile_lock) =
+        match acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel).await {
+            Ok(lease) => lease,
+            Err(result) => return result,
+        };
     let download_dir = match prepare_download_dir(work_dir).await {
         Ok(path) => path,
         Err(error) => {
@@ -325,7 +405,7 @@ pub async fn run_chatgpt_ui_turn(
     command
         .arg(&settings.driver_path)
         .arg("--profile-dir")
-        .arg(&settings.profile_dir)
+        .arg(&profile_dir)
         .arg("--browser")
         .arg(&settings.browser)
         .arg("--headless")
@@ -406,9 +486,7 @@ pub async fn run_chatgpt_ui_turn(
             }
             _ = &mut deadline => {
                 kill_child_tree(&mut child).await;
-                return AgentResult::failure(
-                    format!("chatgpt_ui timed out after {} seconds", settings.timeout.as_secs()), 0
-                ).with_terminal_reason(TerminalReason::LlmError);
+                return timeout_result(settings.timeout);
             }
             line = lines.next_line() => {
                 let line = match line {
@@ -508,14 +586,7 @@ pub async fn run_chatgpt_ui_turn(
     let remaining = deadline_at.saturating_duration_since(Instant::now());
     if remaining.is_zero() {
         kill_child_tree(&mut child).await;
-        return AgentResult::failure(
-            format!(
-                "chatgpt_ui timed out after {} seconds",
-                settings.timeout.as_secs()
-            ),
-            0,
-        )
-        .with_terminal_reason(TerminalReason::LlmError);
+        return timeout_result(settings.timeout);
     }
     let status = tokio::select! {
         _ = cancel.cancelled() => {
@@ -535,9 +606,7 @@ pub async fn run_chatgpt_ui_turn(
         }
         _ = &mut deadline => {
             kill_child_tree(&mut child).await;
-            return AgentResult::failure(
-                format!("chatgpt_ui timed out after {} seconds", settings.timeout.as_secs()), 0
-            ).with_terminal_reason(TerminalReason::LlmError);
+            return timeout_result(settings.timeout);
         }
         status = tokio::time::timeout(remaining.min(Duration::from_secs(5)), child.wait()) => status,
     };
@@ -550,14 +619,7 @@ pub async fn run_chatgpt_ui_turn(
         Err(_) => {
             if Instant::now() >= deadline_at {
                 kill_child_tree(&mut child).await;
-                return AgentResult::failure(
-                    format!(
-                        "chatgpt_ui timed out after {} seconds",
-                        settings.timeout.as_secs()
-                    ),
-                    0,
-                )
-                .with_terminal_reason(TerminalReason::LlmError);
+                return timeout_result(settings.timeout);
             }
             terminate_child_tree(&mut child).await;
             return AgentResult::failure("chatgpt_ui driver did not exit after completion", 0)
@@ -609,6 +671,7 @@ pub async fn run_chatgpt_ui_turn(
         .with_data(serde_json::json!({
             "backend": "chatgpt_ui",
             "usage_source": "chatgpt_web_subscription",
+            "profile_slot": profile_slot + 1,
             "artifact_count": artifact_count,
             "artifact_bytes": artifact_bytes,
         }));
@@ -706,14 +769,54 @@ mod tests {
     }
 
     #[test]
+    fn timeout_is_a_structured_provider_failure() {
+        let result = timeout_result(Duration::from_secs(900));
+        assert!(!result.success);
+        assert_eq!(result.terminal_reason, Some(TerminalReason::LlmError));
+        assert_eq!(result.output, "chatgpt_ui timed out after 900 seconds");
+        assert_eq!(
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("failure_class"))
+                .and_then(serde_json::Value::as_str),
+            Some("provider_error")
+        );
+    }
+
+    #[test]
     fn profile_lock_is_exclusive_and_reusable() {
         let root = tempfile::tempdir().unwrap();
         let profile = root.path().join("profile");
         std::fs::create_dir(&profile).unwrap();
-        let first = lock_profile(&profile).unwrap();
-        assert!(lock_profile(&profile).is_err());
+        let first = try_lock_profile(&profile).unwrap().unwrap();
+        assert!(try_lock_profile(&profile).unwrap().is_none());
         drop(first);
-        assert!(lock_profile(&profile).is_ok());
+        assert!(try_lock_profile(&profile).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn profile_pool_uses_the_next_free_authenticated_slot() {
+        let root = tempfile::tempdir().unwrap();
+        let first_profile = root.path().join("profile-1");
+        let second_profile = root.path().join("profile-2");
+        std::fs::create_dir(&first_profile).unwrap();
+        std::fs::create_dir(&second_profile).unwrap();
+        let _first_lease = try_lock_profile(&first_profile).unwrap().unwrap();
+        let (events_tx, _) = broadcast::channel(8);
+        let cancel = CancellationToken::new();
+
+        let (slot, selected, _lease) = acquire_profile(
+            &[first_profile, second_profile.clone()],
+            Uuid::new_v4(),
+            &events_tx,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(slot, 1);
+        assert_eq!(selected, second_profile);
     }
 
     #[test]

--- a/src/api/supervision.rs
+++ b/src/api/supervision.rs
@@ -29,7 +29,7 @@ use super::control::MissionStatus;
 #[allow(unused_imports)]
 use super::control::*;
 use super::mission_runner::TOOL_CALL_STALL_GRACE_SECS;
-use super::mission_store::{MissionExecutionState, MissionStore};
+use super::mission_store::{MissionExecutionState, MissionRun, MissionStore};
 
 mod bg_autoresume;
 
@@ -349,6 +349,21 @@ fn detached_run_proves_durable_liveness(state: MissionExecutionState) -> bool {
     state == MissionExecutionState::WaitingRemoteJob
 }
 
+fn chatgpt_ui_run_proves_liveness(run: &MissionRun, now: chrono::DateTime<chrono::Utc>) -> bool {
+    if run.execution_state == MissionExecutionState::Stopping || run.execution_state.is_terminal() {
+        return false;
+    }
+    chrono::DateTime::parse_from_rfc3339(&run.heartbeat_at)
+        .ok()
+        .map(|heartbeat| {
+            (now - heartbeat.with_timezone(&chrono::Utc))
+                .num_seconds()
+                .max(0)
+                <= 60
+        })
+        .unwrap_or(false)
+}
+
 async fn mission_has_detached_durable_run(
     mission_store: &dyn MissionStore,
     mission_id: Uuid,
@@ -439,6 +454,28 @@ pub(crate) async fn stuck_mission_watchdog_loop(
         for info in &running_list {
             if info.seconds_since_activity < STUCK_SECONDS {
                 continue;
+            }
+            let is_chatgpt_ui = info.backend_id.as_deref() == Some("chatgpt_ui");
+            if is_chatgpt_ui {
+                match mission_store.get_active_mission_run(info.mission_id).await {
+                    Ok(Some(run)) if chatgpt_ui_run_proves_liveness(&run, chrono::Utc::now()) => {
+                        tracing::debug!(
+                            mission_id = %info.mission_id,
+                            seconds_since_activity = info.seconds_since_activity,
+                            "Stuck-mission watchdog: fresh ChatGPT UI run heartbeat proves liveness"
+                        );
+                        continue;
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            mission_id = %info.mission_id,
+                            %error,
+                            "Stuck-mission watchdog: cannot inspect ChatGPT UI run; deferring cancellation"
+                        );
+                        continue;
+                    }
+                }
             }
             if execution_state_proves_durable_liveness(&info.state) {
                 tracing::debug!(
@@ -809,5 +846,31 @@ mod tests {
         assert!(!detached_run_proves_durable_liveness(
             MissionExecutionState::WaitingTool
         ));
+    }
+
+    #[test]
+    fn fresh_chatgpt_ui_run_heartbeat_proves_liveness_until_driver_timeout() {
+        let now = chrono::Utc::now();
+        let mut run = MissionRun {
+            run_id: Uuid::new_v4(),
+            mission_id: Uuid::new_v4(),
+            generation: 1,
+            execution_state: MissionExecutionState::Running,
+            owner_actor_id: "control:test".to_string(),
+            scope_unit: None,
+            started_at: now.to_rfc3339(),
+            heartbeat_at: (now - chrono::Duration::seconds(30)).to_rfc3339(),
+            stopping_at: None,
+            ended_at: None,
+            terminal_reason: None,
+        };
+        assert!(chatgpt_ui_run_proves_liveness(&run, now));
+
+        run.heartbeat_at = (now - chrono::Duration::seconds(61)).to_rfc3339();
+        assert!(!chatgpt_ui_run_proves_liveness(&run, now));
+
+        run.heartbeat_at = now.to_rfc3339();
+        run.execution_state = MissionExecutionState::Stopping;
+        assert!(!chatgpt_ui_run_proves_liveness(&run, now));
     }
 }

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -2691,6 +2691,16 @@ fn build_recommendation(
     live: &Value,
     analysis: &TraceAnalysis,
 ) -> String {
+    let live_state = live.get("state").and_then(Value::as_str);
+    if backend == Some("chatgpt_ui") && live_state == Some("running") {
+        return "ChatGPT UI Pro is still generating. The web UI may expose only a generic \
+                `Pro thinking` marker until the final answer begins, so event silence is not \
+                evidence of a stall. The driver has its own absolute timeout and the durable \
+                run heartbeat proves ownership. Do not cancel, resume, or submit another \
+                ChatGPT UI mission while this run is non-terminal; wait for its result or \
+                explicit timeout."
+            .to_string();
+    }
     if analysis.signals.contains("rate_limited") || analysis.signals.contains("capacity_limited") {
         return "Provider is rate-limiting or at capacity. Switch to a different backend/provider \
                 with update_mission_settings, or wait and resume_mission."
@@ -2727,16 +2737,6 @@ fn build_recommendation(
         .get("health")
         .and_then(|health| health.get("severity"))
         .and_then(Value::as_str);
-    let live_state = live.get("state").and_then(Value::as_str);
-    if backend == Some("chatgpt_ui") && live_state == Some("running") {
-        return "ChatGPT UI Pro is still generating. The web UI may expose only a generic \
-                `Pro thinking` marker until the final answer begins, so event silence is not \
-                evidence of a stall. The driver has its own absolute timeout and the durable \
-                run heartbeat proves ownership. Do not cancel, resume, or submit another \
-                ChatGPT UI mission while this run is non-terminal; wait for its result or \
-                explicit timeout."
-            .to_string();
-    }
     if health_status == Some("stalled") {
         let seconds = live
             .get("seconds_since_activity")
@@ -3180,7 +3180,10 @@ mod tests {
 
     #[test]
     fn recommendation_does_not_cancel_running_chatgpt_ui_for_event_silence() {
-        let analysis = TraceAnalysis::default();
+        let mut analysis = TraceAnalysis::default();
+        // A previous generation's terminal transport error can remain in the
+        // bounded trace window. It must not preempt a healthy replacement run.
+        analysis.signals.insert("network_error");
         let live = json!({
             "state": "running",
             "seconds_since_activity": 686,


### PR DESCRIPTION
## Summary
- exempt active ChatGPT UI runs from event-silence cancellation while their durable heartbeat is fresh
- pin watchdog decisions to the backend captured by the in-flight runner, not mutable next-turn mission settings
- prioritize a live ChatGPT UI run over historical trace errors from older generations
- keep driver timeouts as structured provider failures instead of soft-promoting them to successful turns
- raise the default GPT Pro deadline from 15 minutes to 4 hours, with a configurable 24-hour maximum
- add a pool of authenticated Chromium profiles so independent GPT Pro missions can run concurrently; busy missions wait for a free slot

## Production evidence
- mission `073e592e-8fc4-448a-8a5d-c2ca003e704c` kept a fresh 15-second heartbeat while the UI exposed only `Pro thinking`
- the old 900-second deadline expired exactly at 900s, proving the driver deadline works independently of visible output
- the timeout result was incorrectly soft-promoted by the old binary; the structured failure regression prevents that

## Verification
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` (1493 passed, 1 ignored; assistant-MCP 26 passed)
- `cargo clippy --all-targets -- -D warnings` (prior head; CI reruns on this head)
- ChatGPT UI settings unit test
- dashboard lint (no errors) and production build
- Python driver bytecode compilation
- profile-pool lock/selection, watchdog, projected-health, historical-signal, and structured-timeout regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission supervision, stall cancellation, and backend config validation for an experimental harness; mis-tuned heartbeats or profile pool sizing could leave runs stuck or block concurrency, but scope is mostly chatgpt_ui-specific with regressions added.
> 
> **Overview**
> **ChatGPT UI** gains a **multi-profile browser pool** (`profile_dirs`), dashboard/API validation, and **lease-based locking** so concurrent GPT Pro missions wait for a free slot instead of failing on a single profile.
> 
> **Timeouts** move from a **15-minute default to 4 hours** (up to **24 hours** in the driver, API, and settings UI). Driver timeouts are returned as **structured provider failures** rather than soft successes.
> 
> **Liveness and watchdog behavior** now treat active `chatgpt_ui` runs as healthy during long silent “Pro thinking” phases: health projection, supervision, and the 15-minute idle interrupt skip ChatGPT UI when the **durable run heartbeat** is fresh. Watchdog decisions use **`running_backend_id`** captured at turn start so mid-run mission setting changes do not alter in-flight semantics. Detached durable rows no longer infer backend from mutable settings. Assistant MCP **prioritizes a live ChatGPT UI run** over stale trace errors when recommending babysitter actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b030726e1b9e0b35e00c8e4408f26d64c308c1ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->