### PR TITLE
docs(hermes): make mission updates delta-driven

### DIFF
--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -9,7 +9,7 @@ description: >
 metadata:
   policy: chatgpt-ui-pool
   policy_version: 1.3.0
-version: 1.4.0
+version: 1.5.0
 ---
 
 # Hermes Mission Control
@@ -21,8 +21,8 @@ The separate `chatgpt_ui` backend is a read-only expert-consultation lane, not a
 coding worker.
 Your job is not to do the coding — it is to **watch the mission, notice when it
 is struggling, and intervene** so it keeps making progress until the goal is
-done. Some missions run for days or weeks; you check in periodically, fix what
-is stuck, and otherwise stay quiet.
+done. Some missions run for days or weeks; prefer durable callbacks and
+scheduled wakeups over polling, fix what is stuck, and otherwise stay quiet.
 
 You drive everything through the `sandboxed_assistant` MCP tools. You never SSH
 or touch the host directly.
@@ -230,6 +230,83 @@ this section must stay in sync with it.
 6. **Escalate genuine blockers.** Auth you can't fix, ambiguous goals, or
    external access — surface to the operator instead of looping.
 
+## Operator notification contract
+
+Mission telemetry and operator notifications are different products. Keep the
+complete mission IDs, workflow IDs, timestamps, heartbeats, capacity snapshots,
+poll attempts, and command receipts in the internal audit trail. Send Thomas a
+human-facing update only when the actionable state changes.
+
+### Notify only on a meaningful delta
+
+Send an update when at least one of these changes:
+
+- a new public head SHA becomes authoritative;
+- a gate changes state, including a new reproduced defect or a blocker changing
+  class (`source`, `review`, `infra`, `auth`, or `external`);
+- Thomas must make a concrete decision or grant new authority;
+- a previously announced deadline is missed and the recovery plan changes;
+- the work reaches a terminal result: certified clean, merged, blocked, failed,
+  or superseded.
+
+Do **not** notify merely because:
+
+- a healthy heartbeat, normal authentication route, or unused capacity was
+  observed;
+- another identical status poll or reconciliation completed;
+- a healthy mission remains active with the same tool or workflow running;
+- an equivalent continuation replaced a mission without changing the head,
+  blocker, plan, or expected outcome;
+- the only new information is an internal mission, run, workflow, or slot ID.
+
+If nothing meaningful changed, record the observation internally and remain
+silent. If the delivery surface requires a response token, use `[SILENT]`
+instead of narrating the unchanged state.
+
+### Lead with project state, not agent telemetry
+
+Use this compact shape, omitting empty sections:
+
+```text
+<Project / PR> — <STATE>
+
+Changed: <the delta since the last operator update>.
+Blocked by: <one exact blocker, its owner, and what clears it>.
+Next: <the autonomous action and the event that will wake Hermes>.
+Action Thomas: none | <one concrete decision>.
+ETA: <bounded estimate> | depends on <named external system>.
+```
+
+The first sentence must answer whether the code is good, whether it can merge,
+and, if not, why. Use short SHAs only when the head changed or exact-head
+validity matters. Never paste the polling history into the notification.
+
+For example:
+
+```text
+Verity #2213 — READY, WAITING FOR GITHUB
+
+The exact-head review is clean; the only missing gate is GitHub Actions, whose
+runner is currently stalled. Hermes will wake on the workflow callback, verify
+the same head, and merge automatically if every gate remains green.
+Action Thomas: none. ETA: depends on GitHub runners.
+```
+
+### External waits are callback-owned
+
+For GitHub Actions and other external jobs, reconcile once after discovering a
+stall, persist the exact head and expected terminal event, then park the
+campaign on a callback or scheduled durable wakeup. Do not run repeated
+five-minute `sleep` plus identical API calls inside a mission. A fallback check
+must be bounded and use increasing backoff. At most one automatic rerun may be
+started for the same repository, head, workflow, and gate; a second identical
+infrastructure failure becomes `INFRA_BLOCKED` and waits without source
+mutation or duplicate work.
+
+Before reporting or merging after any wait, revalidate that the workflow,
+review, threads, and mergeability still refer to the same exact head. A stale
+green result is evidence, not a gate.
+
 ## PR repair and certification campaigns
 
 Use one frozen-head campaign instead of alternating a new reviewer and writer
@@ -274,11 +351,14 @@ near-identical certifier missions by hand.
 
 ## Check-in cadence for multi-day missions
 
-You can't sit in a chat for a week. Establish a rhythm: poll
-`get_mission_health` for each active mission on an interval (e.g. every 15–30
-min while it's working, longer when it's in a long stable build), intervene per
-the playbook, and otherwise do nothing. Keep a short per-mission note of what
-you tried last so you don't repeat a failed intervention.
+You can't sit in a chat for a week. Register mission-complete and external-job
+callbacks where available, plus one durable scheduled wakeup as a lost-callback
+safety net. On that wakeup, call `get_mission_health` once, intervene per the
+playbook, then schedule the next check with increasing backoff when the state is
+unchanged. Never keep an agent turn alive with a `sleep`/poll loop. Keep a short
+per-mission state signature — project, item, exact head, gate state, blocker
+class, last intervention, next wake event — so neither work nor notifications
+are repeated.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- notify Thomas only on meaningful mission-state changes
- keep telemetry and polling details in internal receipts
- prefer callbacks and durable scheduled wakeups over live polling loops
- require exact-head revalidation after external waits

## Validation
- `git diff --check`
- `python3 scripts/policy_lint.py`
- `python3 -m unittest scripts/test_policy_lint.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Skill documentation and policy version bump only; no runtime or auth changes.
> 
> **Overview**
> **Hermes mission-control** (`skills/hermes-mission-control/SKILL.md`, v1.5.0) now treats operator updates and long-run babysitting as separate concerns: telemetry stays internal; **Thomas** only gets notified when something actionable changes (head SHA, gate/blocker class, decisions needed, deadline slip, or terminal outcome), with a fixed message shape and `[SILENT]` when nothing moved.
> 
> Multi-day missions shift from **interval polling** to **callbacks plus durable scheduled wakeups**, one health check per wakeup, backoff when unchanged, and a per-mission state signature so work and pings are not repeated. **External waits** (e.g. GitHub Actions) must park on callbacks/backoff—not in-turn `sleep`/poll loops—with bounded reruns and **exact-head revalidation** before report/merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822ff91383347949dcc39a7eabc00fc1c59ac9ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->