### PR TITLE
feat(chatgpt-ui): privacy-safe multi-hour job durability (workstream D)

### DIFF
--- a/dashboard/src/app/settings/backends/page.test.tsx
+++ b/dashboard/src/app/settings/backends/page.test.tsx
@@ -5,9 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import BackendsPage from './page';
 import { updateBackendConfig } from '@/lib/api';
 
-const { refreshBackendConfigs, getChatgptUiProfilePoolMock, backendConfigsFixture } = vi.hoisted(() => ({
+const { refreshBackendConfigs, getChatgptUiProfilePoolMock, getChatgptUiDurabilityMock, backendConfigsFixture } = vi.hoisted(() => ({
   refreshBackendConfigs: vi.fn(),
   getChatgptUiProfilePoolMock: vi.fn(),
+  getChatgptUiDurabilityMock: vi.fn(),
   backendConfigsFixture: {
     opencode: {
       enabled: true,
@@ -55,6 +56,7 @@ vi.mock('@/lib/api', () => ({
   updateBackendConfig: vi.fn().mockResolvedValue({ message: 'saved' }),
   getProviderForBackend: vi.fn().mockResolvedValue({ configured: false }),
   getChatgptUiProfilePool: getChatgptUiProfilePoolMock,
+  getChatgptUiDurability: getChatgptUiDurabilityMock,
   getHealth: vi.fn().mockResolvedValue({ version: '1.3.0' }),
   getSettings: vi.fn().mockResolvedValue({
     max_parallel_missions: 1,
@@ -86,6 +88,8 @@ describe('BackendsPage ChatGPT UI settings', () => {
     refreshBackendConfigs.mockClear();
     getChatgptUiProfilePoolMock.mockReset();
     getChatgptUiProfilePoolMock.mockResolvedValue({ slots: [] });
+    getChatgptUiDurabilityMock.mockReset();
+    getChatgptUiDurabilityMock.mockResolvedValue({ jobs: [] });
   });
 
   afterEach(() => {
@@ -180,5 +184,56 @@ describe('BackendsPage ChatGPT UI settings', () => {
     expect(screen.getByText('quarantined')).toBeVisible();
     expect(screen.getByText(/auth failure/)).toBeVisible();
     expect(screen.getByText(/retry in 29 min/)).toBeVisible();
+  });
+
+  it('shows durable job health without exposing conversation data', async () => {
+    getChatgptUiDurabilityMock.mockResolvedValue({
+      jobs: [
+        {
+          mission_id: 'a1b2c3d4-0000-0000-0000-000000000000',
+          state: 'submitted',
+          attempts: 2,
+          profile: 'chatgpt-profile',
+          model: 'gpt-5.6-pro',
+          age_secs: 7200,
+          updated_secs_ago: 120,
+          resumable: true,
+          last_error_code: 'driver_crash',
+        },
+        {
+          mission_id: 'e5f6a7b8-0000-0000-0000-000000000000',
+          state: 'completed',
+          attempts: 1,
+          profile: 'chatgpt-profile-2',
+          model: 'gpt-5.6-pro',
+          age_secs: 300,
+          updated_secs_ago: 60,
+          resumable: false,
+          last_error_code: null,
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'ChatGPT UI (experimental)' }));
+
+    expect(screen.queryByTestId('chatgpt-ui-durability-status')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use production defaults' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chatgpt-ui-durability-status')).toBeVisible();
+    });
+    expect(screen.getByText('a1b2c3d4')).toBeVisible();
+    expect(screen.getByText('submitted')).toBeVisible();
+    expect(screen.getByText('resumable')).toBeVisible();
+    expect(screen.getByText(/profile chatgpt-profile · attempt 2 · 2 h old/)).toBeVisible();
+    expect(screen.getByText('driver_crash')).toBeVisible();
+    expect(screen.getByText('e5f6a7b8')).toBeVisible();
+    expect(screen.getByText('completed')).toBeVisible();
+    const panel = screen.getByTestId('chatgpt-ui-durability-status');
+    expect(panel.textContent).not.toContain('/c/');
+    expect(panel.textContent).not.toMatch(/[0-9a-f]{64}/);
   });
 });

--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -8,6 +8,7 @@ import {
   updateBackendConfig,
   getProviderForBackend,
   getChatgptUiProfilePool,
+  getChatgptUiDurability,
   getHealth,
   getSettings,
   updateSettings,
@@ -160,6 +161,14 @@ export default function BackendsPage() {
       ? 'chatgpt-ui-profile-pool'
       : null,
     getChatgptUiProfilePool,
+    { revalidateOnFocus: false, refreshInterval: 15000 }
+  );
+
+  const { data: chatgptUiDurability } = useSWR(
+    activeBackendTab === 'chatgpt_ui' && chatgptUiIsConfigured
+      ? 'chatgpt-ui-durability'
+      : null,
+    getChatgptUiDurability,
     { revalidateOnFocus: false, refreshInterval: 15000 }
   );
 
@@ -778,6 +787,47 @@ export default function BackendsPage() {
                   </ul>
                   <p className="mt-2 text-xs text-white/30">
                     Slots quarantine automatically after auth, launch, or repeated compatibility failures and rejoin the pool when the cooldown ends.
+                  </p>
+                </div>
+              )}
+              {chatgptUiIsConfigured && (chatgptUiDurability?.jobs.length ?? 0) > 0 && (
+                <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4" data-testid="chatgpt-ui-durability-status">
+                  <p className="text-xs font-medium uppercase tracking-[0.16em] text-white/35">
+                    Long-running job durability
+                  </p>
+                  <ul className="mt-3 space-y-2">
+                    {chatgptUiDurability!.jobs.map((job) => (
+                      <li key={job.mission_id} className="flex flex-wrap items-center gap-2 text-xs">
+                        <span className="font-mono text-white/70">{job.mission_id.slice(0, 8)}</span>
+                        <span
+                          className={cn(
+                            'rounded-full px-2 py-0.5',
+                            job.state === 'submitted' && 'bg-indigo-500/10 text-indigo-300',
+                            job.state === 'completed' && 'bg-emerald-500/10 text-emerald-300',
+                            job.state === 'abandoned' && 'bg-rose-500/10 text-rose-300'
+                          )}
+                        >
+                          {job.state}
+                        </span>
+                        {job.state === 'submitted' && (
+                          <span className="text-white/35">
+                            {job.resumable ? 'resumable' : 'not resumable'}
+                          </span>
+                        )}
+                        <span className="text-white/35">
+                          profile {job.profile} · attempt {job.attempts} ·{' '}
+                          {job.age_secs >= 3600
+                            ? `${Math.floor(job.age_secs / 3600)} h old`
+                            : `${Math.max(1, Math.floor(job.age_secs / 60))} min old`}
+                        </span>
+                        {job.last_error_code && (
+                          <span className="text-amber-300/70">{job.last_error_code}</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-2 text-xs text-white/30">
+                    Submitted GPT Pro conversations survive restarts and reattach on retry. Only opaque state is stored — never prompts, responses, or reasoning.
                   </p>
                 </div>
               )}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3304,6 +3304,32 @@ export async function getChatgptUiProfilePool(): Promise<ChatgptUiProfilePoolRes
   );
 }
 
+// Privacy-reduced durable job record: states, counters, and allowlisted error
+// codes only. Conversation routes and prompt fingerprints are never returned.
+export interface ChatgptUiDurabilityJob {
+  mission_id: string;
+  state: "submitted" | "completed" | "abandoned";
+  attempts: number;
+  profile: string;
+  model?: string | null;
+  age_secs: number;
+  updated_secs_ago: number;
+  resumable: boolean;
+  last_error_code?: string | null;
+}
+
+export interface ChatgptUiDurabilityResponse {
+  jobs: ChatgptUiDurabilityJob[];
+}
+
+// Get ChatGPT UI durable job ledger health
+export async function getChatgptUiDurability(): Promise<ChatgptUiDurabilityResponse> {
+  return apiGet(
+    "/api/backends/chatgpt_ui/durability",
+    "Failed to get ChatGPT UI durability status",
+  );
+}
+
 // Update backend configuration
 export async function updateBackendConfig(
   backendId: string,

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -41,6 +41,18 @@ PRO_MODEL_ALIASES = {
     "gpt-5.6 pro",
     "gpt 5.6-pro",
 }
+# Opaque conversation route: `/c/<id>`. This is the only page-derived value the
+# durability protocol ever emits — never titles, prompts, or response text.
+CONVERSATION_PATH_RE = re.compile(r"^/c/[A-Za-z0-9-]{8,64}$")
+CHATGPT_HOSTS = {"chatgpt.com", "chat.openai.com"}
+
+
+class ResumeNotFound(Exception):
+    """The recorded conversation route is not reachable from this profile."""
+
+
+class ResumeMismatch(Exception):
+    """The conversation exists but does not hold exactly this prompt."""
 
 
 def emit(event_type: str, **payload) -> None:
@@ -49,6 +61,34 @@ def emit(event_type: str, **payload) -> None:
 
 def fail(code: str, message: str) -> None:
     emit("error", code=code, message=message)
+
+
+def conversation_path_from_url(url: str) -> str | None:
+    """Return the opaque `/c/<id>` route for a ChatGPT conversation URL."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    if parsed.netloc.lower() not in CHATGPT_HOSTS:
+        return None
+    if CONVERSATION_PATH_RE.fullmatch(parsed.path or ""):
+        return parsed.path
+    return None
+
+
+def resume_conversation_path(resume) -> str | None:
+    """Validate a resume request and return its conversation route."""
+    if not isinstance(resume, dict):
+        return None
+    path = resume.get("conversation_path")
+    if isinstance(path, str) and CONVERSATION_PATH_RE.fullmatch(path):
+        return path
+    return None
+
+
+def normalized_prompt(text: str) -> str:
+    """Whitespace-insensitive prompt identity used only in memory."""
+    return " ".join(text.split())
 
 
 def model_selection(requested: str) -> tuple[str, str]:
@@ -305,10 +345,8 @@ async def close_context_quietly(context) -> None:
         pass
 
 
-async def establish_fresh_chat(page) -> int:
-    """Prove an authenticated, settled blank chat before observing responses."""
-    await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
-    emit("diagnostic", message="stage=page_loaded")
+async def verify_authentication(page) -> None:
+    """Require account-only evidence of an authenticated session."""
     login = page.get_by_role("button", name=re.compile(r"log in|sign in", re.I)).first
     if "/auth/" in page.url or (await login.count() and await login.is_visible()):
         raise PermissionError("login required")
@@ -321,14 +359,52 @@ async def establish_fresh_chat(page) -> int:
         'button[aria-label*="account" i], '
         'button[aria-label*="profile" i]'
     )
-    authenticated = False
     for index in range(await account_controls.count()):
         if await account_controls.nth(index).is_visible():
-            authenticated = True
-            break
-    if not authenticated:
-        raise PermissionError("authenticated account control not found")
-    emit("diagnostic", message="stage=account_confirmed")
+            emit("diagnostic", message="stage=account_confirmed")
+            return
+    raise PermissionError("authenticated account control not found")
+
+
+async def establish_resumed_chat(page, conversation_path: str, message: str) -> int:
+    """Reattach to a recorded conversation and prove it holds this prompt.
+
+    All verification happens in memory; nothing from the page is emitted. The
+    conversation is expected to hold exactly one user message (mission turns
+    always start from a blank chat), and that message must equal the prompt
+    this run was asked to submit — otherwise reattaching would return someone
+    else's response.
+    """
+    await page.goto(
+        f"https://chatgpt.com{conversation_path}",
+        wait_until="domcontentloaded",
+        timeout=60_000,
+    )
+    emit("diagnostic", message="stage=resume_route")
+    await verify_authentication(page)
+    # Unknown or deleted conversations redirect away from the recorded route.
+    await page.wait_for_timeout(2_000)
+    parsed = urlparse(page.url)
+    if parsed.netloc.lower() not in CHATGPT_HOSTS or parsed.path != conversation_path:
+        raise ResumeNotFound()
+    user_messages = page.locator('[data-message-author-role="user"]')
+    count = await user_messages.count()
+    if count == 0:
+        raise ResumeNotFound()
+    if count != 1:
+        raise ResumeMismatch()
+    text = await user_messages.first.inner_text()
+    if normalized_prompt(text) != normalized_prompt(message):
+        raise ResumeMismatch()
+    emit("diagnostic", message="stage=resume_verified")
+    return 0
+
+
+async def establish_fresh_chat(page) -> int:
+    """Prove an authenticated, settled blank chat before observing responses."""
+    await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
+    emit("diagnostic", message="stage=page_loaded")
+    await verify_authentication(page)
 
     # A direct navigation to the root is the stable new-chat primitive. The
     # sidebar's "New chat" control is rollout-dependent and can be a button,
@@ -366,6 +442,17 @@ async def run(args, request) -> None:
         30_000, min(int(request.get("timeout_ms", 14_400_000)), 86_400_000)
     )
     requested_model = request.get("model") or ""
+    durability = request.get("durability") is True
+    resume_request = request.get("resume")
+    resume_path = None
+    if resume_request is not None:
+        resume_path = resume_conversation_path(resume_request)
+        if resume_path is None:
+            fail(
+                "invalid_request",
+                "resume.conversation_path must be an opaque /c/<id> route",
+            )
+            return
     requested_download_dir = request.get("download_dir")
     download_dir = None
     if requested_download_dir is not None:
@@ -408,38 +495,56 @@ async def run(args, request) -> None:
                 return
 
             page = context.pages[0] if context.pages else await context.new_page()
-            stage = "fresh_chat"
-            baseline = await establish_fresh_chat(page)
-            stage = "model_selection"
-            model_used = await choose_model(page, requested_model)
-            stage = "blank_chat_check"
-            await assert_blank_chat(page)
-            stage = "composer"
-            composer = page.locator("#prompt-textarea").first
-            if not await composer.count():
-                composer = page.get_by_role("textbox").last
-            await composer.fill(message)
-            stage = "send"
-            send = None
-            for _ in range(20):  # allow ~10 seconds for the control to attach
-                send, used_fallback = await locate_composer_control(
-                    page, SEND_CONTROL_TESTIDS, SEND_BUTTON_NAME
+            if resume_path is not None:
+                stage = "resume"
+                baseline = await establish_resumed_chat(page, resume_path, message)
+                # The prompt was submitted by a prior run; the picker state it
+                # used is part of the conversation and must not be touched.
+                model_used = (
+                    model_selection(requested_model)[1] if requested_model else ""
                 )
-                if send is not None:
-                    if used_fallback:
-                        emit("diagnostic", message="stage=send_button_fallback")
-                    break
-                await asyncio.sleep(0.5)
-            if send is None:
-                raise RuntimeError("composer send control not found")
-            await send.click()
+            else:
+                stage = "fresh_chat"
+                baseline = await establish_fresh_chat(page)
+                stage = "model_selection"
+                model_used = await choose_model(page, requested_model)
+                stage = "blank_chat_check"
+                await assert_blank_chat(page)
+                stage = "composer"
+                composer = page.locator("#prompt-textarea").first
+                if not await composer.count():
+                    composer = page.get_by_role("textbox").last
+                await composer.fill(message)
+                stage = "send"
+                send = None
+                for _ in range(20):  # allow ~10 seconds for the control to attach
+                    send, used_fallback = await locate_composer_control(
+                        page, SEND_CONTROL_TESTIDS, SEND_BUTTON_NAME
+                    )
+                    if send is not None:
+                        if used_fallback:
+                            emit("diagnostic", message="stage=send_button_fallback")
+                        break
+                    await asyncio.sleep(0.5)
+                if send is None:
+                    raise RuntimeError("composer send control not found")
+                await send.click()
 
             stage = "response"
             last = ""
             stable = 0
             stop_fallback_reported = False
+            submitted_emitted = resume_path is not None
             deadline = asyncio.get_running_loop().time() + timeout_ms / 1000
             while asyncio.get_running_loop().time() < deadline:
+                if durability and not submitted_emitted:
+                    # The URL flips to the opaque conversation route once the
+                    # prompt is accepted. That route is the only durable
+                    # pointer this driver ever reports.
+                    submitted_route = conversation_path_from_url(page.url)
+                    if submitted_route is not None:
+                        submitted_emitted = True
+                        emit("submitted", conversation_path=submitted_route)
                 responses = page.locator('[data-message-author-role="assistant"]')
                 count = await responses.count()
                 if count > baseline:
@@ -457,6 +562,11 @@ async def run(args, request) -> None:
                     emit("diagnostic", message="stage=stop_button_fallback")
                 stop_visible = stop is not None
                 if last and count > baseline and not stop_visible and stable >= 2:
+                    if durability and not submitted_emitted:
+                        emit(
+                            "diagnostic",
+                            message="stage=conversation_ref_unavailable",
+                        )
                     if download_dir is not None:
                         stage = "artifacts"
                         await collect_downloads(
@@ -470,6 +580,16 @@ async def run(args, request) -> None:
         fail(
             "auth_required",
             "ChatGPT login is required in the configured profile; provision it interactively",
+        )
+    except ResumeNotFound:
+        fail(
+            "resume_not_found",
+            "the recorded conversation is not reachable from this profile",
+        )
+    except ResumeMismatch:
+        fail(
+            "resume_mismatch",
+            "the recorded conversation does not hold exactly this prompt",
         )
     except Exception as exc:
         fail(

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -11,10 +11,13 @@ from scripts.chatgpt_ui_driver import (
     STOP_CONTROL_TESTIDS,
     choose_intelligence_model,
     close_context_quietly,
+    conversation_path_from_url,
     download_control_key,
     downloadable_href,
     locate_composer_control,
     model_selection,
+    normalized_prompt,
+    resume_conversation_path,
     safe_download_name,
 )
 
@@ -208,6 +211,56 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertIsNone(
             download_control_key("BUTTON", None, "report.pdf", "generic", "report.pdf")
         )
+
+    def test_conversation_path_is_only_extracted_from_chatgpt_routes(self) -> None:
+        self.assertEqual(
+            conversation_path_from_url("https://chatgpt.com/c/abc123def456"),
+            "/c/abc123def456",
+        )
+        self.assertEqual(
+            conversation_path_from_url(
+                "https://chat.openai.com/c/0a1b2c3d-4e5f-6789-abcd-ef0123456789"
+            ),
+            "/c/0a1b2c3d-4e5f-6789-abcd-ef0123456789",
+        )
+        # Non-conversation routes, foreign hosts, and short ids never become
+        # durability pointers.
+        self.assertIsNone(conversation_path_from_url("https://chatgpt.com/"))
+        self.assertIsNone(conversation_path_from_url("https://chatgpt.com/c/short"))
+        self.assertIsNone(
+            conversation_path_from_url("https://evil.example/c/abc123def456")
+        )
+        self.assertIsNone(
+            conversation_path_from_url("https://chatgpt.com/share/abc123def456")
+        )
+        self.assertIsNone(
+            conversation_path_from_url("https://chatgpt.com/c/abc123def456/extra")
+        )
+
+    def test_resume_requests_only_accept_opaque_conversation_routes(self) -> None:
+        self.assertEqual(
+            resume_conversation_path({"conversation_path": "/c/abc123def456"}),
+            "/c/abc123def456",
+        )
+        self.assertIsNone(resume_conversation_path(None))
+        self.assertIsNone(resume_conversation_path("/c/abc123def456"))
+        self.assertIsNone(resume_conversation_path({"conversation_path": "/settings"}))
+        self.assertIsNone(
+            resume_conversation_path({"conversation_path": "/c/../../etc/passwd"})
+        )
+        self.assertIsNone(
+            resume_conversation_path(
+                {"conversation_path": "https://chatgpt.com/c/abc123def456"}
+            )
+        )
+
+    def test_prompt_identity_is_whitespace_insensitive_and_in_memory_only(
+        self,
+    ) -> None:
+        self.assertEqual(
+            normalized_prompt("hello\n  world\t"), normalized_prompt(" hello world")
+        )
+        self.assertNotEqual(normalized_prompt("hello"), normalized_prompt("hello!"))
 
 
 if __name__ == "__main__":

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -750,6 +750,34 @@ pub async fn chatgpt_ui_profile_pool(
     }))
 }
 
+/// Durable ChatGPT UI job-ledger health.
+///
+/// Summaries expose only job state, counters, and allowlisted error codes.
+/// Conversation routes, prompt fingerprints, and message content are never
+/// serialized here.
+#[derive(Debug, Serialize)]
+pub struct ChatgptUiDurabilityResponse {
+    pub jobs: Vec<crate::api::runners::chatgpt_ui_jobs::JobStatusSummary>,
+}
+
+/// GET /api/backends/chatgpt_ui/durability — persisted long-turn job records
+/// used for restart/disconnect reconciliation of ChatGPT UI missions.
+pub async fn chatgpt_ui_durability(
+    State(state): State<Arc<AppState>>,
+    Extension(_user): Extension<AuthUser>,
+) -> Result<Json<ChatgptUiDurabilityResponse>, (StatusCode, String)> {
+    let working_dir = state.config.working_dir.clone();
+    let jobs = tokio::task::spawn_blocking(move || {
+        // Reconcile on read so the dashboard reflects stale-job expiry even
+        // when no new turn has run since a restart.
+        let _ = crate::api::runners::chatgpt_ui_jobs::reconcile_jobs(&working_dir);
+        crate::api::runners::chatgpt_ui_jobs::jobs_snapshot(&working_dir)
+    })
+    .await
+    .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+    Ok(Json(ChatgptUiDurabilityResponse { jobs }))
+}
+
 #[cfg(test)]
 mod quota_tests {
     use super::*;

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1207,6 +1207,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             get(backends_api::chatgpt_ui_profile_pool),
         )
         .route(
+            "/api/backends/chatgpt_ui/durability",
+            get(backends_api::chatgpt_ui_durability),
+        )
+        .route(
             "/api/backends/:id/agents",
             get(backends_api::list_backend_agents),
         )

--- a/src/api/runners/chatgpt_ui.rs
+++ b/src/api/runners/chatgpt_ui.rs
@@ -23,6 +23,7 @@ use crate::api::control::AgentEvent;
 use crate::api::mission_runner::{
     get_backend_string_list_setting, get_backend_string_setting, get_backend_u64_setting,
 };
+use crate::api::runners::chatgpt_ui_jobs as jobs;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -46,6 +47,11 @@ enum DriverEvent {
     Complete {
         content: String,
         model: Option<String>,
+    },
+    /// The prompt provably lives in a conversation. `conversation_path` is an
+    /// opaque `/c/<id>` route — a durability pointer, never content.
+    Submitted {
+        conversation_path: String,
     },
     Artifact {
         path: String,
@@ -246,7 +252,10 @@ fn safe_driver_diagnostic(message: &str) -> Option<&str> {
         | "stage=model_already_selected"
         | "stage=composer_model_option_unavailable"
         | "stage=artifact_size_limit"
-        | "stage=artifact_download_skipped" => Some(message),
+        | "stage=artifact_download_skipped"
+        | "stage=conversation_ref_unavailable"
+        | "stage=resume_route"
+        | "stage=resume_verified" => Some(message),
         _ => None,
     }
 }
@@ -373,6 +382,24 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
     })
 }
 
+/// Outcome of one driver attempt. Resume-pointer failures are recoverable
+/// inside the same turn (fall back to a fresh submission); everything else is
+/// terminal for the turn.
+enum DriveOutcome {
+    Terminal(AgentResult),
+    /// The persisted conversation pointer is unusable (`resume_not_found` or
+    /// `resume_mismatch`). The prompt is provably absent from the referenced
+    /// conversation, so a fresh submission stays idempotent.
+    ResumeInvalid(&'static str),
+}
+
+fn profile_basename(profile_dir: &Path) -> &str {
+    profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("profile")
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_chatgpt_ui_turn(
     work_dir: &Path,
@@ -389,11 +416,24 @@ pub async fn run_chatgpt_ui_turn(
             return AgentResult::failure(error, 0).with_terminal_reason(TerminalReason::AuthError)
         }
     };
-    let (profile_slot, profile_dir, _profile_lock) =
-        match acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel).await {
-            Ok(lease) => lease,
-            Err(result) => return result,
-        };
+    let fingerprint = jobs::prompt_fingerprint(message, model);
+    let _ = jobs::reconcile_jobs(app_working_dir);
+    let mut prior_attempts = 0u32;
+    let mut resume_record = match jobs::load_job(app_working_dir, mission_id) {
+        Some(record) if jobs::resumable_job(&record, &fingerprint, chrono::Utc::now()) => {
+            Some(record)
+        }
+        Some(record) => {
+            prior_attempts = record.attempts;
+            if record.state == jobs::JobState::Submitted {
+                // Same mission, different prompt: the old submission can no
+                // longer be reattached to this turn.
+                jobs::mark_abandoned(app_working_dir, mission_id, "superseded");
+            }
+            None
+        }
+        None => None,
+    };
     let download_dir = match prepare_download_dir(work_dir).await {
         Ok(path) => path,
         Err(error) => {
@@ -401,6 +441,89 @@ pub async fn run_chatgpt_ui_turn(
         }
     };
 
+    loop {
+        let attempt_resume = resume_record.take();
+        // Conversations are account-scoped: a resume must reuse the profile
+        // that submitted the prompt, or give up on the pointer entirely.
+        let acquisition = if let Some(record) = attempt_resume.as_ref() {
+            match settings
+                .profile_dirs
+                .iter()
+                .position(|dir| profile_basename(dir) == record.profile)
+            {
+                Some(index) => {
+                    let pinned = settings.profile_dirs[index].clone();
+                    acquire_profile(
+                        std::slice::from_ref(&pinned),
+                        mission_id,
+                        &events_tx,
+                        &cancel,
+                    )
+                    .await
+                    .map(|(_, dir, lock)| (index, dir, lock))
+                }
+                None => {
+                    jobs::mark_abandoned(app_working_dir, mission_id, "profile_unavailable");
+                    continue;
+                }
+            }
+        } else {
+            acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel).await
+        };
+        let (profile_slot, profile_dir, _profile_lock) = match acquisition {
+            Ok(lease) => lease,
+            Err(result) => return result,
+        };
+        match drive_once(
+            &settings,
+            work_dir,
+            &download_dir,
+            message,
+            model,
+            mission_id,
+            &events_tx,
+            &cancel,
+            app_working_dir,
+            &fingerprint,
+            prior_attempts,
+            profile_slot,
+            &profile_dir,
+            attempt_resume.as_ref(),
+        )
+        .await
+        {
+            DriveOutcome::Terminal(result) => return result,
+            DriveOutcome::ResumeInvalid(code) => {
+                jobs::mark_abandoned(app_working_dir, mission_id, code);
+                prior_attempts = attempt_resume.map(|record| record.attempts).unwrap_or(0);
+                let _ = events_tx.send(AgentEvent::MissionActivity {
+                    label: "ChatGPT UI conversation could not be reattached — submitting fresh."
+                        .to_string(),
+                    tool_name: "chatgpt_ui_durability".to_string(),
+                    mission_id: Some(mission_id),
+                });
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_once(
+    settings: &Settings,
+    work_dir: &Path,
+    download_dir: &Path,
+    message: &str,
+    model: Option<&str>,
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    cancel: &CancellationToken,
+    app_working_dir: &Path,
+    fingerprint: &str,
+    prior_attempts: u32,
+    profile_slot: usize,
+    profile_dir: &Path,
+    resume: Option<&jobs::JobRecord>,
+) -> DriveOutcome {
     let mut command = Command::new(&settings.python_path);
     command
         .arg(&settings.driver_path)
@@ -431,20 +554,36 @@ pub async fn run_chatgpt_ui_turn(
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
-            return AgentResult::failure(format!("failed to start chatgpt_ui driver: {error}"), 0)
-                .with_terminal_reason(TerminalReason::LlmError)
+            return DriveOutcome::Terminal(
+                AgentResult::failure(format!("failed to start chatgpt_ui driver: {error}"), 0)
+                    .with_terminal_reason(TerminalReason::LlmError),
+            )
         }
     };
     #[cfg(unix)]
     let process_group = child.id().map(|pid| -(pid as i32));
 
-    let request = serde_json::json!({
+    // The prompt itself is passed to the driver over stdin only; the durable
+    // ledger never sees it (a fingerprint stands in for identity).
+    let mut request = serde_json::json!({
         "type": "run",
         "message": message,
         "model": model,
         "timeout_ms": settings.timeout.as_millis() as u64,
         "download_dir": download_dir,
+        "durability": true,
     });
+    if let Some(record) = resume {
+        request["resume"] = serde_json::json!({
+            "conversation_path": record.conversation_path,
+        });
+        jobs::touch_resume_attempt(app_working_dir, mission_id);
+        let _ = events_tx.send(AgentEvent::MissionActivity {
+            label: "Reattaching to the in-flight ChatGPT conversation…".to_string(),
+            tool_name: "chatgpt_ui_durability".to_string(),
+            mission_id: Some(mission_id),
+        });
+    }
     if let Some(mut stdin) = child.stdin.take() {
         if stdin
             .write_all(format!("{request}\n").as_bytes())
@@ -452,8 +591,10 @@ pub async fn run_chatgpt_ui_turn(
             .is_err()
         {
             terminate_child_tree(&mut child).await;
-            return AgentResult::failure("failed to send request to chatgpt_ui driver", 0)
-                .with_terminal_reason(TerminalReason::LlmError);
+            return DriveOutcome::Terminal(
+                AgentResult::failure("failed to send request to chatgpt_ui driver", 0)
+                    .with_terminal_reason(TerminalReason::LlmError),
+            );
         }
     }
 
@@ -464,6 +605,10 @@ pub async fn run_chatgpt_ui_turn(
     let mut pending_tools: HashMap<String, String> = HashMap::new();
     let mut artifact_receipts: Vec<(String, String)> = Vec::new();
     let mut completed = false;
+    // Once true, the prompt provably lives in a conversation: from here on,
+    // every non-complete exit must leave the ledger record resumable so a
+    // retried turn reattaches instead of resubmitting.
+    let mut submitted_recorded = resume.is_some();
     let deadline_at = Instant::now() + settings.timeout;
     let deadline = tokio::time::sleep_until(deadline_at);
     tokio::pin!(deadline);
@@ -472,21 +617,32 @@ pub async fn run_chatgpt_ui_turn(
         tokio::select! {
             _ = cancel.cancelled() => {
                 terminate_child_tree(&mut child).await;
-                return AgentResult::failure(
-                    if crate::api::routes::is_shutdown_initiated() {
+                let shutdown = crate::api::routes::is_shutdown_initiated();
+                if submitted_recorded {
+                    jobs::note_attempt_error(
+                        app_working_dir,
+                        mission_id,
+                        if shutdown { "server_shutdown" } else { "cancelled" },
+                    );
+                }
+                return DriveOutcome::Terminal(AgentResult::failure(
+                    if shutdown {
                         "Server restart — paused. Click Resume to continue."
                     } else {
                         "Mission cancelled"
                     }, 0
-                ).with_terminal_reason(if crate::api::routes::is_shutdown_initiated() {
+                ).with_terminal_reason(if shutdown {
                     TerminalReason::ServerShutdown
                 } else {
                     TerminalReason::Cancelled
-                });
+                }));
             }
             _ = &mut deadline => {
                 kill_child_tree(&mut child).await;
-                return timeout_result(settings.timeout);
+                if submitted_recorded {
+                    jobs::note_attempt_error(app_working_dir, mission_id, "timeout");
+                }
+                return DriveOutcome::Terminal(timeout_result(settings.timeout));
             }
             line = lines.next_line() => {
                 let line = match line {
@@ -494,17 +650,25 @@ pub async fn run_chatgpt_ui_turn(
                     Ok(None) => break,
                     Err(error) => {
                         terminate_child_tree(&mut child).await;
-                        return AgentResult::failure(format!("chatgpt_ui stream read failed: {error}"), 0)
-                            .with_terminal_reason(TerminalReason::LlmError);
+                        if submitted_recorded {
+                            jobs::note_attempt_error(app_working_dir, mission_id, "stream_error");
+                        }
+                        return DriveOutcome::Terminal(
+                            AgentResult::failure(format!("chatgpt_ui stream read failed: {error}"), 0)
+                                .with_terminal_reason(TerminalReason::LlmError),
+                        );
                     }
                 };
                 let event: DriverEvent = match serde_json::from_str(&line) {
                     Ok(event) => event,
                     Err(error) => {
                         terminate_child_tree(&mut child).await;
-                        return AgentResult::failure(
+                        if submitted_recorded {
+                            jobs::note_attempt_error(app_working_dir, mission_id, "driver_protocol");
+                        }
+                        return DriveOutcome::Terminal(AgentResult::failure(
                             format!("chatgpt_ui emitted an invalid protocol event: {error}"), 0
-                        ).with_terminal_reason(TerminalReason::LlmError);
+                        ).with_terminal_reason(TerminalReason::LlmError));
                     }
                 };
                 match event {
@@ -531,18 +695,24 @@ pub async fn run_chatgpt_ui_turn(
                     DriverEvent::ToolCall { id, name, args } => {
                         if pending_tools.insert(id.clone(), name.clone()).is_some() {
                             terminate_child_tree(&mut child).await;
-                            return AgentResult::failure(
+                            if submitted_recorded {
+                                jobs::note_attempt_error(app_working_dir, mission_id, "driver_protocol");
+                            }
+                            return DriveOutcome::Terminal(AgentResult::failure(
                                 "chatgpt_ui emitted a duplicate unresolved tool call id", 0
-                            ).with_terminal_reason(TerminalReason::LlmError);
+                            ).with_terminal_reason(TerminalReason::LlmError));
                         }
                         let _ = events_tx.send(AgentEvent::ToolCall { tool_call_id: id, name, args, mission_id: Some(mission_id) });
                     }
                     DriverEvent::ToolResult { id, name, result } => {
                         if pending_tools.remove(&id).as_deref() != Some(name.as_str()) {
                             terminate_child_tree(&mut child).await;
-                            return AgentResult::failure(
+                            if submitted_recorded {
+                                jobs::note_attempt_error(app_working_dir, mission_id, "driver_protocol");
+                            }
+                            return DriveOutcome::Terminal(AgentResult::failure(
                                 "chatgpt_ui emitted an unmatched tool result", 0
-                            ).with_terminal_reason(TerminalReason::LlmError);
+                            ).with_terminal_reason(TerminalReason::LlmError));
                         }
                         let _ = events_tx.send(AgentEvent::ToolResult { tool_call_id: id, name, result, mission_id: Some(mission_id) });
                     }
@@ -555,10 +725,50 @@ pub async fn run_chatgpt_ui_turn(
                     DriverEvent::Artifact { path, name, .. } => {
                         artifact_receipts.push((path, name));
                     }
+                    DriverEvent::Submitted { conversation_path } => {
+                        if resume.is_none() && !submitted_recorded {
+                            match jobs::record_submitted(
+                                app_working_dir,
+                                mission_id,
+                                fingerprint,
+                                model,
+                                profile_basename(profile_dir),
+                                &conversation_path,
+                                prior_attempts,
+                            ) {
+                                Ok(_) => submitted_recorded = true,
+                                Err(error) => {
+                                    // Not fatal: the turn continues, it is
+                                    // simply not durable across restarts.
+                                    tracing::warn!(
+                                        mission_id = %mission_id,
+                                        error = %error,
+                                        "chatgpt_ui durability record rejected"
+                                    );
+                                }
+                            }
+                        }
+                    }
                     DriverEvent::Error { code, message } => {
-                        let reason = if code.as_deref() == Some("auth_required") {
+                        terminate_child_tree(&mut child).await;
+                        let code_str = code.as_deref().unwrap_or("");
+                        if resume.is_some() {
+                            match code_str {
+                                "resume_not_found" => return DriveOutcome::ResumeInvalid("resume_not_found"),
+                                "resume_mismatch" => return DriveOutcome::ResumeInvalid("resume_mismatch"),
+                                _ => {}
+                            }
+                        }
+                        if submitted_recorded {
+                            jobs::note_attempt_error(
+                                app_working_dir,
+                                mission_id,
+                                if code_str.is_empty() { "other" } else { code_str },
+                            );
+                        }
+                        let reason = if code_str == "auth_required" {
                             TerminalReason::AuthError
-                        } else if code.as_deref() == Some("rate_limited") {
+                        } else if code_str == "rate_limited" {
                             TerminalReason::RateLimited
                         } else {
                             TerminalReason::LlmError
@@ -570,14 +780,13 @@ pub async fn run_chatgpt_ui_turn(
                             }
                             _ => crate::agents::FailureClass::ProviderError,
                         };
-                        terminate_child_tree(&mut child).await;
-                        return AgentResult::failure(format!("chatgpt_ui: {message}"), 0)
+                        return DriveOutcome::Terminal(AgentResult::failure(format!("chatgpt_ui: {message}"), 0)
                             .with_terminal_reason(reason)
                             .with_data(serde_json::json!({
                                 "provider_error_source": "chatgpt_ui_driver",
                                 "failure_class": failure_class,
                                 "classification_source": "structured",
-                            }));
+                            })));
                     }
                 }
             }
@@ -586,13 +795,23 @@ pub async fn run_chatgpt_ui_turn(
     let remaining = deadline_at.saturating_duration_since(Instant::now());
     if remaining.is_zero() {
         kill_child_tree(&mut child).await;
-        return timeout_result(settings.timeout);
+        if submitted_recorded {
+            jobs::note_attempt_error(app_working_dir, mission_id, "timeout");
+        }
+        return DriveOutcome::Terminal(timeout_result(settings.timeout));
     }
     let status = tokio::select! {
         _ = cancel.cancelled() => {
             terminate_child_tree(&mut child).await;
             let shutdown = crate::api::routes::is_shutdown_initiated();
-            return AgentResult::failure(
+            if submitted_recorded {
+                jobs::note_attempt_error(
+                    app_working_dir,
+                    mission_id,
+                    if shutdown { "server_shutdown" } else { "cancelled" },
+                );
+            }
+            return DriveOutcome::Terminal(AgentResult::failure(
                 if shutdown {
                     "Server restart — paused. Click Resume to continue."
                 } else {
@@ -602,28 +821,44 @@ pub async fn run_chatgpt_ui_turn(
                 TerminalReason::ServerShutdown
             } else {
                 TerminalReason::Cancelled
-            });
+            }));
         }
         _ = &mut deadline => {
             kill_child_tree(&mut child).await;
-            return timeout_result(settings.timeout);
+            if submitted_recorded {
+                jobs::note_attempt_error(app_working_dir, mission_id, "timeout");
+            }
+            return DriveOutcome::Terminal(timeout_result(settings.timeout));
         }
         status = tokio::time::timeout(remaining.min(Duration::from_secs(5)), child.wait()) => status,
     };
     let status = match status {
         Ok(Ok(status)) => Some(status),
         Ok(Err(error)) => {
-            return AgentResult::failure(format!("chatgpt_ui driver wait failed: {error}"), 0)
-                .with_terminal_reason(TerminalReason::LlmError);
+            if submitted_recorded {
+                jobs::note_attempt_error(app_working_dir, mission_id, "driver_exit");
+            }
+            return DriveOutcome::Terminal(
+                AgentResult::failure(format!("chatgpt_ui driver wait failed: {error}"), 0)
+                    .with_terminal_reason(TerminalReason::LlmError),
+            );
         }
         Err(_) => {
             if Instant::now() >= deadline_at {
                 kill_child_tree(&mut child).await;
-                return timeout_result(settings.timeout);
+                if submitted_recorded {
+                    jobs::note_attempt_error(app_working_dir, mission_id, "timeout");
+                }
+                return DriveOutcome::Terminal(timeout_result(settings.timeout));
             }
             terminate_child_tree(&mut child).await;
-            return AgentResult::failure("chatgpt_ui driver did not exit after completion", 0)
-                .with_terminal_reason(TerminalReason::LlmError);
+            if submitted_recorded {
+                jobs::note_attempt_error(app_working_dir, mission_id, "driver_exit");
+            }
+            return DriveOutcome::Terminal(
+                AgentResult::failure("chatgpt_ui driver did not exit after completion", 0)
+                    .with_terminal_reason(TerminalReason::LlmError),
+            );
         }
     };
     // A well-behaved driver closes its browser before exiting, but enforce
@@ -640,7 +875,12 @@ pub async fn run_chatgpt_ui_turn(
         pending_tools.len(),
         status.is_some_and(|status| status.success()),
     ) {
-        return AgentResult::failure(message, 0).with_terminal_reason(TerminalReason::LlmError);
+        if submitted_recorded {
+            jobs::note_attempt_error(app_working_dir, mission_id, "driver_exit");
+        }
+        return DriveOutcome::Terminal(
+            AgentResult::failure(message, 0).with_terminal_reason(TerminalReason::LlmError),
+        );
     }
     const MAX_ARTIFACT_FILES: usize = 8;
     const MAX_ARTIFACT_BYTES: u64 = 50 * 1024 * 1024;
@@ -666,6 +906,9 @@ pub async fn run_chatgpt_ui_turn(
             }
         }
     }
+    if submitted_recorded {
+        jobs::mark_completed(app_working_dir, mission_id);
+    }
     let mut result = AgentResult::success(output, 0)
         .with_terminal_reason(TerminalReason::TurnComplete)
         .with_data(serde_json::json!({
@@ -674,11 +917,15 @@ pub async fn run_chatgpt_ui_turn(
             "profile_slot": profile_slot + 1,
             "artifact_count": artifact_count,
             "artifact_bytes": artifact_bytes,
+            "durability": {
+                "resumed": resume.is_some(),
+                "durable": submitted_recorded,
+            },
         }));
     if let Some(model) = model_used {
         result = result.with_model(model);
     }
-    result
+    DriveOutcome::Terminal(result)
 }
 
 fn validate_completion(

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -6,7 +6,7 @@
 pub mod chromium_cleanup;
 pub mod profile_pool;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
@@ -288,7 +288,21 @@ pub(crate) fn configured_profile_dirs(app_working_dir: &Path) -> Result<Vec<Path
             profile_dirs.push(canonical_profile);
         }
     }
+    validate_unique_profile_basenames(&profile_dirs)?;
     Ok(profile_dirs)
+}
+
+fn validate_unique_profile_basenames(profile_dirs: &[PathBuf]) -> Result<(), String> {
+    let mut names = HashSet::with_capacity(profile_dirs.len());
+    for profile_dir in profile_dirs {
+        let name = profile_basename(profile_dir);
+        if !names.insert(name) {
+            return Err(format!(
+                "chatgpt_ui profile directories must have unique basenames; duplicate: {name}"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
@@ -343,15 +357,12 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
     })
 }
 
-/// Outcome of one driver attempt. Resume-pointer failures are recoverable
-/// inside the same turn (fall back to a fresh submission); everything else is
-/// terminal for the turn.
+/// Outcome of one driver attempt. A resume-pointer failure is terminal for the
+/// turn: an invalid pointer does not prove that the original prompt was never
+/// submitted, so automatically starting over could duplicate multi-hour work.
 enum DriveOutcome {
     Terminal(AgentResult),
-    /// The persisted conversation pointer is unusable (`resume_not_found` or
-    /// `resume_mismatch`). The prompt is provably absent from the referenced
-    /// conversation, so a fresh submission stays idempotent.
-    ResumeInvalid(&'static str),
+    ResumeUnresolved(&'static str),
 }
 
 fn profile_basename(profile_dir: &Path) -> &str {
@@ -402,49 +413,47 @@ pub async fn run_chatgpt_ui_turn(
         }
     };
 
-    loop {
-        let attempt_resume = resume_record.take();
-        // Conversations are account-scoped: a resume must reuse the profile
-        // that submitted the prompt, or give up on the pointer entirely. The
-        // pinned path locks the slot directly instead of going through the
-        // pool scan — quarantine and retry-slot exclusions must not reroute a
-        // reattach to an account that cannot see the conversation.
-        let acquisition = if let Some(record) = attempt_resume.as_ref() {
-            match settings
-                .profile_dirs
-                .iter()
-                .position(|dir| profile_basename(dir) == record.profile)
-            {
-                Some(index) => {
-                    let pinned = settings.profile_dirs[index].clone();
-                    acquire_pinned_profile(&pinned, mission_id, &events_tx, &cancel)
-                        .await
-                        .map(|lock| (index, pinned, lock))
-                }
-                None => {
-                    jobs::mark_abandoned(app_working_dir, mission_id, "profile_unavailable");
-                    continue;
-                }
+    let attempt_resume = resume_record.take();
+    // Conversations are account-scoped: a resume must reuse the profile
+    // that submitted the prompt, or give up on the pointer entirely. The
+    // pinned path locks the slot directly instead of going through the
+    // pool scan — quarantine and retry-slot exclusions must not reroute a
+    // reattach to an account that cannot see the conversation.
+    let acquisition = if let Some(record) = attempt_resume.as_ref() {
+        match settings
+            .profile_dirs
+            .iter()
+            .position(|dir| profile_basename(dir) == record.profile)
+        {
+            Some(index) => {
+                let pinned = settings.profile_dirs[index].clone();
+                acquire_pinned_profile(&pinned, mission_id, &events_tx, &cancel)
+                    .await
+                    .map(|lock| (index, pinned, lock))
             }
-        } else {
-            profile_pool::acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel)
-                .await
-        };
-        let (profile_slot, profile_dir, _profile_lock) = match acquisition {
-            Ok(lease) => lease,
-            Err(result) => return result,
-        };
-        if settings.browser == "chromium" {
-            let owned = chromium_cleanup::pool_owns_singletons(&profile_dir);
-            let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, owned);
-            tracing::debug!(
-                mission_id = %mission_id,
-                outcome = outcome.as_str(),
-                "chatgpt_ui pre-launch profile singleton cleanup"
-            );
-            if !outcome.profile_is_launchable() {
-                profile_pool::record_slot_failure(&profile_dir, SlotFailureKind::Launch);
-                let message = match outcome {
+            None => {
+                jobs::note_attempt_error(app_working_dir, mission_id, "profile_unavailable");
+                return unresolved_resume_result("profile_unavailable");
+            }
+        }
+    } else {
+        profile_pool::acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel).await
+    };
+    let (profile_slot, profile_dir, _profile_lock) = match acquisition {
+        Ok(lease) => lease,
+        Err(result) => return result,
+    };
+    if settings.browser == "chromium" {
+        let owned = chromium_cleanup::pool_owns_singletons(&profile_dir);
+        let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, owned);
+        tracing::debug!(
+            mission_id = %mission_id,
+            outcome = outcome.as_str(),
+            "chatgpt_ui pre-launch profile singleton cleanup"
+        );
+        if !outcome.profile_is_launchable() {
+            profile_pool::record_slot_failure(&profile_dir, SlotFailureKind::Launch);
+            let message = match outcome {
                     SingletonCleanup::ActiveProcess => {
                         "chatgpt_ui profile is held by a live browser process outside the profile pool; close it before retrying"
                     }
@@ -456,46 +465,56 @@ pub async fn run_chatgpt_ui_turn(
                     }
                     SingletonCleanup::Clean | SingletonCleanup::Removed(_) => unreachable!(),
                 };
-                return AgentResult::failure(message, 0)
-                    .with_terminal_reason(TerminalReason::LlmError)
-                    .with_data(serde_json::json!({
-                        "provider_error_source": "chatgpt_ui_profile_pool",
-                        "failure_class": FailureClass::TransportError,
-                        "classification_source": "structured",
-                    }));
-            }
-        }
-        match drive_once(
-            &settings,
-            work_dir,
-            &download_dir,
-            message,
-            model,
-            mission_id,
-            &events_tx,
-            &cancel,
-            app_working_dir,
-            &fingerprint,
-            prior_attempts,
-            profile_slot,
-            &profile_dir,
-            attempt_resume.as_ref(),
-        )
-        .await
-        {
-            DriveOutcome::Terminal(result) => return result,
-            DriveOutcome::ResumeInvalid(code) => {
-                jobs::mark_abandoned(app_working_dir, mission_id, code);
-                prior_attempts = attempt_resume.map(|record| record.attempts).unwrap_or(0);
-                let _ = events_tx.send(AgentEvent::MissionActivity {
-                    label: "ChatGPT UI conversation could not be reattached — submitting fresh."
-                        .to_string(),
-                    tool_name: "chatgpt_ui_durability".to_string(),
-                    mission_id: Some(mission_id),
-                });
-            }
+            return AgentResult::failure(message, 0)
+                .with_terminal_reason(TerminalReason::LlmError)
+                .with_data(serde_json::json!({
+                    "provider_error_source": "chatgpt_ui_profile_pool",
+                    "failure_class": FailureClass::TransportError,
+                    "classification_source": "structured",
+                }));
         }
     }
+    match drive_once(
+        &settings,
+        work_dir,
+        &download_dir,
+        message,
+        model,
+        mission_id,
+        &events_tx,
+        &cancel,
+        app_working_dir,
+        &fingerprint,
+        prior_attempts,
+        profile_slot,
+        &profile_dir,
+        attempt_resume.as_ref(),
+    )
+    .await
+    {
+        DriveOutcome::Terminal(result) => result,
+        DriveOutcome::ResumeUnresolved(code) => {
+            jobs::note_attempt_error(app_working_dir, mission_id, code);
+            unresolved_resume_result(code)
+        }
+    }
+}
+
+fn unresolved_resume_result(code: &str) -> AgentResult {
+    AgentResult::failure(
+        format!(
+            "chatgpt_ui could not safely reattach the existing conversation ({code}); no fresh prompt was submitted"
+        ),
+        0,
+    )
+    .with_terminal_reason(TerminalReason::LlmError)
+    .with_data(serde_json::json!({
+        "provider_error_source": "chatgpt_ui_durability",
+        "failure_class": FailureClass::TransportError,
+        "classification_source": "structured",
+        "resume_resolution": code,
+        "fresh_prompt_submitted": false,
+    }))
 }
 
 /// Cancel-aware wait for one specific profile slot. Used only for resume:
@@ -804,11 +823,12 @@ async fn drive_once(
                         terminate_child_tree(&mut child).await;
                         let code_str = code.as_deref().unwrap_or("");
                         if resume.is_some() {
-                            // An unusable pointer is not a slot failure: the
-                            // caller falls back to a fresh submission.
+                            // An unusable pointer is not proof that the prompt
+                            // was never submitted. Preserve the durable record
+                            // and fail closed instead of duplicating the work.
                             match code_str {
-                                "resume_not_found" => return DriveOutcome::ResumeInvalid("resume_not_found"),
-                                "resume_mismatch" => return DriveOutcome::ResumeInvalid("resume_mismatch"),
+                                "resume_not_found" => return DriveOutcome::ResumeUnresolved("resume_not_found"),
+                                "resume_mismatch" => return DriveOutcome::ResumeUnresolved("resume_mismatch"),
                                 _ => {}
                             }
                         }
@@ -1133,6 +1153,41 @@ mod tests {
             "slot-a"
         );
         assert_eq!(profile_basename(Path::new("/")), "profile");
+    }
+
+    #[test]
+    fn duplicate_profile_basenames_are_rejected() {
+        let profiles = vec![
+            PathBuf::from("/profiles/account-a/slot"),
+            PathBuf::from("/profiles/account-b/slot"),
+        ];
+        assert!(validate_unique_profile_basenames(&profiles)
+            .unwrap_err()
+            .contains("duplicate: slot"));
+    }
+
+    #[test]
+    fn distinct_profile_basenames_are_accepted() {
+        let profiles = vec![
+            PathBuf::from("/profiles/account-a/slot-a"),
+            PathBuf::from("/profiles/account-b/slot-b"),
+        ];
+        validate_unique_profile_basenames(&profiles).unwrap();
+    }
+
+    #[test]
+    fn unresolved_resume_fails_closed_without_fresh_submission() {
+        let result = unresolved_resume_result("resume_mismatch");
+        assert!(!result.success);
+        assert!(result.output.contains("no fresh prompt was submitted"));
+        assert_eq!(
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("fresh_prompt_submitted"))
+                .and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
     }
 
     #[test]

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -573,7 +573,7 @@ async fn drive_once(
     command
         .arg(&settings.driver_path)
         .arg("--profile-dir")
-        .arg(&profile_dir)
+        .arg(profile_dir)
         .arg("--browser")
         .arg(&settings.browser)
         .arg("--headless")
@@ -609,7 +609,7 @@ async fn drive_once(
         // Claim ownership only after the driver was successfully spawned. A
         // pre-spawn marker could authorize a later run to remove singleton
         // state that this pool never created.
-        chromium_cleanup::claim_singleton_ownership(&profile_dir);
+        chromium_cleanup::claim_singleton_ownership(profile_dir);
     }
     #[cfg(unix)]
     let process_group = child.id().map(|pid| -(pid as i32));
@@ -924,9 +924,9 @@ async fn drive_once(
         // Best effort: freshly killed descendants may briefly linger as
         // zombies, in which case the ownership marker defers this sweep to
         // the next lease's pre-launch cleanup.
-        let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, true);
+        let outcome = chromium_cleanup::cleanup_profile_singletons(profile_dir, true);
         if outcome.profile_is_launchable() {
-            chromium_cleanup::release_singleton_ownership(&profile_dir);
+            chromium_cleanup::release_singleton_ownership(profile_dir);
         }
         tracing::debug!(
             mission_id = %mission_id,
@@ -1087,6 +1087,52 @@ mod tests {
             None
         );
         assert_eq!(safe_driver_diagnostic("prompt=private text"), None);
+    }
+
+    #[test]
+    fn parses_submitted_event_with_opaque_conversation_pointer() {
+        let event: DriverEvent =
+            serde_json::from_str(r#"{"type":"submitted","conversation_path":"/c/abc123def456"}"#)
+                .unwrap();
+        match event {
+            DriverEvent::Submitted { conversation_path } => {
+                assert_eq!(conversation_path, "/c/abc123def456");
+            }
+            other => panic!("expected submitted event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn durability_diagnostics_are_allowlisted_and_freeform_variants_are_not() {
+        assert_eq!(
+            safe_driver_diagnostic("stage=resume_route"),
+            Some("stage=resume_route")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=resume_verified"),
+            Some("stage=resume_verified")
+        );
+        assert_eq!(
+            safe_driver_diagnostic("stage=conversation_ref_unavailable"),
+            Some("stage=conversation_ref_unavailable")
+        );
+        // Anything carrying extra payload must be dropped, even with a known
+        // stage prefix — conversation ids and prompt text must never land in
+        // server logs via diagnostics.
+        assert_eq!(safe_driver_diagnostic("stage=resume_route /c/abc123"), None);
+        assert_eq!(
+            safe_driver_diagnostic("stage=resume_verified message=hello"),
+            None
+        );
+    }
+
+    #[test]
+    fn profile_basename_uses_directory_name_only() {
+        assert_eq!(
+            profile_basename(Path::new("/var/lib/chatgpt/profiles/slot-a")),
+            "slot-a"
+        );
+        assert_eq!(profile_basename(Path::new("/")), "profile");
     }
 
     #[test]

--- a/src/api/runners/chatgpt_ui_jobs.rs
+++ b/src/api/runners/chatgpt_ui_jobs.rs
@@ -1,0 +1,543 @@
+//! Durable, privacy-safe ledger for long ChatGPT UI (GPT Pro) turns.
+//!
+//! A multi-hour Pro reasoning run keeps generating server-side at OpenAI even
+//! if the local browser, driver, or sandboxed.sh process dies. This ledger
+//! remembers *that* a prompt was submitted — never *what* was said — so a
+//! restarted or reconnected turn can reattach to the existing conversation
+//! instead of resubmitting the prompt (idempotent submission).
+//!
+//! Privacy invariants, enforced here and checked in tests:
+//! - Records store only pointers and digests: a SHA-256 prompt fingerprint,
+//!   an opaque conversation route (`/c/<id>`), a profile basename, states and
+//!   timestamps. Never prompt text, response text, or any reasoning content.
+//! - Hidden chain-of-thought is never fetched by the driver, so it can never
+//!   reach this ledger or the telemetry snapshot.
+//! - The telemetry snapshot exposes even less: no conversation route and no
+//!   fingerprint, only states, counters, and the profile basename.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+pub const JOB_SCHEMA_VERSION: u32 = 1;
+
+/// A submitted prompt stays resumable for this long; afterwards reconciliation
+/// abandons it. Generous on purpose: Pro runs are budgeted in hours.
+pub const RESUME_MAX_AGE: Duration = Duration::from_secs(48 * 60 * 60);
+
+/// Terminal records are kept briefly for dashboard forensics, then purged.
+pub const TERMINAL_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobState {
+    /// Prompt is live in a ChatGPT conversation; completion not yet observed.
+    Submitted,
+    /// The turn observed a completed response for this prompt.
+    Completed,
+    /// The record can no longer be resumed (superseded, stale, or invalid).
+    Abandoned,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobRecord {
+    pub schema_version: u32,
+    pub job_id: Uuid,
+    pub mission_id: Uuid,
+    /// SHA-256 over model + prompt. The text itself is never stored.
+    pub prompt_sha256: String,
+    pub model: Option<String>,
+    /// Basename of the browser profile that owns the conversation. Resume
+    /// must reuse this profile: conversations are account-scoped.
+    pub profile: String,
+    /// Opaque ChatGPT conversation route such as `/c/<id>` — a pointer, not
+    /// content. Never exposed through telemetry or logs.
+    pub conversation_path: String,
+    pub state: JobState,
+    pub attempts: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    /// Allowlisted driver/runner failure code from the latest attempt.
+    pub last_error_code: Option<String>,
+}
+
+/// Privacy-reduced view for the dashboard endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct JobStatusSummary {
+    pub mission_id: Uuid,
+    pub state: JobState,
+    pub attempts: u32,
+    pub profile: String,
+    pub model: Option<String>,
+    pub age_secs: u64,
+    pub updated_secs_ago: u64,
+    pub resumable: bool,
+    pub last_error_code: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ReconcileSummary {
+    pub abandoned: usize,
+    pub purged: usize,
+}
+
+pub fn jobs_dir(app_working_dir: &Path) -> PathBuf {
+    app_working_dir.join(".sandboxed-sh").join("chatgpt-ui-jobs")
+}
+
+fn job_path(app_working_dir: &Path, mission_id: Uuid) -> PathBuf {
+    jobs_dir(app_working_dir).join(format!("{mission_id}.json"))
+}
+
+/// Deterministic digest of everything that makes a prompt submission unique.
+/// A retried turn with the same digest is the same logical submission and
+/// must reattach instead of resubmitting.
+pub fn prompt_fingerprint(message: &str, model: Option<&str>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(model.unwrap_or_default().as_bytes());
+    hasher.update([0u8]);
+    hasher.update(message.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Conversation routes are strictly shaped opaque ids. Anything else is
+/// rejected before it can be persisted or navigated to.
+pub fn valid_conversation_path(path: &str) -> bool {
+    let Some(id) = path.strip_prefix("/c/") else {
+        return false;
+    };
+    (8..=64).contains(&id.len())
+        && id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+}
+
+/// Keep persisted failure codes on a fixed vocabulary so a record can never
+/// smuggle free-form driver output.
+pub fn allowlisted_error_code(code: &str) -> &'static str {
+    match code {
+        "auth_required" => "auth_required",
+        "rate_limited" => "rate_limited",
+        "browser_launch" => "browser_launch",
+        "compatibility" => "compatibility",
+        "timeout" => "timeout",
+        "dependency_missing" => "dependency_missing",
+        "invalid_request" => "invalid_request",
+        "invalid_config" => "invalid_config",
+        "resume_not_found" => "resume_not_found",
+        "resume_mismatch" => "resume_mismatch",
+        "driver_protocol" => "driver_protocol",
+        "driver_exit" => "driver_exit",
+        "stream_error" => "stream_error",
+        "profile_unavailable" => "profile_unavailable",
+        "superseded" => "superseded",
+        "stale" => "stale",
+        "cancelled" => "cancelled",
+        "server_shutdown" => "server_shutdown",
+        _ => "other",
+    }
+}
+
+pub fn load_job(app_working_dir: &Path, mission_id: Uuid) -> Option<JobRecord> {
+    let raw = std::fs::read_to_string(job_path(app_working_dir, mission_id)).ok()?;
+    let record: JobRecord = serde_json::from_str(&raw).ok()?;
+    if record.schema_version != JOB_SCHEMA_VERSION || record.mission_id != mission_id {
+        return None;
+    }
+    Some(record)
+}
+
+pub fn save_job(app_working_dir: &Path, record: &JobRecord) -> Result<(), String> {
+    let dir = jobs_dir(app_working_dir);
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| format!("cannot create ChatGPT UI job ledger directory: {error}"))?;
+    let path = job_path(app_working_dir, record.mission_id);
+    let tmp = dir.join(format!(".{}.tmp", record.mission_id));
+    let payload = serde_json::to_vec_pretty(record)
+        .map_err(|error| format!("cannot serialize ChatGPT UI job record: {error}"))?;
+    std::fs::write(&tmp, payload)
+        .map_err(|error| format!("cannot write ChatGPT UI job record: {error}"))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|error| format!("cannot commit ChatGPT UI job record: {error}"))?;
+    Ok(())
+}
+
+/// Persist the moment a prompt provably lives in a conversation. This is the
+/// only place a durability record is born.
+pub fn record_submitted(
+    app_working_dir: &Path,
+    mission_id: Uuid,
+    prompt_sha256: &str,
+    model: Option<&str>,
+    profile: &str,
+    conversation_path: &str,
+    prior_attempts: u32,
+) -> Result<JobRecord, String> {
+    if !valid_conversation_path(conversation_path) {
+        return Err("refusing to persist a malformed ChatGPT conversation route".to_string());
+    }
+    let now = Utc::now();
+    let record = JobRecord {
+        schema_version: JOB_SCHEMA_VERSION,
+        job_id: Uuid::new_v4(),
+        mission_id,
+        prompt_sha256: prompt_sha256.to_string(),
+        model: model.map(str::to_string),
+        profile: profile.to_string(),
+        conversation_path: conversation_path.to_string(),
+        state: JobState::Submitted,
+        attempts: prior_attempts.saturating_add(1),
+        created_at: now,
+        updated_at: now,
+        last_error_code: None,
+    };
+    save_job(app_working_dir, &record)?;
+    Ok(record)
+}
+
+fn update_job<F: FnOnce(&mut JobRecord)>(app_working_dir: &Path, mission_id: Uuid, apply: F) {
+    if let Some(mut record) = load_job(app_working_dir, mission_id) {
+        apply(&mut record);
+        record.updated_at = Utc::now();
+        if let Err(error) = save_job(app_working_dir, &record) {
+            tracing::warn!(mission_id = %mission_id, error = %error, "failed to update ChatGPT UI job record");
+        }
+    }
+}
+
+pub fn mark_completed(app_working_dir: &Path, mission_id: Uuid) {
+    update_job(app_working_dir, mission_id, |record| {
+        record.state = JobState::Completed;
+        record.last_error_code = None;
+    });
+}
+
+pub fn mark_abandoned(app_working_dir: &Path, mission_id: Uuid, code: &str) {
+    update_job(app_working_dir, mission_id, |record| {
+        record.state = JobState::Abandoned;
+        record.last_error_code = Some(allowlisted_error_code(code).to_string());
+    });
+}
+
+/// A post-submission failure does not kill durability: the conversation keeps
+/// generating server-side. Note the code, bump the attempt counter, and leave
+/// the record resumable.
+pub fn note_attempt_error(app_working_dir: &Path, mission_id: Uuid, code: &str) {
+    update_job(app_working_dir, mission_id, |record| {
+        if record.state == JobState::Submitted {
+            record.last_error_code = Some(allowlisted_error_code(code).to_string());
+        }
+    });
+}
+
+pub fn touch_resume_attempt(app_working_dir: &Path, mission_id: Uuid) {
+    update_job(app_working_dir, mission_id, |record| {
+        record.attempts = record.attempts.saturating_add(1);
+    });
+}
+
+fn age_of(record: &JobRecord, now: DateTime<Utc>) -> Duration {
+    (now - record.created_at).to_std().unwrap_or_default()
+}
+
+pub fn resumable_job(record: &JobRecord, prompt_sha256: &str, now: DateTime<Utc>) -> bool {
+    record.state == JobState::Submitted
+        && record.prompt_sha256 == prompt_sha256
+        && valid_conversation_path(&record.conversation_path)
+        && age_of(record, now) <= RESUME_MAX_AGE
+}
+
+fn read_all_records(app_working_dir: &Path) -> Vec<JobRecord> {
+    let Ok(entries) = std::fs::read_dir(jobs_dir(app_working_dir)) else {
+        return Vec::new();
+    };
+    let mut records = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(mission_id) = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .and_then(|value| Uuid::parse_str(value).ok())
+        else {
+            continue;
+        };
+        if let Some(record) = load_job(app_working_dir, mission_id) {
+            records.push(record);
+        }
+    }
+    records.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    records
+}
+
+/// Restart/disconnect reconciliation: expire records that can no longer be
+/// resumed and purge old terminal records. Safe to call from any attempt or
+/// from the telemetry endpoint — it only ever narrows state.
+pub fn reconcile_jobs(app_working_dir: &Path) -> ReconcileSummary {
+    let now = Utc::now();
+    let mut summary = ReconcileSummary::default();
+    for record in read_all_records(app_working_dir) {
+        match record.state {
+            JobState::Submitted => {
+                if age_of(&record, now) > RESUME_MAX_AGE
+                    || !valid_conversation_path(&record.conversation_path)
+                {
+                    mark_abandoned(app_working_dir, record.mission_id, "stale");
+                    summary.abandoned += 1;
+                }
+            }
+            JobState::Completed | JobState::Abandoned => {
+                let idle = (now - record.updated_at).to_std().unwrap_or_default();
+                if idle > TERMINAL_RETENTION {
+                    let _ = std::fs::remove_file(job_path(app_working_dir, record.mission_id));
+                    summary.purged += 1;
+                }
+            }
+        }
+    }
+    summary
+}
+
+/// Dashboard snapshot. Deliberately omits the conversation route and prompt
+/// fingerprint: operators see health, never pointers into an account.
+pub fn jobs_snapshot(app_working_dir: &Path) -> Vec<JobStatusSummary> {
+    let now = Utc::now();
+    read_all_records(app_working_dir)
+        .into_iter()
+        .map(|record| JobStatusSummary {
+            mission_id: record.mission_id,
+            state: record.state,
+            attempts: record.attempts,
+            profile: record.profile.clone(),
+            model: record.model.clone(),
+            age_secs: age_of(&record, now).as_secs(),
+            updated_secs_ago: (now - record.updated_at).to_std().unwrap_or_default().as_secs(),
+            resumable: resumable_job(&record, &record.prompt_sha256, now),
+            last_error_code: record.last_error_code.clone(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn submit(dir: &Path, mission_id: Uuid, fingerprint: &str) -> JobRecord {
+        record_submitted(
+            dir,
+            mission_id,
+            fingerprint,
+            Some("gpt-5.6-pro"),
+            "profile-1",
+            "/c/0123456789abcdef",
+            0,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn fingerprint_binds_model_and_message_without_storing_text() {
+        let a = prompt_fingerprint("build the report", Some("gpt-5.6-pro"));
+        let b = prompt_fingerprint("build the report", Some("gpt-5.6-pro"));
+        let c = prompt_fingerprint("build the report", None);
+        let d = prompt_fingerprint("build the reports", Some("gpt-5.6-pro"));
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, d);
+        assert_eq!(a.len(), 64);
+        assert!(!a.contains("report"));
+    }
+
+    #[test]
+    fn conversation_routes_are_strictly_validated() {
+        assert!(valid_conversation_path("/c/0123456789abcdef"));
+        assert!(valid_conversation_path(
+            "/c/019969c9-2c6a-7325-a2b1-9e01b4d3ce17"
+        ));
+        assert!(!valid_conversation_path("/c/short"));
+        assert!(!valid_conversation_path("/settings"));
+        assert!(!valid_conversation_path("/c/../../etc/passwd"));
+        assert!(!valid_conversation_path("/c/id with spaces"));
+        assert!(!valid_conversation_path("https://chatgpt.com/c/0123456789abcdef"));
+    }
+
+    #[test]
+    fn submission_persists_and_reloads_idempotently() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let fingerprint = prompt_fingerprint("prompt", Some("Pro"));
+        let record = submit(root.path(), mission_id, &fingerprint);
+        assert_eq!(record.attempts, 1);
+
+        let loaded = load_job(root.path(), mission_id).unwrap();
+        assert_eq!(loaded.state, JobState::Submitted);
+        assert_eq!(loaded.prompt_sha256, fingerprint);
+        assert!(resumable_job(&loaded, &fingerprint, Utc::now()));
+        assert!(!resumable_job(
+            &loaded,
+            &prompt_fingerprint("different prompt", Some("Pro")),
+            Utc::now()
+        ));
+    }
+
+    #[test]
+    fn malformed_conversation_routes_are_never_persisted() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let error = record_submitted(
+            root.path(),
+            mission_id,
+            "fingerprint",
+            None,
+            "profile-1",
+            "/c/../../../steal",
+            0,
+        )
+        .unwrap_err();
+        assert!(error.contains("malformed"));
+        assert!(load_job(root.path(), mission_id).is_none());
+    }
+
+    #[test]
+    fn records_store_no_prompt_or_response_content() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let message = "extremely private mission prompt";
+        let fingerprint = prompt_fingerprint(message, Some("gpt-5.6-pro"));
+        submit(root.path(), mission_id, &fingerprint);
+
+        let raw = std::fs::read_to_string(job_path(root.path(), mission_id)).unwrap();
+        assert!(!raw.contains("private"));
+        assert!(!raw.contains("prompt text"));
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let keys: Vec<&str> = parsed
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        for key in keys {
+            assert!(
+                [
+                    "schema_version",
+                    "job_id",
+                    "mission_id",
+                    "prompt_sha256",
+                    "model",
+                    "profile",
+                    "conversation_path",
+                    "state",
+                    "attempts",
+                    "created_at",
+                    "updated_at",
+                    "last_error_code",
+                ]
+                .contains(&key),
+                "unexpected persisted field: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn post_submission_errors_keep_the_job_resumable() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let fingerprint = prompt_fingerprint("prompt", None);
+        submit(root.path(), mission_id, &fingerprint);
+
+        note_attempt_error(root.path(), mission_id, "stream_error");
+        let record = load_job(root.path(), mission_id).unwrap();
+        assert_eq!(record.state, JobState::Submitted);
+        assert_eq!(record.last_error_code.as_deref(), Some("stream_error"));
+        assert!(resumable_job(&record, &fingerprint, Utc::now()));
+
+        touch_resume_attempt(root.path(), mission_id);
+        assert_eq!(load_job(root.path(), mission_id).unwrap().attempts, 2);
+
+        mark_completed(root.path(), mission_id);
+        let record = load_job(root.path(), mission_id).unwrap();
+        assert_eq!(record.state, JobState::Completed);
+        assert!(!resumable_job(&record, &fingerprint, Utc::now()));
+    }
+
+    #[test]
+    fn unknown_error_codes_collapse_to_other() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        submit(root.path(), mission_id, "fingerprint");
+        note_attempt_error(root.path(), mission_id, "free form driver text!");
+        assert_eq!(
+            load_job(root.path(), mission_id)
+                .unwrap()
+                .last_error_code
+                .as_deref(),
+            Some("other")
+        );
+    }
+
+    #[test]
+    fn reconciliation_abandons_stale_submissions_and_purges_old_terminals() {
+        let root = tempfile::tempdir().unwrap();
+        let stale_mission = Uuid::new_v4();
+        let fresh_mission = Uuid::new_v4();
+        let purged_mission = Uuid::new_v4();
+
+        let mut stale = submit(root.path(), stale_mission, "fingerprint");
+        stale.created_at = Utc::now() - chrono::Duration::hours(72);
+        save_job(root.path(), &stale).unwrap();
+
+        submit(root.path(), fresh_mission, "fingerprint");
+
+        let mut purged = submit(root.path(), purged_mission, "fingerprint");
+        purged.state = JobState::Completed;
+        purged.updated_at = Utc::now() - chrono::Duration::days(30);
+        save_job(root.path(), &purged).unwrap();
+
+        let summary = reconcile_jobs(root.path());
+        assert_eq!(summary.abandoned, 1);
+        assert_eq!(summary.purged, 1);
+        assert_eq!(
+            load_job(root.path(), stale_mission).unwrap().state,
+            JobState::Abandoned
+        );
+        assert_eq!(
+            load_job(root.path(), fresh_mission).unwrap().state,
+            JobState::Submitted
+        );
+        assert!(load_job(root.path(), purged_mission).is_none());
+    }
+
+    #[test]
+    fn snapshot_exposes_health_but_never_pointers() {
+        let root = tempfile::tempdir().unwrap();
+        let mission_id = Uuid::new_v4();
+        let fingerprint = prompt_fingerprint("secret prompt", Some("gpt-5.6-pro"));
+        submit(root.path(), mission_id, &fingerprint);
+
+        let snapshot = jobs_snapshot(root.path());
+        assert_eq!(snapshot.len(), 1);
+        let entry = &snapshot[0];
+        assert_eq!(entry.mission_id, mission_id);
+        assert_eq!(entry.state, JobState::Submitted);
+        assert!(entry.resumable);
+        assert_eq!(entry.profile, "profile-1");
+
+        let serialized = serde_json::to_string(&snapshot).unwrap();
+        assert!(!serialized.contains("/c/"));
+        assert!(!serialized.contains(&fingerprint));
+        assert!(!serialized.contains("secret"));
+    }
+
+    #[test]
+    fn reconciliation_tolerates_a_missing_ledger_directory() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(reconcile_jobs(root.path()), ReconcileSummary::default());
+        assert!(jobs_snapshot(root.path()).is_empty());
+    }
+}

--- a/src/api/runners/chatgpt_ui_jobs.rs
+++ b/src/api/runners/chatgpt_ui_jobs.rs
@@ -15,7 +15,9 @@
 //! - The telemetry snapshot exposes even less: no conversation route and no
 //!   fingerprint, only states, counters, and the profile basename.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -24,6 +26,11 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 pub const JOB_SCHEMA_VERSION: u32 = 1;
+
+/// Serialize record replacements within the backend process. A mission retry,
+/// dashboard reconciliation, and shutdown handling can otherwise all perform
+/// read/modify/write cycles against the same record and lose the newest state.
+static JOB_LEDGER_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 /// A submitted prompt stays resumable for this long; afterwards reconciliation
 /// abandons it. Generous on purpose: Pro runs are budgeted in hours.
@@ -153,19 +160,99 @@ pub fn load_job(app_working_dir: &Path, mission_id: Uuid) -> Option<JobRecord> {
     Some(record)
 }
 
-pub fn save_job(app_working_dir: &Path, record: &JobRecord) -> Result<(), String> {
+fn save_job_unlocked(app_working_dir: &Path, record: &JobRecord) -> Result<(), String> {
     let dir = jobs_dir(app_working_dir);
     std::fs::create_dir_all(&dir)
         .map_err(|error| format!("cannot create ChatGPT UI job ledger directory: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("cannot secure ChatGPT UI job ledger directory: {error}"))?;
+    }
     let path = job_path(app_working_dir, record.mission_id);
-    let tmp = dir.join(format!(".{}.tmp", record.mission_id));
+    // A unique temporary name avoids collisions if an old process is still
+    // unwinding while its replacement reconciles the same mission.
+    let tmp = dir.join(format!(".{}.{}.tmp", record.mission_id, Uuid::new_v4()));
     let payload = serde_json::to_vec_pretty(record)
         .map_err(|error| format!("cannot serialize ChatGPT UI job record: {error}"))?;
-    std::fs::write(&tmp, payload)
-        .map_err(|error| format!("cannot write ChatGPT UI job record: {error}"))?;
-    std::fs::rename(&tmp, &path)
-        .map_err(|error| format!("cannot commit ChatGPT UI job record: {error}"))?;
-    Ok(())
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let write_result = (|| -> Result<(), String> {
+        let mut file = options
+            .open(&tmp)
+            .map_err(|error| format!("cannot create ChatGPT UI job record: {error}"))?;
+        file.write_all(&payload)
+            .map_err(|error| format!("cannot write ChatGPT UI job record: {error}"))?;
+        file.sync_all()
+            .map_err(|error| format!("cannot sync ChatGPT UI job record: {error}"))?;
+        drop(file);
+        std::fs::rename(&tmp, &path)
+            .map_err(|error| format!("cannot commit ChatGPT UI job record: {error}"))?;
+        // Persist the rename itself across a host crash on platforms where a
+        // directory can be opened and synced.
+        #[cfg(unix)]
+        std::fs::File::open(&dir)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("cannot sync ChatGPT UI job ledger directory: {error}"))?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    write_result
+}
+
+pub fn save_job(app_working_dir: &Path, record: &JobRecord) -> Result<(), String> {
+    let _guard = JOB_LEDGER_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    save_job_unlocked(app_working_dir, record)
+}
+
+fn update_job<F: FnOnce(&mut JobRecord)>(app_working_dir: &Path, mission_id: Uuid, apply: F) {
+    let _guard = JOB_LEDGER_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(mut record) = load_job(app_working_dir, mission_id) {
+        apply(&mut record);
+        record.updated_at = Utc::now();
+        if let Err(error) = save_job_unlocked(app_working_dir, &record) {
+            tracing::warn!(mission_id = %mission_id, error = %error, "failed to update ChatGPT UI job record");
+        }
+    }
+}
+
+#[cfg(test)]
+fn ledger_mode(path: &Path) -> u32 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        return std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        0
+    }
+}
+
+#[cfg(test)]
+fn assert_private_ledger_permissions(app_working_dir: &Path, mission_id: Uuid) {
+    #[cfg(unix)]
+    {
+        assert_eq!(ledger_mode(&jobs_dir(app_working_dir)), 0o700);
+        assert_eq!(ledger_mode(&job_path(app_working_dir, mission_id)), 0o600);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (app_working_dir, mission_id);
+    }
 }
 
 /// Persist the moment a prompt provably lives in a conversation. This is the
@@ -199,16 +286,6 @@ pub fn record_submitted(
     };
     save_job(app_working_dir, &record)?;
     Ok(record)
-}
-
-fn update_job<F: FnOnce(&mut JobRecord)>(app_working_dir: &Path, mission_id: Uuid, apply: F) {
-    if let Some(mut record) = load_job(app_working_dir, mission_id) {
-        apply(&mut record);
-        record.updated_at = Utc::now();
-        if let Err(error) = save_job(app_working_dir, &record) {
-            tracing::warn!(mission_id = %mission_id, error = %error, "failed to update ChatGPT UI job record");
-        }
-    }
 }
 
 pub fn mark_completed(app_working_dir: &Path, mission_id: Uuid) {
@@ -381,6 +458,7 @@ mod tests {
         let fingerprint = prompt_fingerprint("prompt", Some("Pro"));
         let record = submit(root.path(), mission_id, &fingerprint);
         assert_eq!(record.attempts, 1);
+        assert_private_ledger_permissions(root.path(), mission_id);
 
         let loaded = load_job(root.path(), mission_id).unwrap();
         assert_eq!(loaded.state, JobState::Submitted);
@@ -471,6 +549,26 @@ mod tests {
         let record = load_job(root.path(), mission_id).unwrap();
         assert_eq!(record.state, JobState::Completed);
         assert!(!resumable_job(&record, &fingerprint, Utc::now()));
+    }
+
+    #[test]
+    fn concurrent_resume_updates_do_not_lose_attempts() {
+        let root = tempfile::tempdir().unwrap();
+        let app_working_dir = root.path().to_path_buf();
+        let mission_id = Uuid::new_v4();
+        submit(&app_working_dir, mission_id, "fingerprint");
+
+        let handles = (0..8)
+            .map(|_| {
+                let app_working_dir = app_working_dir.clone();
+                std::thread::spawn(move || touch_resume_attempt(&app_working_dir, mission_id))
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(load_job(&app_working_dir, mission_id).unwrap().attempts, 9);
     }
 
     #[test]

--- a/src/api/runners/chatgpt_ui_jobs.rs
+++ b/src/api/runners/chatgpt_ui_jobs.rs
@@ -233,7 +233,7 @@ fn ledger_mode(path: &Path) -> u32 {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        return std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
     #[cfg(not(unix))]
     {

--- a/src/api/runners/chatgpt_ui_jobs.rs
+++ b/src/api/runners/chatgpt_ui_jobs.rs
@@ -86,7 +86,9 @@ pub struct ReconcileSummary {
 }
 
 pub fn jobs_dir(app_working_dir: &Path) -> PathBuf {
-    app_working_dir.join(".sandboxed-sh").join("chatgpt-ui-jobs")
+    app_working_dir
+        .join(".sandboxed-sh")
+        .join("chatgpt-ui-jobs")
 }
 
 fn job_path(app_working_dir: &Path, mission_id: Uuid) -> PathBuf {
@@ -272,7 +274,7 @@ fn read_all_records(app_working_dir: &Path) -> Vec<JobRecord> {
             records.push(record);
         }
     }
-    records.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    records.sort_by_key(|record| std::cmp::Reverse(record.updated_at));
     records
 }
 
@@ -317,7 +319,10 @@ pub fn jobs_snapshot(app_working_dir: &Path) -> Vec<JobStatusSummary> {
             profile: record.profile.clone(),
             model: record.model.clone(),
             age_secs: age_of(&record, now).as_secs(),
-            updated_secs_ago: (now - record.updated_at).to_std().unwrap_or_default().as_secs(),
+            updated_secs_ago: (now - record.updated_at)
+                .to_std()
+                .unwrap_or_default()
+                .as_secs(),
             resumable: resumable_job(&record, &record.prompt_sha256, now),
             last_error_code: record.last_error_code.clone(),
         })
@@ -364,7 +369,9 @@ mod tests {
         assert!(!valid_conversation_path("/settings"));
         assert!(!valid_conversation_path("/c/../../etc/passwd"));
         assert!(!valid_conversation_path("/c/id with spaces"));
-        assert!(!valid_conversation_path("https://chatgpt.com/c/0123456789abcdef"));
+        assert!(!valid_conversation_path(
+            "https://chatgpt.com/c/0123456789abcdef"
+        ));
     }
 
     #[test]

--- a/src/api/runners/mod.rs
+++ b/src/api/runners/mod.rs
@@ -6,6 +6,7 @@
 //! shrink down to orchestration (dispatch, retry/fallback, TerminalReason).
 
 pub(crate) mod chatgpt_ui;
+pub(crate) mod chatgpt_ui_jobs;
 pub(crate) mod claudecode;
 pub(crate) mod codex;
 pub(crate) mod errors;


### PR DESCRIPTION
## Summary
- Adds a privacy-reduced durable ledger for multi-hour ChatGPT UI jobs and a status endpoint/dashboard panel.
- Reattaches retries to the exact opaque conversation route and account profile instead of resubmitting.
- Fails closed on missing, mismatched, or unavailable resume state: no fresh prompt is submitted automatically.
- Rejects ambiguous duplicate profile basenames.
- Hardens persistence with private 0700/0600 permissions, unique atomic temp files, fsync, and serialized read-modify-write updates.
- Preserves hidden reasoning privacy: the driver streams only supported UI output and never fetches chain-of-thought.

## Review fixes
- Removed the unsafe resume_not_found/resume_mismatch fallback that could duplicate a multi-hour Pro prompt.
- Kept unresolved records resumable for operator reconciliation.
- Added structured failure evidence with fresh_prompt_submitted=false.
- Added permission, privacy, fail-closed, profile identity, and concurrent ledger update tests.
- Merged current master including #681 without conflicts.

## Verification
- cargo fmt --all --check
- cargo check --all-targets
- cargo test: 1550 passed, 0 failed, 1 ignored in the library plus all binary/doc test suites passing
- Python driver: 13 passed
- Dashboard: 255 passed; lint has 0 errors; production build passes

## Manual follow-up
- Production restart/resume canary will verify a submitted long job remains attached without duplicate submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes mission execution for multi-hour ChatGPT UI work (resume vs duplicate submit) and persists conversation pointers on disk; mis-handling could duplicate costly Pro prompts or leave jobs stuck, though fail-closed resume paths and extensive tests mitigate this.
> 
> **Overview**
> Adds **privacy-safe durability** for long ChatGPT UI (GPT Pro) turns so retries and restarts can **reattach** to an in-flight conversation instead of resubmitting the prompt.
> 
> A new on-disk ledger (`chatgpt_ui_jobs`) stores only opaque state: prompt **SHA-256 fingerprint**, `/c/<id>` conversation route, profile basename, job state, and allowlisted error codes—never prompt/response text. The Python driver gains **`durability` + `resume`** handling: emits `submitted` when the URL becomes an opaque route, navigates back to verify a single matching user message, and fails closed on `resume_not_found` / `resume_mismatch`. The Rust runner records submission, pins the **same profile** for resume, and returns structured failures with `fresh_prompt_submitted: false` when reattach is unsafe.
> 
> **API & UI:** `GET /api/backends/chatgpt_ui/durability` reconciles stale jobs on read; the backends settings tab polls it and shows a **Long-running job durability** panel (mission prefix, state, resumable flag, attempts)—without exposing `/c/` routes or fingerprints. **Config hardening:** duplicate ChatGPT UI profile directory basenames are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73dfcdd2106723b3f872072319efebf672281806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->