### PR TITLE
fix(chatgpt-ui): tolerate delayed picker hydration

### DIFF
--- a/scripts/chatgpt_ui_driver.py
+++ b/scripts/chatgpt_ui_driver.py
@@ -20,7 +20,11 @@ COMPAT_VERSION = "chatgpt-ui-v2"
 CHATGPT_URL = "https://chatgpt.com/"
 MAX_DOWNLOAD_FILES = 8
 MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
-MODEL_PICKER_READY_TIMEOUT_MS = 15_000
+# Account/bootstrap hydration can lag substantially behind the composer on the
+# current ChatGPT shell.  Keep this bounded, but do not classify a healthy
+# account as UI-incompatible merely because the intelligence pill missed the
+# old 15-second window.
+MODEL_PICKER_READY_TIMEOUT_MS = 45_000
 SEND_CONTROL_TESTIDS = (
     '[data-testid="send-button"]',
     '[data-testid="composer-send-button"]',
@@ -236,9 +240,11 @@ async def choose_intelligence_model(page, label: str) -> bool:
     # textbox can be ready several seconds before the model pill is attached.
     # Wait for the composer-scoped control instead of snapshotting its count
     # immediately and incorrectly falling back to the legacy model picker.
-    picker_buttons = page.locator(
-        'form button.__composer-pill[aria-haspopup="menu"]:visible'
-    )
+    # Scope to the composer and require a menu-bearing button, but do not
+    # depend on ChatGPT's private ``__composer-pill`` CSS class.  The visible
+    # label is still checked against the strict intelligence allowlist below,
+    # so unrelated composer menus cannot be selected.
+    picker_buttons = page.locator('form button[aria-haspopup="menu"]:visible')
     try:
         await picker_buttons.first.wait_for(
             state="visible", timeout=MODEL_PICKER_READY_TIMEOUT_MS

--- a/scripts/test_chatgpt_ui_driver.py
+++ b/scripts/test_chatgpt_ui_driver.py
@@ -274,7 +274,7 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertEqual(model_selection("gpt-5.6-pro"), ("Pro", "gpt-5.6-pro"))
         self.assertEqual(model_selection("GPT-5.6 Pro"), ("Pro", "gpt-5.6-pro"))
         self.assertEqual(model_selection("Extra High"), ("Extra High", "Extra High"))
-        self.assertGreaterEqual(MODEL_PICKER_READY_TIMEOUT_MS, 10_000)
+        self.assertGreaterEqual(MODEL_PICKER_READY_TIMEOUT_MS, 45_000)
 
     def test_model_picker_waits_for_hydration_and_accepts_current_selection(
         self,
@@ -287,7 +287,7 @@ class ChatGptUiDriverTests(unittest.TestCase):
         self.assertTrue(selected)
         self.assertEqual(
             page.selector,
-            'form button.__composer-pill[aria-haspopup="menu"]:visible',
+            'form button[aria-haspopup="menu"]:visible',
         )
         self.assertEqual(
             button.wait_timeout, ("visible", MODEL_PICKER_READY_TIMEOUT_MS)


### PR DESCRIPTION
## What changed

- waits up to 45 seconds for the current composer intelligence picker to hydrate
- scopes picker discovery to menu-bearing buttons inside the composer without depending on ChatGPT's private CSS class
- keeps exact allowlisted intelligence labels, including `Pro`

## Root cause

The EVMYulLean mission was the only active ChatGPT UI mission at failure time. The authenticated blank page and composer loaded successfully, but the intelligence picker did not appear inside the prior 15-second window. The driver then tried the legacy picker and reported a misleading `model_selection` compatibility failure. Historical per-slot failure markers made this look like 11 simultaneous incompatible sessions even though there was no slot saturation.

## Impact

Slow or staged ChatGPT UI hydration no longer turns a healthy Pro account into an immediate compatibility failure, and a CSS-class rename will not break the scoped picker lookup.

## Validation

- `python3 -m unittest scripts.test_chatgpt_ui_driver` (19 passed)
- `cargo fmt --all --check`
- `git diff --check`
- read-only production probe confirmed the current picker exposes `Instant`, `Medium`, `High`, `Extra High`, `Pro`, and `GPT-5.6 Sol`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded automation timeout and selector tweak in the ChatGPT UI driver only; label allowlist unchanged.
> 
> **Overview**
> The ChatGPT UI driver now waits **45 seconds** (up from 15) for the composer intelligence pill to appear before treating the session as picker-not-ready and falling back to the legacy model path.
> 
> Picker discovery uses **`form button[aria-haspopup="menu"]:visible`** instead of requiring ChatGPT’s private `__composer-pill` class; selection is still limited to the existing **INTELLIGENCE_LABELS** allowlist (including **Pro**), so unrelated composer menus should not be chosen.
> 
> Unit tests assert the new timeout floor and locator string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5934d32ac98e2ae4e38493e499010aaf6686a63a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->