### PR TITLE
Harden Codex transport failure classification

### DIFF
--- a/src/api/mission_runner.rs
+++ b/src/api/mission_runner.rs
@@ -4398,6 +4398,16 @@ fn is_codex_generic_exit_wrapper(message: &str) -> bool {
     message.contains("Codex CLI exited before completing the turn")
 }
 
+pub(crate) fn is_codex_transport_error_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("stream disconnected before completion")
+        || lower.contains("error sending request for url")
+        || lower.contains("connection reset by peer")
+        || lower.contains("connection closed before message completed")
+        || lower.contains("codex app-server stream closed before responding")
+        || lower.contains("codex app-server stream closed before mission terminated")
+}
+
 fn codex_pending_tools_error_message(
     message: &str,
     pending_tools: &HashMap<String, String>,
@@ -4421,7 +4431,13 @@ pub(crate) fn codex_error_message_to_surface(
     pending_tools: &HashMap<String, String>,
     message: &str,
 ) -> Option<String> {
-    if assistant_message.trim().is_empty() {
+    if is_codex_transport_error_message(message) && !assistant_message.trim().is_empty() {
+        Some(format!(
+            "{}\n\n[Codex transport error: {}]",
+            assistant_message.trim(),
+            message
+        ))
+    } else if assistant_message.trim().is_empty() {
         Some(message.to_string())
     } else if !pending_tools.is_empty() {
         Some(codex_pending_tools_error_message(message, pending_tools))
@@ -4435,11 +4451,17 @@ pub(crate) fn record_codex_error_message(
     message: String,
 ) -> bool {
     let new_is_generic_exit_wrapper = is_codex_generic_exit_wrapper(&message);
+    let new_is_transport = is_codex_transport_error_message(&message);
     let already_have_specific = error_message
         .as_deref()
         .is_some_and(|existing| !is_codex_generic_exit_wrapper(existing));
+    let already_have_pending_tool_failure = error_message
+        .as_deref()
+        .is_some_and(|existing| existing.starts_with(CODEX_PENDING_TOOLS_ERROR_PREFIX));
 
-    if new_is_generic_exit_wrapper && already_have_specific {
+    if (new_is_generic_exit_wrapper && already_have_specific)
+        || (new_is_transport && already_have_pending_tool_failure)
+    {
         false
     } else {
         *error_message = Some(message);
@@ -8813,8 +8835,8 @@ mod tests {
         ensure_opencode_provider_for_model, extract_codex_reset_window, extract_model_from_message,
         extract_opencode_session_id, extract_part_text, extract_str, extract_think_content,
         is_capacity_limited_error, is_codex_chatgpt_account_model_blocked, is_codex_node_wrapper,
-        is_opencode_session_id, is_provider_payload_error, is_rate_limited_error,
-        is_session_corruption_error, is_success_path_auth_error,
+        is_codex_transport_error_message, is_opencode_session_id, is_provider_payload_error,
+        is_rate_limited_error, is_session_corruption_error, is_success_path_auth_error,
         is_success_path_provider_payload_error, is_success_path_rate_limited_error,
         is_tool_call_only_output, opencode_goal_terminal_status,
         opencode_idle_timeout_result_message, opencode_output_needs_fallback,
@@ -8833,7 +8855,8 @@ mod tests {
         ClaudeIncompleteTurnContext, ClaudeTransportFailureStage, ClaudeTransportRecoveryStrategy,
         ClaudeTurnWaitState, CopiedOpenCodeProbe, MissionHealth, MissionRunState, MissionRunner,
         MissionStallSeverity, OpencodeSseState, CODEX_AUTH_ERROR_COOLDOWN, CODEX_CAPACITY_COOLDOWN,
-        CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS, STALL_WARN_SECS,
+        CODEX_PENDING_TOOLS_ERROR_PREFIX, CODEX_RATE_LIMIT_COOLDOWN, STALL_SEVERE_SECS,
+        STALL_WARN_SECS,
     };
     use super::{
         extract_telegram_instructions, grok_event_reasoning, grok_event_text, grok_event_usage,
@@ -9657,6 +9680,18 @@ mod tests {
     }
 
     #[test]
+    fn codex_post_response_transport_eof_is_preserved() {
+        let pending_tools = std::collections::HashMap::new();
+        let eof = "Codex app-server stream closed before mission terminated";
+
+        assert!(is_codex_transport_error_message(eof));
+        let surfaced = codex_error_message_to_surface("Partial response", &pending_tools, eof)
+            .expect("partial output plus EOF should be surfaced");
+        assert!(surfaced.starts_with("Partial response"));
+        assert!(surfaced.contains(eof));
+    }
+
+    #[test]
     fn codex_error_recording_keeps_specific_error_over_exit_wrapper() {
         let mut error_message =
             Some("Selected model is at capacity. Please try a different model.".to_string());
@@ -9670,6 +9705,21 @@ mod tests {
             error_message.as_deref(),
             Some("Selected model is at capacity. Please try a different model.")
         );
+    }
+
+    #[test]
+    fn codex_error_recording_keeps_pending_tool_failure_over_later_eof() {
+        let mut error_message = Some(format!(
+            "{CODEX_PENDING_TOOLS_ERROR_PREFIX} (bash): execution outcome unknown"
+        ));
+
+        assert!(!record_codex_error_message(
+            &mut error_message,
+            "Codex app-server stream closed before mission terminated".to_string(),
+        ));
+        assert!(error_message
+            .as_deref()
+            .is_some_and(|message| message.starts_with(CODEX_PENDING_TOOLS_ERROR_PREFIX)));
     }
 
     #[test]

--- a/src/api/runners/codex.rs
+++ b/src/api/runners/codex.rs
@@ -21,12 +21,7 @@ use crate::workspace_exec::WorkspaceExec;
 /// Stable Codex transport failures emitted by the app-server/ChatGPT stream.
 /// Keep this narrow so ordinary model or tool failures never become retryable.
 fn codex_transport_failure_stage(message: &str, tool_events_seen: usize) -> Option<&'static str> {
-    let lower = message.to_ascii_lowercase();
-    let is_transport = lower.contains("stream disconnected before completion")
-        || lower.contains("error sending request for url")
-        || lower.contains("connection reset by peer")
-        || lower.contains("connection closed before message completed");
-    if !is_transport {
+    if !is_codex_transport_error_message(message) {
         return None;
     }
     Some(if tool_events_seen == 0 {
@@ -34,6 +29,10 @@ fn codex_transport_failure_stage(message: &str, tool_events_seen: usize) -> Opti
     } else {
         "stream"
     })
+}
+
+fn codex_transport_reason_is_retryable(terminal_reason: Option<TerminalReason>) -> bool {
+    matches!(terminal_reason, Some(TerminalReason::LlmError))
 }
 
 fn codex_workspace_home_dir(workspace: &Workspace) -> PathBuf {
@@ -1105,13 +1104,15 @@ pub async fn run_codex_turn(
                 TerminalReason::LlmError
             };
             let mut result = AgentResult::failure(message.clone(), 0).with_terminal_reason(reason);
-            if let Some(stage) = codex_transport_failure_stage(&message, 0) {
-                result = result.with_data(serde_json::json!({
-                    "provider_error_source": "codex_app_server",
-                    "transport_failure_stage": stage,
-                    "failure_class": crate::agents::FailureClass::TransportError,
-                    "classification_source": "structured",
-                }));
+            if codex_transport_reason_is_retryable(Some(reason)) {
+                if let Some(stage) = codex_transport_failure_stage(&message, 0) {
+                    result = result.with_data(serde_json::json!({
+                        "provider_error_source": "codex_app_server",
+                        "transport_failure_stage": stage,
+                        "failure_class": crate::agents::FailureClass::TransportError,
+                        "classification_source": "structured",
+                    }));
+                }
             }
             return result;
         }
@@ -1119,6 +1120,7 @@ pub async fn run_codex_turn(
 
     // Process events until completion or cancellation
     let mut assistant_message = String::new();
+    let mut raw_error_message: Option<String> = None;
     let mut text_delta_coalescer = TextDeltaCoalescer::new();
     let mut text_delta_pending = false;
     let mut success = false;
@@ -1341,6 +1343,7 @@ pub async fn run_codex_turn(
                                 surfaced_message.clone(),
                             );
                             if recorded {
+                                raw_error_message = Some(message.clone());
                                 if pending_tools.is_empty() {
                                     tracing::error!("Codex error: {}", surfaced_message);
                                 } else {
@@ -1498,7 +1501,9 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
 
     let model_for_cost = resolved_model.as_deref();
     let (cost_cents, cost_source) = resolve_cost_cents_and_source(None, model_for_cost, &usage);
-    let codex_transport_stage = codex_transport_failure_stage(&final_message, tool_events_seen);
+    let classification_message = raw_error_message.as_deref().unwrap_or(&final_message);
+    let codex_transport_stage =
+        codex_transport_failure_stage(classification_message, tool_events_seen);
 
     let mut result = if let Some(marker) = cancel_marker {
         // Cancellation outranks success/error classification: keep the partial
@@ -1519,11 +1524,11 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
         // configured account instead of surfacing the bare error.
         let reason = if stopped_before_required_tools || stopped_on_progress_update {
             TerminalReason::Stalled
-        } else if is_capacity_limited_error(&final_message) {
+        } else if is_capacity_limited_error(classification_message) {
             TerminalReason::CapacityLimited
-        } else if is_rate_limited_error(&final_message) {
+        } else if is_rate_limited_error(classification_message) {
             TerminalReason::RateLimited
-        } else if is_auth_error(&final_message) {
+        } else if is_auth_error(classification_message) {
             TerminalReason::AuthError
         } else if stopped_with_pending_tool_error {
             // This is a provider/stream disconnect after Codex emitted tool
@@ -1551,7 +1556,9 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
     if let Some(m) = resolved_model.as_deref() {
         result = result.with_model(m.to_string());
     }
-    if stopped_with_pending_tool_error {
+    if stopped_with_pending_tool_error
+        && codex_transport_reason_is_retryable(result.terminal_reason)
+    {
         let mut pending_tool_names = pending_tools.values().cloned().collect::<Vec<_>>();
         pending_tool_names.sort_unstable();
         pending_tool_names.dedup();
@@ -1562,7 +1569,7 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
             "failure_class": crate::agents::FailureClass::TransportError,
             "classification_source": "structured",
         }));
-    } else if !result.success {
+    } else if !result.success && codex_transport_reason_is_retryable(result.terminal_reason) {
         if let Some(stage) = codex_transport_stage {
             result = result.with_data(serde_json::json!({
                 "provider_error_source": "codex_app_server",
@@ -1578,7 +1585,8 @@ Update it to the latest version (`npm install -g @openai/codex@latest`) and retr
 
 #[cfg(test)]
 mod tests {
-    use super::codex_transport_failure_stage;
+    use super::{codex_transport_failure_stage, codex_transport_reason_is_retryable};
+    use crate::agents::TerminalReason;
 
     #[test]
     fn classifies_codex_stream_disconnect_before_tools() {
@@ -1592,10 +1600,42 @@ mod tests {
     }
 
     #[test]
+    fn classifies_canonical_app_server_eof_signatures() {
+        assert_eq!(
+            codex_transport_failure_stage(
+                "Codex app-server stream closed before responding; no terminal event received",
+                0,
+            ),
+            Some("pre_tool_stream")
+        );
+        assert_eq!(
+            codex_transport_failure_stage(
+                "Codex app-server stream closed before mission terminated",
+                2,
+            ),
+            Some("stream")
+        );
+    }
+
+    #[test]
     fn keeps_ordinary_codex_failures_non_transport() {
         assert_eq!(
             codex_transport_failure_stage("lake build failed with exit status 1", 0),
             None
         );
+    }
+
+    #[test]
+    fn pending_tools_transport_never_overrides_provider_classification() {
+        assert!(codex_transport_reason_is_retryable(Some(
+            TerminalReason::LlmError
+        )));
+        for reason in [
+            TerminalReason::AuthError,
+            TerminalReason::RateLimited,
+            TerminalReason::CapacityLimited,
+        ] {
+            assert!(!codex_transport_reason_is_retryable(Some(reason)));
+        }
     }
 }

--- a/src/backend/codex/mod.rs
+++ b/src/backend/codex/mod.rs
@@ -1223,10 +1223,15 @@ impl AppServerEventTranslator {
                         .get("willRetry")
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
-                    events.push(ExecutionEvent::Error {
-                        message: message.clone(),
-                    });
-                    if !will_retry {
+                    if will_retry {
+                        tracing::warn!(
+                            %message,
+                            "Codex app-server reported a transient error and will retry internally"
+                        );
+                    } else {
+                        events.push(ExecutionEvent::Error {
+                            message: message.clone(),
+                        });
                         terminal = true;
                     }
                 }
@@ -1600,6 +1605,36 @@ mod tests {
         ));
         assert!(translator.pending_tool_ids().is_empty());
         assert!(translator.transport_failures(&interrupted).is_empty());
+    }
+
+    #[test]
+    fn app_server_retrying_error_is_not_exposed_as_terminal() {
+        let mut translator = AppServerEventTranslator::default();
+        let retrying = translator.handle_notification(
+            "error",
+            &json!({
+                "error": {"message": "stream disconnected before completion"},
+                "willRetry": true
+            }),
+            false,
+        );
+        assert!(!retrying.terminal);
+        assert!(retrying.events.is_empty());
+
+        let exhausted = translator.handle_notification(
+            "error",
+            &json!({
+                "error": {"message": "stream disconnected before completion"},
+                "willRetry": false
+            }),
+            false,
+        );
+        assert!(exhausted.terminal);
+        assert!(matches!(
+            exhausted.events.as_slice(),
+            [ExecutionEvent::Error { message }]
+                if message.contains("stream disconnected before completion")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- recognize the canonical Codex app-server EOF errors as structured transport failures
- only attach pending-tool transport metadata to `LlmError`, preserving auth, quota, and capacity classifications
- add regression coverage for both cases

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test api::runners::codex::tests --lib`
- `cargo check --all-targets`

Follow-up to #689 review findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission failure classification, user-visible error text, and retry metadata for Codex runs; scope is limited to transport handling with regression tests.
> 
> **Overview**
> **Hardens how Codex transport/stream failures are detected, surfaced, and classified** so missions retry and report errors more accurately.
> 
> Shared **`is_codex_transport_error_message`** now covers canonical app-server EOF strings (e.g. stream closed before responding or before mission terminated) and replaces duplicated matching in the Codex runner. When the model already produced partial text, transport failures are **appended** to the surfaced message instead of being dropped. **`record_codex_error_message`** no longer lets a later transport EOF **overwrite** a pending-tool failure.
> 
> The Codex runner keeps the **raw** provider error for terminal-reason and transport-stage classification (instead of the composed user-facing string) and only attaches **`FailureClass::TransportError`** metadata when the terminal reason is **`LlmError`**, so auth, rate limit, and capacity outcomes are not mislabeled as retryable transport.
> 
> On the app-server path, notifications with **`willRetry: true`** are logged and **not** emitted as terminal errors until retries are exhausted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b26af187624b6e5ca742c84c08f10afe662d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->