### PR TITLE
Harden ChatGPT pacing and read-only mission leases

### DIFF
--- a/docs/CHATGPT_UI_HARNESS.md
+++ b/docs/CHATGPT_UI_HARNESS.md
@@ -68,7 +68,8 @@ Configure the backend through `PUT /api/backends/chatgpt_ui/config`:
     "proxy_server": "socks5://127.0.0.1:10880",
     "headless": false,
     "display": ":93",
-    "timeout_secs": 900,
+    "timeout_secs": 14400,
+    "launch_interval_secs": 30,
     "model": "gpt-5.6-pro"
   }
 }
@@ -85,6 +86,11 @@ configure `display` with a dedicated Xvfb display such as `:93`.
 Timeouts must be between 30–86400 seconds; values outside that accepted range
 are rejected before launch. A cross-process profile lock rejects concurrent use;
 configure a distinct dedicated profile for each concurrent mission.
+`launch_interval_secs` (default 30, accepted range 5–300) spaces new browser
+navigation/submission starts across the shared profile pool. It does not limit
+already-running Pro conversations. If ChatGPT renders its exact “Too many
+requests” interstitial, the runtime opens a ten-minute account-wide circuit;
+new turns wait instead of probing additional profiles.
 
 ## Model selection
 

--- a/docs/policy/CHATGPT_UI_POOL_POLICY.md
+++ b/docs/policy/CHATGPT_UI_POOL_POLICY.md
@@ -1,6 +1,6 @@
 # ChatGPT UI pool operational policy
 
-Version: 1.1.0
+Version: 1.2.0
 
 This document is the human-readable form of the versioned operational policy
 for the `chatgpt_ui` backend pool. The machine-readable form lives beside it in
@@ -26,12 +26,19 @@ Each slot is one dedicated browser profile guarded by a cross-process
 exclusive file lock. Acquisition prefers the first available slot with no
 recorded failure, preserving configured order among equivalent candidates.
 A deployment may configure more than four slots; practical concurrency is the
-number of independently usable, authenticated profiles, not an implementation
-limit. Never point two slots at the same profile directory.
+number of usable authenticated profiles and the account's live allowance, not
+an implementation limit. Cloned profiles for one account share the same
+server-side rate limit. Never point two slots at the same profile directory.
 A compatibility-failed slot remains usable, but a clean alternative wins the
 next lease. Locked, quarantined, and unavailable slots are never reused; when
 none is healthy and available, the runtime waits until a slot recovers or the
 mission is cancelled.
+
+New browser launches for one profile pool are spaced by 30 seconds by default.
+This permits many multi-hour Pro conversations to overlap while avoiding a
+burst of navigation/send requests from every slot at once. The interval is
+configurable from 5–300 seconds; lowering it requires observed account evidence,
+not merely additional browser slots.
 
 ## 2. Read-only Pro lanes: concurrent, disjoint
 
@@ -64,6 +71,11 @@ remain queued and emit a cooldown activity instead of consuming another
 profile. One later successful turn closes the circuit immediately. Capacity
 callbacks must treat an open circuit as unavailable capacity and must not
 redispatch into it.
+
+One exact ChatGPT “Too many requests” interstitial is conclusive account-wide
+evidence and opens a ten-minute circuit immediately. A completion from a turn
+that was already running does not close this rate-limit circuit; only its timed
+cooldown does. The controller must not redispatch rate-limited work meanwhile.
 
 The runtime preference for a clean alternative supports this policy but does
 not authorize a retry by itself. The controller must confirm from live pool

