### PR TITLE
Fix private remote-build transport limits

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -705,8 +705,13 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         .nest("/api/spark", super::spark::routes())
         // Remote lean-build dispatch: same per-mission HMAC capability-token
         // model as spark (domain-separated), verified inside the handlers,
-        // so it also bypasses require_auth.
-        .nest("/api/remote-build", super::remote_build::routes());
+        // so it also bypasses require_auth. A complete source snapshot is
+        // bounded to 16 MiB before base64 encoding; allow enough wire overhead
+        // for that snapshot and its manifest instead of Axum's 2 MiB default.
+        .nest(
+            "/api/remote-build",
+            super::remote_build::routes().layer(DefaultBodyLimit::max(32 * 1024 * 1024)),
+        );
 
     // File upload routes with increased body limit (10GB)
     let upload_route = Router::new()

--- a/src/bin/sandboxed_node.rs
+++ b/src/bin/sandboxed_node.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Path as AxumPath, Query, State},
+    extract::{DefaultBodyLimit, Path as AxumPath, Query, State},
     http::{HeaderMap, StatusCode},
     routing::{get, post},
     Json, Router,
@@ -136,7 +136,15 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .route("/heartbeat", get(heartbeat))
         .route("/execute", post(execute))
-        .route("/jobs", post(submit_job).get(list_jobs))
+        // Complete private-source jobs carry up to 16 MiB before base64
+        // encoding, so the submit route needs the same bounded wire allowance
+        // as the core `/api/remote-build` endpoint.
+        .route(
+            "/jobs",
+            post(submit_job)
+                .layer(DefaultBodyLimit::max(32 * 1024 * 1024))
+                .get(list_jobs),
+        )
         .route("/jobs/:id", get(get_job))
         .route("/jobs/:id/cancel", post(cancel_job))
         .with_state(state);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2233,6 +2233,24 @@ pub(crate) async fn install_remote_build_wrapper(
         }
         tokio::fs::rename(&tmp, &destination).await?;
     }
+
+    // Older container images shipped a second, unmanaged copy at
+    // `/usr/local/bin/remote-lean-build`.  Keep that historical entry point as
+    // an alias to the mission-managed wrapper so agents cannot inspect or run
+    // a stale protocol implementation by using the absolute legacy path.
+    #[cfg(unix)]
+    if workspace.workspace_type == WorkspaceType::Container && !is_container_fallback(workspace) {
+        use std::os::unix::fs::symlink;
+
+        let legacy = workspace.path.join("usr/local/bin/remote-lean-build");
+        if let Some(parent) = legacy.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let tmp = legacy.with_extension(format!("tmp-{}-{mission_id}", std::process::id()));
+        let _ = tokio::fs::remove_file(&tmp).await;
+        symlink("/usr/local/lib/sandboxed-sh/bin/remote-lean-build", &tmp)?;
+        tokio::fs::rename(&tmp, &legacy).await?;
+    }
     Ok(())
 }
 
@@ -4396,6 +4414,12 @@ sandboxed-harness-version:grok=\n";
         assert_eq!(
             tokio::fs::read(shim).await.unwrap(),
             include_bytes!("../../scripts/lake")
+        );
+        assert_eq!(
+            tokio::fs::read_link(root.path().join("usr/local/bin/remote-lean-build"))
+                .await
+                .unwrap(),
+            PathBuf::from("/usr/local/lib/sandboxed-sh/bin/remote-lean-build")
         );
     }
 


### PR DESCRIPTION
## Summary
- raise the remote-build route body cap for the bounded 16 MiB complete-source protocol
- atomically alias the historical container wrapper path to the mission-managed wrapper
- add regression coverage for the legacy path

## Validation
- `cargo fmt --all --check`
- `cargo test container_lake_shim_does_not_overwrite_the_real_binary`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded HTTP limit changes and a container-only symlink alias; no auth or data-model changes.
> 
> **Overview**
> Fixes **private remote-build transport** by applying a **32 MiB** `DefaultBodyLimit` on `/api/remote-build` and on sandboxed-node **`POST /jobs`**, so payloads up to the **16 MiB** complete-source cap (plus base64/manifest overhead) are not rejected by Axum’s default **2 MiB** limit.
> 
> For **container workspaces**, **`install_remote_build_wrapper`** now atomically symlinks **`/usr/local/bin/remote-lean-build`** to **`/usr/local/lib/sandboxed-sh/bin/remote-lean-build`**, so the old absolute path cannot run a stale copy of the wrapper. A unit test asserts the symlink target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315129961d770490a0e9e097254ee39a87d76b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->