### PR TITLE
Allow independent remote certification receipts

### DIFF
--- a/scripts/remote-lean-build
+++ b/scripts/remote-lean-build
@@ -74,6 +74,8 @@ if toolchain_path.is_file():
 expected_head = os.environ.get("REMOTE_BUILD_EXPECTED_HEAD", "").strip()
 if expected_head:
     req["expected_head"] = expected_head
+if os.environ.get("REMOTE_BUILD_FORCE_NEW", "0") == "1":
+    req["force_new"] = True
 
 source_mode = os.environ.get("REMOTE_BUILD_SOURCE_MODE", "overlay").strip().lower()
 if source_mode not in {"overlay", "full"}:

--- a/src/api/remote_build.rs
+++ b/src/api/remote_build.rs
@@ -328,6 +328,11 @@ pub struct RemoteBuildRequest {
     /// fire-and-forget clients leave it false.
     #[serde(default)]
     pub resume_mission_on_terminal: bool,
+    /// Deliberately request independent evidence instead of reusing an
+    /// equivalent successful receipt. Intended for explicit multi-node
+    /// certification; ordinary builds should leave this false.
+    #[serde(default)]
+    pub force_new: bool,
     /// Artifact patterns (relative to the checkout root) to digest after a
     /// successful build.
     #[serde(default)]
@@ -951,7 +956,7 @@ async fn submit_remote_build(
     // Reuse completed evidence even when every runner is currently offline.
     // This optimistic read is repeated under the placement lock after any
     // explicit network probe, which closes the concurrent-submit race.
-    if req.source_archive.is_none() {
+    if req.source_archive.is_none() && !req.force_new {
         if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
         {
             return response;
@@ -966,7 +971,7 @@ async fn submit_remote_build(
     // tentative-handle persistence. No network probe runs while this mutex is
     // held, so a slow explicit runner cannot block unrelated auto placement.
     let placement_guard = placement_lock().lock().await;
-    if req.source_archive.is_none() {
+    if req.source_archive.is_none() && !req.force_new {
         if let Some(response) = equivalent_remote_validation_response(&state, &req, &identity).await
         {
             return response;
@@ -2109,6 +2114,7 @@ printf '503'
             .env("REMOTE_BUILD_TOKEN", "test-token")
             .env("REMOTE_BUILD_MISSION_ID", Uuid::new_v4().to_string())
             .env("REMOTE_BUILD_EXPECTED_HEAD", "a".repeat(40))
+            .env("REMOTE_BUILD_FORCE_NEW", "1")
             .env("REMOTE_BUILD_TEST_CAPTURE", &capture)
             .output()
             .unwrap();
@@ -2135,6 +2141,12 @@ printf '503'
                 .get("expected_head")
                 .and_then(serde_json::Value::as_str),
             Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(
+            request
+                .get("force_new")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
         );
         let archive = request.get("source_archive").unwrap();
         let archive_bytes = base64::engine::general_purpose::STANDARD


### PR DESCRIPTION
## Summary
- propagate `REMOTE_BUILD_FORCE_NEW=1` to the authenticated core request
- bypass immutable-receipt reuse only for explicitly forced certification jobs
- preserve deduplication for ordinary builds

## Validation
- `cargo fmt --all --check`
- `cargo test wrapper_sends_dirty_sources_as_a_hashed_bounded_bundle`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted opt-in bypass of receipt deduplication; default behavior unchanged and scoped to explicit certification use.
> 
> **Overview**
> Introduces an explicit **force new build** path for multi-node certification: when `REMOTE_BUILD_FORCE_NEW=1`, the `remote-lean-build` wrapper sets `force_new: true` on the POST body, and the API **skips immutable receipt reuse** (`equivalent_remote_validation_response`) for requests without a `source_archive`.
> 
> Ordinary builds keep the default (`force_new: false`) and still deduplicate against prior successful validations. The wrapper test now asserts `force_new` is forwarded when the env var is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e31484f5653cb7dd3bd91d4dcf7b923d62c103e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->