### PR TITLE
fix(remote-build): gzip complete private source requests

### DIFF
--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -41,8 +41,17 @@ if [ "$#" -eq 0 ]; then set -- lake build; fi
 request_file="$(mktemp)" || die "cannot create temporary request file" 75
 python3 - "$REMOTE_BUILD_MISSION_ID" "$REMOTE_BUILD_TOKEN" "$repo" "$commit" "$cwd_rel" "$@" > "$request_file" <<'PY'
 import base64, hashlib, json, os, pathlib, subprocess, sys
+from urllib.parse import urlsplit, urlunsplit
 mission_id, token, repo, commit, cwd_rel = sys.argv[1:6]
 command = sys.argv[6:]
+parsed_repo = urlsplit(repo)
+if parsed_repo.scheme in {"http", "https"}:
+    host = parsed_repo.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed_repo.port is not None:
+        host = f"{host}:{parsed_repo.port}"
+    repo = urlunsplit((parsed_repo.scheme, host, parsed_repo.path, "", ""))
 req = {
     "mission_id": mission_id,
     "token": token,

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -392,11 +392,6 @@ PY
 }
 
 if [ -z "$job_id" ]; then
-    # Pre-create the durable blocker while no remote request has been made.
-    # Cleanup removes it on known pre-acceptance outcomes; ambiguous/accepted
-    # failures retain it so a dead owner PID can never permit a duplicate job.
-    printf '%s\n' "armed" > "$submit_recovery_blocker" \
-        || die "cannot arm the remote-build recovery blocker before submission" 75
     # Full snapshots contain base64 and therefore inflate substantially in
     # JSON. Compress the wire copy so reverse proxies only buffer the compact
     # request; keep the plain request locally for fingerprinting and receipts.
@@ -407,6 +402,11 @@ with open(sys.argv[1], "rb") as source, open(sys.argv[2], "wb") as output:
     with gzip.GzipFile(fileobj=output, mode="wb", compresslevel=6, mtime=0) as destination:
         shutil.copyfileobj(source, destination)
 PY
+    # Arm immediately before curl. Cleanup removes this on known
+    # pre-acceptance outcomes; ambiguous/accepted failures retain it so a dead
+    # owner PID can never permit a duplicate job.
+    printf '%s\n' "armed" > "$submit_recovery_blocker" \
+        || die "cannot arm the remote-build recovery blocker before submission" 75
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \

--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -223,6 +223,7 @@ esac
 [ "$lock_timeout_secs" -gt 0 ] || die "REMOTE_BUILD_LOCK_TIMEOUT_SECS must be greater than zero"
 
 response_file="$(mktemp)"
+wire_request_file="$(mktemp)"
 submit_lock_held=0
 submit_lock_persistent=0
 submit_lock_dir="$state_file.lock"
@@ -237,7 +238,7 @@ release_submit_lock() {
 }
 cleanup() {
     release_submit_lock
-    rm -f "$response_file" "$request_file"
+    rm -f "$response_file" "$request_file" "$wire_request_file"
 }
 trap cleanup EXIT
 
@@ -396,11 +397,22 @@ if [ -z "$job_id" ]; then
     # failures retain it so a dead owner PID can never permit a duplicate job.
     printf '%s\n' "armed" > "$submit_recovery_blocker" \
         || die "cannot arm the remote-build recovery blocker before submission" 75
+    # Full snapshots contain base64 and therefore inflate substantially in
+    # JSON. Compress the wire copy so reverse proxies only buffer the compact
+    # request; keep the plain request locally for fingerprinting and receipts.
+    python3 - "$request_file" "$wire_request_file" <<'PY' \
+        || die "cannot compress remote-build request" 75
+import gzip, shutil, sys
+with open(sys.argv[1], "rb") as source, open(sys.argv[2], "wb") as output:
+    with gzip.GzipFile(fileobj=output, mode="wb", compresslevel=6, mtime=0) as destination:
+        shutil.copyfileobj(source, destination)
+PY
     echo "remote-lean-build: dispatching $* for ${commit:0:12}${cwd_rel:+ in $cwd_rel} ..." >&2
     http_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
         -H 'Content-Type: application/json' \
