### PR TITLE
Support credential-free private remote builds

### DIFF
--- a/docs/REMOTE_NODES.md
+++ b/docs/REMOTE_NODES.md
@@ -130,9 +130,10 @@ To rotate a node token with zero downtime:
 `GET /heartbeat` returns the v1 fields (`node_id`, `online`, `capacity_total`,
 `capacity_available`, `active_leases`, `version`) plus:
 
-- `protocol_version` (currently `3`; core treats a missing field as `1`).
-  Version 3 is required for source-bundle jobs so a rolling deployment can
-  never silently drop a dirty overlay on an older node.
+- `protocol_version` (currently `4`; core treats a missing field as `1`).
+  Version 3 is required for overlay jobs and version 4 for complete-source
+  jobs, so a rolling deployment can never silently fetch a private repository
+  or drop source content on an older node.
 - `labels` (from `SANDBOXED_NODE_LABELS`)
 - `cpu_total` (logical cores)
 - `mem_total_bytes` / `mem_available_bytes`
@@ -226,8 +227,9 @@ Node env vars for lean-build jobs:
   filesystem drops below it, checkout dirs then lake cache slots are
   LRU-deleted (by dir mtime) until the threshold is met.
 - `SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES` — maximum decoded size of a local
-  source overlay (default 1 MiB; at most 256 regular files). Paths, per-file
-  hashes and the manifest hash are verified before any file is applied.
+  source bundle (default 1 MiB/256 files for overlays and 16 MiB/4096 files
+  for complete snapshots). Paths, per-file hashes and the manifest hash are
+  verified before any file is applied.
 - `SANDBOXED_NODE_GIT_SSH_KEY` — path to an SSH key used for git fetches
   (`GIT_SSH_COMMAND="ssh -i <key> -o IdentitiesOnly=yes -o
   StrictHostKeyChecking=accept-new"`); unset = default git auth.
@@ -444,7 +446,12 @@ It derives `repo` (`git remote get-url origin`), `commit`
 (`git rev-parse HEAD`), the Lean toolchain, and `cwd_rel`
 (`git rev-parse --show-prefix`). Dirty Lean sources and build metadata are sent
 as a bounded hashed overlay; unsupported deletions/renames fail before
-submission. It submits asynchronously to
+submission. For a private repository, set
+`REMOTE_BUILD_SOURCE_MODE=full`: the wrapper sends a content-addressed snapshot
+of all tracked files (plus the same narrow untracked Lean/build metadata
+allowlist), and the node materializes it without any Git fetch or repository
+credential. The receipt binds both the declared commit and the snapshot digest.
+It submits asynchronously to
 `$REMOTE_BUILD_URL` with `$REMOTE_BUILD_TOKEN`/`$REMOTE_BUILD_MISSION_ID`,
 persists the returned job/node receipt under
 `${XDG_STATE_HOME:-$HOME/.local/state}/sandboxed-sh/remote-builds/`, then polls

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -70,13 +70,20 @@ def git_paths(*args):
     raw = subprocess.check_output(["git", "-C", str(repo_root), *args])
     return [item.decode("utf-8") for item in raw.split(b"\0") if item]
 
+source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
+if source_mode not in {"overlay", "full"}:
+    raise SystemExit("REMOTE_BUILD_SOURCE_MODE must be 'overlay' or 'full'")
 deleted = git_paths("diff", "--name-only", "-z", "--diff-filter=DR", "HEAD")
-if deleted:
+if deleted and source_mode != "full":
     raise SystemExit(
         "remote source bundles do not encode deletions or renames; commit/stash these paths first: "
         + ", ".join(deleted[:8])
     )
-tracked = git_paths("diff", "--name-only", "-z", "--diff-filter=ACMRTUXB", "HEAD")
+tracked = (
+    git_paths("ls-files", "--full-name", "-z")
+    if source_mode == "full"
+    else git_paths("diff", "--name-only", "-z", "--diff-filter=ACMRTUXB", "HEAD")
+)
 untracked = git_paths("ls-files", "--full-name", "--others", "--exclude-standard", "-z")
 untracked_source = [
     path for path in untracked
@@ -93,15 +100,22 @@ if ignored_untracked:
         file=sys.stderr,
     )
 paths = sorted(set(tracked + untracked_source))
