### PR TITLE
feat: discover Kimi models dynamically

### DIFF
--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8800,55 +8800,15 @@ async fn upsert_kimi_oauth_provider(
 pub fn spawn_kimi_oauth_refresh_loop(state: Arc<super::routes::AppState>) {
     tokio::spawn(async move {
         loop {
+            // Run immediately at startup, then every five minutes. Reuse the
+            // same serialized store refresh path as catalog discovery so
+            // rotating refresh tokens cannot race.
+            let (_, refreshed) =
+                refresh_due_store_oauth(&state.ai_providers, ProviderType::Kimi, 600_000).await;
+            if refreshed > 0 {
+                tracing::info!(refreshed, "Refreshed Kimi OAuth credentials");
+            }
             tokio::time::sleep(Duration::from_secs(300)).await;
-
-            // Only do work if a Kimi provider exists.
-            if state
-                .ai_providers
-                .get_all_by_type(ProviderType::Kimi)
-                .await
-                .is_empty()
-            {
-                continue;
-            }
-            let Some(entry) = read_oauth_token_entry(ProviderType::Kimi) else {
-                continue;
-            };
-            // Refresh only when within 10 minutes of expiry.
-            let now_ms = chrono::Utc::now().timestamp_millis();
-            if entry.expires_at > now_ms + 600_000 || entry.refresh_token.trim().is_empty() {
-                continue;
-            }
-
-            let client = reqwest::Client::new();
-            match refresh_kimi_oauth_tokens(&client, &entry.refresh_token).await {
-                Ok((access, refresh, expires_at)) => {
-                    if let Err(e) =
-                        sync_to_opencode_auth(ProviderType::Kimi, &refresh, &access, expires_at)
-                    {
-                        tracing::warn!("Failed to persist refreshed Kimi token: {e}");
-                    }
-                    // Update store rows so the chain resolver sees the fresh token.
-                    for mut acct in state.ai_providers.get_all_by_type(ProviderType::Kimi).await {
-                        if acct.oauth.is_some() {
-                            acct.oauth = Some(crate::ai_providers::OAuthCredentials {
-                                refresh_token: refresh.clone(),
-                                access_token: access.clone(),
-                                expires_at,
-                            });
-                            let id = acct.id;
-                            state.ai_providers.update(id, acct).await;
-                        }
-                    }
-                    tracing::info!("Refreshed Kimi OAuth token (expires_at={expires_at})");
-                }
-                Err(OAuthRefreshError::InvalidGrant(msg)) => {
-                    tracing::warn!("Kimi refresh token invalid; user must re-authenticate: {msg}");
-                }
-                Err(e) => {
-                    tracing::debug!("Kimi token refresh failed: {e}");
-                }
-            }
         }
     });
 }
@@ -10065,6 +10025,7 @@ pub async fn refresh_oauth_token_internal(
             // **Solution #2: OpenAI may also rotate refresh tokens**
             Ok((new_access, new_refresh, expires_at))
         }
+        ProviderType::Kimi => refresh_kimi_oauth_tokens(&client, refresh_token).await,
         ProviderType::Google => {
             // Google refresh token request
             let token_response = client

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8105,6 +8105,8 @@ async fn update_provider(
     }
     .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Provider {} not found", id)))?;
 
+    let refresh_kimi_catalog = existing.provider_type == ProviderType::Kimi
+        && (req.priority.is_some() || req.enabled.is_some() || req.base_url.is_some());
     let uuid = existing.id;
     let mut updated = existing.clone();
     if let Some(name) = req.name {
@@ -8170,6 +8172,9 @@ async fn update_provider(
     if pt != ProviderType::Custom {
         sync_store_to_opencode(&state.ai_providers, &state.config.working_dir, pt).await;
     }
+    if refresh_kimi_catalog {
+        reconcile_preferred_kimi_catalog(&state).await;
+    }
 
     if pt == ProviderType::Xai && result.enabled && provider_targets_grok(&result) {
         if let Err(e) = state.backend_configs.set_enabled("grok", true).await {
@@ -8220,6 +8225,11 @@ async fn delete_provider(
 
     let provider_type = provider.provider_type;
     let uuid = provider.id;
+    if provider_type == ProviderType::Kimi {
+        // The row will no longer be addressable after deletion; fence any
+        // in-flight probe and discard its account-specific snapshot first.
+        crate::api::providers::invalidate_kimi_model_cache(&provider).await;
+    }
 
     // Delete from AIProviderStore
     if !state.ai_providers.delete(uuid).await {
@@ -8234,6 +8244,9 @@ async fn delete_provider(
             provider_type,
         )
         .await;
+    }
+    if provider_type == ProviderType::Kimi {
+        reconcile_preferred_kimi_catalog(&state).await;
     }
 
     // Clear default if this was the default
@@ -8259,6 +8272,30 @@ async fn delete_provider(
         StatusCode::OK,
         format!("Provider {} deleted successfully", id),
     ))
+}
+
+/// Reconcile the shared Kimi picker catalog after an operator changes which
+/// stored account is preferred. Workspace config and live discovery must use
+/// the same account; otherwise account-specific future models can be exposed
+/// by the picker but omitted from the mission's generated provider block.
+async fn reconcile_preferred_kimi_catalog(state: &super::routes::AppState) {
+    crate::api::providers::advance_kimi_catalog_generation();
+    let providers = state.ai_providers.get_all_by_type(ProviderType::Kimi).await;
+    // Fence every account because a periodic probe for the previously
+    // preferred row may already be in flight while a different row is being
+    // promoted. Only a probe started after this preference generation may
+    // repopulate the shared catalog.
+    for provider in &providers {
+        crate::api::providers::invalidate_kimi_model_cache(provider).await;
+    }
+    let preferred = crate::api::providers::preferred_usable_kimi_provider(&providers);
+    state.model_catalog.write().await.remove("kimi");
+    if let Some(provider) = preferred {
+        let catalog = Arc::clone(&state.model_catalog);
+        tokio::spawn(async move {
+            crate::api::providers::refresh_connected_kimi_catalog(catalog, provider).await;
+        });
+    }
 }
 
 /// POST /api/ai/providers/:id/auth - Initiate authentication for a provider.
@@ -8786,16 +8823,10 @@ async fn upsert_kimi_oauth_provider(
         )
     })?;
 
-    // The same local row can be reconnected to a different upstream account.
-    // Remove both account-specific cache layers before asynchronously probing
-    // the fresh credentials, so old entitlements are never exposed meanwhile.
-    crate::api::providers::invalidate_kimi_model_cache(&stored).await;
-    state.model_catalog.write().await.remove("kimi");
-    let catalog = Arc::clone(&state.model_catalog);
-    let catalog_provider = stored.clone();
-    tokio::spawn(async move {
-        crate::api::providers::refresh_connected_kimi_catalog(catalog, catalog_provider).await;
-    });
+    // The same local row can be reconnected to a different upstream account,
+    // and a newly connected row can become preferred. Fence all old probes and
+    // rebuild the shared catalog from the newly preferred account.
+    reconcile_preferred_kimi_catalog(state).await;
 
     if let Err(e) =
         update_provider_backends(&state.config.working_dir, ProviderType::Kimi.id(), backends)

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8440,7 +8440,7 @@ const KIMI_TOKEN_URL: &str = "https://auth.kimi.com/api/oauth/token";
 pub(crate) const KIMI_API_BASE_URL: &str = "https://api.kimi.com/coding/v1";
 /// The coding endpoint returns 403 unless the User-Agent matches a known
 /// coding-agent pattern, so pin it to the Kimi CLI's UA.
-const KIMI_USER_AGENT: &str = "KimiCLI/1.5";
+pub(crate) const KIMI_USER_AGENT: &str = "KimiCLI/1.5";
 const KIMI_DEVICE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
 
 #[derive(Clone)]

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -8696,6 +8696,7 @@ async fn refresh_kimi_oauth_tokens(
         ("client_id", KIMI_CLIENT_ID),
         ("refresh_token", refresh_token),
     ]))
+    .timeout(Duration::from_secs(10))
     .send()
     .await
     .map_err(|e| OAuthRefreshError::Other(format!("Failed to refresh Kimi token: {e}")))?;
@@ -8784,6 +8785,17 @@ async fn upsert_kimi_oauth_provider(
             "Failed to save Kimi OAuth provider".to_string(),
         )
     })?;
+
+    // The same local row can be reconnected to a different upstream account.
+    // Remove both account-specific cache layers before asynchronously probing
+    // the fresh credentials, so old entitlements are never exposed meanwhile.
+    crate::api::providers::invalidate_kimi_model_cache(&stored).await;
+    state.model_catalog.write().await.remove("kimi");
+    let catalog = Arc::clone(&state.model_catalog);
+    let catalog_provider = stored.clone();
+    tokio::spawn(async move {
+        crate::api::providers::refresh_connected_kimi_catalog(catalog, catalog_provider).await;
+    });
 
     if let Err(e) =
         update_provider_backends(&state.config.working_dir, ProviderType::Kimi.id(), backends)

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1381,6 +1381,20 @@ pub(crate) async fn cached_kimi_models(
         .map(|entry| entry.models.clone())
 }
 
+fn preferred_usable_kimi_provider(providers: &[AIProvider]) -> Option<AIProvider> {
+    providers
+        .iter()
+        .filter(|provider| {
+            provider.provider_type == ProviderType::Kimi
+                && provider.enabled
+                && provider.oauth.as_ref().is_some_and(|oauth| {
+                    !oauth.access_token.trim().is_empty() && !oauth.refresh_token.trim().is_empty()
+                })
+        })
+        .min_by_key(|provider| (provider.priority, provider.id))
+        .cloned()
+}
+
 /// Discover the models available to a connected Kimi Code account.
 ///
 /// Kimi is an OpenAI-compatible provider but requires its coding-agent
