### PR TITLE
Add server-controlled merge authority to Hermes missions

### DIFF
--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -159,13 +159,6 @@ struct StartMissionParams {
     /// server derives grants only from its operator-owned environment.
     #[serde(default)]
     request_merge_authority: Option<bool>,
-    /// Injected by the Hermes MCP client. Deliberately absent from the public
-    /// tool schema so the model cannot choose its own provenance.
-    #[serde(default)]
-    origin_session_id: Option<String>,
-    /// Injected alongside `origin_session_id` for channel-level attribution.
-    #[serde(default)]
-    origin_platform: Option<String>,
     #[serde(default)]
     tags: Option<Vec<String>>,
     #[serde(default)]
@@ -190,8 +183,6 @@ fn mission_start_tags(
     tags: Option<Vec<String>>,
     request_merge_authority: bool,
     github_pr: Option<&str>,
-    origin_session_id: Option<&str>,
-    origin_platform: Option<&str>,
     merge_grant: Option<&MergeGrantConfig>,
 ) -> Result<Vec<String>, String> {
     let mut tags: Vec<String> = tags
@@ -209,21 +200,6 @@ fn mission_start_tags(
             && !tag.starts_with("origin-platform:")
     });
     tags.push("origin:hermes-assistant".to_string());
-    for (prefix, value) in [
-        ("origin-session", origin_session_id),
-        ("origin-platform", origin_platform),
-    ] {
-        if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
-            if value.len() <= 128
-                && value.chars().all(|character| {
-                    character.is_ascii_alphanumeric()
-                        || matches!(character, '-' | '_' | ':' | '/' | '#' | '.')
-                })
-            {
-                tags.push(format!("{prefix}:{value}"));
-            }
-        }
-    }
 
     if !request_merge_authority {
         return Ok(tags);
@@ -1612,8 +1588,6 @@ impl AssistantMcp {
             params.tags,
             params.request_merge_authority.unwrap_or(false),
             params.github_pr.as_deref(),
-            params.origin_session_id.as_deref(),
-            params.origin_platform.as_deref(),
             MergeGrantConfig::from_environment().as_ref(),
         )?;
         let body = json!({
@@ -3588,8 +3562,6 @@ mod tests {
             ]),
             true,
             Some("lfglabs-dev/verity#2209"),
-            Some("20260729_080825_2df2a0"),
-            Some("desktop"),
             Some(&grant),
         )
         .unwrap();
@@ -3599,8 +3571,6 @@ mod tests {
             vec![
                 "verity",
                 "origin:hermes-assistant",
-                "origin-session:20260729_080825_2df2a0",
-                "origin-platform:desktop",
                 "merge-authority:granted",
                 "merge-authority-source:owner-standing-grant-2026-07-29",
                 "merge-authority-target:lfglabs-dev/verity#2209"
@@ -3614,13 +3584,9 @@ mod tests {
             authority_source: "owner-grant".to_string(),
             repositories: vec!["owner/repo".to_string()],
         };
-        assert!(mission_start_tags(None, true, Some("owner/repo#1"), None, None, None).is_err());
-        assert!(
-            mission_start_tags(None, true, Some("owner/repo"), None, None, Some(&grant)).is_err()
-        );
-        assert!(
-            mission_start_tags(None, true, Some("other/repo#1"), None, None, Some(&grant)).is_err()
-        );
+        assert!(mission_start_tags(None, true, Some("owner/repo#1"), None).is_err());
+        assert!(mission_start_tags(None, true, Some("owner/repo"), Some(&grant)).is_err());
+        assert!(mission_start_tags(None, true, Some("other/repo#1"), Some(&grant)).is_err());
         let tags = mission_start_tags(
             Some(vec![
                 "merge-authority:granted".to_string(),
@@ -3628,8 +3594,6 @@ mod tests {
             ]),
             false,
             Some("owner/repo#1"),
-            None,
-            None,
             Some(&grant),
         )
         .unwrap();

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -182,6 +182,7 @@ fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
 fn mission_start_tags(
     tags: Option<Vec<String>>,
     request_merge_authority: bool,
+    writer: bool,
     github_pr: Option<&str>,
     merge_grant: Option<&MergeGrantConfig>,
 ) -> Result<Vec<String>, String> {
@@ -203,6 +204,11 @@ fn mission_start_tags(
 
     if !request_merge_authority {
         return Ok(tags);
+    }
+    if !writer {
+        return Err(
+            "merge authority requires writer=true so the PR writer lease is held".to_string(),
+        );
     }
     let github_pr = github_pr
         .map(str::trim)
@@ -1587,6 +1593,7 @@ impl AssistantMcp {
         let tags = mission_start_tags(
             params.tags,
             params.request_merge_authority.unwrap_or(false),
+            params.writer.unwrap_or(false),
             params.github_pr.as_deref(),
             MergeGrantConfig::from_environment().as_ref(),
         )?;
@@ -3561,6 +3568,7 @@ mod tests {
                 " origin:hermes-assistant ".to_string(),
             ]),
             true,
+            true,
             Some("lfglabs-dev/verity#2209"),
             Some(&grant),
         )
@@ -3584,14 +3592,16 @@ mod tests {
             authority_source: "owner-grant".to_string(),
             repositories: vec!["owner/repo".to_string()],
         };
-        assert!(mission_start_tags(None, true, Some("owner/repo#1"), None).is_err());
-        assert!(mission_start_tags(None, true, Some("owner/repo"), Some(&grant)).is_err());
-        assert!(mission_start_tags(None, true, Some("other/repo#1"), Some(&grant)).is_err());
+        assert!(mission_start_tags(None, true, true, Some("owner/repo#1"), None).is_err());
+        assert!(mission_start_tags(None, true, true, Some("owner/repo"), Some(&grant)).is_err());
+        assert!(mission_start_tags(None, true, true, Some("other/repo#1"), Some(&grant)).is_err());
+        assert!(mission_start_tags(None, true, false, Some("owner/repo#1"), Some(&grant)).is_err());
         let tags = mission_start_tags(
             Some(vec![
                 "merge-authority:granted".to_string(),
                 "merge-authority-source:spoofed".to_string(),
             ]),
+            false,
             false,
             Some("owner/repo#1"),
             Some(&grant),

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -162,6 +162,13 @@ struct StartMissionParams {
     /// Durable owner/campaign grant that authorizes `may_merge=true`.
     #[serde(default)]
     merge_authority_source: Option<String>,
+    /// Injected by the Hermes MCP client. Deliberately absent from the public
+    /// tool schema so the model cannot choose its own provenance.
+    #[serde(default)]
+    origin_session_id: Option<String>,
+    /// Injected alongside `origin_session_id` for channel-level attribution.
+    #[serde(default)]
+    origin_platform: Option<String>,
     #[serde(default)]
     tags: Option<Vec<String>>,
     #[serde(default)]
@@ -187,6 +194,8 @@ fn mission_start_tags(
     may_merge: bool,
     merge_authority_source: Option<&str>,
     github_pr: Option<&str>,
+    origin_session_id: Option<&str>,
+    origin_platform: Option<&str>,
 ) -> Result<Vec<String>, String> {
     let mut tags: Vec<String> = tags
         .unwrap_or_default()
@@ -198,8 +207,25 @@ fn mission_start_tags(
         tag != "origin:hermes-assistant"
             && tag != "merge-authority:granted"
             && !tag.starts_with("merge-authority-source:")
+            && !tag.starts_with("origin-session:")
+            && !tag.starts_with("origin-platform:")
     });
     tags.push("origin:hermes-assistant".to_string());
+    for (prefix, value) in [
+        ("origin-session", origin_session_id),
+        ("origin-platform", origin_platform),
+    ] {
+        if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+            if value.len() <= 128
+                && value.chars().all(|character| {
+                    character.is_ascii_alphanumeric()
+                        || matches!(character, '-' | '_' | ':' | '/' | '#' | '.')
+                })
+            {
+                tags.push(format!("{prefix}:{value}"));
+            }
+        }
+    }
 
     let authority_source = merge_authority_source
         .map(str::trim)
@@ -1524,6 +1550,8 @@ impl AssistantMcp {
             params.may_merge.unwrap_or(false),
             params.merge_authority_source.as_deref(),
             params.github_pr.as_deref(),
+            params.origin_session_id.as_deref(),
+            params.origin_platform.as_deref(),
         )?;
         let body = json!({
             "title": params.title,
@@ -3494,6 +3522,8 @@ mod tests {
             true,
             Some("owner-standing-grant-2026-07-29"),
             Some("lfglabs-dev/verity#2209"),
+            Some("20260729_080825_2df2a0"),
+            Some("desktop"),
         )
         .unwrap();
 
@@ -3502,6 +3532,8 @@ mod tests {
             vec![
                 "verity",
                 "origin:hermes-assistant",
+                "origin-session:20260729_080825_2df2a0",
+                "origin-platform:desktop",
                 "merge-authority:granted",
                 "merge-authority-source:owner-standing-grant-2026-07-29"
             ]
@@ -3510,12 +3542,26 @@ mod tests {
 
     #[test]
     fn mission_start_tags_reject_ambiguous_merge_authority() {
-        assert!(mission_start_tags(None, true, None, Some("owner/repo#1")).is_err());
-        assert!(mission_start_tags(None, true, Some("owner grant"), Some("owner/repo#1")).is_err());
-        assert!(mission_start_tags(None, true, Some("owner-grant"), None).is_err());
-        assert!(
-            mission_start_tags(None, false, Some("owner-grant"), Some("owner/repo#1")).is_err()
-        );
+        assert!(mission_start_tags(None, true, None, Some("owner/repo#1"), None, None).is_err());
+        assert!(mission_start_tags(
+            None,
+            true,
+            Some("owner grant"),
+            Some("owner/repo#1"),
+            None,
+            None
+        )
+        .is_err());
+        assert!(mission_start_tags(None, true, Some("owner-grant"), None, None, None).is_err());
+        assert!(mission_start_tags(
+            None,
+            false,
+            Some("owner-grant"),
+            Some("owner/repo#1"),
+            None,
+            None
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -155,6 +155,11 @@ struct StartMissionParams {
     github_pr: Option<String>,
     #[serde(default)]
     writer: Option<bool>,
+    /// Model-visible request for merge capability. It is not authority: a
+    /// trusted Hermes client must independently inject `may_merge` and the
+    /// configured grant source.
+    #[serde(default)]
+    request_merge_authority: Option<bool>,
     /// Whether this mission may perform the final guarded PR merge. Branch
     /// write ownership and merge authority are deliberately separate.
     #[serde(default)]
@@ -191,6 +196,7 @@ fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
 
 fn mission_start_tags(
     tags: Option<Vec<String>>,
+    request_merge_authority: bool,
     may_merge: bool,
     merge_authority_source: Option<&str>,
     github_pr: Option<&str>,
@@ -207,6 +213,7 @@ fn mission_start_tags(
         tag != "origin:hermes-assistant"
             && tag != "merge-authority:granted"
             && !tag.starts_with("merge-authority-source:")
+            && !tag.starts_with("merge-authority-target:")
             && !tag.starts_with("origin-session:")
             && !tag.starts_with("origin-platform:")
     });
@@ -230,6 +237,12 @@ fn mission_start_tags(
     let authority_source = merge_authority_source
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    if request_merge_authority && !may_merge {
+        return Err(
+            "merge authority was requested but not granted by the trusted Hermes client"
+                .to_string(),
+        );
+    }
     if !may_merge {
         if authority_source.is_some() {
             return Err("merge_authority_source requires may_merge=true".to_string());
@@ -237,9 +250,12 @@ fn mission_start_tags(
         return Ok(tags);
     }
 
-    if github_pr.is_none_or(|value| value.trim().is_empty()) {
-        return Err("may_merge=true requires github_pr".to_string());
-    }
+    let github_pr = github_pr
+        .map(str::trim)
+        .filter(|value| canonical_github_pr_ref(value))
+        .ok_or_else(|| {
+            "may_merge=true requires github_pr in owner/repository#123 form".to_string()
+        })?;
     let authority_source = authority_source
         .ok_or_else(|| "may_merge=true requires merge_authority_source".to_string())?;
     if authority_source.len() > 128
@@ -252,7 +268,29 @@ fn mission_start_tags(
     }
     tags.push("merge-authority:granted".to_string());
     tags.push(format!("merge-authority-source:{authority_source}"));
+    tags.push(format!("merge-authority-target:{github_pr}"));
     Ok(tags)
+}
+
+fn canonical_github_pr_ref(value: &str) -> bool {
+    let Some((repository, number)) = value.split_once('#') else {
+        return false;
+    };
+    if number.is_empty() || !number.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    let mut parts = repository.split('/');
+    let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    let valid_component = |component: &str| {
+        !component.is_empty()
+            && component.len() <= 100
+            && component
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    };
+    valid_component(owner) && valid_component(repo)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1045,8 +1083,7 @@ impl AssistantMcp {
                         "intent": {"type": "string", "description": "Intent (e.g. \"review_merge_pr\")."},
                         "github_pr": {"type": "string", "description": "Associated PR ref (e.g. \"owner/repo#123\")."},
                         "writer": {"type": "boolean", "description": "Whether this mission may modify the associated PR branch. Concurrent writers for one PR are rejected."},
-                        "may_merge": {"type": "boolean", "description": "Whether this mission may perform the final guarded PR merge. Set only for a dedicated integrator covered by a durable owner/campaign grant."},
-                        "merge_authority_source": {"type": "string", "description": "Required with may_merge=true. Stable grant slug, for example owner-standing-grant-2026-07-29. Recorded in mission tags for audit provenance."},
+                        "request_merge_authority": {"type": "boolean", "description": "Request final guarded merge capability for a dedicated integrator. This is not self-authorization: the trusted Hermes client grants it only when github_pr matches the operator-configured repository allowlist."},
                         "tags": {"type": "array", "items": {"type": "string"}},
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
                         "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."},
@@ -1547,6 +1584,7 @@ impl AssistantMcp {
             .or_else(|| native_backend_from_agent(params.agent.as_deref()));
         let tags = mission_start_tags(
             params.tags,
+            params.request_merge_authority.unwrap_or(false),
             params.may_merge.unwrap_or(false),
             params.merge_authority_source.as_deref(),
             params.github_pr.as_deref(),
@@ -3520,6 +3558,7 @@ mod tests {
                 " origin:hermes-assistant ".to_string(),
             ]),
             true,
+            true,
             Some("owner-standing-grant-2026-07-29"),
             Some("lfglabs-dev/verity#2209"),
             Some("20260729_080825_2df2a0"),
@@ -3535,16 +3574,20 @@ mod tests {
                 "origin-session:20260729_080825_2df2a0",
                 "origin-platform:desktop",
                 "merge-authority:granted",
-                "merge-authority-source:owner-standing-grant-2026-07-29"
+                "merge-authority-source:owner-standing-grant-2026-07-29",
+                "merge-authority-target:lfglabs-dev/verity#2209"
             ]
         );
     }
 
     #[test]
     fn mission_start_tags_reject_ambiguous_merge_authority() {
-        assert!(mission_start_tags(None, true, None, Some("owner/repo#1"), None, None).is_err());
+        assert!(
+            mission_start_tags(None, true, true, None, Some("owner/repo#1"), None, None).is_err()
+        );
         assert!(mission_start_tags(
             None,
+            true,
             true,
             Some("owner grant"),
             Some("owner/repo#1"),
@@ -3552,9 +3595,12 @@ mod tests {
             None
         )
         .is_err());
-        assert!(mission_start_tags(None, true, Some("owner-grant"), None, None, None).is_err());
+        assert!(
+            mission_start_tags(None, true, true, Some("owner-grant"), None, None, None).is_err()
+        );
         assert!(mission_start_tags(
             None,
+            false,
             false,
             Some("owner-grant"),
             Some("owner/repo#1"),
@@ -3562,6 +3608,19 @@ mod tests {
             None
         )
         .is_err());
+        assert!(mission_start_tags(
+            None,
+            true,
+            true,
+            Some("owner-grant"),
+            Some("owner/repo"),
+            None,
+            None
+        )
+        .is_err());
+        assert!(
+            mission_start_tags(None, true, false, None, Some("owner/repo#1"), None, None).is_err()
+        );
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -155,6 +155,13 @@ struct StartMissionParams {
     github_pr: Option<String>,
     #[serde(default)]
     writer: Option<bool>,
+    /// Whether this mission may perform the final guarded PR merge. Branch
+    /// write ownership and merge authority are deliberately separate.
+    #[serde(default)]
+    may_merge: Option<bool>,
+    /// Durable owner/campaign grant that authorizes `may_merge=true`.
+    #[serde(default)]
+    merge_authority_source: Option<String>,
     #[serde(default)]
     tags: Option<Vec<String>>,
     #[serde(default)]
@@ -173,6 +180,53 @@ fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
         "grok" => Some("grok".to_string()),
         _ => None,
     }
+}
+
+fn mission_start_tags(
+    tags: Option<Vec<String>>,
+    may_merge: bool,
+    merge_authority_source: Option<&str>,
+    github_pr: Option<&str>,
+) -> Result<Vec<String>, String> {
+    let mut tags: Vec<String> = tags
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    tags.retain(|tag| {
+        tag != "origin:hermes-assistant"
+            && tag != "merge-authority:granted"
+            && !tag.starts_with("merge-authority-source:")
+    });
+    tags.push("origin:hermes-assistant".to_string());
+
+    let authority_source = merge_authority_source
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if !may_merge {
+        if authority_source.is_some() {
+            return Err("merge_authority_source requires may_merge=true".to_string());
+        }
+        return Ok(tags);
+    }
+
+    if github_pr.is_none_or(|value| value.trim().is_empty()) {
+        return Err("may_merge=true requires github_pr".to_string());
+    }
+    let authority_source = authority_source
+        .ok_or_else(|| "may_merge=true requires merge_authority_source".to_string())?;
+    if authority_source.len() > 128
+        || !authority_source.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '_' | ':' | '/' | '#' | '.')
+        })
+    {
+        return Err("merge_authority_source must be a <=128 character audit slug".to_string());
+    }
+    tags.push("merge-authority:granted".to_string());
+    tags.push(format!("merge-authority-source:{authority_source}"));
+    Ok(tags)
 }
 
 #[derive(Debug, Deserialize)]
@@ -965,6 +1019,8 @@ impl AssistantMcp {
                         "intent": {"type": "string", "description": "Intent (e.g. \"review_merge_pr\")."},
                         "github_pr": {"type": "string", "description": "Associated PR ref (e.g. \"owner/repo#123\")."},
                         "writer": {"type": "boolean", "description": "Whether this mission may modify the associated PR branch. Concurrent writers for one PR are rejected."},
+                        "may_merge": {"type": "boolean", "description": "Whether this mission may perform the final guarded PR merge. Set only for a dedicated integrator covered by a durable owner/campaign grant."},
+                        "merge_authority_source": {"type": "string", "description": "Required with may_merge=true. Stable grant slug, for example owner-standing-grant-2026-07-29. Recorded in mission tags for audit provenance."},
                         "tags": {"type": "array", "items": {"type": "string"}},
                         "desired_state": {"type": "string", "description": "Track state, e.g. waiting_ci / waiting_review / blocked_external."},
                         "next_check_at": {"type": "string", "description": "When the track should next be checked (RFC3339)."},
@@ -1463,6 +1519,12 @@ impl AssistantMcp {
         let backend = params
             .backend
             .or_else(|| native_backend_from_agent(params.agent.as_deref()));
+        let tags = mission_start_tags(
+            params.tags,
+            params.may_merge.unwrap_or(false),
+            params.merge_authority_source.as_deref(),
+            params.github_pr.as_deref(),
+        )?;
         let body = json!({
             "title": params.title,
             "workspace_id": workspace_id,
@@ -1484,7 +1546,7 @@ impl AssistantMcp {
             "intent": params.intent,
             "github_pr": params.github_pr,
             "writer": params.writer,
-            "tags": params.tags,
+            "tags": tags,
             "desired_state": params.desired_state,
             "next_check_at": params.next_check_at,
             "estimated_disk_gib": params.estimated_disk_gib,
@@ -3420,6 +3482,40 @@ mod tests {
         let backwards = mission_events_path(id, 40, "all", Some(99), Some(17));
         assert!(backwards.ends_with("&before_seq=99"));
         assert!(!backwards.contains("since_seq"));
+    }
+
+    #[test]
+    fn mission_start_tags_record_hermes_merge_authority() {
+        let tags = mission_start_tags(
+            Some(vec![
+                "verity".to_string(),
+                " origin:hermes-assistant ".to_string(),
+            ]),
+            true,
+            Some("owner-standing-grant-2026-07-29"),
+            Some("lfglabs-dev/verity#2209"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            tags,
+            vec![
+                "verity",
+                "origin:hermes-assistant",
+                "merge-authority:granted",
+                "merge-authority-source:owner-standing-grant-2026-07-29"
+            ]
+        );
+    }
+
+    #[test]
+    fn mission_start_tags_reject_ambiguous_merge_authority() {
+        assert!(mission_start_tags(None, true, None, Some("owner/repo#1")).is_err());
+        assert!(mission_start_tags(None, true, Some("owner grant"), Some("owner/repo#1")).is_err());
+        assert!(mission_start_tags(None, true, Some("owner-grant"), None).is_err());
+        assert!(
+            mission_start_tags(None, false, Some("owner-grant"), Some("owner/repo#1")).is_err()
+        );
     }
 
     #[test]

--- a/src/bin/assistant_mcp.rs
+++ b/src/bin/assistant_mcp.rs
@@ -155,18 +155,10 @@ struct StartMissionParams {
     github_pr: Option<String>,
     #[serde(default)]
     writer: Option<bool>,
-    /// Model-visible request for merge capability. It is not authority: a
-    /// trusted Hermes client must independently inject `may_merge` and the
-    /// configured grant source.
+    /// Model-visible request for merge capability. It is not authority: this
+    /// server derives grants only from its operator-owned environment.
     #[serde(default)]
     request_merge_authority: Option<bool>,
-    /// Whether this mission may perform the final guarded PR merge. Branch
-    /// write ownership and merge authority are deliberately separate.
-    #[serde(default)]
-    may_merge: Option<bool>,
-    /// Durable owner/campaign grant that authorizes `may_merge=true`.
-    #[serde(default)]
-    merge_authority_source: Option<String>,
     /// Injected by the Hermes MCP client. Deliberately absent from the public
     /// tool schema so the model cannot choose its own provenance.
     #[serde(default)]
@@ -197,11 +189,10 @@ fn native_backend_from_agent(agent: Option<&str>) -> Option<String> {
 fn mission_start_tags(
     tags: Option<Vec<String>>,
     request_merge_authority: bool,
-    may_merge: bool,
-    merge_authority_source: Option<&str>,
     github_pr: Option<&str>,
     origin_session_id: Option<&str>,
     origin_platform: Option<&str>,
+    merge_grant: Option<&MergeGrantConfig>,
 ) -> Result<Vec<String>, String> {
     let mut tags: Vec<String> = tags
         .unwrap_or_default()
@@ -234,42 +225,77 @@ fn mission_start_tags(
         }
     }
 
-    let authority_source = merge_authority_source
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-    if request_merge_authority && !may_merge {
-        return Err(
-            "merge authority was requested but not granted by the trusted Hermes client"
-                .to_string(),
-        );
-    }
-    if !may_merge {
-        if authority_source.is_some() {
-            return Err("merge_authority_source requires may_merge=true".to_string());
-        }
+    if !request_merge_authority {
         return Ok(tags);
     }
-
     let github_pr = github_pr
         .map(str::trim)
         .filter(|value| canonical_github_pr_ref(value))
         .ok_or_else(|| {
-            "may_merge=true requires github_pr in owner/repository#123 form".to_string()
+            "merge authority requires github_pr in owner/repository#123 form".to_string()
         })?;
-    let authority_source = authority_source
-        .ok_or_else(|| "may_merge=true requires merge_authority_source".to_string())?;
-    if authority_source.len() > 128
-        || !authority_source.chars().all(|character| {
-            character.is_ascii_alphanumeric()
-                || matches!(character, '-' | '_' | ':' | '/' | '#' | '.')
-        })
-    {
-        return Err("merge_authority_source must be a <=128 character audit slug".to_string());
+    let merge_grant = merge_grant.ok_or_else(|| {
+        "merge authority was requested but no operator grant is configured".to_string()
+    })?;
+    let repository = github_pr.split_once('#').expect("validated PR ref").0;
+    if !merge_grant.allows(repository) {
+        return Err(format!(
+            "merge authority was requested outside the configured repository scope: {repository}"
+        ));
     }
     tags.push("merge-authority:granted".to_string());
-    tags.push(format!("merge-authority-source:{authority_source}"));
+    tags.push(format!(
+        "merge-authority-source:{}",
+        merge_grant.authority_source
+    ));
     tags.push(format!("merge-authority-target:{github_pr}"));
     Ok(tags)
+}
+
+#[derive(Debug)]
+struct MergeGrantConfig {
+    authority_source: String,
+    repositories: Vec<String>,
+}
+
+impl MergeGrantConfig {
+    fn from_environment() -> Option<Self> {
+        let authority_source = std::env::var("HERMES_MERGE_AUTHORITY_SOURCE")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| {
+                !value.is_empty()
+                    && value.len() <= 128
+                    && value.chars().all(|character| {
+                        character.is_ascii_alphanumeric()
+                            || matches!(character, '-' | '_' | ':' | '/' | '#' | '.')
+                    })
+            })?;
+        let repositories: Vec<String> = std::env::var("HERMES_MERGE_AUTHORITY_REPOSITORIES")
+            .ok()?
+            .split(',')
+            .map(|value| value.trim().to_ascii_lowercase())
+            .filter(|value| !value.is_empty())
+            .collect();
+        if repositories.is_empty() {
+            return None;
+        }
+        Some(Self {
+            authority_source,
+            repositories,
+        })
+    }
+
+    fn allows(&self, repository: &str) -> bool {
+        let repository = repository.to_ascii_lowercase();
+        let owner = repository.split_once('/').map(|(owner, _)| owner);
+        self.repositories.iter().any(|allowed| {
+            allowed == &repository
+                || allowed
+                    .strip_suffix("/*")
+                    .is_some_and(|allowed_owner| owner == Some(allowed_owner))
+        })
+    }
 }
 
 fn canonical_github_pr_ref(value: &str) -> bool {
@@ -1585,11 +1611,10 @@ impl AssistantMcp {
         let tags = mission_start_tags(
             params.tags,
             params.request_merge_authority.unwrap_or(false),
-            params.may_merge.unwrap_or(false),
-            params.merge_authority_source.as_deref(),
             params.github_pr.as_deref(),
             params.origin_session_id.as_deref(),
             params.origin_platform.as_deref(),
+            MergeGrantConfig::from_environment().as_ref(),
         )?;
         let body = json!({
             "title": params.title,
@@ -3552,17 +3577,20 @@ mod tests {
 
     #[test]
     fn mission_start_tags_record_hermes_merge_authority() {
+        let grant = MergeGrantConfig {
+            authority_source: "owner-standing-grant-2026-07-29".to_string(),
+            repositories: vec!["lfglabs-dev/*".to_string()],
+        };
         let tags = mission_start_tags(
             Some(vec![
                 "verity".to_string(),
                 " origin:hermes-assistant ".to_string(),
             ]),
             true,
-            true,
-            Some("owner-standing-grant-2026-07-29"),
             Some("lfglabs-dev/verity#2209"),
             Some("20260729_080825_2df2a0"),
             Some("desktop"),
+            Some(&grant),
         )
         .unwrap();
 
@@ -3582,45 +3610,30 @@ mod tests {
 
     #[test]
     fn mission_start_tags_reject_ambiguous_merge_authority() {
+        let grant = MergeGrantConfig {
+            authority_source: "owner-grant".to_string(),
+            repositories: vec!["owner/repo".to_string()],
+        };
+        assert!(mission_start_tags(None, true, Some("owner/repo#1"), None, None, None).is_err());
         assert!(
-            mission_start_tags(None, true, true, None, Some("owner/repo#1"), None, None).is_err()
+            mission_start_tags(None, true, Some("owner/repo"), None, None, Some(&grant)).is_err()
         );
-        assert!(mission_start_tags(
-            None,
-            true,
-            true,
-            Some("owner grant"),
+        assert!(
+            mission_start_tags(None, true, Some("other/repo#1"), None, None, Some(&grant)).is_err()
+        );
+        let tags = mission_start_tags(
+            Some(vec![
+                "merge-authority:granted".to_string(),
+                "merge-authority-source:spoofed".to_string(),
+            ]),
+            false,
             Some("owner/repo#1"),
             None,
-            None
+            None,
+            Some(&grant),
         )
-        .is_err());
-        assert!(
-            mission_start_tags(None, true, true, Some("owner-grant"), None, None, None).is_err()
-        );
-        assert!(mission_start_tags(
-            None,
-            false,
-            false,
-            Some("owner-grant"),
-            Some("owner/repo#1"),
-            None,
-            None
-        )
-        .is_err());
-        assert!(mission_start_tags(
-            None,
-            true,
-            true,
-            Some("owner-grant"),
-            Some("owner/repo"),
-            None,
-            None
-        )
-        .is_err());
-        assert!(
-            mission_start_tags(None, true, false, None, Some("owner/repo#1"), None, None).is_err()
-        );
+        .unwrap();
+        assert!(!tags.iter().any(|tag| tag.starts_with("merge-authority:")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- record Hermes-origin mission tags without exporting durable conversation identifiers
- expose a model-visible merge-authority request while deriving actual grants from operator-owned server configuration
- validate grants against canonical exact PR targets and repository allowlists
- strip caller-supplied authority/provenance tags before persisting mission metadata

## Validation
- `cargo fmt --all --check`
- focused assistant-mcp mission tag tests
- `cargo check --all-targets`
- full GitHub CI on the exact head

Companion Hermes change: Th0rgal/hermes-agent#28.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge capability and mission metadata trust boundaries, but grants are env-only, spoofed authority tags are stripped, and failures are explicit when prerequisites or scope do not match.
> 
> **Overview**
> Adds **operator-gated merge authority** to Hermes `start_mission`: models may pass `request_merge_authority`, but the MCP server only records grant tags when env-configured allowlists and mission fields validate.
> 
> **Mission tags** are now built by `mission_start_tags` instead of forwarding caller `tags` verbatim. It normalizes tags, strips client-supplied `origin:*` and `merge-authority:*` provenance, always adds `origin:hermes-assistant`, and when merge is requested and allowed adds `merge-authority:granted`, `merge-authority-source:…`, and `merge-authority-target:owner/repo#N`.
> 
> **Grants** come from `HERMES_MERGE_AUTHORITY_SOURCE` and comma-separated `HERMES_MERGE_AUTHORITY_REPOSITORIES` (exact repo or `owner/*`). Requests fail without env grant, without `writer=true`, without a canonical `github_pr`, or when the PR repo is outside scope. `canonical_github_pr_ref` enforces `owner/repo#digits` shape.
> 
> The `start_mission` tool schema documents the new flag; unit tests cover happy-path tagging and rejection/spoof-stripping cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72441fe68b434ed77e6e69d422534893994894ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->