### PR TITLE
Fix legacy Kimi K3 mission aliases

### DIFF
--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -5834,6 +5834,11 @@ fn normalize_model_override_for_backend(backend: Option<&str>, raw_model: &str) 
     if trimmed.is_empty() {
         return None;
     }
+    if backend == Some("opencode") {
+        return Some(
+            crate::api::runners::opencode::normalize_opencode_model_id(trimmed).into_owned(),
+        );
+    }
     if backend == Some("codex") && trimmed == "gpt-5.6" {
         return Some("gpt-5.6-sol".to_string());
     }
@@ -26573,6 +26578,18 @@ And the report:
         assert_eq!(
             normalize_model_override_for_backend(Some("opencode"), " openai/gpt-5-codex "),
             Some("openai/gpt-5-codex".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_model_override_for_backend_maps_legacy_kimi_aliases() {
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), "kimi-k3"),
+            Some("kimi/k3".to_string())
+        );
+        assert_eq!(
+            normalize_model_override_for_backend(Some("opencode"), " KIMI-K3-256K "),
+            Some("kimi/k3-256k".to_string())
         );
     }
 

--- a/src/api/runners/opencode.rs
+++ b/src/api/runners/opencode.rs
@@ -32,6 +32,21 @@ const PROXY_STREAM_RECENT: std::time::Duration = std::time::Duration::from_secs(
 /// stopped consuming its own LLM stream).
 const PROXY_STREAM_INACTIVITY_CAP: std::time::Duration = std::time::Duration::from_secs(1800);
 
+/// Convert legacy controller-facing OpenCode model aliases into the canonical
+/// `provider/model` ids required by the OpenCode CLI.
+///
+/// Older Hermes skills used `kimi-k3`. OpenCode parses a slash-less value as
+/// a provider name with an empty model and fails with `Model not found:
+/// kimi-k3/`, even when the Kimi subscription itself is healthy.
+pub(crate) fn normalize_opencode_model_id(model: &str) -> Cow<'_, str> {
+    let model = model.trim();
+    match model.to_ascii_lowercase().as_str() {
+        "kimi-k3" => Cow::Borrowed("kimi/k3"),
+        "kimi-k3-256k" => Cow::Borrowed("kimi/k3-256k"),
+        _ => Cow::Borrowed(model),
+    }
+}
+
 /// Execute a turn using OpenCode CLI backend.
 ///
 /// For Host workspaces: spawns the CLI directly on the host.
@@ -105,7 +120,8 @@ pub async fn run_opencode_turn(
             std::env::var("OPENCODE_DEFAULT_MODEL")
                 .ok()
                 .filter(|v| !v.trim().is_empty())
-        });
+        })
+        .map(|model| normalize_opencode_model_id(&model).into_owned());
     let auth_state = detect_opencode_provider_auth(Some(app_working_dir));
     let has_openai = auth_state.has_openai;
     let has_anthropic = auth_state.has_anthropic;
@@ -254,7 +270,8 @@ pub async fn run_opencode_turn(
     let mut total_output_tokens: u64 = 0;
     let mut total_cache_creation_input_tokens: u64 = 0;
     let mut total_cache_read_input_tokens: u64 = 0;
-    let agent_model = resolve_opencode_model_from_config(&opencode_config_dir_host, agent);
+    let agent_model = resolve_opencode_model_from_config(&opencode_config_dir_host, agent)
+        .map(|model| normalize_opencode_model_id(&model).into_owned());
     if resolved_model.is_none() {
         resolved_model = agent_model.clone();
     }
@@ -2117,7 +2134,18 @@ fn opencode_path(
 
 #[cfg(test)]
 mod path_tests {
-    use super::{opencode_model_argument, opencode_path};
+    use super::{normalize_opencode_model_id, opencode_model_argument, opencode_path};
+
+    #[test]
+    fn legacy_kimi_k3_aliases_are_canonicalized() {
+        assert_eq!(normalize_opencode_model_id("kimi-k3"), "kimi/k3");
+        assert_eq!(
+            normalize_opencode_model_id(" KIMI-K3-256K "),
+            "kimi/k3-256k"
+        );
+        assert_eq!(normalize_opencode_model_id("kimi/k3"), "kimi/k3");
+        assert_eq!(normalize_opencode_model_id("zai/glm-5"), "zai/glm-5");
+    }
 
     #[test]
     fn grok_cli_model_keeps_its_full_proxy_chain_id() {


### PR DESCRIPTION
Summary:
- Normalize legacy kimi-k3 and kimi-k3-256k controller aliases to canonical OpenCode model IDs.
- Apply normalization when mission settings are written and before runner dispatch, so persisted missions recover.
- Add regression coverage for canonical, legacy, and unrelated model IDs.

Production incident:
Hermes session 20260726_072508_021b79 created Kimi reviews using model_override=kimi-k3. OpenCode parsed that as provider kimi-k3 plus an empty model and emitted Model not found: kimi-k3/. Direct kimi/k3 provider smokes remained healthy.

Verification:
- cargo fmt --all --check
- cargo check --all-targets
- cargo test: 1552 passed, 1 ignored; all binary and doc tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted alias mapping for OpenCode model IDs with unit tests; no auth, billing, or broad routing changes.
> 
> **Overview**
> Fixes OpenCode missions that still use legacy Hermes **`kimi-k3`** / **`kimi-k3-256k`** overrides, which OpenCode mis-parsed as provider `kimi-k3` with an empty model (`Model not found: kimi-k3/`).
> 
> Adds **`normalize_opencode_model_id`** to map those aliases (case-insensitive, trimmed) to **`kimi/k3`** and **`kimi/k3-256k`**, while leaving already-canonical `provider/model` strings unchanged.
> 
> **Controller path:** For the OpenCode backend, **`normalize_model_override_for_backend`** now runs this normalization early so persisted mission settings are rewritten on write and existing missions recover without manual edits.
> 
> **Runner path:** Resolved models from overrides, agent config, and env defaults are normalized before CLI dispatch and provider setup.
> 
> Regression tests cover controller normalization and the runner helper (legacy aliases, whitespace/casing, unrelated models).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d4dd3c3927138c97af7df9f9ec8056509d1f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->