-max_files = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES", "256"))
-max_bytes = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES", str(1 << 20)))
+default_max_files = "4096" if source_mode == "full" else "256"
+default_max_bytes = str(16 << 20) if source_mode == "full" else str(1 << 20)
+max_files = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_FILES", default_max_files))
+max_bytes = int(os.environ.get("REMOTE_BUILD_MAX_SOURCE_BUNDLE_BYTES", default_max_bytes))
 if max_files <= 0 or max_bytes <= 0:
     raise SystemExit("remote source bundle limits must be positive integers")
 if len(paths) > max_files:
     raise SystemExit(f"source bundle has {len(paths)} files; maximum is {max_files}")
 files = []
 total = 0
-manifest = hashlib.sha256(b"sandboxed-source-bundle-v1\n")
+manifest_domain = (
+    b"sandboxed-source-bundle-v2-complete\n"
+    if source_mode == "full"
+    else b"sandboxed-source-bundle-v1\n"
+)
+manifest = hashlib.sha256(manifest_domain)
 for rel in paths:
     components = rel.split("/")
     if (
@@ -117,6 +131,9 @@ for rel in paths:
     ):
         raise SystemExit(f"unsafe source bundle path: {rel!r}")
     path = repo_root / rel
+    if source_mode == "full" and not path.exists():
+        # A complete snapshot represents tracked deletions by omission.
+        continue
     if path.is_symlink() or not path.is_file():
         raise SystemExit(f"source bundle path must be a regular file, not a symlink: {rel}")
     data = path.read_bytes()
@@ -137,6 +154,7 @@ if files:
     req["source_bundle"] = {
         "manifest_sha256": manifest.hexdigest(),
         "files": files,
+        "complete": source_mode == "full",
     }
 if cwd_rel:
     req["cwd_rel"] = cwd_rel

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -266,6 +266,14 @@ fn default_wait() -> bool {
     true
 }
 
