### PR TITLE
feat(chatgpt-ui): profile pool hardening — slot health, safe Chromium cleanup, telemetry

### DIFF
--- a/dashboard/src/app/settings/backends/page.test.tsx
+++ b/dashboard/src/app/settings/backends/page.test.tsx
@@ -5,8 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import BackendsPage from './page';
 import { updateBackendConfig } from '@/lib/api';
 
-const { refreshBackendConfigs, backendConfigsFixture } = vi.hoisted(() => ({
+const { refreshBackendConfigs, getChatgptUiProfilePoolMock, backendConfigsFixture } = vi.hoisted(() => ({
   refreshBackendConfigs: vi.fn(),
+  getChatgptUiProfilePoolMock: vi.fn(),
   backendConfigsFixture: {
     opencode: {
       enabled: true,
@@ -53,6 +54,7 @@ vi.mock('@/lib/api', () => ({
   ]),
   updateBackendConfig: vi.fn().mockResolvedValue({ message: 'saved' }),
   getProviderForBackend: vi.fn().mockResolvedValue({ configured: false }),
+  getChatgptUiProfilePool: getChatgptUiProfilePoolMock,
   getHealth: vi.fn().mockResolvedValue({ version: '1.3.0' }),
   getSettings: vi.fn().mockResolvedValue({
     max_parallel_missions: 1,
@@ -82,6 +84,8 @@ describe('BackendsPage ChatGPT UI settings', () => {
   beforeEach(() => {
     mockedUpdateBackendConfig.mockClear();
     refreshBackendConfigs.mockClear();
+    getChatgptUiProfilePoolMock.mockReset();
+    getChatgptUiProfilePoolMock.mockResolvedValue({ slots: [] });
   });
 
   afterEach(() => {
@@ -137,5 +141,44 @@ describe('BackendsPage ChatGPT UI settings', () => {
       );
     });
     expect(refreshBackendConfigs).toHaveBeenCalled();
+  });
+
+  it('shows profile pool slot health once runtime paths are configured', async () => {
+    getChatgptUiProfilePoolMock.mockResolvedValue({
+      slots: [
+        {
+          slot: 1,
+          profile_name: 'chatgpt-profile',
+          state: 'in_use',
+          consecutive_failures: 0,
+        },
+        {
+          slot: 2,
+          profile_name: 'chatgpt-profile-2',
+          state: 'quarantined',
+          consecutive_failures: 1,
+          quarantine_remaining_secs: 1700,
+          last_failure: 'auth',
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'ChatGPT UI (experimental)' }));
+
+    expect(screen.queryByTestId('chatgpt-ui-pool-status')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use production defaults' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chatgpt-ui-pool-status')).toBeVisible();
+    });
+    expect(screen.getByText('chatgpt-profile')).toBeVisible();
+    expect(screen.getByText('in use')).toBeVisible();
+    expect(screen.getByText('chatgpt-profile-2')).toBeVisible();
+    expect(screen.getByText('quarantined')).toBeVisible();
+    expect(screen.getByText(/auth failure/)).toBeVisible();
+    expect(screen.getByText(/retry in 29 min/)).toBeVisible();
   });
 });

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -7,6 +7,7 @@ import {
   listBackends,
   updateBackendConfig,
   getProviderForBackend,
+  getChatgptUiProfilePool,
   getHealth,
   getSettings,
   updateSettings,
@@ -152,6 +153,14 @@ export default function BackendsPage() {
     'claudecode-provider',
     () => getProviderForBackend('claudecode'),
     { revalidateOnFocus: false }
+  );
+
+  const { data: chatgptUiPool } = useSWR(
+    activeBackendTab === 'chatgpt_ui' && chatgptUiIsConfigured
+      ? 'chatgpt-ui-profile-pool'
+      : null,
+    getChatgptUiProfilePool,
+    { revalidateOnFocus: false, refreshInterval: 15000 }
   );
 
   useEffect(() => {
@@ -731,6 +740,46 @@ export default function BackendsPage() {
                   One authenticated profile per line. Each concurrent GPT Pro mission leases one free profile; missions wait when the pool is full.
                 </p>
               </div>
+              {chatgptUiIsConfigured && (chatgptUiPool?.slots.length ?? 0) > 0 && (
+                <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4" data-testid="chatgpt-ui-pool-status">
+                  <p className="text-xs font-medium uppercase tracking-[0.16em] text-white/35">
+                    Profile pool status
+                  </p>
+                  <ul className="mt-3 space-y-2">
+                    {chatgptUiPool!.slots.map((slot) => (
+                      <li key={slot.slot} className="flex flex-wrap items-center gap-2 text-xs">
+                        <span className="font-mono text-white/70">{slot.profile_name}</span>
+                        <span
+                          className={cn(
+                            'rounded-full px-2 py-0.5',
+                            slot.state === 'available' && 'bg-emerald-500/10 text-emerald-300',
+                            slot.state === 'in_use' && 'bg-indigo-500/10 text-indigo-300',
+                            slot.state === 'quarantined' && 'bg-amber-500/10 text-amber-300'
+                          )}
+                        >
+                          {slot.state === 'in_use' ? 'in use' : slot.state}
+                        </span>
+                        {slot.state === 'quarantined' && (
+                          <span className="text-white/35">
+                            {slot.last_failure ? `${slot.last_failure} failure` : 'failure'}
+                            {typeof slot.quarantine_remaining_secs === 'number'
+                              ? ` · retry in ${Math.max(1, Math.ceil(slot.quarantine_remaining_secs / 60))} min`
+                              : ''}
+                          </span>
+                        )}
+                        {slot.state !== 'quarantined' && slot.consecutive_failures > 0 && (
+                          <span className="text-white/35">
+                            {slot.consecutive_failures} recent failure{slot.consecutive_failures === 1 ? '' : 's'}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-2 text-xs text-white/30">
+                    Slots quarantine automatically after auth, launch, or repeated compatibility failures and rejoin the pool when the cooldown ends.
+                  </p>
+                </div>
+              )}
               <div>
                 <label htmlFor="chatgpt-ui-driver-path" className="block text-xs text-white/60 mb-1.5">Driver path</label>
                 <input id="chatgpt-ui-driver-path" type="text" value={chatgptUiForm.driver_path} onChange={(e) => setChatgptUiForm((prev) => ({ ...prev, driver_path: e.target.value }))} placeholder="/opt/sandboxed-sh/scripts/chatgpt_ui_driver.py" className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-white focus:outline-none focus:border-indigo-500/50" />

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -754,7 +754,8 @@ export default function BackendsPage() {
                             'rounded-full px-2 py-0.5',
                             slot.state === 'available' && 'bg-emerald-500/10 text-emerald-300',
                             slot.state === 'in_use' && 'bg-indigo-500/10 text-indigo-300',
-                            slot.state === 'quarantined' && 'bg-amber-500/10 text-amber-300'
+                            slot.state === 'quarantined' && 'bg-amber-500/10 text-amber-300',
+                            slot.state === 'unavailable' && 'bg-rose-500/10 text-rose-300'
                           )}
                         >
                           {slot.state === 'in_use' ? 'in use' : slot.state}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3286,7 +3286,7 @@ export async function getBackendConfig(
 export interface ChatgptUiProfilePoolSlot {
   slot: number;
   profile_name: string;
-  state: "available" | "in_use" | "quarantined";
+  state: "available" | "in_use" | "quarantined" | "unavailable";
   consecutive_failures: number;
   quarantine_remaining_secs?: number | null;
   last_failure?: string | null;

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3283,6 +3283,27 @@ export async function getBackendConfig(
   );
 }
 
+export interface ChatgptUiProfilePoolSlot {
+  slot: number;
+  profile_name: string;
+  state: "available" | "in_use" | "quarantined";
+  consecutive_failures: number;
+  quarantine_remaining_secs?: number | null;
+  last_failure?: string | null;
+}
+
+export interface ChatgptUiProfilePoolResponse {
+  slots: ChatgptUiProfilePoolSlot[];
+}
+
+// Get ChatGPT UI profile pool slot telemetry
+export async function getChatgptUiProfilePool(): Promise<ChatgptUiProfilePoolResponse> {
+  return apiGet(
+    "/api/backends/chatgpt_ui/profile-pool",
+    "Failed to get ChatGPT UI profile pool status",
+  );
+}
+
 // Update backend configuration
 export async function updateBackendConfig(
   backendId: string,

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -21,6 +21,19 @@ CHATGPT_URL = "https://chatgpt.com/"
 MAX_DOWNLOAD_FILES = 8
 MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
 MODEL_PICKER_READY_TIMEOUT_MS = 15_000
+SEND_CONTROL_TESTIDS = (
+    '[data-testid="send-button"]',
+    '[data-testid="composer-send-button"]',
+)
+STOP_CONTROL_TESTIDS = (
+    '[data-testid="stop-button"]',
+    '[data-testid="composer-stop-button"]',
+)
+# Anchored so unrelated page chrome ("Resend", "Nonstop…") cannot match; the
+# lookup is additionally scoped to the composer form, keeping controls such as
+# a sidebar "Send feedback" out of reach.
+SEND_BUTTON_NAME = re.compile(r"^send\b", re.I)
+STOP_BUTTON_NAME = re.compile(r"^stop\b", re.I)
 INTELLIGENCE_LABELS = ("Instant", "5.5", "Medium", "High", "Extra High", "Pro")
 PRO_MODEL_ALIASES = {
     "gpt-5.6-pro",
@@ -44,6 +57,28 @@ def model_selection(requested: str) -> tuple[str, str]:
     if normalized in PRO_MODEL_ALIASES:
         return "Pro", "gpt-5.6-pro"
     return requested.strip(), requested.strip()
+
+
+async def locate_composer_control(page, testid_selectors, accessible_name):
+    """Find a composer control by stable test id, else composer-scoped role.
+
+    Returns ``(locator_or_none, used_fallback)``. Never scans the whole page
+    by loose text, which could match private sidebar content.
+    """
+    for selector in testid_selectors:
+        control = page.locator(selector).last
+        try:
+            if await control.count() and await control.is_visible():
+                return control, False
+        except Exception:
+            continue
+    control = page.locator("form").get_by_role("button", name=accessible_name).last
+    try:
+        if await control.count() and await control.is_visible():
+            return control, True
+    except Exception:
+        pass
+    return None, False
 
 
 async def choose_intelligence_model(page, label: str) -> bool:
@@ -385,13 +420,24 @@ async def run(args, request) -> None:
                 composer = page.get_by_role("textbox").last
             await composer.fill(message)
             stage = "send"
-            send = page.get_by_role("button", name=re.compile(r"send", re.I)).last
-            await send.wait_for(state="visible", timeout=10_000)
+            send = None
+            for _ in range(20):  # allow ~10 seconds for the control to attach
+                send, used_fallback = await locate_composer_control(
+                    page, SEND_CONTROL_TESTIDS, SEND_BUTTON_NAME
+                )
+                if send is not None:
+                    if used_fallback:
+                        emit("diagnostic", message="stage=send_button_fallback")
+                    break
+                await asyncio.sleep(0.5)
+            if send is None:
+                raise RuntimeError("composer send control not found")
             await send.click()
 
             stage = "response"
             last = ""
             stable = 0
+            stop_fallback_reported = False
             deadline = asyncio.get_running_loop().time() + timeout_ms / 1000
             while asyncio.get_running_loop().time() < deadline:
                 responses = page.locator('[data-message-author-role="assistant"]')
@@ -403,8 +449,13 @@ async def run(args, request) -> None:
                         emit("text_delta", content=text)
                     elif text:
                         stable += 1
-                stop = page.get_by_role("button", name=re.compile(r"stop", re.I)).last
-                stop_visible = await stop.count() and await stop.is_visible()
+                stop, stop_fallback = await locate_composer_control(
+                    page, STOP_CONTROL_TESTIDS, STOP_BUTTON_NAME
+                )
+                if stop_fallback and not stop_fallback_reported:
+                    stop_fallback_reported = True
+                    emit("diagnostic", message="stage=stop_button_fallback")
+                stop_visible = stop is not None
                 if last and count > baseline and not stop_visible and stable >= 2:
                     if download_dir is not None:
                         stage = "artifacts"

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -5,10 +5,15 @@ import unittest
 
 from scripts.chatgpt_ui_driver import (
     MODEL_PICKER_READY_TIMEOUT_MS,
+    SEND_BUTTON_NAME,
+    SEND_CONTROL_TESTIDS,
+    STOP_BUTTON_NAME,
+    STOP_CONTROL_TESTIDS,
     choose_intelligence_model,
     close_context_quietly,
     download_control_key,
     downloadable_href,
+    locate_composer_control,
     model_selection,
     safe_download_name,
 )
@@ -61,6 +66,46 @@ class ComposerPage:
         return self.picker
 
 
+class FakeControl:
+    def __init__(self, visible: bool) -> None:
+        self.visible = visible
+
+    @property
+    def last(self):
+        return self
+
+    async def count(self) -> int:
+        return 1 if self.visible else 0
+
+    async def is_visible(self) -> bool:
+        return self.visible
+
+
+class FakeComposerForm:
+    def __init__(self, control: FakeControl) -> None:
+        self.control = control
+        self.requested_role = None
+        self.requested_name = None
+
+    def get_by_role(self, role, name=None):
+        self.requested_role = role
+        self.requested_name = name
+        return self.control
+
+
+class FakeComposerPage:
+    def __init__(self, testid_visible: bool, fallback_visible: bool) -> None:
+        self.testid_control = FakeControl(testid_visible)
+        self.form = FakeComposerForm(FakeControl(fallback_visible))
+        self.selectors = []
+
+    def locator(self, selector):
+        self.selectors.append(selector)
+        if selector == "form":
+            return self.form
+        return self.testid_control
+
+
 class ChatGptUiDriverTests(unittest.TestCase):
     def test_cleanup_preserves_existing_protocol_result(self) -> None:
         asyncio.run(close_context_quietly(ClosedContext()))
@@ -88,6 +133,48 @@ class ChatGptUiDriverTests(unittest.TestCase):
             button.wait_timeout, ("visible", MODEL_PICKER_READY_TIMEOUT_MS)
         )
         self.assertFalse(button.clicked)
+
+    def test_composer_control_prefers_stable_test_ids(self) -> None:
+        page = FakeComposerPage(testid_visible=True, fallback_visible=True)
+
+        control, used_fallback = asyncio.run(
+            locate_composer_control(page, SEND_CONTROL_TESTIDS, SEND_BUTTON_NAME)
+        )
+
+        self.assertIs(control, page.testid_control)
+        self.assertFalse(used_fallback)
+        self.assertNotIn("form", page.selectors)
+
+    def test_composer_control_falls_back_to_the_composer_scoped_role(self) -> None:
+        page = FakeComposerPage(testid_visible=False, fallback_visible=True)
+
+        control, used_fallback = asyncio.run(
+            locate_composer_control(page, STOP_CONTROL_TESTIDS, STOP_BUTTON_NAME)
+        )
+
+        self.assertIs(control, page.form.control)
+        self.assertTrue(used_fallback)
+        self.assertEqual(page.form.requested_role, "button")
+        self.assertIs(page.form.requested_name, STOP_BUTTON_NAME)
+        self.assertEqual(page.selectors[-1], "form")
+
+    def test_composer_control_reports_absence_instead_of_guessing(self) -> None:
+        page = FakeComposerPage(testid_visible=False, fallback_visible=False)
+
+        control, used_fallback = asyncio.run(
+            locate_composer_control(page, SEND_CONTROL_TESTIDS, SEND_BUTTON_NAME)
+        )
+
+        self.assertIsNone(control)
+        self.assertFalse(used_fallback)
+
+    def test_composer_control_names_are_anchored(self) -> None:
+        self.assertIsNotNone(SEND_BUTTON_NAME.match("Send prompt"))
+        self.assertIsNotNone(SEND_BUTTON_NAME.match("Send"))
+        self.assertIsNone(SEND_BUTTON_NAME.match("Resend message"))
+        self.assertIsNone(SEND_BUTTON_NAME.match("Sending options"))
+        self.assertIsNotNone(STOP_BUTTON_NAME.match("Stop generating"))
+        self.assertIsNone(STOP_BUTTON_NAME.match("Nonstop mode"))
 
     def test_download_links_are_limited_to_chatgpt_artifact_surfaces(self) -> None:
         self.assertTrue(downloadable_href("sandbox:/mnt/data/report.pdf"))

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -727,6 +727,36 @@ pub async fn get_backend_quota(
     Ok(Json(quotas))
 }
 
+/// Active ChatGPT UI profile-slot telemetry.
+///
+/// Slot names are directory basenames only; full operator paths and profile
+/// contents are never exposed here.
+#[derive(Debug, Serialize)]
+pub struct ChatgptUiProfilePoolResponse {
+    pub slots: Vec<crate::api::runners::chatgpt_ui::profile_pool::ProfileSlotStatus>,
+}
+
+/// GET /api/backends/chatgpt_ui/profile-pool — per-slot pool state
+/// (available / in use / quarantined) for the ChatGPT UI browser pool.
+pub async fn chatgpt_ui_profile_pool(
+    State(_state): State<Arc<AppState>>,
+    Extension(_user): Extension<AuthUser>,
+) -> Json<ChatgptUiProfilePoolResponse> {
+    let mut profile_dirs: Vec<std::path::PathBuf> =
+        crate::api::mission_runner::get_backend_string_setting("chatgpt_ui", "profile_dir")
+            .into_iter()
+            .chain(crate::api::mission_runner::get_backend_string_list_setting(
+                "chatgpt_ui",
+                "profile_dirs",
+            ))
+            .map(std::path::PathBuf::from)
+            .collect();
+    profile_dirs.dedup();
+    Json(ChatgptUiProfilePoolResponse {
+        slots: crate::api::runners::chatgpt_ui::profile_pool::pool_snapshot(&profile_dirs),
+    })
+}
+
 #[cfg(test)]
 mod quota_tests {
     use super::*;

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -739,22 +739,15 @@ pub struct ChatgptUiProfilePoolResponse {
 /// GET /api/backends/chatgpt_ui/profile-pool — per-slot pool state
 /// (available / in use / quarantined) for the ChatGPT UI browser pool.
 pub async fn chatgpt_ui_profile_pool(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Extension(_user): Extension<AuthUser>,
-) -> Json<ChatgptUiProfilePoolResponse> {
-    let mut profile_dirs: Vec<std::path::PathBuf> =
-        crate::api::mission_runner::get_backend_string_setting("chatgpt_ui", "profile_dir")
-            .into_iter()
-            .chain(crate::api::mission_runner::get_backend_string_list_setting(
-                "chatgpt_ui",
-                "profile_dirs",
-            ))
-            .map(std::path::PathBuf::from)
-            .collect();
-    profile_dirs.dedup();
-    Json(ChatgptUiProfilePoolResponse {
+) -> Result<Json<ChatgptUiProfilePoolResponse>, (StatusCode, String)> {
+    let profile_dirs =
+        crate::api::runners::chatgpt_ui::configured_profile_dirs(&state.config.working_dir)
+            .map_err(|error| (StatusCode::BAD_REQUEST, error))?;
+    Ok(Json(ChatgptUiProfilePoolResponse {
         slots: crate::api::runners::chatgpt_ui::profile_pool::pool_snapshot(&profile_dirs),
-    })
+    }))
 }
 
 #[cfg(test)]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1203,6 +1203,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             get(backends_api::get_backend_quota),
         )
         .route(
+            "/api/backends/chatgpt_ui/profile-pool",
+            get(backends_api::chatgpt_ui_profile_pool),
+        )
+        .route(
             "/api/backends/:id/agents",
             get(backends_api::list_backend_agents),
         )

--- a/src/api/runners/chatgpt_ui/chromium_cleanup.rs
+++ b/src/api/runners/chatgpt_ui/chromium_cleanup.rs
@@ -1,0 +1,337 @@
+//! Conservative cleanup of Chromium singleton state in a leased profile.
+//!
+//! Chromium serializes profile access through `SingletonLock` (a symlink whose
+//! target is `hostname-pid`), `SingletonCookie`, and `SingletonSocket`. When a
+//! browser dies without unwinding — a SIGKILL from the runner deadline, a
+//! server crash, a container restart — those entries survive and the next
+//! launch refuses the profile. Removal is only safe while the pool's exclusive
+//! profile lock is held, and only when the evidence says no live browser owns
+//! the entries:
+//!
+//! - same host, dead pid: stale, remove.
+//! - same host, live pid: a browser outside the pool owns the profile; keep.
+//! - foreign host: keep, unless a pool ownership marker proves the previous
+//!   pool-managed run left them behind (containers change hostname between
+//!   runs, which would otherwise strand the profile forever).
+//! - anything unrecognized (regular files, unexpected types): keep.
+
+use std::path::{Path, PathBuf};
+
+const SINGLETON_NAMES: [&str; 3] = ["SingletonLock", "SingletonCookie", "SingletonSocket"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SingletonCleanup {
+    /// No singleton entries were present.
+    Clean,
+    /// Stale entries were removed; the count is how many.
+    Removed(usize),
+    /// The lock names another host and the pool does not own it; kept.
+    ForeignHost,
+    /// The lock names a live process on this host; kept.
+    ActiveProcess,
+    /// The lock is not the symlink Chromium writes; kept.
+    Unrecognized,
+}
+
+impl SingletonCleanup {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clean => "clean",
+            Self::Removed(_) => "removed",
+            Self::ForeignHost => "foreign_host",
+            Self::ActiveProcess => "active_process",
+            Self::Unrecognized => "unrecognized",
+        }
+    }
+
+    /// Whether the profile is safe to hand to a fresh browser launch.
+    pub fn profile_is_launchable(self) -> bool {
+        matches!(self, Self::Clean | Self::Removed(_) | Self::Unrecognized)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LockVerdict {
+    Stale,
+    ForeignHost,
+    ActiveProcess,
+}
+
+/// Judge a `SingletonLock` symlink target of the form `hostname-pid`.
+fn judge_lock_target(
+    target: &str,
+    local_hostname: &str,
+    pid_is_alive: impl Fn(i32) -> bool,
+) -> LockVerdict {
+    // Hostnames may themselves contain '-', so split on the last one.
+    let Some((host, pid)) = target.rsplit_once('-') else {
+        // Not the shape Chromium writes; with the profile lock held this is a
+        // dangling leftover, not a live browser.
+        return LockVerdict::Stale;
+    };
+    let Ok(pid) = pid.parse::<i32>() else {
+        return LockVerdict::Stale;
+    };
+    if host != local_hostname {
+        return LockVerdict::ForeignHost;
+    }
+    if pid > 0 && pid_is_alive(pid) {
+        return LockVerdict::ActiveProcess;
+    }
+    LockVerdict::Stale
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: i32) -> bool {
+    // Signal 0 probes existence; EPERM still means the process exists.
+    let result = unsafe { libc::kill(pid, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+fn local_hostname() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/hostname")
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Remove a singleton entry only when it is the kind of node Chromium
+/// creates (symlink or socket) — never a regular file or directory.
+fn remove_singleton_entry(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    let file_type = metadata.file_type();
+    #[cfg(unix)]
+    let removable = {
+        use std::os::unix::fs::FileTypeExt;
+        file_type.is_symlink() || file_type.is_socket()
+    };
+    #[cfg(not(unix))]
+    let removable = file_type.is_symlink();
+    if !removable {
+        return false;
+    }
+    std::fs::remove_file(path).is_ok()
+}
+
+fn cleanup_with(
+    profile_dir: &Path,
+    owned_by_pool: bool,
+    local_hostname: &str,
+    pid_alive: impl Fn(i32) -> bool,
+) -> SingletonCleanup {
+    let lock_path = profile_dir.join("SingletonLock");
+    match std::fs::symlink_metadata(&lock_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let target = std::fs::read_link(&lock_path)
+                .map(|target| target.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            match judge_lock_target(&target, local_hostname, pid_alive) {
+                LockVerdict::ActiveProcess => return SingletonCleanup::ActiveProcess,
+                LockVerdict::ForeignHost if !owned_by_pool => return SingletonCleanup::ForeignHost,
+                LockVerdict::ForeignHost | LockVerdict::Stale => {}
+            }
+        }
+        Ok(_) => return SingletonCleanup::Unrecognized,
+        Err(_) => {}
+    }
+    let mut removed = 0usize;
+    for name in SINGLETON_NAMES {
+        if remove_singleton_entry(&profile_dir.join(name)) {
+            removed += 1;
+        }
+    }
+    if removed == 0 {
+        SingletonCleanup::Clean
+    } else {
+        SingletonCleanup::Removed(removed)
+    }
+}
+
+/// Clean stale Chromium singleton entries from an exclusively leased profile.
+#[cfg(unix)]
+pub fn cleanup_profile_singletons(profile_dir: &Path, owned_by_pool: bool) -> SingletonCleanup {
+    cleanup_with(profile_dir, owned_by_pool, &local_hostname(), pid_is_alive)
+}
+
+#[cfg(not(unix))]
+pub fn cleanup_profile_singletons(_profile_dir: &Path, _owned_by_pool: bool) -> SingletonCleanup {
+    SingletonCleanup::Clean
+}
+
+fn ownership_marker_path(profile_dir: &Path) -> PathBuf {
+    let name = profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("profile");
+    profile_dir
+        .parent()
+        .unwrap_or_else(|| Path::new("/"))
+        .join(format!(".{name}.sandboxed-chatgpt-ui.owner"))
+}
+
+/// Whether the previous pool-managed run on this profile ended without a
+/// graceful cleanup. The marker lives beside the pool lock file, never
+/// inside the profile itself, and contains no data.
+pub fn pool_owns_singletons(profile_dir: &Path) -> bool {
+    ownership_marker_path(profile_dir).is_file()
+}
+
+pub fn claim_singleton_ownership(profile_dir: &Path) {
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(ownership_marker_path(profile_dir));
+}
+
+pub fn release_singleton_ownership(profile_dir: &Path) {
+    let _ = std::fs::remove_file(ownership_marker_path(profile_dir));
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    // Beyond any real pid: kernel pid_max is at most 2^22 on 64-bit Linux.
+    const DEAD_PID: i32 = 0x7fff_fffe;
+
+    fn write_singletons(profile: &Path, lock_target: &str) {
+        symlink(lock_target, profile.join("SingletonLock")).unwrap();
+        symlink("cookie-value", profile.join("SingletonCookie")).unwrap();
+        symlink(
+            "/tmp/does-not-exist.socket",
+            profile.join("SingletonSocket"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn judges_lock_targets_conservatively() {
+        let alive = |_pid: i32| true;
+        let dead = |_pid: i32| false;
+        assert_eq!(
+            judge_lock_target("host-42", "host", dead),
+            LockVerdict::Stale
+        );
+        assert_eq!(
+            judge_lock_target("host-42", "host", alive),
+            LockVerdict::ActiveProcess
+        );
+        assert_eq!(
+            judge_lock_target("other-42", "host", alive),
+            LockVerdict::ForeignHost
+        );
+        assert_eq!(
+            judge_lock_target("my-host-42", "my-host", dead),
+            LockVerdict::Stale
+        );
+        assert_eq!(
+            judge_lock_target("garbage", "host", alive),
+            LockVerdict::Stale
+        );
+        assert_eq!(
+            judge_lock_target("host-0", "host", alive),
+            LockVerdict::Stale
+        );
+    }
+
+    #[test]
+    fn removes_stale_same_host_singletons() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        write_singletons(&profile, &format!("{}-{DEAD_PID}", local_hostname()));
+
+        let outcome = cleanup_profile_singletons(&profile, false);
+
+        assert_eq!(outcome, SingletonCleanup::Removed(3));
+        assert!(outcome.profile_is_launchable());
+        for name in SINGLETON_NAMES {
+            assert!(!profile.join(name).exists());
+        }
+    }
+
+    #[test]
+    fn keeps_singletons_owned_by_a_live_process() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        let live_pid = std::process::id() as i32;
+        write_singletons(&profile, &format!("{}-{live_pid}", local_hostname()));
+
+        let outcome = cleanup_profile_singletons(&profile, true);
+
+        assert_eq!(outcome, SingletonCleanup::ActiveProcess);
+        assert!(!outcome.profile_is_launchable());
+        assert!(profile.join("SingletonLock").symlink_metadata().is_ok());
+    }
+
+    #[test]
+    fn keeps_foreign_host_singletons_unless_pool_owned() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        write_singletons(&profile, "some-other-container-4242");
+
+        assert_eq!(
+            cleanup_profile_singletons(&profile, false),
+            SingletonCleanup::ForeignHost
+        );
+        assert!(profile.join("SingletonLock").symlink_metadata().is_ok());
+
+        // A previous pool-managed run crashed in a container with another
+        // hostname: the ownership marker makes removal safe.
+        assert_eq!(
+            cleanup_profile_singletons(&profile, true),
+            SingletonCleanup::Removed(3)
+        );
+    }
+
+    #[test]
+    fn never_removes_regular_files_with_singleton_names() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        std::fs::write(profile.join("SingletonLock"), "not a symlink").unwrap();
+        std::fs::write(profile.join("SingletonCookie"), "data").unwrap();
+
+        let outcome = cleanup_profile_singletons(&profile, true);
+
+        assert_eq!(outcome, SingletonCleanup::Unrecognized);
+        assert!(profile.join("SingletonLock").is_file());
+        assert!(profile.join("SingletonCookie").is_file());
+    }
+
+    #[test]
+    fn missing_lock_still_sweeps_dangling_cookie_and_socket() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        symlink("cookie-value", profile.join("SingletonCookie")).unwrap();
+
+        assert_eq!(
+            cleanup_profile_singletons(&profile, false),
+            SingletonCleanup::Removed(1)
+        );
+        assert_eq!(
+            cleanup_profile_singletons(&profile, false),
+            SingletonCleanup::Clean
+        );
+    }
+
+    #[test]
+    fn ownership_marker_lives_outside_the_profile_and_round_trips() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+
+        assert!(!pool_owns_singletons(&profile));
+        claim_singleton_ownership(&profile);
+        assert!(pool_owns_singletons(&profile));
+        assert!(std::fs::read_dir(&profile).unwrap().next().is_none());
+        release_singleton_ownership(&profile);
+        assert!(!pool_owns_singletons(&profile));
+    }
+}

--- a/src/api/runners/chatgpt_ui/chromium_cleanup.rs
+++ b/src/api/runners/chatgpt_ui/chromium_cleanup.rs
@@ -46,7 +46,7 @@ impl SingletonCleanup {
 
     /// Whether the profile is safe to hand to a fresh browser launch.
     pub fn profile_is_launchable(self) -> bool {
-        matches!(self, Self::Clean | Self::Removed(_) | Self::Unrecognized)
+        matches!(self, Self::Clean | Self::Removed(_))
     }
 }
 

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -168,7 +168,11 @@ fn classify_driver_error(
         Some("browser_launch") => (
             TerminalReason::LlmError,
             FailureClass::TransportError,
-            Some(SlotFailureKind::Launch),
+            // The driver cannot currently distinguish a profile-local launch
+            // problem from a global Playwright/browser installation failure.
+            // Quarantining the selected profile here would eventually poison
+            // every slot for one host-wide outage.
+            None,
         ),
         Some("compatibility") => (
             TerminalReason::LlmError,
@@ -425,7 +429,6 @@ pub async fn run_chatgpt_ui_turn(
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
-            profile_pool::record_slot_failure(&profile_dir, SlotFailureKind::Launch);
             return AgentResult::failure(format!("failed to start chatgpt_ui driver: {error}"), 0)
                 .with_terminal_reason(TerminalReason::LlmError);
         }
@@ -815,11 +818,7 @@ mod tests {
         );
         assert_eq!(
             classify_driver_error(Some("browser_launch")),
-            (
-                TerminalReason::LlmError,
-                FailureClass::TransportError,
-                Some(SlotFailureKind::Launch)
-            )
+            (TerminalReason::LlmError, FailureClass::TransportError, None)
         );
         assert_eq!(
             classify_driver_error(Some("compatibility")),

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -234,7 +234,7 @@ fn validate_display(value: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
+pub(crate) fn configured_profile_dirs(app_working_dir: &Path) -> Result<Vec<PathBuf>, String> {
     let mut configured_profiles = get_backend_string_setting("chatgpt_ui", "profile_dir")
         .into_iter()
         .chain(get_backend_string_list_setting(
@@ -246,18 +246,6 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
     configured_profiles.dedup();
     if configured_profiles.is_empty() {
         return Err("chatgpt_ui profile_dir or profile_dirs is required".to_string());
-    }
-    let driver_path = get_backend_string_setting("chatgpt_ui", "driver_path")
-        .map(PathBuf::from)
-        .ok_or_else(|| "chatgpt_ui driver_path is required".to_string())?;
-    if !driver_path.is_absolute() {
-        return Err("chatgpt_ui driver_path must be an absolute path".to_string());
-    }
-    if !driver_path.is_file() {
-        return Err(format!(
-            "chatgpt_ui browser driver not found: {}",
-            driver_path.display()
-        ));
     }
     let canonical_working_dir = app_working_dir.canonicalize().ok();
     let mut profile_dirs = Vec::with_capacity(configured_profiles.len());
@@ -286,6 +274,23 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
         if !profile_dirs.contains(&canonical_profile) {
             profile_dirs.push(canonical_profile);
         }
+    }
+    Ok(profile_dirs)
+}
+
+fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
+    let profile_dirs = configured_profile_dirs(app_working_dir)?;
+    let driver_path = get_backend_string_setting("chatgpt_ui", "driver_path")
+        .map(PathBuf::from)
+        .ok_or_else(|| "chatgpt_ui driver_path is required".to_string())?;
+    if !driver_path.is_absolute() {
+        return Err("chatgpt_ui driver_path must be an absolute path".to_string());
+    }
+    if !driver_path.is_file() {
+        return Err(format!(
+            "chatgpt_ui browser driver not found: {}",
+            driver_path.display()
+        ));
     }
     let timeout_secs = get_backend_u64_setting("chatgpt_ui", "timeout_secs").unwrap_or(14_400);
     if !(30..=86_400).contains(&timeout_secs) {
@@ -366,9 +371,13 @@ pub async fn run_chatgpt_ui_turn(
                 SingletonCleanup::ActiveProcess => {
                     "chatgpt_ui profile is held by a live browser process outside the profile pool; close it before retrying"
                 }
-                _ => {
+                SingletonCleanup::ForeignHost => {
                     "chatgpt_ui profile holds a SingletonLock from another host; remove it manually if that browser is gone"
                 }
+                SingletonCleanup::Unrecognized => {
+                    "chatgpt_ui profile has an unrecognized Chromium SingletonLock; inspect it manually before retrying"
+                }
+                SingletonCleanup::Clean | SingletonCleanup::Removed(_) => unreachable!(),
             };
             return AgentResult::failure(message, 0)
                 .with_terminal_reason(TerminalReason::LlmError)
@@ -378,9 +387,6 @@ pub async fn run_chatgpt_ui_turn(
                     "classification_source": "structured",
                 }));
         }
-        // From here the pool owns any singleton state this run leaves behind,
-        // even across a crash or a container hostname change.
-        chromium_cleanup::claim_singleton_ownership(&profile_dir);
     }
     let download_dir = match prepare_download_dir(work_dir).await {
         Ok(path) => path,
@@ -419,10 +425,17 @@ pub async fn run_chatgpt_ui_turn(
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
+            profile_pool::record_slot_failure(&profile_dir, SlotFailureKind::Launch);
             return AgentResult::failure(format!("failed to start chatgpt_ui driver: {error}"), 0)
-                .with_terminal_reason(TerminalReason::LlmError)
+                .with_terminal_reason(TerminalReason::LlmError);
         }
     };
+    if settings.browser == "chromium" {
+        // Claim ownership only after the driver was successfully spawned. A
+        // pre-spawn marker could authorize a later run to remove singleton
+        // state that this pool never created.
+        chromium_cleanup::claim_singleton_ownership(&profile_dir);
+    }
     #[cfg(unix)]
     let process_group = child.id().map(|pid| -(pid as i32));
 

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -3,13 +3,14 @@
 //! The browser helper speaks NDJSON on stdout. Browser profiles remain outside
 //! mission workspaces and are referenced by an operator-supplied absolute path.
 
+pub mod chromium_cleanup;
+pub mod profile_pool;
+
 use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use fs2::FileExt;
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
@@ -18,11 +19,13 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::agents::{AgentResult, TerminalReason};
+use crate::agents::{AgentResult, FailureClass, TerminalReason};
 use crate::api::control::AgentEvent;
 use crate::api::mission_runner::{
     get_backend_string_list_setting, get_backend_string_setting, get_backend_u64_setting,
 };
+use chromium_cleanup::SingletonCleanup;
+use profile_pool::SlotFailureKind;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -71,85 +74,6 @@ struct Settings {
     display: Option<String>,
     timeout: Duration,
     headless: bool,
-}
-
-struct ProfileLock(File);
-
-impl Drop for ProfileLock {
-    fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.0);
-    }
-}
-
-fn try_lock_profile(profile_dir: &Path) -> Result<Option<ProfileLock>, String> {
-    let name = profile_dir
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("profile");
-    let lock_path = profile_dir
-        .parent()
-        .unwrap_or_else(|| Path::new("/"))
-        .join(format!(".{name}.sandboxed-chatgpt-ui.lock"));
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(&lock_path)
-        .map_err(|error| format!("cannot create ChatGPT UI profile lock: {error}"))?;
-    match file.try_lock_exclusive() {
-        Ok(()) => Ok(Some(ProfileLock(file))),
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
-        Err(error) => Err(format!("cannot lock ChatGPT UI profile: {error}")),
-    }
-}
-
-async fn acquire_profile(
-    profile_dirs: &[PathBuf],
-    mission_id: Uuid,
-    events_tx: &broadcast::Sender<AgentEvent>,
-    cancel: &CancellationToken,
-) -> Result<(usize, PathBuf, ProfileLock), AgentResult> {
-    let mut announced_wait = false;
-    loop {
-        for (slot, profile_dir) in profile_dirs.iter().enumerate() {
-            match try_lock_profile(profile_dir) {
-                Ok(Some(lock)) => return Ok((slot, profile_dir.clone(), lock)),
-                Ok(None) => {}
-                Err(error) => {
-                    return Err(AgentResult::failure(error, 0)
-                        .with_terminal_reason(TerminalReason::LlmError))
-                }
-            }
-        }
-        if !announced_wait {
-            let _ = events_tx.send(AgentEvent::MissionActivity {
-                label: "Waiting for a ChatGPT UI browser slot…".to_string(),
-                tool_name: "chatgpt_ui_profile_pool".to_string(),
-                mission_id: Some(mission_id),
-            });
-            announced_wait = true;
-        }
-        tokio::select! {
-            _ = cancel.cancelled() => {
-                let shutdown = crate::api::routes::is_shutdown_initiated();
-                return Err(AgentResult::failure(
-                    if shutdown {
-                        "Server restart — paused while waiting for a ChatGPT UI browser slot."
-                    } else {
-                        "Mission cancelled while waiting for a ChatGPT UI browser slot"
-                    },
-                    0,
-                )
-                .with_terminal_reason(if shutdown {
-                    TerminalReason::ServerShutdown
-                } else {
-                    TerminalReason::Cancelled
-                }));
-            }
-            _ = tokio::time::sleep(Duration::from_secs(2)) => {}
-        }
-    }
 }
 
 async fn prepare_download_dir(work_dir: &Path) -> Result<PathBuf, String> {
@@ -229,6 +153,32 @@ fn timeout_result(timeout: Duration) -> AgentResult {
     }))
 }
 
+/// Map a structured driver error code onto a terminal reason, a failure
+/// class, and — when the failure is slot-local — a profile-pool health record.
+fn classify_driver_error(
+    code: Option<&str>,
+) -> (TerminalReason, FailureClass, Option<SlotFailureKind>) {
+    match code {
+        Some("auth_required") => (
+            TerminalReason::AuthError,
+            FailureClass::AuthError,
+            Some(SlotFailureKind::Auth),
+        ),
+        Some("rate_limited") => (TerminalReason::RateLimited, FailureClass::RateLimited, None),
+        Some("browser_launch") => (
+            TerminalReason::LlmError,
+            FailureClass::TransportError,
+            Some(SlotFailureKind::Launch),
+        ),
+        Some("compatibility") => (
+            TerminalReason::LlmError,
+            FailureClass::ProviderError,
+            Some(SlotFailureKind::Compatibility),
+        ),
+        _ => (TerminalReason::LlmError, FailureClass::ProviderError, None),
+    }
+}
+
 fn parse_bool_setting(key: &str, default: bool) -> bool {
     crate::api::mission_runner::get_backend_bool_setting("chatgpt_ui", key).unwrap_or(default)
 }
@@ -242,6 +192,8 @@ fn safe_driver_diagnostic(message: &str) -> Option<&str> {
         | "stage=account_confirmed"
         | "stage=blank_route"
         | "stage=composer_ready"
+        | "stage=send_button_fallback"
+        | "stage=stop_button_fallback"
         | "stage=composer_model_picker_not_ready"
         | "stage=model_already_selected"
         | "stage=composer_model_option_unavailable"
@@ -389,11 +341,47 @@ pub async fn run_chatgpt_ui_turn(
             return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::AuthError)
         }
     };
-    let (profile_slot, profile_dir, _profile_lock) =
-        match acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel).await {
-            Ok(lease) => lease,
-            Err(result) => return result,
-        };
+    let (profile_slot, profile_dir, _profile_lock) = match profile_pool::acquire_profile(
+        &settings.profile_dirs,
+        mission_id,
+        &events_tx,
+        &cancel,
+    )
+    .await
+    {
+        Ok(lease) => lease,
+        Err(result) => return result,
+    };
+    if settings.browser == "chromium" {
+        let owned = chromium_cleanup::pool_owns_singletons(&profile_dir);
+        let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, owned);
+        tracing::debug!(
+            mission_id = %mission_id,
+            outcome = outcome.as_str(),
+            "chatgpt_ui pre-launch profile singleton cleanup"
+        );
+        if !outcome.profile_is_launchable() {
+            profile_pool::record_slot_failure(&profile_dir, SlotFailureKind::Launch);
+            let message = match outcome {
+                SingletonCleanup::ActiveProcess => {
+                    "chatgpt_ui profile is held by a live browser process outside the profile pool; close it before retrying"
+                }
+                _ => {
+                    "chatgpt_ui profile holds a SingletonLock from another host; remove it manually if that browser is gone"
+                }
+            };
+            return AgentResult::failure(message, 0)
+                .with_terminal_reason(TerminalReason::LlmError)
+                .with_data(serde_json::json!({
+                    "provider_error_source": "chatgpt_ui_profile_pool",
+                    "failure_class": FailureClass::TransportError,
+                    "classification_source": "structured",
+                }));
+        }
+        // From here the pool owns any singleton state this run leaves behind,
+        // even across a crash or a container hostname change.
+        chromium_cleanup::claim_singleton_ownership(&profile_dir);
+    }
     let download_dir = match prepare_download_dir(work_dir).await {
         Ok(path) => path,
         Err(error) => {
@@ -556,20 +544,11 @@ pub async fn run_chatgpt_ui_turn(
                         artifact_receipts.push((path, name));
                     }
                     DriverEvent::Error { code, message } => {
-                        let reason = if code.as_deref() == Some("auth_required") {
-                            TerminalReason::AuthError
-                        } else if code.as_deref() == Some("rate_limited") {
-                            TerminalReason::RateLimited
-                        } else {
-                            TerminalReason::LlmError
-                        };
-                        let failure_class = match reason {
-                            TerminalReason::AuthError => crate::agents::FailureClass::AuthError,
-                            TerminalReason::RateLimited => {
-                                crate::agents::FailureClass::RateLimited
-                            }
-                            _ => crate::agents::FailureClass::ProviderError,
-                        };
+                        let (reason, failure_class, slot_failure) =
+                            classify_driver_error(code.as_deref());
+                        if let Some(kind) = slot_failure {
+                            profile_pool::record_slot_failure(&profile_dir, kind);
+                        }
                         terminate_child_tree(&mut child).await;
                         return AgentResult::failure(format!("chatgpt_ui: {message}"), 0)
                             .with_terminal_reason(reason)
@@ -634,6 +613,20 @@ pub async fn run_chatgpt_ui_turn(
             libc::kill(process_group, libc::SIGKILL);
         }
     }
+    if settings.browser == "chromium" {
+        // Best effort: freshly killed descendants may briefly linger as
+        // zombies, in which case the ownership marker defers this sweep to
+        // the next lease's pre-launch cleanup.
+        let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, true);
+        if outcome.profile_is_launchable() {
+            chromium_cleanup::release_singleton_ownership(&profile_dir);
+        }
+        tracing::debug!(
+            mission_id = %mission_id,
+            outcome = outcome.as_str(),
+            "chatgpt_ui post-run profile singleton cleanup"
+        );
+    }
     if let Err(message) = validate_completion(
         completed,
         &output,
@@ -666,6 +659,7 @@ pub async fn run_chatgpt_ui_turn(
             }
         }
     }
+    profile_pool::record_slot_success(&profile_dir);
     let mut result = AgentResult::success(output, 0)
         .with_terminal_reason(TerminalReason::TurnComplete)
         .with_data(serde_json::json!({
@@ -762,6 +756,14 @@ mod tests {
             Some("compatibility=chatgpt-ui-v2; browser=chromium")
         );
         assert_eq!(
+            safe_driver_diagnostic("stage=send_button_fallback"),
+            Some("stage=send_button_fallback")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=stop_button_fallback"),
+            Some("stage=stop_button_fallback")
+        );
+        assert_eq!(
             safe_driver_diagnostic("stage=page_loaded account=user@example.com"),
             None
         );
@@ -785,38 +787,43 @@ mod tests {
     }
 
     #[test]
-    fn profile_lock_is_exclusive_and_reusable() {
-        let root = tempfile::tempdir().unwrap();
-        let profile = root.path().join("profile");
-        std::fs::create_dir(&profile).unwrap();
-        let first = try_lock_profile(&profile).unwrap().unwrap();
-        assert!(try_lock_profile(&profile).unwrap().is_none());
-        drop(first);
-        assert!(try_lock_profile(&profile).unwrap().is_some());
-    }
-
-    #[tokio::test]
-    async fn profile_pool_uses_the_next_free_authenticated_slot() {
-        let root = tempfile::tempdir().unwrap();
-        let first_profile = root.path().join("profile-1");
-        let second_profile = root.path().join("profile-2");
-        std::fs::create_dir(&first_profile).unwrap();
-        std::fs::create_dir(&second_profile).unwrap();
-        let _first_lease = try_lock_profile(&first_profile).unwrap().unwrap();
-        let (events_tx, _) = broadcast::channel(8);
-        let cancel = CancellationToken::new();
-
-        let (slot, selected, _lease) = acquire_profile(
-            &[first_profile, second_profile.clone()],
-            Uuid::new_v4(),
-            &events_tx,
-            &cancel,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(slot, 1);
-        assert_eq!(selected, second_profile);
+    fn driver_error_codes_map_to_failure_classes_and_slot_health() {
+        assert_eq!(
+            classify_driver_error(Some("auth_required")),
+            (
+                TerminalReason::AuthError,
+                FailureClass::AuthError,
+                Some(SlotFailureKind::Auth)
+            )
+        );
+        assert_eq!(
+            classify_driver_error(Some("rate_limited")),
+            (TerminalReason::RateLimited, FailureClass::RateLimited, None)
+        );
+        assert_eq!(
+            classify_driver_error(Some("browser_launch")),
+            (
+                TerminalReason::LlmError,
+                FailureClass::TransportError,
+                Some(SlotFailureKind::Launch)
+            )
+        );
+        assert_eq!(
+            classify_driver_error(Some("compatibility")),
+            (
+                TerminalReason::LlmError,
+                FailureClass::ProviderError,
+                Some(SlotFailureKind::Compatibility)
+            )
+        );
+        assert_eq!(
+            classify_driver_error(Some("timeout")),
+            (TerminalReason::LlmError, FailureClass::ProviderError, None)
+        );
+        assert_eq!(
+            classify_driver_error(None),
+            (TerminalReason::LlmError, FailureClass::ProviderError, None)
+        );
     }
 
     #[test]

--- a/src/api/runners/chatgpt_ui/profile_pool.rs
+++ b/src/api/runners/chatgpt_ui/profile_pool.rs
@@ -1,0 +1,492 @@
+//! Exclusive browser-profile leases with per-slot health and quarantine.
+//!
+//! Every ChatGPT UI turn leases exactly one profile directory through an
+//! advisory file lock. Slots that keep failing in ways that a retry cannot fix
+//! (logged-out profile, broken browser launch, repeated UI incompatibility)
+//! are quarantined for a cooldown so healthy slots are preferred. The pool
+//! fails open: when every slot is quarantined, leases are still granted.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use serde::Serialize;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::agents::{AgentResult, TerminalReason};
+use crate::api::control::AgentEvent;
+
+const AUTH_QUARANTINE: Duration = Duration::from_secs(30 * 60);
+const LAUNCH_QUARANTINE: Duration = Duration::from_secs(5 * 60);
+const COMPATIBILITY_QUARANTINE: Duration = Duration::from_secs(10 * 60);
+const COMPATIBILITY_QUARANTINE_THRESHOLD: u32 = 3;
+
+pub struct ProfileLock(File);
+
+impl Drop for ProfileLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.0);
+    }
+}
+
+pub fn try_lock_profile(profile_dir: &Path) -> Result<Option<ProfileLock>, String> {
+    let name = profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("profile");
+    let lock_path = profile_dir
+        .parent()
+        .unwrap_or_else(|| Path::new("/"))
+        .join(format!(".{name}.sandboxed-chatgpt-ui.lock"));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| format!("cannot create ChatGPT UI profile lock: {error}"))?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(ProfileLock(file))),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(format!("cannot lock ChatGPT UI profile: {error}")),
+    }
+}
+
+/// Failure kinds that indicate a slot-local problem rather than a one-off
+/// model or network hiccup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlotFailureKind {
+    /// The profile is logged out; retries cannot recover it.
+    Auth,
+    /// The browser could not launch or the profile is held by a foreign
+    /// browser process.
+    Launch,
+    /// The driver failed a UI compatibility check on this profile.
+    Compatibility,
+}
+
+impl SlotFailureKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auth => "auth",
+            Self::Launch => "launch",
+            Self::Compatibility => "compatibility",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct SlotHealth {
+    consecutive_failures: u32,
+    quarantined_until: Option<Instant>,
+    last_failure: Option<SlotFailureKind>,
+}
+
+fn registry() -> &'static Mutex<HashMap<PathBuf, SlotHealth>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<PathBuf, SlotHealth>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn quarantine_for(kind: SlotFailureKind, consecutive_failures: u32) -> Option<Duration> {
+    match kind {
+        SlotFailureKind::Auth => Some(AUTH_QUARANTINE),
+        SlotFailureKind::Launch => Some(LAUNCH_QUARANTINE),
+        SlotFailureKind::Compatibility => (consecutive_failures
+            >= COMPATIBILITY_QUARANTINE_THRESHOLD)
+            .then_some(COMPATIBILITY_QUARANTINE),
+    }
+}
+
+fn record_slot_failure_at(profile_dir: &Path, kind: SlotFailureKind, now: Instant) {
+    let mut slots = registry().lock().expect("profile pool registry poisoned");
+    let health = slots.entry(profile_dir.to_path_buf()).or_default();
+    health.consecutive_failures = health.consecutive_failures.saturating_add(1);
+    health.last_failure = Some(kind);
+    if let Some(cooldown) = quarantine_for(kind, health.consecutive_failures) {
+        let until = now + cooldown;
+        health.quarantined_until = Some(
+            health
+                .quarantined_until
+                .map_or(until, |existing| existing.max(until)),
+        );
+    }
+}
+
+pub fn record_slot_failure(profile_dir: &Path, kind: SlotFailureKind) {
+    record_slot_failure_at(profile_dir, kind, Instant::now());
+    tracing::warn!(
+        failure_kind = kind.as_str(),
+        "ChatGPT UI profile slot recorded a slot-local failure"
+    );
+}
+
+pub fn record_slot_success(profile_dir: &Path) {
+    let mut slots = registry().lock().expect("profile pool registry poisoned");
+    slots.remove(profile_dir);
+}
+
+fn slot_health_at(profile_dir: &Path, now: Instant) -> SlotHealth {
+    let mut slots = registry().lock().expect("profile pool registry poisoned");
+    let Some(health) = slots.get_mut(profile_dir) else {
+        return SlotHealth::default();
+    };
+    if health.quarantined_until.is_some_and(|until| until <= now) {
+        health.quarantined_until = None;
+    }
+    *health
+}
+
+fn is_quarantined_at(profile_dir: &Path, now: Instant) -> bool {
+    slot_health_at(profile_dir, now)
+        .quarantined_until
+        .is_some_and(|until| until > now)
+}
+
+/// Test-only: clear pool health so tests do not observe each other's state.
+#[cfg(test)]
+pub(crate) fn reset_registry_for_tests(profile_dirs: &[PathBuf]) {
+    let mut slots = registry().lock().expect("profile pool registry poisoned");
+    for profile_dir in profile_dirs {
+        slots.remove(profile_dir);
+    }
+}
+
+pub async fn acquire_profile(
+    profile_dirs: &[PathBuf],
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    cancel: &CancellationToken,
+) -> Result<(usize, PathBuf, ProfileLock), AgentResult> {
+    let mut announced_wait = false;
+    loop {
+        let now = Instant::now();
+        // Prefer healthy slots, but fail open: a fully quarantined pool still
+        // grants leases so a transient outage cannot deadlock every mission.
+        let all_quarantined = profile_dirs
+            .iter()
+            .all(|profile_dir| is_quarantined_at(profile_dir, now));
+        for (slot, profile_dir) in profile_dirs.iter().enumerate() {
+            if !all_quarantined && is_quarantined_at(profile_dir, now) {
+                continue;
+            }
+            match try_lock_profile(profile_dir) {
+                Ok(Some(lock)) => return Ok((slot, profile_dir.clone(), lock)),
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(AgentResult::failure(error, 0)
+                        .with_terminal_reason(TerminalReason::LlmError))
+                }
+            }
+        }
+        if !announced_wait {
+            let _ = events_tx.send(AgentEvent::MissionActivity {
+                label: "Waiting for a ChatGPT UI browser slot…".to_string(),
+                tool_name: "chatgpt_ui_profile_pool".to_string(),
+                mission_id: Some(mission_id),
+            });
+            announced_wait = true;
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let shutdown = crate::api::routes::is_shutdown_initiated();
+                return Err(AgentResult::failure(
+                    if shutdown {
+                        "Server restart — paused while waiting for a ChatGPT UI browser slot."
+                    } else {
+                        "Mission cancelled while waiting for a ChatGPT UI browser slot"
+                    },
+                    0,
+                )
+                .with_terminal_reason(if shutdown {
+                    TerminalReason::ServerShutdown
+                } else {
+                    TerminalReason::Cancelled
+                }));
+            }
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileSlotState {
+    Available,
+    InUse,
+    Quarantined,
+}
+
+/// Privacy-safe snapshot of one pool slot: exposes only the directory
+/// basename, never the full operator path or any profile contents.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProfileSlotStatus {
+    pub slot: usize,
+    pub profile_name: String,
+    pub state: ProfileSlotState,
+    pub consecutive_failures: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_remaining_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_failure: Option<SlotFailureKind>,
+}
+
+pub fn pool_snapshot(profile_dirs: &[PathBuf]) -> Vec<ProfileSlotStatus> {
+    let now = Instant::now();
+    profile_dirs
+        .iter()
+        .enumerate()
+        .map(|(index, profile_dir)| {
+            let health = slot_health_at(profile_dir, now);
+            let quarantine_remaining = health
+                .quarantined_until
+                .and_then(|until| until.checked_duration_since(now));
+            // A momentary probe lock is released immediately and cannot
+            // starve waiting missions, which retry every two seconds.
+            let in_use = matches!(try_lock_profile(profile_dir), Ok(None));
+            let state = if in_use {
+                ProfileSlotState::InUse
+            } else if quarantine_remaining.is_some() {
+                ProfileSlotState::Quarantined
+            } else {
+                ProfileSlotState::Available
+            };
+            ProfileSlotStatus {
+                slot: index + 1,
+                profile_name: profile_dir
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("profile")
+                    .to_string(),
+                state,
+                consecutive_failures: health.consecutive_failures,
+                quarantine_remaining_secs: quarantine_remaining
+                    .map(|remaining| remaining.as_secs()),
+                last_failure: health.last_failure,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_lock_is_exclusive_and_reusable() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        let first = try_lock_profile(&profile).unwrap().unwrap();
+        assert!(try_lock_profile(&profile).unwrap().is_none());
+        drop(first);
+        assert!(try_lock_profile(&profile).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn profile_pool_uses_the_next_free_authenticated_slot() {
+        let root = tempfile::tempdir().unwrap();
+        let first_profile = root.path().join("profile-1");
+        let second_profile = root.path().join("profile-2");
+        std::fs::create_dir(&first_profile).unwrap();
+        std::fs::create_dir(&second_profile).unwrap();
+        reset_registry_for_tests(&[first_profile.clone(), second_profile.clone()]);
+        let _first_lease = try_lock_profile(&first_profile).unwrap().unwrap();
+        let (events_tx, _) = broadcast::channel(8);
+        let cancel = CancellationToken::new();
+
+        let (slot, selected, _lease) = acquire_profile(
+            &[first_profile, second_profile.clone()],
+            Uuid::new_v4(),
+            &events_tx,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(slot, 1);
+        assert_eq!(selected, second_profile);
+    }
+
+    #[tokio::test]
+    async fn quarantined_slot_is_skipped_while_a_healthy_slot_exists() {
+        let root = tempfile::tempdir().unwrap();
+        let first_profile = root.path().join("profile-1");
+        let second_profile = root.path().join("profile-2");
+        std::fs::create_dir(&first_profile).unwrap();
+        std::fs::create_dir(&second_profile).unwrap();
+        reset_registry_for_tests(&[first_profile.clone(), second_profile.clone()]);
+        record_slot_failure(&first_profile, SlotFailureKind::Auth);
+        let (events_tx, _) = broadcast::channel(8);
+        let cancel = CancellationToken::new();
+
+        let (slot, selected, _lease) = acquire_profile(
+            &[first_profile.clone(), second_profile.clone()],
+            Uuid::new_v4(),
+            &events_tx,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(slot, 1);
+        assert_eq!(selected, second_profile);
+        reset_registry_for_tests(&[first_profile]);
+    }
+
+    #[tokio::test]
+    async fn fully_quarantined_pool_fails_open() {
+        let root = tempfile::tempdir().unwrap();
+        let only_profile = root.path().join("profile-1");
+        std::fs::create_dir(&only_profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&only_profile));
+        record_slot_failure(&only_profile, SlotFailureKind::Launch);
+        let (events_tx, _) = broadcast::channel(8);
+        let cancel = CancellationToken::new();
+
+        let (slot, selected, _lease) = acquire_profile(
+            std::slice::from_ref(&only_profile),
+            Uuid::new_v4(),
+            &events_tx,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(slot, 0);
+        assert_eq!(selected, only_profile);
+        reset_registry_for_tests(&[only_profile]);
+    }
+
+    #[test]
+    fn auth_and_launch_failures_quarantine_immediately() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+        let now = Instant::now();
+
+        record_slot_failure_at(&profile, SlotFailureKind::Auth, now);
+        assert!(is_quarantined_at(&profile, now));
+        assert!(!is_quarantined_at(&profile, now + AUTH_QUARANTINE));
+
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+        record_slot_failure_at(&profile, SlotFailureKind::Launch, now);
+        assert!(is_quarantined_at(&profile, now));
+        assert!(!is_quarantined_at(&profile, now + LAUNCH_QUARANTINE));
+        reset_registry_for_tests(&[profile]);
+    }
+
+    #[test]
+    fn compatibility_failures_quarantine_only_after_repeats() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+        let now = Instant::now();
+
+        record_slot_failure_at(&profile, SlotFailureKind::Compatibility, now);
+        record_slot_failure_at(&profile, SlotFailureKind::Compatibility, now);
+        assert!(!is_quarantined_at(&profile, now));
+        record_slot_failure_at(&profile, SlotFailureKind::Compatibility, now);
+        assert!(is_quarantined_at(&profile, now));
+
+        record_slot_success(&profile);
+        assert!(!is_quarantined_at(&profile, now));
+        reset_registry_for_tests(&[profile]);
+    }
+
+    #[test]
+    fn success_resets_slot_health() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+        record_slot_failure(&profile, SlotFailureKind::Auth);
+        record_slot_success(&profile);
+        let status = pool_snapshot(std::slice::from_ref(&profile));
+        assert_eq!(status[0].state, ProfileSlotState::Available);
+        assert_eq!(status[0].consecutive_failures, 0);
+        assert!(status[0].last_failure.is_none());
+        reset_registry_for_tests(&[profile]);
+    }
+
+    #[test]
+    fn pool_snapshot_reports_slot_states_without_full_paths() {
+        let root = tempfile::tempdir().unwrap();
+        let busy = root.path().join("busy-profile");
+        let sick = root.path().join("sick-profile");
+        let free = root.path().join("free-profile");
+        for profile in [&busy, &sick, &free] {
+            std::fs::create_dir(profile).unwrap();
+        }
+        reset_registry_for_tests(&[busy.clone(), sick.clone(), free.clone()]);
+        let _lease = try_lock_profile(&busy).unwrap().unwrap();
+        record_slot_failure(&sick, SlotFailureKind::Auth);
+
+        let snapshot = pool_snapshot(&[busy.clone(), sick.clone(), free.clone()]);
+
+        assert_eq!(snapshot.len(), 3);
+        assert_eq!(snapshot[0].slot, 1);
+        assert_eq!(snapshot[0].profile_name, "busy-profile");
+        assert_eq!(snapshot[0].state, ProfileSlotState::InUse);
+        assert_eq!(snapshot[1].state, ProfileSlotState::Quarantined);
+        assert_eq!(snapshot[1].last_failure, Some(SlotFailureKind::Auth));
+        assert!(snapshot[1].quarantine_remaining_secs.is_some());
+        assert_eq!(snapshot[2].state, ProfileSlotState::Available);
+        for status in &snapshot {
+            assert!(!status.profile_name.contains('/'));
+        }
+        reset_registry_for_tests(&[busy, sick, free]);
+    }
+
+    #[tokio::test]
+    async fn concurrent_missions_never_share_a_profile_slot() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let root = tempfile::tempdir().unwrap();
+        let profiles: Vec<PathBuf> = (0..2)
+            .map(|index| {
+                let profile = root.path().join(format!("profile-{index}"));
+                std::fs::create_dir(&profile).unwrap();
+                profile
+            })
+            .collect();
+        reset_registry_for_tests(&profiles);
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let (events_tx, _) = broadcast::channel(64);
+
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            let profiles = profiles.clone();
+            let active = Arc::clone(&active);
+            let peak = Arc::clone(&peak);
+            let events_tx = events_tx.clone();
+            handles.push(tokio::spawn(async move {
+                let cancel = CancellationToken::new();
+                let (slot, profile, lease) =
+                    acquire_profile(&profiles, Uuid::new_v4(), &events_tx, &cancel)
+                        .await
+                        .unwrap();
+                let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now_active, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                drop(lease);
+                (slot, profile)
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert!(peak.load(Ordering::SeqCst) <= profiles.len());
+    }
+}

--- a/src/api/runners/chatgpt_ui/profile_pool.rs
+++ b/src/api/runners/chatgpt_ui/profile_pool.rs
@@ -3,8 +3,7 @@
 //! Every ChatGPT UI turn leases exactly one profile directory through an
 //! advisory file lock. Slots that keep failing in ways that a retry cannot fix
 //! (logged-out profile, broken browser launch, repeated UI incompatibility)
-//! are quarantined for a cooldown so healthy slots are preferred. The pool
-//! fails open: when every slot is quarantined, leases are still granted.
+//! are quarantined for a cooldown so unhealthy slots are not retried blindly.
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -106,7 +105,11 @@ fn quarantine_for(kind: SlotFailureKind, consecutive_failures: u32) -> Option<Du
 fn record_slot_failure_at(profile_dir: &Path, kind: SlotFailureKind, now: Instant) {
     let mut slots = registry().lock().expect("profile pool registry poisoned");
     let health = slots.entry(profile_dir.to_path_buf()).or_default();
-    health.consecutive_failures = health.consecutive_failures.saturating_add(1);
+    health.consecutive_failures = if health.last_failure == Some(kind) {
+        health.consecutive_failures.saturating_add(1)
+    } else {
+        1
+    };
     health.last_failure = Some(kind);
     if let Some(cooldown) = quarantine_for(kind, health.consecutive_failures) {
         let until = now + cooldown;
@@ -166,13 +169,16 @@ pub async fn acquire_profile(
     let mut announced_wait = false;
     loop {
         let now = Instant::now();
-        // Prefer healthy slots, but fail open: a fully quarantined pool still
-        // grants leases so a transient outage cannot deadlock every mission.
-        let all_quarantined = profile_dirs
-            .iter()
-            .all(|profile_dir| is_quarantined_at(profile_dir, now));
-        for (slot, profile_dir) in profile_dirs.iter().enumerate() {
-            if !all_quarantined && is_quarantined_at(profile_dir, now) {
+        let mut candidates = profile_dirs.iter().enumerate().collect::<Vec<_>>();
+        // A compatibility failure is not quarantined until it repeats, but a
+        // clean alternative must still win the next lease. This lets a
+        // controller perform its single different-slot retry without making
+        // one transient selector miss sideline the profile for ten minutes.
+        candidates.sort_by_key(|(_, profile_dir)| {
+            slot_health_at(profile_dir, now).last_failure.is_some()
+        });
+        for (slot, profile_dir) in candidates {
+            if is_quarantined_at(profile_dir, now) {
                 continue;
             }
             match try_lock_profile(profile_dir) {
@@ -220,6 +226,7 @@ pub enum ProfileSlotState {
     Available,
     InUse,
     Quarantined,
+    Unavailable,
 }
 
 /// Privacy-safe snapshot of one pool slot: exposes only the directory
@@ -248,13 +255,12 @@ pub fn pool_snapshot(profile_dirs: &[PathBuf]) -> Vec<ProfileSlotStatus> {
                 .and_then(|until| until.checked_duration_since(now));
             // A momentary probe lock is released immediately and cannot
             // starve waiting missions, which retry every two seconds.
-            let in_use = matches!(try_lock_profile(profile_dir), Ok(None));
-            let state = if in_use {
-                ProfileSlotState::InUse
-            } else if quarantine_remaining.is_some() {
-                ProfileSlotState::Quarantined
-            } else {
-                ProfileSlotState::Available
+            let lock_state = try_lock_profile(profile_dir);
+            let state = match lock_state {
+                Ok(None) => ProfileSlotState::InUse,
+                Ok(Some(_)) if quarantine_remaining.is_some() => ProfileSlotState::Quarantined,
+                Ok(Some(_)) => ProfileSlotState::Available,
+                Err(_) => ProfileSlotState::Unavailable,
             };
             ProfileSlotStatus {
                 slot: index + 1,
@@ -340,17 +346,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fully_quarantined_pool_fails_open() {
+    async fn compatibility_failure_prefers_a_different_clean_slot() {
         let root = tempfile::tempdir().unwrap();
-        let only_profile = root.path().join("profile-1");
-        std::fs::create_dir(&only_profile).unwrap();
-        reset_registry_for_tests(std::slice::from_ref(&only_profile));
-        record_slot_failure(&only_profile, SlotFailureKind::Launch);
+        let first_profile = root.path().join("profile-1");
+        let second_profile = root.path().join("profile-2");
+        std::fs::create_dir(&first_profile).unwrap();
+        std::fs::create_dir(&second_profile).unwrap();
+        reset_registry_for_tests(&[first_profile.clone(), second_profile.clone()]);
+        record_slot_failure(&first_profile, SlotFailureKind::Compatibility);
         let (events_tx, _) = broadcast::channel(8);
         let cancel = CancellationToken::new();
 
         let (slot, selected, _lease) = acquire_profile(
-            std::slice::from_ref(&only_profile),
+            &[first_profile.clone(), second_profile.clone()],
             Uuid::new_v4(),
             &events_tx,
             &cancel,
@@ -358,8 +366,31 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(slot, 0);
-        assert_eq!(selected, only_profile);
+        assert_eq!(slot, 1);
+        assert_eq!(selected, second_profile);
+        reset_registry_for_tests(&[first_profile]);
+    }
+
+    #[tokio::test]
+    async fn fully_quarantined_pool_waits_until_cancelled() {
+        let root = tempfile::tempdir().unwrap();
+        let only_profile = root.path().join("profile-1");
+        std::fs::create_dir(&only_profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&only_profile));
+        record_slot_failure(&only_profile, SlotFailureKind::Launch);
+        let (events_tx, _) = broadcast::channel(8);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let result = acquire_profile(
+            std::slice::from_ref(&only_profile),
+            Uuid::new_v4(),
+            &events_tx,
+            &cancel,
+        )
+        .await;
+
+        assert!(result.is_err());
         reset_registry_for_tests(&[only_profile]);
     }
 
@@ -398,6 +429,22 @@ mod tests {
 
         record_slot_success(&profile);
         assert!(!is_quarantined_at(&profile, now));
+        reset_registry_for_tests(&[profile]);
+    }
+
+    #[test]
+    fn compatibility_threshold_counts_only_consecutive_compatibility_failures() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+        let now = Instant::now();
+
+        record_slot_failure_at(&profile, SlotFailureKind::Compatibility, now);
+        record_slot_failure_at(&profile, SlotFailureKind::Compatibility, now);
+        record_slot_failure_at(&profile, SlotFailureKind::Launch, now);
+        assert_eq!(slot_health_at(&profile, now).consecutive_failures, 1);
+
         reset_registry_for_tests(&[profile]);
     }
 
@@ -443,6 +490,16 @@ mod tests {
             assert!(!status.profile_name.contains('/'));
         }
         reset_registry_for_tests(&[busy, sick, free]);
+    }
+
+    #[test]
+    fn pool_snapshot_never_reports_an_unlockable_slot_as_available() {
+        let root = tempfile::tempdir().unwrap();
+        let missing_parent = root.path().join("missing").join("profile");
+
+        let snapshot = pool_snapshot(&[missing_parent]);
+
+        assert_eq!(snapshot[0].state, ProfileSlotState::Unavailable);
     }
 
     #[tokio::test]

--- a/src/api/runners/chatgpt_ui/profile_pool.rs
+++ b/src/api/runners/chatgpt_ui/profile_pool.rs
@@ -2,7 +2,7 @@
 //!
 //! Every ChatGPT UI turn leases exactly one profile directory through an
 //! advisory file lock. Slots that keep failing in ways that a retry cannot fix
-//! (logged-out profile, broken browser launch, repeated UI incompatibility)
+//! (logged-out profile, profile-local Chromium singleton conflict, repeated UI incompatibility)
 //! are quarantined for a cooldown so unhealthy slots are not retried blindly.
 
 use std::collections::HashMap;
@@ -63,8 +63,9 @@ pub fn try_lock_profile(profile_dir: &Path) -> Result<Option<ProfileLock>, Strin
 pub enum SlotFailureKind {
     /// The profile is logged out; retries cannot recover it.
     Auth,
-    /// The browser could not launch or the profile is held by a foreign
-    /// browser process.
+    /// The profile is held by a live, foreign-host, or unrecognized Chromium
+    /// singleton. Undifferentiated browser launch failures are host-global and
+    /// must not be recorded against a slot.
     Launch,
     /// The driver failed a UI compatibility check on this profile.
     Compatibility,


### PR DESCRIPTION
## Summary
- **Per-slot health/quarantine** (`src/api/runners/chatgpt_ui/profile_pool.rs`): auth failures quarantine a slot 30 min, launch failures 5 min, compatibility failures 10 min after 3 consecutive strikes; success resets. A fully quarantined pool **fails open** so missions never deadlock. Existing lease/wait/cancel semantics preserved.
- **Safe Chromium Singleton cleanup** (`src/api/runners/chatgpt_ui/chromium_cleanup.rs`): `SingletonLock`/`SingletonCookie`/`SingletonSocket` are removed only when provably safe — same-host + dead pid, or pool-owned via an ownership marker (`.{name}.sandboxed-chatgpt-ui.owner`, stored outside the profile) that survives container hostname churn. Live-process locks, foreign unowned locks, and regular files are never touched; unlaunchable profiles fail fast with a structured error instead of a browser crash loop.
- **Failure classes**: driver error codes map to `TerminalReason`/`FailureClass` (`auth_required`→AuthError, `rate_limited`→RateLimited, `browser_launch`→TransportError, `compatibility`→ProviderError) and feed slot health.
- **Selector hardening** (`scripts/chatgpt_ui_driver.py`): send/stop controls resolve via stable `data-testid`s first, falling back to composer-form-scoped anchored accessible-name regexes; fallback use emits one fixed-string diagnostic.
- **Privacy-safe telemetry**: `GET /api/backends/chatgpt_ui/profile-pool` returns slot state (available/in_use/quarantined), failure counts, and quarantine countdown — profile **basenames only**, never full paths or contents. Diagnostics remain on the fixed-string allowlist.
- **Dashboard**: read-only "Profile pool status" panel in the ChatGPT UI backend tab (SWR, 15 s refresh, shown only when runtime paths are configured).

Baseline: `17bbf178` (current origin/master, includes #677 — no overlap: #677 covered watchdog/liveness, this covers pool health/cleanup/telemetry).

## Verification
- `cargo fmt --all` / `cargo fmt --all --check` — clean
- `cargo check --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1513 passed / 1 ignored / 1 failed: `api::remote_build::tests::wrapper_resumes_an_interrupted_async_job_without_resubmitting`, **pre-existing** (reproduced identically on pristine `17bbf178`), unrelated to this change
- `cargo test --lib chatgpt_ui` — 27/27 (pool quarantine, fail-open, concurrency lease exclusivity, Singleton judgment, ownership marker, error-code classification, diagnostics allowlist)
- Python `unittest` in `scripts/` — 17/17 (selector fallback matrix, anchored names, download safety)
- Dashboard: `vitest` 254/254 (incl. new pool-panel test), `eslint` 0 errors (no findings in touched files), `next build` production build passes

## Test plan
- [ ] Review quarantine durations and fail-open policy
- [ ] Verify Singleton cleanup rules against a real multi-profile deployment (hostname churn case)
- [ ] Confirm telemetry endpoint exposes no sensitive paths
- [ ] Smoke-test dashboard panel against a live pool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ChatGPT UI mission path (profile selection, on-disk browser profile cleanup, and failure classification); cleanup is conservative but incorrect judgment could affect live browser processes or profile locks.
> 
> **Overview**
> Hardens the **ChatGPT UI** browser profile pool so missions skip bad slots, recover from crashed Chromium state, and expose operator-friendly status.
> 
> **Runner / pool:** Profile leasing moves into `profile_pool` with per-slot health: auth and launch failures quarantine slots for timed cooldowns; compatibility failures quarantine after repeated strikes; successes reset health. Acquisition prefers cleaner slots over ones with recent failures. Driver error codes map to terminal reasons and, where appropriate, slot-local failure records (`browser_launch` deliberately does not quarantine a slot).
> 
> **Chromium:** Before/after each Chromium turn, conservative cleanup of `SingletonLock` / cookie / socket entries runs only under the profile lock, with pool ownership markers so container hostname changes do not strand profiles. Unlaunchable singleton states fail fast with structured errors instead of looping launches.
> 
> **Driver:** Send/stop controls resolve via `data-testid` first, then composer-scoped anchored button names, with one-shot fallback diagnostics.
> 
> **API & dashboard:** `GET /api/backends/chatgpt_ui/profile-pool` returns basename-only slot telemetry (state, failures, quarantine countdown). The ChatGPT UI backends tab polls this when runtime paths are configured and shows a read-only pool status panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb22bddcc535c94aaa5191c3dfb56f9d4bcf0fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->