--- a/docs/policy/chatgpt_ui_pool_policy.json
+++ b/docs/policy/chatgpt_ui_pool_policy.json
@@ -1,6 +1,6 @@
 {
   "policy": "chatgpt-ui-pool",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "source_of_truth": {
     "runtime": "src/api/runners/chatgpt_ui/mod.rs",
     "pool": "src/api/runners/chatgpt_ui/profile_pool.rs",
@@ -13,7 +13,8 @@
     "source": "profile_dirs",
     "static_limit": null,
     "slot_exclusivity": "cross_process_file_lock",
-    "acquire_strategy": "first_healthy_available"
+    "acquire_strategy": "first_healthy_available",
+    "shared_account_launch_interval_secs": 30
   },
   "lanes": {
     "read_only_pro": {
@@ -46,7 +47,8 @@
     "rate_limited": {
       "signal": "rate_limited",
       "max_automatic_retries": 0,
-      "wait_for_allowance_recovery": true
+      "wait_for_allowance_recovery": true,
+      "account_cooldown_secs": 600
     },
     "browser_launch": {
       "signal": "browser_launch",

--- a/docs/policy/chatgpt_ui_pool_policy.schema.json
+++ b/docs/policy/chatgpt_ui_pool_policy.schema.json
@@ -37,12 +37,13 @@
     "capacity": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["source", "static_limit", "slot_exclusivity", "acquire_strategy"],
+      "required": ["source", "static_limit", "slot_exclusivity", "acquire_strategy", "shared_account_launch_interval_secs"],
       "properties": {
         "source": { "const": "profile_dirs" },
         "static_limit": { "type": "null" },
         "slot_exclusivity": { "const": "cross_process_file_lock" },
-        "acquire_strategy": { "const": "first_healthy_available" }
+        "acquire_strategy": { "const": "first_healthy_available" },
+        "shared_account_launch_interval_secs": { "const": 30 }
       }
     },
     "lanes": {
@@ -105,11 +106,12 @@
         "rate_limited": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["signal", "max_automatic_retries", "wait_for_allowance_recovery"],
+          "required": ["signal", "max_automatic_retries", "wait_for_allowance_recovery", "account_cooldown_secs"],
           "properties": {
             "signal": { "const": "rate_limited" },
             "max_automatic_retries": { "const": 0 },
-            "wait_for_allowance_recovery": { "const": true }
+            "wait_for_allowance_recovery": { "const": true },
+            "account_cooldown_secs": { "const": 600 }
           }
         },
         "browser_launch": {

--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -45,6 +45,13 @@ PRO_MODEL_ALIASES = {
 
 class TransportUnavailable(Exception):
     pass
+
+
+class RateLimited(Exception):
+    """ChatGPT rendered its explicit account request-rate interstitial."""
+
+
+RATE_LIMIT_HEADING = "Too many requests"
 # Opaque conversation route: `/c/<id>`. This is the only page-derived value the
 # durability protocol ever emits — never titles, prompts, or response text.
 CONVERSATION_PATH_RE = re.compile(r"^/c/[A-Za-z0-9-]{8,64}$")
@@ -133,6 +140,23 @@ async def locate_composer_control(page, testid_selectors, accessible_name):
     return None, False
 
 
+async def raise_if_rate_limited(page) -> None:
+    """Detect the stable, account-wide ChatGPT rate-limit heading.
+
+    Keep this exact and narrow: arbitrary page text is private conversation
+    data and must neither be logged nor used for fuzzy classification.
+    """
+    heading = page.get_by_text(RATE_LIMIT_HEADING, exact=True).first
+    try:
+        if await heading.count() and await heading.is_visible():
+            raise RateLimited()
+    except RateLimited:
+        raise
+    except Exception:
+        # A missing/transient locator is not rate-limit evidence.
+        return
+
+
 async def click_send_control(page) -> bool:
     """Click the composer send control after proving it is actionable.
 
@@ -162,6 +186,7 @@ async def click_send_control(page) -> bool:
                 break
             await page.wait_for_timeout(1_000)
     try:
+        await raise_if_rate_limited(page)
         response = await page.request.get(CHATGPT_URL, timeout=10_000)
         network_reachable = response.status > 0
     except Exception:
@@ -431,6 +456,7 @@ async def establish_resumed_chat(page, conversation_path: str, message: str) -> 
         timeout=60_000,
     )
     emit("diagnostic", message="stage=resume_route")
+    await raise_if_rate_limited(page)
     await verify_authentication(page)
     # Unknown or deleted conversations redirect away from the recorded route.
     await page.wait_for_timeout(2_000)
@@ -458,14 +484,22 @@ async def establish_continued_chat(page, conversation_path: str) -> int:
         timeout=60_000,
     )
     emit("diagnostic", message="stage=continuation_route")
+    await raise_if_rate_limited(page)
     await verify_authentication(page)
-    await page.wait_for_timeout(2_000)
     parsed = urlparse(page.url)
     if parsed.netloc.lower() not in CHATGPT_HOSTS or parsed.path != conversation_path:
         raise ResumeNotFound()
     user_messages = page.locator('[data-message-author-role="user"]')
     responses = page.locator('[data-message-author-role="assistant"]')
-    if await user_messages.count() == 0 or await responses.count() == 0:
+    # The route and account shell settle before the historical messages are
+    # hydrated. A fixed two-second delay was flaky under concurrent profiles:
+    # the same conversation became visible on an immediate retry. Wait for
+    # positive evidence from both sides of the completed turn instead.
+    for _ in range(40):
+        if await user_messages.count() > 0 and await responses.count() > 0:
+            break
+        await page.wait_for_timeout(500)
+    else:
         raise ResumeNotFound()
     composer = page.locator("#prompt-textarea").first
     if not await composer.count():
@@ -479,6 +513,7 @@ async def establish_fresh_chat(page) -> int:
     """Prove an authenticated, settled blank chat before observing responses."""
     await page.goto(CHATGPT_URL, wait_until="domcontentloaded", timeout=60_000)
     emit("diagnostic", message="stage=page_loaded")
+    await raise_if_rate_limited(page)
     await verify_authentication(page)
 
     # A direct navigation to the root is the stable new-chat primitive. The
@@ -627,6 +662,7 @@ async def run(args, request) -> None:
             submitted_emitted = resume_path is not None
             deadline = asyncio.get_running_loop().time() + timeout_ms / 1000
             while asyncio.get_running_loop().time() < deadline:
+                await raise_if_rate_limited(page)
                 if durability and not submitted_emitted:
                     # The URL flips to the opaque conversation route once the
                     # prompt is accepted. That route is the only durable
@@ -670,6 +706,12 @@ async def run(args, request) -> None:
         fail(
             "auth_required",
             "ChatGPT login is required in the configured profile; provision it interactively",
+        )
+    except RateLimited:
+        fail(
+            "rate_limited",
+            "ChatGPT temporarily limited this account after requests were made too quickly; the shared account circuit is cooling down",
+            stage=stage,
         )
     except ResumeNotFound:
         fail(

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -9,6 +9,7 @@ from scripts.chatgpt_ui_driver import (
     SEND_CONTROL_TESTIDS,
     STOP_BUTTON_NAME,
     STOP_CONTROL_TESTIDS,
+    RateLimited,
     TransportUnavailable,
     choose_intelligence_model,
     click_send_control,
@@ -17,9 +18,11 @@ from scripts.chatgpt_ui_driver import (
     conversation_path_from_url,
     download_control_key,
     downloadable_href,
+    establish_continued_chat,
     locate_composer_control,
     model_selection,
     normalized_prompt,
+    raise_if_rate_limited,
     resume_conversation_path,
     safe_download_name,
 )
@@ -80,6 +83,10 @@ class FakeControl:
     def last(self):
         return self
 
+    @property
+    def first(self):
+        return self
+
     async def count(self) -> int:
         return 1 if self.visible else 0
 
@@ -123,12 +130,17 @@ class FakeComposerPage:
             return type("Response", (), {"status": 403})()
 
     def __init__(
-        self, testid_visible: bool, fallback_visible: bool, network_reachable: bool = True
+        self,
+        testid_visible: bool,
+        fallback_visible: bool,
+        network_reachable: bool = True,
+        rate_limited: bool = False,
     ) -> None:
         self.testid_control = FakeControl(testid_visible)
         self.form = FakeComposerForm(FakeControl(fallback_visible))
         self.selectors = []
         self.request = self.Request(network_reachable)
+        self.rate_limited = rate_limited
 
     def locator(self, selector):
         self.selectors.append(selector)
@@ -139,10 +151,90 @@ class FakeComposerPage:
     async def wait_for_timeout(self, _timeout) -> None:
         return None
 
+    def get_by_text(self, text, exact=False):
+        return FakeControl(
+            self.rate_limited and text == "Too many requests" and exact
+        )
+
+
+class HydratingLocator:
+    def __init__(self, counts) -> None:
+        self.counts = iter(counts)
+        self.last = 0
+
+    @property
+    def first(self):
+        return self
+
+    def nth(self, _index):
+        return self
+
+    async def count(self) -> int:
+        self.last = next(self.counts, self.last)
+        return self.last
+
+    async def wait_for(self, **_kwargs) -> None:
+        return None
+
+    async def is_visible(self) -> bool:
+        return self.last > 0
+
+
+class HydratingConversationPage:
+    def __init__(self) -> None:
+        self.url = ""
+        self.user_messages = HydratingLocator([0, 0, 1])
+        self.assistant_messages = HydratingLocator([0, 1, 1])
+        self.composer = HydratingLocator([1])
+        self.login = HydratingLocator([0])
+        self.account = HydratingLocator([1])
+        self.waits = 0
+
+    async def goto(self, url, **_kwargs) -> None:
+        self.url = url
+
+    def locator(self, selector):
+        if selector == '[data-message-author-role="user"]':
+            return self.user_messages
+        if selector == '[data-message-author-role="assistant"]':
+            return self.assistant_messages
+        if selector == "#prompt-textarea":
+            return self.composer
+        if selector.startswith('[data-testid="accounts-profile-button"]'):
+            return self.account
+        raise AssertionError(selector)
+
+    async def wait_for_timeout(self, _timeout) -> None:
+        self.waits += 1
+
+    def get_by_role(self, role, name=None):
+        if role == "button" and name is not None:
+            return self.login
+        return self.composer
+
+    def get_by_text(self, _text, exact=False):
+        return HydratingLocator([0 if exact else 0])
+
 
 class ChatGptUiDriverTests(unittest.TestCase):
+    def test_explicit_rate_limit_heading_is_classified(self) -> None:
+        page = FakeComposerPage(False, False, rate_limited=True)
+
+        with self.assertRaises(RateLimited):
+            asyncio.run(raise_if_rate_limited(page))
+
     def test_cleanup_preserves_existing_protocol_result(self) -> None:
         asyncio.run(close_context_quietly(ClosedContext()))
+
+    def test_continuation_waits_for_history_hydration(self) -> None:
+        page = HydratingConversationPage()
+
+        baseline = asyncio.run(
+            establish_continued_chat(page, "/c/abc123def456")
+        )
+
+        self.assertEqual(baseline, 1)
+        self.assertGreaterEqual(page.waits, 2)
 
     def test_pro_model_alias_maps_to_current_verified_picker_option(self) -> None:
         self.assertEqual(model_selection("gpt-5.6-pro"), ("Pro", "gpt-5.6-pro"))

--- a/scripts/test_policy_lint.py
+++ b/scripts/test_policy_lint.py
@@ -223,8 +223,11 @@ class PolicyLintMutationTest(unittest.TestCase):
     def test_skill_must_declare_matching_policy_version(self):
         skill = self.root / SKILL_DOC
         skill.write_text(
-            skill.read_text(encoding="utf-8").replace(
-                "policy_version: 1.1.0", "policy_version: 0.9.0"
+            re.sub(
+                r"policy_version: [^\n]+",
+                "policy_version: 0.9.0",
+                skill.read_text(encoding="utf-8"),
+                count=1,
             ),
             encoding="utf-8",
         )
@@ -233,7 +236,7 @@ class PolicyLintMutationTest(unittest.TestCase):
     def test_skill_without_version_fails(self):
         skill = self.root / SKILL_DOC
         content = skill.read_text(encoding="utf-8")
-        content = content.replace("version: 1.1.0\n", "", 1)
+        content = re.sub(r"^version: [^\n]+\n", "", content, count=1, flags=re.MULTILINE)
         skill.write_text(content, encoding="utf-8")
         self.assert_error("missing frontmatter 'version:'")
 

--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -6,10 +6,10 @@ description: >
   to exhaust its budget instead of giving up, and send targeted hints. Trigger
   terms: mission, sandboxed.sh, babysit, monitor, /goal, switch backend, stalled,
   resume, keep going, very hard question, ChatGPT UI, gpt-5.6-pro.
-version: 1.1.0
+version: 1.2.0
 metadata:
   policy: chatgpt-ui-pool
-  policy_version: 1.1.0
+  policy_version: 1.2.0
 ---
 
 # Hermes Mission Control
@@ -150,7 +150,7 @@ When a model "isn't working," first prove it's the **model** and not the
 concluding the model is too weak. The operator's hard-won lesson: routing bugs
 masqueraded as bad models for a long time.
 
-## ChatGPT UI pool policy (policy_version 1.1.0)
+## ChatGPT UI pool policy (policy_version 1.2.0)
 
 Binding rules for every `chatgpt_ui` mission you start or manage. The
 authoritative versioned policy is `docs/policy/CHATGPT_UI_POOL_POLICY.md` in
@@ -164,6 +164,10 @@ this section must stay in sync with it.
   mission against a locked slot. The pool
   prefers clean profiles and waits when every slot is locked, quarantined, or
   unavailable; it never fails open onto an unhealthy profile.
+- **Pace shared-account starts.** Extra browser slots increase the number of
+  long Pro turns that can overlap, but profiles for one account share its
+  server-side request allowance. The runtime spaces new launches by 30 seconds
+  by default. Do not defeat this pacing or burst-dispatch manually.
 - **Read-only Pro lanes.** Concurrent `gpt-5.6-pro` consultations are fine
   **only** with `writer: false` and **only** on disjoint slots (distinct
   profiles). A `chatgpt_ui` mission never writes repositories or owns a PR.
@@ -188,7 +192,9 @@ this section must stay in sync with it.
   not prove the login was repaired. Never use an auth-failed slot for the
   one compatibility retry.
 - **Rate limited → wait.** 0 automatic retries; allowance must recover.
-  Do not shuffle the request across slots of the same account.
+  Do not shuffle the request across slots of the same account. One exact “Too
+  many requests” page opens a shared 10-minute circuit immediately; an older
+  in-flight turn completing does not close it.
 - **Global browser launch failure → preserve the pool.** A generic
   `browser_launch` failure can be a host-wide Chromium/Playwright problem and
   does not make the selected profile unhealthy. Only a proven profile-local

--- a/src/api/control/mod.rs
+++ b/src/api/control/mod.rs
@@ -6205,9 +6205,19 @@ async fn mission_is_pr_writer_in_store(
 
 fn message_requests_pr_writer(mission: &Mission, content: &str) -> bool {
     mission.project.github_pr.is_some()
-        // A follow-up message is a new capability request. A persisted
-        // `pr-readonly` tag describes the old mandate and must not suppress an
-        // explicit later instruction to fix/commit/push.
+        // An explicit read-only capability is an authority boundary, not a
+        // prompt hint. In particular, the scheduler re-injects a pending
+        // mission's deferred initial goal as a message; inferring an upgrade
+        // from that text made read-only PR validators contend for the writer
+        // lease before their harness ever started. Callers that want to expand
+        // authority must first use the structured project update with
+        // `writer=true`, which replaces this tag with `pr-writer` under the
+        // durable lease lock.
+        && !mission
+            .project
+            .tags
+            .iter()
+            .any(|tag| tag == "pr-readonly")
         && inferred_pr_writer(None, None, Some(content))
 }
 
@@ -6476,7 +6486,34 @@ async fn activate_mission_for_message(
     // Keep the writer mutex until Active is persisted so a replacement writer
     // cannot race a terminal mission's message-based reactivation.
     let _pr_writer_guard =
-        acquire_pr_writer_lease_for_message(control_hub, store, mission, content).await?;
+        match acquire_pr_writer_lease_for_message(control_hub, store, mission, content).await {
+            Ok(guard) => guard,
+            Err(error)
+                if mission.status == MissionStatus::Pending
+                    && error.contains("PR writer lease is already held") =>
+            {
+                // A pending writer that conflicts with an existing durable writer
+                // cannot become runnable by retrying the same deferred goal. Make
+                // the deterministic rejection terminal and clear the goal so the
+                // scheduler does not emit the same error every cooldown interval.
+                let reason = "pr_writer_lease_conflict";
+                store
+                    .update_mission_status_with_reason(
+                        mission.id,
+                        MissionStatus::Interrupted,
+                        Some(reason),
+                    )
+                    .await?;
+                store.set_deferred_goal(mission.id, None).await?;
+                let _ = events_tx.send(AgentEvent::MissionStatusChanged {
+                    mission_id: mission.id,
+                    status: MissionStatus::Interrupted,
+                    summary: Some(format!("{reason}: {error}")),
+                });
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        };
 
     if message_activates_mission(mission.status) {
         store
@@ -23514,7 +23551,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn readonly_initial_goal_does_not_lease_but_followup_can_escalate() {
+    async fn readonly_authority_cannot_be_escalated_by_prompt_text() {
         let store: Arc<dyn MissionStore> = Arc::new(mission_store::InMemoryMissionStore::new());
         let mission = store
             .create_mission(
@@ -23545,8 +23582,15 @@ mod tests {
             &mission,
             Some("Fix and update the PR after review")
         ));
-        assert!(message_requests_pr_writer(
+        assert!(!message_requests_pr_writer(
             &mission,
+            "Fix and update the PR after review"
+        ));
+
+        let mut unclassified = mission.clone();
+        unclassified.project.tags.clear();
+        assert!(message_requests_pr_writer(
+            &unclassified,
             "Fix and update the PR after review"
         ));
     }

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -80,6 +80,7 @@ struct Settings {
     proxy_server: Option<String>,
     display: Option<String>,
     timeout: Duration,
+    launch_interval: Duration,
     headless: bool,
 }
 
@@ -329,6 +330,11 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
     if !(30..=86_400).contains(&timeout_secs) {
         return Err("chatgpt_ui timeout_secs must be between 30 and 86400".to_string());
     }
+    let launch_interval_secs =
+        get_backend_u64_setting("chatgpt_ui", "launch_interval_secs").unwrap_or(30);
+    if !(5..=300).contains(&launch_interval_secs) {
+        return Err("chatgpt_ui launch_interval_secs must be between 5 and 300".to_string());
+    }
     let browser = get_backend_string_setting("chatgpt_ui", "browser")
         .unwrap_or_else(|| "chromium".to_string());
     if !matches!(browser.as_str(), "chromium" | "firefox" | "webkit") {
@@ -359,6 +365,7 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
         proxy_server,
         display,
         timeout: Duration::from_secs(timeout_secs),
+        launch_interval: Duration::from_secs(launch_interval_secs),
         headless,
     })
 }
@@ -424,6 +431,20 @@ pub async fn run_chatgpt_ui_turn(
 
     let attempt_resume = resume_record.take();
     let attempt_continuation = continuation_record.take();
+    // The configured profiles share one ChatGPT account in normal
+    // deployments. Pace navigation/submission starts for that account pool;
+    // already-running Pro conversations remain fully concurrent.
+    if let Err(result) = profile_pool::wait_for_launch_turn(
+        &settings.profile_dirs[0],
+        settings.launch_interval,
+        mission_id,
+        &events_tx,
+        &cancel,
+    )
+    .await
+    {
+        return result;
+    }
     // Conversations are account-scoped: a resume must reuse the profile
     // that submitted the prompt, or give up on the pointer entirely. The
     // pinned path locks the slot directly instead of going through the
@@ -522,7 +543,12 @@ fn unresolved_resume_result(code: &str) -> AgentResult {
     .with_terminal_reason(TerminalReason::LlmError)
     .with_data(serde_json::json!({
         "provider_error_source": "chatgpt_ui_durability",
-        "failure_class": FailureClass::TransportError,
+        // The driver has already waited for the route to hydrate. If the
+        // mission-owned pointer still cannot be proved, fail closed and wait
+        // for operator/controller reconciliation. Classifying this as generic
+        // transport caused the control loop to auto-resume with a synthesized
+        // recovery prompt, changing the user's requested follow-up.
+        "failure_class": FailureClass::AgentError,
         "classification_source": "structured",
         "resume_resolution": code,
         "fresh_prompt_submitted": false,
@@ -871,6 +897,9 @@ async fn drive_once(
                                 profile_pool::BackendFailureKind::Transport,
                             );
                         }
+                        if code.as_deref() == Some("rate_limited") {
+                            profile_pool::record_backend_rate_limit(profile_dir);
+                        }
                         if submitted_recorded {
                             jobs::note_attempt_error(
                                 app_working_dir,
@@ -1118,6 +1147,22 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(artifact, DriverEvent::Artifact { .. }));
+    }
+
+    #[test]
+    fn unresolved_conversation_does_not_trigger_generic_transport_resume() {
+        let result = unresolved_resume_result("continuation_not_found");
+
+        assert!(!result.success);
+        assert_eq!(result.terminal_reason, Some(TerminalReason::LlmError));
+        assert_eq!(
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("failure_class"))
+                .and_then(serde_json::Value::as_str),
+            Some("agent_error")
+        );
     }
 
     #[test]

--- a/src/api/runners/chatgpt_ui/profile_pool.rs
+++ b/src/api/runners/chatgpt_ui/profile_pool.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use serde::Serialize;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Mutex as AsyncMutex};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -26,6 +26,7 @@ const COMPATIBILITY_QUARANTINE: Duration = Duration::from_secs(10 * 60);
 const COMPATIBILITY_QUARANTINE_THRESHOLD: u32 = 3;
 const GLOBAL_BACKEND_FAILURE_WINDOW: Duration = Duration::from_secs(3 * 60);
 const GLOBAL_BACKEND_FAILURE_COOLDOWN: Duration = Duration::from_secs(5 * 60);
+const GLOBAL_RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(10 * 60);
 const GLOBAL_BACKEND_FAILURE_THRESHOLD: usize = 2;
 
 pub struct ProfileLock(File);
@@ -108,6 +109,7 @@ struct BackendCircuit {
 pub enum BackendFailureKind {
     Compatibility,
     Transport,
+    RateLimited,
 }
 
 fn backend_circuits() -> &'static Mutex<HashMap<PathBuf, BackendCircuit>> {
@@ -161,10 +163,21 @@ fn backend_circuit_remaining_at(profile_dir: &Path, now: Instant) -> Option<Dura
 }
 
 fn clear_backend_circuit(profile_dir: &Path) {
-    backend_circuits()
+    let key = circuit_key(profile_dir);
+    let mut circuits = backend_circuits()
         .lock()
-        .expect("profile compatibility circuit poisoned")
-        .remove(&circuit_key(profile_dir));
+        .expect("profile compatibility circuit poisoned");
+    // A turn that was already in flight can finish successfully after a
+    // different browser receives the account-wide rate-limit page. That does
+    // not prove new navigation/submission traffic is accepted again, so keep
+    // the timed rate-limit circuit until its cooldown expires.
+    if circuits
+        .get(&key)
+        .is_some_and(|circuit| circuit.reason == Some(BackendFailureKind::RateLimited))
+    {
+        return;
+    }
+    circuits.remove(&key);
 }
 
 pub fn record_backend_failure(profile_dir: &Path, kind: BackendFailureKind) {
@@ -174,6 +187,98 @@ pub fn record_backend_failure(profile_dir: &Path, kind: BackendFailureKind) {
             cooldown_secs = GLOBAL_BACKEND_FAILURE_COOLDOWN.as_secs(),
             "ChatGPT UI backend circuit opened after failures on distinct profile slots"
         );
+    }
+}
+
+/// Open the account-wide circuit immediately when ChatGPT itself renders its
+/// explicit rate-limit interstitial. Unlike a selector or transport miss,
+/// this is already conclusive shared-account evidence and must not be sampled
+/// on a second profile before slowing the fleet down.
+pub fn record_backend_rate_limit(profile_dir: &Path) {
+    let now = Instant::now();
+    let mut circuits = backend_circuits()
+        .lock()
+        .expect("profile compatibility circuit poisoned");
+    let circuit = circuits.entry(circuit_key(profile_dir)).or_default();
+    let until = now + GLOBAL_RATE_LIMIT_COOLDOWN;
+    circuit.open_until = Some(
+        circuit
+            .open_until
+            .map_or(until, |existing| existing.max(until)),
+    );
+    circuit.reason = Some(BackendFailureKind::RateLimited);
+    tracing::warn!(
+        cooldown_secs = GLOBAL_RATE_LIMIT_COOLDOWN.as_secs(),
+        "ChatGPT UI account circuit opened after an explicit rate-limit page"
+    );
+}
+
+fn launch_gates() -> &'static AsyncMutex<HashMap<PathBuf, Instant>> {
+    static GATES: OnceLock<AsyncMutex<HashMap<PathBuf, Instant>>> = OnceLock::new();
+    GATES.get_or_init(|| AsyncMutex::new(HashMap::new()))
+}
+
+/// Serialize browser launches for profiles that share one account pool while
+/// allowing already-submitted multi-hour turns to continue concurrently.
+/// This limits high-risk navigation/send bursts without imposing a low hard
+/// ceiling on the number of useful Pro conversations in flight.
+pub async fn wait_for_launch_turn(
+    profile_dir: &Path,
+    min_interval: Duration,
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    cancel: &CancellationToken,
+) -> Result<(), AgentResult> {
+    if min_interval.is_zero() {
+        return Ok(());
+    }
+    let key = circuit_key(profile_dir);
+    let mut announced_wait = false;
+    loop {
+        let wait = {
+            let mut gates = launch_gates().lock().await;
+            let now = Instant::now();
+            match gates
+                .get(&key)
+                .and_then(|next| next.checked_duration_since(now))
+            {
+                Some(wait) if !wait.is_zero() => wait,
+                _ => {
+                    gates.insert(key.clone(), now + min_interval);
+                    return Ok(());
+                }
+            }
+        };
+        if !announced_wait {
+            let _ = events_tx.send(AgentEvent::MissionActivity {
+                label: format!(
+                    "Pacing ChatGPT UI account traffic (about {}s)…",
+                    wait.as_secs().max(1)
+                ),
+                tool_name: "chatgpt_ui_launch_pacing".to_string(),
+                mission_id: Some(mission_id),
+            });
+            announced_wait = true;
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let shutdown = crate::api::routes::is_shutdown_initiated();
+                return Err(AgentResult::failure(
+                    if shutdown {
+                        "Server restart — paused while pacing ChatGPT UI account traffic."
+                    } else {
+                        "Mission cancelled while pacing ChatGPT UI account traffic"
+                    },
+                    0,
+                )
+                .with_terminal_reason(if shutdown {
+                    TerminalReason::ServerShutdown
+                } else {
+                    TerminalReason::Cancelled
+                }));
+            }
+            _ = tokio::time::sleep(wait.min(Duration::from_secs(2))) => {}
+        }
     }
 }
 
@@ -304,6 +409,11 @@ pub(crate) fn reset_registry_for_tests(profile_dirs: &[PathBuf]) {
     for profile_dir in profile_dirs {
         circuits.remove(&circuit_key(profile_dir));
     }
+    if let Ok(mut gates) = launch_gates().try_lock() {
+        for profile_dir in profile_dirs {
+            gates.remove(&circuit_key(profile_dir));
+        }
+    }
 }
 
 pub async fn acquire_profile(
@@ -326,7 +436,7 @@ pub async fn acquire_profile(
             if !announced_wait {
                 let _ = events_tx.send(AgentEvent::MissionActivity {
                     label: format!(
-                        "Waiting for ChatGPT UI compatibility recovery (about {}s)…",
+                        "Waiting for ChatGPT UI backend recovery (about {}s)…",
                         remaining.as_secs().max(1)
                     ),
                     tool_name: "chatgpt_ui_backend_circuit".to_string(),
@@ -778,6 +888,64 @@ mod tests {
         record_slot_failure_at(&profile, SlotFailureKind::Compatibility, now);
 
         assert!(backend_circuit_remaining_at(&profile, now).is_none());
+        reset_registry_for_tests(&[profile]);
+    }
+
+    #[test]
+    fn explicit_rate_limit_opens_account_circuit_immediately() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+
+        record_backend_rate_limit(&profile);
+
+        let status = backend_circuit_status(std::slice::from_ref(&profile));
+        assert!(status.open);
+        assert_eq!(status.reason, Some(BackendFailureKind::RateLimited));
+        assert!(status.retry_after_secs.is_some_and(|seconds| seconds > 0));
+
+        record_slot_success(&profile);
+        assert!(backend_circuit_status(std::slice::from_ref(&profile)).open);
+        reset_registry_for_tests(&[profile]);
+    }
+
+    #[tokio::test]
+    async fn account_launches_are_serialized_by_minimum_interval() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile");
+        std::fs::create_dir(&profile).unwrap();
+        reset_registry_for_tests(std::slice::from_ref(&profile));
+        let (events_tx, _) = broadcast::channel(8);
+        let first_cancel = CancellationToken::new();
+        wait_for_launch_turn(
+            &profile,
+            Duration::from_millis(200),
+            Uuid::new_v4(),
+            &events_tx,
+            &first_cancel,
+        )
+        .await
+        .unwrap();
+
+        let second_cancel = CancellationToken::new();
+        let task_cancel = second_cancel.clone();
+        let task_profile = profile.clone();
+        let task_events = events_tx.clone();
+        let second = tokio::spawn(async move {
+            wait_for_launch_turn(
+                &task_profile,
+                Duration::from_millis(200),
+                Uuid::new_v4(),
+                &task_events,
+                &task_cancel,
+            )
+            .await
+        });
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(!second.is_finished());
+        second_cancel.cancel();
+        assert!(second.await.unwrap().is_err());
         reset_registry_for_tests(&[profile]);
     }
 


### PR DESCRIPTION
## Summary
- wait for ChatGPT conversation history hydration and preserve exact follow-up semantics
- pace shared-account browser launches and open an immediate cooldown on the exact rate-limit interstitial
- make explicit PR read-only authority immune to prompt inference and stop deterministic lease retry loops
- update the versioned Hermes ChatGPT pool policy

## Production evidence
- nine ChatGPT UI browser starts occurred in 51 seconds, including five-second gaps, before the account displayed Too many requests
- lean-silicon hardware validator 44cbf270 carried pr-readonly but its deferred goal was reinterpreted as a writer message 23 times

## Verification
- cargo fmt --all --check
- cargo check --all-targets
- cargo test (1563 passed, 1 ignored)
- cargo clippy --all-targets -- -D warnings
- python3 -m unittest scripts.test_chatgpt_ui_driver
- python3 scripts/policy_lint.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mission scheduling (PR writer leases), ChatGPT pool dispatch/cooldowns, and failure classification paths that affect auto-resume behavior; changes are well-tested but affect production concurrency and authority boundaries.
> 
> **Overview**
> Hardens **ChatGPT UI** operation under shared-account load and bumps the versioned pool policy to **1.2.0**.
> 
> The driver now detects the exact **“Too many requests”** heading (mapped to `rate_limited`), checks it across navigation/send/response, and **waits for conversation history to hydrate** on continuations instead of a fixed delay. The Rust runner adds configurable **`launch_interval_secs`** (default 30s) to space new browser starts while long Pro turns stay concurrent, opens a **10-minute account circuit** on rate limits (success on an in-flight turn does not clear it), and classifies unresolved resume/continuation as **`agent_error`** so the controller does not auto-resume with the wrong prompt.
> 
> **Mission control** treats **`pr-readonly`** as a hard boundary: follow-up text cannot infer a PR writer lease, and pending missions that hit a writer lease conflict are **interrupted** with the deferred goal cleared instead of retrying every cooldown.
> 
> Docs, Hermes skill, policy JSON/schema, and tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688987c00878c498d0e0983db7a2b82eb616c25c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->