### PR TITLE
Standardize private Lean certification transport

### DIFF
--- a/skills/hermes-mission-control/SKILL.md
+++ b/skills/hermes-mission-control/SKILL.md
@@ -9,7 +9,7 @@ description: >
 metadata:
   policy: chatgpt-ui-pool
   policy_version: 1.3.0
-version: 1.6.0
+version: 1.7.0
 ---
 
 # Hermes Mission Control
@@ -357,6 +357,30 @@ scanner, serializer, or policy family, stop patching examples. Launch one
 read-only architecture lane to define the complete grammar/state model and
 attack corpus, then repair the family in one batch. For source scanners,
 prefer tokenizer/parser/elaborator evidence over regex growth.
+
+### Private Lean certification transport
+
+Remote Lean workers are declarative build targets, not SSH hosts to discover or
+configure from a mission. Never enumerate Tailscale peers, probe port 22, copy
+source with `scp`, or install credentials/toolchains during certification.
+
+For a private repository, use the injected wrapper and complete-source mode:
+
+```bash
+REMOTE_BUILD_SOURCE_MODE=full \
+REMOTE_BUILD_NODE_ID=ashur \
+REMOTE_BUILD_EXPECTED_HEAD="$PINNED_SHA" \
+remote-lean-build lake build
+```
+
+For independent two-node evidence, repeat from the unchanged exact head with a
+different explicit `REMOTE_BUILD_NODE_ID` such as `babylon` or `nippur`. Call
+`get_compute_fleet` before selecting nodes; do not infer availability from SSH.
+Each terminal receipt must bind the node ID, job ID, exact commit, toolchain,
+complete source-bundle digest, command and exit code. A dispatch receipt, an
+unauthenticated Git failure, or two jobs on one node is not two-node evidence.
+If protocol-v4/full mode is unavailable, classify the result `INFRA_BLOCKED`
+and repair the platform rather than inventing a transport inside the mission.
 
 Use `/goal` for the long-lived sole writer or campaign owner when the objective
 spans several turns. Keep reviewers as bounded task missions. Use the task


### PR DESCRIPTION
## Summary
- forbid ad-hoc SSH/Tailscale discovery during remote Lean certification
- require protocol-v4 complete snapshots for private repositories
- define exact two-node receipt requirements and explicit node selection

## Validation
- `python3 scripts/policy_lint.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill policy update; no runtime or certification pipeline code changes.
> 
> **Overview**
> Bumps **hermes-mission-control** to **1.7.0** and adds a **Private Lean certification transport** section under PR repair and certification campaigns.
> 
> The new guidance tells Hermes to treat remote Lean workers as declarative build targets only: no Tailscale/SSH discovery, `scp`, or ad-hoc credential/toolchain setup during certification. Private repos must use `remote-lean-build` with `REMOTE_BUILD_SOURCE_MODE=full`, explicit `REMOTE_BUILD_NODE_ID`, and `REMOTE_BUILD_EXPECTED_HEAD` pinned to the campaign SHA. Two-node evidence requires repeating from the same head on a second node chosen via `get_compute_fleet`, with terminal receipts binding node, job, commit, toolchain, full source-bundle digest, and exit code—dispatch-only or same-node runs do not count. Missing protocol-v4/full mode is **`INFRA_BLOCKED`**, with platform repair instead of mission-invented transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1288b071f1b41d1393c61bac5d3a1077907f9e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->