### PR TITLE
Close ChatGPT availability race windows

### DIFF
--- a/src/api/runners/chatgpt_ui/availability.rs
+++ b/src/api/runners/chatgpt_ui/availability.rs
@@ -73,6 +73,7 @@ impl Default for AvailabilityStatus {
 struct Entry {
     status: AvailabilityStatus,
     state_path: PathBuf,
+    profile_dirs: Vec<PathBuf>,
     probe_claimed: bool,
 }
 
@@ -149,7 +150,8 @@ pub fn configure(profile_dirs: &[PathBuf], app_working_dir: &Path) {
     let mut entries = registry()
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
-    if entries.contains_key(&key) {
+    if let Some(entry) = entries.get_mut(&key) {
+        entry.profile_dirs = profile_dirs.to_vec();
         return;
     }
     let status = std::fs::read(&path)
@@ -166,6 +168,7 @@ pub fn configure(profile_dirs: &[PathBuf], app_working_dir: &Path) {
     let mut entry = Entry {
         status,
         state_path: path,
+        profile_dirs: profile_dirs.to_vec(),
         // A process restart cannot inherit ownership of a prior probe.
         probe_claimed: false,
     };
@@ -200,17 +203,22 @@ pub fn is_configured(profile_dirs: &[PathBuf]) -> bool {
 }
 
 pub fn open_cooldown(profile_dir: &Path, reason: AvailabilityReason, cooldown: Duration) {
-    let key = profile_dir
-        .parent()
-        .unwrap_or_else(|| Path::new("/"))
-        .to_path_buf();
     let now = Utc::now();
     let retry_at = now
         + chrono::Duration::from_std(cooldown).unwrap_or_else(|_| chrono::Duration::minutes(10));
     let mut entries = registry()
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
-    let Some(entry) = entries.get_mut(&key) else {
+    // A configured account pool may intentionally use profile directories
+    // from different parents. Resolve the owning pool from the complete
+    // configured membership instead of deriving an incompatible key from the
+    // failing slot alone.
+    let Some(entry) = entries.values_mut().find(|entry| {
+        entry
+            .profile_dirs
+            .iter()
+            .any(|profile| profile == profile_dir)
+    }) else {
         return;
     };
     let was_available = entry.status.state == AvailabilityState::Available;
@@ -404,6 +412,29 @@ mod tests {
 
         assert_eq!(status(&profiles).state, AvailabilityState::Probing);
         assert!(claim_probe(&profiles));
+        reset_for_tests(&profiles);
+    }
+
+    #[test]
+    fn failure_from_a_different_parent_opens_the_configured_pool() {
+        let root = tempfile::tempdir().unwrap();
+        let first = root.path().join("account-a/one");
+        let second = root.path().join("account-b/two");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        let profiles = vec![first, second.clone()];
+        configure(&profiles, root.path());
+        mark_available(&profiles);
+
+        open_cooldown(
+            &second,
+            AvailabilityReason::RateLimited,
+            Duration::from_secs(600),
+        );
+
+        let snapshot = status(&profiles);
+        assert_eq!(snapshot.state, AvailabilityState::Cooldown);
+        assert_eq!(snapshot.reason, Some(AvailabilityReason::RateLimited));
         reset_for_tests(&profiles);
     }
 }

--- a/src/api/runners/chatgpt_ui/availability.rs
+++ b/src/api/runners/chatgpt_ui/availability.rs
@@ -73,7 +73,9 @@ impl Default for AvailabilityStatus {
 struct Entry {
     status: AvailabilityStatus,
     state_path: PathBuf,
-    profile_dirs: Vec<PathBuf>,
+    current_profile_dirs: Vec<PathBuf>,
+    known_profile_dirs: Vec<PathBuf>,
+    known_configurations: Vec<Vec<PathBuf>>,
     probe_claimed: bool,
 }
 
@@ -82,12 +84,16 @@ fn registry() -> &'static Mutex<HashMap<PathBuf, Entry>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn pool_key(profile_dirs: &[PathBuf]) -> Option<PathBuf> {
-    profile_dirs.first().map(|profile| {
-        profile
-            .parent()
-            .unwrap_or_else(|| Path::new("/"))
-            .to_path_buf()
+fn entry_for_profiles_mut<'a>(
+    entries: &'a mut HashMap<PathBuf, Entry>,
+    profile_dirs: &[PathBuf],
+) -> Option<&'a mut Entry> {
+    entries.values_mut().find(|entry| {
+        entry.current_profile_dirs == profile_dirs
+            || entry
+                .known_configurations
+                .iter()
+                .any(|configuration| configuration == profile_dirs)
     })
 }
 
@@ -143,22 +149,30 @@ fn reconcile(entry: &mut Entry, now: DateTime<Utc>) {
 }
 
 pub fn configure(profile_dirs: &[PathBuf], app_working_dir: &Path) {
-    let Some(key) = pool_key(profile_dirs) else {
+    if profile_dirs.is_empty() {
         return;
-    };
+    }
     let path = state_path(app_working_dir);
     let mut entries = registry()
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
-    if let Some(entry) = entries.get_mut(&key) {
+    if let Some(entry) = entries.get_mut(&path) {
         // Retain prior members for the lifetime of this process. A settings
         // refresh can remove a profile while an already-running browser turn
         // still owns it; a later failure from that turn must continue to open
         // the account-wide gate. Process restart naturally clears mappings
         // once no old turns can still report.
+        entry.current_profile_dirs = profile_dirs.to_vec();
+        if !entry
+            .known_configurations
+            .iter()
+            .any(|configuration| configuration == profile_dirs)
+        {
+            entry.known_configurations.push(profile_dirs.to_vec());
+        }
         for profile_dir in profile_dirs {
-            if !entry.profile_dirs.contains(profile_dir) {
-                entry.profile_dirs.push(profile_dir.clone());
+            if !entry.known_profile_dirs.contains(profile_dir) {
+                entry.known_profile_dirs.push(profile_dir.clone());
             }
         }
         return;
@@ -176,8 +190,10 @@ pub fn configure(profile_dirs: &[PathBuf], app_working_dir: &Path) {
         });
     let mut entry = Entry {
         status,
-        state_path: path,
-        profile_dirs: profile_dirs.to_vec(),
+        state_path: path.clone(),
+        current_profile_dirs: profile_dirs.to_vec(),
+        known_profile_dirs: profile_dirs.to_vec(),
+        known_configurations: vec![profile_dirs.to_vec()],
         // A process restart cannot inherit ownership of a prior probe.
         probe_claimed: false,
     };
@@ -185,17 +201,17 @@ pub fn configure(profile_dirs: &[PathBuf], app_working_dir: &Path) {
     if entry.status.state == AvailabilityState::Probing {
         entry.probe_claimed = false;
     }
-    entries.insert(key, entry);
+    entries.insert(path, entry);
 }
 
 pub fn status(profile_dirs: &[PathBuf]) -> AvailabilityStatus {
-    let Some(key) = pool_key(profile_dirs) else {
+    if profile_dirs.is_empty() {
         return AvailabilityStatus::default();
-    };
+    }
     let mut entries = registry()
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
-    let Some(entry) = entries.get_mut(&key) else {
+    let Some(entry) = entry_for_profiles_mut(&mut entries, profile_dirs) else {
         return AvailabilityStatus::default();
     };
     reconcile(entry, Utc::now());
@@ -203,12 +219,13 @@ pub fn status(profile_dirs: &[PathBuf]) -> AvailabilityStatus {
 }
 
 pub fn is_configured(profile_dirs: &[PathBuf]) -> bool {
-    pool_key(profile_dirs).is_some_and(|key| {
-        registry()
+    entry_for_profiles_mut(
+        &mut registry()
             .lock()
-            .expect("ChatGPT UI availability registry poisoned")
-            .contains_key(&key)
-    })
+            .expect("ChatGPT UI availability registry poisoned"),
+        profile_dirs,
+    )
+    .is_some()
 }
 
 pub fn open_cooldown(profile_dir: &Path, reason: AvailabilityReason, cooldown: Duration) {
@@ -222,12 +239,24 @@ pub fn open_cooldown(profile_dir: &Path, reason: AvailabilityReason, cooldown: D
     // from different parents. Resolve the owning pool from the complete
     // configured membership instead of deriving an incompatible key from the
     // failing slot alone.
-    let Some(entry) = entries.values_mut().find(|entry| {
-        entry
-            .profile_dirs
-            .iter()
-            .any(|profile| profile == profile_dir)
-    }) else {
+    let owner = entries
+        .iter()
+        .find(|(_, entry)| {
+            entry
+                .current_profile_dirs
+                .iter()
+                .any(|profile| profile == profile_dir)
+        })
+        .or_else(|| {
+            entries.iter().find(|(_, entry)| {
+                entry
+                    .known_profile_dirs
+                    .iter()
+                    .any(|profile| profile == profile_dir)
+            })
+        })
+        .map(|(key, _)| key.clone());
+    let Some(entry) = owner.and_then(|key| entries.get_mut(&key)) else {
         return;
     };
     let was_available = entry.status.state == AvailabilityState::Available;
@@ -251,13 +280,13 @@ pub fn open_cooldown(profile_dir: &Path, reason: AvailabilityReason, cooldown: D
 }
 
 pub fn claim_probe(profile_dirs: &[PathBuf]) -> bool {
-    let Some(key) = pool_key(profile_dirs) else {
+    if profile_dirs.is_empty() {
         return false;
-    };
+    }
     let mut entries = registry()
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
-    let Some(entry) = entries.get_mut(&key) else {
+    let Some(entry) = entry_for_profiles_mut(&mut entries, profile_dirs) else {
         return false;
     };
     reconcile(entry, Utc::now());
@@ -271,26 +300,25 @@ pub fn claim_probe(profile_dirs: &[PathBuf]) -> bool {
 }
 
 pub fn release_probe(profile_dirs: &[PathBuf]) {
-    let Some(key) = pool_key(profile_dirs) else {
+    if profile_dirs.is_empty() {
         return;
-    };
-    if let Some(entry) = registry()
+    }
+    let mut entries = registry()
         .lock()
-        .expect("ChatGPT UI availability registry poisoned")
-        .get_mut(&key)
-    {
+        .expect("ChatGPT UI availability registry poisoned");
+    if let Some(entry) = entry_for_profiles_mut(&mut entries, profile_dirs) {
         entry.probe_claimed = false;
     }
 }
 
 pub fn mark_available(profile_dirs: &[PathBuf]) {
-    let Some(key) = pool_key(profile_dirs) else {
+    if profile_dirs.is_empty() {
         return;
-    };
+    }
     let mut entries = registry()
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
-    let Some(entry) = entries.get_mut(&key) else {
+    let Some(entry) = entry_for_profiles_mut(&mut entries, profile_dirs) else {
         return;
     };
     let now = Utc::now();
@@ -359,12 +387,10 @@ pub async fn wait_until_available(
 
 #[cfg(test)]
 pub(crate) fn reset_for_tests(profile_dirs: &[PathBuf]) {
-    if let Some(key) = pool_key(profile_dirs) {
-        registry()
-            .lock()
-            .expect("ChatGPT UI availability registry poisoned")
-            .remove(&key);
-    }
+    registry()
+        .lock()
+        .expect("ChatGPT UI availability registry poisoned")
+        .retain(|_, entry| entry.current_profile_dirs != profile_dirs);
 }
 
 #[cfg(test)]
@@ -454,7 +480,9 @@ mod tests {
         let removed = root.path().join("profiles/removed");
         std::fs::create_dir_all(&retained).unwrap();
         std::fs::create_dir_all(&removed).unwrap();
-        let original_profiles = vec![retained.clone(), removed.clone()];
+        // Remove the original first profile so a parent/first-profile-derived
+        // registry identity would change during the refresh.
+        let original_profiles = vec![removed.clone(), retained.clone()];
         configure(&original_profiles, root.path());
         mark_available(&original_profiles);
 
@@ -467,6 +495,10 @@ mod tests {
 
         assert_eq!(
             status(std::slice::from_ref(&retained)).state,
+            AvailabilityState::Cooldown
+        );
+        assert_eq!(
+            status(&original_profiles).state,
             AvailabilityState::Cooldown
         );
         reset_for_tests(std::slice::from_ref(&retained));

--- a/src/api/runners/chatgpt_ui/availability.rs
+++ b/src/api/runners/chatgpt_ui/availability.rs
@@ -151,7 +151,16 @@ pub fn configure(profile_dirs: &[PathBuf], app_working_dir: &Path) {
         .lock()
         .expect("ChatGPT UI availability registry poisoned");
     if let Some(entry) = entries.get_mut(&key) {
-        entry.profile_dirs = profile_dirs.to_vec();
+        // Retain prior members for the lifetime of this process. A settings
+        // refresh can remove a profile while an already-running browser turn
+        // still owns it; a later failure from that turn must continue to open
+        // the account-wide gate. Process restart naturally clears mappings
+        // once no old turns can still report.
+        for profile_dir in profile_dirs {
+            if !entry.profile_dirs.contains(profile_dir) {
+                entry.profile_dirs.push(profile_dir.clone());
+            }
+        }
         return;
     }
     let status = std::fs::read(&path)
@@ -436,5 +445,30 @@ mod tests {
         assert_eq!(snapshot.state, AvailabilityState::Cooldown);
         assert_eq!(snapshot.reason, Some(AvailabilityReason::RateLimited));
         reset_for_tests(&profiles);
+    }
+
+    #[test]
+    fn settings_refresh_retains_profiles_owned_by_in_flight_turns() {
+        let root = tempfile::tempdir().unwrap();
+        let retained = root.path().join("profiles/retained");
+        let removed = root.path().join("profiles/removed");
+        std::fs::create_dir_all(&retained).unwrap();
+        std::fs::create_dir_all(&removed).unwrap();
+        let original_profiles = vec![retained.clone(), removed.clone()];
+        configure(&original_profiles, root.path());
+        mark_available(&original_profiles);
+
+        configure(std::slice::from_ref(&retained), root.path());
+        open_cooldown(
+            &removed,
+            AvailabilityReason::RateLimited,
+            Duration::from_secs(600),
+        );
+
+        assert_eq!(
+            status(std::slice::from_ref(&retained)).state,
+            AvailabilityState::Cooldown
+        );
+        reset_for_tests(std::slice::from_ref(&retained));
     }
 }

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -375,6 +375,36 @@ fn validated_settings(app_working_dir: &Path) -> Result<Settings, String> {
 
 const RECOVERY_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
+async fn wait_for_available_launch_turn(
+    settings: &Settings,
+    mission_id: Uuid,
+    events_tx: &broadcast::Sender<AgentEvent>,
+    cancel: &CancellationToken,
+) -> Result<u64, AgentResult> {
+    loop {
+        availability::wait_until_available(&settings.profile_dirs, mission_id, events_tx, cancel)
+            .await?;
+        let transition_id = availability::status(&settings.profile_dirs).transition_id;
+        profile_pool::wait_for_launch_turn(
+            &settings.profile_dirs[0],
+            settings.launch_interval,
+            mission_id,
+            events_tx,
+            cancel,
+        )
+        .await?;
+        let after_pacing = availability::status(&settings.profile_dirs);
+        if after_pacing.state == availability::AvailabilityState::Available
+            && after_pacing.transition_id == transition_id
+        {
+            return Ok(transition_id);
+        }
+        // A cooldown opened while this mission waited for its launch turn.
+        // Discard that reservation and repeat availability plus pacing so a
+        // recovered queue cannot bypass account-wide launch spacing.
+    }
+}
+
 /// Start the single backend-wide recovery worker. Cooldown expiry only makes a
 /// probe eligible; this worker is the sole path that can mark the backend
 /// available again without submitting user content.
@@ -590,27 +620,14 @@ pub async fn run_chatgpt_ui_turn(
     // This gate is deliberately before both normal and pinned acquisition.
     // A durable continuation must not bypass an account-wide cooldown merely
     // because it already owns a conversation route.
-    if let Err(result) =
-        availability::wait_until_available(&settings.profile_dirs, mission_id, &events_tx, &cancel)
-            .await
-    {
-        return result;
-    }
-    let paced_transition_id = availability::status(&settings.profile_dirs).transition_id;
     // The configured profiles share one ChatGPT account in normal
     // deployments. Pace navigation/submission starts for that account pool;
     // already-running Pro conversations remain fully concurrent.
-    if let Err(result) = profile_pool::wait_for_launch_turn(
-        &settings.profile_dirs[0],
-        settings.launch_interval,
-        mission_id,
-        &events_tx,
-        &cancel,
-    )
-    .await
-    {
-        return result;
-    }
+    let paced_transition_id =
+        match wait_for_available_launch_turn(&settings, mission_id, &events_tx, &cancel).await {
+            Ok(transition_id) => transition_id,
+            Err(result) => return result,
+        };
     // Conversations are account-scoped: a resume must reuse the profile
     // that submitted the prompt, or give up on the pointer entirely. The
     // pinned path locks the slot directly instead of going through the
@@ -661,14 +678,8 @@ pub async fn run_chatgpt_ui_turn(
     // reserve a fresh launch turn whenever the availability generation changed
     // and preserve account-wide spacing after the probe succeeds.
     if availability::status(&settings.profile_dirs).transition_id != paced_transition_id {
-        if let Err(result) = profile_pool::wait_for_launch_turn(
-            &settings.profile_dirs[0],
-            settings.launch_interval,
-            mission_id,
-            &events_tx,
-            &cancel,
-        )
-        .await
+        if let Err(result) =
+            wait_for_available_launch_turn(&settings, mission_id, &events_tx, &cancel).await
         {
             return result;
         }

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -624,9 +624,15 @@ pub async fn run_chatgpt_ui_turn(
         {
             Some(index) => {
                 let pinned = settings.profile_dirs[index].clone();
-                acquire_pinned_profile(&pinned, mission_id, &events_tx, &cancel)
-                    .await
-                    .map(|lock| (index, pinned, lock))
+                acquire_pinned_profile(
+                    &settings.profile_dirs,
+                    &pinned,
+                    mission_id,
+                    &events_tx,
+                    &cancel,
+                )
+                .await
+                .map(|lock| (index, pinned, lock))
             }
             None => {
                 jobs::note_attempt_error(app_working_dir, mission_id, "profile_unavailable");
@@ -640,6 +646,15 @@ pub async fn run_chatgpt_ui_turn(
         Ok(lease) => lease,
         Err(result) => return result,
     };
+    // Close the launch-pacing/acquisition window too. Holding the profile lock
+    // here prevents this turn from losing its lease while a newly opened
+    // account cooldown blocks it before browser launch.
+    if let Err(result) =
+        availability::wait_until_available(&settings.profile_dirs, mission_id, &events_tx, &cancel)
+            .await
+    {
+        return result;
+    }
     if settings.browser == "chromium" {
         let owned = chromium_cleanup::pool_owns_singletons(&profile_dir);
         let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, owned);
@@ -725,6 +740,7 @@ fn unresolved_resume_result(code: &str) -> AgentResult {
 /// health routing does not apply — either this slot frees up or the caller
 /// gives up via cancellation.
 async fn acquire_pinned_profile(
+    profile_dirs: &[PathBuf],
     profile_dir: &Path,
     mission_id: Uuid,
     events_tx: &broadcast::Sender<AgentEvent>,
@@ -732,8 +748,16 @@ async fn acquire_pinned_profile(
 ) -> Result<profile_pool::ProfileLock, AgentResult> {
     let mut announced_wait = false;
     loop {
+        availability::wait_until_available(profile_dirs, mission_id, events_tx, cancel).await?;
         match profile_pool::try_lock_profile(profile_dir) {
-            Ok(Some(lock)) => return Ok(lock),
+            Ok(Some(lock)) => {
+                if availability::status(profile_dirs).state
+                    == availability::AvailabilityState::Available
+                {
+                    return Ok(lock);
+                }
+                drop(lock);
+            }
             Ok(None) => {}
             Err(error) => {
                 // The record stays Submitted, so a later turn can still

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -623,67 +623,63 @@ pub async fn run_chatgpt_ui_turn(
     // The configured profiles share one ChatGPT account in normal
     // deployments. Pace navigation/submission starts for that account pool;
     // already-running Pro conversations remain fully concurrent.
-    let paced_transition_id =
-        match wait_for_available_launch_turn(&settings, mission_id, &events_tx, &cancel).await {
-            Ok(transition_id) => transition_id,
-            Err(result) => return result,
-        };
     // Conversations are account-scoped: a resume must reuse the profile
     // that submitted the prompt, or give up on the pointer entirely. The
     // pinned path locks the slot directly instead of going through the
     // pool scan — quarantine and retry-slot exclusions must not reroute a
     // reattach to an account that cannot see the conversation.
     let pinned_record = attempt_resume.as_ref().or(attempt_continuation.as_ref());
-    let acquisition = if let Some(record) = pinned_record {
-        match settings
-            .profile_dirs
-            .iter()
-            .position(|dir| profile_basename(dir) == record.profile)
+    let (profile_slot, profile_dir, _profile_lock) = loop {
+        let paced_transition_id = match wait_for_available_launch_turn(
+            &settings, mission_id, &events_tx, &cancel,
+        )
+        .await
         {
-            Some(index) => {
-                let pinned = settings.profile_dirs[index].clone();
-                acquire_pinned_profile(
-                    &settings.profile_dirs,
-                    &pinned,
-                    mission_id,
-                    &events_tx,
-                    &cancel,
-                )
+            Ok(transition_id) => transition_id,
+            Err(result) => return result,
+        };
+        let acquisition = if let Some(record) = pinned_record {
+            match settings
+                .profile_dirs
+                .iter()
+                .position(|dir| profile_basename(dir) == record.profile)
+            {
+                Some(index) => {
+                    let pinned = settings.profile_dirs[index].clone();
+                    acquire_pinned_profile(
+                        &settings.profile_dirs,
+                        &pinned,
+                        mission_id,
+                        &events_tx,
+                        &cancel,
+                    )
+                    .await
+                    .map(|lock| (index, pinned, lock))
+                }
+                None => {
+                    jobs::note_attempt_error(app_working_dir, mission_id, "profile_unavailable");
+                    return unresolved_resume_result("profile_unavailable");
+                }
+            }
+        } else {
+            profile_pool::acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel)
                 .await
-                .map(|lock| (index, pinned, lock))
-            }
-            None => {
-                jobs::note_attempt_error(app_working_dir, mission_id, "profile_unavailable");
-                return unresolved_resume_result("profile_unavailable");
-            }
-        }
-    } else {
-        profile_pool::acquire_profile(&settings.profile_dirs, mission_id, &events_tx, &cancel).await
-    };
-    let (profile_slot, profile_dir, _profile_lock) = match acquisition {
-        Ok(lease) => lease,
-        Err(result) => return result,
-    };
-    // Close the launch-pacing/acquisition window too. Holding the profile lock
-    // here prevents this turn from losing its lease while a newly opened
-    // account cooldown blocks it before browser launch.
-    if let Err(result) =
-        availability::wait_until_available(&settings.profile_dirs, mission_id, &events_tx, &cancel)
-            .await
-    {
-        return result;
-    }
-    // Missions may already have reserved launch turns when another browser
-    // opens a cooldown. Recovery wakes those queued acquisitions together, so
-    // reserve a fresh launch turn whenever the availability generation changed
-    // and preserve account-wide spacing after the probe succeeds.
-    if availability::status(&settings.profile_dirs).transition_id != paced_transition_id {
-        if let Err(result) =
-            wait_for_available_launch_turn(&settings, mission_id, &events_tx, &cancel).await
+        };
+        let lease = match acquisition {
+            Ok(lease) => lease,
+            Err(result) => return result,
+        };
+        let after_acquisition = availability::status(&settings.profile_dirs);
+        if after_acquisition.state == availability::AvailabilityState::Available
+            && after_acquisition.transition_id == paced_transition_id
         {
-            return result;
+            break lease;
         }
-    }
+        // Never hold a profile while waiting for recovery: the single-flight
+        // probe may need this exact slot to reopen the backend. Dropping the
+        // lease before the next loop also forces fresh launch pacing.
+        drop(lease);
+    };
     if settings.browser == "chromium" {
         let owned = chromium_cleanup::pool_owns_singletons(&profile_dir);
         let outcome = chromium_cleanup::cleanup_profile_singletons(&profile_dir, owned);

--- a/src/api/runners/chatgpt_ui/mod.rs
+++ b/src/api/runners/chatgpt_ui/mod.rs
@@ -596,6 +596,7 @@ pub async fn run_chatgpt_ui_turn(
     {
         return result;
     }
+    let paced_transition_id = availability::status(&settings.profile_dirs).transition_id;
     // The configured profiles share one ChatGPT account in normal
     // deployments. Pace navigation/submission starts for that account pool;
     // already-running Pro conversations remain fully concurrent.
@@ -654,6 +655,23 @@ pub async fn run_chatgpt_ui_turn(
             .await
     {
         return result;
+    }
+    // Missions may already have reserved launch turns when another browser
+    // opens a cooldown. Recovery wakes those queued acquisitions together, so
+    // reserve a fresh launch turn whenever the availability generation changed
+    // and preserve account-wide spacing after the probe succeeds.
+    if availability::status(&settings.profile_dirs).transition_id != paced_transition_id {
+        if let Err(result) = profile_pool::wait_for_launch_turn(
+            &settings.profile_dirs[0],
+            settings.launch_interval,
+            mission_id,
+            &events_tx,
+            &cancel,
+        )
+        .await
+        {
+            return result;
+        }
     }
     if settings.browser == "chromium" {
         let owned = chromium_cleanup::pool_owns_singletons(&profile_dir);

--- a/src/api/runners/chatgpt_ui/profile_pool.rs
+++ b/src/api/runners/chatgpt_ui/profile_pool.rs
@@ -444,6 +444,10 @@ pub async fn acquire_profile(
         .remove(&mission_id);
     let mut announced_wait = false;
     loop {
+        // Availability can change while this mission is queued behind launch
+        // pacing or another profile lease. Recheck on every acquisition pass,
+        // not only once at the start of the turn.
+        availability::wait_until_available(profile_dirs, mission_id, events_tx, cancel).await?;
         let now = Instant::now();
         let mut candidates = profile_dirs.iter().enumerate().collect::<Vec<_>>();
         // A compatibility failure is not quarantined until it repeats, but a
@@ -465,7 +469,13 @@ pub async fn acquire_profile(
                 continue;
             }
             match try_lock_profile(profile_dir) {
-                Ok(Some(lock)) => return Ok((slot, profile_dir.clone(), lock)),
+                Ok(Some(lock)) => {
+                    if availability::status(profile_dirs).state == AvailabilityState::Available {
+                        return Ok((slot, profile_dir.clone(), lock));
+                    }
+                    drop(lock);
+                    break;
+                }
                 Ok(None) => {}
                 Err(error) => {
                     // A broken lock path is local to this profile. Keep the
@@ -672,6 +682,51 @@ mod tests {
 
         assert_eq!(slot, 1);
         assert_eq!(selected, second_profile);
+    }
+
+    #[tokio::test]
+    async fn queued_acquisition_rechecks_a_new_backend_cooldown() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join("profile-1");
+        std::fs::create_dir(&profile).unwrap();
+        let profiles = vec![profile.clone()];
+        reset_registry_for_tests(&profiles);
+        availability::configure(&profiles, root.path());
+        availability::mark_available(&profiles);
+        let busy_lease = try_lock_profile(&profile).unwrap().unwrap();
+        let (events_tx, _) = broadcast::channel(8);
+        let cancel = CancellationToken::new();
+        let acquire_cancel = cancel.clone();
+        let acquire_profiles = profiles.clone();
+
+        let acquisition = tokio::spawn(async move {
+            acquire_profile(
+                &acquire_profiles,
+                Uuid::new_v4(),
+                &events_tx,
+                &acquire_cancel,
+            )
+            .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        availability::open_cooldown(
+            &profile,
+            AvailabilityReason::RateLimited,
+            Duration::from_secs(600),
+        );
+        drop(busy_lease);
+
+        tokio::time::sleep(Duration::from_millis(2200)).await;
+        assert!(!acquisition.is_finished());
+
+        availability::mark_available(&profiles);
+        let (_, selected, _lease) = tokio::time::timeout(Duration::from_secs(3), acquisition)
+            .await
+            .expect("acquisition should finish after recovery")
+            .expect("acquisition task should not panic")
+            .expect("profile should be selected after recovery");
+        assert_eq!(selected, profile);
+        reset_registry_for_tests(&profiles);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #691 for two review findings that arrived at merge time:

- resolve cooldown ownership from the complete configured profile membership, including profiles under different parent directories
- recheck availability in normal and pinned acquisition loops and once more while holding the selected lease after launch pacing
- add regressions for cross-parent cooldown propagation and a cooldown opening while acquisition is queued

## Validation

- cargo fmt --all --check
- cargo test api::runners::chatgpt_ui::availability::tests
- cargo test queued_acquisition_rechecks_a_new_backend_cooldown
- cargo clippy --all-targets -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and gating around browser profile acquisition and account-wide cooldowns; incorrect behavior could block launches or allow traffic during cooldown, but regressions are covered by new tests.
> 
> **Overview**
> Tightens **ChatGPT UI account-wide availability** so cooldowns and recovery cannot be skipped or mis-attributed when profile layout or timing changes.
> 
> **Availability registry** no longer keys pools by the first profile’s parent directory. Entries are keyed by persisted state path and track **current**, **known**, and **historical** profile sets so `open_cooldown` applies to the right pool when profiles live under different parents or a settings refresh drops a slot while an in-flight turn still uses it.
> 
> **Turn startup** wraps availability wait, launch pacing, and profile acquisition in loops that compare `transition_id` before and after each step. If a cooldown opens mid-wait or mid-lease, the mission **drops the lease** and retries instead of launching on a closed backend or holding a slot the recovery probe needs.
> 
> **Profile pool** re-runs `wait_until_available` on every acquisition attempt and only returns a lock when availability is still `Available`; pinned resume acquisition follows the same rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277d5755edfe199fd1c1c449a7680d2ee45a2e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->