+fn minimum_node_protocol_version(source_bundle: Option<&SourceBundle>) -> u32 {
+    match source_bundle {
+        Some(bundle) if bundle.complete => crate::remote_node::protocol::NODE_PROTOCOL_VERSION,
+        Some(_) => 3,
+        None => 1,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RemoteBuildRequest {
     /// Mission this build belongs to; `token` must be the capability token
@@ -908,11 +916,7 @@ async fn submit_remote_build(
             .into_response();
     }
     let min_disk_bytes = required_node_disk_bytes(req.estimated_disk_bytes);
-    let min_protocol_version = if req.source_bundle.is_some() {
-        crate::remote_node::protocol::NODE_PROTOCOL_VERSION
-    } else {
-        1
-    };
+    let min_protocol_version = minimum_node_protocol_version(req.source_bundle.as_ref());
     // Every endpoint payload is a declarative Lean build. Callers may add
     // placement labels, but may not remove the runtime readiness gate by
     // sending an empty or unrelated requirements list.
@@ -1509,6 +1513,32 @@ mod tests {
         assert!(!heartbeat_protocol_has_job_counters(1));
         assert!(heartbeat_protocol_has_job_counters(2));
         assert!(heartbeat_protocol_has_job_counters(3));
+        assert!(heartbeat_protocol_has_job_counters(4));
+    }
+
+    #[test]
+    fn complete_source_requires_v4_but_overlay_remains_v3_compatible() {
+        let file = crate::remote_node::SourceBundleFile {
+            path: "lean-toolchain".to_string(),
+            sha256: "a".repeat(64),
+            data_base64: String::new(),
+        };
+        let overlay = SourceBundle {
+            manifest_sha256: "b".repeat(64),
+            files: vec![file.clone()],
+            complete: false,
+        };
+        let complete = SourceBundle {
+            manifest_sha256: "c".repeat(64),
+            files: vec![file],
+            complete: true,
+        };
+        assert_eq!(minimum_node_protocol_version(None), 1);
+        assert_eq!(minimum_node_protocol_version(Some(&overlay)), 3);
+        assert_eq!(
+            minimum_node_protocol_version(Some(&complete)),
+            crate::remote_node::protocol::NODE_PROTOCOL_VERSION
+        );
     }
 
     #[test]
@@ -2037,7 +2067,7 @@ printf '503'
                 "/scripts/remote-lean-build"
             ))
             .current_dir(repo.join("Theory"))
-            .env("PATH", path)
+            .env("PATH", &path)
             .env(
                 "REMOTE_BUILD_URL",
                 "http://example.invalid/api/remote-build",
@@ -2051,7 +2081,7 @@ printf '503'
         assert_eq!(output.status.code(), Some(75));
 
         let request: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+            serde_json::from_slice(&std::fs::read(&capture).unwrap()).unwrap();
         assert_eq!(
             request
                 .get("estimated_disk_bytes")
@@ -2088,7 +2118,73 @@ printf '503'
             .collect::<Vec<_>>();
         assert_eq!(
             bundle.get("manifest_sha256").unwrap().as_str().unwrap(),
-            crate::node::lean::bundle_manifest_sha256(&manifest)
+            crate::node::lean::bundle_manifest_sha256_for_mode(&manifest, false)
+        );
+        assert_eq!(
+            bundle.get("complete").and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+
+        let full_output = std::process::Command::new("bash")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/remote-lean-build"
+            ))
+            .current_dir(repo.join("Theory"))
+            .env("PATH", &path)
+            .env(
+                "REMOTE_BUILD_URL",
+                "http://example.invalid/api/remote-build",
+            )
+            .env("REMOTE_BUILD_TOKEN", "test-token")
+            .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
+            .env("REMOTE_BUILD_EXPECTED_HEAD", "a".repeat(40))
+            .env("REMOTE_BUILD_TEST_CAPTURE", &capture)
+            .env("REMOTE_BUILD_SOURCE_MODE", "full")
+            .output()
+            .unwrap();
+        assert_eq!(full_output.status.code(), Some(75));
+
+        let full_request: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+        let full_bundle = full_request.get("source_bundle").unwrap();
+        assert_eq!(
+            full_bundle
+                .get("complete")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            full_bundle
+                .get("files")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|file| file.get("path").unwrap().as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["Theory/Proof.lean", "Theory/Witness.lean", "lean-toolchain"]
+        );
+        let full_manifest = full_bundle
+            .get("files")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|file| {
+                (
+                    file.get("path").unwrap().as_str().unwrap().to_string(),
+                    file.get("sha256").unwrap().as_str().unwrap().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            full_bundle
+                .get("manifest_sha256")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            crate::node::lean::bundle_manifest_sha256_for_mode(&full_manifest, true)
         );
     }
 

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -40,7 +40,9 @@ pub const ALLOWED_COMMANDS: [&str; 2] = ["lake", "lean"];
 /// filesystem backing the work dir (`SANDBOXED_NODE_MIN_FREE_GB` overrides).
 const DEFAULT_MIN_FREE_GB: u64 = 10;
 const DEFAULT_MAX_SOURCE_BUNDLE_BYTES: u64 = 1 << 20;
+const DEFAULT_MAX_COMPLETE_SOURCE_BUNDLE_BYTES: u64 = 16 << 20;
 const MAX_SOURCE_BUNDLE_FILES: usize = 256;
+const MAX_COMPLETE_SOURCE_BUNDLE_FILES: usize = 4096;
 
 /// Interval between node-side cache GC passes.
 const GC_INTERVAL: Duration = Duration::from_secs(30 * 60);
@@ -104,12 +106,16 @@ pub fn rel_path_is_safe(rel_clean: &str) -> bool {
         })
 }
 
