### PR TITLE
feat: harness version probing + settings-managed harness version pins

### DIFF
--- a/dashboard/src/app/settings/backends/page.tsx
+++ b/dashboard/src/app/settings/backends/page.tsx
@@ -648,6 +648,11 @@ export default function BackendsPage() {
                 />
                 <p className="mt-1.5 text-xs text-white/30">
                   Path to the Claude CLI executable. Leave blank to use default from PATH.
+                  {claudecodeBackendConfig?.cli_version && (
+                    <span className="ml-1 text-white/45">
+                      Detected: {claudecodeBackendConfig.cli_version}
+                    </span>
+                  )}
                 </p>
               </div>
               <div className="flex items-center gap-2 pt-1">
@@ -928,6 +933,11 @@ export default function BackendsPage() {
                 />
                 <p className="mt-1.5 text-xs text-white/30">
                   Grok opens a browser for X authentication on first launch. In headless environments, configure an xAI provider for Grok Build.
+                  {grokBackendConfig?.cli_version && (
+                    <span className="ml-1 text-white/45">
+                      Detected: {grokBackendConfig.cli_version}
+                    </span>
+                  )}
                 </p>
               </div>
               <div className="flex items-center gap-2 pt-1">

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -3244,6 +3244,8 @@ export interface BackendConfig {
   settings: Record<string, unknown>;
   /** Whether the CLI for this backend is available on the system */
   cli_available?: boolean;
+  /** First line of `<cli> --version` on the host, when detected */
+  cli_version?: string;
   /** Whether authentication for this backend is configured (omitted when not applicable) */
   auth_configured?: boolean;
 }

--- a/dashboard/src/lib/api/workspaces.ts
+++ b/dashboard/src/lib/api/workspaces.ts
@@ -29,6 +29,15 @@ export interface Workspace {
   shared_network?: boolean | null;
   tailscale_mode?: TailscaleMode | null;
   config_profile?: string | null;
+  /** Harness CLI versions last probed inside this container workspace. */
+  harness_versions?: WorkspaceHarnessVersions | null;
+}
+
+/** Harness CLI versions detected inside a container workspace after build. */
+export interface WorkspaceHarnessVersions {
+  probed_at: string;
+  /** CLI name (`claude`, `codex`, `opencode`, `gemini`, `grok`) → version. */
+  versions: Record<string, string>;
 }
 
 export type ContainerDistro =

--- a/src/api/backends.rs
+++ b/src/api/backends.rs
@@ -146,6 +146,10 @@ pub struct BackendConfig {
     /// Whether the CLI for this backend is available on the system
     #[serde(default)]
     pub cli_available: bool,
+    /// First line of `<cli> --version` on the host (None = unavailable or
+    /// version probe failed). Cached for a few minutes server-side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cli_version: Option<String>,
     /// Whether authentication for this backend is configured (None = not applicable / not checked)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_configured: Option<bool>,
@@ -166,6 +170,76 @@ fn check_cli_available(cli_name: &str) -> bool {
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
+}
+
+/// TTL for the host CLI version cache. Version probes spawn the CLI itself
+/// (`--version`), which can take ~1s for node-based harnesses, so results are
+/// reused across requests.
+const CLI_VERSION_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
+type CliVersionCache =
+    tokio::sync::Mutex<std::collections::HashMap<String, (std::time::Instant, Option<String>)>>;
+
+fn cli_version_cache() -> &'static CliVersionCache {
+    static CACHE: std::sync::OnceLock<CliVersionCache> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// First line of `<cli> --version` on the host, cached for
+/// [`CLI_VERSION_CACHE_TTL`]. Returns None when the CLI is missing, errors,
+/// or takes longer than 10s.
+async fn probe_host_cli_version(cli: &str) -> Option<String> {
+    {
+        let cache = cli_version_cache().lock().await;
+        if let Some((probed_at, version)) = cache.get(cli) {
+            if probed_at.elapsed() < CLI_VERSION_CACHE_TTL {
+                return version.clone();
+            }
+        }
+    }
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        tokio::process::Command::new(cli).arg("--version").output(),
+    )
+    .await;
+    let version = match result {
+        Ok(Ok(output)) if output.status.success() => {
+            parse_cli_version_output(&String::from_utf8_lossy(&output.stdout))
+        }
+        _ => None,
+    };
+
+    cli_version_cache().lock().await.insert(
+        cli.to_string(),
+        (std::time::Instant::now(), version.clone()),
+    );
+    version
+}
+
+/// Extract the version from `--version` output: first non-empty line, trimmed.
+fn parse_cli_version_output(raw: &str) -> Option<String> {
+    raw.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+/// Pick the CLI to version-probe: explicit `cli_path` override first,
+/// otherwise the first declared name that is actually available.
+fn version_probe_target(settings: &serde_json::Value, declared: &[&'static str]) -> Option<String> {
+    if let Some(custom) = settings
+        .get("cli_path")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Some(custom.to_string());
+    }
+    declared
+        .iter()
+        .find(|name| check_cli_available(name))
+        .map(|name| name.to_string())
 }
 
 /// Probe a backend's declared CLI names — true if any are on PATH.
@@ -229,6 +303,14 @@ pub async fn get_backend_config(
     } else {
         probe_backend_cli(&settings, cli_names)
     };
+    let cli_version = if cli_available && !cli_names.is_empty() {
+        match version_probe_target(&settings, cli_names) {
+            Some(cli) => probe_host_cli_version(&cli).await,
+            None => None,
+        }
+    } else {
+        None
+    };
 
     Ok(Json(BackendConfig {
         id: backend.id().to_string(),
@@ -236,6 +318,7 @@ pub async fn get_backend_config(
         enabled: config_entry.enabled,
         settings,
         cli_available,
+        cli_version,
         auth_configured,
     }))
 }
@@ -836,5 +919,39 @@ mod quota_tests {
         let n = normalizer_for("some-unknown-provider")(&snap);
         assert_eq!(n.window_kind, "requests");
         assert_eq!(n.used, Some(60));
+    }
+}
+
+#[cfg(test)]
+mod cli_version_tests {
+    use super::*;
+
+    #[test]
+    fn parse_cli_version_output_takes_first_nonempty_line() {
+        assert_eq!(
+            parse_cli_version_output("2.1.139 (Claude Code)\nextra\n"),
+            Some("2.1.139 (Claude Code)".to_string())
+        );
+        assert_eq!(
+            parse_cli_version_output("\n  codex-cli 0.48.0  \n"),
+            Some("codex-cli 0.48.0".to_string())
+        );
+        assert_eq!(parse_cli_version_output("\n \n"), None);
+    }
+
+    #[test]
+    fn version_probe_target_prefers_cli_path_override() {
+        let settings = serde_json::json!({"cli_path": "/opt/custom/claude"});
+        assert_eq!(
+            version_probe_target(&settings, &["claude"]),
+            Some("/opt/custom/claude".to_string())
+        );
+        // Blank override falls through to declared names (availability-gated,
+        // so a nonexistent declared CLI yields None).
+        let settings = serde_json::json!({"cli_path": "  "});
+        assert_eq!(
+            version_probe_target(&settings, &["definitely-not-a-real-cli-xyz"]),
+            None
+        );
     }
 }

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -42,6 +42,7 @@ pub struct SettingsResponse {
     pub auto_cleanup_orphans_enabled: Option<bool>,
     pub ask_assistant_model: Option<String>,
     pub metadata_model: Option<String>,
+    pub harness_versions: Option<crate::settings::HarnessVersionPolicy>,
 }
 
 impl From<Settings> for SettingsResponse {
@@ -57,6 +58,7 @@ impl From<Settings> for SettingsResponse {
             auto_cleanup_orphans_enabled: settings.auto_cleanup_orphans_enabled,
             ask_assistant_model: settings.ask_assistant_model,
             metadata_model: settings.metadata_model,
+            harness_versions: settings.harness_versions,
         }
     }
 }
@@ -87,6 +89,10 @@ pub struct UpdateSettingsRequest {
     /// `ask_assistant_model`; only routable values are honored at runtime.
     #[serde(default)]
     pub metadata_model: Option<Option<String>>,
+    /// Harness CLI version pins for container bootstrap. Double-Option so a
+    /// present `null` clears every pin.
+    #[serde(default)]
+    pub harness_versions: Option<Option<crate::settings::HarnessVersionPolicy>>,
 }
 
 /// Request to update library remote specifically.
@@ -253,6 +259,25 @@ async fn update_settings(
     if let Some(value) = req.ask_assistant_model {
         // Normalize empty string to None (fall back to env/default).
         new_settings.ask_assistant_model = value.filter(|s| !s.trim().is_empty());
+    }
+    if let Some(value) = req.harness_versions {
+        // Normalize empty pins away; an all-empty policy clears the field.
+        new_settings.harness_versions = value
+            .map(|mut policy| {
+                let trim = |v: &mut Option<String>| {
+                    *v = v
+                        .take()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty());
+                };
+                trim(&mut policy.claude_code);
+                trim(&mut policy.codex);
+                trim(&mut policy.gemini);
+                trim(&mut policy.opencode);
+                trim(&mut policy.grok);
+                policy
+            })
+            .filter(|p| *p != crate::settings::HarnessVersionPolicy::default());
     }
 
     state

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -274,7 +274,6 @@ async fn update_settings(
                 trim(&mut policy.codex);
                 trim(&mut policy.gemini);
                 trim(&mut policy.opencode);
-                trim(&mut policy.grok);
                 policy
             })
             .filter(|p| *p != crate::settings::HarnessVersionPolicy::default());

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2719,10 +2719,8 @@ async fn check_claude_code_update(current_version: Option<&str>) -> Option<Strin
 }
 
 fn desired_claude_code_version() -> String {
-    std::env::var("SANDBOXED_SH_CLAUDECODE_VERSION")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "2.1.139".to_string())
+    // Env override → settings pin (harness_versions.claude_code) → default.
+    crate::settings::harness_versions_cached().effective_claude_code()
 }
 
 /// Check if there's a newer version of Codex available.