@@ -1953,11 +1967,7 @@ pub async fn fetch_model_catalog(
     // Kimi has an OpenAI-compatible catalog but requires its coding User-Agent.
     // Use the shared, credential-aware cache so startup refresh also primes
     // mission workspace generation.
-    let kimi_provider = providers_list
-        .iter()
-        .filter(|provider| provider.provider_type == ProviderType::Kimi && provider.enabled)
-        .min_by_key(|provider| (provider.priority, provider.id))
-        .cloned();
+    let kimi_provider = preferred_usable_kimi_provider(&providers_list);
     let kimi_handle = tokio::spawn(async move {
         match kimi_provider {
             Some(provider) => match fetch_kimi_models(&provider).await {
@@ -2699,6 +2709,24 @@ fn is_grok_backend_model_id(model_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn kimi_catalog_skips_a_higher_priority_account_without_oauth() {
+        let mut disconnected = AIProvider::new(ProviderType::Kimi, "Disconnected Kimi".to_string());
+        disconnected.priority = 0;
+
+        let mut connected = AIProvider::new(ProviderType::Kimi, "Connected Kimi".to_string());
+        connected.priority = 10;
+        connected.oauth = Some(crate::ai_providers::OAuthCredentials {
+            access_token: "connected-access".to_string(),
+            refresh_token: "connected-refresh".to_string(),
+            expires_at: i64::MAX,
+        });
+
+        let selected = preferred_usable_kimi_provider(&[disconnected, connected.clone()])
+            .expect("connected Kimi account should remain selectable");
+        assert_eq!(selected.id, connected.id);
+    }
 
     #[test]
     fn test_model_id_to_display_name() {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1358,7 +1358,7 @@ fn kimi_route_fingerprint(
         .filter(|url| !url.trim().is_empty())
         .unwrap_or(crate::api::ai_providers::KIMI_API_BASE_URL);
     Ok((
-        hash_u64(&format!("{base_url}\0{access_token}")),
+        hash_u64(&format!("{}\0{base_url}", provider.id)),
         base_url,
         access_token,
     ))
@@ -1400,8 +1400,9 @@ fn preferred_usable_kimi_provider(providers: &[AIProvider]) -> Option<AIProvider
 /// Kimi is an OpenAI-compatible provider but requires its coding-agent
 /// User-Agent on catalog requests. Cache successful responses briefly so
 /// preparing many mission workspaces does not hit the subscription endpoint
-/// once per mission. The cache key includes the route and a non-secret token
-/// fingerprint, so an OAuth refresh or endpoint change triggers discovery.
+/// once per mission. The cache key includes the stable provider identity and
+/// route, so normal OAuth token rotation does not hide a catalog that is still
+/// valid for that account.
 pub(crate) async fn fetch_kimi_models(
     provider: &crate::ai_providers::AIProvider,
 ) -> Result<Vec<ProviderModel>, String> {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -41,7 +41,13 @@ struct KimiModelCacheEntry {
     expires_at: Instant,
 }
 
-static KIMI_MODEL_CACHE: OnceLock<RwLock<HashMap<u64, KimiModelCacheEntry>>> = OnceLock::new();
+#[derive(Debug, Default)]
+struct KimiModelCache {
+    entries: HashMap<u64, KimiModelCacheEntry>,
+    generations: HashMap<u64, u64>,
+}
+
+static KIMI_MODEL_CACHE: OnceLock<RwLock<KimiModelCache>> = OnceLock::new();
 const KIMI_MODEL_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 const RETIRED_KIMI_MODEL_IDS: &[&str] = &["kimi-k2.6", "kimi-k2-thinking"];
 
@@ -1335,8 +1341,8 @@ fn parse_openai_compatible_models(
     Ok(models)
 }
 
-fn kimi_model_cache() -> &'static RwLock<HashMap<u64, KimiModelCacheEntry>> {
-    KIMI_MODEL_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+fn kimi_model_cache() -> &'static RwLock<KimiModelCache> {
+    KIMI_MODEL_CACHE.get_or_init(|| RwLock::new(KimiModelCache::default()))
 }
 
 fn kimi_route_fingerprint(
@@ -1375,6 +1381,7 @@ pub(crate) async fn cached_kimi_models(
     kimi_model_cache()
         .read()
         .await
+        .entries
         .get(&route_fingerprint)
         .map(|entry| entry.models.clone())
 }
@@ -1385,7 +1392,10 @@ pub(crate) async fn cached_kimi_models(
 /// account with different model entitlements.
 pub(crate) async fn invalidate_kimi_model_cache(provider: &crate::ai_providers::AIProvider) {
     if let Ok((route_fingerprint, _, _)) = kimi_route_fingerprint(provider) {
-        kimi_model_cache().write().await.remove(&route_fingerprint);
+        let mut cache = kimi_model_cache().write().await;
+        cache.entries.remove(&route_fingerprint);
+        let generation = cache.generations.entry(route_fingerprint).or_default();
+        *generation = generation.wrapping_add(1);
     }
 }
 
@@ -1419,7 +1429,7 @@ pub(crate) async fn refresh_connected_kimi_catalog(catalog: ModelCatalog, provid
     }
 }
 
-fn preferred_usable_kimi_provider(providers: &[AIProvider]) -> Option<AIProvider> {
+pub(crate) fn preferred_usable_kimi_provider(providers: &[AIProvider]) -> Option<AIProvider> {
     providers
         .iter()
         .filter(|provider| {
@@ -1446,15 +1456,29 @@ pub(crate) async fn fetch_kimi_models(
 ) -> Result<Vec<ProviderModel>, String> {
     let (route_fingerprint, base_url, access_token) = kimi_route_fingerprint(provider)?;
 
-    let stale_models = {
+    let (stale_models, probe_generation) = {
         let cache = kimi_model_cache().read().await;
-        if let Some(entry) = cache.get(&route_fingerprint) {
+        if let Some(entry) = cache.entries.get(&route_fingerprint) {
             if entry.expires_at > Instant::now() {
                 return Ok(entry.models.clone());
             }
-            Some(entry.models.clone())
+            (
+                Some(entry.models.clone()),
+                cache
+                    .generations
+                    .get(&route_fingerprint)
+                    .copied()
+                    .unwrap_or_default(),
+            )
         } else {
-            None
+            (
+                None,
+                cache
+                    .generations
+                    .get(&route_fingerprint)
+                    .copied()
+                    .unwrap_or_default(),
+            )
         }
     };
 
@@ -1472,13 +1496,13 @@ pub(crate) async fn fetch_kimi_models(
         Ok(_) => {
             if let Some(models) = stale_models {
                 tracing::warn!("Kimi model catalog was empty; reusing stale catalog");
-                kimi_model_cache().write().await.insert(
+                store_kimi_models_if_current(
                     route_fingerprint,
-                    KimiModelCacheEntry {
-                        models: models.clone(),
-                        expires_at: Instant::now() + Duration::from_secs(60),
-                    },
-                );
+                    probe_generation,
+                    models.clone(),
+                    Duration::from_secs(60),
+                )
+                .await?;
                 return Ok(models);
             }
             return Err("Kimi model catalog was empty".to_string());
@@ -1489,27 +1513,52 @@ pub(crate) async fn fetch_kimi_models(
                     error = %error,
                     "Kimi model discovery failed; reusing stale catalog"
                 );
-                kimi_model_cache().write().await.insert(
+                store_kimi_models_if_current(
                     route_fingerprint,
-                    KimiModelCacheEntry {
-                        models: models.clone(),
-                        expires_at: Instant::now() + Duration::from_secs(60),
-                    },
-                );
+                    probe_generation,
+                    models.clone(),
+                    Duration::from_secs(60),
+                )
+                .await?;
                 return Ok(models);
             }
             return Err(error);
         }
     };
 
-    kimi_model_cache().write().await.insert(
+    store_kimi_models_if_current(
+        route_fingerprint,
+        probe_generation,
+        models.clone(),
+        KIMI_MODEL_CACHE_TTL,
+    )
+    .await?;
+    Ok(models)
+}
+
+async fn store_kimi_models_if_current(
+    route_fingerprint: u64,
+    probe_generation: u64,
+    models: Vec<ProviderModel>,
+    ttl: Duration,
+) -> Result<(), String> {
+    let mut cache = kimi_model_cache().write().await;
+    let current_generation = cache
+        .generations
+        .get(&route_fingerprint)
+        .copied()
+        .unwrap_or_default();
+    if current_generation != probe_generation {
+        return Err("Kimi account changed while its model catalog was being fetched".to_string());
+    }
+    cache.entries.insert(
         route_fingerprint,
         KimiModelCacheEntry {
-            models: models.clone(),
-            expires_at: Instant::now() + KIMI_MODEL_CACHE_TTL,
+            models,
+            expires_at: Instant::now() + ttl,
         },
     );
-    Ok(models)
+    Ok(())
 }
 
 /// Fetch models from the Anthropic /v1/models endpoint.
@@ -2767,6 +2816,42 @@ mod tests {
         let selected = preferred_usable_kimi_provider(&[disconnected, connected.clone()])
             .expect("connected Kimi account should remain selectable");
         assert_eq!(selected.id, connected.id);
+    }
+
+    #[tokio::test]
+    async fn kimi_catalog_rejects_a_result_from_before_reconnect() {
+        let mut provider = AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
+        provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+            access_token: "old-account-access".to_string(),
+            refresh_token: "old-account-refresh".to_string(),
+            expires_at: i64::MAX,
+        });
+        provider.base_url = Some("https://example.invalid".to_string());
+
+        let (route_fingerprint, _, _) = kimi_route_fingerprint(&provider).unwrap();
+        let probe_generation = kimi_model_cache()
+            .read()
+            .await
+            .generations
+            .get(&route_fingerprint)
+            .copied()
+            .unwrap_or_default();
+
+        invalidate_kimi_model_cache(&provider).await;
+        let result = store_kimi_models_if_current(
+            route_fingerprint,
+            probe_generation,
+            vec![ProviderModel {
+                id: "old-account-only".to_string(),
+                name: "Old account only".to_string(),
+                description: None,
+            }],
+            KIMI_MODEL_CACHE_TTL,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(cached_kimi_models(&provider).await.is_none());
     }
 
     #[test]

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -44,6 +44,7 @@ struct KimiModelCacheEntry {
 
 static KIMI_MODEL_CACHE: OnceLock<RwLock<Option<KimiModelCacheEntry>>> = OnceLock::new();
 const KIMI_MODEL_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+const RETIRED_KIMI_MODEL_IDS: &[&str] = &["kimi-k2.6", "kimi-k2-thinking"];
 
 /// Provider IDs that are part of the default catalog and should not be duplicated
 /// from the AIProviderStore.
@@ -295,7 +296,7 @@ pub(crate) async fn catalog_model_options_for_state(
     let working_dir = state.config.working_dir.to_string_lossy().to_string();
     let mut config = load_providers_config(&working_dir);
 
-    let cached = state.model_catalog.read().await;
+    let cached = state.model_catalog.read().await.clone();
     merge_cached_provider_models(&mut config, &cached, include_unverified);
 
     let mut configured = get_configured_provider_ids(state.config.working_dir.as_path());
@@ -322,7 +323,7 @@ pub(crate) async fn catalog_model_options_for_state(
         config.providers
     };
     merge_store_provider_models(&mut providers, &store_providers, !configured_only);
-    apply_live_custom_provider_models(
+    apply_live_authoritative_provider_models(
         &mut providers,
         &store_providers,
         &cached,
@@ -414,6 +415,14 @@ fn merge_default_provider_models(config: &mut ProvidersConfig) {
             .iter_mut()
             .find(|provider| provider.id == default_provider.id)
         {
+            // Old generated/provider configuration survives binary upgrades.
+            // Do not let Kimi's retired hardcoded entries remain selectable
+            // forever merely because defaults use additive merge semantics.
+            if existing.id == "kimi" {
+                existing
+                    .models
+                    .retain(|model| !RETIRED_KIMI_MODEL_IDS.contains(&model.id.as_str()));
+            }
             merge_provider_models(&mut existing.models, default_provider.models);
             continue;
         }
@@ -1357,16 +1366,23 @@ pub(crate) async fn fetch_kimi_models(
         .unwrap_or(crate::api::ai_providers::KIMI_API_BASE_URL);
     let route_fingerprint = hash_u64(&format!("{base_url}\0{access_token}"));
 
-    {
+    let stale_models = {
         let cache = kimi_model_cache().read().await;
         if let Some(entry) = cache.as_ref() {
             if entry.route_fingerprint == route_fingerprint && entry.expires_at > Instant::now() {
                 return Ok(entry.models.clone());
             }
+            if entry.route_fingerprint == route_fingerprint {
+                Some(entry.models.clone())
+            } else {
+                None
+            }
+        } else {
+            None
         }
-    }
+    };
 
-    let models = fetch_openai_compatible_models_with_headers(
+    let discovered = fetch_openai_compatible_models_with_headers(
         base_url,
         access_token,
         &[],
@@ -1374,10 +1390,37 @@ pub(crate) async fn fetch_kimi_models(
         true,
         &[("User-Agent", crate::api::ai_providers::KIMI_USER_AGENT)],
     )
-    .await?;
-    if models.is_empty() {
-        return Err("Kimi model catalog was empty".to_string());
-    }
+    .await;
+    let models = match discovered {
+        Ok(models) if !models.is_empty() => models,
+        Ok(_) => {
+            if let Some(models) = stale_models {
+                tracing::warn!("Kimi model catalog was empty; reusing stale catalog");
+                *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
+                    route_fingerprint,
+                    models: models.clone(),
+                    expires_at: Instant::now() + Duration::from_secs(60),
+                });
+                return Ok(models);
+            }
+            return Err("Kimi model catalog was empty".to_string());
+        }
+        Err(error) => {
+            if let Some(models) = stale_models {
+                tracing::warn!(
+                    error = %error,
+                    "Kimi model discovery failed; reusing stale catalog"
+                );
+                *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
+                    route_fingerprint,
+                    models: models.clone(),
+                    expires_at: Instant::now() + Duration::from_secs(60),
+                });
+                return Ok(models);
+            }
+            return Err(error);
+        }
+    };
 
     *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
         route_fingerprint,
@@ -1748,8 +1791,6 @@ pub async fn fetch_model_catalog(
         /// Set for prefix-less, large catalogs (OpenRouter) to keep the
         /// routing picker bounded; `None` means no cap.
         max_models: Option<usize>,
-        /// Provider-specific headers required by the catalog endpoint.
-        extra_headers: Vec<(&'static str, &'static str)>,
     }
 
     let targets = vec![
@@ -1762,7 +1803,6 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
-            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::OpenRouter,
@@ -1774,7 +1814,6 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: false,
             allow_unauthenticated: true,
             max_models: Some(MAX_CATALOG_MODELS_PER_PROVIDER),
-            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Xai,
@@ -1785,7 +1824,6 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
-            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Cerebras,
@@ -1796,7 +1834,6 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
-            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Zai,
@@ -1807,7 +1844,6 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
-            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Minimax,
@@ -1818,18 +1854,6 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
-            extra_headers: vec![],
-        },
-        FetchTarget {
-            provider_type: ProviderType::Kimi,
-            provider_id: "kimi",
-            base_url: crate::api::ai_providers::KIMI_API_BASE_URL,
-            prefix_filters: vec![],
-            models_query: None,
-            sort_results_by_id: true,
-            allow_unauthenticated: false,
-            max_models: None,
-            extra_headers: vec![("User-Agent", crate::api::ai_providers::KIMI_USER_AGENT)],
         },
     ];
 
@@ -1883,8 +1907,35 @@ pub async fn fetch_model_catalog(
         }
     });
 
+    // Kimi has an OpenAI-compatible catalog but requires its coding User-Agent.
+    // Use the shared, credential-aware cache so startup refresh also primes
+    // mission workspace generation.
+    let kimi_provider = providers_list
+        .iter()
+        .filter(|provider| provider.provider_type == ProviderType::Kimi && provider.enabled)
+        .min_by_key(|provider| (provider.priority, provider.id))
+        .cloned();
+    let kimi_handle = tokio::spawn(async move {
+        match kimi_provider {
+            Some(provider) => match fetch_kimi_models(&provider).await {
+                Ok(models) => {
+                    tracing::info!("Fetched {} models from Kimi API", models.len());
+                    Some(("kimi".to_string(), models))
+                }
+                Err(error) => {
+                    tracing::warn!("Failed to fetch Kimi models: {}", error);
+                    None
+                }
+            },
+            None => {
+                tracing::debug!("No Kimi OAuth account, skipping model fetch");
+                None
+            }
+        }
+    });
+
     // Fetch OpenAI-compatible providers concurrently
-    let mut handles = vec![anthropic_handle];
+    let mut handles = vec![anthropic_handle, kimi_handle];
     for (target, key) in target_keys {
         let provider_id = target.provider_id.to_string();
         let base_url = target.base_url.to_string();
@@ -1892,7 +1943,6 @@ pub async fn fetch_model_catalog(
         let models_query = target.models_query.map(str::to_string);
         let sort_results_by_id = target.sort_results_by_id;
         let allow_unauthenticated = target.allow_unauthenticated;
-        let extra_headers = target.extra_headers;
         let prefix_filters: Vec<String> = target
             .prefix_filters
             .iter()
@@ -1908,13 +1958,12 @@ pub async fn fetch_model_catalog(
             match api_key {
                 Some(api_key) => {
                     let filters: Vec<&str> = prefix_filters.iter().map(|s| s.as_str()).collect();
-                    match fetch_openai_compatible_models_with_headers(
+                    match fetch_openai_compatible_models(
                         &base_url,
                         &api_key,
                         &filters,
                         models_query.as_deref(),
                         sort_results_by_id,
-                        &extra_headers,
                     )
                     .await
                     {
@@ -2118,31 +2167,43 @@ fn get_configured_provider_ids(working_dir: &std::path::Path) -> HashSet<String>
 /// and descriptions. Only includes providers that are actually configured
 /// and authenticated. This endpoint is used by the frontend to render
 /// a grouped model selector.
-/// Replace each custom provider's operator-configured `custom_models` with the
-/// live model list fetched from its `/v1/models` (cached in `model_catalog`).
-/// Built-in providers are left untouched — they keep MERGE semantics so a
-/// subscription probe can't hide valid defaults. Custom providers (self-hosted
-/// OpenAI-compatible routers like the dgx-spark-router) instead treat the
-/// router's reported models as the source of truth.
-fn apply_live_custom_provider_models(
+/// Replace authoritative provider catalogs with their live `/v1/models` list.
+///
+/// Custom routers and Kimi return complete model catalogs, so merging would
+/// leave removed/renamed models selectable forever. Other built-in providers
+/// retain additive semantics because some subscription probes expose only a
+/// subset of valid choices.
+fn apply_live_authoritative_provider_models(
     providers: &mut [Provider],
     store_providers: &[crate::ai_providers::AIProvider],
     cached: &HashMap<String, Vec<CatalogEntry>>,
     include_unverified: bool,
 ) {
-    let custom_provider_ids: HashSet<String> = store_providers
+    let mut authoritative_provider_ids: HashSet<String> = store_providers
         .iter()
         .filter(|p| p.provider_type == ProviderType::Custom && p.enabled)
         .map(|p| sanitize_custom_provider_id(&p.name))
         .collect();
+    if store_providers
+        .iter()
+        .any(|p| p.provider_type == ProviderType::Kimi && p.enabled)
+    {
+        authoritative_provider_ids.insert("kimi".to_string());
+    }
     for provider in providers.iter_mut() {
-        if !custom_provider_ids.contains(&provider.id) {
+        if !authoritative_provider_ids.contains(&provider.id) {
             continue;
         }
         if let Some(entries) = cached.get(&provider.id) {
             let live: Vec<ProviderModel> = entries
                 .iter()
-                .filter(|e| include_unverified || e.is_selectable_by_default())
+                .filter(|entry| {
+                    if provider.id == "kimi" {
+                        entry.availability == CatalogAvailability::Available
+                    } else {
+                        include_unverified || entry.is_selectable_by_default()
+                    }
+                })
                 .map(CatalogEntry::to_provider_model)
                 .collect();
             if !live.is_empty() {
@@ -2162,7 +2223,7 @@ pub async fn list_providers(
     // Extend hardcoded defaults with the dynamic catalog. Some subscription
     // catalog probes can return only a currently-selected model, so replacing
     // the defaults would hide valid choices such as newly released Claude Opus.
-    let cached = state.model_catalog.read().await;
+    let cached = state.model_catalog.read().await.clone();
     merge_cached_provider_models(&mut config, &cached, query.include_unverified);
 
     // Get the set of configured provider IDs
@@ -2182,7 +2243,7 @@ pub async fn list_providers(
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, query.include_all);
 
-    apply_live_custom_provider_models(
+    apply_live_authoritative_provider_models(
         &mut providers,
         &store_providers,
         &cached,
@@ -2227,9 +2288,8 @@ pub async fn list_backend_model_options(
     let mut config = load_providers_config(&working_dir);
 
     // Extend hardcoded defaults with the dynamic catalog.
-    let cached = state.model_catalog.read().await;
+    let cached = state.model_catalog.read().await.clone();
     merge_cached_provider_models(&mut config, &cached, query.include_unverified);
-    drop(cached);
 
     let configured = get_configured_provider_ids(state.config.working_dir.as_path());
     let mut providers = if query.include_all {
@@ -2244,6 +2304,13 @@ pub async fn list_backend_model_options(
 
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, query.include_all);
+    apply_live_authoritative_provider_models(
+        &mut providers,
+        &store_providers,
+        &cached,
+        query.include_unverified,
+    );
+    drop(cached);
 
     let mut backends: std::collections::HashMap<String, Vec<BackendModelOption>> =
         std::collections::HashMap::new();
@@ -2376,14 +2443,15 @@ pub async fn validate_model_override(
     let mut config = load_providers_config(&working_dir);
 
     // Extend hardcoded defaults with the dynamic catalog.
-    let cached = state.model_catalog.read().await;
+    let cached = state.model_catalog.read().await.clone();
     merge_cached_provider_models(&mut config, &cached, true);
-    drop(cached);
 
     // Load all providers (including configured and non-default)
     let mut providers = config.providers;
     let store_providers = state.ai_providers.list().await;
     merge_store_provider_models(&mut providers, &store_providers, true);
+    apply_live_authoritative_provider_models(&mut providers, &store_providers, &cached, true);
+    drop(cached);
 
     match backend {
         "opencode" => {
@@ -2620,6 +2688,71 @@ mod tests {
         );
         assert!(!ids.iter().any(|id| id == "kimi-k2.6"));
         assert!(!ids.iter().any(|id| id == "kimi-k2-thinking"));
+    }
+
+    #[test]
+    fn provider_config_upgrade_removes_retired_kimi_models() {
+        let mut config = ProvidersConfig {
+            providers: vec![Provider {
+                id: "kimi".to_string(),
+                name: "Kimi".to_string(),
+                billing: "subscription".to_string(),
+                description: "stale config".to_string(),
+                models: vec![
+                    ProviderModel {
+                        id: "kimi-k2.6".to_string(),
+                        name: "Kimi K2.6".to_string(),
+                        description: None,
+                    },
+                    ProviderModel {
+                        id: "operator-model".to_string(),
+                        name: "Operator model".to_string(),
+                        description: None,
+                    },
+                ],
+            }],
+        };
+
+        merge_default_provider_models(&mut config);
+
+        let ids: Vec<&str> = config.providers[0]
+            .models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect();
+        assert!(!ids.contains(&"kimi-k2.6"));
+        assert!(ids.contains(&"operator-model"));
+        assert!(ids.contains(&"k3"));
+    }
+
+    #[test]
+    fn live_kimi_catalog_replaces_fallback_and_removed_models() {
+        let mut providers = default_providers_config().providers;
+        let kimi_account =
+            crate::ai_providers::AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
+        let cached = HashMap::from([(
+            "kimi".to_string(),
+            vec![CatalogEntry::from_provider_model(
+                "kimi",
+                ProviderModel {
+                    id: "k4-future".to_string(),
+                    name: "K4 Future".to_string(),
+                    description: None,
+                },
+                CatalogSource::ProviderApi,
+                CatalogAvailability::Available,
+                chrono::Utc::now(),
+            )],
+        )]);
+
+        apply_live_authoritative_provider_models(&mut providers, &[kimi_account], &cached, true);
+
+        let kimi = providers
+            .iter()
+            .find(|provider| provider.id == "kimi")
+            .unwrap();
+        assert_eq!(kimi.models.len(), 1);
+        assert_eq!(kimi.models[0].id, "k4-future");
     }
 
     #[test]

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -35,6 +35,16 @@ static CODEX_MODEL_PROBE_CACHE: OnceLock<RwLock<HashMap<String, CodexProbeCacheE
 
 const CODEX_MODEL_PROBE_TTL: Duration = Duration::from_secs(10 * 60);
 
+#[derive(Debug, Clone)]
+struct KimiModelCacheEntry {
+    route_fingerprint: u64,
+    models: Vec<ProviderModel>,
+    expires_at: Instant,
+}
+
+static KIMI_MODEL_CACHE: OnceLock<RwLock<Option<KimiModelCacheEntry>>> = OnceLock::new();
+const KIMI_MODEL_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+
 /// Provider IDs that are part of the default catalog and should not be duplicated
 /// from the AIProviderStore.
 pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] = &[
@@ -46,6 +56,7 @@ pub const DEFAULT_CATALOG_PROVIDER_IDS: &[&str] = &[
     "cerebras",
     "zai",
     "minimax",
+    "kimi",
 ];
 
 /// Upper bound on models merged for a single provider from live `/v1/models`
@@ -169,6 +180,35 @@ pub struct ProviderModel {
     /// Optional description
     #[serde(default)]
     pub description: Option<String>,
+}
+
+/// Models documented for Kimi Code and returned by its coding `/v1/models`
+/// endpoint as of July 2026. These are only a resilient startup fallback:
+/// connected accounts are refreshed from the live endpoint, so future Kimi
+/// models become selectable without a Sandboxed.sh release.
+pub(crate) fn kimi_fallback_models() -> Vec<ProviderModel> {
+    vec![
+        ProviderModel {
+            id: "kimi-for-coding".to_string(),
+            name: "K2.7 Coding".to_string(),
+            description: Some("Stable Kimi K2.7 coding alias".to_string()),
+        },
+        ProviderModel {
+            id: "kimi-for-coding-highspeed".to_string(),
+            name: "K2.7 Coding Highspeed".to_string(),
+            description: Some("High-speed Kimi K2.7 coding alias".to_string()),
+        },
+        ProviderModel {
+            id: "k3".to_string(),
+            name: "K3".to_string(),
+            description: Some("Kimi K3 with up to a 1M-token context window".to_string()),
+        },
+        ProviderModel {
+            id: "k3-256k".to_string(),
+            name: "K3-256K".to_string(),
+            description: Some("Kimi K3 with a 256K-token context window".to_string()),
+        },
+    ]
 }
 
 /// A provider configuration.
@@ -1132,27 +1172,7 @@ fn default_providers_config() -> ProvidersConfig {
                 name: "Kimi (Subscription)".to_string(),
                 billing: "subscription".to_string(),
                 description: "Kimi Code via Moonshot OAuth (device login)".to_string(),
-                models: vec![
-                    ProviderModel {
-                        id: "kimi-for-coding".to_string(),
-                        name: "Kimi for Coding".to_string(),
-                        description: Some(
-                            "Stable coding alias that tracks the latest Kimi coding model \
-                             (recommended)"
-                                .to_string(),
-                        ),
-                    },
-                    ProviderModel {
-                        id: "kimi-k2.6".to_string(),
-                        name: "Kimi K2.6".to_string(),
-                        description: Some("Latest Kimi K2 model".to_string()),
-                    },
-                    ProviderModel {
-                        id: "kimi-k2-thinking".to_string(),
-                        name: "Kimi K2 Thinking".to_string(),
-                        description: Some("Extended-reasoning Kimi K2 variant".to_string()),
-                    },
-                ],
+                models: kimi_fallback_models(),
             },
         ],
     }
@@ -1212,6 +1232,25 @@ pub async fn fetch_openai_compatible_models(
     models_query: Option<&str>,
     sort_results_by_id: bool,
 ) -> Result<Vec<ProviderModel>, String> {
+    fetch_openai_compatible_models_with_headers(
+        base_url,
+        api_key,
+        prefix_filters,
+        models_query,
+        sort_results_by_id,
+        &[],
+    )
+    .await
+}
+
+async fn fetch_openai_compatible_models_with_headers(
+    base_url: &str,
+    api_key: &str,
+    prefix_filters: &[&str],
+    models_query: Option<&str>,
+    sort_results_by_id: bool,
+    extra_headers: &[(&str, &str)],
+) -> Result<Vec<ProviderModel>, String> {
     let client = reqwest::Client::new();
     let base = base_url.trim_end_matches('/');
     let url = match models_query.filter(|query| !query.is_empty()) {
@@ -1219,10 +1258,14 @@ pub async fn fetch_openai_compatible_models(
         None => format!("{base}/models"),
     };
 
-    let resp = client
+    let mut request = client
         .get(&url)
         .header("Authorization", format!("Bearer {}", api_key))
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(10));
+    for (name, value) in extra_headers {
+        request = request.header(*name, *value);
+    }
+    let resp = request
         .send()
         .await
         .map_err(|e| format!("HTTP request failed: {}", e))?;
@@ -1236,6 +1279,14 @@ pub async fn fetch_openai_compatible_models(
         .await
         .map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
+    parse_openai_compatible_models(body, prefix_filters, sort_results_by_id)
+}
+
+fn parse_openai_compatible_models(
+    body: serde_json::Value,
+    prefix_filters: &[&str],
+    sort_results_by_id: bool,
+) -> Result<Vec<ProviderModel>, String> {
     let data = body
         .get("data")
         .and_then(|d| d.as_array())
@@ -1273,6 +1324,66 @@ pub async fn fetch_openai_compatible_models(
     if sort_results_by_id {
         models.sort_by(|a, b| a.id.cmp(&b.id));
     }
+    Ok(models)
+}
+
+fn kimi_model_cache() -> &'static RwLock<Option<KimiModelCacheEntry>> {
+    KIMI_MODEL_CACHE.get_or_init(|| RwLock::new(None))
+}
+
+/// Discover the models available to a connected Kimi Code account.
+///
+/// Kimi is an OpenAI-compatible provider but requires its coding-agent
+/// User-Agent on catalog requests. Cache successful responses briefly so
+/// preparing many mission workspaces does not hit the subscription endpoint
+/// once per mission. The cache key includes the route and a non-secret token
+/// fingerprint, so an OAuth refresh or endpoint change triggers discovery.
+pub(crate) async fn fetch_kimi_models(
+    provider: &crate::ai_providers::AIProvider,
+) -> Result<Vec<ProviderModel>, String> {
+    if provider.provider_type != ProviderType::Kimi {
+        return Err("Cannot fetch Kimi models for a non-Kimi provider".to_string());
+    }
+    let access_token = provider
+        .oauth
+        .as_ref()
+        .map(|oauth| oauth.access_token.trim())
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| "Kimi OAuth access token is missing".to_string())?;
+    let base_url = provider
+        .base_url
+        .as_deref()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or(crate::api::ai_providers::KIMI_API_BASE_URL);
+    let route_fingerprint = hash_u64(&format!("{base_url}\0{access_token}"));
+
+    {
+        let cache = kimi_model_cache().read().await;
+        if let Some(entry) = cache.as_ref() {
+            if entry.route_fingerprint == route_fingerprint && entry.expires_at > Instant::now() {
+                return Ok(entry.models.clone());
+            }
+        }
+    }
+
+    let models = fetch_openai_compatible_models_with_headers(
+        base_url,
+        access_token,
+        &[],
+        None,
+        true,
+        &[("User-Agent", crate::api::ai_providers::KIMI_USER_AGENT)],
+    )
+    .await?;
+    if models.is_empty() {
+        return Err("Kimi model catalog was empty".to_string());
+    }
+
+    *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
+        route_fingerprint,
+        models: models.clone(),
+        expires_at: Instant::now() + KIMI_MODEL_CACHE_TTL,
+    });
     Ok(models)
 }
 
@@ -1637,6 +1748,8 @@ pub async fn fetch_model_catalog(
         /// Set for prefix-less, large catalogs (OpenRouter) to keep the
         /// routing picker bounded; `None` means no cap.
         max_models: Option<usize>,
+        /// Provider-specific headers required by the catalog endpoint.
+        extra_headers: Vec<(&'static str, &'static str)>,
     }
 
     let targets = vec![
@@ -1649,6 +1762,7 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
+            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::OpenRouter,
@@ -1660,6 +1774,7 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: false,
             allow_unauthenticated: true,
             max_models: Some(MAX_CATALOG_MODELS_PER_PROVIDER),
+            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Xai,
@@ -1670,6 +1785,7 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
+            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Cerebras,
@@ -1680,6 +1796,7 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
+            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Zai,
@@ -1690,6 +1807,7 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
+            extra_headers: vec![],
         },
         FetchTarget {
             provider_type: ProviderType::Minimax,
@@ -1700,6 +1818,18 @@ pub async fn fetch_model_catalog(
             sort_results_by_id: true,
             allow_unauthenticated: false,
             max_models: None,
+            extra_headers: vec![],
+        },
+        FetchTarget {
+            provider_type: ProviderType::Kimi,
+            provider_id: "kimi",
+            base_url: crate::api::ai_providers::KIMI_API_BASE_URL,
+            prefix_filters: vec![],
+            models_query: None,
+            sort_results_by_id: true,
+            allow_unauthenticated: false,
+            max_models: None,
+            extra_headers: vec![("User-Agent", crate::api::ai_providers::KIMI_USER_AGENT)],
         },
     ];
 
@@ -1762,6 +1892,7 @@ pub async fn fetch_model_catalog(
         let models_query = target.models_query.map(str::to_string);
         let sort_results_by_id = target.sort_results_by_id;
         let allow_unauthenticated = target.allow_unauthenticated;
+        let extra_headers = target.extra_headers;
         let prefix_filters: Vec<String> = target
             .prefix_filters
             .iter()
@@ -1777,12 +1908,13 @@ pub async fn fetch_model_catalog(
             match api_key {
                 Some(api_key) => {
                     let filters: Vec<&str> = prefix_filters.iter().map(|s| s.as_str()).collect();
-                    match fetch_openai_compatible_models(
+                    match fetch_openai_compatible_models_with_headers(
                         &base_url,
                         &api_key,
                         &filters,
                         models_query.as_deref(),
                         sort_results_by_id,
+                        &extra_headers,
                     )
                     .await
                     {
@@ -2469,6 +2601,44 @@ mod tests {
         // Acronyms <= 3 chars get uppercased
         assert_eq!(model_id_to_display_name("gpt-4"), "GPT 4");
         assert_eq!(model_id_to_display_name("glm-4.6v-flash"), "GLM 4.6v Flash");
+    }
+
+    #[test]
+    fn kimi_fallback_catalog_matches_current_coding_models() {
+        let ids: Vec<String> = kimi_fallback_models()
+            .into_iter()
+            .map(|model| model.id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "kimi-for-coding",
+                "kimi-for-coding-highspeed",
+                "k3",
+                "k3-256k"
+            ]
+        );
+        assert!(!ids.iter().any(|id| id == "kimi-k2.6"));
+        assert!(!ids.iter().any(|id| id == "kimi-k2-thinking"));
+    }
+
+    #[test]
+    fn openai_compatible_catalog_parser_accepts_future_kimi_models() {
+        let models = parse_openai_compatible_models(
+            serde_json::json!({
+                "data": [
+                    {"id": "k3", "display_name": "K3"},
+                    {"id": "k4-future", "display_name": "K4 Future"}
+                ]
+            }),
+            &[],
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(models[0].id, "k3");
+        assert_eq!(models[1].id, "k4-future");
+        assert_eq!(models[1].name, "K4 Future");
     }
 
     #[test]

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -37,12 +37,11 @@ const CODEX_MODEL_PROBE_TTL: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Debug, Clone)]
 struct KimiModelCacheEntry {
-    route_fingerprint: u64,
     models: Vec<ProviderModel>,
     expires_at: Instant,
 }
 
-static KIMI_MODEL_CACHE: OnceLock<RwLock<Option<KimiModelCacheEntry>>> = OnceLock::new();
+static KIMI_MODEL_CACHE: OnceLock<RwLock<HashMap<u64, KimiModelCacheEntry>>> = OnceLock::new();
 const KIMI_MODEL_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 const RETIRED_KIMI_MODEL_IDS: &[&str] = &["kimi-k2.6", "kimi-k2-thinking"];
 
@@ -1336,8 +1335,8 @@ fn parse_openai_compatible_models(
     Ok(models)
 }
 
-fn kimi_model_cache() -> &'static RwLock<Option<KimiModelCacheEntry>> {
-    KIMI_MODEL_CACHE.get_or_init(|| RwLock::new(None))
+fn kimi_model_cache() -> &'static RwLock<HashMap<u64, KimiModelCacheEntry>> {
+    KIMI_MODEL_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 fn kimi_route_fingerprint(
@@ -1376,9 +1375,48 @@ pub(crate) async fn cached_kimi_models(
     kimi_model_cache()
         .read()
         .await
-        .as_ref()
-        .filter(|entry| entry.route_fingerprint == route_fingerprint)
+        .get(&route_fingerprint)
         .map(|entry| entry.models.clone())
+}
+
+/// Drop the cached catalog before replacing a Kimi provider's credentials.
+///
+/// Reconnect keeps the local provider UUID but may select a different upstream
+/// account with different model entitlements.
+pub(crate) async fn invalidate_kimi_model_cache(provider: &crate::ai_providers::AIProvider) {
+    if let Ok((route_fingerprint, _, _)) = kimi_route_fingerprint(provider) {
+        kimi_model_cache().write().await.remove(&route_fingerprint);
+    }
+}
+
+/// Re-populate Kimi's shared catalog after a reconnect without blocking the
+/// OAuth callback. The caller removes the old entry before spawning this task.
+pub(crate) async fn refresh_connected_kimi_catalog(catalog: ModelCatalog, provider: AIProvider) {
+    match fetch_kimi_models(&provider).await {
+        Ok(models) => {
+            let checked_at = chrono::Utc::now();
+            let entries = models
+                .into_iter()
+                .map(|model| {
+                    CatalogEntry::from_provider_model(
+                        "kimi",
+                        model,
+                        CatalogSource::ProviderApi,
+                        CatalogAvailability::Available,
+                        checked_at,
+                    )
+                })
+                .collect();
+            catalog.write().await.insert("kimi".to_string(), entries);
+        }
+        Err(error) => {
+            tracing::warn!(
+                provider_id = %provider.id,
+                error = %error,
+                "Failed to refresh Kimi catalog after account reconnect"
+            );
+        }
+    }
 }
 
 fn preferred_usable_kimi_provider(providers: &[AIProvider]) -> Option<AIProvider> {
@@ -1410,15 +1448,11 @@ pub(crate) async fn fetch_kimi_models(
 
     let stale_models = {
         let cache = kimi_model_cache().read().await;
-        if let Some(entry) = cache.as_ref() {
-            if entry.route_fingerprint == route_fingerprint && entry.expires_at > Instant::now() {
+        if let Some(entry) = cache.get(&route_fingerprint) {
+            if entry.expires_at > Instant::now() {
                 return Ok(entry.models.clone());
             }
-            if entry.route_fingerprint == route_fingerprint {
-                Some(entry.models.clone())
-            } else {
-                None
-            }
+            Some(entry.models.clone())
         } else {
             None
         }
@@ -1438,11 +1472,13 @@ pub(crate) async fn fetch_kimi_models(
         Ok(_) => {
             if let Some(models) = stale_models {
                 tracing::warn!("Kimi model catalog was empty; reusing stale catalog");
-                *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
+                kimi_model_cache().write().await.insert(
                     route_fingerprint,
-                    models: models.clone(),
-                    expires_at: Instant::now() + Duration::from_secs(60),
-                });
+                    KimiModelCacheEntry {
+                        models: models.clone(),
+                        expires_at: Instant::now() + Duration::from_secs(60),
+                    },
+                );
                 return Ok(models);
             }
             return Err("Kimi model catalog was empty".to_string());
@@ -1453,22 +1489,26 @@ pub(crate) async fn fetch_kimi_models(
                     error = %error,
                     "Kimi model discovery failed; reusing stale catalog"
                 );
-                *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
+                kimi_model_cache().write().await.insert(
                     route_fingerprint,
-                    models: models.clone(),
-                    expires_at: Instant::now() + Duration::from_secs(60),
-                });
+                    KimiModelCacheEntry {
+                        models: models.clone(),
+                        expires_at: Instant::now() + Duration::from_secs(60),
+                    },
+                );
                 return Ok(models);
             }
             return Err(error);
         }
     };
 
-    *kimi_model_cache().write().await = Some(KimiModelCacheEntry {
+    kimi_model_cache().write().await.insert(
         route_fingerprint,
-        models: models.clone(),
-        expires_at: Instant::now() + KIMI_MODEL_CACHE_TTL,
-    });
+        KimiModelCacheEntry {
+            models: models.clone(),
+            expires_at: Instant::now() + KIMI_MODEL_CACHE_TTL,
+        },
+    );
     Ok(models)
 }
 

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -48,6 +49,7 @@ struct KimiModelCache {
 }
 
 static KIMI_MODEL_CACHE: OnceLock<RwLock<KimiModelCache>> = OnceLock::new();
+static KIMI_CATALOG_GENERATION: AtomicU64 = AtomicU64::new(0);
 const KIMI_MODEL_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 const RETIRED_KIMI_MODEL_IDS: &[&str] = &["kimi-k2.6", "kimi-k2-thinking"];
 
@@ -1399,9 +1401,18 @@ pub(crate) async fn invalidate_kimi_model_cache(provider: &crate::ai_providers::
     }
 }
 
+pub(crate) fn advance_kimi_catalog_generation() {
+    KIMI_CATALOG_GENERATION.fetch_add(1, Ordering::AcqRel);
+}
+
+fn kimi_catalog_generation() -> u64 {
+    KIMI_CATALOG_GENERATION.load(Ordering::Acquire)
+}
+
 /// Re-populate Kimi's shared catalog after a reconnect without blocking the
 /// OAuth callback. The caller removes the old entry before spawning this task.
 pub(crate) async fn refresh_connected_kimi_catalog(catalog: ModelCatalog, provider: AIProvider) {
+    let catalog_generation = kimi_catalog_generation();
     match fetch_kimi_models(&provider).await {
         Ok(models) => {
             let checked_at = chrono::Utc::now();
@@ -1417,7 +1428,20 @@ pub(crate) async fn refresh_connected_kimi_catalog(catalog: ModelCatalog, provid
                     )
                 })
                 .collect();
+            let cache = kimi_model_cache().read().await;
+            if kimi_catalog_generation() != catalog_generation {
+                tracing::debug!(
+                    provider_id = %provider.id,
+                    "Discarded Kimi catalog from an obsolete preference generation"
+                );
+                return;
+            }
+            // Keep the generation read-lock until the catalog write commits.
+            // Preference reconciliation advances cache generations before it
+            // takes the catalog write-lock, so the final state cannot be an
+            // obsolete account snapshot.
             catalog.write().await.insert("kimi".to_string(), entries);
+            drop(cache);
         }
         Err(error) => {
             tracing::warn!(
@@ -1827,10 +1851,18 @@ async fn refresh_catalog_once(
     ai_providers: &AIProviderStore,
     working_dir: &Path,
 ) -> (usize, usize) {
-    let fetched = fetch_model_catalog(ai_providers, working_dir).await;
+    let (mut fetched, fetched_kimi_generation) =
+        fetch_model_catalog(ai_providers, working_dir).await;
+    let mut current = catalog.write().await;
+    if kimi_catalog_generation() != fetched_kimi_generation {
+        fetched.remove("kimi");
+        if let Some(kimi) = current.get("kimi").cloned() {
+            fetched.insert("kimi".to_string(), kimi);
+        }
+    }
     let provider_count = fetched.len();
     let model_count: usize = fetched.values().map(|v| v.len()).sum();
-    *catalog.write().await = fetched;
+    *current = fetched;
     (provider_count, model_count)
 }
 
@@ -1899,10 +1931,10 @@ pub async fn refresh_model_catalog(
     })
 }
 
-pub async fn fetch_model_catalog(
+async fn fetch_model_catalog(
     ai_providers: &AIProviderStore,
     _working_dir: &Path,
-) -> HashMap<String, Vec<CatalogEntry>> {
+) -> (HashMap<String, Vec<CatalogEntry>>, u64) {
     // Kimi access tokens are short-lived. Refresh a due store credential
     // synchronously before taking the provider snapshot so the initial catalog
     // probe cannot race the independent refresh task at startup.
@@ -1919,6 +1951,7 @@ pub async fn fetch_model_catalog(
         );
     }
 
+    let catalog_generation = kimi_catalog_generation();
     let providers_list = ai_providers.list().await;
     let mut result = HashMap::new();
 
@@ -2212,7 +2245,7 @@ pub async fn fetch_model_catalog(
         }
     }
 
-    result
+    (result, catalog_generation)
 }
 
 /// Check if a JSON value contains valid auth credentials.

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1340,16 +1340,9 @@ fn kimi_model_cache() -> &'static RwLock<Option<KimiModelCacheEntry>> {
     KIMI_MODEL_CACHE.get_or_init(|| RwLock::new(None))
 }
 
-/// Discover the models available to a connected Kimi Code account.
-///
-/// Kimi is an OpenAI-compatible provider but requires its coding-agent
-/// User-Agent on catalog requests. Cache successful responses briefly so
-/// preparing many mission workspaces does not hit the subscription endpoint
-/// once per mission. The cache key includes the route and a non-secret token
-/// fingerprint, so an OAuth refresh or endpoint change triggers discovery.
-pub(crate) async fn fetch_kimi_models(
+fn kimi_route_fingerprint(
     provider: &crate::ai_providers::AIProvider,
-) -> Result<Vec<ProviderModel>, String> {
+) -> Result<(u64, &str, &str), String> {
     if provider.provider_type != ProviderType::Kimi {
         return Err("Cannot fetch Kimi models for a non-Kimi provider".to_string());
     }
@@ -1364,7 +1357,41 @@ pub(crate) async fn fetch_kimi_models(
         .as_deref()
         .filter(|url| !url.trim().is_empty())
         .unwrap_or(crate::api::ai_providers::KIMI_API_BASE_URL);
-    let route_fingerprint = hash_u64(&format!("{base_url}\0{access_token}"));
+    Ok((
+        hash_u64(&format!("{base_url}\0{access_token}")),
+        base_url,
+        access_token,
+    ))
+}
+
+/// Return the last account-specific Kimi catalog without performing I/O.
+///
+/// Workspace preparation is latency-sensitive and must not wait on a provider
+/// outage. The background model-catalog refresher owns live discovery; callers
+/// on the workspace path use this snapshot or fall back immediately.
+pub(crate) async fn cached_kimi_models(
+    provider: &crate::ai_providers::AIProvider,
+) -> Option<Vec<ProviderModel>> {
+    let (route_fingerprint, _, _) = kimi_route_fingerprint(provider).ok()?;
+    kimi_model_cache()
+        .read()
+        .await
+        .as_ref()
+        .filter(|entry| entry.route_fingerprint == route_fingerprint)
+        .map(|entry| entry.models.clone())
+}
+
+/// Discover the models available to a connected Kimi Code account.
+///
+/// Kimi is an OpenAI-compatible provider but requires its coding-agent
+/// User-Agent on catalog requests. Cache successful responses briefly so
+/// preparing many mission workspaces does not hit the subscription endpoint
+/// once per mission. The cache key includes the route and a non-secret token
+/// fingerprint, so an OAuth refresh or endpoint change triggers discovery.
+pub(crate) async fn fetch_kimi_models(
+    provider: &crate::ai_providers::AIProvider,
+) -> Result<Vec<ProviderModel>, String> {
+    let (route_fingerprint, base_url, access_token) = kimi_route_fingerprint(provider)?;
 
     let stale_models = {
         let cache = kimi_model_cache().read().await;
@@ -1772,6 +1799,22 @@ pub async fn fetch_model_catalog(
     ai_providers: &AIProviderStore,
     _working_dir: &Path,
 ) -> HashMap<String, Vec<CatalogEntry>> {
+    // Kimi access tokens are short-lived. Refresh a due store credential
+    // synchronously before taking the provider snapshot so the initial catalog
+    // probe cannot race the independent refresh task at startup.
+    let (_, refreshed) = crate::api::ai_providers::refresh_due_store_oauth(
+        ai_providers,
+        ProviderType::Kimi,
+        10 * 60 * 1000,
+    )
+    .await;
+    if refreshed > 0 {
+        tracing::info!(
+            refreshed,
+            "Refreshed Kimi OAuth credentials before model catalog discovery"
+        );
+    }
+
     let providers_list = ai_providers.list().await;
     let mut result = HashMap::new();
 

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -256,11 +256,16 @@ pub(crate) async fn write_opencode_config(
         // providers it is not an OpenCode built-in, so it needs an explicit
         // provider block (OpenAI-compatible npm package + base URL + creds).
         if let Some(providers) = custom_providers {
+            let preferred_kimi_id =
+                crate::api::providers::preferred_usable_kimi_provider(providers)
+                    .map(|provider| provider.id);
             let provider_blocks: Vec<_> = providers
                 .iter()
                 .filter(|p| {
-                    matches!(p.provider_type, ProviderType::Custom | ProviderType::Kimi)
-                        && p.enabled
+                    p.enabled
+                        && (p.provider_type == ProviderType::Custom
+                            || (p.provider_type == ProviderType::Kimi
+                                && preferred_kimi_id == Some(p.id)))
                 })
                 .collect();
 
@@ -1492,13 +1497,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn kimi_workspace_config_uses_the_catalog_selected_account() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mission_dir = temp.path().join("mission");
+        std::fs::create_dir_all(&mission_dir).unwrap();
+
+        let mut preferred = AIProvider::new(ProviderType::Kimi, "Preferred Kimi".to_string());
+        preferred.priority = 0;
+        preferred.oauth = Some(crate::ai_providers::OAuthCredentials {
+            refresh_token: "preferred-refresh".to_string(),
+            access_token: "preferred-access".to_string(),
+            expires_at: i64::MAX,
+        });
+        preferred.custom_models = Some(vec![crate::ai_providers::CustomModel {
+            id: "preferred-only".to_string(),
+            name: Some("Preferred only".to_string()),
+            context_limit: None,
+            output_limit: None,
+        }]);
+
+        let mut secondary = AIProvider::new(ProviderType::Kimi, "Secondary Kimi".to_string());
+        secondary.priority = 10;
+        secondary.oauth = Some(crate::ai_providers::OAuthCredentials {
+            refresh_token: "secondary-refresh".to_string(),
+            access_token: "secondary-access".to_string(),
+            expires_at: i64::MAX,
+        });
+        secondary.custom_models = Some(vec![crate::ai_providers::CustomModel {
+            id: "secondary-only".to_string(),
+            name: Some("Secondary only".to_string()),
+            context_limit: None,
+            output_limit: None,
+        }]);
+
+        // Put the secondary account last to reproduce the old overwrite bug.
+        let providers = vec![preferred, secondary];
+        write_opencode_config(
+            &mission_dir,
+            Vec::new(),
+            temp.path(),
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            Some(&providers),
+        )
+        .await
+        .unwrap();
+
+        let config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(mission_dir.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            config["provider"]["kimi"]["options"]["apiKey"],
+            "preferred-access"
+        );
+        assert!(config["provider"]["kimi"]["models"]["preferred-only"].is_object());
+        assert!(config["provider"]["kimi"]["models"]["secondary-only"].is_null());
+    }
+
+    #[tokio::test]
     async fn kimi_offline_config_merges_fallback_and_operator_models() {
         let temp = tempfile::TempDir::new().unwrap();
         let mission_dir = temp.path().join("mission");
         std::fs::create_dir_all(&mission_dir).unwrap();
         let mut provider = AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
-        // No OAuth token makes discovery fail immediately without a network
-        // request, exercising resilient offline generation.
+        // No catalog snapshot exercises resilient offline generation without
+        // performing network I/O on the workspace path.
+        provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+            refresh_token: "offline-refresh".to_string(),
+            access_token: "offline-access".to_string(),
+            expires_at: i64::MAX,
+        });
         provider.custom_models = Some(vec![crate::ai_providers::CustomModel {
             id: "k4-operator-preview".to_string(),
             name: Some("K4 Operator Preview".to_string()),

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -314,24 +314,25 @@ pub(crate) async fn write_opencode_config(
                                     error = %error,
                                     "Failed to discover Kimi models; using configured fallback catalog"
                                 );
-                                provider
-                                    .custom_models
-                                    .as_ref()
-                                    .filter(|models| !models.is_empty())
-                                    .map(|models| {
-                                        models
-                                            .iter()
-                                            .map(|model| crate::api::providers::ProviderModel {
-                                                id: model.id.clone(),
-                                                name: model
-                                                    .name
-                                                    .clone()
-                                                    .unwrap_or_else(|| model.id.clone()),
-                                                description: None,
-                                            })
-                                            .collect()
-                                    })
-                                    .unwrap_or_else(crate::api::providers::kimi_fallback_models)
+                                let mut models = crate::api::providers::kimi_fallback_models();
+                                if let Some(configured) = provider.custom_models.as_ref() {
+                                    for model in configured {
+                                        if model.id.trim().is_empty()
+                                            || models.iter().any(|existing| existing.id == model.id)
+                                        {
+                                            continue;
+                                        }
+                                        models.push(crate::api::providers::ProviderModel {
+                                            id: model.id.clone(),
+                                            name: model
+                                                .name
+                                                .clone()
+                                                .unwrap_or_else(|| model.id.clone()),
+                                            description: None,
+                                        });
+                                    }
+                                }
+                                models
                             }
                         };
                         let mut models_map = serde_json::Map::new();
@@ -1429,6 +1430,47 @@ mod tests {
         );
         assert!(config["provider"]["kimi"]["models"]["k3"].is_object());
         assert!(config["provider"]["kimi"]["models"]["kimi-k2.6"].is_null());
+    }
+
+    #[tokio::test]
+    async fn kimi_offline_config_merges_fallback_and_operator_models() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mission_dir = temp.path().join("mission");
+        std::fs::create_dir_all(&mission_dir).unwrap();
+        let mut provider = AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
+        // No OAuth token makes discovery fail immediately without a network
+        // request, exercising resilient offline generation.
+        provider.custom_models = Some(vec![crate::ai_providers::CustomModel {
+            id: "k4-operator-preview".to_string(),
+            name: Some("K4 Operator Preview".to_string()),
+            context_limit: None,
+            output_limit: None,
+        }]);
+        let providers = vec![provider];
+
+        write_opencode_config(
+            &mission_dir,
+            Vec::new(),
+            temp.path(),
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            Some(&providers),
+        )
+        .await
+        .unwrap();
+
+        let config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(mission_dir.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(config["provider"]["kimi"]["models"]["k3"].is_object());
+        assert_eq!(
+            config["provider"]["kimi"]["models"]["k4-operator-preview"]["name"],
+            "K4 Operator Preview"
+        );
     }
 
     #[test]

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -1410,6 +1410,12 @@ mod tests {
             .unwrap();
         server.await.unwrap();
         providers[0].oauth.as_mut().unwrap().access_token = "test-kimi-rotated-token".to_string();
+        assert!(
+            crate::api::providers::cached_kimi_models(&providers[0])
+                .await
+                .is_some(),
+            "routine access-token rotation must retain the account catalog"
+        );
 
         write_opencode_config(
             &mission_dir,
@@ -1435,6 +1441,14 @@ mod tests {
         );
         assert!(config["provider"]["kimi"]["models"]["k3"].is_object());
         assert!(config["provider"]["kimi"]["models"]["kimi-k2.6"].is_null());
+
+        crate::api::providers::invalidate_kimi_model_cache(&providers[0]).await;
+        assert!(
+            crate::api::providers::cached_kimi_models(&providers[0])
+                .await
+                .is_none(),
+            "account reconnect must invalidate the previous catalog"
+        );
     }
 
     #[tokio::test]

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -280,7 +280,10 @@ pub(crate) async fn write_opencode_config(
                         let mut options = serde_json::Map::new();
                         options.insert(
                             "baseURL".to_string(),
-                            json!(crate::api::ai_providers::KIMI_API_BASE_URL),
+                            json!(provider
+                                .base_url
+                                .as_deref()
+                                .unwrap_or(crate::api::ai_providers::KIMI_API_BASE_URL)),
                         );
                         if let Some(oauth) = &provider.oauth {
                             if !oauth.access_token.trim().is_empty() {
@@ -288,23 +291,54 @@ pub(crate) async fn write_opencode_config(
                             }
                         }
                         let mut headers = serde_json::Map::new();
-                        headers.insert("User-Agent".to_string(), json!("KimiCLI/1.5"));
+                        headers.insert(
+                            "User-Agent".to_string(),
+                            json!(crate::api::ai_providers::KIMI_USER_AGENT),
+                        );
                         options.insert("headers".to_string(), serde_json::Value::Object(headers));
                         provider_config
                             .insert("options".to_string(), serde_json::Value::Object(options));
 
+                        // Kimi's catalog is account-aware and evolves independently
+                        // from Sandboxed.sh. Discover it through the same OAuth
+                        // credentials used for inference so newly released models
+                        // are immediately valid in OpenCode mission configs. Keep
+                        // configured/fallback models only for transient catalog
+                        // failures and first-time/offline workspace preparation.
+                        let models = match crate::api::providers::fetch_kimi_models(provider).await
+                        {
+                            Ok(models) => models,
+                            Err(error) => {
+                                tracing::warn!(
+                                    provider_id = %provider.id,
+                                    error = %error,
+                                    "Failed to discover Kimi models; using configured fallback catalog"
+                                );
+                                provider
+                                    .custom_models
+                                    .as_ref()
+                                    .filter(|models| !models.is_empty())
+                                    .map(|models| {
+                                        models
+                                            .iter()
+                                            .map(|model| crate::api::providers::ProviderModel {
+                                                id: model.id.clone(),
+                                                name: model
+                                                    .name
+                                                    .clone()
+                                                    .unwrap_or_else(|| model.id.clone()),
+                                                description: None,
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_else(crate::api::providers::kimi_fallback_models)
+                            }
+                        };
                         let mut models_map = serde_json::Map::new();
-                        for (model_id, model_name) in [
-                            ("kimi-for-coding", "Kimi for Coding"),
-                            ("kimi-k2.6", "Kimi K2.6"),
-                            ("kimi-k2-thinking", "Kimi K2 Thinking"),
-                        ] {
+                        for model in models {
                             let mut model_config = serde_json::Map::new();
-                            model_config.insert("name".to_string(), json!(model_name));
-                            models_map.insert(
-                                model_id.to_string(),
-                                serde_json::Value::Object(model_config),
-                            );
+                            model_config.insert("name".to_string(), json!(model.name));
+                            models_map.insert(model.id, serde_json::Value::Object(model_config));
                         }
                         provider_config
                             .insert("models".to_string(), serde_json::Value::Object(models_map));
@@ -1327,6 +1361,75 @@ pub async fn write_backend_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn kimi_opencode_config_discovers_future_models_from_live_catalog() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0_u8; 4096];
+            let bytes = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..bytes]).to_ascii_lowercase();
+            assert!(request.starts_with("get /models "));
+            assert!(request.contains("authorization: bearer test-kimi-future-token"));
+            assert!(request.contains("user-agent: kimicli/1.5"));
+
+            let body = serde_json::json!({
+                "data": [
+                    {"id": "k3", "display_name": "K3"},
+                    {"id": "k4-future", "display_name": "K4 Future"}
+                ]
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mission_dir = temp.path().join("mission");
+        std::fs::create_dir_all(&mission_dir).unwrap();
+        let mut provider = AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
+        provider.base_url = Some(format!("http://{address}"));
+        provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+            refresh_token: "test-refresh".to_string(),
+            access_token: "test-kimi-future-token".to_string(),
+            expires_at: i64::MAX,
+        });
+        let providers = vec![provider];
+
+        write_opencode_config(
+            &mission_dir,
+            Vec::new(),
+            temp.path(),
+            WorkspaceType::Host,
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            Some(&providers),
+        )
+        .await
+        .unwrap();
+        server.await.unwrap();
+
+        let config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(mission_dir.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            config["provider"]["kimi"]["models"]["k4-future"]["name"],
+            "K4 Future"
+        );
+        assert!(config["provider"]["kimi"]["models"]["k3"].is_object());
+        assert!(config["provider"]["kimi"]["models"]["kimi-k2.6"].is_null());
+    }
 
     #[test]
     fn codex_generated_state_is_mission_scoped() {

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -299,20 +299,17 @@ pub(crate) async fn write_opencode_config(
                         provider_config
                             .insert("options".to_string(), serde_json::Value::Object(options));
 
-                        // Kimi's catalog is account-aware and evolves independently
-                        // from Sandboxed.sh. Discover it through the same OAuth
-                        // credentials used for inference so newly released models
-                        // are immediately valid in OpenCode mission configs. Keep
-                        // configured/fallback models only for transient catalog
-                        // failures and first-time/offline workspace preparation.
-                        let models = match crate::api::providers::fetch_kimi_models(provider).await
+                        // Live discovery is owned by the background provider
+                        // catalog refresh. Workspace creation only consumes its
+                        // last snapshot, so an unavailable Kimi endpoint can
+                        // never block mission startup.
+                        let models = match crate::api::providers::cached_kimi_models(provider).await
                         {
-                            Ok(models) => models,
-                            Err(error) => {
-                                tracing::warn!(
+                            Some(models) => models,
+                            None => {
+                                tracing::debug!(
                                     provider_id = %provider.id,
-                                    error = %error,
-                                    "Failed to discover Kimi models; using configured fallback catalog"
+                                    "No cached Kimi catalog; using configured fallback catalog"
                                 );
                                 let mut models = crate::api::providers::kimi_fallback_models();
                                 if let Some(configured) = provider.custom_models.as_ref() {
@@ -1405,6 +1402,14 @@ mod tests {
         });
         let providers = vec![provider];
 
+        // The background provider catalog owns network discovery. Prime its
+        // cache explicitly, then verify workspace preparation only consumes
+        // the cached snapshot.
+        crate::api::providers::fetch_kimi_models(&providers[0])
+            .await
+            .unwrap();
+        server.await.unwrap();
+
         write_opencode_config(
             &mission_dir,
             Vec::new(),
@@ -1418,7 +1423,6 @@ mod tests {
         )
         .await
         .unwrap();
-        server.await.unwrap();
 
         let config: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(mission_dir.join("opencode.json")).unwrap(),
@@ -1430,6 +1434,46 @@ mod tests {
         );
         assert!(config["provider"]["kimi"]["models"]["k3"].is_object());
         assert!(config["provider"]["kimi"]["models"]["kimi-k2.6"].is_null());
+    }
+
+    #[tokio::test]
+    async fn kimi_workspace_config_never_waits_for_live_catalog() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let mission_dir = temp.path().join("mission");
+        std::fs::create_dir_all(&mission_dir).unwrap();
+        let mut provider = AIProvider::new(ProviderType::Kimi, "Kimi".to_string());
+        provider.base_url = Some("http://192.0.2.1:9".to_string());
+        provider.oauth = Some(crate::ai_providers::OAuthCredentials {
+            refresh_token: "unreachable-refresh".to_string(),
+            access_token: "unreachable-unique-access-token".to_string(),
+            expires_at: i64::MAX,
+        });
+        let providers = vec![provider];
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            write_opencode_config(
+                &mission_dir,
+                Vec::new(),
+                temp.path(),
+                WorkspaceType::Host,
+                &HashMap::new(),
+                None,
+                None,
+                None,
+                Some(&providers),
+            ),
+        )
+        .await
+        .expect("workspace config must not perform live Kimi I/O")
+        .unwrap();
+
+        let config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(mission_dir.join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(config["provider"]["kimi"]["models"]["k3"].is_object());
+        assert!(config["provider"]["kimi"]["models"]["k3-256k"].is_object());
     }
 
     #[tokio::test]

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -1400,15 +1400,16 @@ mod tests {
             access_token: "test-kimi-future-token".to_string(),
             expires_at: i64::MAX,
         });
-        let providers = vec![provider];
+        let mut providers = vec![provider];
 
         // The background provider catalog owns network discovery. Prime its
-        // cache explicitly, then verify workspace preparation only consumes
-        // the cached snapshot.
+        // cache explicitly, rotate the short-lived access token, then verify
+        // workspace preparation still consumes the account's cached snapshot.
         crate::api::providers::fetch_kimi_models(&providers[0])
             .await
             .unwrap();
         server.await.unwrap();
+        providers[0].oauth.as_mut().unwrap().access_token = "test-kimi-rotated-token".to_string();
 
         write_opencode_config(
             &mission_dir,


### PR DESCRIPTION
## What changed

- replace the stale Kimi K2 fallback entries with the current Kimi Code catalog: `kimi-for-coding`, `kimi-for-coding-highspeed`, `k3`, and `k3-256k`
- fetch the account-visible Kimi `/models` catalog with the stored OAuth token and required Kimi CLI User-Agent
- refresh provider/backend model pickers from the live catalog every ten minutes
- inject live Kimi models into generated OpenCode workspace configuration, with a credential-and-route keyed cache and resilient fallback
- preserve operator-provided custom Kimi models when live discovery is unavailable

## Why

The Kimi account was connected and `kimi-for-coding` worked, but Sandboxed.sh rejected `kimi/k3` because both the provider picker and generated OpenCode configuration used a stale hardcoded K2-era list. The provider now discovers new models automatically rather than requiring a release for each Kimi model launch.

## Verification

- live production `/models` probe returned the four current account-visible models
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test` — 1,496 passed, 0 failed, 1 ignored
- regression test verifies OAuth/UA catalog discovery and injection of an unknown future model into generated `opencode.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token refresh, multi-account catalog races, and mission `opencode.json` generation for a subscription provider; mitigated by caching, generation fencing, and extensive tests.
> 
> **Overview**
> **Kimi** no longer relies on a stale K2-era hardcoded model list. The provider catalog is populated from the account’s live Kimi Code `/models` API (OAuth bearer + required Kimi CLI `User-Agent`), with updated startup fallbacks (`kimi-for-coding`, `k3`, etc.) and removal of retired IDs from persisted config on upgrade.
> 
> **Pickers and mission config stay aligned:** Kimi is treated like custom routers—live catalog **replaces** defaults rather than merging—so removed models don’t stay selectable. A per-account cache (with generation fencing on reconnect, delete, or priority changes) and `reconcile_preferred_kimi_catalog` ensure only the **preferred** enabled Kimi account drives the shared `kimi` catalog and `opencode.json` provider block. Workspace generation reads the cached snapshot only (fallback + operator custom models if offline), so missions don’t block on network I/O.
> 
> **OAuth refresh** for Kimi is centralized via `refresh_due_store_oauth` (including the background loop and pre-catalog discovery) to avoid refresh-token races, and Kimi is wired into the generic OAuth refresh path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e981ddd957a0c55ea70259e5c075c132dffa164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->