### PR TITLE
Secure private source transport for remote builds

### DIFF
--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -75,81 +75,85 @@ expected_head = os.environ.get("REMOTE_BUILD_EXPECTED_HEAD", "").strip()
 if expected_head:
     req["expected_head"] = expected_head
 
+source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
+if source_mode not in {"overlay", "full"}:
+    raise SystemExit("REMOTE_BUILD_SOURCE_MODE must be 'overlay' or 'full'")
+
 # Send the complete pinned Git snapshot as an object pack. Unlike forwarding a
 # credential or asking the node to fetch `origin`, this contains only immutable
-# repository objects reachable from the requested commit's tree.
-tree_records = subprocess.check_output(
-    ["git", "-C", str(repo_root), "ls-tree", "-r", "-t", "-z", "--full-tree", commit]
-).split(b"\0")
-root_tree = subprocess.check_output(
-    ["git", "-C", str(repo_root), "rev-parse", f"{commit}^{{tree}}"], text=True
-).strip()
-object_ids = [commit, root_tree]
-has_gitlinks = False
-for record in tree_records:
-    if not record:
-        continue
-    try:
-        metadata, _path = record.split(b"\t", 1)
-        mode, _kind, object_id = metadata.split(b" ", 2)
-    except ValueError:
-        raise SystemExit("git returned a malformed tree entry while creating source archive")
-    if mode == b"160000":
-        # A gitlink names an object in another repository. Preserve the legacy
-        # public fetch/submodule path instead of creating a knowingly incomplete
-        # archive or asking pack-objects for an object that cannot exist here.
-        has_gitlinks = True
-        continue
-    object_ids.append(object_id.decode("ascii"))
-max_archive_bytes = int(
-    os.environ.get("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES", str(32 << 20))
-)
-if max_archive_bytes <= 0:
-    raise SystemExit("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES must be positive")
-if has_gitlinks:
-    print(
-        "remote-lean-build: pinned tree contains submodules; using legacy runner fetch",
-        file=sys.stderr,
+# repository objects reachable from the requested commit's tree. Full source
+# mode already sends a bounded complete snapshot, so attaching both transports
+# would duplicate private source and can exceed the request-body limit.
+if source_mode != "full":
+    tree_records = subprocess.check_output(
+        ["git", "-C", str(repo_root), "ls-tree", "-r", "-t", "-z", "--full-tree", commit]
+    ).split(b"\0")
+    root_tree = subprocess.check_output(
+        ["git", "-C", str(repo_root), "rev-parse", f"{commit}^{{tree}}"], text=True
+    ).strip()
+    object_ids = [commit, root_tree]
+    has_gitlinks = False
+    for record in tree_records:
+        if not record:
+            continue
+        try:
+            metadata, _path = record.split(b"\t", 1)
+            mode, _kind, object_id = metadata.split(b" ", 2)
+        except ValueError:
+            raise SystemExit("git returned a malformed tree entry while creating source archive")
+        if mode == b"160000":
+            # A gitlink names an object in another repository. Preserve the legacy
+            # public fetch/submodule path instead of creating a knowingly incomplete
+            # archive or asking pack-objects for an object that cannot exist here.
+            has_gitlinks = True
+            continue
+        object_ids.append(object_id.decode("ascii"))
+    max_archive_bytes = int(
+        os.environ.get("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES", str(32 << 20))
     )
-else:
-    pack_process = subprocess.Popen(
-        ["git", "-C", str(repo_root), "pack-objects", "--stdout", "--no-reuse-delta"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-    )
-    assert pack_process.stdin is not None and pack_process.stdout is not None
-    pack_process.stdin.write(("\n".join(object_ids) + "\n").encode("ascii"))
-    pack_process.stdin.close()
-    pack = pack_process.stdout.read(max_archive_bytes + 1)
-    if len(pack) > max_archive_bytes:
-        pack_process.kill()
-        pack_process.wait()
-        raise SystemExit(
-            f"source archive exceeds maximum of {max_archive_bytes} bytes"
+    if max_archive_bytes <= 0:
+        raise SystemExit("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES must be positive")
+    if has_gitlinks:
+        print(
+            "remote-lean-build: pinned tree contains submodules; using legacy runner fetch",
+            file=sys.stderr,
         )
-    if pack_process.wait() != 0:
-        raise SystemExit("git pack-objects failed while creating source archive")
-    if not pack:
-        raise SystemExit("git pack-objects returned an empty source archive")
-    archive_hash = hashlib.sha256(
-        b"sandboxed-source-archive-v1\0"
-        + commit.encode("ascii")
-        + b"\0"
-        + pack
-    ).hexdigest()
-    req["source_archive"] = {
-        "sha256": archive_hash,
-        "size_bytes": len(pack),
-        "data_base64": base64.b64encode(pack).decode("ascii"),
-    }
+    else:
+        pack_process = subprocess.Popen(
+            ["git", "-C", str(repo_root), "pack-objects", "--stdout", "--no-reuse-delta"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        assert pack_process.stdin is not None and pack_process.stdout is not None
+        pack_process.stdin.write(("\n".join(object_ids) + "\n").encode("ascii"))
+        pack_process.stdin.close()
+        pack = pack_process.stdout.read(max_archive_bytes + 1)
+        if len(pack) > max_archive_bytes:
+            pack_process.kill()
+            pack_process.wait()
+            raise SystemExit(
+                f"source archive exceeds maximum of {max_archive_bytes} bytes"
+            )
+        if pack_process.wait() != 0:
+            raise SystemExit("git pack-objects failed while creating source archive")
+        if not pack:
+            raise SystemExit("git pack-objects returned an empty source archive")
+        archive_hash = hashlib.sha256(
+            b"sandboxed-source-archive-v1\0"
+            + commit.encode("ascii")
+            + b"\0"
+            + pack
+        ).hexdigest()
+        req["source_archive"] = {
+            "sha256": archive_hash,
+            "size_bytes": len(pack),
+            "data_base64": base64.b64encode(pack).decode("ascii"),
+        }
 
 def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
     return [item.decode("utf-8") for item in raw.split(b"\0") if item]
 
-source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
-if source_mode not in {"overlay", "full"}:
-    raise SystemExit("REMOTE_BUILD_SOURCE_MODE must be 'overlay' or 'full'")
 deleted = git_paths("diff", "--name-only", "-z", "--diff-filter=DR", "HEAD")
 if deleted and source_mode != "full":
     raise SystemExit(

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -41,8 +41,17 @@ if [ "$#" -eq 0 ]; then set -- lake build; fi
 request_file="$(mktemp)" || die "cannot create temporary request file" 75
 python3 - "$REMOTE_BUILD_MISSION_ID" "$REMOTE_BUILD_TOKEN" "$repo" "$commit" "$cwd_rel" "$@" > "$request_file" <<'PY'
 import base64, hashlib, json, os, pathlib, subprocess, sys
+from urllib.parse import urlsplit, urlunsplit
 mission_id, token, repo, commit, cwd_rel = sys.argv[1:6]
 command = sys.argv[6:]
+parsed_repo = urlsplit(repo)
+if parsed_repo.scheme in {"http", "https"}:
+    host = parsed_repo.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed_repo.port is not None:
+        host = f"{host}:{parsed_repo.port}"
+    repo = urlunsplit((parsed_repo.scheme, host, parsed_repo.path, "", ""))
 req = {
     "mission_id": mission_id,
     "token": token,
@@ -65,6 +74,52 @@ if toolchain_path.is_file():
 expected_head = os.environ.get("REMOTE_BUILD_EXPECTED_HEAD", "").strip()
 if expected_head:
     req["expected_head"] = expected_head
+
+# Send the complete pinned Git snapshot as an object pack. Unlike forwarding a
+# credential or asking the node to fetch `origin`, this contains only immutable
+# repository objects reachable from the requested commit's tree.
+tree_records = subprocess.check_output(
+    ["git", "-C", str(repo_root), "ls-tree", "-r", "-t", "-z", "--full-tree", commit]
+).split(b"\0")
+root_tree = subprocess.check_output(
+    ["git", "-C", str(repo_root), "rev-parse", f"{commit}^{{tree}}"], text=True
+).strip()
+object_ids = [commit, root_tree]
+for record in tree_records:
+    if not record:
+        continue
+    try:
+        metadata, _path = record.split(b"\t", 1)
+        _mode, _kind, object_id = metadata.split(b" ", 2)
+    except ValueError:
+        raise SystemExit("git returned a malformed tree entry while creating source archive")
+    object_ids.append(object_id.decode("ascii"))
+pack = subprocess.run(
+    ["git", "-C", str(repo_root), "pack-objects", "--stdout", "--no-reuse-delta"],
+    input=("\n".join(object_ids) + "\n").encode("ascii"),
+    stdout=subprocess.PIPE,
+    check=True,
+).stdout
+max_archive_bytes = int(
+    os.environ.get("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES", str(32 << 20))
+)
+if max_archive_bytes <= 0:
+    raise SystemExit("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES must be positive")
+if not pack or len(pack) > max_archive_bytes:
+    raise SystemExit(
+        f"source archive is {len(pack)} bytes; maximum is {max_archive_bytes}"
+    )
+archive_hash = hashlib.sha256(
+    b"sandboxed-source-archive-v1\0"
+    + commit.encode("ascii")
+    + b"\0"
+    + pack
+).hexdigest()
+req["source_archive"] = {
+    "sha256": archive_hash,
+    "size_bytes": len(pack),
+    "data_base64": base64.b64encode(pack).decode("ascii"),
+}
 
 def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -85,41 +85,63 @@ root_tree = subprocess.check_output(
     ["git", "-C", str(repo_root), "rev-parse", f"{commit}^{{tree}}"], text=True
 ).strip()
 object_ids = [commit, root_tree]
+has_gitlinks = False
 for record in tree_records:
     if not record:
         continue
     try:
         metadata, _path = record.split(b"\t", 1)
-        _mode, _kind, object_id = metadata.split(b" ", 2)
+        mode, _kind, object_id = metadata.split(b" ", 2)
     except ValueError:
         raise SystemExit("git returned a malformed tree entry while creating source archive")
+    if mode == b"160000":
+        # A gitlink names an object in another repository. Preserve the legacy
+        # public fetch/submodule path instead of creating a knowingly incomplete
+        # archive or asking pack-objects for an object that cannot exist here.
+        has_gitlinks = True
+        continue
     object_ids.append(object_id.decode("ascii"))
-pack = subprocess.run(
-    ["git", "-C", str(repo_root), "pack-objects", "--stdout", "--no-reuse-delta"],
-    input=("\n".join(object_ids) + "\n").encode("ascii"),
-    stdout=subprocess.PIPE,
-    check=True,
-).stdout
 max_archive_bytes = int(
     os.environ.get("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES", str(32 << 20))
 )
 if max_archive_bytes <= 0:
     raise SystemExit("REMOTE_BUILD_MAX_SOURCE_ARCHIVE_BYTES must be positive")
-if not pack or len(pack) > max_archive_bytes:
-    raise SystemExit(
-        f"source archive is {len(pack)} bytes; maximum is {max_archive_bytes}"
+if has_gitlinks:
+    print(
+        "remote-lean-build: pinned tree contains submodules; using legacy runner fetch",
+        file=sys.stderr,
     )
-archive_hash = hashlib.sha256(
-    b"sandboxed-source-archive-v1\0"
-    + commit.encode("ascii")
-    + b"\0"
-    + pack
-).hexdigest()
-req["source_archive"] = {
-    "sha256": archive_hash,
-    "size_bytes": len(pack),
-    "data_base64": base64.b64encode(pack).decode("ascii"),
-}
+else:
+    pack_process = subprocess.Popen(
+        ["git", "-C", str(repo_root), "pack-objects", "--stdout", "--no-reuse-delta"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    assert pack_process.stdin is not None and pack_process.stdout is not None
+    pack_process.stdin.write(("\n".join(object_ids) + "\n").encode("ascii"))
+    pack_process.stdin.close()
+    pack = pack_process.stdout.read(max_archive_bytes + 1)
+    if len(pack) > max_archive_bytes:
+        pack_process.kill()
+        pack_process.wait()
+        raise SystemExit(
+            f"source archive exceeds maximum of {max_archive_bytes} bytes"
+        )
+    if pack_process.wait() != 0:
+        raise SystemExit("git pack-objects failed while creating source archive")
+    if not pack:
+        raise SystemExit("git pack-objects returned an empty source archive")
+    archive_hash = hashlib.sha256(
+        b"sandboxed-source-archive-v1\0"
+        + commit.encode("ascii")
+        + b"\0"
+        + pack
+    ).hexdigest()
+    req["source_archive"] = {
+        "sha256": archive_hash,
+        "size_bytes": len(pack),
+        "data_base64": base64.b64encode(pack).decode("ascii"),
+    }
 
 def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
@@ -414,6 +436,10 @@ request.pop("resume_mission_on_terminal", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
     request["source_bundle_sha256"] = bundle.get("manifest_sha256")
+archive = request.pop("source_archive", None)
+if archive:
+    request["source_archive_sha256"] = archive.get("sha256")
+    request["source_archive_size_bytes"] = archive.get("size_bytes")
 request.update({"state": "ambiguous", "submit_outcome": reason})
 fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
 try:
@@ -501,6 +527,10 @@ request.pop("resume_mission_on_terminal", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
     request["source_bundle_sha256"] = bundle.get("manifest_sha256")
+archive = request.pop("source_archive", None)
+if archive:
+    request["source_archive_sha256"] = archive.get("sha256")
+    request["source_archive_size_bytes"] = archive.get("size_bytes")
 request.update(response)
 fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
 try:
@@ -569,6 +599,10 @@ request.pop("resume_mission_on_terminal", None)
 bundle = request.pop("source_bundle", None)
 if bundle:
     request["source_bundle_sha256"] = bundle.get("manifest_sha256")
+archive = request.pop("source_archive", None)
+if archive:
+    request["source_archive_sha256"] = archive.get("sha256")
+    request["source_archive_size_bytes"] = archive.get("size_bytes")
 request.update({"job_id": job_id, "node_id": node_id, "state": "submitted"})
 fd, tmp = tempfile.mkstemp(prefix=".remote-build-", dir=os.path.dirname(path))
 try:

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -365,11 +365,10 @@ fn repository_url_has_credentials(repo: &str) -> bool {
     let Ok(parsed) = url::Url::parse(repo) else {
         return false;
     };
-    matches!(parsed.scheme(), "http" | "https")
-        && (!parsed.username().is_empty()
-            || parsed.password().is_some()
-            || parsed.query().is_some()
-            || parsed.fragment().is_some())
+    parsed.password().is_some()
+        || (matches!(parsed.scheme(), "http" | "https") && !parsed.username().is_empty())
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
 }
 
 fn remote_job_identity(
@@ -910,7 +909,7 @@ async fn submit_remote_build(
     if repository_url_has_credentials(&req.repo) {
         return (
             StatusCode::BAD_REQUEST,
-            "HTTP repository URL must not contain userinfo, query parameters, or a fragment",
+            "repository URL must not contain credentials, query parameters, or a fragment",
         )
             .into_response();
     }
@@ -946,8 +945,11 @@ async fn submit_remote_build(
     // Reuse completed evidence even when every runner is currently offline.
     // This optimistic read is repeated under the placement lock after any
     // explicit network probe, which closes the concurrent-submit race.
-    if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await {
-        return response;
+    if req.source_archive.is_none() {
+        if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
+        {
+            return response;
+        }
     }
     if let Err((status, message)) =
         probe_explicit_lean_node(&state, &req.node_id, &requirements).await
@@ -958,8 +960,11 @@ async fn submit_remote_build(
     // tentative-handle persistence. No network probe runs while this mutex is
     // held, so a slow explicit runner cannot block unrelated auto placement.
     let placement_guard = placement_lock().lock().await;
-    if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await {
-        return response;
+    if req.source_archive.is_none() {
+        if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
+        {
+            return response;
+        }
     }
     let node = match resolve_node(
         &state,
@@ -2317,6 +2322,18 @@ esac
         assert!(receipt.get("token").is_none());
         assert!(receipt.get("repo").is_none());
         assert!(receipt.get("wait").is_none());
+        assert!(
+            receipt.get("source_archive").is_none(),
+            "private source bytes must never be retained in a receipt"
+        );
+        assert!(receipt
+            .get("source_archive_sha256")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|digest| digest.len() == 64));
+        assert!(receipt
+            .get("source_archive_size_bytes")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|size| size > 0));
         assert_eq!(
             receipt.get("job_id").and_then(serde_json::Value::as_str),
             Some("11111111-1111-1111-1111-111111111111")

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -30,8 +30,8 @@ use uuid::Uuid;
 use super::routes::AppState;
 use crate::remote_node::{
     ArtifactEntry, DispatchOutcome, JobPayload, JobSource, LeaseClaims, NodeJobStatus,
-    RemoteNodeClient, RemoteNodeConfig, RemoteNodeError, RemoteNodeStatus, SourceBundle,
-    SubmitJobRequest, SCOPE_JOB_SUBMIT,
+    RemoteNodeClient, RemoteNodeConfig, RemoteNodeError, RemoteNodeStatus, SourceArchive,
+    SourceBundle, SubmitJobRequest, SCOPE_JOB_SUBMIT,
 };
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -272,7 +272,7 @@ pub struct RemoteBuildRequest {
     /// minted for exactly this mission.
     pub mission_id: Uuid,
     pub token: String,
-    /// Git clone/fetch URL; the node fetches it itself.
+    /// Credential-free repository identity and legacy public clone/fetch URL.
     pub repo: String,
     /// Full 40-char lowercase hex commit SHA.
     pub commit: String,
@@ -285,6 +285,10 @@ pub struct RemoteBuildRequest {
     /// reads the pinned checkout's toolchain file as the execution authority.
     #[serde(default)]
     pub toolchain: Option<String>,
+    /// Optional complete, commit-bound Git object pack. The bundled client
+    /// sends this so private sources never require credentials on a node.
+    #[serde(default)]
+    pub source_archive: Option<SourceArchive>,
     /// Optional, bounded source overlay whose hashes are verified by the node
     /// before it is applied over the pinned commit.
     #[serde(default)]
@@ -355,6 +359,17 @@ fn repository_identity(repo: &str) -> String {
     parsed.set_query(None);
     parsed.set_fragment(None);
     parsed.to_string()
+}
+
+fn repository_url_has_credentials(repo: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(repo) else {
+        return false;
+    };
+    matches!(parsed.scheme(), "http" | "https")
+        && (!parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some())
 }
 
 fn remote_job_identity(
@@ -892,6 +907,13 @@ async fn submit_remote_build(
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
     }
+    if repository_url_has_credentials(&req.repo) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "HTTP repository URL must not contain userinfo, query parameters, or a fragment",
+        )
+            .into_response();
+    }
     if let Err(message) = validate_expected_head(&req.commit, req.expected_head.as_deref()) {
         return (StatusCode::CONFLICT, message).into_response();
     }
@@ -908,8 +930,10 @@ async fn submit_remote_build(
             .into_response();
     }
     let min_disk_bytes = required_node_disk_bytes(req.estimated_disk_bytes);
-    let min_protocol_version = if req.source_bundle.is_some() {
+    let min_protocol_version = if req.source_archive.is_some() {
         crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+    } else if req.source_bundle.is_some() {
+        3
     } else {
         1
     };
@@ -974,6 +998,7 @@ async fn submit_remote_build(
             source: JobSource {
                 repo: req.repo.clone(),
                 commit: req.commit.clone(),
+                archive: req.source_archive.clone().map(Box::new),
                 bundle: req.source_bundle.clone(),
             },
             cwd_rel: req.cwd_rel.clone(),
@@ -1440,6 +1465,7 @@ async fn get_remote_build(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
 
     #[tokio::test]
     async fn terminal_handle_finalization_reports_persistence_failure() {
@@ -1595,7 +1621,7 @@ mod tests {
             "remote",
             "add",
             "origin",
-            "https://example.invalid/repo.git",
+            "https://build-user:placeholder@example.invalid/repo.git?token=placeholder#fragment",
         ]);
 
         let fake_curl = bin.join("curl");
@@ -1810,6 +1836,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         assert_eq!(req.timeout_secs, None);
         assert!(!req.resume_mission_on_terminal);
         assert_eq!(req.estimated_disk_bytes, 12 * GIB);
+        assert!(req.source_archive.is_none());
         assert!(req.source_bundle.is_none());
         assert!(req.artifacts.is_empty());
 
@@ -1998,7 +2025,7 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             "remote",
             "add",
             "origin",
-            "https://example.invalid/repo.git",
+            "https://build-user:placeholder@example.invalid/repo.git?token=placeholder#fragment",
         ]);
         std::fs::write(repo.join("Theory/Proof.lean"), "new proof\n").unwrap();
         std::fs::write(repo.join("Theory/Witness.lean"), "new witness\n").unwrap();
@@ -2059,6 +2086,10 @@ printf '503'
             Some(12 * GIB)
         );
         assert_eq!(
+            request.get("repo").and_then(serde_json::Value::as_str),
+            Some("https://example.invalid/repo.git")
+        );
+        assert_eq!(
             request.get("toolchain").and_then(serde_json::Value::as_str),
             Some("leanprover/lean4:v4.19.0")
         );
@@ -2067,6 +2098,23 @@ printf '503'
                 .get("expected_head")
                 .and_then(serde_json::Value::as_str),
             Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        let archive = request.get("source_archive").unwrap();
+        let archive_bytes = base64::engine::general_purpose::STANDARD
+            .decode(archive.get("data_base64").unwrap().as_str().unwrap())
+            .unwrap();
+        assert_eq!(
+            archive
+                .get("size_bytes")
+                .and_then(serde_json::Value::as_u64),
+            Some(archive_bytes.len() as u64)
+        );
+        assert_eq!(
+            archive.get("sha256").unwrap().as_str().unwrap(),
+            crate::node::lean::source_archive_sha256(
+                request.get("commit").unwrap().as_str().unwrap(),
+                &archive_bytes
+            )
         );
         let bundle = request.get("source_bundle").unwrap();
         let files = bundle.get("files").unwrap().as_array().unwrap();

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -2202,6 +2202,10 @@ printf '503'
 
         let full_request: serde_json::Value =
             serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+        assert!(
+            full_request.get("source_archive").is_none(),
+            "complete source mode must not duplicate source bytes in an archive"
+        );
         let full_bundle = full_request.get("source_bundle").unwrap();
         assert_eq!(
             full_bundle

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -706,7 +706,10 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         // Remote lean-build dispatch: same per-mission HMAC capability-token
         // model as spark (domain-separated), verified inside the handlers,
         // so it also bypasses require_auth.
-        .nest("/api/remote-build", super::remote_build::routes());
+        .nest(
+            "/api/remote-build",
+            super::remote_build::routes().layer(DefaultBodyLimit::max(50 * 1024 * 1024)),
+        );
 
     // File upload routes with increased body limit (10GB)
     let upload_route = Router::new()

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -770,6 +770,7 @@ mod tests {
                     source: sandboxed_sh::remote_node::JobSource {
                         repo: "/node/local/repo".to_string(),
                         commit: "a".repeat(40),
+                        archive: None,
                         bundle: None,
                     },
                     cwd_rel: None,

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -136,7 +136,12 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .route("/heartbeat", get(heartbeat))
         .route("/execute", post(execute))
-        .route("/jobs", post(submit_job).get(list_jobs))
+        .route(
+            "/jobs",
+            post(submit_job)
+                .layer(axum::extract::DefaultBodyLimit::max(50 * 1024 * 1024))
+                .get(list_jobs),
+        )
         .route("/jobs/:id", get(get_job))
         .route("/jobs/:id/cancel", post(cancel_job))
         .with_state(state);

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1,8 +1,10 @@
 //! Declarative `lean_build` job execution for the `sandboxed-node` runner.
 //!
-//! A lean-build job carries only a git source (repo + pinned commit), a
+//! A lean-build job carries a git source (credential-free repo identity,
+//! pinned commit, and normally a complete commit-bound object pack), a
 //! constrained argv (`lake build`/`lean`), and artifact patterns. The node
-//! materializes a content-addressed checkout, restores trusted shared runtime
+//! materializes a content-addressed checkout without network access when the
+//! archive is present, restores trusted shared runtime
 //! caches, runs the build, and records artifact digests. Lake dependency-cache
 //! plumbing fails closed until the evaluated package layout can be attested.
 //! No workspace sync with core, no shell interpretation of the payload.
@@ -27,7 +29,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::job_store::JobState;
 use super::runner::{clamp_timeout, run_logged_command, CommandEnvironment};
-use crate::remote_node::{ArtifactEntry, JobPayload, JobSource, SourceBundle};
+use crate::remote_node::{ArtifactEntry, JobPayload, JobSource, SourceArchive, SourceBundle};
 
 /// Default allowlist for lean-build env keys
 /// (`SANDBOXED_NODE_ENV_ALLOWLIST` overrides, comma-separated).
@@ -41,6 +43,7 @@ pub const ALLOWED_COMMANDS: [&str; 2] = ["lake", "lean"];
 const DEFAULT_MIN_FREE_GB: u64 = 10;
 const DEFAULT_MAX_SOURCE_BUNDLE_BYTES: u64 = 1 << 20;
 const MAX_SOURCE_BUNDLE_FILES: usize = 256;
+const DEFAULT_MAX_SOURCE_ARCHIVE_BYTES: u64 = 32 << 20;
 
 /// Interval between node-side cache GC passes.
 const GC_INTERVAL: Duration = Duration::from_secs(30 * 60);
@@ -110,6 +113,50 @@ fn source_bundle_max_bytes() -> u64 {
         .and_then(|raw| raw.trim().parse::<u64>().ok())
         .filter(|bytes| *bytes > 0)
         .unwrap_or(DEFAULT_MAX_SOURCE_BUNDLE_BYTES)
+}
+
+fn source_archive_max_bytes() -> u64 {
+    std::env::var("SANDBOXED_NODE_MAX_SOURCE_ARCHIVE_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|bytes| *bytes > 0)
+        .unwrap_or(DEFAULT_MAX_SOURCE_ARCHIVE_BYTES)
+}
+
+pub(crate) fn source_archive_sha256(commit: &str, bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"sandboxed-source-archive-v1\0");
+    hasher.update(commit.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn decode_source_archive(source: &JobSource, archive: &SourceArchive) -> Result<Vec<u8>, String> {
+    if archive.sha256.len() != 64
+        || !archive
+            .sha256
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ('a'..='f').contains(&ch))
+    {
+        return Err("invalid source archive sha256".to_string());
+    }
+    if archive.size_bytes == 0 || archive.size_bytes > source_archive_max_bytes() {
+        return Err(format!(
+            "source archive size must be between 1 and {} bytes",
+            source_archive_max_bytes()
+        ));
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&archive.data_base64)
+        .map_err(|_| "invalid source archive base64".to_string())?;
+    if bytes.len() as u64 != archive.size_bytes {
+        return Err("source archive decoded size mismatch".to_string());
+    }
+    if source_archive_sha256(&source.commit, &bytes) != archive.sha256 {
+        return Err("source archive commit-bound hash mismatch".to_string());
+    }
+    Ok(bytes)
 }
 
 fn bundle_path_is_safe(path: &str) -> bool {
@@ -206,6 +253,17 @@ fn repo_url_is_remote(repo: &str) -> bool {
     false
 }
 
+fn repo_url_has_credentials(repo: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(repo) else {
+        return false;
+    };
+    matches!(parsed.scheme(), "http" | "https")
+        && (!parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some())
+}
+
 /// Validate a lean-build payload before touching the filesystem or network.
 pub fn validate_lean_build(
     source: &JobSource,
@@ -216,6 +274,12 @@ pub fn validate_lean_build(
 ) -> Result<(), String> {
     if source.repo.trim().is_empty() {
         return Err("source.repo is required".to_string());
+    }
+    if repo_url_has_credentials(&source.repo) {
+        return Err(
+            "source.repo HTTP URL must not contain userinfo, query parameters, or a fragment"
+                .to_string(),
+        );
     }
     if !repo_url_is_remote(&source.repo) {
         return Err(format!(
@@ -229,6 +293,9 @@ pub fn validate_lean_build(
             "source.commit must be a full 40-char lowercase hex SHA (got '{}')",
             source.commit
         ));
+    }
+    if let Some(archive) = &source.archive {
+        decode_source_archive(source, archive)?;
     }
     if let Some(bundle) = &source.bundle {
         validate_source_bundle(bundle)?;
@@ -760,6 +827,148 @@ async fn run_git_step(
     Ok(())
 }
 
+fn validate_archive_tree_output(output: &[u8]) -> Result<(), String> {
+    for record in output
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+    {
+        let separator = record
+            .iter()
+            .position(|byte| *byte == b'\t')
+            .ok_or_else(|| "malformed source archive tree entry".to_string())?;
+        let (metadata, path_with_separator) = record.split_at(separator);
+        let path = &path_with_separator[1..];
+        let mode = metadata
+            .split(|byte| *byte == b' ')
+            .next()
+            .ok_or_else(|| "malformed source archive tree mode".to_string())?;
+        if !matches!(mode, b"040000" | b"100644" | b"100755") {
+            return Err(format!(
+                "source archive contains unsupported tree mode {}",
+                String::from_utf8_lossy(mode)
+            ));
+        }
+        let path = std::str::from_utf8(path)
+            .map_err(|_| "source archive paths must be UTF-8".to_string())?;
+        if path.starts_with('/')
+            || path.contains('\\')
+            || path.chars().any(char::is_control)
+            || path
+                .split('/')
+                .any(|component| component.is_empty() || matches!(component, "." | ".." | ".git"))
+        {
+            return Err(format!("unsafe source archive path '{path}'"));
+        }
+    }
+    Ok(())
+}
+
+async fn import_source_archive(
+    tmp: &Path,
+    source: &JobSource,
+    archive: &SourceArchive,
+    log_path: &Path,
+    token: &CancellationToken,
+) -> anyhow::Result<()> {
+    let bytes = decode_source_archive(source, archive).map_err(|error| anyhow::anyhow!(error))?;
+    run_git_step(&["init", "--quiet"], tmp, log_path, token).await?;
+
+    let mut child = tokio::process::Command::new("git")
+        // The transport deliberately contains the requested commit and its
+        // complete snapshot, not historical parent commits. `index-pack`
+        // still verifies pack/object integrity; `--strict` cannot be used
+        // because it requires every referenced parent object.
+        .args(["index-pack", "--stdin"])
+        .current_dir(tmp)
+        .kill_on_drop(true)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("git index-pack stdin unavailable"))?
+        .write_all(&bytes)
+        .await?;
+    if token.is_cancelled() {
+        anyhow::bail!("source archive import cancelled");
+    }
+    let output = tokio::time::timeout(
+        Duration::from_secs(GIT_STEP_TIMEOUT_SECS),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("source archive import timed out"))??;
+    if !output.status.success() {
+        anyhow::bail!(
+            "source archive is not a valid Git object pack: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let commit_object = format!("{}^{{commit}}", source.commit);
+    run_git_step(
+        &["cat-file", "-e", commit_object.as_str()],
+        tmp,
+        log_path,
+        token,
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "source archive does not contain requested commit {}",
+            source.commit
+        )
+    })?;
+    let tree = tokio::process::Command::new("git")
+        .args([
+            "ls-tree",
+            "-r",
+            "-t",
+            "-z",
+            "--full-tree",
+            source.commit.as_str(),
+        ])
+        .current_dir(tmp)
+        .output()
+        .await?;
+    if !tree.status.success() {
+        anyhow::bail!(
+            "source archive does not contain the complete tree for commit {}",
+            source.commit
+        );
+    }
+    validate_archive_tree_output(&tree.stdout).map_err(|error| anyhow::anyhow!(error))?;
+    run_git_step(
+        &["checkout", "--quiet", "--detach", source.commit.as_str()],
+        tmp,
+        log_path,
+        token,
+    )
+    .await?;
+    tokio::fs::write(
+        tmp.join(".git/sandboxed-source-archive"),
+        format!("{}\n", archive.sha256),
+    )
+    .await?;
+
+    let mut log = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .await?;
+    log.write_all(
+        format!(
+            "source archive verified sha256={} commit={} bytes={}\n",
+            archive.sha256, source.commit, archive.size_bytes
+        )
+        .as_bytes(),
+    )
+    .await?;
+    Ok(())
+}
+
 /// Ensure `<workdir>/checkouts/<repo-hash>/<commit>/` exists, fetching it if
 /// needed. Builds into a temp sibling and atomically renames so a partially
 /// fetched tree is never observed at the final path. Callers must hold the
@@ -772,7 +981,20 @@ async fn ensure_checkout(
 ) -> anyhow::Result<PathBuf> {
     let dest = checkout_dir(work_root, &source.repo, &source.commit);
     if dest.is_dir() {
-        return Ok(dest);
+        match &source.archive {
+            None => return Ok(dest),
+            Some(archive)
+                if tokio::fs::read_to_string(dest.join(".git/sandboxed-source-archive"))
+                    .await
+                    .is_ok_and(|digest| digest.trim() == archive.sha256) =>
+            {
+                return Ok(dest);
+            }
+            // A legacy/network checkout or a different archive digest cannot
+            // attest this request. Validate the supplied pack in a temporary
+            // repository before reusing the already materialized commit.
+            Some(_) => {}
+        }
     }
     let parent = dest
         .parent()
@@ -781,41 +1003,44 @@ async fn ensure_checkout(
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&tmp).await?;
 
-    let fetch = async {
-        run_git_step(&["init", "--quiet"], &tmp, log_path, token).await?;
-        run_git_step(
-            &[
-                "fetch",
-                "--depth",
-                "1",
-                "--quiet",
-                source.repo.as_str(),
-                source.commit.as_str(),
-            ],
-            &tmp,
-            log_path,
-            token,
-        )
-        .await?;
-        run_git_step(
-            &["checkout", "--quiet", "--detach", "FETCH_HEAD"],
-            &tmp,
-            log_path,
-            token,
-        )
-        .await?;
-        // Best-effort: many Lean repos have no submodules and lakefile deps
-        // are fetched by lake itself.
-        let _ = run_git_step(
-            &["submodule", "update", "--init", "--depth", "1"],
-            &tmp,
-            log_path,
-            token,
-        )
-        .await;
-        anyhow::Ok(())
-    }
-    .await;
+    let fetch = if let Some(archive) = &source.archive {
+        import_source_archive(&tmp, source, archive, log_path, token).await
+    } else {
+        async {
+            run_git_step(&["init", "--quiet"], &tmp, log_path, token).await?;
+            run_git_step(
+                &[
+                    "fetch",
+                    "--depth",
+                    "1",
+                    "--quiet",
+                    source.repo.as_str(),
+                    source.commit.as_str(),
+                ],
+                &tmp,
+                log_path,
+                token,
+            )
+            .await?;
+            run_git_step(
+                &["checkout", "--quiet", "--detach", "FETCH_HEAD"],
+                &tmp,
+                log_path,
+                token,
+            )
+            .await?;
+            // Legacy public-source path: preserve best-effort submodule fetch.
+            let _ = run_git_step(
+                &["submodule", "update", "--init", "--depth", "1"],
+                &tmp,
+                log_path,
+                token,
+            )
+            .await;
+            anyhow::Ok(())
+        }
+        .await
+    };
 
     if let Err(err) = fetch {
         let _ = tokio::fs::remove_dir_all(&tmp).await;
@@ -1379,11 +1604,13 @@ fn gc_once(work_root: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
 
     fn source(commit: &str) -> JobSource {
         JobSource {
             repo: "https://github.com/example/verity.git".to_string(),
             commit: commit.to_string(),
+            archive: None,
             bundle: None,
         }
     }
@@ -1402,6 +1629,213 @@ mod tests {
                 data_base64: base64::engine::general_purpose::STANDARD.encode(contents),
             }],
         }
+    }
+
+    fn committed_archive() -> (tempfile::TempDir, String, SourceArchive) {
+        let repo = tempfile::tempdir().unwrap();
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(repo.path())
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            output.stdout
+        };
+        git(&["init", "--quiet"]);
+        git(&["config", "user.name", "Archive Test"]);
+        git(&["config", "user.email", "archive@example.invalid"]);
+        std::fs::create_dir(repo.path().join("Proof")).unwrap();
+        std::fs::write(
+            repo.path().join("Proof/Main.lean"),
+            "theorem ok : True := by trivial\n",
+        )
+        .unwrap();
+        git(&["add", "Proof/Main.lean"]);
+        git(&[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            "source",
+        ]);
+        let commit = String::from_utf8(git(&["rev-parse", "HEAD"]))
+            .unwrap()
+            .trim()
+            .to_string();
+        let tree = git(&["ls-tree", "-r", "-t", "-z", "--full-tree", &commit]);
+        let root_tree = String::from_utf8(git(&["rev-parse", &format!("{commit}^{{tree}}")]))
+            .unwrap()
+            .trim()
+            .to_string();
+        let mut objects = vec![commit.clone(), root_tree];
+        for record in tree
+            .split(|byte| *byte == 0)
+            .filter(|record| !record.is_empty())
+        {
+            let metadata = record.split(|byte| *byte == b'\t').next().unwrap();
+            objects.push(
+                String::from_utf8(
+                    metadata
+                        .split(|byte| *byte == b' ')
+                        .nth(2)
+                        .unwrap()
+                        .to_vec(),
+                )
+                .unwrap(),
+            );
+        }
+        let mut child = Command::new("git")
+            .args(["pack-objects", "--stdout", "--no-reuse-delta"])
+            .current_dir(repo.path())
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        use std::io::Write;
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(format!("{}\n", objects.join("\n")).as_bytes())
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success());
+        let archive = SourceArchive {
+            sha256: source_archive_sha256(&commit, &output.stdout),
+            size_bytes: output.stdout.len() as u64,
+            data_base64: base64::engine::general_purpose::STANDARD.encode(output.stdout),
+        };
+        (repo, commit, archive)
+    }
+
+    #[tokio::test]
+    async fn private_equivalent_archive_materializes_without_runner_git_credentials() {
+        let (_source_repo, commit, archive) = committed_archive();
+        let work_root = tempfile::tempdir().unwrap();
+        let log = work_root.path().join("job.log");
+        let mut source = JobSource {
+            repo: "https://127.0.0.1:9/private/repository.git".to_string(),
+            commit: commit.clone(),
+            archive: Some(Box::new(archive)),
+            bundle: None,
+        };
+
+        let checkout = ensure_checkout(work_root.path(), &source, &log, &CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(checkout.join("Proof/Main.lean")).unwrap(),
+            "theorem ok : True := by trivial\n"
+        );
+        assert_eq!(
+            String::from_utf8(
+                Command::new("git")
+                    .args(["rev-parse", "HEAD"])
+                    .current_dir(&checkout)
+                    .output()
+                    .unwrap()
+                    .stdout
+            )
+            .unwrap()
+            .trim(),
+            commit
+        );
+        assert!(std::fs::read_to_string(log)
+            .unwrap()
+            .contains("source archive verified"));
+
+        let invalid_pack = b"not a git pack";
+        source.archive = Some(Box::new(SourceArchive {
+            sha256: source_archive_sha256(&commit, invalid_pack),
+            size_bytes: invalid_pack.len() as u64,
+            data_base64: base64::engine::general_purpose::STANDARD.encode(invalid_pack),
+        }));
+        assert!(
+            ensure_checkout(
+                work_root.path(),
+                &source,
+                &work_root.path().join("retry.log"),
+                &CancellationToken::new()
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("not a valid Git object pack"),
+            "a cached checkout must not bypass validation of a different archive"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_archive_is_commit_bound_and_missing_commit_fails_closed() {
+        let (_source_repo, commit, archive) = committed_archive();
+        let other_commit = "b".repeat(40);
+        let mut source = JobSource {
+            repo: "https://127.0.0.1:9/private/repository.git".to_string(),
+            commit: other_commit.clone(),
+            archive: Some(Box::new(archive.clone())),
+            bundle: None,
+        };
+        assert!(validate_lean_build(
+            &source,
+            None,
+            &["lake".to_string(), "build".to_string()],
+            &HashMap::new(),
+            &allowlist(),
+        )
+        .unwrap_err()
+        .contains("commit-bound hash mismatch"));
+
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&archive.data_base64)
+            .unwrap();
+        source.archive.as_mut().unwrap().sha256 = source_archive_sha256(&other_commit, &bytes);
+        let work_root = tempfile::tempdir().unwrap();
+        let error = ensure_checkout(
+            work_root.path(),
+            &source,
+            &work_root.path().join("job.log"),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("does not contain requested commit"),
+            "{error}; original commit was {commit}"
+        );
+    }
+
+    #[test]
+    fn source_archive_tree_validation_rejects_unsafe_paths_and_special_entries() {
+        assert!(validate_archive_tree_output(
+            b"100644 blob aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\t../escape\0"
+        )
+        .unwrap_err()
+        .contains("unsafe"));
+        assert!(validate_archive_tree_output(
+            b"120000 blob aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tlink\0"
+        )
+        .unwrap_err()
+        .contains("unsupported tree mode"));
+    }
+
+    #[test]
+    fn legacy_public_source_without_archive_remains_valid() {
+        assert!(validate_lean_build(
+            &source(&"a".repeat(40)),
+            None,
+            &["lake".to_string(), "build".to_string()],
+            &HashMap::new(),
+            &allowlist(),
+        )
+        .is_ok());
     }
 
     #[test]
@@ -1614,12 +2048,15 @@ mod tests {
             "../repo",
             "repo",
             "C:/repos/x",
+            "https://user:placeholder@example.invalid/private.git",
+            "https://example.invalid/private.git?token=placeholder",
         ] {
             assert!(
                 validate_lean_build(
                     &JobSource {
                         repo: bad.to_string(),
                         commit: "a".repeat(40),
+                        archive: None,
                         bundle: None,
                     },
                     None,
@@ -1641,6 +2078,7 @@ mod tests {
                     &JobSource {
                         repo: good.to_string(),
                         commit: "a".repeat(40),
+                        archive: None,
                         bundle: None,
                     },
                     None,
@@ -1834,16 +2272,19 @@ mod tests {
         let source_a = JobSource {
             repo: "https://example.com/a.git".to_string(),
             commit: "a".repeat(40),
+            archive: None,
             bundle: None,
         };
         let source_a_next_commit = JobSource {
             repo: source_a.repo.clone(),
             commit: "b".repeat(40),
+            archive: None,
             bundle: None,
         };
         let source_b = JobSource {
             repo: "https://example.com/b.git".to_string(),
             commit: "a".repeat(40),
+            archive: None,
             bundle: None,
         };
         let build = vec!["lake".to_string(), "build".to_string(), "A".to_string()];

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -44,6 +44,8 @@ const DEFAULT_MIN_FREE_GB: u64 = 10;
 const DEFAULT_MAX_SOURCE_BUNDLE_BYTES: u64 = 1 << 20;
 const MAX_SOURCE_BUNDLE_FILES: usize = 256;
 const DEFAULT_MAX_SOURCE_ARCHIVE_BYTES: u64 = 32 << 20;
+const DEFAULT_MAX_SOURCE_ARCHIVE_EXPANDED_BYTES: u64 = 2 << 30;
+const MAX_SOURCE_ARCHIVE_OBJECTS: usize = 100_000;
 
 /// Interval between node-side cache GC passes.
 const GC_INTERVAL: Duration = Duration::from_secs(30 * 60);
@@ -123,6 +125,14 @@ fn source_archive_max_bytes() -> u64 {
         .unwrap_or(DEFAULT_MAX_SOURCE_ARCHIVE_BYTES)
 }
 
+fn source_archive_expanded_max_bytes() -> u64 {
+    std::env::var("SANDBOXED_NODE_MAX_SOURCE_ARCHIVE_EXPANDED_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|bytes| *bytes > 0)
+        .unwrap_or(DEFAULT_MAX_SOURCE_ARCHIVE_EXPANDED_BYTES)
+}
+
 pub(crate) fn source_archive_sha256(commit: &str, bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"sandboxed-source-archive-v1\0");
@@ -153,8 +163,21 @@ fn decode_source_archive(source: &JobSource, archive: &SourceArchive) -> Result<
     if bytes.len() as u64 != archive.size_bytes {
         return Err("source archive decoded size mismatch".to_string());
     }
-    if source_archive_sha256(&source.commit, &bytes) != archive.sha256 {
+    let computed = source_archive_sha256(&source.commit, &bytes);
+    if !crate::remote_node::protocol::constant_time_eq(
+        computed.as_bytes(),
+        archive.sha256.as_bytes(),
+    ) {
         return Err("source archive commit-bound hash mismatch".to_string());
+    }
+    if bytes.len() < 12 || &bytes[..4] != b"PACK" {
+        return Err("source archive is not a Git pack".to_string());
+    }
+    let object_count = u32::from_be_bytes(bytes[8..12].try_into().expect("fixed pack header"));
+    if object_count as usize > MAX_SOURCE_ARCHIVE_OBJECTS {
+        return Err(format!(
+            "source archive contains more than {MAX_SOURCE_ARCHIVE_OBJECTS} objects"
+        ));
     }
     Ok(bytes)
 }
@@ -257,11 +280,10 @@ fn repo_url_has_credentials(repo: &str) -> bool {
     let Ok(parsed) = url::Url::parse(repo) else {
         return false;
     };
-    matches!(parsed.scheme(), "http" | "https")
-        && (!parsed.username().is_empty()
-            || parsed.password().is_some()
-            || parsed.query().is_some()
-            || parsed.fragment().is_some())
+    parsed.password().is_some()
+        || (matches!(parsed.scheme(), "http" | "https") && !parsed.username().is_empty())
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
 }
 
 /// Validate a lean-build payload before touching the filesystem or network.
@@ -277,7 +299,7 @@ pub fn validate_lean_build(
     }
     if repo_url_has_credentials(&source.repo) {
         return Err(
-            "source.repo HTTP URL must not contain userinfo, query parameters, or a fragment"
+            "source.repo URL must not contain credentials, query parameters, or a fragment"
                 .to_string(),
         );
     }
@@ -848,6 +870,17 @@ fn validate_archive_tree_output(output: &[u8]) -> Result<(), String> {
                 String::from_utf8_lossy(mode)
             ));
         }
+        let fields = metadata.split(|byte| *byte == b' ').collect::<Vec<_>>();
+        if fields.len() != 3
+            || !matches!(
+                (fields[0], fields[1]),
+                (b"040000", b"tree") | (b"100644" | b"100755", b"blob")
+            )
+            || fields[2].len() != 40
+            || !fields[2].iter().all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err("malformed source archive tree metadata".to_string());
+        }
         let path = std::str::from_utf8(path)
             .map_err(|_| "source archive paths must be UTF-8".to_string())?;
         if path.starts_with('/')
@@ -906,6 +939,54 @@ async fn import_source_archive(
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
+    let pack_hash_output = std::str::from_utf8(&output.stdout)
+        .map_err(|_| anyhow::anyhow!("git index-pack returned a non-UTF-8 pack id"))?
+        .trim();
+    let pack_hash = pack_hash_output
+        .strip_prefix("pack\t")
+        .unwrap_or(pack_hash_output);
+    if pack_hash.len() != 40 || !pack_hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        anyhow::bail!("git index-pack returned an invalid pack id");
+    }
+    let index_path = tmp.join(format!(".git/objects/pack/pack-{pack_hash}.idx"));
+    let verified = tokio::process::Command::new("git")
+        .args(["verify-pack", "-v"])
+        .arg(&index_path)
+        .current_dir(tmp)
+        .output()
+        .await?;
+    if !verified.status.success() {
+        anyhow::bail!("source archive pack verification failed");
+    }
+    let expanded_limit = source_archive_expanded_max_bytes();
+    let mut expanded_bytes = 0_u64;
+    let mut object_count = 0_usize;
+    for line in verified.stdout.split(|byte| *byte == b'\n') {
+        let mut fields = line
+            .split(|byte| byte.is_ascii_whitespace())
+            .filter(|field| !field.is_empty());
+        let Some(object_id) = fields.next() else {
+            continue;
+        };
+        if object_id.len() != 40 || !object_id.iter().all(|byte| byte.is_ascii_hexdigit()) {
+            continue;
+        }
+        let _kind = fields.next();
+        let size = fields
+            .next()
+            .and_then(|raw| std::str::from_utf8(raw).ok())
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .ok_or_else(|| anyhow::anyhow!("malformed source archive object size"))?;
+        object_count = object_count.saturating_add(1);
+        if object_count > MAX_SOURCE_ARCHIVE_OBJECTS {
+            anyhow::bail!("source archive contains more than {MAX_SOURCE_ARCHIVE_OBJECTS} objects");
+        }
+        expanded_bytes = expanded_bytes.saturating_add(size);
+        if expanded_bytes > expanded_limit {
+            anyhow::bail!("source archive expands to more than {expanded_limit} bytes");
+        }
+    }
+    tokio::fs::write(tmp.join(".git/shallow"), format!("{}\n", source.commit)).await?;
 
     let commit_object = format!("{}^{{commit}}", source.commit);
     run_git_step(
@@ -1046,15 +1127,39 @@ async fn ensure_checkout(
         let _ = tokio::fs::remove_dir_all(&tmp).await;
         return Err(err);
     }
+    let stale = if dest.is_dir() {
+        let stale = parent.join(format!(".stale-{}", uuid::Uuid::new_v4()));
+        tokio::fs::rename(&dest, &stale).await?;
+        Some(stale)
+    } else {
+        None
+    };
     match tokio::fs::rename(&tmp, &dest).await {
-        Ok(()) => Ok(dest),
+        Ok(()) => {
+            if let Some(stale) = stale {
+                let _ = tokio::fs::remove_dir_all(stale).await;
+            }
+            Ok(dest)
+        }
         // A concurrent build (other lock domain) won the rename; reuse theirs.
-        Err(_) if dest.is_dir() => {
+        Err(_)
+            if dest.is_dir()
+                && source.archive.as_ref().is_none_or(|archive| {
+                    std::fs::read_to_string(dest.join(".git/sandboxed-source-archive"))
+                        .is_ok_and(|digest| digest.trim() == archive.sha256)
+                }) =>
+        {
             let _ = tokio::fs::remove_dir_all(&tmp).await;
+            if let Some(stale) = stale {
+                let _ = tokio::fs::remove_dir_all(stale).await;
+            }
             Ok(dest)
         }
         Err(err) => {
             let _ = tokio::fs::remove_dir_all(&tmp).await;
+            if let Some(stale) = stale {
+                let _ = tokio::fs::rename(stale, &dest).await;
+            }
             Err(err.into())
         }
     }
@@ -1650,6 +1755,16 @@ mod tests {
         git(&["config", "user.name", "Archive Test"]);
         git(&["config", "user.email", "archive@example.invalid"]);
         std::fs::create_dir(repo.path().join("Proof")).unwrap();
+        std::fs::write(repo.path().join("Proof/Main.lean"), "baseline\n").unwrap();
+        git(&["add", "Proof/Main.lean"]);
+        git(&[
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            "parent",
+        ]);
         std::fs::write(
             repo.path().join("Proof/Main.lean"),
             "theorem ok : True := by trivial\n",
@@ -1750,6 +1865,36 @@ mod tests {
         assert!(std::fs::read_to_string(log)
             .unwrap()
             .contains("source archive verified"));
+        let log_history = Command::new("git")
+            .args(["log", "--format=%H", "-1"])
+            .current_dir(&checkout)
+            .output()
+            .unwrap();
+        assert!(
+            log_history.status.success(),
+            "the archived commit must be a valid shallow history boundary"
+        );
+
+        // A legacy or differently attested cached checkout must be replaced by
+        // the verified archive, never returned after the temporary validation.
+        std::fs::write(checkout.join("Proof/Main.lean"), "stale checkout\n").unwrap();
+        std::fs::write(
+            checkout.join(".git/sandboxed-source-archive"),
+            format!("{}\n", "0".repeat(64)),
+        )
+        .unwrap();
+        let replaced = ensure_checkout(
+            work_root.path(),
+            &source,
+            &work_root.path().join("replace.log"),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(replaced.join("Proof/Main.lean")).unwrap(),
+            "theorem ok : True := by trivial\n"
+        );
 
         let invalid_pack = b"not a git pack";
         source.archive = Some(Box::new(SourceArchive {
@@ -1767,7 +1912,7 @@ mod tests {
             .await
             .unwrap_err()
             .to_string()
-            .contains("not a valid Git object pack"),
+            .contains("not a Git pack"),
             "a cached checkout must not bypass validation of a different archive"
         );
     }

--- a/src/node/runner.rs
+++ b/src/node/runner.rs
@@ -55,6 +55,16 @@ struct QueuedJob {
     payload: JobPayload,
 }
 
+fn persisted_payload_json(payload: &JobPayload) -> anyhow::Result<String> {
+    let mut persisted_payload = payload.clone();
+    if let JobPayload::LeanBuild { source, .. } = &mut persisted_payload {
+        if let Some(archive) = &mut source.archive {
+            archive.data_base64.clear();
+        }
+    }
+    Ok(serde_json::to_string(&persisted_payload)?)
+}
+
 /// Shared job runner; construct with [`JobRunner::spawn`].
 pub struct JobRunner {
     store: JobStore,
@@ -171,7 +181,10 @@ impl JobRunner {
         mission_id: Uuid,
         payload: JobPayload,
     ) -> anyhow::Result<()> {
-        let payload_json = serde_json::to_string(&payload)?;
+        // The executable payload remains only in the in-memory queue. Durable
+        // rows are status receipts (in-flight jobs become `lost` on restart),
+        // so never retain commit-pack source bytes in jobs.db.
+        let payload_json = persisted_payload_json(&payload)?;
         // The dispatcher drains the mpsc channel into semaphore waiters so a
         // cancelled queued job releases its channel slot immediately. Keep an
         // explicit atomic bound across both locations.
@@ -759,6 +772,41 @@ pub async fn read_log_tail(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::remote_node::{JobSource, SourceArchive};
+
+    #[test]
+    fn persisted_lean_payload_redacts_source_archive_bytes() {
+        let payload = JobPayload::LeanBuild {
+            source: JobSource {
+                repo: "https://example.invalid/private.git".to_string(),
+                commit: "a".repeat(40),
+                archive: Some(Box::new(SourceArchive {
+                    sha256: "b".repeat(64),
+                    size_bytes: 18,
+                    data_base64: "private-source-data".to_string(),
+                })),
+                bundle: None,
+            },
+            cwd_rel: None,
+            command: vec!["lake".to_string(), "build".to_string()],
+            timeout_secs: None,
+            estimated_disk_bytes: None,
+            cache_key: None,
+            artifacts: Vec::new(),
+            env: HashMap::new(),
+        };
+
+        let persisted = persisted_payload_json(&payload).unwrap();
+        assert!(!persisted.contains("private-source-data"));
+        let decoded: JobPayload = serde_json::from_str(&persisted).unwrap();
+        let JobPayload::LeanBuild { source, .. } = decoded else {
+            panic!("expected Lean payload");
+        };
+        let archive = source.archive.unwrap();
+        assert!(archive.data_base64.is_empty());
+        assert_eq!(archive.sha256, "b".repeat(64));
+        assert_eq!(archive.size_bytes, 18);
+    }
 
     #[tokio::test]
     async fn runs_a_job_and_captures_its_log() {

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -15,7 +15,7 @@ use super::RemoteNodeError;
 type HmacSha256 = Hmac<Sha256>;
 
 /// Current node protocol version reported by heartbeats.
-pub const NODE_PROTOCOL_VERSION: u32 = 3;
+pub const NODE_PROTOCOL_VERSION: u32 = 4;
 /// First protocol that reports `active_jobs` and `queued_jobs` in heartbeats.
 pub const NODE_JOB_COUNTER_PROTOCOL_VERSION: u32 = 2;
 
@@ -118,20 +118,32 @@ pub struct ExecuteResponse {
     pub stderr: String,
 }
 
-/// Git source of a declarative build job: the node fetches exactly this
-/// commit itself, so no workspace sync between core and node is needed.
+/// Git source of a declarative build job. New clients attach a complete,
+/// commit-bound archive; legacy public builds may still let the node fetch.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct JobSource {
-    /// Clone/fetch URL (https or ssh).
+    /// Credential-free repository identity and legacy clone/fetch URL.
     pub repo: String,
     /// Full 40-char lowercase hex commit SHA. Branch names are rejected so a
     /// job always builds a pinned, reproducible tree.
     pub commit: String,
+    /// Optional complete Git object pack for `commit`. When present, the node
+    /// materializes the checkout without contacting `repo`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archive: Option<Box<SourceArchive>>,
     /// Optional bounded overlay applied after resetting the pinned checkout.
     /// This lets a local-only proof source run remotely without creating or
     /// pushing a Git commit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bundle: Option<SourceBundle>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceArchive {
+    /// SHA-256 over `sandboxed-source-archive-v1\0<commit>\0<pack bytes>`.
+    pub sha256: String,
+    pub size_bytes: u64,
+    pub data_base64: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -488,6 +500,7 @@ mod tests {
             source: JobSource {
                 repo: "https://github.com/example/verity.git".to_string(),
                 commit: "a".repeat(40),
+                archive: None,
                 bundle: None,
             },
             cwd_rel: Some("morpho-verity".to_string()),


### PR DESCRIPTION
## Summary

- send a bounded Git object pack containing the exact requested commit snapshot from the authenticated workspace to the runner
- bind the pack digest to the immutable commit SHA, require the exact commit and complete tree, reject unsafe paths/special entries, and attest cached checkouts
- strip HTTP repository credentials/query data before submission and reject credential-bearing URLs at both control-plane and node boundaries
- retain the existing hashed working-tree overlay and legacy unauthenticated fetch path for public requests without an archive
- bump the node protocol so archive jobs are placed only on upgraded runners

No credentials are included in the source transport. This PR does not deploy or run the affected Lido build.

## Tests

Passing focused regressions:

```text
cargo test --lib node::lean::tests::private_equivalent_archive_materializes_without_runner_git_credentials -- --exact --nocapture
cargo test --lib source_archive -- --nocapture
cargo test --lib api::remote_build::tests::wrapper_sends_dirty_sources_as_a_hashed_bounded_bundle -- --exact --nocapture
cargo test --lib node::lean::tests::legacy_public_source_without_archive_remains_valid -- --exact --nocapture
```

Also passed:

```text
cargo fmt --all --check
cargo check --all-targets
```

`cargo test` ran 1,600 non-ignored library tests: 1,599 passed. The sole failure was the pre-existing `wrapper_resumes_an_interrupted_async_job_without_resubmitting` permission simulation: it expects `chmod 500` to prevent a receipt write, but the local test process runs as root and the write succeeds. The focused wrapper regression above passes; CI's non-root environment should exercise the intended permission failure.

## Rollout / canary (not performed)

1. Upgrade remote nodes first and confirm heartbeat protocol version 4 on each eligible Lean runner.
2. Upgrade the control plane only after protocol-4 capacity is available; archive submissions intentionally exclude older nodes.
3. Canary with a small throwaway private repository and a no-op/minimal Lean target, with runner Git credentials unset; confirm the receipt records the exact commit and the log reports archive verification without a fetch.
4. Canary a small public repository through both the new bundled wrapper and a legacy request without `source_archive`.
5. Exercise tampered archive digest and mismatched-commit requests and confirm they fail before build execution.
6. Observe node disk/memory, request-size behavior, placement, receipts, and error logs before enabling normal private-repository traffic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches private source transport, authentication boundaries, and checkout materialization on remote runners; archive jobs require protocol v4 rollout before control-plane upgrade.
> 
> **Overview**
> **Private remote Lean builds** no longer depend on runners fetching `origin` with credentials. The `remote-lean-build` wrapper builds a bounded Git object pack for the pinned commit (overlay mode), strips userinfo/query/fragment from `repo`, and sends `source_archive` alongside the existing dirty-file overlay; full source mode skips the archive to avoid duplicating bytes.
> 
> The **control plane** accepts `source_archive`, rejects credential-bearing repository URLs, requires current protocol (v4) for archive jobs, skips equivalent-validation reuse when an archive is present, and raises HTTP body limits. **Runners** validate the pack (commit-bound SHA-256, size/object limits, tree safety), import via `git index-pack` into a shallow checkout, and cache by archive digest; legacy public fetch and complete/overlay bundles still work. Submodule trees fall back to runner fetch; receipts persist only archive hash/size, not pack bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad4c8fed51f44ad52a4f150acfce279ba647f57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->