--- a/src/api/workspaces.rs
+++ b/src/api/workspaces.rs
@@ -162,6 +162,9 @@ pub struct WorkspaceResponse {
     pub config_profile: Option<String>,
     pub config: serde_json::Value,
     pub compute_policy: workspace::ComputePolicy,
+    /// Harness CLI versions last probed inside this container workspace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub harness_versions: Option<workspace::HarnessVersions>,
 }
 
 impl From<Workspace> for WorkspaceResponse {
@@ -189,6 +192,7 @@ impl From<Workspace> for WorkspaceResponse {
             config_profile: w.config_profile,
             config: w.config,
             compute_policy,
+            harness_versions: w.harness_versions,
         }
     }
 }
@@ -209,6 +213,9 @@ async fn merge_build_result(store: &workspace::WorkspaceStore, built: Workspace)
         latest.status = built.status;
         latest.error_message = built.error_message;
         latest.distro = built.distro;
+        if built.harness_versions.is_some() {
+            latest.harness_versions = built.harness_versions;
+        }
         store.update(latest).await;
     } else {
         store.update(built).await;
@@ -524,6 +531,7 @@ async fn create_workspace(
             mcps_replace_defaults,
             config_profile: config_profile.clone(),
             resolved_git_credentials: None,
+            harness_versions: None,
         },
         WorkspaceType::Container => {
             let mut ws = Workspace::new_container(req.name, path);
@@ -586,6 +594,7 @@ async fn create_workspace(
         let mut workspace_for_build = workspace.clone();
         // Get library for init script assembly
         let library = clone_library(&state.library).await;
+        let harness_policy = state.settings.get_harness_versions().await;
 
         tokio::spawn(async move {
             let result = crate::workspace::build_container_workspace(
@@ -594,6 +603,7 @@ async fn create_workspace(
                 false, // don't force rebuild
                 &working_dir,
                 library.as_deref(),
+                &harness_policy,
             )
             .await;
 
@@ -1190,6 +1200,7 @@ async fn build_workspace(
     let workspaces_store = Arc::clone(&state.workspaces);
     let working_dir = state.config.working_dir.clone();
     let mut workspace_for_build = workspace.clone();
+    let harness_policy = state.settings.get_harness_versions().await;
 
     tokio::spawn(async move {
         let result = crate::workspace::build_container_workspace(
@@ -1198,6 +1209,7 @@ async fn build_workspace(
             force_rebuild,
             &working_dir,
             library.as_deref(),
+            &harness_policy,
         )
         .await;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -41,8 +41,6 @@ pub struct HarnessVersionPolicy {
     pub gemini: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opencode: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub grok: Option<String>,
 }
 
 impl HarnessVersionPolicy {
@@ -477,6 +475,10 @@ mod tests {
         assert_eq!(back, policy);
         // Unpinned harnesses are omitted from the serialized form.
         assert!(!json.contains("gemini"));
+        // Grok's upstream installer only installs latest, so an old pin is
+        // ignored instead of being exposed as an enforceable setting.
+        let legacy: HarnessVersionPolicy = serde_json::from_str(r#"{"grok":"1.2.3"}"#).unwrap();
+        assert_eq!(legacy, HarnessVersionPolicy::default());
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,6 +19,70 @@ static MAX_CONCURRENT_TASKS_CACHED: AtomicUsize = AtomicUsize::new(0);
 /// Default repo path for sandboxed.sh source (used for self-updates).
 pub const DEFAULT_SANDBOXED_REPO_PATH: &str = "/opt/sandboxed-sh/vaduz-v1";
 
+/// Fallback Claude Code version installed into container workspaces when no
+/// pin is configured (settings `harness_versions.claude_code` or the
+/// `SANDBOXED_SH_CLAUDECODE_VERSION` env var).
+pub const DEFAULT_CLAUDE_CODE_VERSION: &str = "2.1.139";
+
+/// Per-harness version pins for container workspace bootstrap.
+///
+/// `None` for a harness means "no pin": Claude Code falls back to
+/// [`DEFAULT_CLAUDE_CODE_VERSION`], the others install latest-if-missing.
+/// A pinned harness is reinstalled whenever `--version` stops matching the
+/// pin, so editing these (Settings UI / `PUT /api/settings`) takes effect on
+/// the next workspace build or rebuild without a redeploy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessVersionPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gemini: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grok: Option<String>,
+}
+
+impl HarnessVersionPolicy {
+    /// Effective Claude Code version: env override, then settings pin, then
+    /// the built-in default.
+    pub fn effective_claude_code(&self) -> String {
+        std::env::var("SANDBOXED_SH_CLAUDECODE_VERSION")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .or_else(|| self.claude_code.clone())
+            .unwrap_or_else(|| DEFAULT_CLAUDE_CODE_VERSION.to_string())
+    }
+}
+
+/// Globally cached harness version policy, refreshed whenever settings are
+/// loaded, updated, or reloaded. Lets code without a `SettingsStore` handle
+/// (e.g. the system component update checks) read the current pins.
+static HARNESS_VERSIONS_CACHED: std::sync::OnceLock<std::sync::RwLock<HarnessVersionPolicy>> =
+    std::sync::OnceLock::new();
+
+fn harness_versions_cell() -> &'static std::sync::RwLock<HarnessVersionPolicy> {
+    HARNESS_VERSIONS_CACHED.get_or_init(|| std::sync::RwLock::new(HarnessVersionPolicy::default()))
+}
+
+/// Current harness version policy from the global cache.
+pub fn harness_versions_cached() -> HarnessVersionPolicy {
+    harness_versions_cell()
+        .read()
+        .map(|p| p.clone())
+        .unwrap_or_default()
+}
+
+/// Refresh the global harness version cache.
+pub fn set_harness_versions_cached(policy: Option<&HarnessVersionPolicy>) {
+    if let Ok(mut cell) = harness_versions_cell().write() {
+        *cell = policy.cloned().unwrap_or_default();
+    }
+}
+
 /// Authentication settings managed via the dashboard.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AuthSettings {
@@ -79,6 +143,10 @@ pub struct Settings {
     /// None or non-routable the auto provider ladder picks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata_model: Option<String>,
+    /// Version pins for harness CLIs installed into container workspaces.
+    /// When None, every harness uses its built-in default behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_versions: Option<HarnessVersionPolicy>,
 }
 
 /// In-memory store for global settings with disk persistence.
@@ -119,6 +187,8 @@ impl SettingsStore {
             Self::defaults_from_env()
         };
 
+        set_harness_versions_cached(settings.harness_versions.as_ref());
+
         Self {
             settings: RwLock::new(settings),
             storage_path,
@@ -153,7 +223,18 @@ impl SettingsStore {
             auto_cleanup_orphans_enabled: None,
             ask_assistant_model: std::env::var("ASK_ASSISTANT_MODEL").ok(),
             metadata_model: None,
+            harness_versions: None,
         }
+    }
+
+    /// Effective harness version policy (empty policy when unset).
+    pub async fn get_harness_versions(&self) -> HarnessVersionPolicy {
+        self.settings
+            .read()
+            .await
+            .harness_versions
+            .clone()
+            .unwrap_or_default()
     }
 
     /// Get the auto-cleanup enabled state.
@@ -269,6 +350,7 @@ impl SettingsStore {
 
     /// Update multiple settings at once.
     pub async fn update(&self, new_settings: Settings) -> Result<(), std::io::Error> {
+        set_harness_versions_cached(new_settings.harness_versions.as_ref());
         let mut settings = self.settings.write().await;
         *settings = new_settings;
         drop(settings);
@@ -291,6 +373,7 @@ impl SettingsStore {
             if let Some(limit) = settings.max_concurrent_tasks {
                 set_max_concurrent_tasks_cached(limit);
             }
+            set_harness_versions_cached(settings.harness_versions.as_ref());
             tracing::info!("Reloaded settings from {}", self.storage_path.display());
         }
         Ok(())
@@ -372,4 +455,45 @@ pub fn max_concurrent_tasks_cached_or(default: usize) -> usize {
 /// Values less than 1 are normalized to 1.
 pub fn set_max_concurrent_tasks_cached(max_concurrent_tasks: usize) {
     MAX_CONCURRENT_TASKS_CACHED.store(max_concurrent_tasks.max(1), Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harness_version_policy_roundtrips_and_defaults() {
+        // Old settings files without the field still deserialize.
+        let old: Settings = serde_json::from_str("{}").unwrap();
+        assert!(old.harness_versions.is_none());
+
+        let policy = HarnessVersionPolicy {
+            claude_code: Some("2.2.0".to_string()),
+            codex: Some("0.48.0".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&policy).unwrap();
+        let back: HarnessVersionPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, policy);
+        // Unpinned harnesses are omitted from the serialized form.
+        assert!(!json.contains("gemini"));
+    }
+
+    #[test]
+    fn effective_claude_code_prefers_pin_over_default() {
+        let unpinned = HarnessVersionPolicy::default();
+        // Env var may leak from the host environment; only assert the
+        // settings-pin path when it is unset.
+        if std::env::var("SANDBOXED_SH_CLAUDECODE_VERSION").is_err() {
+            assert_eq!(
+                unpinned.effective_claude_code(),
+                DEFAULT_CLAUDE_CODE_VERSION
+            );
+            let pinned = HarnessVersionPolicy {
+                claude_code: Some("9.9.9".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(pinned.effective_claude_code(), "9.9.9");
+        }
+    }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3461,7 +3461,6 @@ fn render_harness_bootstrap_script(
         .replace("@CODEX_PIN@", &pin(&policy.codex))
         .replace("@GEMINI_PIN@", &pin(&policy.gemini))
         .replace("@OPENCODE_PIN@", &pin(&policy.opencode))
-        .replace("@GROK_PIN@", &pin(&policy.grok))
         .replace("@INSTALL_CLAUDECODE@", bool_str(flags.claudecode))
         .replace("@INSTALL_CODEX@", bool_str(flags.codex))
         .replace("@INSTALL_GEMINI@", bool_str(flags.gemini))
@@ -3562,7 +3561,6 @@ CLAUDE_CODE_VERSION="${SANDBOXED_SH_CLAUDECODE_VERSION:-@CLAUDE_VERSION@}"
 CODEX_VERSION="@CODEX_PIN@"
 GEMINI_VERSION="@GEMINI_PIN@"
 OPENCODE_VERSION="@OPENCODE_PIN@"
-GROK_VERSION="@GROK_PIN@"
 
 # Detect package manager: prefer bun, fallback to npm
 if command -v bun >/dev/null 2>&1; then
@@ -3585,6 +3583,15 @@ if [ "$PKG_MGR" = "bun" ] && command -v npm >/dev/null 2>&1; then
   NATIVE_PKG_MGR="npm"
 fi
 
+# Print the first semantic version token from a CLI's version banner. Comparing
+# this token exactly prevents a pin such as 0.4 from matching 0.48.0.
+installed_version() {
+  "$1" --version 2>/dev/null \
+    | head -n1 \
+    | grep -Eo '[0-9]+(\.[0-9]+){1,3}([+-][0-9A-Za-z.-]+)?' \
+    | head -n1
+}
+
 # needs_install <cli> <pin>: CLI missing, or version drifted off a non-empty pin.
 needs_install() {
   ni_cli="$1"
@@ -3592,9 +3599,13 @@ needs_install() {
   if ! command -v "$ni_cli" >/dev/null 2>&1; then
     return 0
   fi
-  if [ -n "$ni_pin" ] && ! "$ni_cli" --version 2>/dev/null | grep -F "$ni_pin" >/dev/null 2>&1; then
-    echo "[sandboxed] $ni_cli version drifted off pin $ni_pin; reinstalling"
-    return 0
+  if [ -n "$ni_pin" ]; then
+    ni_expected="${ni_pin#v}"
+    ni_installed="$(installed_version "$ni_cli" || true)"
+    if [ "$ni_installed" != "$ni_expected" ]; then
+      echo "[sandboxed] $ni_cli version $ni_installed drifted off pin $ni_pin; reinstalling"
+      return 0
+    fi
   fi
   return 1
 }
@@ -3645,9 +3656,8 @@ if [ "@INSTALL_OPENCODE@" = "true" ] && needs_install opencode "$OPENCODE_VERSIO
   fi
 fi
 
-if [ "@INSTALL_GROK@" = "true" ] && needs_install grok "$GROK_VERSION"; then
+if [ "@INSTALL_GROK@" = "true" ] && needs_install grok ""; then
   if command -v curl >/dev/null 2>&1; then
-    # x.ai's installer has no version pinning; a pin only decides when to rerun it.
     echo "[sandboxed] Installing Grok Build (installer fetches latest)..."
     if ! curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash; then
       echo "[sandboxed] Grok Build CLI install failed"
@@ -3718,7 +3728,7 @@ const HARNESS_VERSION_PROBE_SCRIPT: &str = r#"
 export PATH="/root/.bun/bin:/root/.cache/.bun/bin:/usr/local/bin:$PATH"
 for cli in claude codex opencode gemini grok; do
   if command -v "$cli" >/dev/null 2>&1; then
-    v="$("$cli" --version 2>/dev/null | head -n1 | tr -d '\r')"
+    v="$(timeout --signal=KILL 10s "$cli" --version 2>/dev/null | head -n1 | tr -d '\r')"
     printf 'sandboxed-harness-version:%s=%s\n' "$cli" "$v"
   fi
 done
@@ -3765,7 +3775,12 @@ pub async fn probe_workspace_harness_versions(
         "-c".to_string(),
         HARNESS_VERSION_PROBE_SCRIPT.to_string(),
     ];
-    let output = nspawn::execute_in_container(&workspace.path, &command, &config).await?;
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        nspawn::execute_in_container(&workspace.path, &command, &config),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("harness version probe timed out after 60 seconds"))??;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(anyhow::anyhow!(
@@ -4038,6 +4053,9 @@ mod tests {
         assert!(script.contains("GEMINI_VERSION=\"\""));
         assert!(script.contains("@openai/codex@"));
         assert!(script.contains("@google/gemini-cli@"));
+        assert!(script.contains("[ \"$ni_installed\" != \"$ni_expected\" ]"));
+        assert!(!script.contains("GROK_VERSION="));
+        assert!(script.contains("needs_install grok \"\""));
         assert!(!script.contains("@INSTALL_"));
         assert!(!script.contains("@CLAUDE_VERSION@"));
         assert!(!script.contains("@CODEX_PIN@"));

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -254,6 +254,23 @@ pub struct Workspace {
     /// so env injection does not re-read the connection file.
     #[serde(skip, default)]
     pub resolved_git_credentials: Option<git_credentials::GitCredentialConfig>,
+    /// Harness CLI versions last probed inside this container workspace
+    /// (after harness bootstrap on build/rebuild). None = never probed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_versions: Option<HarnessVersions>,
+}
+
+/// Harness CLI versions detected inside a container workspace.
+///
+/// Keyed by CLI name (`claude`, `codex`, `opencode`, `gemini`, `grok`); a CLI
+/// that is not installed is simply absent. The value is the first line of
+/// `<cli> --version`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HarnessVersions {
+    /// When the probe ran.
+    pub probed_at: DateTime<Utc>,
+    /// CLI name → version line.
+    pub versions: std::collections::BTreeMap<String, String>,
 }
 
 impl Workspace {
@@ -495,6 +512,7 @@ impl Workspace {
             mcps_replace_defaults: true,
             config_profile: None,
             resolved_git_credentials: None,
+            harness_versions: None,
         }
     }
 
@@ -522,6 +540,7 @@ impl Workspace {
             mcps: Vec::new(),
             mcps_replace_defaults: true,
             resolved_git_credentials: None,
+            harness_versions: None,
         }
     }
 }
@@ -715,6 +734,7 @@ impl WorkspaceStore {
                     mcps_replace_defaults: true,
                     config_profile: None,
                     resolved_git_credentials: None,
+                    harness_versions: None,
                 };
 
                 orphaned.push(workspace);
@@ -3164,6 +3184,7 @@ pub async fn build_container_workspace(
     force_rebuild: bool,
     working_dir: &Path,
     library: Option<&LibraryStore>,
+    harness_policy: &crate::settings::HarnessVersionPolicy,
 ) -> anyhow::Result<()> {
     if workspace.workspace_type != WorkspaceType::Container {
         return Err(anyhow::anyhow!("Workspace is not a container type"));
@@ -3288,12 +3309,41 @@ pub async fn build_container_workspace(
                 return Err(e);
             }
             append_to_init_log(&workspace.path, "[sandboxed] Installing harnesses...\n");
-            if let Err(e) = bootstrap_workspace_harnesses(workspace).await {
+            if let Err(e) = bootstrap_workspace_harnesses(workspace, harness_policy).await {
                 tracing::warn!(
                     workspace = %workspace.name,
                     error = %e,
                     "Harness bootstrap failed; workspace will still be marked ready"
                 );
+            }
+            // Record which harness CLIs (and versions) actually exist inside
+            // the container, whether or not the bootstrap fully succeeded.
+            match probe_workspace_harness_versions(workspace).await {
+                Ok(Some(versions)) => {
+                    let summary = if versions.versions.is_empty() {
+                        "none detected".to_string()
+                    } else {
+                        versions
+                            .versions
+                            .iter()
+                            .map(|(cli, v)| format!("{}={}", cli, v))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+                    append_to_init_log(
+                        &workspace.path,
+                        &format!("[sandboxed] Harness versions: {}\n", summary),
+                    );
+                    workspace.harness_versions = Some(versions);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        workspace = %workspace.name,
+                        error = %e,
+                        "Harness version probe failed"
+                    );
+                }
             }
             workspace.status = WorkspaceStatus::Ready;
             workspace.error_message = None;
@@ -3369,22 +3419,83 @@ async fn seed_shard_data(container_root: &Path) -> anyhow::Result<bool> {
 
 use crate::util::copy_dir_recursive;
 
-async fn bootstrap_workspace_harnesses(workspace: &Workspace) -> anyhow::Result<()> {
+/// Which harnesses the container bootstrap manages, from
+/// `SANDBOXED_SH_BOOTSTRAP_*` env vars (all default true).
+struct HarnessBootstrapFlags {
+    claudecode: bool,
+    codex: bool,
+    gemini: bool,
+    opencode: bool,
+    grok: bool,
+}
+
+impl HarnessBootstrapFlags {
+    fn from_env() -> Self {
+        Self {
+            claudecode: env_var_bool("SANDBOXED_SH_BOOTSTRAP_CLAUDECODE", true),
+            codex: env_var_bool("SANDBOXED_SH_BOOTSTRAP_CODEX", true),
+            gemini: env_var_bool("SANDBOXED_SH_BOOTSTRAP_GEMINI", true),
+            opencode: env_var_bool("SANDBOXED_SH_BOOTSTRAP_OPENCODE", true),
+            grok: env_var_bool("SANDBOXED_SH_BOOTSTRAP_GROK", true),
+        }
+    }
+
+    fn any(&self) -> bool {
+        self.claudecode || self.codex || self.gemini || self.opencode || self.grok
+    }
+}
+
+/// Render the container harness-bootstrap script.
+///
+/// Placeholders are substituted with `str::replace` rather than `format!` so
+/// the shell's own `${...}` expansions and function bodies don't need brace
+/// escaping. Empty pins mean "install latest when missing"; a non-empty pin
+/// also reinstalls when `--version` stops matching it.
+fn render_harness_bootstrap_script(
+    policy: &crate::settings::HarnessVersionPolicy,
+    flags: &HarnessBootstrapFlags,
+) -> String {
+    let pin = |v: &Option<String>| v.clone().unwrap_or_default();
+    HARNESS_BOOTSTRAP_TEMPLATE
+        .replace("@CLAUDE_VERSION@", &policy.effective_claude_code())
+        .replace("@CODEX_PIN@", &pin(&policy.codex))
+        .replace("@GEMINI_PIN@", &pin(&policy.gemini))
+        .replace("@OPENCODE_PIN@", &pin(&policy.opencode))
+        .replace("@GROK_PIN@", &pin(&policy.grok))
+        .replace("@INSTALL_CLAUDECODE@", bool_str(flags.claudecode))
+        .replace("@INSTALL_CODEX@", bool_str(flags.codex))
+        .replace("@INSTALL_GEMINI@", bool_str(flags.gemini))
+        .replace("@INSTALL_OPENCODE@", bool_str(flags.opencode))
+        .replace("@INSTALL_GROK@", bool_str(flags.grok))
+}
+
+fn bool_str(v: bool) -> &'static str {
+    if v {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+async fn bootstrap_workspace_harnesses(
+    workspace: &Workspace,
+    policy: &crate::settings::HarnessVersionPolicy,
+) -> anyhow::Result<()> {
     if workspace.workspace_type != WorkspaceType::Container || !use_nspawn_for_workspace(workspace)
     {
         return Ok(());
     }
 
-    let install_claudecode = env_var_bool("SANDBOXED_SH_BOOTSTRAP_CLAUDECODE", true);
-    let install_opencode = env_var_bool("SANDBOXED_SH_BOOTSTRAP_OPENCODE", true);
-    let install_grok = env_var_bool("SANDBOXED_SH_BOOTSTRAP_GROK", true);
-
-    if !install_claudecode && !install_opencode && !install_grok {
+    let flags = HarnessBootstrapFlags::from_env();
+    if !flags.any() {
         return Ok(());
     }
 
-    let script = format!(
-        r#"#!/usr/bin/env bash
+    let script = render_harness_bootstrap_script(policy, &flags);
+    run_harness_bootstrap_script(workspace, script).await
+}
+
+const HARNESS_BOOTSTRAP_TEMPLATE: &str = r#"#!/usr/bin/env bash
 set -euo pipefail
 
 LOG=/var/log/sandboxed-init.log
@@ -3445,15 +3556,13 @@ if [ -x /root/.bun/bin/bun ] && ! command -v bun >/dev/null 2>&1; then
   echo "[sandboxed] Linked bun into /usr/local/bin"
 fi
 
-CLAUDE_CODE_VERSION="${{SANDBOXED_SH_CLAUDECODE_VERSION:-2.1.139}}"
-claude_needs_install=true
-if command -v claude >/dev/null 2>&1; then
-  if claude --version 2>&1 | grep -F "$CLAUDE_CODE_VERSION" >/dev/null 2>&1; then
-    claude_needs_install=false
-  else
-    echo "[sandboxed] Claude Code version mismatch; installing $CLAUDE_CODE_VERSION"
-  fi
-fi
+# Version policy, injected by render_harness_bootstrap_script. An empty pin
+# means "install latest when missing"; a pin also reinstalls on drift.
+CLAUDE_CODE_VERSION="${SANDBOXED_SH_CLAUDECODE_VERSION:-@CLAUDE_VERSION@}"
+CODEX_VERSION="@CODEX_PIN@"
+GEMINI_VERSION="@GEMINI_PIN@"
+OPENCODE_VERSION="@OPENCODE_PIN@"
+GROK_VERSION="@GROK_PIN@"
 
 # Detect package manager: prefer bun, fallback to npm
 if command -v bun >/dev/null 2>&1; then
@@ -3462,49 +3571,84 @@ elif command -v npm >/dev/null 2>&1; then
   PKG_MGR="npm"
 else
   PKG_MGR=""
-  echo "[sandboxed] No package manager (bun/npm) found; skipping harness install"
+  echo "[sandboxed] No package manager (bun/npm) found; skipping npm-based harness installs"
 fi
 
-if [ -n "$PKG_MGR" ]; then
-  # --- Patched: claude-code via npm to dodge bun ELF wrapping bug.
-  #     bun global-install of @anthropic-ai/claude-code points the
-  #     `claude` exec at the precompiled ELF inside the platform sub-package
-  #     and bun then tries to interpret it as JavaScript at runtime
-  #     (`error: Unexpected at .../claude:1:1`). npm wraps platform packages
-  #     correctly, so use npm for claude even when bun is preferred elsewhere.
-  CLAUDE_PKG_MGR="$PKG_MGR"
-  if [ "$PKG_MGR" = "bun" ] && command -v npm >/dev/null 2>&1; then
-    CLAUDE_PKG_MGR="npm"
+# --- Patched: native-binary CLIs (claude, codex) via npm to dodge the bun ELF
+#     wrapping bug. bun global-install points the exec at the precompiled ELF
+#     inside the platform sub-package and then tries to interpret it as
+#     JavaScript at runtime (`error: Unexpected at .../claude:1:1`). npm wraps
+#     platform packages correctly, so prefer npm for those even when bun is
+#     the general package manager.
+NATIVE_PKG_MGR="$PKG_MGR"
+if [ "$PKG_MGR" = "bun" ] && command -v npm >/dev/null 2>&1; then
+  NATIVE_PKG_MGR="npm"
+fi
+
+# needs_install <cli> <pin>: CLI missing, or version drifted off a non-empty pin.
+needs_install() {
+  ni_cli="$1"
+  ni_pin="$2"
+  if ! command -v "$ni_cli" >/dev/null 2>&1; then
+    return 0
   fi
-  if [ "{install_claudecode}" = "true" ] && [ "$claude_needs_install" = "true" ]; then
-    echo "[sandboxed] Installing Claude Code $CLAUDE_CODE_VERSION via $CLAUDE_PKG_MGR..."
-    if ! $CLAUDE_PKG_MGR install -g @anthropic-ai/claude-code@"$CLAUDE_CODE_VERSION"; then
-      echo "[sandboxed] Claude Code install failed"
-    fi
+  if [ -n "$ni_pin" ] && ! "$ni_cli" --version 2>/dev/null | grep -F "$ni_pin" >/dev/null 2>&1; then
+    echo "[sandboxed] $ni_cli version drifted off pin $ni_pin; reinstalling"
+    return 0
   fi
-  if [ "{install_opencode}" = "true" ] && ! command -v opencode >/dev/null 2>&1; then
-    if command -v curl >/dev/null 2>&1; then
-      echo "[sandboxed] Installing opencode..."
-      if curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path; then
-        if [ -x \"$HOME/.opencode/bin/opencode\" ]; then
-          if command -v install >/dev/null 2>&1; then
-            install -m 0755 \"$HOME/.opencode/bin/opencode\" /usr/local/bin/opencode || true
-          else
-            cp \"$HOME/.opencode/bin/opencode\" /usr/local/bin/opencode && chmod 755 /usr/local/bin/opencode || true
-          fi
-        fi
-      else
-        echo "[sandboxed] OpenCode CLI install failed"
+  return 1
+}
+
+if [ "@INSTALL_CLAUDECODE@" = "true" ] && [ -n "$NATIVE_PKG_MGR" ] && needs_install claude "$CLAUDE_CODE_VERSION"; then
+  echo "[sandboxed] Installing Claude Code $CLAUDE_CODE_VERSION via $NATIVE_PKG_MGR..."
+  if ! $NATIVE_PKG_MGR install -g @anthropic-ai/claude-code@"$CLAUDE_CODE_VERSION"; then
+    echo "[sandboxed] Claude Code install failed"
+  fi
+fi
+
+if [ "@INSTALL_CODEX@" = "true" ] && [ -n "$NATIVE_PKG_MGR" ] && needs_install codex "$CODEX_VERSION"; then
+  echo "[sandboxed] Installing Codex ${CODEX_VERSION:-latest} via $NATIVE_PKG_MGR..."
+  if ! $NATIVE_PKG_MGR install -g @openai/codex@"${CODEX_VERSION:-latest}"; then
+    echo "[sandboxed] Codex install failed"
+  fi
+fi
+
+if [ "@INSTALL_GEMINI@" = "true" ] && [ -n "$PKG_MGR" ] && needs_install gemini "$GEMINI_VERSION"; then
+  echo "[sandboxed] Installing Gemini CLI ${GEMINI_VERSION:-latest} via $PKG_MGR..."
+  if ! $PKG_MGR install -g @google/gemini-cli@"${GEMINI_VERSION:-latest}"; then
+    echo "[sandboxed] Gemini CLI install failed"
+  fi
+fi
+
+if [ "@INSTALL_OPENCODE@" = "true" ] && needs_install opencode "$OPENCODE_VERSION"; then
+  if command -v curl >/dev/null 2>&1; then
+    echo "[sandboxed] Installing opencode ${OPENCODE_VERSION:-latest}..."
+    opencode_install_ok=no
+    if [ -n "$OPENCODE_VERSION" ]; then
+      if curl -fsSL https://opencode.ai/install | VERSION="$OPENCODE_VERSION" bash -s -- --no-modify-path; then
+        opencode_install_ok=yes
       fi
     else
-      echo "[sandboxed] curl not found; skipping opencode install"
+      if curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path; then
+        opencode_install_ok=yes
+      fi
     fi
+    if [ "$opencode_install_ok" = "yes" ]; then
+      if [ -x "$HOME/.opencode/bin/opencode" ]; then
+        install -m 0755 "$HOME/.opencode/bin/opencode" /usr/local/bin/opencode || true
+      fi
+    else
+      echo "[sandboxed] OpenCode CLI install failed"
+    fi
+  else
+    echo "[sandboxed] curl not found; skipping opencode install"
   fi
 fi
 
-if [ "{install_grok}" = "true" ] && ! command -v grok >/dev/null 2>&1; then
+if [ "@INSTALL_GROK@" = "true" ] && needs_install grok "$GROK_VERSION"; then
   if command -v curl >/dev/null 2>&1; then
-    echo "[sandboxed] Installing Grok Build..."
+    # x.ai's installer has no version pinning; a pin only decides when to rerun it.
+    echo "[sandboxed] Installing Grok Build (installer fetches latest)..."
     if ! curl -fsSL https://x.ai/cli/install.sh | GROK_BIN_DIR=/usr/local/bin bash; then
       echo "[sandboxed] Grok Build CLI install failed"
     fi
@@ -3514,9 +3658,9 @@ if [ "{install_grok}" = "true" ] && ! command -v grok >/dev/null 2>&1; then
 fi
 
 echo "[sandboxed] Harness bootstrap done"
-"#
-    );
+"#;
 
+async fn run_harness_bootstrap_script(workspace: &Workspace, script: String) -> anyhow::Result<()> {
     let script_path = workspace.path.join("sandboxed-bootstrap.sh");
     tokio::fs::write(&script_path, script).await?;
 
@@ -3563,6 +3707,77 @@ echo "[sandboxed] Harness bootstrap done"
     }
 
     Ok(())
+}
+
+/// Marker prefix for harness-version probe output lines.
+const HARNESS_VERSION_LINE_PREFIX: &str = "sandboxed-harness-version:";
+
+/// Shell snippet that prints one `sandboxed-harness-version:<cli>=<version>`
+/// line per installed harness CLI. Missing CLIs print nothing.
+const HARNESS_VERSION_PROBE_SCRIPT: &str = r#"
+export PATH="/root/.bun/bin:/root/.cache/.bun/bin:/usr/local/bin:$PATH"
+for cli in claude codex opencode gemini grok; do
+  if command -v "$cli" >/dev/null 2>&1; then
+    v="$("$cli" --version 2>/dev/null | head -n1 | tr -d '\r')"
+    printf 'sandboxed-harness-version:%s=%s\n' "$cli" "$v"
+  fi
+done
+"#;
+
+/// Parse `sandboxed-harness-version:<cli>=<version>` lines from probe output.
+fn parse_harness_version_output(stdout: &str) -> std::collections::BTreeMap<String, String> {
+    let mut versions = std::collections::BTreeMap::new();
+    for line in stdout.lines() {
+        if let Some(rest) = line.trim().strip_prefix(HARNESS_VERSION_LINE_PREFIX) {
+            if let Some((cli, version)) = rest.split_once('=') {
+                let version = version.trim();
+                if !version.is_empty() {
+                    versions.insert(cli.trim().to_string(), version.to_string());
+                }
+            }
+        }
+    }
+    versions
+}
+
+/// Probe which harness CLIs (and versions) exist inside a container
+/// workspace. Returns None for workspaces where the probe does not apply
+/// (host workspaces, container fallback without nspawn).
+pub async fn probe_workspace_harness_versions(
+    workspace: &Workspace,
+) -> anyhow::Result<Option<HarnessVersions>> {
+    if workspace.workspace_type != WorkspaceType::Container || !use_nspawn_for_workspace(workspace)
+    {
+        return Ok(None);
+    }
+
+    let shell = if workspace.path.join("bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "/bin/sh"
+    };
+    let config = nspawn::NspawnConfig {
+        env: workspace.env_vars.clone(),
+        ..Default::default()
+    };
+    let command = vec![
+        shell.to_string(),
+        "-c".to_string(),
+        HARNESS_VERSION_PROBE_SCRIPT.to_string(),
+    ];
+    let output = nspawn::execute_in_container(&workspace.path, &command, &config).await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!(
+            "harness version probe failed: {}",
+            stderr.trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(Some(HarnessVersions {
+        probed_at: Utc::now(),
+        versions: parse_harness_version_output(&stdout),
+    }))
 }
 
 async fn run_workspace_init_script(
@@ -3794,6 +4009,92 @@ pub async fn read_sandboxed_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn all_bootstrap_flags() -> HarnessBootstrapFlags {
+        HarnessBootstrapFlags {
+            claudecode: true,
+            codex: true,
+            gemini: true,
+            opencode: true,
+            grok: true,
+        }
+    }
+
+    #[test]
+    fn bootstrap_script_injects_pins_and_leaves_no_placeholders() {
+        let policy = crate::settings::HarnessVersionPolicy {
+            claude_code: Some("2.2.5".to_string()),
+            codex: Some("0.48.0".to_string()),
+            ..Default::default()
+        };
+        let script = render_harness_bootstrap_script(&policy, &all_bootstrap_flags());
+
+        // The env var can still override the settings pin at container level.
+        if std::env::var("SANDBOXED_SH_CLAUDECODE_VERSION").is_err() {
+            assert!(script.contains("${SANDBOXED_SH_CLAUDECODE_VERSION:-2.2.5}"));
+        }
+        assert!(script.contains("CODEX_VERSION=\"0.48.0\""));
+        // Unpinned harnesses get an empty pin (= install latest when missing).
+        assert!(script.contains("GEMINI_VERSION=\"\""));
+        assert!(script.contains("@openai/codex@"));
+        assert!(script.contains("@google/gemini-cli@"));
+        assert!(!script.contains("@INSTALL_"));
+        assert!(!script.contains("@CLAUDE_VERSION@"));
+        assert!(!script.contains("@CODEX_PIN@"));
+    }
+
+    #[test]
+    fn bootstrap_script_defaults_claude_pin_when_unpinned() {
+        if std::env::var("SANDBOXED_SH_CLAUDECODE_VERSION").is_ok() {
+            return;
+        }
+        let script = render_harness_bootstrap_script(
+            &crate::settings::HarnessVersionPolicy::default(),
+            &all_bootstrap_flags(),
+        );
+        assert!(script.contains(crate::settings::DEFAULT_CLAUDE_CODE_VERSION));
+    }
+
+    #[test]
+    fn bootstrap_flags_disable_sections() {
+        let script = render_harness_bootstrap_script(
+            &crate::settings::HarnessVersionPolicy::default(),
+            &HarnessBootstrapFlags {
+                claudecode: true,
+                codex: false,
+                gemini: false,
+                opencode: true,
+                grok: true,
+            },
+        );
+        assert!(script.contains(
+            "[ \"true\" = \"true\" ] && [ -n \"$NATIVE_PKG_MGR\" ] && needs_install claude"
+        ));
+        assert!(script.contains(
+            "[ \"false\" = \"true\" ] && [ -n \"$NATIVE_PKG_MGR\" ] && needs_install codex"
+        ));
+    }
+
+    #[test]
+    fn harness_version_probe_output_parses() {
+        let stdout = "\
+noise line\n\
+sandboxed-harness-version:claude=2.1.139 (Claude Code)\n\
+sandboxed-harness-version:codex=codex-cli 0.48.0\n\
+sandboxed-harness-version:grok=\n";
+        let versions = parse_harness_version_output(stdout);
+        assert_eq!(
+            versions.get("claude").map(String::as_str),
+            Some("2.1.139 (Claude Code)")
+        );
+        assert_eq!(
+            versions.get("codex").map(String::as_str),
+            Some("codex-cli 0.48.0")
+        );
+        // Empty version (CLI present but --version failed) is omitted.
+        assert!(!versions.contains_key("grok"));
+        assert!(!versions.contains_key("noise"));
+    }
 
     #[test]
     fn verity_project_path_maps_to_container_checkout() {


### PR DESCRIPTION
## Why

Harness CLI versions are invisible where missions actually run, and the Claude Code container pin (`2.1.139`) was hardcoded in source — updating it required a redeploy. Codex and Gemini were never installed by the container bootstrap at all, and OpenCode/Grok were install-if-missing only.

## What

### Version probing in the right contexts
- **Host**: `GET /api/backends/:id/config` now returns `cli_version` (first line of `<cli> --version`, honoring the `cli_path` override; 10-min server-side cache).
- **Container workspaces**: after harness bootstrap on build/rebuild, a probe records `{probed_at, versions}` (claude/codex/opencode/gemini/grok) on the workspace record. Exposed as `harness_versions` on the workspace API, summarized in the init log, and preserved through `merge_build_result`.

### Version pins moved out of source into settings
- New `settings.harness_versions` (`HarnessVersionPolicy`) with per-harness pins, editable at runtime via `PUT /api/settings` (double-Option clear semantics, empty pins normalized away).
- Precedence for Claude Code: `SANDBOXED_SH_CLAUDECODE_VERSION` env → settings pin → `DEFAULT_CLAUDE_CODE_VERSION` constant (single source in `settings.rs`).
- The policy is globally cached (same pattern as `max_parallel_missions`), so `desired_claude_code_version()` in the system components subsystem now follows the settings pin too — the components page update check and host update stream stay in lockstep with the container bootstrap.

### Bootstrap script overhaul (`src/workspace/mod.rs`)
- Rendered from a template via placeholder substitution (unit-testable, no format!-brace escaping).
- **Codex and Gemini CLI are now installed** in container workspaces (npm/bun; npm preferred for native-binary packages to dodge the bun ELF wrapping bug, same as claude).
- Every harness is **pin-aware**: a pinned CLI reinstalls when `--version` drifts off the pin; unpinned harnesses keep the previous install-latest-if-missing behavior. OpenCode passes `VERSION` to its installer when pinned; Grok's installer has no pinning, so a pin only decides when to rerun it (logged).
- New `SANDBOXED_SH_BOOTSTRAP_CODEX` / `SANDBOXED_SH_BOOTSTRAP_GEMINI` opt-outs (default true, matching the existing flags).
- Fixes broken quoting in the opencode → `/usr/local/bin` copy step (the old `\"` inside the raw string made the path test always fail).

### Dashboard
- `cli_version` / `harness_versions` added to API types; detected-version hint under the Claude and Grok CLI Path fields in Backend Settings.

## Tests
- Settings: policy serde roundtrip + `effective_claude_code` precedence.
- Workspace: bootstrap template renders pins with no leftover placeholders, flag gating, probe-output parsing (including empty-version omission).
- Backends: `--version` output parsing, `cli_path` override preference in probe-target selection.
- `cargo fmt --all --check` clean; `cargo build` + targeted `cargo test` green. The two dashboard `tsc` errors in `new-mission-dialog.test.tsx` pre-exist on master (verified via stash).

## Behavior notes
- Existing workspaces get versions probed on their next rebuild; until then `harness_versions` is absent (never fabricated).
- Adding codex/gemini to bootstrap changes container builds to include them by default; disable with the new env flags if undesired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container build/bootstrap behavior (new default installs and version-driven reinstalls) and runs host CLI `--version` probes on backend config requests; mis-pins or probe failures are mostly non-fatal but can alter what gets installed on rebuild.
> 
> **Overview**
> Adds **visibility** and **runtime control** for harness CLI versions on the host and inside container workspaces.
> 
> **Host backends:** `GET /api/backends/:id/config` now includes optional `cli_version` (first line of `<cli> --version`, respecting `cli_path`, with a ~10-minute server cache). The Backends settings page shows a “Detected: …” hint under Claude and Grok CLI path fields.
> 
> **Settings:** New `harness_versions` (`HarnessVersionPolicy`) on global settings—editable via `PUT /api/settings` with trim/normalize and clear semantics. Claude Code effective version is **env → settings pin → default constant** (replacing a hardcoded value in system component update checks via a global cache).
> 
> **Container workspaces:** Builds/rebuilds pass the policy into a refactored harness bootstrap template that installs **Codex and Gemini** by default, applies **pin-aware reinstall** for all managed CLIs (OpenCode versioned install when pinned; Grok still latest-only), and adds opt-out env flags for Codex/Gemini bootstrap. After bootstrap, an in-container probe stores `harness_versions` on the workspace API and init log; build merge preserves that field.
> 
> **Types:** Dashboard/API types gain `cli_version`, `harness_versions`, and workspace harness version maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1e0a4f84b6d599a05f146e9607a20e49ad93f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->