### PR TITLE
Fix Codex OAuth status and false stalled turns

### DIFF
--- a/dashboard/src/app/settings/providers/page.tsx
+++ b/dashboard/src/app/settings/providers/page.tsx
@@ -66,6 +66,18 @@ function getProviderConfig(type: string) {
   return providerConfig[type] || providerConfig.custom;
 }
 
+function authSurfaceLabel(status: 'connected' | 'needs_reauth' | 'not_configured'): string {
+  if (status === 'connected') return 'Connected';
+  if (status === 'needs_reauth') return 'Reconnect';
+  return 'Not configured';
+}
+
+function authSurfaceColor(status: 'connected' | 'needs_reauth' | 'not_configured'): string {
+  if (status === 'connected') return 'text-emerald-400/70';
+  if (status === 'needs_reauth') return 'text-amber-400/80';
+  return 'text-white/30';
+}
+
 const defaultProviderTypes: AIProviderTypeInfo[] = [
   { id: 'anthropic', name: 'Anthropic', uses_oauth: true, env_var: 'ANTHROPIC_API_KEY' },
   { id: 'openai', name: 'OpenAI', uses_oauth: true, env_var: 'OPENAI_API_KEY' },
@@ -892,6 +904,16 @@ export default function ProvidersPage() {
                             {provider.account_email && (
                               <span className="text-[11px] text-white/35 truncate block">
                                 {provider.account_email}
+                              </span>
+                            )}
+                            {provider.openai_auth && (
+                              <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px]">
+                                <span className={authSurfaceColor(provider.openai_auth.codex_oauth)}>
+                                  Codex OAuth: {authSurfaceLabel(provider.openai_auth.codex_oauth)}
+                                </span>
+                                <span className={authSurfaceColor(provider.openai_auth.api_platform)}>
+                                  API Platform: {authSurfaceLabel(provider.openai_auth.api_platform)}
+                                </span>
                               </span>
                             )}
                           </div>

--- a/dashboard/src/lib/api/providers.ts
+++ b/dashboard/src/lib/api/providers.ts
@@ -43,6 +43,15 @@ export interface AIProviderStatus {
   message?: string;
 }
 
+export type OpenAIAuthSurfaceStatus = "connected" | "needs_reauth" | "not_configured";
+
+export interface OpenAIAuthStatus {
+  /** ChatGPT subscription OAuth used by the Codex backend. */
+  codex_oauth: OpenAIAuthSurfaceStatus;
+  /** API key used by api.openai.com (billing/organization is separate). */
+  api_platform: OpenAIAuthSurfaceStatus;
+}
+
 export interface AIProviderAuthMethod {
   label: string;
   type: "oauth" | "api";
@@ -81,6 +90,8 @@ export interface AIProvider {
   uses_oauth: boolean;
   auth_methods: AIProviderAuthMethod[];
   status: AIProviderStatus;
+  /** Independent OpenAI authentication surfaces; only present for OpenAI providers. */
+  openai_auth?: OpenAIAuthStatus;
   use_for_backends: string[];
   /** Account identifier (email) from the connected OAuth account */
   account_email?: string | null;

--- a/src/api/ai_providers.rs
+++ b/src/api/ai_providers.rs
@@ -823,6 +823,136 @@ mod grok_oauth_tests {
     }
 }
 
+#[cfg(test)]
+mod openai_provider_status_tests {
+    use super::{
+        build_response_from_store, merge_oauth_callback_credentials,
+        oauth_refresh_token_fingerprint, AuthSurfaceStatusResponse, ProviderStatusResponse,
+    };
+    use crate::ai_providers::{AIProvider, OAuthCredentials, ProviderType};
+
+    fn oauth_credentials() -> OAuthCredentials {
+        OAuthCredentials {
+            access_token: "openai-access-token".to_string(),
+            refresh_token: "openai-refresh-token".to_string(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60 * 60 * 1000,
+        }
+    }
+
+    #[test]
+    fn openai_oauth_only_reports_codex_connected_and_platform_not_configured() {
+        let mut provider = AIProvider::new(ProviderType::OpenAI, "OpenAI OAuth".to_string());
+        provider.oauth = Some(oauth_credentials());
+
+        let response = build_response_from_store(&provider);
+        let openai_auth = response.openai_auth.as_ref().expect("OpenAI auth surfaces");
+
+        assert!(matches!(response.status, ProviderStatusResponse::Connected));
+        assert_eq!(
+            openai_auth.codex_oauth,
+            AuthSurfaceStatusResponse::Connected
+        );
+        assert_eq!(
+            openai_auth.api_platform,
+            AuthSurfaceStatusResponse::NotConfigured
+        );
+        let json = serde_json::to_value(&response).expect("serialize provider response");
+        assert_eq!(json["status"]["type"], "connected");
+        assert_eq!(json["openai_auth"]["codex_oauth"], "connected");
+        assert_eq!(json["openai_auth"]["api_platform"], "not_configured");
+    }
+
+    #[test]
+    fn openai_api_key_only_reports_platform_connected_and_codex_not_configured() {
+        let mut provider = AIProvider::new(ProviderType::OpenAI, "OpenAI API".to_string());
+        provider.api_key = Some("sk-openai-api-key".to_string());
+
+        let response = build_response_from_store(&provider);
+        let openai_auth = response.openai_auth.as_ref().expect("OpenAI auth surfaces");
+
+        assert!(matches!(response.status, ProviderStatusResponse::Connected));
+        assert_eq!(
+            openai_auth.codex_oauth,
+            AuthSurfaceStatusResponse::NotConfigured
+        );
+        assert_eq!(
+            openai_auth.api_platform,
+            AuthSurfaceStatusResponse::Connected
+        );
+    }
+
+    #[test]
+    fn rejected_openai_oauth_does_not_hide_healthy_platform_key() {
+        let mut provider = AIProvider::new(ProviderType::OpenAI, "OpenAI mixed".to_string());
+        provider.api_key = Some("sk-openai-api-key".to_string());
+        provider.oauth = Some(oauth_credentials());
+        provider.rejected_oauth_refresh_fingerprint =
+            Some(oauth_refresh_token_fingerprint("openai-refresh-token"));
+
+        let response = build_response_from_store(&provider);
+        let openai_auth = response.openai_auth.as_ref().expect("OpenAI auth surfaces");
+
+        assert!(matches!(response.status, ProviderStatusResponse::Connected));
+        assert_eq!(
+            openai_auth.codex_oauth,
+            AuthSurfaceStatusResponse::NeedsReauth
+        );
+        assert_eq!(
+            openai_auth.api_platform,
+            AuthSurfaceStatusResponse::Connected
+        );
+    }
+
+    #[test]
+    fn empty_openai_credentials_are_not_reported_as_connected() {
+        let mut provider = AIProvider::new(ProviderType::OpenAI, "OpenAI empty".to_string());
+        provider.api_key = Some("   ".to_string());
+        provider.oauth = Some(OAuthCredentials {
+            access_token: String::new(),
+            refresh_token: String::new(),
+            expires_at: 0,
+        });
+
+        let response = build_response_from_store(&provider);
+        let openai_auth = response.openai_auth.as_ref().expect("OpenAI auth surfaces");
+
+        assert!(matches!(
+            response.status,
+            ProviderStatusResponse::NeedsAuth { .. }
+        ));
+        assert_eq!(
+            openai_auth.codex_oauth,
+            AuthSurfaceStatusResponse::NotConfigured
+        );
+        assert_eq!(
+            openai_auth.api_platform,
+            AuthSurfaceStatusResponse::NotConfigured
+        );
+    }
+
+    #[test]
+    fn oauth_reconnect_preserves_or_attaches_platform_key_on_same_account() {
+        let mut existing = AIProvider::new(ProviderType::OpenAI, "OpenAI".to_string());
+        existing.api_key = Some("existing-platform-key".to_string());
+        let mut oauth_callback = AIProvider::new(ProviderType::OpenAI, "OpenAI".to_string());
+        oauth_callback.oauth = Some(oauth_credentials());
+
+        merge_oauth_callback_credentials(&mut existing, &oauth_callback);
+
+        assert_eq!(existing.api_key.as_deref(), Some("existing-platform-key"));
+        assert!(existing.oauth.is_some());
+
+        oauth_callback.api_key = Some("newly-minted-platform-key".to_string());
+        merge_oauth_callback_credentials(&mut existing, &oauth_callback);
+
+        assert_eq!(
+            existing.api_key.as_deref(),
+            Some("newly-minted-platform-key")
+        );
+        assert!(existing.oauth.is_some());
+    }
+}
+
 async fn forward_grok_login_lines<R>(stream: R, sender: mpsc::UnboundedSender<String>)
 where
     R: AsyncRead + Unpin,
@@ -3446,6 +3576,12 @@ pub struct ProviderResponse {
     pub uses_oauth: bool,
     pub auth_methods: Vec<AuthMethod>,
     pub status: ProviderStatusResponse,
+    /// OpenAI exposes two independent authentication surfaces. ChatGPT OAuth
+    /// powers Codex subscription models, while an API Platform key powers
+    /// `api.openai.com`. Keep their state separate so a missing Platform
+    /// organization does not make a healthy Codex OAuth account look broken.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub openai_auth: Option<OpenAIAuthStatusResponse>,
     /// Which backends this provider is used for (e.g., ["opencode", "claudecode"])
     pub use_for_backends: Vec<String>,
     /// Account identifier (email or username) from the connected OAuth account
@@ -3453,6 +3589,20 @@ pub struct ProviderResponse {
     pub account_email: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct OpenAIAuthStatusResponse {
+    pub codex_oauth: AuthSurfaceStatusResponse,
+    pub api_platform: AuthSurfaceStatusResponse,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthSurfaceStatusResponse {
+    Connected,
+    NeedsReauth,
+    NotConfigured,
 }
 
 #[derive(Debug, Serialize)]
@@ -3544,6 +3694,12 @@ fn build_provider_response(
         Some(AuthKind::ApiKey) | Some(AuthKind::OAuth) => ProviderStatusResponse::Connected,
         None => ProviderStatusResponse::NeedsAuth { auth_url: None },
     };
+    let openai_auth = openai_auth_status(
+        provider_type,
+        matches!(auth, Some(AuthKind::ApiKey)),
+        matches!(auth, Some(AuthKind::OAuth)),
+        false,
+    );
 
     // Most providers are only usable via OpenCode, but we still store and render
     // `use_for_backends` generically so the UI can express intent and we can grow
@@ -3569,6 +3725,7 @@ fn build_provider_response(
         uses_oauth: provider_type.uses_oauth(),
         auth_methods: provider_type.auth_methods(),
         status,
+        openai_auth,
         use_for_backends,
         account_email,
         created_at: now,
@@ -3580,8 +3737,13 @@ fn build_provider_response(
 /// Used for all provider types now that everything is stored in AIProviderStore.
 fn build_response_from_store(provider: &crate::ai_providers::AIProvider) -> ProviderResponse {
     let pt = provider.provider_type;
-    let has_api_key = provider.api_key.is_some();
-    let has_oauth = provider.oauth.is_some();
+    let has_api_key = provider
+        .api_key
+        .as_ref()
+        .is_some_and(|key| !key.trim().is_empty());
+    let has_oauth = provider.oauth.as_ref().is_some_and(|oauth| {
+        !oauth.access_token.trim().is_empty() || !oauth.refresh_token.trim().is_empty()
+    });
     let oauth_expired = provider
         .oauth
         .as_ref()
@@ -3609,6 +3771,7 @@ fn build_response_from_store(provider: &crate::ai_providers::AIProvider) -> Prov
     } else {
         ProviderStatusResponse::NeedsAuth { auth_url: None }
     };
+    let openai_auth = openai_auth_status(pt, has_api_key, has_oauth, oauth_refresh_rejected);
     let use_for_backends = provider
         .use_for_backends
         .clone()
@@ -3633,11 +3796,41 @@ fn build_response_from_store(provider: &crate::ai_providers::AIProvider) -> Prov
         uses_oauth: pt.uses_oauth(),
         auth_methods: pt.auth_methods(),
         status,
+        openai_auth,
         use_for_backends,
         account_email: provider.account_email.clone(),
         created_at: provider.created_at,
         updated_at: provider.updated_at,
     }
+}
+
+fn openai_auth_status(
+    provider_type: ProviderType,
+    has_api_key: bool,
+    has_oauth: bool,
+    oauth_refresh_rejected: bool,
+) -> Option<OpenAIAuthStatusResponse> {
+    if provider_type != ProviderType::OpenAI {
+        return None;
+    }
+
+    let codex_oauth = if has_oauth && oauth_refresh_rejected {
+        AuthSurfaceStatusResponse::NeedsReauth
+    } else if has_oauth {
+        AuthSurfaceStatusResponse::Connected
+    } else {
+        AuthSurfaceStatusResponse::NotConfigured
+    };
+    let api_platform = if has_api_key {
+        AuthSurfaceStatusResponse::Connected
+    } else {
+        AuthSurfaceStatusResponse::NotConfigured
+    };
+
+    Some(OpenAIAuthStatusResponse {
+        codex_oauth,
+        api_platform,
+    })
 }
 
 /// Sync the highest-priority enabled provider of a given type from the store
@@ -9057,6 +9250,35 @@ async fn oauth_authorize(
 }
 
 /// POST /api/ai/providers/:id/oauth/callback - Exchange OAuth code for credentials.
+struct OAuthCallbackInnerResponse {
+    response: ProviderResponse,
+    openai_api_platform_key: Option<String>,
+}
+
+impl OAuthCallbackInnerResponse {
+    fn oauth_only(response: ProviderResponse) -> Self {
+        Self {
+            response,
+            openai_api_platform_key: None,
+        }
+    }
+}
+
+fn merge_oauth_callback_credentials(
+    existing: &mut crate::ai_providers::AIProvider,
+    callback: &crate::ai_providers::AIProvider,
+) {
+    // OAuth reconnect must not erase an independently configured API key.
+    // Conversely, when the OAuth exchange minted a Platform key, attach it to
+    // the same account row as the fresh Codex OAuth credentials.
+    if callback.api_key.is_some() {
+        existing.api_key = callback.api_key.clone();
+    }
+    if callback.oauth.is_some() {
+        existing.oauth = callback.oauth.clone();
+    }
+}
+
 async fn oauth_callback(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
@@ -9065,7 +9287,8 @@ async fn oauth_callback(
     let use_for_backends = req.use_for_backends.clone();
     let provider_type_id = id.clone();
     match oauth_callback_inner(State(state.clone()), AxumPath(id), Json(req)).await {
-        Ok(json) => {
+        Ok(callback) => {
+            let json = Json(callback.response);
             // Resolve the provider type. The add-provider flow passes a
             // provider-type id ("anthropic", ...); the reconnect button passes
             // the stored provider's *UUID*, which `ProviderType::from_id` does
@@ -9119,17 +9342,20 @@ async fn oauth_callback(
                 let mut provider = crate::ai_providers::AIProvider::new(provider_type, name);
                 provider.use_for_backends = Some(backends);
                 provider.account_email = account_email;
+                provider.api_key = callback.openai_api_platform_key;
 
                 // Extract credentials from auth.json
                 if let Some(entry) = auth_entry {
                     let auth_type = entry.get("type").and_then(|v| v.as_str());
                     match auth_type {
                         Some("api_key") | Some("api") => {
-                            provider.api_key = entry
-                                .get("key")
-                                .or_else(|| entry.get("api_key"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
+                            if provider.api_key.is_none() {
+                                provider.api_key = entry
+                                    .get("key")
+                                    .or_else(|| entry.get("api_key"))
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string());
+                            }
                         }
                         Some("oauth") => {
                             let refresh = entry
@@ -9176,10 +9402,7 @@ async fn oauth_callback(
                     // returned nothing (e.g. a failed auth.json sync that still
                     // reported success), keep the existing creds rather than
                     // wiping a row the user just re-authorized.
-                    if provider.api_key.is_some() || provider.oauth.is_some() {
-                        existing.api_key = provider.api_key.clone();
-                        existing.oauth = provider.oauth.clone();
-                    }
+                    merge_oauth_callback_credentials(&mut existing, &provider);
                     existing.use_for_backends = provider.use_for_backends.clone();
                     existing.enabled = true;
                     // Only overwrite the display name/email when the new
@@ -9214,7 +9437,7 @@ async fn oauth_callback_inner(
     State(state): State<Arc<super::routes::AppState>>,
     AxumPath(id): AxumPath<String>,
     Json(req): Json<OAuthCallbackRequest>,
-) -> Result<Json<ProviderResponse>, (axum::http::StatusCode, String)> {
+) -> Result<OAuthCallbackInnerResponse, (axum::http::StatusCode, String)> {
     // Resolve provider type from UUID or type ID
     let provider_type = if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
         state
@@ -9251,7 +9474,7 @@ async fn oauth_callback_inner(
         let response =
             upsert_grok_oauth_provider(&state, &entry, req.use_for_backends.clone(), target_id)
                 .await?;
-        return Ok(Json(response));
+        return Ok(OAuthCallbackInnerResponse::oauth_only(response));
     }
 
     if provider_type == ProviderType::Kimi {
@@ -9278,7 +9501,7 @@ async fn oauth_callback_inner(
                     target_id,
                 )
                 .await?;
-                return Ok(Json(response));
+                return Ok(OAuthCallbackInnerResponse::oauth_only(response));
             }
             Some(KimiDeviceStatus::Expired) => {
                 KIMI_DEVICE_FLOWS.lock().unwrap().remove(&id);
@@ -9524,7 +9747,7 @@ async fn oauth_callback_inner(
 
                 tracing::info!("Created API key for provider: {} ({})", response.name, id);
 
-                Ok(Json(response))
+                Ok(OAuthCallbackInnerResponse::oauth_only(response))
             } else {
                 // Store OAuth credentials (Claude Pro/Max mode)
                 let refresh_token = token_data["refresh_token"].as_str().ok_or_else(|| {
@@ -9643,7 +9866,7 @@ async fn oauth_callback_inner(
                     account_email.clone(),
                 );
 
-                Ok(Json(response))
+                Ok(OAuthCallbackInnerResponse::oauth_only(response))
             }
         }
         ProviderType::OpenAI => {
@@ -9739,37 +9962,39 @@ async fn oauth_callback_inner(
                 tracing::error!("Failed to save provider backends: {}", e);
             }
 
-            // If the user wants to use Codex, Codex CLI requires an API key. In the Codex CLI
-            // flow, this is minted by exchanging the id_token for an OpenAI API key.
+            // ChatGPT OAuth is already sufficient for Codex subscription
+            // inference. Opportunistically mint a separate API Platform key
+            // when the account has a Platform organization; failure must not
+            // downgrade the healthy Codex OAuth surface.
+            let mut openai_api_platform_key = None;
             if backends.iter().any(|b| b == "codex") {
-                let id_token = token_data.get("id_token").and_then(|v| v.as_str());
-                let id_token = id_token.ok_or_else(|| {
-                    (
-                        StatusCode::BAD_GATEWAY,
-                        "OpenAI OAuth token response did not include id_token; cannot mint API key for Codex. Try reconnecting."
-                            .to_string(),
-                    )
-                })?;
-
-                match exchange_openai_id_token_for_api_key(&client, id_token).await {
-                    Ok(api_key) => {
-                        if let Err(e) = upsert_openai_api_key_in_ai_providers(
-                            &state.config.working_dir,
-                            &api_key,
-                        ) {
-                            tracing::error!("Failed to save OpenAI API key for Codex: {}", e);
-                            return Err((
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "Failed to save OpenAI API key for Codex".to_string(),
-                            ));
+                match token_data.get("id_token").and_then(|v| v.as_str()) {
+                    Some(id_token) => {
+                        match exchange_openai_id_token_for_api_key(&client, id_token).await {
+                            Ok(api_key) => {
+                                tracing::info!(
+                                    "Minted OpenAI API Platform key alongside Codex OAuth"
+                                );
+                                openai_api_platform_key = Some(api_key);
+                            }
+                            Err(e) => {
+                                // Don't fail the entire OAuth callback – the OAuth credentials
+                                // are already saved and usable for ChatGPT/Codex subscription
+                                // models. API Platform access is a separate capability and
+                                // remains unavailable until an organization/API key exists.
+                                tracing::warn!(
+                                    "OpenAI OAuth saved and Codex subscription access remains available; \
+                                     API Platform key was not configured: {}",
+                                    e
+                                );
+                            }
                         }
-                        tracing::info!("Minted and stored OpenAI API key for Codex via OAuth");
                     }
-                    Err(e) => {
-                        // Don't fail the entire OAuth callback – the OAuth credentials
-                        // are already saved and usable for OpenCode.  The API-key
-                        // minting can be retried later (e.g. on the next Codex mission).
-                        tracing::warn!("Failed to mint OpenAI API key for Codex (credentials saved, Codex may not work until platform org is set up): {}", e);
+                    None => {
+                        tracing::warn!(
+                            "OpenAI OAuth saved and Codex subscription access remains available; \
+                             token response had no id_token, so API Platform key was not configured"
+                        );
                     }
                 }
             }
@@ -9796,7 +10021,10 @@ async fn oauth_callback_inner(
                 account_email,
             );
 
-            Ok(Json(response))
+            Ok(OAuthCallbackInnerResponse {
+                response,
+                openai_api_platform_key,
+            })
         }
         ProviderType::Google => {
             // Parse the callback input (URL or code)
@@ -9945,7 +10173,7 @@ async fn oauth_callback_inner(
 
             tracing::info!("Google OAuth credentials saved for provider: {}", id);
 
-            Ok(Json(response))
+            Ok(OAuthCallbackInnerResponse::oauth_only(response))
         }
         _ => Err((
             axum::http::StatusCode::BAD_REQUEST,

--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -9198,6 +9198,42 @@ mod tests {
     }
 
     #[test]
+    fn codex_turn_requires_tool_activity_respects_negated_tool_instructions() {
+        assert!(!codex_turn_requires_tool_activity(
+            "OAuth recovery smoke test. Do not call tools or modify files. Reply with exactly: CODEX_OAUTH_SMOKE_OK.",
+            "CODEX_OAUTH_SMOKE_OK"
+        ));
+        assert!(!codex_turn_requires_tool_activity(
+            "Never edit the workspace. Reply with the current diagnosis only.",
+            "The workspace remains unchanged."
+        ));
+        assert!(!codex_turn_requires_tool_activity(
+            "Reply with exactly OK; please don't use tools or modify files.",
+            "OK"
+        ));
+        assert!(!codex_turn_requires_tool_activity(
+            "You must not edit files. Give a text-only answer.",
+            "Here is the answer."
+        ));
+    }
+
+    #[test]
+    fn codex_turn_requires_tool_activity_keeps_positive_clause_after_negation() {
+        assert!(codex_turn_requires_tool_activity(
+            "Do not edit files, but run the test suite once.",
+            "The files will remain unchanged."
+        ));
+        assert!(codex_turn_requires_tool_activity(
+            "Never modify the repository. However, execute cargo test and report the result.",
+            "I will leave the repository unchanged."
+        ));
+        assert!(codex_turn_requires_tool_activity(
+            "Without delay, run the test suite.",
+            "I will start immediately."
+        ));
+    }
+
+    #[test]
     fn codex_turn_requires_tool_activity_allows_advisory_verbs() {
         // User asks "how to run tests" — advisory, even though "run " appears.
         assert!(!codex_turn_requires_tool_activity(

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1420,9 +1420,10 @@ pub fn get_api_key_for_provider(
                 }
             }
             // OAuth access tokens can also be used as bearer tokens for some APIs.
-            // Grok Build OAuth is CLI-only here; it is not a replacement for
-            // XAI_API_KEY on xAI's OpenAI-compatible API.
-            if provider_type != ProviderType::Xai {
+            // ChatGPT/Codex and Grok Build OAuth are CLI/subscription credentials;
+            // neither is a replacement for an API Platform key on the respective
+            // OpenAI-compatible API.
+            if !matches!(provider_type, ProviderType::OpenAI | ProviderType::Xai) {
                 if let Some(ref oauth) = provider.oauth {
                     if !oauth.access_token.is_empty() {
                         return Some(oauth.access_token.clone());
@@ -1458,13 +1459,8 @@ pub fn get_api_key_for_provider(
             if let Ok(auth) = serde_json::from_str::<serde_json::Value>(&contents) {
                 for key in &auth_keys {
                     if let Some(entry) = auth.get(*key) {
-                        // Check for API key fields
-                        for field in &["key", "api_key", "apiKey"] {
-                            if let Some(val) = entry.get(*field).and_then(|v| v.as_str()) {
-                                if !val.is_empty() {
-                                    return Some(val.to_string());
-                                }
-                            }
+                        if let Some(api_key) = provider_auth_entry_api_key(provider_type, entry) {
+                            return Some(api_key);
                         }
                     }
                 }
@@ -1478,12 +1474,8 @@ pub fn get_api_key_for_provider(
         .join(format!("{}.json", provider_type.id()));
     if let Ok(contents) = std::fs::read_to_string(&provider_auth_file) {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) {
-            for field in &["key", "api_key", "apiKey"] {
-                if let Some(val) = value.get(*field).and_then(|v| v.as_str()) {
-                    if !val.is_empty() {
-                        return Some(val.to_string());
-                    }
-                }
+            if let Some(api_key) = provider_auth_entry_api_key(provider_type, &value) {
+                return Some(api_key);
             }
         }
     }
@@ -1498,6 +1490,29 @@ pub fn get_api_key_for_provider(
     }
 
     None
+}
+
+fn provider_auth_entry_api_key(
+    provider_type: ProviderType,
+    entry: &serde_json::Value,
+) -> Option<String> {
+    let auth_type = entry
+        .get("type")
+        .or_else(|| entry.get("auth_mode"))
+        .and_then(|value| value.as_str());
+    if matches!(provider_type, ProviderType::OpenAI | ProviderType::Xai)
+        && matches!(auth_type, Some("oauth" | "chatgpt" | "oidc"))
+    {
+        return None;
+    }
+
+    ["key", "api_key", "apiKey"].iter().find_map(|field| {
+        entry
+            .get(*field)
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+    })
 }
 
 /// Resolve an actual Anthropic API key for `/v1/models`.
@@ -1529,6 +1544,24 @@ fn get_anthropic_models_api_key(
 ) -> Option<String> {
     get_enabled_store_api_key(ProviderType::Anthropic, ai_providers)
         .or_else(|| get_api_key_for_provider(ProviderType::Anthropic, &[]))
+}
+
+/// Resolve credentials for an OpenAI-compatible `/v1/models` catalog.
+///
+/// OpenAI ChatGPT OAuth tokens authenticate the Codex subscription endpoint,
+/// not `api.openai.com`. Passing that token to the API Platform model catalog
+/// yields a misleading 401 even while Codex is healthy. Only a real API key
+/// may be used for OpenAI's Platform catalog.
+fn get_openai_compatible_models_api_key(
+    provider_type: ProviderType,
+    ai_providers: &[crate::ai_providers::AIProvider],
+) -> Option<String> {
+    if provider_type == ProviderType::OpenAI {
+        return get_enabled_store_api_key(provider_type, ai_providers)
+            .or_else(|| get_api_key_for_provider(provider_type, &[]));
+    }
+
+    get_api_key_for_provider(provider_type, ai_providers)
 }
 
 /// Fetch model lists from all supported provider APIs concurrently.
@@ -1708,7 +1741,7 @@ pub async fn fetch_model_catalog(
     let target_keys: Vec<(FetchTarget, Option<String>)> = targets
         .into_iter()
         .map(|t| {
-            let key = get_api_key_for_provider(t.provider_type, &providers_list);
+            let key = get_openai_compatible_models_api_key(t.provider_type, &providers_list);
             (t, key)
         })
         .collect();
@@ -2506,6 +2539,46 @@ mod tests {
         assert_eq!(
             get_enabled_store_api_key(ProviderType::Anthropic, &[api]).as_deref(),
             Some("sk-ant-api-key")
+        );
+    }
+
+    #[test]
+    fn openai_platform_catalog_key_ignores_codex_oauth_only_accounts() {
+        let mut oauth =
+            crate::ai_providers::AIProvider::new(ProviderType::OpenAI, "Codex OAuth".into());
+        oauth.oauth = Some(crate::ai_providers::OAuthCredentials {
+            access_token: "chatgpt-oauth-access-token".into(),
+            refresh_token: "chatgpt-oauth-refresh-token".into(),
+            expires_at: chrono::Utc::now().timestamp_millis() + 60_000,
+        });
+        assert_eq!(
+            get_openai_compatible_models_api_key(ProviderType::OpenAI, &[oauth]),
+            None
+        );
+
+        let mut api =
+            crate::ai_providers::AIProvider::new(ProviderType::OpenAI, "API Platform".into());
+        api.api_key = Some("sk-openai-api-key".into());
+        assert_eq!(
+            get_openai_compatible_models_api_key(ProviderType::OpenAI, &[api]).as_deref(),
+            Some("sk-openai-api-key")
+        );
+
+        let legacy_oauth = serde_json::json!({
+            "type": "oauth",
+            "key": "legacy-chatgpt-access-token"
+        });
+        assert_eq!(
+            provider_auth_entry_api_key(ProviderType::OpenAI, &legacy_oauth),
+            None
+        );
+        let platform_key = serde_json::json!({
+            "type": "api_key",
+            "key": "sk-openai-api-key"
+        });
+        assert_eq!(
+            provider_auth_entry_api_key(ProviderType::OpenAI, &platform_key).as_deref(),
+            Some("sk-openai-api-key")
         );
     }
 

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -115,6 +115,7 @@ pub(crate) fn codex_turn_requires_tool_activity(
 ) -> bool {
     let user_request = current_user_request_for_tool_activity(user_message);
     let user = user_request.to_ascii_lowercase();
+    let actionable_user = user_without_negated_tool_clauses(&user);
     let assistant = assistant_message.trim().to_ascii_lowercase();
 
     let deferred_action_prefixes = [
@@ -153,7 +154,9 @@ pub(crate) fn codex_turn_requires_tool_activity(
     // fix failures." still request execution; the advisory heuristic
     // must not bypass the imperative half. Only short-circuit when no
     // explicit imperative follow-up is present.
-    if user_looks_advisory(&user) && !user_has_imperative_execution_request(&user) {
+    if user_looks_advisory(&actionable_user)
+        && !user_has_imperative_execution_request(&actionable_user)
+    {
         return false;
     }
 
@@ -196,7 +199,7 @@ pub(crate) fn codex_turn_requires_tool_activity(
     ];
     if explicit_tool_markers
         .iter()
-        .any(|marker| user.contains(marker))
+        .any(|marker| actionable_user.contains(marker))
     {
         return true;
     }
@@ -229,8 +232,67 @@ pub(crate) fn codex_turn_requires_tool_activity(
 
     action_markers
         .iter()
-        .any(|action| contains_ascii_word(&user, action))
-        && object_markers.iter().any(|object| user.contains(object))
+        .any(|action| contains_ascii_word(&actionable_user, action))
+        && object_markers
+            .iter()
+            .any(|object| actionable_user.contains(object))
+}
+
+/// Remove clauses that explicitly prohibit tool activity before applying the
+/// keyword heuristic.
+///
+/// Prompts used for auth/model smoke tests commonly say things like
+/// "Do not call tools or modify files. Reply with exactly: OK". Looking only
+/// for `modify files` turns a correct text-only response into a false
+/// `Stalled` failure. A positive clause after "but" remains actionable:
+/// "Do not edit files, but run the tests" must still require tool activity.
+fn user_without_negated_tool_clauses(user_lower: &str) -> String {
+    let clause_separated = user_lower
+        .replace(" but ", ". but ")
+        .replace(" however, ", ". however, ");
+    let mut actionable = String::with_capacity(clause_separated.len());
+
+    for clause in clause_separated.split_inclusive(['.', '!', '?', ';', '\n']) {
+        let trimmed = clause.trim_start();
+        let directive = trimmed
+            .strip_prefix("but ")
+            .or_else(|| trimmed.strip_prefix("however, "))
+            .unwrap_or(trimmed);
+        let negated = [
+            "do not ",
+            "don't ",
+            "dont ",
+            "never ",
+            "must not ",
+            "should not ",
+            "please do not ",
+            "please don't ",
+            "please dont ",
+            "please never ",
+            "you must not ",
+            "you should not ",
+            "kindly do not ",
+            "kindly don't ",
+            "kindly dont ",
+            "no tool ",
+            "no tools ",
+            "without calling ",
+            "without using ",
+            "without running ",
+            "without editing ",
+            "without modifying ",
+        ]
+        .iter()
+        .any(|prefix| directive.starts_with(prefix));
+
+        if negated {
+            actionable.push(' ');
+        } else {
+            actionable.push_str(clause);
+        }
+    }
+
+    actionable
 }
 
 pub(crate) fn codex_is_goal_request(user_message: &str) -> bool {


### PR DESCRIPTION
## What changed

- ignore explicitly negated tool/file instructions when deciding whether a Codex turn required tool activity, while preserving positive clauses such as “do not edit files, but run tests”
- expose independent `Codex OAuth` and `API Platform` status surfaces for OpenAI providers
- preserve a configured API Platform key across Codex OAuth reconnects and attach a newly minted Platform key to the same provider row
- stop using ChatGPT/Codex OAuth tokens as bearer keys for the OpenAI Platform model catalog
- show both OpenAI authentication surfaces independently in provider settings

## Root cause

A text-only OAuth smoke prompt containing “Do not call tools or modify files” matched the positive `modify files` heuristic. The correct response was therefore misclassified as `Stalled`. Separately, ChatGPT subscription OAuth and OpenAI API Platform credentials were treated as interchangeable, so a Platform 401 or missing Platform organization could make healthy Codex OAuth look broken.

## Impact

Text-only Codex smoke turns no longer become false stalls. Operators can see whether Codex subscription OAuth, API Platform, or both are configured without conflating failures between them.

## Validation

- `cargo fmt --all --check`
- `cargo test --lib` — 1501 passed, 1 ignored
- ESLint passed for both modified dashboard files
- dev runtime smoke with `gpt-5.6-terra` returned the exact requested text and ended `turn_complete`, not `Stalled`
- global dashboard TypeScript validation currently stops on pre-existing errors in `src/components/new-mission-dialog.test.tsx` (missing `default_agent` / `default_model` fields); those files are unchanged by this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth callback merging, provider status reporting, and API key resolution for OpenAI—auth-adjacent paths with broad operator impact, but behavior is covered by new unit tests and narrows false failures rather than loosening security.
> 
> **Overview**
> Fixes **false Codex `Stalled` turns** on text-only prompts that forbid tools (e.g. OAuth smoke tests) by stripping negated clauses before the tool-activity heuristic, while still honoring positive follow-ups like “do not edit files, but run tests.”
> 
> **OpenAI credentials** are no longer treated as one blob: the API adds per-surface `openai_auth` (`codex_oauth` vs `api_platform`), overall provider status can stay connected when only one surface is healthy, OAuth reconnect merges credentials without wiping an existing Platform key, and optional Platform key minting after Codex OAuth no longer fails the whole callback. ChatGPT/Codex OAuth is excluded from Platform model-catalog and generic API-key resolution so Platform 401s do not look like broken Codex.
> 
> The **providers settings** UI shows both surfaces with separate labels/colors for OpenAI rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf39f7759b2aa9671a82b1df89ef41fd801e6cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->