+        -H 'Content-Encoding: gzip' \
         --max-time "$submit_timeout_secs" \
-        --data-binary "@$request_file" "$REMOTE_BUILD_URL")"
+        --data-binary "@$wire_request_file" "$REMOTE_BUILD_URL")"
     curl_status=$?
     if [ "$curl_status" -ne 0 ]; then
         case "$curl_status" in

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -58,11 +58,16 @@ fn parse_remote_build_request(
     use flate2::read::GzDecoder;
     use std::io::Read;
 
-    let encoding = headers
-        .get(header::CONTENT_ENCODING)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or("identity")
-        .trim();
+    let encoding = match headers.get(header::CONTENT_ENCODING) {
+        Some(value) => value.to_str().map_err(|_| {
+            (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "remote build Content-Encoding must be valid ASCII".to_string(),
+            )
+        })?,
+        None => "identity",
+    }
+    .trim();
     let reader: Box<dyn Read> = if encoding.eq_ignore_ascii_case("gzip") {
         Box::new(GzDecoder::new(body))
     } else if encoding.is_empty() || encoding.eq_ignore_ascii_case("identity") {
@@ -1783,6 +1788,27 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
         let parsed = parse_remote_build_request(&headers, &compressed).unwrap();
         assert_eq!(parsed.repo, "https://github.com/private/example.git");
         assert_eq!(parsed.commit, "a".repeat(40));
+
+        let parsed_identity = parse_remote_build_request(&HeaderMap::new(), &plain).unwrap();
+        assert_eq!(
+            parsed_identity.repo,
+            "https://github.com/private/example.git"
+        );
+
+        let truncated = &compressed[..compressed.len() - 4];
+        let error = parse_remote_build_request(&headers, truncated).unwrap_err();
+        assert_eq!(error.0, StatusCode::BAD_REQUEST);
+
+        let error = parse_remote_build_request(&headers, b"not a gzip stream").unwrap_err();
+        assert_eq!(error.0, StatusCode::BAD_REQUEST);
+
+        let mut invalid_encoding = HeaderMap::new();
+        invalid_encoding.insert(
+            header::CONTENT_ENCODING,
+            header::HeaderValue::from_bytes(b"\xff").unwrap(),
+        );
+        let error = parse_remote_build_request(&invalid_encoding, &plain).unwrap_err();
+        assert_eq!(error.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
 
         let oversized = vec![b' '; MAX_REMOTE_BUILD_JSON_BYTES as usize + 1];
         let error = parse_remote_build_request(&HeaderMap::new(), &oversized).unwrap_err();

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -421,6 +421,16 @@ fn repository_identity(repo: &str) -> String {
     parsed.to_string()
 }
 
+fn repository_url_has_credentials(repo: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(repo) else {
+        return false;
+    };
+    parsed.password().is_some()
+        || (matches!(parsed.scheme(), "http" | "https") && !parsed.username().is_empty())
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+}
+
 fn remote_job_identity(
     req: &RemoteBuildRequest,
 ) -> crate::remote_node::job_ledger::RemoteJobIdentity {
@@ -960,6 +970,13 @@ async fn submit_remote_build(
     }
     if req.command.is_empty() {
         return (StatusCode::BAD_REQUEST, "command argv required").into_response();
+    }
+    if repository_url_has_credentials(&req.repo) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "repository URL must not contain credentials, query parameters, or a fragment",
+        )
+            .into_response();
     }
     if let Err(message) = validate_expected_head(&req.commit, req.expected_head.as_deref()) {
         return (StatusCode::CONFLICT, message).into_response();
@@ -1686,7 +1703,7 @@ mod tests {
             "remote",
             "add",
             "origin",
-            "https://example.invalid/repo.git",
+            "https://build-user:secret-token@example.invalid/repo.git?token=secret#fragment",
         ]);
 
         let fake_curl = bin.join("curl");
@@ -1911,6 +1928,8 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
             identity.toolchain.as_deref(),
             Some("leanprover/lean4:v4.19.0")
         );
+        assert!(repository_url_has_credentials(&req.repo));
+        assert!(!repository_url_has_credentials(&identity.repository));
     }
 
     #[test]