-fn source_bundle_max_bytes() -> u64 {
+fn source_bundle_max_bytes(bundle: &SourceBundle) -> u64 {
     std::env::var("SANDBOXED_NODE_MAX_SOURCE_BUNDLE_BYTES")
         .ok()
         .and_then(|raw| raw.trim().parse::<u64>().ok())
         .filter(|bytes| *bytes > 0)
-        .unwrap_or(DEFAULT_MAX_SOURCE_BUNDLE_BYTES)
+        .unwrap_or(if bundle.complete {
+            DEFAULT_MAX_COMPLETE_SOURCE_BUNDLE_BYTES
+        } else {
+            DEFAULT_MAX_SOURCE_BUNDLE_BYTES
+        })
 }
 
 fn bundle_path_is_safe(path: &str) -> bool {
@@ -120,9 +126,16 @@ fn bundle_path_is_safe(path: &str) -> bool {
             .any(|component| matches!(component, ".git" | ".lake"))
 }
 
-pub(crate) fn bundle_manifest_sha256(files: &[(String, String)]) -> String {
+pub(crate) fn bundle_manifest_sha256_for_mode(
+    files: &[(String, String)],
+    complete: bool,
+) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"sandboxed-source-bundle-v1\n");
+    if complete {
+        hasher.update(b"sandboxed-source-bundle-v2-complete\n");
+    } else {
+        hasher.update(b"sandboxed-source-bundle-v1\n");
+    }
     for (path, sha256) in files {
         hasher.update(path.as_bytes());
         hasher.update(b"\0");
@@ -136,9 +149,14 @@ fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
     if bundle.files.is_empty() {
         return Err("source.bundle.files must not be empty".to_string());
     }
-    if bundle.files.len() > MAX_SOURCE_BUNDLE_FILES {
+    let max_files = if bundle.complete {
+        MAX_COMPLETE_SOURCE_BUNDLE_FILES
+    } else {
+        MAX_SOURCE_BUNDLE_FILES
+    };
+    if bundle.files.len() > max_files {
         return Err(format!(
-            "source bundle has {} files; maximum is {MAX_SOURCE_BUNDLE_FILES}",
+            "source bundle has {} files; maximum is {max_files}",
             bundle.files.len()
         ));
     }
@@ -165,10 +183,10 @@ fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
             .decode(&file.data_base64)
             .map_err(|_| format!("invalid source bundle base64 for '{}'", file.path))?;
         total = total.saturating_add(bytes.len() as u64);
-        if total > source_bundle_max_bytes() {
+        if total > source_bundle_max_bytes(bundle) {
             return Err(format!(
                 "source bundle is {total} bytes; maximum is {}",
-                source_bundle_max_bytes()
+                source_bundle_max_bytes(bundle)
             ));
         }
         if hex::encode(Sha256::digest(&bytes)) != file.sha256 {
@@ -179,7 +197,7 @@ fn validate_source_bundle(bundle: &SourceBundle) -> Result<u64, String> {
         }
         manifest_files.push((file.path.clone(), file.sha256.clone()));
     }
-    let expected = bundle_manifest_sha256(&manifest_files);
+    let expected = bundle_manifest_sha256_for_mode(&manifest_files, bundle.complete);
     if expected != bundle.manifest_sha256 {
         return Err("source bundle manifest hash mismatch".to_string());
     }
@@ -770,8 +788,34 @@ async fn ensure_checkout(
     log_path: &Path,
     token: &CancellationToken,
 ) -> anyhow::Result<PathBuf> {
-    let dest = checkout_dir(work_root, &source.repo, &source.commit);
-    if dest.is_dir() {
+    let base = checkout_dir(work_root, &source.repo, &source.commit);
+    let complete_bundle = source.bundle.as_ref().filter(|bundle| bundle.complete);
+    let dest = complete_bundle.map_or(base.clone(), |bundle| {
+        base.with_file_name(format!(
+            "{}-source-{}",
+            source.commit, bundle.manifest_sha256
+        ))
+    });
+    if complete_bundle.is_some() {
+        match tokio::fs::symlink_metadata(&dest).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => anyhow::bail!(
+                "complete source checkout must not be a symlink: {}",
+                dest.display()
+            ),
+            Ok(metadata) if metadata.is_dir() => {
+                // Complete snapshots have no Git metadata to reset. Recreate
+                // their source before each build so stale `.lake` output can
+                // never turn into validation evidence.
+                tokio::fs::remove_dir_all(&dest).await?;
+            }
+            Ok(_) => anyhow::bail!(
+                "complete source checkout is not a directory: {}",
+                dest.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    } else if dest.is_dir() {
         return Ok(dest);
     }
     let parent = dest
@@ -781,7 +825,11 @@ async fn ensure_checkout(
     let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&tmp).await?;
 
-    let fetch = async {
+    let materialize = async {
+        if let Some(bundle) = complete_bundle {
+            apply_source_bundle(&tmp, bundle, log_path).await?;
+            return anyhow::Ok(());
+        }
         run_git_step(&["init", "--quiet"], &tmp, log_path, token).await?;
         run_git_step(
             &[
@@ -817,7 +865,7 @@ async fn ensure_checkout(
     }
     .await;
 
-    if let Err(err) = fetch {
+    if let Err(err) = materialize {
         let _ = tokio::fs::remove_dir_all(&tmp).await;
         return Err(err);
     }
@@ -1089,15 +1137,17 @@ pub async fn execute_lean_build(
     // Reset it before every invocation so a cancelled/different-target build
     // cannot leave `.lake` files or artifacts that a later job mistakes for
     // its own output.
-    run_git_step(
-        &["reset", "--hard", source.commit.as_str()],
-        &checkout,
-        log_path,
-        token,
-    )
-    .await?;
-    run_git_step(&["clean", "-ffdx"], &checkout, log_path, token).await?;
-    if let Some(bundle) = &source.bundle {
+    if source.bundle.as_ref().is_none_or(|bundle| !bundle.complete) {
+        run_git_step(
+            &["reset", "--hard", source.commit.as_str()],
+            &checkout,
+            log_path,
+            token,
+        )
+        .await?;
+        run_git_step(&["clean", "-ffdx"], &checkout, log_path, token).await?;
+    }
+    if let Some(bundle) = source.bundle.as_ref().filter(|bundle| !bundle.complete) {
         apply_source_bundle(&checkout, bundle, log_path).await?;
     }
 
@@ -1395,12 +1445,16 @@ mod tests {
     fn source_bundle(path: &str, contents: &[u8]) -> SourceBundle {
         let sha256 = hex::encode(Sha256::digest(contents));
         SourceBundle {
-            manifest_sha256: bundle_manifest_sha256(&[(path.to_string(), sha256.clone())]),
+            manifest_sha256: bundle_manifest_sha256_for_mode(
+                &[(path.to_string(), sha256.clone())],
+                false,
+            ),
             files: vec![crate::remote_node::SourceBundleFile {
                 path: path.to_string(),
                 sha256,
                 data_base64: base64::engine::general_purpose::STANDARD.encode(contents),
             }],
+            complete: false,
         }
     }
 
@@ -1603,6 +1657,51 @@ mod tests {
         let receipt = tokio::fs::read_to_string(log).await.unwrap();
         assert!(receipt.contains(&bundle.manifest_sha256));
         assert!(receipt.contains("files=1 bytes=10"));
+    }
+
+    #[tokio::test]
+    async fn complete_source_bundle_materializes_without_git_and_rebuilds_cleanly() {
+        let temp = tempfile::tempdir().unwrap();
+        let log = temp.path().join("job.log");
+        let mut bundled_source = source(&"a".repeat(40));
+        let mut bundle = source_bundle("lean-toolchain", b"leanprover/lean4:v4.31.0\n");
+        bundle.complete = true;
+        bundle.manifest_sha256 = bundle_manifest_sha256_for_mode(
+            &bundle
+                .files
+                .iter()
+                .map(|file| (file.path.clone(), file.sha256.clone()))
+                .collect::<Vec<_>>(),
+            true,
+        );
+        bundled_source.bundle = Some(bundle);
+        let token = CancellationToken::new();
+
+        let checkout = ensure_checkout(temp.path(), &bundled_source, &log, &token)
+            .await
+            .unwrap();
+        assert_ne!(
+            checkout,
+            checkout_dir(temp.path(), &bundled_source.repo, &bundled_source.commit)
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(checkout.join("lean-toolchain"))
+                .await
+                .unwrap(),
+            "leanprover/lean4:v4.31.0\n"
+        );
+        tokio::fs::create_dir_all(checkout.join(".lake/build"))
+            .await
+            .unwrap();
+        tokio::fs::write(checkout.join(".lake/build/stale.olean"), b"stale")
+            .await
+            .unwrap();
+
+        let rebuilt = ensure_checkout(temp.path(), &bundled_source, &log, &token)
+            .await
+            .unwrap();
+        assert_eq!(checkout, rebuilt);
+        assert!(!rebuilt.join(".lake").exists());
     }
 
     #[test]

--- a/src/remote_node/protocol.rs
+++ b/src/remote_node/protocol.rs
@@ -15,7 +15,7 @@ use super::RemoteNodeError;
 type HmacSha256 = Hmac<Sha256>;
 
 /// Current node protocol version reported by heartbeats.
-pub const NODE_PROTOCOL_VERSION: u32 = 3;
+pub const NODE_PROTOCOL_VERSION: u32 = 4;
 /// First protocol that reports `active_jobs` and `queued_jobs` in heartbeats.
 pub const NODE_JOB_COUNTER_PROTOCOL_VERSION: u32 = 2;
 
@@ -145,6 +145,10 @@ pub struct SourceBundleFile {
 pub struct SourceBundle {
     pub manifest_sha256: String,
     pub files: Vec<SourceBundleFile>,
+    /// Complete source tree that can be materialized without fetching the
+    /// repository. Private-repository runners therefore need no Git secret.
+    #[serde(default)]
+    pub complete: bool,
 }
 
 /// One artifact produced by a build job, relative to the checkout root.


### PR DESCRIPTION
## Summary
- add protocol-v4 complete source snapshots for remote builds
- materialize private sources without Git credentials and rebuild from a clean tree
- expose `REMOTE_BUILD_SOURCE_MODE=full` and document private-repo use

## Validation
- `cargo test --lib` (1591 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote build checkout materialization and fleet protocol gating; mis-versioned nodes are rejected, but complete snapshots change how sources are trusted vs Git fetch.
> 
> **Overview**
> Introduces **complete source snapshots** for remote Lean builds so private repositories never need Git credentials on runner nodes. Overlay behavior (dirty-tree patches over a fetched commit) is unchanged; **full** mode sends a hashed snapshot of tracked sources and the node materializes it without `git fetch`.
> 
> **Client (`remote-lean-build`)**: `REMOTE_BUILD_SOURCE_MODE` defaults to `overlay`; `full` uses `git ls-files`, relaxes deletion/encode rules (tracked deletions by omission), raises default bundle limits (16 MiB / 4096 files), sets `source_bundle.complete: true`, and uses manifest domain `sandboxed-source-bundle-v2-complete`.
> 
> **Node**: Validates and applies complete bundles with separate size/file caps; checkouts for complete jobs are content-addressed (`<commit>-source-<manifest>`), rebuilt from the bundle each time (no stale `.lake`), and skip `git reset`/`clean` plus overlay-only git fetch.
> 
> **Core**: Bumps `NODE_PROTOCOL_VERSION` to **4**; placement requires **v3** for overlay bundles and **v4** for complete bundles so rolling deploys cannot drop snapshots on old nodes.
> 
> Docs describe heartbeat v4 gating and private-repo workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf569d2d16b312fbda822c1e17ecfe0d9cf4ce54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->