### PR TITLE
Teach Hermes to sign recurring monitor state

### DIFF
--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -9,7 +9,7 @@ description: >
 metadata:
   policy: chatgpt-ui-pool
   policy_version: 1.3.0
-version: 1.5.0
+version: 1.6.0
 ---
 
 # Hermes Mission Control
@@ -262,6 +262,20 @@ Do **not** notify merely because:
 If nothing meaningful changed, record the observation internally and remain
 silent. If the delivery surface requires a response token, use `[SILENT]`
 instead of narrating the unchanged state.
+
+For every recurring monitor or fallback reconciliation cron, end a deliverable
+response with one machine-only line:
+
+```text
+[STATE_SIGNATURE: <project>|<item>|<exact-head>|<gate-state>|<blocker-class>|<next-event>]
+```
+
+Keep the fields canonical and stable; use `none` for an absent head or blocker.
+Do not include timestamps, heartbeat values, mission IDs, prose, or secrets.
+Hermes removes this line before delivery, records its digest only after the
+delivery succeeds, and suppresses later responses with the same semantic
+state. A meaningful delta must change the signature. `[SILENT]` remains the
+right response when the monitor has nothing human-facing to say at all.
 
 ### Lead with project state, not agent telemetry
 


### PR DESCRIPTION
## Summary
- require stable semantic state signatures on recurring monitor deliveries
- exclude volatile telemetry and secrets from signatures
- document interaction with `[SILENT]` and meaningful deltas

## Validation
- `python3 scripts/policy_lint.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to operator notification policy; no runtime code in this diff.
> 
> **Overview**
> **Hermes mission-control skill (v1.6.0)** now requires recurring monitor and fallback reconciliation cron responses to end with a machine-only **`[STATE_SIGNATURE: …]`** line when there is something deliverable (not `[SILENT]`).
> 
> The signature encodes stable semantic fields (`project`, `item`, `exact-head`, `gate-state`, `blocker-class`, `next-event`) and explicitly excludes volatile telemetry, IDs, timestamps, and secrets. The doc states that Hermes strips the line before operator delivery, stores a digest only after successful delivery, and suppresses repeat notifications when the semantic state is unchanged—aligning with the existing “meaningful delta” / `[SILENT]` rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea54267f8fb866b8b265f0c761244124879e0840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->