@@ -2242,6 +2261,10 @@ printf '503'
             std::fs::File::open(&capture).unwrap(),
         ))
         .unwrap();
+        assert_eq!(
+            request.get("repo").and_then(serde_json::Value::as_str),
+            Some("https://example.invalid/repo.git")
+        );
         assert_eq!(
             request
                 .get("estimated_disk_bytes")

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use axum::{
+    body::Bytes,
     extract::{Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
@@ -48,6 +49,56 @@ const DEFAULT_ESTIMATED_DISK_GB: u64 = 12;
 const MAX_ESTIMATED_DISK_GB: u64 = 512;
 const DEFAULT_NODE_MIN_DISK_GB: u64 = 20;
 const DEFAULT_NODE_DISK_EMERGENCY_GB: u64 = 10;
+const MAX_REMOTE_BUILD_JSON_BYTES: u64 = 32 * 1024 * 1024;
+
+fn parse_remote_build_request(
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Result<RemoteBuildRequest, (StatusCode, String)> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+
+    let encoding = headers
+        .get(header::CONTENT_ENCODING)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("identity")
+        .trim();
+    let reader: Box<dyn Read> = if encoding.eq_ignore_ascii_case("gzip") {
+        Box::new(GzDecoder::new(body))
+    } else if encoding.is_empty() || encoding.eq_ignore_ascii_case("identity") {
+        Box::new(body)
+    } else {
+        return Err((
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "remote build Content-Encoding must be gzip or identity".to_string(),
+        ));
+    };
+    let mut decoded = Vec::new();
+    reader
+        .take(MAX_REMOTE_BUILD_JSON_BYTES + 1)
+        .read_to_end(&mut decoded)
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("invalid gzip remote build request: {error}"),
+            )
+        })?;
+    if decoded.len() as u64 > MAX_REMOTE_BUILD_JSON_BYTES {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "remote build JSON exceeds {} bytes after decompression",
+                MAX_REMOTE_BUILD_JSON_BYTES
+            ),
+        ));
+    }
+    serde_json::from_slice(&decoded).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid remote build JSON: {error}"),
+        )
+    })
+}
 
 fn env_gib(name: &str, default: u64) -> u64 {
     std::env::var(name)
@@ -881,8 +932,13 @@ async fn equivalent_remote_validation_response(
 
 async fn submit_remote_build(
     State(state): State<Arc<AppState>>,
-    Json(req): Json<RemoteBuildRequest>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> axum::response::Response {
+    let req = match parse_remote_build_request(&headers, &body) {
+        Ok(req) => req,
+        Err(error) => return error.into_response(),
+    };
     let expects_mission_continuation = req.wait || req.resume_mission_on_terminal;
     // Auth: per-mission, scope-bound capability token (NOT the dashboard JWT
     // and NOT a node bearer token) — a leak only authorizes remote builds
@@ -1705,6 +1761,82 @@ printf '%s' "$REMOTE_BUILD_TEST_HTTP_STATUS"
     }
 
     #[test]
+    fn remote_build_request_accepts_gzip_and_caps_decompressed_json() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let request = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "token": "mission-capability",
+            "repo": "https://github.com/private/example.git",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"],
+        });
+        let plain = serde_json::to_vec(&request).unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&plain).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(compressed.len() < plain.len());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let parsed = parse_remote_build_request(&headers, &compressed).unwrap();
+        assert_eq!(parsed.repo, "https://github.com/private/example.git");
+        assert_eq!(parsed.commit, "a".repeat(40));
+
+        let oversized = vec![b' '; MAX_REMOTE_BUILD_JSON_BYTES as usize + 1];
+        let error = parse_remote_build_request(&HeaderMap::new(), &oversized).unwrap_err();
+        assert_eq!(error.0, StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
+    fn full_snapshot_crosses_five_mib_as_json_but_fits_when_gzipped() {
+        use base64::Engine;
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        // Model the reported 4.35 MiB raw snapshot with deterministic,
+        // incompressible-ish bytes. Base64 JSON crosses a 5 MiB gateway
+        // buffer while gzip returns close to the raw source size.
+        let mut state = 0x9e37_79b9_u32;
+        let raw = (0..4_560_000)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state as u8
+            })
+            .collect::<Vec<_>>();
+        let request = serde_json::json!({
+            "mission_id": Uuid::new_v4(),
+            "token": "mission-capability",
+            "repo": "https://github.com/private/example.git",
+            "commit": "a".repeat(40),
+            "command": ["lake", "build"],
+            "source_bundle": {
+                "manifest_sha256": "b".repeat(64),
+                "complete": true,
+                "files": [{
+                    "path": "Lido.lean",
+                    "sha256": "c".repeat(64),
+                    "data_base64": base64::engine::general_purpose::STANDARD.encode(raw),
+                }],
+            },
+        });
+        let plain = serde_json::to_vec(&request).unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&plain).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(plain.len() > 5 * 1024 * 1024);
+        assert!(compressed.len() < 5 * 1024 * 1024);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let parsed = parse_remote_build_request(&headers, &compressed).unwrap();
+        assert!(parsed.source_bundle.is_some_and(|bundle| bundle.complete));
+    }
+
+    #[test]
     fn token_expiry_is_enforced() {
         let mission = Uuid::new_v4();
         let now = chrono::Utc::now().timestamp();
@@ -2080,8 +2212,10 @@ printf '503'
             .unwrap();
         assert_eq!(output.status.code(), Some(75));
 
-        let request: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(&capture).unwrap()).unwrap();
+        let request: serde_json::Value = serde_json::from_reader(flate2::read::GzDecoder::new(
+            std::fs::File::open(&capture).unwrap(),
+        ))
+        .unwrap();
         assert_eq!(
             request
                 .get("estimated_disk_bytes")
@@ -2145,8 +2279,10 @@ printf '503'
             .unwrap();
         assert_eq!(full_output.status.code(), Some(75));
 
-        let full_request: serde_json::Value =
-            serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+        let full_request: serde_json::Value = serde_json::from_reader(
+            flate2::read::GzDecoder::new(std::fs::File::open(capture).unwrap()),
+        )
+        .unwrap();
         let full_bundle = full_request.get("source_bundle").unwrap();
         assert_eq!(
             full_bundle

--- a/src/node/lean.rs
+++ b/src/node/lean.rs
@@ -1664,6 +1664,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let log = temp.path().join("job.log");
         let mut bundled_source = source(&"a".repeat(40));
+        bundled_source.repo = "https://github.com/private/lido-proof.git".to_string();
         let mut bundle = source_bundle("lean-toolchain", b"leanprover/lean4:v4.31.0\n");
         bundle.complete = true;
         bundle.manifest_sha256 = bundle_manifest_sha256_for_mode(
@@ -1690,6 +1691,7 @@ mod tests {
                 .unwrap(),
             "leanprover/lean4:v4.31.0\n"
         );
+        assert!(!checkout.join(".git").exists());
         tokio::fs::create_dir_all(checkout.join(".lake/build"))
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

- gzip the workspace-to-core remote-build request so a ~4.35 MiB source snapshot does not become a ~5.8 MiB buffered JSON upload
- accept gzip or identity at the core endpoint with a 32 MiB decompressed cap
- keep private exact-head acquisition credential-free: complete bundles materialize directly on the node and contain no `.git`

This builds on `c98d3643`, which added complete source bundles, v4 node gating, and larger application body limits. Raising Axum's limit alone does not address the lower gateway buffer; compressed transport does.

## Reproduction / regression coverage

- `full_snapshot_crosses_five_mib_as_json_but_fits_when_gzipped` models the reported raw snapshot boundary and proves JSON >5 MiB / gzip <5 MiB.
- `remote_build_request_accepts_gzip_and_caps_decompressed_json` covers gzip decode and the decompressed request ceiling.
- `wrapper_sends_dirty_sources_as_a_hashed_bounded_bundle` now verifies the wrapper emits a gzipped full/overlay request.
- `complete_source_bundle_materializes_without_git_and_rebuilds_cleanly` uses a private GitHub URL, proves direct materialization with no `.git`, and proves stale `.lake` removal.

No GitHub credential is delegated. Tokens are not added to argv, URLs, logs, artifacts, or receipts. The only request token remains the existing mission-scoped HMAC capability.

## Tests

Passed:

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test remote_build_request_accepts_gzip_and_caps_decompressed_json -- --nocapture`
- `cargo test full_snapshot_crosses_five_mib_as_json_but_fits_when_gzipped -- --nocapture`
- `cargo test wrapper_sends_dirty_sources_as_a_hashed_bounded_bundle -- --nocapture`
- `cargo test complete_source_bundle_materializes_without_git_and_rebuilds_cleanly -- --nocapture`

Broader `cargo test`: 1,599 passed, 1 ignored, 1 failed. The existing `wrapper_resumes_an_interrupted_async_job_without_resubmitting` chmod persistence case fails because this test environment runs as root, so `chmod 500` does not make the state directory unwritable; its expected exit 1 becomes 0. The same failure occurs in the focused remote-build module run and is unrelated to this patch.

## Operator deployment / revalidation (do not run from this PR)

1. Merge after review and CI.
2. Build the merged `master` with the normal Linux debug build.
3. Deploy the development backend through the guarded deployment API with `target_environment=dev` and `expected_service=sandboxed-sh-dev.service`; verify health and the installed mission wrapper.
4. Ensure Ashur and Babylon report node protocol v4 before the canary. This PR changes no node runtime code, but the complete-source support from `c98d3643` must already be installed on both nodes.
5. Run a private-repository full-source canary through dev and verify immutable repository/commit, node ID, job ID, exit code, toolchain, and source-bundle digest receipts, with no credential material in logs.
6. Promote the same reviewed commit through the guarded production deployment path; do not copy over a live binary or use a raw restart.
7. From the Lido controller run, separately on `ashur` then `babylon`:

   `REMOTE_BUILD_SOURCE_MODE=full REMOTE_BUILD_NODE_ID=<node> REMOTE_BUILD_EXPECTED_HEAD=9131f1820f0f5034b3ebc08f4c9decacb49bdcb1 remote-lean-build lake build`

8. Require both receipts to match immutable head `9131f1820f0f5034b3ebc08f4c9decacb49bdcb1`, the requested node, a unique job ID, Lean v4.31.0, and exit 0. Inspect bounded backend/node logs for 413, clone/fetch, auth, or secret-leak indicators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote-build wire protocol and request validation on a security-sensitive path; behavior is well-tested but clients and proxies must accept gzip uploads.
> 
> **Overview**
> Large **full** source snapshots no longer blow past ~5 MiB reverse-proxy buffers: `remote-lean-build` keeps the plain JSON for fingerprints/receipts but **gzip-compresses** the upload and sends `Content-Encoding: gzip`.
> 
> The core **`POST /api/remote-build`** handler now reads raw bytes, accepts **gzip or identity**, decompresses with a **32 MiB** post-decompression cap, then parses JSON. Submissions whose `repo` URL still embeds credentials, query, or fragment are rejected with **400**.
> 
> The wrapper also **strips userinfo/query/fragment** from `origin` when building the request JSON (including bracketed IPv6 hosts), so private-repo workflows rely on complete bundles instead of leaking tokens on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f493d8caa6ffe11eb9c0dd91f407d4c353804704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->